### PR TITLE
[feat](connector) P3 hudi connector hardening + test baseline + dispatch design (hybrid, T02-T08)

### DIFF
--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorMetadataPartitionPruningTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorMetadataPartitionPruningTest.java
@@ -1,0 +1,256 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hive;
+
+import org.apache.doris.connector.api.ConnectorType;
+import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.api.pushdown.ConnectorAnd;
+import org.apache.doris.connector.api.pushdown.ConnectorColumnRef;
+import org.apache.doris.connector.api.pushdown.ConnectorComparison;
+import org.apache.doris.connector.api.pushdown.ConnectorExpression;
+import org.apache.doris.connector.api.pushdown.ConnectorFilterConstraint;
+import org.apache.doris.connector.api.pushdown.ConnectorIn;
+import org.apache.doris.connector.api.pushdown.ConnectorLiteral;
+import org.apache.doris.connector.api.pushdown.FilterApplicationResult;
+import org.apache.doris.connector.hms.HmsClient;
+import org.apache.doris.connector.hms.HmsDatabaseInfo;
+import org.apache.doris.connector.hms.HmsPartitionInfo;
+import org.apache.doris.connector.hms.HmsTableInfo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Tests {@link HiveConnectorMetadata#applyFilter} partition pruning (P3-T07 batch C).
+ *
+ * <p>WHY: this is the direct analog of fe-connector-hudi's HudiPartitionPruningTest —
+ * both exercise the same EQ/IN partition-pruning helpers (the Hudi T05 fix was mirrored
+ * from this Hive code). The tests are intentionally near-identical; they differ only in
+ * the handle type and that Hive resolves matched partition NAMES to
+ * {@link HmsPartitionInfo} via {@code getPartitions} (capped at 100000), whereas Hudi
+ * keeps the matched relative paths. Consolidating the two is deferred to the P7 Hive
+ * migration. These assertions pin: EQ / IN on partition columns prune; predicates on
+ * non-partition columns never prune; a no-effect predicate leaves the handle untouched
+ * ({@code Optional.empty()}); a zero-match predicate yields an empty pruned set.</p>
+ */
+public class HiveConnectorMetadataPartitionPruningTest {
+
+    private static final List<String> PARTITIONS = Arrays.asList(
+            "year=2023/month=12",
+            "year=2024/month=01",
+            "year=2024/month=02");
+
+    private static final List<String> PART_KEYS = Arrays.asList("year", "month");
+
+    @Test
+    public void testEqOnPartitionColumnPrunes() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), eq("year", "2024"));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Arrays.asList("year=2024/month=01", "year=2024/month=02"),
+                prunedLocations(result));
+    }
+
+    @Test
+    public void testInOnPartitionColumnPrunes() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), in("month", "01", "12"));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Arrays.asList("year=2023/month=12", "year=2024/month=01"),
+                prunedLocations(result));
+    }
+
+    @Test
+    public void testAndOfTwoPartitionColumnsPrunes() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), and(eq("year", "2024"), eq("month", "01")));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Collections.singletonList("year=2024/month=01"),
+                prunedLocations(result));
+    }
+
+    @Test
+    public void testNonPartitionColumnInAndIsIgnored() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), and(eq("year", "2024"), eq("price", "100")));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Arrays.asList("year=2024/month=01", "year=2024/month=02"),
+                prunedLocations(result));
+    }
+
+    @Test
+    public void testNonPartitionPredicateOnlyLeavesHandleUntouched() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), eq("price", "100"));
+        Assertions.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testPredicateMatchingAllPartitionsHasNoEffect() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), in("year", "2023", "2024"));
+        Assertions.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testPredicateMatchingNoPartitionYieldsEmptyPrunedList() {
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), eq("year", "1999"));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertTrue(prunedLocations(result).isEmpty());
+    }
+
+    @Test
+    public void testUnpartitionedTableIsNotTouched() {
+        HiveTableHandle handle = new HiveTableHandle.Builder("db", "t", HiveTableType.HIVE)
+                .partitionKeyNames(Collections.emptyList())
+                .build();
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(handle, eq("year", "2024"));
+        Assertions.assertFalse(result.isPresent());
+    }
+
+    // ===== helpers =====
+
+    private Optional<FilterApplicationResult<ConnectorTableHandle>> applyFilter(
+            HiveTableHandle handle, ConnectorExpression expr) {
+        HiveConnectorMetadata metadata = new HiveConnectorMetadata(
+                new FakeHmsClient(PARTITIONS), Collections.emptyMap());
+        return metadata.applyFilter(null, handle, new ConnectorFilterConstraint(expr));
+    }
+
+    private HiveTableHandle partitionedHandle() {
+        return new HiveTableHandle.Builder("db", "t", HiveTableType.HIVE)
+                .partitionKeyNames(PART_KEYS)
+                .build();
+    }
+
+    private List<String> prunedLocations(Optional<FilterApplicationResult<ConnectorTableHandle>> result) {
+        List<HmsPartitionInfo> pruned =
+                ((HiveTableHandle) result.get().getHandle()).getPrunedPartitions();
+        List<String> locations = new ArrayList<>();
+        for (HmsPartitionInfo p : pruned) {
+            locations.add(p.getLocation());
+        }
+        return locations;
+    }
+
+    private static ConnectorColumnRef colRef(String name) {
+        return new ConnectorColumnRef(name, ConnectorType.of("STRING"));
+    }
+
+    private static ConnectorLiteral lit(String value) {
+        return new ConnectorLiteral(ConnectorType.of("STRING"), value);
+    }
+
+    private static ConnectorComparison eq(String col, String value) {
+        return new ConnectorComparison(ConnectorComparison.Operator.EQ, colRef(col), lit(value));
+    }
+
+    private static ConnectorIn in(String col, String... values) {
+        List<ConnectorExpression> inList = new ArrayList<>();
+        for (String v : values) {
+            inList.add(lit(v));
+        }
+        return new ConnectorIn(colRef(col), inList, false);
+    }
+
+    private static ConnectorAnd and(ConnectorExpression... children) {
+        return new ConnectorAnd(Arrays.asList(children));
+    }
+
+    /**
+     * Minimal {@link HmsClient} double. {@code listPartitionNames} returns a fixed list;
+     * {@code getPartitions} echoes each requested name back as an {@link HmsPartitionInfo}
+     * whose location IS the partition name (so the pruning selection can be asserted).
+     * The rest fail loud.
+     */
+    private static final class FakeHmsClient implements HmsClient {
+        private final List<String> partitionNames;
+
+        FakeHmsClient(List<String> partitionNames) {
+            this.partitionNames = partitionNames;
+        }
+
+        @Override
+        public List<String> listPartitionNames(String dbName, String tableName, int maxParts) {
+            return partitionNames;
+        }
+
+        @Override
+        public List<HmsPartitionInfo> getPartitions(String dbName, String tableName,
+                List<String> partNames) {
+            List<HmsPartitionInfo> result = new ArrayList<>();
+            for (String name : partNames) {
+                result.add(new HmsPartitionInfo(Collections.emptyList(), name,
+                        null, null, null, Collections.emptyMap()));
+            }
+            return result;
+        }
+
+        @Override
+        public List<String> listDatabases() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsDatabaseInfo getDatabase(String dbName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> listTables(String dbName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tableExists(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsTableInfo getTable(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getDefaultColumnValues(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsPartitionInfo getPartition(String dbName, String tableName, List<String> values) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveFileFormatTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveFileFormatTest.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hive;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link HiveFileFormat} detection (first test for fe-connector-hive; P3-T07 batch C).
+ *
+ * <p>WHY: the detected format selects which BE file reader runs (parquet/orc/text/json
+ * scanner). Misdetection causes read failures or silent corruption. Detection is a
+ * case-insensitive substring match on the InputFormat class name with a SerDe-library
+ * fallback — these tests pin that contract, the inputFormat-wins precedence, and the
+ * splittability of each format.</p>
+ */
+public class HiveFileFormatTest {
+
+    @Test
+    public void testFromInputFormatDetectsByContent() {
+        Assertions.assertEquals(HiveFileFormat.PARQUET,
+                HiveFileFormat.fromInputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"));
+        Assertions.assertEquals(HiveFileFormat.ORC,
+                HiveFileFormat.fromInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"));
+        Assertions.assertEquals(HiveFileFormat.TEXT,
+                HiveFileFormat.fromInputFormat("org.apache.hadoop.mapred.TextInputFormat"));
+        Assertions.assertEquals(HiveFileFormat.JSON,
+                HiveFileFormat.fromInputFormat("org.apache.hadoop.hive.json.JsonInputFormat"));
+    }
+
+    @Test
+    public void testFromInputFormatUnknownAndNull() {
+        Assertions.assertEquals(HiveFileFormat.UNKNOWN, HiveFileFormat.fromInputFormat(null));
+        Assertions.assertEquals(HiveFileFormat.UNKNOWN,
+                HiveFileFormat.fromInputFormat("com.example.CustomInputFormat"));
+    }
+
+    @Test
+    public void testFromSerDeLib() {
+        Assertions.assertEquals(HiveFileFormat.PARQUET,
+                HiveFileFormat.fromSerDeLib("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"));
+        Assertions.assertEquals(HiveFileFormat.ORC,
+                HiveFileFormat.fromSerDeLib("org.apache.hadoop.hive.ql.io.orc.OrcSerde"));
+        Assertions.assertEquals(HiveFileFormat.TEXT,
+                HiveFileFormat.fromSerDeLib("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"));
+        Assertions.assertEquals(HiveFileFormat.TEXT,
+                HiveFileFormat.fromSerDeLib("org.apache.hadoop.hive.serde2.OpenCSVSerde"));
+        Assertions.assertEquals(HiveFileFormat.JSON,
+                HiveFileFormat.fromSerDeLib("org.apache.hive.hcatalog.data.JsonSerDe"));
+        Assertions.assertEquals(HiveFileFormat.UNKNOWN, HiveFileFormat.fromSerDeLib(null));
+    }
+
+    @Test
+    public void testDetectPrefersInputFormatThenFallsBackToSerDe() {
+        // inputFormat wins when recognized (even if the SerDe says otherwise)...
+        Assertions.assertEquals(HiveFileFormat.PARQUET,
+                HiveFileFormat.detect(
+                        "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+                        "org.apache.hadoop.hive.ql.io.orc.OrcSerde"));
+        // ...and the SerDe is the fallback when the inputFormat is unrecognized.
+        Assertions.assertEquals(HiveFileFormat.TEXT,
+                HiveFileFormat.detect("com.example.CustomInputFormat",
+                        "org.apache.hadoop.hive.serde2.OpenCSVSerde"));
+    }
+
+    @Test
+    public void testIsSplittable() {
+        Assertions.assertTrue(HiveFileFormat.PARQUET.isSplittable());
+        Assertions.assertTrue(HiveFileFormat.ORC.isSplittable());
+        Assertions.assertTrue(HiveFileFormat.TEXT.isSplittable());
+        Assertions.assertFalse(HiveFileFormat.JSON.isSplittable());
+        Assertions.assertFalse(HiveFileFormat.UNKNOWN.isSplittable());
+    }
+
+    @Test
+    public void testFormatName() {
+        Assertions.assertEquals("parquet", HiveFileFormat.PARQUET.getFormatName());
+        Assertions.assertEquals("orc", HiveFileFormat.ORC.getFormatName());
+        Assertions.assertEquals("text", HiveFileFormat.TEXT.getFormatName());
+        Assertions.assertEquals("json", HiveFileFormat.JSON.getFormatName());
+    }
+}

--- a/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsTypeMappingTest.java
+++ b/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsTypeMappingTest.java
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hms;
+
+import org.apache.doris.connector.api.ConnectorType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/**
+ * Tests {@link HmsTypeMapping} — the Hive type-string parser shared by the hms and hive
+ * connectors (first test for fe-connector-hms; P3-T07 batch C baseline).
+ *
+ * <p>WHY: this is the SPI-clean equivalent of fe-core
+ * {@code HiveMetaStoreClientHelper.hiveTypeToDorisType}. It is pure parsing logic where
+ * bugs hide — nested complex types, precision/scale extraction, and option-driven
+ * mappings. A wrong mapping silently mistypes every column of an HMS/Hive/Iceberg-on-HMS
+ * table. These tests pin the exact ConnectorType per Hive type string and the
+ * nesting-aware field splitting (Rule 9: encode the contract, not just the happy path).</p>
+ */
+public class HmsTypeMappingTest {
+
+    private static ConnectorType map(String hiveType) {
+        return HmsTypeMapping.toConnectorType(hiveType);
+    }
+
+    @Test
+    public void testPrimitives() {
+        Assertions.assertEquals(ConnectorType.of("BOOLEAN"), map("boolean"));
+        Assertions.assertEquals(ConnectorType.of("TINYINT"), map("tinyint"));
+        Assertions.assertEquals(ConnectorType.of("SMALLINT"), map("smallint"));
+        Assertions.assertEquals(ConnectorType.of("INT"), map("int"));
+        Assertions.assertEquals(ConnectorType.of("BIGINT"), map("bigint"));
+        Assertions.assertEquals(ConnectorType.of("FLOAT"), map("float"));
+        Assertions.assertEquals(ConnectorType.of("DOUBLE"), map("double"));
+        Assertions.assertEquals(ConnectorType.of("STRING"), map("string"));
+        Assertions.assertEquals(ConnectorType.of("DATEV2"), map("date"));
+    }
+
+    @Test
+    public void testTimestampUsesTimeScale() {
+        // Default time scale is 6.
+        Assertions.assertEquals(ConnectorType.of("DATETIMEV2", 6, -1), map("timestamp"));
+        // A custom time scale flows through.
+        Assertions.assertEquals(ConnectorType.of("DATETIMEV2", 3, -1),
+                HmsTypeMapping.toConnectorType("timestamp", new HmsTypeMapping.Options(3, false, false)));
+    }
+
+    @Test
+    public void testBinaryDefaultAndVarbinaryOption() {
+        Assertions.assertEquals(ConnectorType.of("STRING"), map("binary"));
+        Assertions.assertEquals(ConnectorType.of("VARBINARY"),
+                HmsTypeMapping.toConnectorType("binary", new HmsTypeMapping.Options(6, true, false)));
+    }
+
+    @Test
+    public void testCharAndVarcharLength() {
+        Assertions.assertEquals(ConnectorType.of("CHAR", 10, -1), map("char(10)"));
+        Assertions.assertEquals(ConnectorType.of("VARCHAR", 255, -1), map("varchar(255)"));
+        // Missing length parameter degrades to the unparameterized type, not a crash.
+        Assertions.assertEquals(ConnectorType.of("CHAR"), map("char"));
+        Assertions.assertEquals(ConnectorType.of("VARCHAR"), map("varchar"));
+    }
+
+    @Test
+    public void testDecimalPrecisionScaleAndDefaults() {
+        Assertions.assertEquals(ConnectorType.of("DECIMALV3", 10, 2), map("decimal(10,2)"));
+        // Only precision given -> default scale 0.
+        Assertions.assertEquals(ConnectorType.of("DECIMALV3", 10, 0), map("decimal(10)"));
+        // Bare decimal -> default precision 9, scale 0.
+        Assertions.assertEquals(ConnectorType.of("DECIMALV3", 9, 0), map("decimal"));
+    }
+
+    @Test
+    public void testArrayIncludingNested() {
+        Assertions.assertEquals(ConnectorType.arrayOf(ConnectorType.of("INT")), map("array<int>"));
+        Assertions.assertEquals(
+                ConnectorType.arrayOf(ConnectorType.arrayOf(ConnectorType.of("STRING"))),
+                map("array<array<string>>"));
+    }
+
+    @Test
+    public void testMapIncludingNestedValue() {
+        Assertions.assertEquals(
+                ConnectorType.mapOf(ConnectorType.of("STRING"), ConnectorType.of("INT")),
+                map("map<string,int>"));
+        // The inner comma of the nested array value must NOT be mistaken for the key/value
+        // separator — this is exactly what findNextNestedField guards.
+        Assertions.assertEquals(
+                ConnectorType.mapOf(ConnectorType.of("INT"),
+                        ConnectorType.arrayOf(ConnectorType.of("STRING"))),
+                map("map<int,array<string>>"));
+    }
+
+    @Test
+    public void testStructIncludingNestedFields() {
+        Assertions.assertEquals(
+                ConnectorType.structOf(Arrays.asList("a", "b"),
+                        Arrays.asList(ConnectorType.of("INT"), ConnectorType.of("STRING"))),
+                map("struct<a:int,b:string>"));
+        Assertions.assertEquals(
+                ConnectorType.structOf(Arrays.asList("x", "y"),
+                        Arrays.asList(ConnectorType.arrayOf(ConnectorType.of("INT")),
+                                ConnectorType.mapOf(ConnectorType.of("STRING"), ConnectorType.of("BIGINT")))),
+                map("struct<x:array<int>,y:map<string,bigint>>"));
+    }
+
+    @Test
+    public void testTimestampWithLocalTimeZone() {
+        // Default: mapped to DATETIMEV2.
+        Assertions.assertEquals(ConnectorType.of("DATETIMEV2", 6, -1),
+                map("timestamp with local time zone"));
+        // With the timestamp-tz option: mapped to TIMESTAMPTZ.
+        Assertions.assertEquals(ConnectorType.of("TIMESTAMPTZ", 6, -1),
+                HmsTypeMapping.toConnectorType("timestamp with local time zone",
+                        new HmsTypeMapping.Options(6, false, true)));
+    }
+
+    @Test
+    public void testUnsupportedTypeIsUnsupportedNotCrash() {
+        Assertions.assertEquals(ConnectorType.of("UNSUPPORTED"), map("interval_day_time"));
+        Assertions.assertEquals(ConnectorType.of("UNSUPPORTED"), map("void"));
+    }
+
+    @Test
+    public void testCaseInsensitiveAndLowercasesNestedNames() {
+        Assertions.assertEquals(ConnectorType.of("INT"), map("INT"));
+        Assertions.assertEquals(ConnectorType.arrayOf(ConnectorType.of("STRING")), map("ARRAY<STRING>"));
+        // The whole type string is lowercased first, so struct field names are lowercased too.
+        Assertions.assertEquals(
+                ConnectorType.structOf(Arrays.asList("name"), Arrays.asList(ConnectorType.of("INT"))),
+                map("STRUCT<Name:INT>"));
+    }
+
+    @Test
+    public void testFindNextNestedFieldRespectsNesting() {
+        // Top-level comma found at the right index...
+        Assertions.assertEquals(3, HmsTypeMapping.findNextNestedField("int,string"));
+        Assertions.assertEquals(10, HmsTypeMapping.findNextNestedField("array<int>,string"));
+        // ...and a comma nested inside <> is skipped (returns the next top-level comma).
+        Assertions.assertEquals(15, HmsTypeMapping.findNextNestedField("map<string,int>,extra"));
+        // No top-level comma -> returns the length.
+        Assertions.assertEquals(3, HmsTypeMapping.findNextNestedField("int"));
+    }
+}

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
@@ -24,7 +24,12 @@ import org.apache.doris.connector.api.ConnectorTableSchema;
 import org.apache.doris.connector.api.ConnectorType;
 import org.apache.doris.connector.api.handle.ConnectorColumnHandle;
 import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.api.pushdown.ConnectorAnd;
+import org.apache.doris.connector.api.pushdown.ConnectorComparison;
+import org.apache.doris.connector.api.pushdown.ConnectorExpression;
 import org.apache.doris.connector.api.pushdown.ConnectorFilterConstraint;
+import org.apache.doris.connector.api.pushdown.ConnectorIn;
+import org.apache.doris.connector.api.pushdown.ConnectorLiteral;
 import org.apache.doris.connector.api.pushdown.FilterApplicationResult;
 import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsClientException;
@@ -39,10 +44,12 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -150,17 +157,38 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             return Optional.empty();
         }
 
-        // List all partition names from HMS (e.g. "year=2024/month=01")
-        // These are relative paths that double as partition identifiers
-        List<String> partitionNames = hmsClient.listPartitionNames(
-                hudiHandle.getDbName(), hudiHandle.getTableName(), -1);
-        if (partitionNames == null || partitionNames.isEmpty()) {
+        // Extract equality/IN predicates on partition columns from the expression.
+        // No partition predicate -> leave the handle untouched so resolvePartitions
+        // falls back to Hudi's own metadata listing (HoodieTableMetadata.getAllPartitionPaths).
+        Map<String, List<String>> partitionPredicates = extractPartitionPredicates(
+                constraint.getExpression(), partKeyNames);
+        if (partitionPredicates.isEmpty()) {
             return Optional.empty();
         }
 
-        // Build updated handle with partition paths for scan planning
+        // List candidate partition names from HMS (e.g. "year=2024/month=01"). These
+        // relative paths double as partition identifiers consumed by HudiScanPlanProvider.
+        // Keep maxParts=-1 (unlimited): no silent partition truncation.
+        List<String> allPartNames = hmsClient.listPartitionNames(
+                hudiHandle.getDbName(), hudiHandle.getTableName(), -1);
+        if (allPartNames == null || allPartNames.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<String> matchedPartNames = prunePartitionNames(
+                allPartNames, partKeyNames, partitionPredicates);
+        if (matchedPartNames.size() == allPartNames.size()) {
+            // No pruning effect
+            return Optional.empty();
+        }
+
+        LOG.info("Partition pruning: {}.{} all={} pruned={}",
+                hudiHandle.getDbName(), hudiHandle.getTableName(),
+                allPartNames.size(), matchedPartNames.size());
+
+        // Build updated handle carrying only the matched partition paths for scan planning.
         HudiTableHandle updatedHandle = hudiHandle.toBuilder()
-                .prunedPartitionPaths(partitionNames)
+                .prunedPartitionPaths(matchedPartNames)
                 .build();
 
         return Optional.of(new FilterApplicationResult<>(updatedHandle, constraint.getExpression(), false));
@@ -302,5 +330,114 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             }
         }
         return conf;
+    }
+
+    // ========== Partition pruning helpers ==========
+    // Mirrors HiveConnectorMetadata's EQ/IN partition pruning. Duplicated rather than
+    // shared because fe-connector-hudi depends on fe-connector-hms, not fe-connector-hive;
+    // consolidate during the Hive (P7) migration. See P3-T05 design.
+
+    /**
+     * Extracts equality predicates on partition columns from the expression tree.
+     * Supports: col = 'value', col IN ('v1', 'v2', ...), AND combinations.
+     */
+    private Map<String, List<String>> extractPartitionPredicates(
+            ConnectorExpression expr, List<String> partKeyNames) {
+        Set<String> partKeySet = partKeyNames.stream().collect(Collectors.toSet());
+        Map<String, List<String>> result = new HashMap<>();
+        extractPredicatesRecursive(expr, partKeySet, result);
+        return result;
+    }
+
+    private void extractPredicatesRecursive(ConnectorExpression expr,
+            Set<String> partKeySet, Map<String, List<String>> result) {
+        if (expr instanceof ConnectorAnd) {
+            for (ConnectorExpression child : ((ConnectorAnd) expr).getConjuncts()) {
+                extractPredicatesRecursive(child, partKeySet, result);
+            }
+        } else if (expr instanceof ConnectorComparison) {
+            ConnectorComparison cmp = (ConnectorComparison) expr;
+            if (cmp.getOperator() == ConnectorComparison.Operator.EQ) {
+                String colName = extractColumnName(cmp.getLeft());
+                String value = extractLiteralValue(cmp.getRight());
+                if (colName != null && value != null && partKeySet.contains(colName)) {
+                    result.computeIfAbsent(colName, k -> new ArrayList<>()).add(value);
+                }
+            }
+        } else if (expr instanceof ConnectorIn) {
+            ConnectorIn inExpr = (ConnectorIn) expr;
+            if (!inExpr.isNegated()) {
+                String colName = extractColumnName(inExpr.getValue());
+                if (colName != null && partKeySet.contains(colName)) {
+                    List<String> values = new ArrayList<>();
+                    for (ConnectorExpression item : inExpr.getInList()) {
+                        String val = extractLiteralValue(item);
+                        if (val != null) {
+                            values.add(val);
+                        }
+                    }
+                    if (!values.isEmpty()) {
+                        result.computeIfAbsent(colName, k -> new ArrayList<>()).addAll(values);
+                    }
+                }
+            }
+        }
+    }
+
+    private String extractColumnName(ConnectorExpression expr) {
+        if (expr instanceof org.apache.doris.connector.api.pushdown.ConnectorColumnRef) {
+            return ((org.apache.doris.connector.api.pushdown.ConnectorColumnRef) expr).getColumnName();
+        }
+        return null;
+    }
+
+    private String extractLiteralValue(ConnectorExpression expr) {
+        if (expr instanceof ConnectorLiteral) {
+            Object val = ((ConnectorLiteral) expr).getValue();
+            return val != null ? String.valueOf(val) : null;
+        }
+        return null;
+    }
+
+    /**
+     * Prunes partition names based on extracted equality predicates.
+     * Partition names follow the Hive convention: key1=val1/key2=val2
+     */
+    private List<String> prunePartitionNames(List<String> allPartNames,
+            List<String> partKeyNames, Map<String, List<String>> predicates) {
+        List<String> matched = new ArrayList<>();
+        for (String partName : allPartNames) {
+            Map<String, String> partValues = parsePartitionName(partName, partKeyNames);
+            if (matchesPredicates(partValues, predicates)) {
+                matched.add(partName);
+            }
+        }
+        return matched;
+    }
+
+    private Map<String, String> parsePartitionName(String partName,
+            List<String> partKeyNames) {
+        Map<String, String> values = new HashMap<>();
+        String[] parts = partName.split("/");
+        for (String part : parts) {
+            int eq = part.indexOf('=');
+            if (eq > 0) {
+                values.put(part.substring(0, eq), part.substring(eq + 1));
+            }
+        }
+        return values;
+    }
+
+    private boolean matchesPredicates(Map<String, String> partValues,
+            Map<String, List<String>> predicates) {
+        for (Map.Entry<String, List<String>> entry : predicates.entrySet()) {
+            String colName = entry.getKey();
+            List<String> allowedValues = entry.getValue();
+            String actualValue = partValues.get(colName);
+            if (actualValue == null || !allowedValues.contains(actualValue)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -258,8 +259,11 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
 
     /**
      * Convert Avro schema fields to ConnectorColumn list.
+     *
+     * <p>Package-private and static so it can be unit-tested directly with a
+     * hand-built Avro schema (no live HoodieTableMetaClient needed).</p>
      */
-    private List<ConnectorColumn> avroSchemaToColumns(Schema avroSchema) {
+    static List<ConnectorColumn> avroSchemaToColumns(Schema avroSchema) {
         List<Schema.Field> fields = avroSchema.getFields();
         List<ConnectorColumn> columns = new ArrayList<>(fields.size());
         for (Schema.Field field : fields) {
@@ -267,7 +271,12 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             Schema fieldSchema = unwrapNullable(field.schema());
             ConnectorType connectorType = HudiTypeMapping.fromAvroSchema(fieldSchema);
             String comment = field.doc() != null ? field.doc() : "";
-            columns.add(new ConnectorColumn(field.name(), connectorType, comment, nullable, null));
+            // Lower-case the top-level column name to mirror legacy
+            // HMSExternalTable.initHudiSchema (name().toLowerCase(Locale.ROOT)).
+            // Nested struct field names are left as-is here and in HudiTypeMapping,
+            // matching legacy (which lowercases only the top-level column name).
+            String columnName = field.name().toLowerCase(Locale.ROOT);
+            columns.add(new ConnectorColumn(columnName, connectorType, comment, nullable, null));
         }
         return columns;
     }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
@@ -116,7 +116,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
             columnNames = avroSchema.getFields().stream()
                     .map(Schema.Field::name).collect(Collectors.toList());
             columnTypes = avroSchema.getFields().stream()
-                    .map(f -> HudiTypeMapping.fromAvroSchema(unwrapNullable(f.schema())).getTypeName())
+                    .map(f -> HudiTypeMapping.toHiveTypeString(f.schema()))
                     .collect(Collectors.toList());
         } catch (Exception e) {
             LOG.warn("Failed to resolve Hudi schema for JNI reader, JNI splits may fail: {}",
@@ -345,17 +345,6 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
             return "orc";
         }
         return "parquet";
-    }
-
-    private static Schema unwrapNullable(Schema schema) {
-        if (schema.getType() == Schema.Type.UNION) {
-            for (Schema s : schema.getTypes()) {
-                if (s.getType() != Schema.Type.NULL) {
-                    return s;
-                }
-            }
-        }
-        return schema;
     }
 
     private Configuration buildHadoopConf() {

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanRange.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanRange.java
@@ -26,7 +26,6 @@ import org.apache.doris.thrift.THudiFileDesc;
 import org.apache.doris.thrift.TTableFormatFileDesc;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +55,15 @@ public class HudiScanRange implements ConnectorScanRange {
     private final String fileFormat;
     private final Map<String, String> partitionValues;
     private final Map<String, String> properties;
+    // JNI reader list fields. Kept as typed lists (NOT joined into the
+    // properties map) because Hive type strings contain commas
+    // (e.g. decimal(10,2), struct<a:int,b:string>): a comma join+split
+    // round-trip would shatter them and misalign column_names/column_types.
+    // BE (hudi_jni_reader.cpp) joins these lists itself with the correct
+    // delimiters (names ',', types '#', delta logs ',').
+    private final List<String> deltaLogs;
+    private final List<String> columnNames;
+    private final List<String> columnTypes;
 
     private HudiScanRange(Builder builder) {
         this.path = builder.path;
@@ -85,16 +93,17 @@ public class HudiScanRange implements ConnectorScanRange {
             props.put("hudi.data_file_path", builder.dataFilePath);
         }
         props.put("hudi.data_file_length", String.valueOf(builder.dataFileLength));
-        if (builder.deltaLogs != null && !builder.deltaLogs.isEmpty()) {
-            props.put("hudi.delta_logs", String.join(",", builder.deltaLogs));
-        }
-        if (builder.columnNames != null && !builder.columnNames.isEmpty()) {
-            props.put("hudi.column_names", String.join(",", builder.columnNames));
-        }
-        if (builder.columnTypes != null && !builder.columnTypes.isEmpty()) {
-            props.put("hudi.column_types", String.join(",", builder.columnTypes));
-        }
         this.properties = Collections.unmodifiableMap(props);
+
+        this.deltaLogs = builder.deltaLogs != null
+                ? Collections.unmodifiableList(new ArrayList<>(builder.deltaLogs))
+                : Collections.emptyList();
+        this.columnNames = builder.columnNames != null
+                ? Collections.unmodifiableList(new ArrayList<>(builder.columnNames))
+                : Collections.emptyList();
+        this.columnTypes = builder.columnTypes != null
+                ? Collections.unmodifiableList(new ArrayList<>(builder.columnTypes))
+                : Collections.emptyList();
     }
 
     @Override
@@ -158,8 +167,7 @@ public class HudiScanRange implements ConnectorScanRange {
 
         // Dynamic format downgrade: if JNI but no delta logs, use native reader
         if (isJni) {
-            String deltaLogs = props.get("hudi.delta_logs");
-            if (deltaLogs == null || deltaLogs.isEmpty()) {
+            if (deltaLogs.isEmpty()) {
                 String dataFilePath = props.getOrDefault(
                         "hudi.data_file_path", "");
                 if (!dataFilePath.isEmpty()) {
@@ -188,20 +196,18 @@ public class HudiScanRange implements ConnectorScanRange {
             fileDesc.setDataFileLength(Long.parseLong(
                     props.getOrDefault("hudi.data_file_length", "0")));
 
-            String deltaLogs = props.get("hudi.delta_logs");
-            if (deltaLogs != null && !deltaLogs.isEmpty()) {
-                fileDesc.setDeltaLogs(
-                        Arrays.asList(deltaLogs.split(",")));
+            // Set typed lists directly. BE (hudi_jni_reader.cpp) joins them with
+            // the correct delimiters: column_names ',', column_types '#', delta
+            // logs ','. Joining/splitting here would shatter comma-bearing Hive
+            // type strings (decimal(10,2), struct<...>).
+            if (!deltaLogs.isEmpty()) {
+                fileDesc.setDeltaLogs(deltaLogs);
             }
-            String colNames = props.get("hudi.column_names");
-            if (colNames != null && !colNames.isEmpty()) {
-                fileDesc.setColumnNames(
-                        Arrays.asList(colNames.split(",")));
+            if (!columnNames.isEmpty()) {
+                fileDesc.setColumnNames(columnNames);
             }
-            String colTypes = props.get("hudi.column_types");
-            if (colTypes != null && !colTypes.isEmpty()) {
-                fileDesc.setColumnTypes(
-                        Arrays.asList(colTypes.split(",")));
+            if (!columnTypes.isEmpty()) {
+                fileDesc.setColumnTypes(columnTypes);
             }
         }
 

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiTypeMapping.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiTypeMapping.java
@@ -78,6 +78,99 @@ public final class HudiTypeMapping {
         }
     }
 
+    /**
+     * Convert an Avro schema to a Hive type string, mirroring fe-core
+     * {@code HudiUtils.convertAvroToHiveType}.
+     *
+     * <p>This feeds the BE Hudi JNI scanner's {@code hudi_column_types} param.
+     * The BE joins the per-column type list with {@code '#'} and the scanner
+     * ({@code HadoopHudiJniScanner}) splits it back on {@code '#'} — so each
+     * returned string is a single list element and may safely contain commas
+     * (e.g. {@code decimal(10,2)}, {@code struct<a:int,b:string>},
+     * {@code map<string,int>}).</p>
+     *
+     * <p>This is distinct from {@link #fromAvroSchema}, which maps Avro to a
+     * Doris {@link ConnectorType} for schema reporting. The JNI reader needs
+     * Hive type strings, not Doris type names.</p>
+     *
+     * @throws IllegalArgumentException for unsupported types (matches the
+     *         legacy fail-loud behavior)
+     */
+    public static String toHiveTypeString(Schema schema) {
+        Schema.Type type = schema.getType();
+        LogicalType logicalType = schema.getLogicalType();
+
+        switch (type) {
+            case BOOLEAN:
+                return "boolean";
+            case INT:
+                if (logicalType instanceof LogicalTypes.Date) {
+                    return "date";
+                }
+                if (logicalType instanceof LogicalTypes.TimeMillis) {
+                    throw unsupportedLogicalType(schema);
+                }
+                return "int";
+            case LONG:
+                if (logicalType instanceof LogicalTypes.TimestampMillis
+                        || logicalType instanceof LogicalTypes.TimestampMicros) {
+                    return "timestamp";
+                }
+                if (logicalType instanceof LogicalTypes.TimeMicros) {
+                    throw unsupportedLogicalType(schema);
+                }
+                return "bigint";
+            case FLOAT:
+                return "float";
+            case DOUBLE:
+                return "double";
+            case STRING:
+                return "string";
+            case FIXED:
+            case BYTES:
+                if (logicalType instanceof LogicalTypes.Decimal) {
+                    LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) logicalType;
+                    return String.format("decimal(%d,%d)",
+                            decimalType.getPrecision(), decimalType.getScale());
+                }
+                return "string";
+            case ARRAY:
+                return String.format("array<%s>",
+                        toHiveTypeString(schema.getElementType()));
+            case RECORD:
+                List<Schema.Field> recordFields = schema.getFields();
+                if (recordFields.isEmpty()) {
+                    throw new IllegalArgumentException("Record must have fields");
+                }
+                String structFields = recordFields.stream()
+                        .map(field -> String.format("%s:%s", field.name(),
+                                toHiveTypeString(field.schema())))
+                        .collect(Collectors.joining(","));
+                return String.format("struct<%s>", structFields);
+            case MAP:
+                return String.format("map<string,%s>",
+                        toHiveTypeString(schema.getValueType()));
+            case UNION:
+                List<Schema> unionTypes = schema.getTypes().stream()
+                        .filter(s -> s.getType() != Schema.Type.NULL)
+                        .collect(Collectors.toList());
+                if (unionTypes.size() == 1) {
+                    return toHiveTypeString(unionTypes.get(0));
+                }
+                break;
+            default:
+                break;
+        }
+
+        throw new IllegalArgumentException(String.format(
+                "Unsupported type: %s for column: %s", type.getName(), schema.getName()));
+    }
+
+    private static IllegalArgumentException unsupportedLogicalType(Schema schema) {
+        return new IllegalArgumentException(
+                String.format("Unsupported logical type: %s", schema.getLogicalType()));
+    }
+
     private static ConnectorType mapIntType(LogicalType logicalType) {
         if (logicalType instanceof LogicalTypes.Date) {
             return ConnectorType.of("DATEV2");

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
@@ -1,0 +1,265 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hudi;
+
+import org.apache.doris.connector.api.ConnectorType;
+import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.api.pushdown.ConnectorAnd;
+import org.apache.doris.connector.api.pushdown.ConnectorColumnRef;
+import org.apache.doris.connector.api.pushdown.ConnectorComparison;
+import org.apache.doris.connector.api.pushdown.ConnectorExpression;
+import org.apache.doris.connector.api.pushdown.ConnectorFilterConstraint;
+import org.apache.doris.connector.api.pushdown.ConnectorIn;
+import org.apache.doris.connector.api.pushdown.ConnectorLiteral;
+import org.apache.doris.connector.api.pushdown.FilterApplicationResult;
+import org.apache.doris.connector.hms.HmsClient;
+import org.apache.doris.connector.hms.HmsDatabaseInfo;
+import org.apache.doris.connector.hms.HmsPartitionInfo;
+import org.apache.doris.connector.hms.HmsTableInfo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Tests {@link HudiConnectorMetadata#applyFilter} partition pruning (P3-T05).
+ *
+ * <p>WHY: the SPI Hudi path previously listed ALL partitions unconditionally and
+ * stored them as {@code prunedPartitionPaths}, doing no EQ/IN pruning at all and
+ * silently forcing the partition source to HMS for any filtered query. These tests
+ * pin the corrected behavior, mirroring {@code HiveConnectorMetadata}:
+ * <ul>
+ *   <li>EQ / IN predicates on partition columns reduce the scanned partition set;</li>
+ *   <li>predicates on non-partition columns (or range predicates) never prune;</li>
+ *   <li>when no partition predicate applies, the handle is left untouched
+ *       ({@code Optional.empty()}) so scan planning falls back to Hudi's own listing;</li>
+ *   <li>a predicate that matches every / no partition is handled correctly.</li>
+ * </ul>
+ * A test that passed against the old stub (which always returned all partitions)
+ * would be wrong — each assertion checks the precise pruned set.</p>
+ */
+public class HudiPartitionPruningTest {
+
+    private static final List<String> PARTITIONS = Arrays.asList(
+            "year=2023/month=12",
+            "year=2024/month=01",
+            "year=2024/month=02");
+
+    private static final List<String> PART_KEYS = Arrays.asList("year", "month");
+
+    @Test
+    public void testEqOnPartitionColumnPrunes() {
+        // year = '2024' -> only the two 2024 partitions
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), eq("year", "2024"));
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Arrays.asList("year=2024/month=01", "year=2024/month=02"),
+                prunedPaths(result));
+    }
+
+    @Test
+    public void testInOnPartitionColumnPrunes() {
+        // month IN ('01', '12') -> spans years, keeps original order
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), in("month", "01", "12"));
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Arrays.asList("year=2023/month=12", "year=2024/month=01"),
+                prunedPaths(result));
+    }
+
+    @Test
+    public void testAndOfTwoPartitionColumnsPrunes() {
+        // year = '2024' AND month = '01' -> a single partition
+        ConnectorExpression expr = and(eq("year", "2024"), eq("month", "01"));
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), expr);
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Collections.singletonList("year=2024/month=01"),
+                prunedPaths(result));
+    }
+
+    @Test
+    public void testNonPartitionColumnInAndIsIgnored() {
+        // year = '2024' AND price = '100' -> prune on year only; non-partition pred ignored
+        ConnectorExpression expr = and(eq("year", "2024"), eq("price", "100"));
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), expr);
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(
+                Arrays.asList("year=2024/month=01", "year=2024/month=02"),
+                prunedPaths(result));
+    }
+
+    @Test
+    public void testNonPartitionPredicateOnlyLeavesHandleUntouched() {
+        // price = '100' -> no partition predicate -> Optional.empty() (no source switch)
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), eq("price", "100"));
+
+        Assertions.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testPredicateMatchingAllPartitionsHasNoEffect() {
+        // year IN ('2023', '2024') -> matches every partition -> Optional.empty()
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), in("year", "2023", "2024"));
+
+        Assertions.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testPredicateMatchingNoPartitionYieldsEmptyPrunedList() {
+        // year = '1999' -> matches nothing -> present handle with empty pruned set (scan 0)
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(partitionedHandle(), eq("year", "1999"));
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertTrue(prunedPaths(result).isEmpty());
+    }
+
+    @Test
+    public void testUnpartitionedTableIsNotTouched() {
+        HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(Collections.emptyList())
+                .build();
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result =
+                applyFilter(handle, eq("year", "2024"));
+
+        Assertions.assertFalse(result.isPresent());
+    }
+
+    // ========== helpers ==========
+
+    private Optional<FilterApplicationResult<ConnectorTableHandle>> applyFilter(
+            HudiTableHandle handle, ConnectorExpression expr) {
+        HudiConnectorMetadata metadata = new HudiConnectorMetadata(
+                new FakeHmsClient(PARTITIONS), Collections.emptyMap());
+        return metadata.applyFilter(null, handle, new ConnectorFilterConstraint(expr));
+    }
+
+    private HudiTableHandle partitionedHandle() {
+        return new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(PART_KEYS)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> prunedPaths(Optional<FilterApplicationResult<ConnectorTableHandle>> result) {
+        return ((HudiTableHandle) result.get().getHandle()).getPrunedPartitionPaths();
+    }
+
+    private static ConnectorColumnRef colRef(String name) {
+        return new ConnectorColumnRef(name, ConnectorType.of("STRING"));
+    }
+
+    private static ConnectorLiteral lit(String value) {
+        return new ConnectorLiteral(ConnectorType.of("STRING"), value);
+    }
+
+    private static ConnectorComparison eq(String col, String value) {
+        return new ConnectorComparison(ConnectorComparison.Operator.EQ, colRef(col), lit(value));
+    }
+
+    private static ConnectorIn in(String col, String... values) {
+        List<ConnectorExpression> inList = new ArrayList<>();
+        for (String v : values) {
+            inList.add(lit(v));
+        }
+        return new ConnectorIn(colRef(col), inList, false);
+    }
+
+    private static ConnectorAnd and(ConnectorExpression... children) {
+        return new ConnectorAnd(Arrays.asList(children));
+    }
+
+    /**
+     * Minimal {@link HmsClient} double returning a fixed partition-name list.
+     * Only {@code listPartitionNames} is exercised by partition pruning; the rest fail loud.
+     */
+    private static final class FakeHmsClient implements HmsClient {
+        private final List<String> partitionNames;
+
+        FakeHmsClient(List<String> partitionNames) {
+            this.partitionNames = partitionNames;
+        }
+
+        @Override
+        public List<String> listPartitionNames(String dbName, String tableName, int maxParts) {
+            return partitionNames;
+        }
+
+        @Override
+        public List<String> listDatabases() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsDatabaseInfo getDatabase(String dbName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> listTables(String dbName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tableExists(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsTableInfo getTable(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getDefaultColumnValues(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<HmsPartitionInfo> getPartitions(String dbName, String tableName,
+                List<String> partNames) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsPartitionInfo getPartition(String dbName, String tableName, List<String> values) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiScanRangeTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiScanRangeTest.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hudi;
+
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.THudiFileDesc;
+import org.apache.doris.thrift.TTableFormatFileDesc;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/**
+ * Tests {@link HudiScanRange#populateRangeParams}.
+ *
+ * <p>WHY: column_names/column_types/delta_logs are thrift {@code list<string>};
+ * BE ({@code hudi_jni_reader.cpp}) joins them with distinct delimiters
+ * (names ',', types '#', delta logs ','). The FE must pass each per-column type
+ * as a single list element. The previous code joined them with ',' and split
+ * back by ',', which shattered comma-bearing Hive type strings
+ * ({@code decimal(10,2)}, {@code struct<...>}) and misaligned names/types.
+ * These tests pin that the typed lists survive intact and aligned.</p>
+ */
+public class HudiScanRangeTest {
+
+    @Test
+    public void testJniListsSurviveIntactAndAligned() {
+        HudiScanRange range = new HudiScanRange.Builder()
+                .path("s3://bucket/t/file")
+                .fileFormat("jni")
+                .instantTime("20240101000000000")
+                .serde("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
+                .inputFormat("org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat")
+                .basePath("s3://bucket/t")
+                .dataFilePath("s3://bucket/t/base.parquet")
+                .dataFileLength(123L)
+                .deltaLogs(Arrays.asList("s3://bucket/t/.f.log.1_0", "s3://bucket/t/.f.log.2_0"))
+                .columnNames(Arrays.asList("x", "y", "z"))
+                .columnTypes(Arrays.asList("int", "decimal(10,2)", "struct<a:int,b:string>"))
+                .build();
+
+        TTableFormatFileDesc formatDesc = new TTableFormatFileDesc();
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        range.populateRangeParams(formatDesc, rangeDesc);
+
+        THudiFileDesc fileDesc = formatDesc.getHudiParams();
+
+        // Types must NOT be shattered: 3 columns -> 3 type strings (old bug
+        // produced 5: "decimal(10","2)","struct<a:int","b:string>").
+        Assertions.assertEquals(Arrays.asList("int", "decimal(10,2)", "struct<a:int,b:string>"),
+                fileDesc.getColumnTypes());
+        Assertions.assertEquals(Arrays.asList("x", "y", "z"), fileDesc.getColumnNames());
+        Assertions.assertEquals(Arrays.asList("s3://bucket/t/.f.log.1_0", "s3://bucket/t/.f.log.2_0"),
+                fileDesc.getDeltaLogs());
+
+        // names <-> types alignment (the JNI scanner zips them positionally).
+        Assertions.assertEquals(fileDesc.getColumnNames().size(), fileDesc.getColumnTypes().size());
+    }
+
+    @Test
+    public void testNoDeltaLogsDowngradesToNativeParquet() {
+        // MOR file slice with no delta logs -> native parquet reader; no JNI lists set.
+        HudiScanRange range = new HudiScanRange.Builder()
+                .path("s3://bucket/t/base.parquet")
+                .fileFormat("jni")
+                .dataFilePath("s3://bucket/t/base.parquet")
+                .dataFileLength(456L)
+                .build();
+
+        TTableFormatFileDesc formatDesc = new TTableFormatFileDesc();
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        range.populateRangeParams(formatDesc, rangeDesc);
+
+        Assertions.assertEquals(TFileFormatType.FORMAT_PARQUET, rangeDesc.getFormatType());
+        Assertions.assertFalse(formatDesc.getHudiParams().isSetColumnTypes());
+        Assertions.assertFalse(formatDesc.getHudiParams().isSetColumnNames());
+    }
+}

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiSchemaParityTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiSchemaParityTest.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hudi;
+
+import org.apache.doris.connector.api.ConnectorColumn;
+import org.apache.doris.connector.api.ConnectorType;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Schema-level parity for the SPI Hudi metadata path (P3-T07, batch C).
+ *
+ * <p>WHY: {@code getTableSchema} derives its column list from the Hudi Avro schema
+ * via {@link HudiConnectorMetadata#avroSchemaToColumns}. This must produce the same
+ * column set — names, order, Doris types, nullability — and the same per-column
+ * Hive type strings ({@code colTypes}) as legacy fe-core
+ * {@code HMSExternalTable.initHudiSchema} (:740-753) +
+ * {@code HudiUtils.fromAvroHudiTypeToDorisType} / {@code convertAvroToHiveType}.
+ * Because no compile path sees both modules (fe-core does not depend on the concrete
+ * connector modules), parity is asserted against golden values transcribed from —
+ * and annotated with — the legacy contract.</p>
+ *
+ * <p>COW vs MOR: schema derivation is table-type-agnostic on BOTH sides (neither
+ * consults COW/MOR), so a single golden schema covers both; the COW/MOR distinction
+ * lives only in scan planning and is pinned separately by {@link HudiTableTypeTest}.</p>
+ *
+ * <p>Two assertions deliberately encode the P3-T07 column-name-casing fix: the
+ * top-level column name is lower-cased (legacy {@code toLowerCase(Locale.ROOT)} at
+ * {@code HMSExternalTable.java:745}), while a NESTED struct field name keeps its
+ * original case (legacy lowercases only the top-level column). A test that passed
+ * with the old raw-case behavior would be wrong.</p>
+ */
+public class HudiSchemaParityTest {
+
+    // A representative Hudi table schema in Avro JSON (the form Hudi actually stores).
+    // Mixed-case top-level names (Id, Name, Addr) and a mixed-case nested field
+    // (Street) exercise the casing boundary; the type variety mirrors the legacy
+    // type matrix (primitive, decimal, date, timestamp, nullable, array, map, struct).
+    private static final String SCHEMA_JSON =
+            "{\"type\":\"record\",\"name\":\"hudi_t\",\"fields\":["
+            + "{\"name\":\"Id\",\"type\":\"long\"},"
+            + "{\"name\":\"Name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+            + "{\"name\":\"price\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\","
+            + "\"precision\":10,\"scale\":2}},"
+            + "{\"name\":\"event_date\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},"
+            + "{\"name\":\"created_at\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}},"
+            + "{\"name\":\"tags\",\"type\":{\"type\":\"array\",\"items\":\"string\"}},"
+            + "{\"name\":\"props\",\"type\":{\"type\":\"map\",\"values\":\"int\"}},"
+            + "{\"name\":\"Addr\",\"type\":{\"type\":\"record\",\"name\":\"AddrRec\",\"fields\":["
+            + "{\"name\":\"Street\",\"type\":\"string\"},{\"name\":\"zip\",\"type\":\"int\"}]}}"
+            + "]}";
+
+    // Golden column contract, mirroring legacy initHudiSchema field-by-field.
+    private static final List<String> EXPECTED_NAMES = Arrays.asList(
+            "id", "name", "price", "event_date", "created_at", "tags", "props", "addr");
+
+    private static final List<ConnectorType> EXPECTED_TYPES = Arrays.asList(
+            ConnectorType.of("BIGINT"),
+            ConnectorType.of("STRING"),
+            ConnectorType.of("DECIMALV3", 10, 2),
+            ConnectorType.of("DATEV2"),
+            ConnectorType.of("DATETIMEV2", 6, 0),
+            ConnectorType.arrayOf(ConnectorType.of("STRING")),
+            ConnectorType.mapOf(ConnectorType.of("STRING"), ConnectorType.of("INT")),
+            ConnectorType.structOf(Arrays.asList("Street", "zip"),
+                    Arrays.asList(ConnectorType.of("STRING"), ConnectorType.of("INT"))));
+
+    // Only the union-typed "Name" field is nullable; the flag must track the union,
+    // not be a constant.
+    private static final List<Boolean> EXPECTED_NULLABLE = Arrays.asList(
+            false, true, false, false, false, false, false, false);
+
+    // Hive type strings = legacy colTypes (convertAvroToHiveType per field).
+    private static final List<String> EXPECTED_HIVE_TYPES = Arrays.asList(
+            "bigint", "string", "decimal(10,2)", "date", "timestamp",
+            "array<string>", "map<string,int>", "struct<Street:string,zip:int>");
+
+    private static Schema schema() {
+        return new Schema.Parser().parse(SCHEMA_JSON);
+    }
+
+    @Test
+    public void testSchemaColumnsMirrorLegacyContract() {
+        List<ConnectorColumn> columns = HudiConnectorMetadata.avroSchemaToColumns(schema());
+        Assertions.assertEquals(EXPECTED_NAMES.size(), columns.size());
+        for (int i = 0; i < columns.size(); i++) {
+            ConnectorColumn col = columns.get(i);
+            Assertions.assertEquals(EXPECTED_NAMES.get(i), col.getName(), "name[" + i + "]");
+            Assertions.assertEquals(EXPECTED_TYPES.get(i), col.getType(), "type[" + i + "]");
+            Assertions.assertEquals(EXPECTED_NULLABLE.get(i), col.isNullable(), "nullable[" + i + "]");
+        }
+    }
+
+    @Test
+    public void testColumnTypeStringsMirrorLegacyColTypes() {
+        List<Schema.Field> fields = schema().getFields();
+        Assertions.assertEquals(EXPECTED_HIVE_TYPES.size(), fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+            Assertions.assertEquals(EXPECTED_HIVE_TYPES.get(i),
+                    HudiTypeMapping.toHiveTypeString(fields.get(i).schema()), "colType[" + i + "]");
+        }
+    }
+
+    @Test
+    public void testTopLevelNameLoweredButNestedStructNamePreserved() {
+        List<ConnectorColumn> columns = HudiConnectorMetadata.avroSchemaToColumns(schema());
+        ConnectorColumn addr = columns.get(7);
+        // top-level "Addr" -> "addr"
+        Assertions.assertEquals("addr", addr.getName());
+        // nested struct field "Street" keeps its case (legacy lowercases only top-level)
+        Assertions.assertEquals(Arrays.asList("Street", "zip"), addr.getType().getFieldNames());
+        Assertions.assertEquals("struct<Street:string,zip:int>",
+                HudiTypeMapping.toHiveTypeString(schema().getFields().get(7).schema()));
+    }
+}

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTableTypeTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTableTypeTest.java
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hudi;
+
+import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.hms.HmsClient;
+import org.apache.doris.connector.hms.HmsDatabaseInfo;
+import org.apache.doris.connector.hms.HmsPartitionInfo;
+import org.apache.doris.connector.hms.HmsTableInfo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * COW vs MOR table-type classification on the SPI Hudi metadata path (P3-T07, batch C).
+ *
+ * <p>WHY: schema derivation is table-type-agnostic, so the ONLY place the metadata SPI
+ * distinguishes Copy-On-Write from Merge-On-Read is {@code detectHudiTableType}, surfaced
+ * through {@code getTableHandle}. Misclassifying the type routes scan planning to the wrong
+ * split/reader strategy. These tests pin the detection from the HMS input format and the
+ * Spark provider table parameter — the "COW & MOR each one" parity requirement — plus the
+ * UNKNOWN fallback when no Hudi signal is present.</p>
+ */
+public class HudiTableTypeTest {
+
+    private String detect(String inputFormat, Map<String, String> parameters) {
+        HmsTableInfo info = HmsTableInfo.builder()
+                .dbName("db").tableName("t")
+                .location("s3://b/t")
+                .inputFormat(inputFormat)
+                .parameters(parameters)
+                .build();
+        HudiConnectorMetadata metadata =
+                new HudiConnectorMetadata(new FakeHmsClient(info), Collections.emptyMap());
+        Optional<ConnectorTableHandle> handle = metadata.getTableHandle(null, "db", "t");
+        Assertions.assertTrue(handle.isPresent());
+        return ((HudiTableHandle) handle.get()).getHudiTableType();
+    }
+
+    @Test
+    public void testCowDetectedFromInputFormat() {
+        Assertions.assertEquals("COPY_ON_WRITE",
+                detect("org.apache.hudi.hadoop.HoodieParquetInputFormat", Collections.emptyMap()));
+    }
+
+    @Test
+    public void testCowDetectedFromSparkProviderParam() {
+        // A Spark-registered Hudi table may carry no Hudi input format; the provider
+        // parameter still identifies it as COW.
+        Assertions.assertEquals("COPY_ON_WRITE",
+                detect(null, Collections.singletonMap("spark.sql.sources.provider", "hudi")));
+    }
+
+    @Test
+    public void testMorDetectedFromRealtimeInputFormat() {
+        Assertions.assertEquals("MERGE_ON_READ",
+                detect("org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat",
+                        Collections.emptyMap()));
+    }
+
+    @Test
+    public void testUnknownWhenNoHudiSignal() {
+        Assertions.assertEquals("UNKNOWN",
+                detect("org.apache.hadoop.mapred.TextInputFormat", Collections.emptyMap()));
+    }
+
+    /**
+     * Minimal {@link HmsClient} double returning a fixed table. Only {@code tableExists}
+     * and {@code getTable} are exercised by {@code getTableHandle}; the rest fail loud.
+     */
+    private static final class FakeHmsClient implements HmsClient {
+        private final HmsTableInfo tableInfo;
+
+        FakeHmsClient(HmsTableInfo tableInfo) {
+            this.tableInfo = tableInfo;
+        }
+
+        @Override
+        public boolean tableExists(String dbName, String tableName) {
+            return true;
+        }
+
+        @Override
+        public HmsTableInfo getTable(String dbName, String tableName) {
+            return tableInfo;
+        }
+
+        @Override
+        public List<String> listDatabases() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsDatabaseInfo getDatabase(String dbName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> listTables(String dbName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getDefaultColumnValues(String dbName, String tableName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> listPartitionNames(String dbName, String tableName, int maxParts) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<HmsPartitionInfo> getPartitions(String dbName, String tableName,
+                List<String> partNames) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HmsPartitionInfo getPartition(String dbName, String tableName, List<String> values) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTypeMappingTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTypeMappingTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.connector.hudi;
 
+import org.apache.doris.connector.api.ConnectorType;
+
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Assertions;
@@ -25,14 +27,21 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 /**
- * Tests {@link HudiTypeMapping#toHiveTypeString}.
+ * Tests {@link HudiTypeMapping#toHiveTypeString} and {@link HudiTypeMapping#fromAvroSchema}.
  *
- * <p>WHY: the BE Hudi JNI scanner ({@code HadoopHudiJniScanner}) parses
- * {@code hudi_column_types} as Hive type strings split on {@code '#'}. The FE
+ * <p>WHY (toHiveTypeString): the BE Hudi JNI scanner ({@code HadoopHudiJniScanner})
+ * parses {@code hudi_column_types} as Hive type strings split on {@code '#'}. The FE
  * must therefore emit full Hive type strings carrying precision/scale and
  * subtypes — not Doris type names — or the scanner reads wrong/null columns.
  * These tests pin the exact strings, matching fe-core
  * {@code HudiUtils.convertAvroToHiveType}.</p>
+ *
+ * <p>WHY (fromAvroSchema): {@code getTableSchema} reports each column's
+ * {@link ConnectorType} from this mapper. These tests pin the Doris type per Avro
+ * type, matching fe-core {@code HudiUtils.fromAvroHudiTypeToDorisType} (P3-T07
+ * parity baseline — previously uncovered). Note the deliberate asymmetry: time
+ * types map to {@code TIMEV2} here but fail loud in {@code toHiveTypeString},
+ * exactly as the two legacy converters diverge.</p>
  */
 public class HudiTypeMappingTest {
 
@@ -116,5 +125,96 @@ public class HudiTypeMappingTest {
         Schema timeMillis = LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT));
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> HudiTypeMapping.toHiveTypeString(timeMillis));
+    }
+
+    // ===== fromAvroSchema -> ConnectorType (parity with HudiUtils.fromAvroHudiTypeToDorisType) =====
+
+    @Test
+    public void testFromAvroSchemaPrimitives() {
+        Assertions.assertEquals(ConnectorType.of("BOOLEAN"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.BOOLEAN)));
+        Assertions.assertEquals(ConnectorType.of("INT"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.INT)));
+        Assertions.assertEquals(ConnectorType.of("BIGINT"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.LONG)));
+        Assertions.assertEquals(ConnectorType.of("FLOAT"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.FLOAT)));
+        Assertions.assertEquals(ConnectorType.of("DOUBLE"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.DOUBLE)));
+        Assertions.assertEquals(ConnectorType.of("STRING"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.STRING)));
+        // Avro bytes/fixed without a decimal logical type degrade to STRING (legacy parity).
+        Assertions.assertEquals(ConnectorType.of("STRING"),
+                HudiTypeMapping.fromAvroSchema(Schema.create(Schema.Type.BYTES)));
+    }
+
+    @Test
+    public void testFromAvroSchemaLogicalTypes() {
+        Assertions.assertEquals(ConnectorType.of("DATEV2"),
+                HudiTypeMapping.fromAvroSchema(
+                        LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT))));
+        Assertions.assertEquals(ConnectorType.of("DATETIMEV2", 3, 0),
+                HudiTypeMapping.fromAvroSchema(
+                        LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))));
+        Assertions.assertEquals(ConnectorType.of("DATETIMEV2", 6, 0),
+                HudiTypeMapping.fromAvroSchema(
+                        LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG))));
+        // Time types map to TIMEV2 here, unlike toHiveTypeString which fails loud —
+        // matching legacy HudiUtils.fromAvroHudiTypeToDorisType.
+        Assertions.assertEquals(ConnectorType.of("TIMEV2", 3, 0),
+                HudiTypeMapping.fromAvroSchema(
+                        LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT))));
+        Assertions.assertEquals(ConnectorType.of("TIMEV2", 6, 0),
+                HudiTypeMapping.fromAvroSchema(
+                        LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG))));
+    }
+
+    @Test
+    public void testFromAvroSchemaDecimalKeepsPrecisionAndScale() {
+        Schema decimal = LogicalTypes.decimal(10, 2).addToSchema(Schema.create(Schema.Type.BYTES));
+        Assertions.assertEquals(ConnectorType.of("DECIMALV3", 10, 2),
+                HudiTypeMapping.fromAvroSchema(decimal));
+    }
+
+    @Test
+    public void testFromAvroSchemaComplexTypes() {
+        Assertions.assertEquals(
+                ConnectorType.arrayOf(ConnectorType.of("INT")),
+                HudiTypeMapping.fromAvroSchema(Schema.createArray(Schema.create(Schema.Type.INT))));
+        // Avro maps always have string keys.
+        Assertions.assertEquals(
+                ConnectorType.mapOf(ConnectorType.of("STRING"), ConnectorType.of("BIGINT")),
+                HudiTypeMapping.fromAvroSchema(Schema.createMap(Schema.create(Schema.Type.LONG))));
+        Schema struct = Schema.createRecord("r", null, null, false, Arrays.asList(
+                new Schema.Field("a", Schema.create(Schema.Type.INT)),
+                new Schema.Field("b", Schema.create(Schema.Type.STRING))));
+        Assertions.assertEquals(
+                ConnectorType.structOf(Arrays.asList("a", "b"),
+                        Arrays.asList(ConnectorType.of("INT"), ConnectorType.of("STRING"))),
+                HudiTypeMapping.fromAvroSchema(struct));
+    }
+
+    @Test
+    public void testFromAvroSchemaNullableUnionUnwrapped() {
+        Schema nullableInt = Schema.createUnion(
+                Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT));
+        Assertions.assertEquals(ConnectorType.of("INT"),
+                HudiTypeMapping.fromAvroSchema(nullableInt));
+    }
+
+    @Test
+    public void testFromAvroSchemaEnumMapsToString() {
+        Schema enumSchema = Schema.createEnum("e", null, null, Arrays.asList("A", "B"));
+        Assertions.assertEquals(ConnectorType.of("STRING"),
+                HudiTypeMapping.fromAvroSchema(enumSchema));
+    }
+
+    @Test
+    public void testFromAvroSchemaMultiMemberUnionUnsupported() {
+        // A true union (no single non-null member) is unsupported (legacy parity).
+        Schema union = Schema.createUnion(
+                Schema.create(Schema.Type.INT), Schema.create(Schema.Type.STRING));
+        Assertions.assertEquals(ConnectorType.of("UNSUPPORTED"),
+                HudiTypeMapping.fromAvroSchema(union));
     }
 }

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTypeMappingTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTypeMappingTest.java
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hudi;
+
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/**
+ * Tests {@link HudiTypeMapping#toHiveTypeString}.
+ *
+ * <p>WHY: the BE Hudi JNI scanner ({@code HadoopHudiJniScanner}) parses
+ * {@code hudi_column_types} as Hive type strings split on {@code '#'}. The FE
+ * must therefore emit full Hive type strings carrying precision/scale and
+ * subtypes — not Doris type names — or the scanner reads wrong/null columns.
+ * These tests pin the exact strings, matching fe-core
+ * {@code HudiUtils.convertAvroToHiveType}.</p>
+ */
+public class HudiTypeMappingTest {
+
+    @Test
+    public void testPrimitives() {
+        Assertions.assertEquals("boolean", HudiTypeMapping.toHiveTypeString(Schema.create(Schema.Type.BOOLEAN)));
+        Assertions.assertEquals("int", HudiTypeMapping.toHiveTypeString(Schema.create(Schema.Type.INT)));
+        Assertions.assertEquals("bigint", HudiTypeMapping.toHiveTypeString(Schema.create(Schema.Type.LONG)));
+        Assertions.assertEquals("float", HudiTypeMapping.toHiveTypeString(Schema.create(Schema.Type.FLOAT)));
+        Assertions.assertEquals("double", HudiTypeMapping.toHiveTypeString(Schema.create(Schema.Type.DOUBLE)));
+        Assertions.assertEquals("string", HudiTypeMapping.toHiveTypeString(Schema.create(Schema.Type.STRING)));
+    }
+
+    @Test
+    public void testDateAndTimestampLogicalTypes() {
+        Schema date = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
+        Assertions.assertEquals("date", HudiTypeMapping.toHiveTypeString(date));
+
+        Schema tsMillis = LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+        Assertions.assertEquals("timestamp", HudiTypeMapping.toHiveTypeString(tsMillis));
+
+        Schema tsMicros = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+        Assertions.assertEquals("timestamp", HudiTypeMapping.toHiveTypeString(tsMicros));
+    }
+
+    @Test
+    public void testDecimalKeepsPrecisionAndScale() {
+        // Directly targets bug (a): getTypeName() previously dropped precision/scale.
+        Schema decimal = LogicalTypes.decimal(10, 2).addToSchema(Schema.create(Schema.Type.BYTES));
+        Assertions.assertEquals("decimal(10,2)", HudiTypeMapping.toHiveTypeString(decimal));
+
+        Schema decimalFixed = LogicalTypes.decimal(38, 18)
+                .addToSchema(Schema.createFixed("d", null, null, 16));
+        Assertions.assertEquals("decimal(38,18)", HudiTypeMapping.toHiveTypeString(decimalFixed));
+    }
+
+    @Test
+    public void testArray() {
+        Schema arr = Schema.createArray(Schema.create(Schema.Type.INT));
+        Assertions.assertEquals("array<int>", HudiTypeMapping.toHiveTypeString(arr));
+    }
+
+    @Test
+    public void testMap() {
+        // Avro maps always have string keys.
+        Schema map = Schema.createMap(Schema.create(Schema.Type.LONG));
+        Assertions.assertEquals("map<string,bigint>", HudiTypeMapping.toHiveTypeString(map));
+    }
+
+    @Test
+    public void testStructContainsCommas() {
+        // Directly targets bug (b): the comma in struct<...> must survive as a
+        // single type string; a comma join+split would shatter it.
+        Schema struct = Schema.createRecord("r", null, null, false, Arrays.asList(
+                new Schema.Field("a", Schema.create(Schema.Type.INT)),
+                new Schema.Field("b", Schema.create(Schema.Type.STRING))));
+        Assertions.assertEquals("struct<a:int,b:string>", HudiTypeMapping.toHiveTypeString(struct));
+    }
+
+    @Test
+    public void testNestedComplexType() {
+        Schema struct = Schema.createRecord("r", null, null, false, Arrays.asList(
+                new Schema.Field("id", Schema.create(Schema.Type.LONG)),
+                new Schema.Field("amount",
+                        LogicalTypes.decimal(12, 4).addToSchema(Schema.create(Schema.Type.BYTES)))));
+        Schema arrOfStruct = Schema.createArray(struct);
+        Assertions.assertEquals("array<struct<id:bigint,amount:decimal(12,4)>>",
+                HudiTypeMapping.toHiveTypeString(arrOfStruct));
+    }
+
+    @Test
+    public void testNullableUnionIsUnwrapped() {
+        Schema nullableInt = Schema.createUnion(
+                Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT));
+        Assertions.assertEquals("int", HudiTypeMapping.toHiveTypeString(nullableInt));
+    }
+
+    @Test
+    public void testUnsupportedLogicalTypeFailsLoud() {
+        // Matches legacy fail-loud: time types are unsupported.
+        Schema timeMillis = LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HudiTypeMapping.toHiveTypeString(timeMillis));
+    }
+}

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -794,8 +794,9 @@ under the License.
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- fastutil-core: keep as direct dependency to ensure classpath priority
-             over the ancient unrelocated fastutil classes embedded in hive-catalog-shade -->
+        <!-- fastutil-core: fastutil used directly by FE catalog/tablet-index code
+             (e.g. Long2ObjectOpenHashMap). The ancient copy once bundled unrelocated in
+             hive-catalog-shade is now relocated under shade.doris.hive.*, so no collision remains. -->
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil-core</artifactId>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -795,8 +795,10 @@ under the License.
             <scope>test</scope>
         </dependency>
         <!-- fastutil-core: fastutil used directly by FE catalog/tablet-index code
-             (e.g. Long2ObjectOpenHashMap). The ancient copy once bundled unrelocated in
-             hive-catalog-shade is now relocated under shade.doris.hive.*, so no collision remains. -->
+             (e.g. Long2ObjectOpenHashMap). hive-catalog-shade bundles an ancient, unrelocated
+             fastutil (6.5.6) that collides on the classpath; the maven-shade-plugin below
+             bundles this real fastutil-core into doris-fe.jar (pinned first on the FE classpath
+             by bin/start_fe.sh), so the correct class wins. -->
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil-core</artifactId>
@@ -948,6 +950,48 @@ under the License.
                                 <!-- add arbitrary num of src dirs here -->
                                 <source>${basedir}/target/generated-sources/</source>
                             </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Bundle the real fastutil-core (8.5.18) into doris-fe.jar, UNRELOCATED, so the
+                 correct Long2ObjectOpenHashMap (with computeIfAbsent(long, Long2ObjectFunction))
+                 wins over the ancient fastutil (6.5.6) that hive-catalog-shade embeds. start_fe.sh
+                 pins doris-fe.jar first on the FE classpath, so whatever it contains takes load
+                 priority. This avoids touching the hive-catalog-shade dependency. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-fastutil-into-doris-fe</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Keep fe-core's dependency list intact: fastutil-core stays a normal
+                                 dependency (still copied into lib/ by fe-lib.xml, and resolved
+                                 normally by fe_plugins which depend on fe-core with scope=provided). -->
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!-- ONLY fastutil-core; do NOT turn doris-fe.jar into a full uber-jar.
+                                 The project's own classes are always included by shade. -->
+                            <artifactSet>
+                                <includes>
+                                    <include>it.unimi.dsi:fastutil-core</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -68,6 +68,16 @@ under the License.
             <groupId>${project.groupId}</groupId>
             <artifactId>fe-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- fe-common transitively drags in io.trino:trino-main, which brings the Jetty
+                     Servlet 5.0 API repackage. Its jakarta.servlet.http.Cookie lacks getAttributes()
+                     and would shadow the Servlet 6.1 jakarta.servlet-api that Jetty 12.0.34 needs,
+                     re-introducing the NoSuchMethodError. Keep it off fe-core's classpath. -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-jakarta-servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- fe-filesystem-api: consumer-facing filesystem API (FileSystem, Location, FileEntry, etc.) -->
         <dependency>
@@ -735,6 +745,16 @@ under the License.
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+        </dependency>
+        <!-- The FE HTTP server runs on Jetty 12.0.34, which calls jakarta.servlet.http.Cookie
+             #getAttributes() (a Jakarta Servlet 6.1 method) whenever it writes a Set-Cookie header.
+             Declare the servlet API explicitly so fe-core resolves 6.1.0 instead of the transitive
+             6.0.0 from spring-boot; otherwise the server throws NoSuchMethodError while setting the
+             session cookie (surfaced by removing io.trino:trino-main; see RemoteDorisRestClientTest). -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet-api.version}</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -822,17 +822,28 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         TupleDescriptor tupleDescriptor = generateTupleDesc(slots, table, context);
         SessionVariable sv = ConnectContext.get().getSessionVariable();
 
-        // Plugin-driven (SPI) Hudi: route through PluginDrivenScanNode. Incremental scan
-        // (hudiScan.getIncrementalRelation) is not yet representable in the SPI; that
-        // gap is tracked for P3 when Hudi migrates to the connector framework.
+        // Plugin-driven (SPI) Hudi: route through PluginDrivenScanNode.
         if (table instanceof PluginDrivenExternalTable) {
+            // Fail loud: the SPI Hudi path does not yet honor time travel or incremental
+            // reads. HudiScanPlanProvider always reads the latest snapshot, and the
+            // incremental relation has no SPI representation, so honoring them silently
+            // would return wrong results (latest snapshot / full scan instead). Full
+            // support is deferred to the Hudi connector live cutover (batch E); see
+            // plan-doc DV-006 / tasks/P3.
+            if (hudiScan.getIncrementalRelation().isPresent()) {
+                throw new AnalysisException("Hudi incremental read is not yet supported via the "
+                        + "catalog SPI; it is deferred to the Hudi connector migration.");
+            }
+            if (hudiScan.getTableSnapshot().isPresent()) {
+                throw new AnalysisException("Hudi time travel (FOR TIME/VERSION AS OF) is not yet "
+                        + "supported via the catalog SPI; it is deferred to the Hudi connector migration.");
+            }
             PluginDrivenExternalCatalog pluginCatalog =
                     (PluginDrivenExternalCatalog) table.getCatalog();
             ScanNode scanNode = PluginDrivenScanNode.create(context.nextPlanNodeId(), tupleDescriptor,
                     false, sv, context.getScanContext(), pluginCatalog,
                     (PluginDrivenExternalTable) table);
             FileQueryScanNode fileScan = (FileQueryScanNode) scanNode;
-            hudiScan.getTableSnapshot().ifPresent(fileScan::setQueryTableSnapshot);
             hudiScan.getScanParams().ifPresent(fileScan::setScanParams);
             return getPlanFragmentForPhysicalFileScan(hudiScan, context, scanNode);
         }

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -278,6 +278,11 @@ under the License.
         <jackson.version>2.16.0</jackson.version>
         <javassist.version>3.18.2-GA</javassist.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+        <!-- Jetty 12.0.34 (jetty-ee10-servlet) invokes jakarta.servlet.http.Cookie#getAttributes(),
+             which only exists since Jakarta Servlet 6.1. Pin the API to 6.1.0 so it matches the
+             jetty version; otherwise the transitive 6.0.0 from spring-boot triggers NoSuchMethodError
+             when the FE HTTP server writes a Set-Cookie (SameSite) header. -->
+        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <je.version>18.3.14-doris-SNAPSHOT</je.version>
         <commons-io.version>2.18.0</commons-io.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -234,7 +234,7 @@ under the License.
         <module>fe-grpc</module>
     </modules>
     <properties>
-        <doris.hive.catalog.shade.version>3.1.2-SNAPSHOT</doris.hive.catalog.shade.version>
+        <doris.hive.catalog.shade.version>3.1.1</doris.hive.catalog.shade.version>
         <!-- iceberg 1.9.1 depends avro on 1.12 -->
         <avro.version>1.12.1</avro.version>
         <parquet.version>1.17.0</parquet.version>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -234,7 +234,7 @@ under the License.
         <module>fe-grpc</module>
     </modules>
     <properties>
-        <doris.hive.catalog.shade.version>3.1.1</doris.hive.catalog.shade.version>
+        <doris.hive.catalog.shade.version>3.1.2-SNAPSHOT</doris.hive.catalog.shade.version>
         <!-- iceberg 1.9.1 depends avro on 1.12 -->
         <avro.version>1.12.1</avro.version>
         <parquet.version>1.17.0</parquet.version>

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -9,8 +9,8 @@
 ## 📅 最后一次 handoff
 
 - **日期 / 时间**：2026-06-05
-- **本 session 主题**：**P3 批 B 编码完成**——T05（applyFilter 真实 EQ/IN 分区裁剪，镜像 Hive）✅ 落地；T06（MVCC/snapshot SPI）经 code-grounded recon + 用户签字定为 **keep default opt-out（零代码）**；两处 scope 校正记 [DV-007]（T05 `listPartitions*` override 推迟批 E、T06 不抛异常 override）。
-- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`；P0→P1→P2→recon(D-019) 之上）。工作树 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/`/`regression-conf.bak`）。
+- **本 session 主题**：**P3 批 C 编码完成**——T07 三模块测试基线（hms/hive 零→有；hudi 扩）+ COW/MOR schema parity（golden-value）落地；列名 casing gap-1 **当场修**（用户签字），Hudi meta-field gap-2 推迟批 E（[DV-008]）。
+- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`；P0→P1→P2→recon→批 A/B/C 之上）。工作树预期 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/`/`plan-doc/research/`/`regression-conf.bak`）。
 
 ---
 
@@ -18,79 +18,79 @@
 
 | Task | 结果 | commits |
 |---|---|---|
-| **P3-T05** applyFilter EQ/IN 分区裁剪 | ✅ 镜像 Hive 7 步 + 7 helper；`HudiPartitionPruningTest` 8 测全绿（模块 19）；checkstyle 0 + import-gate 通过 | `10b72d4`(code) + 本 doc commit |
-| **P3-T06** MVCC/snapshot SPI | ✅ **keep default opt-out 决策**（[DV-007]，零代码）——recon 证抛异常 override 错（破 opt-out 约定/死代码/T04 已 fail-loud）；完整 MVCC→批 E | 本 doc commit（含 `designs/P3-T06-*` + DV-007）|
+| **P3-T07** 三模块测试基线 + COW/MOR parity | ✅ 三模块 59 测全绿（hudi 33 + hms 12 + hive 14）；checkstyle 0（含 test 源）+ import-gate 通过 | `435065f`(feat) + 本 doc commit |
 
-**commit stack**（新→旧）：本 doc commit→`10b72d4`(T05)→`301fe38`(批 A handoff)→`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2 #64096)→`2b1a3bb`(P1 #63641)→`72d6d01`(P0 #63582)。
+**净产出** = 三连接器模块测试网从 {hudi 19, hms 0, hive 0} → {hudi 33, hms 12, hive 14} + COW/MOR schema golden parity + 1 个正确性修（gap-1 列名 casing 对齐 legacy，gate 后硬化、零 live 风险、零回归）。**批 A+B+C 编码完成**。
 
-**批 B 净产出** = 1 个正确性/性能修复（分区裁剪 + 修复"分区来源静默切换"，gate 后硬化，零 live 风险，零回归）+ 1 个 code-grounded 决策（MVCC opt-out）。**批 A+B 编码完成**。每 task 走 design 备忘（`tasks/designs/P3-T0X-*.md`）→ impl → build → commit → 5 步文档同步。
+**commit stack**（新→旧）：本 doc commit→`435065f`(T07 feat)→`04f6576`(批 B handoff)→`10b72d4`(T05)→`301fe38`(批 A handoff)→`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2)→`2b1a3bb`(P1)→`72d6d01`(P0)。
 
 ---
 
-## 🚧 未完成 / 待办（下一 session = 批 C）
+## 🚧 未完成 / 待办（下一 session = 批 D）
 
-1. **P3-T07（批 C，下一 session 第一件事）**：三模块（hms/hive/hudi）测试基线 + **COW/MOR parity 测试**。当前 fe-connector-hms/hive/hudi **零测试**（hudi 已有 `HudiTypeMappingTest`/`HudiScanRangeTest`/`HudiPartitionPruningTest` 3 个；hms/hive 仍零）。parity = SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`（fe-core），COW & MOR 各一。注：parity 也该覆盖 T02 的 column_names/types 列集合+顺序 vs legacy。**Rule 9：测意图**（type-string 编码、裁剪正确、列集合一致）。
-2. **批 D（T08）**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core**）。
-3. **批 E（deferred，不在 P3 hybrid 编码）**：T03（schema_id/history 完整 field-id evolution，DV-006）、T05 的 `listPartitions*` override（DV-007）、T06 的完整 MVCC（`HudiMvccSnapshot`+snapshot 透传+增量时序，DV-007）、T04 的完整 snapshot 透传+增量 SPI、T09–T11（模型落地/gate flip/删 legacy/集群验证）。并入 hive/HMS migration。
-4. **T05 regression 推迟批 E**（gate 关，端到端不可触达；批 E 翻闸后断言带分区谓词查询仅扫匹配分区，explain/profile 校 partition 数；precedent DV-003）。
+1. **P3-T08（批 D，下一 session 第一件事）**：`tableFormatType` 分流消费**设计备忘（design-only，零代码）**。写清 `PluginDrivenExternalTable` 如何按 `ConnectorTableSchema.tableFormatType`（现 fe-core **从不消费**）把一个 `"hms"` catalog 的 per-table 路由到 HUDI/HIVE/ICEBERG。**不实现 fe-core 消费**（那是批 E）。作为 (a) 落地入口设计，可催生 D-NNN。
+   - **已有素材**：`plan-doc/research/spi-multi-format-hms-catalog-analysis.md`（28KB，本地未跟踪——上一 session 起草的多格式 HMS catalog 分析；T08 设计的直接输入，**先读**，避免重复 recon）。
+2. **批 E（deferred，不在 P3 hybrid 编码）**：见下「批 E backlog」。
+3. （沿用）T05 regression 推迟批 E（gate 关端到端不可触达；翻闸后断言带分区谓词查询仅扫匹配分区，explain/profile 校 partition 数；precedent DV-003）。
+
+### 批 E backlog（登记，不在 P3 编码）
+- T03 schema_id/history 完整 field-id evolution（DV-006）
+- T05 `listPartitions*` override（DV-007）
+- T06 完整 MVCC（`HudiMvccSnapshot` + snapshot 透传 + 增量时序，DV-007）
+- T04 完整 snapshot 透传 + 增量 SPI
+- **T07 gap-2**：Hudi meta-field 纳入（SPI 无参 `getTableAvroSchema()` vs legacy `(true)`）真实 fixture 实证（DV-008）
+- **T07 gap-1 余项**：`ThriftHmsClient` 源头防御性降字（与 hive 共享，DV-008）
+- T09–T11（模型落地/gate flip/删 legacy/集群验证）；端到端/集群验证（含 COW/MOR schema vs live legacy、BE JNI parse parity）
 
 ---
 
 ## ⚠️ 关键认知 / 临时发现
 
-### 1.【批 B 已用】SPI 分区裁剪链路 + Hive 是 parity 基准（T05 已修）
-- **链路**（end-to-end，spi-invoke recon 确认正确）：`PluginDrivenScanNode.convertPredicate` 调 `metadata.applyFilter` → `currentHandle = result.getHandle()`（:293）→ `getSplits` 把 `currentHandle` 传 `scanProvider.planScan`（:371）→ `HudiScanPlanProvider.planScan` 调 `resolvePartitions`（:137）→ 读 `handle.getPrunedPartitionPaths()`（:287-289）。**plumbing 一直正确，缺的是 applyFilter 里的裁剪逻辑**。
-- **T05 修法**：`HudiConnectorMetadata.applyFilter` 忠实镜像 `HiveConnectorMetadata.applyFilter`（:193-234 + 7 helper：extractPartitionPredicates/extractPredicatesRecursive/extractColumnName/extractLiteralValue/prunePartitionNames/parsePartitionName/matchesPredicates）。**关键差异**：Hudi 保留 `List<String> prunedPartitionPaths`（resolvePartitions 喂路径给 FileSystemView，非 HmsPartitionInfo）；上限保留 `-1`（不静默截断，安全于 Hive 100000）。**只裁 EQ/IN over partition cols**，范围/非分区谓词不裁、`remaining=全表达式`交 BE 复评（不漏行）。
-- **`ConnectorFilterConstraint.getColumnDomains()` 在 fe-core 侧为空**（`PluginDrivenScanNode.buildFilterConstraint` 传 `Collections.emptyMap()`）→ 唯一可用谓词表示是 `getExpression()`（与 Hive 同）。
-- **helper duplicate 不共享**：fe-connector-hudi 仅依赖 fe-connector-hms（**不依赖 fe-connector-hive**，pom 确认）；连接器互 import metadata 类错误分层；import-gate 禁连接器 import fe-core。故复刻，待 P7 hive migration consolidate（同 T02 `toHiveTypeString` 先例）。
+### 1.【批 C 已用，批 D/E 仍需】parity 可行性 = golden-value（无跨模块编译路径）
+- `fe-core` 只依赖 `fe-connector-api` + `fe-connector-spi`，**不依赖**具体 `-hudi`/`-hms`/`-hive` 模块；连接器模块不依赖 fe-core。import-gate（`tools/check-connector-imports.sh`）**只扫 `*/src/main/java`、只禁 connector→fe-core 单向**（test 目录豁免，但无编译路径仍使跨模块 parity 不可行）。
+- → 任何 legacy↔SPI parity 用 **golden 值**（注 legacy `file:line`）。测试栈 **JUnit5 only，无 mockito**，替身手写（`FakeHmsClient` 先例：`tableExists`/`getTable`/`listPartitionNames`/`getPartitions` 按需实现，其余 throw）。checkstyle **含 test 源**（`fe/pom.xml:162` `includeTestSourceDirectory=true`）、**禁 static import**（用 `Assertions.assertX`），且 **test 阶段不跑 checkstyle**，需单独 `mvn -pl <module> checkstyle:check`。
 
-### 2.【批 C 必读】SPI partition/MVCC 方法零 live caller（决定批 C 测什么、批 E 做什么）
-- **`listPartitions/listPartitionNames/listPartitionValues`（SPI）在 fe-core 零 live caller**：`PluginDrivenScanNode` 不调用（分区走 applyFilter 链路）；`ShowPartitionsCommand`/`HudiExternalMetaCache`/`MetadataGenerator` 调的是 **legacy** metastore 路径（`dorisTable.getRemoteName()`）非 SPI。Hive 基准**也不 override** 这三方法。→ T05 只做 applyFilter 裁剪，`listPartitions*` override 推迟批 E（fe-core 长出 SPI 消费 + `SHOW PARTITIONS` 改走 SPI 时）。
-- **MVCC 三方法（`beginQuerySnapshot/getSnapshotAt/getSnapshotById`）无 production caller**（仅 `ConnectorMvccSnapshotAdapter` 测试用）；全体连接器（Iceberg/Paimon/Hive/Trino）**无一 override**，default `Optional.empty()`=opt-out（`FakeConnectorPluginTest` 断言）。→ T06 保持 default + 文档化，**不新增抛异常 override**（会破约定 + 死代码；T04 已在 time-travel fail-loud）。
+### 2.【批 C 关键结论】COW/MOR schema = type-agnostic
+- legacy `HMSExternalTable.initHudiSchema` 与 SPI `HudiConnectorMetadata.getTableSchema`→`avroSchemaToColumns` 都从**同一 avro schema** 推导列表，**零表型分支**。COW/MOR 区别**只在 scan planning**（`HudiScanNode.canUseNativeReader` / `HudiScanPlanProvider.planScan:92`：COW=base files native、MOR=merged slices + delta logs JNI）。→ schema parity 是 avro→column 的纯函数；表型只影响 `detectHudiTableType` + split 收集。
 
-### 3.【沿用】BE Hudi JNI column_types/names/delta 契约（T02）
-- `THudiFileDesc.{delta_logs,column_names,column_types}` thrift `list<string>`；**BE 自做 join**：names `,` / types **`#`** / delta `,`（`hudi_jni_reader.cpp:52-54`），Java `HadoopHudiJniScanner` split 同。**FE 永远传 typed list、不 join/split**；类型串用 Hive 串（`HudiTypeMapping.toHiveTypeString`），**不是** `getTypeName()`。
+### 3.【批 D 直接相关】tableFormatType 模型（T08 设计目标）
+- hudi **无独立 catalog**：寄生 `HMSExternalTable.dlaType=HUDI`（D-005）。SPI 侧 `ConnectorTableSchema.tableFormatType`（`getTableSchema` 设 `"HUDI"`）是区分符，但 **fe-core 从不消费**。
+- T08 = 设计 `PluginDrivenExternalTable` 如何按 tableFormatType per-table 路由到 HUDI/HIVE/ICEBERG（**design-only，不动 fe-core live 路径**）。legacy 对照：`HMSExternalTable.dlaType` + `initSchema` 分流（`initHudiSchema`/`initIcebergSchema`/`initHiveSchema`）。素材 `research/spi-multi-format-hms-catalog-analysis.md`。
 
-### 4.【沿用】T03 schema_id/history 为何批 E（DV-006）
-- BE `table_schema_change_helper.h:219-267`：`history_schema_info` unset → `by_parquet_name`（鲁棒名匹配）= 现状；裸 `current==file==-1`→`ConstNode`(大小写敏感) **弱于**现状 = 净回归。faithful 需连接器 field-id + Hudi `InternalSchema` + type→thrift（现无），批 E 与 hive/HMS 一并建。
+### 4.（沿用）SPI 分区裁剪链路 + Hive parity 基准（T05）
+- `PluginDrivenScanNode.applyFilter`→`currentHandle`→`getSplits`→`HudiScanPlanProvider.resolvePartitions` 读 `getPrunedPartitionPaths()`。Hudi `applyFilter` 镜像 `HiveConnectorMetadata.applyFilter`（7 步 + 7 helper duplicate，hudi 仅依赖 fe-connector-hms）。
 
-### 5.【沿用】T04 fail-loud + 完整实现去向
-- 守卫在 `PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支（唯一同时可见 snapshot+incremental 处）。完整 snapshot 透传 + 增量 SPI + MVCC 入批 E。
+### 5.（沿用）BE Hudi JNI column_types/names/delta 契约（T02）
+- `THudiFileDesc.{delta_logs,column_names,column_types}` thrift `list<string>`；**BE 自做 join**：names `,` / types **`#`** / delta `,`（`hudi_jni_reader.cpp:52-54`）。FE 传 typed list、类型串用 Hive 串（`HudiTypeMapping.toHiveTypeString`，非 `getTypeName()`）。
 
-### 6.（沿用）rebase 后 fe-core 编译坑 + import gate + docs-next
-- rebase 后 `fe-core/target/generated-sources/.../DorisParser.java` 残留 → cannot find symbol。**修法：clean fe-core**（非 fe-sql-parser），别当代码 bug 查。
-- `tools/check-connector-imports.sh`：双向 import 守门（fe-core ↔ connector）。
-- `PhysicalPlanTranslator` 里 hudi **之外**的连接器 `instanceof` 分支待各自 P 阶段迁完再删，**本场只动 hudi 的 SPI 路径**，别乱碰其他。
-- 用户向文档在 doris-website 仓（DV-004），本仓只有 `docs/`。
+### 6.（沿用）批 E 去向 + 沿用坑
+- T03（DV-006）/ T04 完整 snapshot+增量 / T06 完整 MVCC / T05 list* / T07 gap-2 + ThriftHmsClient 降字：见批 E backlog。
+- rebase 后 fe-core `target/generated-sources/.../DorisParser.java` 残留 → cannot find symbol：**clean fe-core**（非 fe-sql-parser），别当代码 bug 查。
+- `PhysicalPlanTranslator` 里 hudi **之外**的连接器 `instanceof` 分支待各自 P 阶段迁完再删，**本场只动 hudi**。
+- 用户向文档在 doris-website 仓（DV-004）。
 
 ---
 
-## 🎯 下一个 session 第一件事（P3 批 C / T07）
+## 🎯 下一个 session 第一件事（P3 批 D / T08）
 
 ```
 1. 自检：
    git branch --show-current → catalog-spi-04
-   git log --oneline -6 → <doc commit>(批 B handoff) 10b72d4(T05) 301fe38(批 A handoff) 2758cf9(T04 doc) feceabb(T04) 517c9cf(T03 defer)
-   git status → clean（除 .audit-scratch/ conf.cmy/ regression-conf.bak）
-   Read plan-doc/tasks/P3-hudi-migration.md（批 C = T07）+ 本文件关键认知 2/3
+   git log --oneline -6 → <doc>(批 C handoff) 435065f(T07 feat) 04f6576(批 B handoff) 10b72d4(T05) 301fe38 2758cf9
+   git status → clean（除 .audit-scratch/ conf.cmy/ plan-doc/research/ regression-conf.bak）
+   Read plan-doc/tasks/P3-hudi-migration.md（批 D = T08）+ 本文件关键认知 3
 
-2. 启动【批 C / T07】（仍 behind 关闭的 gate，零 live 风险）：三模块测试基线 + COW/MOR parity。
+2. 启动【批 D / T08】（design-only，不动 fe-core；零代码）：
+   先读 plan-doc/research/spi-multi-format-hms-catalog-analysis.md（已有 28KB 分析，直接输入）。
    recon 锚点：
-     legacy parity 源: fe-core HiveMetaStoreClientHelper.getHudiTableSchema / HMSExternalTable.initHudiSchema(~722-759)
-     SPI 被测: HudiConnectorMetadata.getTableSchema / getColumnHandles / applyFilter（已有 3 测试类可扩展）
-     hms/hive 模块: 当前零测试——补 metadata/schema 单测基线
-   先 recon（可用 workflow，参 .audit-scratch/p3-t0X-recon.workflow.js 模板）→ 设计备忘 → 实现 → 单测 → 守门。
-   注意：parity 测试可能需 mock/fake HMS（HmsClient 是 8 方法 interface，可手写替身——见 HudiPartitionPruningTest.FakeHmsClient 先例）；
-        legacy 侧在 fe-core，import-gate 禁连接器直接调——parity 比对可能需在 fe-core test 或用固定 golden 值。
+     fe-core 不消费处: PluginDrivenExternalTable（getEngine/schema 路径）、ConnectorTableSchema.tableFormatType（getTableSchema 设但无消费方）
+     legacy 模型:      HMSExternalTable.dlaType（HIVE/HUDI/ICEBERG）+ initSchema 分流（initHudiSchema/initIcebergSchema/initHiveSchema）
+     decision:         D-005（DLA 用 tableFormatType）
+   产出 = 设计备忘 plan-doc/tasks/designs/P3-T08-tableformat-dispatch-design.md（不动 fe-core live 路径），可催生 D-NNN。
 
-3. 守门 / 构建（每 task）：
-   mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false（cwd=fe/）
-   checkstyle: mvn -pl <module> checkstyle:check（test 阶段不跑 checkstyle！需单独跑）+ import-gate（bash tools/check-connector-imports.sh）。
-   **Doris checkstyle 禁 static import**（用 Assertions.assertX）。HmsClient 有 9 方法（含 getDatabase + Closeable.close）。
+3. 文档同步（playbook §5.1 五步）：tasks/P3 状态 + phase log + PROGRESS §三/四 + connectors/hudi（+ 新 D-NNN 如有）。
 
-4. 文档同步（每 task，playbook §5.1 五步）：tasks/P3 状态+phase log + PROGRESS §一/三/四/六 + connectors/hudi（+ 新 DV/D 如有）。
-
-5. commit：`[feat|doc](connector) [P3-Tnn] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐）。
+4. commit：`[doc](connector) [P3-T08] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐）。
 ```
 
 ---
@@ -98,18 +98,19 @@
 ## 📂 P3 关键文件锚点
 
 ```
-T02（已修）:  fe-connector-hudi/HudiTypeMapping.toHiveTypeString / HudiScanPlanProvider:118-120 / HudiScanRange（typed list）
-              BE: hudi_jni_reader.cpp:52-54 / HadoopHudiJniScanner.java:106/113/212
-T03（批 E）:  ExternalUtil.initSchemaInfo / HudiScanNode:240,288-324 / BE table_schema_change_helper.h:219-267 / HudiColumnHandle（无 field id）
+T02（已修）:  HudiTypeMapping.toHiveTypeString / HudiScanRange（typed list）/ BE hudi_jni_reader.cpp:52-54
+T03（批 E）:  ExternalUtil.initSchemaInfo / BE table_schema_change_helper.h:219-267 / HudiColumnHandle（无 field id）
 T04（已修）:  PhysicalPlanTranslator.visitPhysicalHudiScan SPI 分支（两守卫）
-T05（已修）:  HudiConnectorMetadata.applyFilter（:144-209，7 步 + 7 helper）/ HudiTableHandle.prunedPartitionPaths
-              对标 HiveConnectorMetadata.applyFilter:193-234 + helpers / 链路 PluginDrivenScanNode:289-293,371 → HudiScanPlanProvider.resolvePartitions:287-289
-              测试: HudiPartitionPruningTest（FakeHmsClient 替身先例）
-T06（决策）:  ConnectorMetadata.java:60-77（MVCC 三 default）/ designs/P3-T06-mvcc-design.md / 无 override（opt-out）
-T07（批 C 下一步）: fe-core HiveMetaStoreClientHelper.getHudiTableSchema / HMSExternalTable.initHudiSchema
-              SPI HudiConnectorMetadata.getTableSchema/getColumnHandles；hms/hive 模块零测试待补
+T05（已修）:  HudiConnectorMetadata.applyFilter（7 步 + 7 helper）/ HudiPartitionPruningTest（FakeHmsClient 先例）
+T06（决策）:  ConnectorMetadata MVCC 三 default / 无 override（opt-out）
+T07（已修）:  HudiConnectorMetadata.avroSchemaToColumns（顶层降字 + package-private static）
+              测试: hudi HudiTypeMappingTest/HudiSchemaParityTest/HudiTableTypeTest；hms HmsTypeMappingTest；hive HiveFileFormatTest/HiveConnectorMetadataPartitionPruningTest
+              legacy 锚: HMSExternalTable.initHudiSchema:734-758 / HudiUtils.convertAvroToHiveType / fromAvroHudiTypeToDorisType
+              设计: designs/P3-T07-test-baseline-design.md
+T08（批 D 下一步）: PluginDrivenExternalTable / ConnectorTableSchema.tableFormatType / HMSExternalTable.dlaType+initSchema 分流 / D-005
+              素材: plan-doc/research/spi-multi-format-hms-catalog-analysis.md（未跟踪）
 gate:         CatalogFactory.java:52（SPI_READY_TYPES，不含 hms/hudi——别动）
-设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / T04 / T05 / T06
+设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / T04 / T05 / T06 / T07
 scratch:      .audit-scratch/p3-t0X-*.workflow.js（本地 workflow 脚本，未跟踪）
 ```
 
@@ -117,9 +118,7 @@ scratch:      .audit-scratch/p3-t0X-*.workflow.js（本地 workflow 脚本，未
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **批 C 仍是 model-agnostic SPI 硬化/测试网**（gate 关，零 live 风险）；不要碰 `SPI_READY_TYPES`、不删 legacy、不动 hudi 之外的连接器 `instanceof` 分支。
-- **批 C 的难点是 parity 比对的可行性**：legacy 在 fe-core、SPI 在连接器模块、import-gate 隔离。先 recon 确认怎么拿 legacy 输出（fe-core test？golden 值？）再设计，别假设能直接跨模块调。
-- **测试基准**：hudi 模块已有 3 测试类 + FakeHmsClient 先例（`HmsClient` 8 方法 interface + close 易 fake）；hms/hive 模块零测试，先补 metadata 单测基线。
-- 偏差先记 `deviations-log.md`（本场记 DV-007）再改文档；架构/可行性 fork 先问用户（本场 T05 list*/T06 MVCC 两 fork 已问并签字）。
-- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 单独跑**（test 阶段不触发）；**禁 static import**。
-```
+- **批 D 是 design-only**（T08）：**不动 fe-core live 路径、不实现 tableFormatType 消费（批 E）、不碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器**。产出是设计备忘 + 可能的 D-NNN。
+- **先读 `research/spi-multi-format-hms-catalog-analysis.md`**（已有 28KB 分析，避免重复 recon）；recon 可用 workflow（参 `.audit-scratch/p3-t0X-recon.workflow.js` 模板）。
+- 偏差先记 `deviations-log.md` 再改文档；架构/可行性 fork 先问用户（本场 T07 casing/baseline 两 fork 已签字 → DV-008）。
+- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 单独跑**（含 test 源）；**禁 static import**（用 `Assertions.assertX`）。

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -8,158 +8,115 @@
 
 ## 📅 最后一次 handoff
 
-- **日期 / 时间**：2026-06-04
-- **本 session 主题**：**P2 已合入** `branch-catalog-spi`（#64096）；**P3 Hudi 两轮 recon + 定策略**——code-grounded 确认 HMS-over-SPI 现状（记 DV-005），用户定 **hybrid**（记 D-019），已建 [`tasks/P3-hudi-migration.md`](./tasks/P3-hudi-migration.md)
-- **分支**：`branch-catalog-spi`（P0 → P1 → P2 已干净 stack，工作树 clean）
+- **日期 / 时间**：2026-06-05
+- **本 session 主题**：**P3 批 A 编码完成**——T02（column_types 双 bug）✅ + T04（time-travel/增量 fail-loud）✅ 落地；T03（schema_id/history）经 code-grounded recon 证非 model-agnostic SPI 修复，**推迟批 E**（[DV-006]，用户签字）。
+- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`；P0→P1→P2→recon(D-019) 之上）。工作树 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/` 等）。
 
 ---
 
 ## ✅ 本 session 完成项
 
-### 1. P2 trino-connector 已合入主集成分支
+| Task | 结果 | commits |
+|---|---|---|
+| **P3-T02** column_types 双 bug | ✅ 修复 + 模块首批 11 单测全绿 + 3-lens 对抗 review 零确认缺陷 | `95f23e9`(code) `ac0dc7c`(doc) |
+| **P3-T03** schema_id/history_schema_info | 🟡 **推迟批 E**（[DV-006]）——recon 证：连接器缺 field-id/InternalSchema/type→thrift；裸基线 BE 走 `ConstNode`(大小写敏感) 弱于现状 `by_parquet_name` = 净回归 | `517c9cf`(DV-006+doc) |
+| **P3-T04** time-travel/增量 fail-loud | ✅ `visitPhysicalHudiScan` SPI 分支抛 `AnalysisException`；fe-core 编译+checkstyle 0 | `feceabb`(code) `2758cf9`(doc) |
 
-`catalog-spi-03` 已 squash-merge 为单条 commit `0793f032662 [feat](connector) P2 migrate trino-connector to catalog SPI (T01-T13) (#64096)`，叠在 `2b1a3bb2197 [P1 #63641]` → `72d6d0109b9 [P0 #63582]` 之上。**旧 HANDOFF 的头号阻塞「PR base 错位（191-commit）」已消失**——`branch-catalog-spi` 已重建到新 master（P0/P1 hash 随之更新）。P2 阶段除 T12（回归测试，DV-003 推迟）外全部完成。
+**commit stack**（新→旧）：`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2 #64096)→`2b1a3bb`(P1 #63641)→`72d6d01`(P0 #63582)。
 
-### 2. P3 Hudi 启动 recon（8-agent workflow，code-grounded + 对抗验证）
-
-用户准备启动 P3，要求**根据代码**确认 `fe-connector-hms` 的 SPI 元数据路径是否就绪。结论见下「关键认知 1」——简言之：**原计划「P3 需等 P5/P7 交付 HMS-over-SPI」的依赖假设与代码不符**（读码早已存在但 dormant），**真正阻塞是 catalog 模型错配 + gate 关闭**。verdict `hmsMetadataOverSpiReady=false`（high confidence，2 路对抗验证一致）。已记 **DV-005**，并同步 PROGRESS / connectors/hudi。
-
-### 3. 第二轮 scan/split recon + 定 hybrid 策略 + 建 tasks/P3
-
-第二轮 recon（scan/split 路径，verified）确认**混合 COW-native/MOR-JNI 不是问题**、plumbing 正确（详见关键认知 1b）。基于两轮 recon，用户拍板 **hybrid 策略**（记 **D-019**）：现做 (b) 连接器硬化+测试（behind 关闭的 gate，零 live-path 风险），推迟 (a) 模型落地+cutover 到 hive/HMS migration。已建 [`tasks/P3-hudi-migration.md`](./tasks/P3-hudi-migration.md)（hybrid 范围 + 批 A–E + file:line 锚点），批 A 待启动。
+**批 A 净产出** = 2 个正确性修复（gate 后硬化，零 live 风险，零回归）+ 1 个 code-grounded 推迟决策。每 task 走 design 备忘（`tasks/designs/P3-T0X-*.md`）→ impl → build → commit → 5 步文档同步。
 
 ---
 
-## 🚧 未完成 / 待办
+## 🚧 未完成 / 待办（下一 session = 批 B）
 
-1. **P3 Hudi 批 A 待启动**——策略已定 **hybrid**（[D-019](./decisions-log.md)），已建 [`tasks/P3`](./tasks/P3-hudi-migration.md)。下一 session 第一件事见下（批 A T02 起）。批 E（live cutover/模型落地）deferred 到 hive/HMS migration。
-2. **T12 回归测试推迟**（DV-003）——`trino_connector_migration_compat`（CREATE CATALOG→image→重启读回 + 旧 image 含 `TRINO_CONNECTOR` 枚举反序列化），需有 Trino plugin + docker/集群环境。
-3. **DV-001 后续**：评估 `MetastoreProperties.Type.TRINO_CONNECTOR` + `TrinoConnectorPropertiesFactory` 是否真被 SPI 路径使用（纯死代码可清）。
-4. **DV-004 后续**：trino-connector 用户向安装文档在 doris-website 仓补（不在本仓）。
+1. **P3-T05（批 B，下一 session 第一件事）**：`listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` EQ/IN 分区裁剪。现状：Hudi `applyFilter` 列**全部**分区不裁剪（`HudiScanPlanProvider.resolvePartitions` 用 `handle.getPrunedPartitionPaths()`，但没人 set 它 → 永远 null → 列全部）；Hive 已做 EQ/IN。**对标** `HiveConnectorMetadata.applyFilter`。
+2. **P3-T06（批 B）**：MVCC/snapshot SPI。`HudiConnectorMetadata` 未 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`（默认 `Optional.empty()`=unsupported）。与 T04 关联：大概率**显式 unsupported**（与 T04 fail-loud 一致）即可，完整 MVCC 入批 E。
+3. **批 C**（T07）：三模块（hms/hive/hudi）测试基线 + COW/MOR parity 测试（SPI `HudiConnectorMetadata` schema/partition vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`）。注：T07 parity 也该覆盖 T02 的 column_names/types 列集合+顺序 vs legacy。
+4. **批 D**（T08）：`tableFormatType` 分流消费设计备忘（design-only，不动 fe-core）。
+5. **批 E（deferred，不在 P3 hybrid 编码）**：T03（schema_id/history 完整 field-id evolution）、T04 的完整 snapshot 透传+增量 SPI+MVCC、T09–T11（模型落地/gate flip/删 legacy/集群验证）。并入 hive/HMS migration。
+6. **T04 单测推迟批 E**（dormant 分支不可 exercise；regression 断言 `FOR TIME AS OF`/增量→报错；precedent DV-003）。
 
 ---
 
 ## ⚠️ 关键认知 / 临时发现
 
-### 1. 【P3 核心】HMS-over-SPI「读码已存在但 dormant」；真正阻塞是 catalog 模型错配（DV-005，verified high-confidence）
+### 1.【批 A 已用】BE Hudi JNI column_types/names/delta 契约（T02 已修，code-grounded 两点确认）
+- `THudiFileDesc.{delta_logs,column_names,column_types}` 是 thrift `list<string>`；**BE 自做 join**：names `,` / types **`#`** / delta `,`（`be/src/format/table/hudi_jni_reader.cpp:52-54`），Java `HadoopHudiJniScanner.java` split 同（types `#`@:113 / names `,`@:212 / delta `,`@:106）。types 用 `#` 正因类型串含逗号（`decimal(10,2)`/`struct<...>`）。**FE 永远传 typed list、不 join/split**；类型串用 Hive 串（`HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），**不是** Doris `getTypeName()`。
 
-recon（8 agent，读真实方法体 + 2 路对抗验证）的关键事实：
+### 2.【批 E 必读】T03 schema_id/history 为何不是 SPI-surface 可修（DV-006，code-grounded）
+- BE `table_schema_change_helper.h:219-267`：`history_schema_info` **unset** → `by_parquet_name`/`by_orc_name`（鲁棒名匹配，处理大小写/缺列）= **现状**；`current==file` schema_id → **`ConstNode`**(`:92-121`，**identity-by-name，大小写敏感**)；id 不同 → `by_table_field_id`（唯一 field-id evolution 路径）。
+- **裸基线 `current==file==-1`→ConstNode 弱于现状名匹配 = 净回归**。faithful 需：`HudiColumnHandle` 加 field id（现无）+ Hudi `InternalSchema` 版本（`getCommitInstantInternalSchema`）+ 连接器内 type→`TColumnType` thrift（legacy 在 fe-core `ExternalUtil`，import-gate 禁复用）。legacy hudi baseline = `ExternalUtil.initSchemaInfo(params,-1L,table.getColumns())`（`HudiScanNode:240`）+ native split per-commit `InternalSchema.schemaId()`。**「Paimon/ES 已 override hook 设 schema」前提失真**——其 override 为 predicate/docvalue。
+- **结论**：批 E 与 hive/HMS migration 一并建机制。
 
-- **读码早已存在且非 stub**（在 `branch-catalog-spi` HEAD，源自更早的 #62183/#62821，一直 dormant 在 gate 后）：
-  - `fe-connector-hms` = 共享 **HMS Thrift 客户端库**（`HmsClient`/`ThriftHmsClient`，**不是** ConnectorMetadata）。
-  - `fe-connector-hive` = `HiveConnectorMetadata`(type `"hms"`)，真实读路径 + applyFilter 真分区裁剪。
-  - `fe-connector-hudi` = `HudiConnectorMetadata`(type `"hudi"`)，从 Hudi Avro MetaClient 读 schema（HMS fallback），COW/MOR 探测，`HudiScanPlanProvider` 快照扫描规划。
-  - D-005 区分符 `ConnectorTableSchema.tableFormatType` 已存在并被各连接器写入。
-- **但全部未接线（zero live caller）**：`CatalogFactory.SPI_READY_TYPES = {jdbc, es, trino-connector}`（`CatalogFactory.java:52`）不含 hms/hudi → 任何 HMS 系 catalog 永远走 legacy `HMSExternalCatalog`，不进 SPI。
-- **真正阻塞 = catalog 模型错配（架构级，用户/设计决策）**：现存连接器注册的是**独立 `"hudi"` catalog type**（`HudiConnectorProvider.getType()=="hudi"`），而 Doris 真实模型是 hudi **寄生**在 `"hms"` catalog 内、以 `HMSExternalTable.DLAType.HUDI` 暴露；fe-core **没有 `"hudi"` catalog type**，且 `PluginDrivenExternalTable` **从不消费** `tableFormatType`（只读 `getColumns()`，按 catalog TYPE 字串路由）。即单个 `"hms"` 连接器**没有 per-table HUDI/HIVE/ICEBERG 分流的 SPI 机制**。
-- **其他确认缺口**：增量读无 SPI 表示（P1-T04 的 `visitPhysicalHudiScan` SPI 分支丢弃 `getIncrementalRelation()`；MVCC trio 未实现；4 个 `*IncrementalRelation` 仍在 fe-core）；hive/hudi 未 override `listPartitions*`（Hudi applyFilter 列全部分区**不做**约束裁剪，Hive applyFilter **做** EQ/IN 裁剪）；三个连接器模块**零测试**。
-- **已验证非阻塞**：SPI scan/split **通用链路**（`PluginDrivenScanNode.planScan` → BE）已被合入的 trino-connector 走通；**hudi-specific** 的「单 ScanNode 混合 COW-native + MOR-JNI 每-split 格式」正确性才是待验证项。
+### 3.【批 E 必读】T04 fail-loud 位置 + 完整实现去向
+- 守卫在 `PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支（`:828-841` 附近）——**唯一**同时可见 `getTableSnapshot()` + `getIncrementalRelation()` 处（SPI surface 拿不到 incremental；`IncrementalRelation` 是 fe-core 概念，4 个 `*IncrementalRelation` 仍在 fe-core）。完整：snapshot 透传到 `HudiScanPlanProvider.planScan`（现永远用 `timeline.lastInstant()`@`:103`）+ 增量 SPI 表示 + MVCC（T06）。
 
-**→ catalog 模型决策【已定 2026-06-04 = hybrid，[D-019](./decisions-log.md)】**：现做 (b)（批 A–D，behind gate，零 live 风险），推迟 (a)（批 E，并入 hive/HMS migration）。原选项供回溯：
+### 4.（沿用）rebase 后 fe-core 编译坑：stale `DorisParser`
+- rebase 拉入 nereids 语法拆分后，`fe-core/target/generated-sources/.../DorisParser.java` 残留导致 cannot find symbol。**修法：clean fe-core**（不是 fe-sql-parser），别当代码 bug 查。
 
-- **(a) hms-first**：把 `HiveConnectorProvider(type="hms")` 接入 `PluginDrivenExternalCatalog` + fe-core 消费 `tableFormatType` 分流，hudi 作薄增量。一次命中真正架构阻塞、契合现存 `type="hms"` 设计；但把 P7(hive/HMS) 范围拉进 P3、触碰 **live 重度使用的 HMS 路径**、零测试网，回归风险大。
-- **(b) gate 后建脚手架**：先做 format-dispatch / 增量 SPI hook / MVCC + 补测试（design+stub，**不动 live 路径，零回归**）；但 hudi 不会单独端到端可用，推迟模型决策。
-- **(c) 直接 flip gate** —— **否决**（模型错配下 `"hudi"` provider 不可达；把 live hms catalog 推到未测 SPI；增量丢失；高回归）。
-- 对抗验证的 framing nit：**不要**在备忘里预设「推荐 (a)」——(a) 让 P3 依赖完成 P7 模型迁移、且在零测试的 live 路径上，是大而易回归的首交付；把 (a)/(b) 留给用户真实选择。
-
-### 1b. 【P3 scan 侧】scan/split 路径 recon 完成（verified；mixed-format 是非问题，parity gap 多数可在 SPI 层修）
-
-第二个 recon（4 reader + synthesis + 2 对抗验证，verdict `spiHudiCanReachBeModuloGate=false`——false **只因 gate/模型未解，不是 plumbing 问题**）：
-
-- **✅ 混合 COW-native + MOR-JNI 不是问题（之前最担心的点，已排除）**：单 `PluginDrivenScanNode` 能正确服务混合格式。node 级 `getFileFormatType()` 只是**默认种子**；真正生效的是 **per-range** `TFileRangeDesc.format_type`（`PlanNodes.thrift:566`），node 级 `TFileScanRangeParams.format_type`（:469）已标 **deprecated**。BE `file_scanner.h:291-295` per-range 优先于 node 级，且**每 range 新建 reader**（`_get_next_reader`），FORMAT_JNI+hudi→HudiJniReader / PARQUET/ORC→native。`HudiScanRange.populateRangeParams`(160-176) 自做 JNI→native 降级，与 legacy `HudiScanNode.setScanParams`(263-276) **逐行等价**。两路对抗验证确认，其中一路尝试 refute 失败。
-- **parity gap（FE 侧数据/特性缺口，多数可在 SPI surface 内修，不动 fe-core）**：
-  - **HIGH ① schema_id / history_schema_info 全缺**：legacy 每个 native split 设 `THudiFileDesc.schema_id` + `params.history_schema_info`；SPI 都没设 → BE 退化为**列名匹配**（`table_schema_change_helper.h:219-236`），重命名/schema-evolution/大小写不一致的列返 null/错列（**退化非崩溃**）。可经现有 SPI hook `ConnectorScanPlanProvider.populateScanLevelParams`（Paimon/ES 已 override，hudi 没）+ 在 `HudiScanRange` 设 schema_id 修复，**无需 fe-core 改动**。
-  - **HIGH ② column_types 双 bug**（对抗验证从 MEDIUM 升级）：(a) 用 `ConnectorType.getTypeName()` 返裸 `"DECIMAL"`/`"STRUCT"`，**丢精度/scale/子类型**（legacy 发 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 把 column_names/types/delta_logs 用**逗号 join 再 split**，而 Hive 类型串本身含逗号 → decimal/复杂类型元素被**打碎**、names 与 types 长度错位。命中**任何含 decimal/复杂列的 MOR-with-logs JNI split**。修：发完整 Hive 类型串 + 改 typed list 端到端（停止逗号 join/split）。
-  - **HIGH ③ time-travel 静默返最新**：snapshot 传到 node（`PhysicalPlanTranslator:835 setQueryTableSnapshot`）但 `HudiTableHandle` 无 snapshot 字段、`HudiScanPlanProvider` 永远用 `timeline.lastInstant` → `FOR TIME AS OF` 静默返最新。修：透传 snapshot，否则 fail-loud。
-  - **HIGH ④ 增量读无 SPI 表示**（代码已 defer）：失败模式未验证，**必须 fail-loud 而非静默全扫**。
-  - **MEDIUM**：MOR node（node=JNI）下 per-range 降级的 native split 继承 node 级 JNI location-props——很可能 parity（native reader 按 resolved format 派发、直接读 schema_id），但是唯一需 runtime 验证项。
-  - **LOW**：`forceJniScanner` 被忽略；runtime-filter 分区裁剪值缺；limit pushdown 被丢（4-arg vs 5-arg planScan，perf 非正确性）；`nested_fields` 两路都没设（at parity）。
-- **仍 false 的原因**：gate（`SPI_READY_TYPES` 不含 hms/hudi）+ 关键认知 1 的 catalog 模型错配。**scan plumbing 正确是必要非充分。**
-- **对 a/b 的影响**：scan 侧 HIGH 修复项（①schema_id/history、②column_types、④增量 fail-loud）**与模型选择无关、多数在 SPI surface 内可修**——正是选项 (b) 的高价值内容；无论 a/b 都要做。
-
-### 2.（沿用）rebase 后 fe-core 编译坑：stale `DorisParser`
-
-rebase 拉入 #63823（nereids 语法拆到 `fe-sql-parser`）后，`fe-core/target/generated-sources/.../DorisParser.java` 旧生成物残留导致 `LogicalPlanBuilder` 报 cannot find symbol。**修法：clean fe-core**（不是 fe-sql-parser）。任何 rebase 后遇此先 clean，别当代码 bug 查。
-
-### 3.（沿用）P1 fallback `instanceof` 分支
-
-`PhysicalPlanTranslator` 里其余连接器的 `instanceof` 分支待各自 P 阶段迁完再删；本场未动。hudi 的 `visitPhysicalHudiScan` 已有 SPI 分支（P1-T04）但 incrementalRelation 缺口见关键认知 1。**不要乱碰 hudi 之外的连接器分支。**
-
-### 4.（沿用）import gate
-
-`tools/check-connector-imports.sh`：fe-core 不能 import `org.apache.doris.connector.*`。
-
-### 5.（沿用）docs-next 不在本仓（DV-004）
-
-用户向文档在 doris-website 仓；本仓只有 `docs/`。
+### 5.（沿用）import gate + P1 fallback + docs-next
+- `tools/check-connector-imports.sh`：fe-core 不能 import `org.apache.doris.connector.*`；连接器模块不能 import fe-core `org.apache.doris.(catalog|common|datasource|qe|analysis|nereids|planner)`。
+- `PhysicalPlanTranslator` 里 hudi **之外**的连接器 `instanceof` 分支待各自 P 阶段迁完再删，**本场只动了 hudi 的 SPI 分支**，别乱碰其他。
+- 用户向文档在 doris-website 仓（DV-004），本仓只有 `docs/`。
 
 ---
 
-## 🎯 下一个 session 第一件事（P3 Hudi）
+## 🎯 下一个 session 第一件事（P3 批 B / T05）
 
 ```
 1. 自检：
-   git branch --show-current → branch-catalog-spi
-   git log --oneline -3 → 0793f032662 (P2 #64096) → 2b1a3bb2197 (P1 #63641) → 72d6d0109b9 (P0 #63582)
-   git status → clean（除 .audit-scratch/ conf.cmy/ 等本地未跟踪物）
-   Read plan-doc/tasks/P3-hudi-migration.md（hybrid 范围 + 批 A–E + file:line 锚点）
+   git branch --show-current → catalog-spi-04
+   git log --oneline -6 → 2758cf9(T04 doc) feceabb(T04) 517c9cf(T03 defer) ac0dc7c(T02 doc) 95f23e9(T02) 9fcf21a(recon)
+   git status → clean（除 .audit-scratch/ conf.cmy/ regression-conf.bak）
+   Read plan-doc/tasks/P3-hudi-migration.md（批 B = T05/T06）+ 本文件关键认知
 
-2. 从 branch-catalog-spi 切 P3 工作分支（catalog-spi-04 / catalog-spi-p3-hudi）。
+2. 启动【批 B / T05】（仍 behind 关闭的 gate，零 live 风险）：listPartitions override + 真实 applyFilter EQ/IN 裁剪。
+   recon 锚点：
+     fe-connector-hudi: HudiScanPlanProvider.resolvePartitions(:284-312)（用 handle.getPrunedPartitionPaths，永远 null）
+                        HudiConnectorMetadata（看有无 applyFilter；listPartitions* 默认空）
+                        HudiTableHandle（prunedPartitionPaths 字段 + toBuilder）
+     对标 fe-connector-hive: HiveConnectorMetadata.applyFilter（真 EQ/IN 分区裁剪——recon DV-005 已确认 Hive 做、Hudi 不做）
+     SPI: ConnectorMetadata.applyFilter / listPartitions* 签名（fe-connector-api）
+   先 recon（可用 workflow，参 .audit-scratch/p3-t03-recon.workflow.js 模板）→ 设计备忘 → 实现 → 单测 → 守门。
 
-3. 启动【批 A】（全部 behind 关闭的 gate，零 live-path 风险；不要碰 SPI_READY_TYPES、不删 legacy）。
-   第一个 task = P3-T02（column_types 双 bug）：
-   - 读 fe-connector-hudi: HudiScanPlanProvider.java（getScanNodeProperties / collectMorSplits 塞 column_types 处）
-            HudiScanRange.java（~89/92/95 逗号 join、~194/199/202 split）
-            HudiTypeMapping.java（fromAvroSchema().getTypeName() —— 丢精度/子类型）
-     对照 fe-core legacy HudiUtils.convertAvroToHiveType（发完整 Hive 类型串）
-   - 关键：先读 BE hudi_jni_reader.cpp 确认 JNI scanner 期望的精确串格式（names ',' / types '#'），再改
-   - 改：发完整 Hive 类型串（decimal(10,2)/struct<...>）+ 停止逗号 join/split（typed list 端到端）+ 单测
-
-4. 批 A 续：P3-T03（schema_id/history —— override populateScanLevelParams，无需动 fe-core）
-            → P3-T04（time-travel/增量 fail-loud）。
-   再 批 B（T05 partition 裁剪 / T06 MVCC）→ 批 C（T07 测试基线 + parity）→ 批 D（T08 dispatch 设计 design-only）。
-
-5. 守门 / 构建（每 task）：
+3. 守门 / 构建（每 task）：
    mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false
-   （cwd=fe/ 或 -f fe/pom.xml）；fe-connector 编译 + checkstyle 0 + import-gate 通过；
-   rebase 后 fe-core 编译失败先 clean fe-core（关键认知 2）。
+   （cwd=fe/）；checkstyle 0 + import-gate 通过。**注意 Doris checkstyle 禁 static import**（用 `Assertions.assertX`，非 `import static`）。
+   若改 fe-core：mvn -pl fe-core -am compile（大；rebase 后失败先 clean fe-core）。
 
-6. 文档同步（每 task）：tasks/P3 状态 + PROGRESS §三 + connectors/hudi（playbook §5.1）。
+4. 文档同步（每 task，playbook §5.1 五步）：tasks/P3 状态+phase log + PROGRESS §一/三/四 + connectors/hudi（+ 新 DV/D 如有）。
 
-7. 批 E（T09–T11，deferred）不在本阶段编码——并入 hive/HMS migration（D-019）。
-   T12（trino 回归，DV-003）在有集群/plugin 环境补。
+5. commit：`[feat|doc](connector) [P3-Tnn] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐）。
 ```
 
 ---
 
-## 📂 P3 关键文件锚点（recon 已定位，附 file:line）
+## 📂 P3 关键文件锚点
 
 ```
-gate:          fe-core/.../datasource/CatalogFactory.java:52  (SPI_READY_TYPES，不含 hms/hudi)
-legacy 模型:   fe-core/.../datasource/hive/HMSExternalTable.java:208-210 (DLAType enum),
-                 250-281 / 297-306 (HUDI 探测), 722-759 (initHudiSchema 走 legacy)
-               fe-core/.../datasource/hive/HMSExternalCatalog.java:52 (extends ExternalCatalog，非 PluginDriven)
-               fe-core/.../datasource/hive/HudiDlaTable.java (dlaType=HUDI 表对象，在 hive/ 不在 hudi/)
-relation 分流: fe-core/.../nereids/rules/analysis/BindRelation.java:483-548
-                 (HMS_EXTERNAL_TABLE + dlaType==HUDI → LogicalHudiScan)
-scan 桥:       fe-core/.../nereids/glue/translator/PhysicalPlanTranslator.java:828-854
-                 (SPI 分支 828-838 丢 incrementalRelation；legacy 分支 840-854 传)
-legacy hudi:   fe-core/.../datasource/hudi/  15 文件 ~2403 LOC（top 9 + source/ 6），
-                 含 4 个 *IncrementalRelation + HudiScanNode(614 LOC)；live caller 仅 7 个 fe-core 文件，零测试
-SPI 已存在:    fe-connector/fe-connector-hms/  (HmsClient/ThriftHmsClient 客户端库，非 ConnectorMetadata)
-               fe-connector/fe-connector-hive/HiveConnectorMetadata.java  (type "hms")
-               fe-connector/fe-connector-hudi/HudiConnectorMetadata.java  (type "hudi")
-                 + HudiConnector(自建 ThriftHmsClient) + HudiScanPlanProvider
-               fe-connector/fe-connector-api/ConnectorTableSchema.java:33/58
-                 (tableFormatType；fe-core 从不消费 schema 级区分符)
+T02（已修）:  fe-connector-hudi/HudiTypeMapping.java（toHiveTypeString）
+              HudiScanPlanProvider.java:118-120（用 toHiveTypeString）
+              HudiScanRange.java（typed list 字段 + populateRangeParams 直接 set）
+              BE: hudi_jni_reader.cpp:52-54 / be-java-extensions/.../HadoopHudiJniScanner.java:106/113/212
+T03（批 E）:  ExternalUtil.initSchemaInfo（fe-core:86-92）/ HudiScanNode:240,288-324（per-split schema_id）
+              BE: table_schema_change_helper.h:219-267（ConstNode vs by_parquet_name vs by_table_field_id）
+              HudiColumnHandle（无 field id）/ ConnectorScanPlanProvider.populateScanLevelParams（hook，:162-165）
+T04（已修）:  PhysicalPlanTranslator.visitPhysicalHudiScan SPI 分支（:828-841 附近，两守卫）
+T05（批 B 下一步）: HudiScanPlanProvider.resolvePartitions / HudiConnectorMetadata / HudiTableHandle.prunedPartitionPaths
+              对标 HiveConnectorMetadata.applyFilter
+gate:         CatalogFactory.java:52（SPI_READY_TYPES，不含 hms/hudi——别动）
+设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / P3-T04-*.md
+scratch:      .audit-scratch/p3-t02-review.workflow.js / p3-t03-recon.workflow.js（本地 workflow 脚本，未跟踪）
 ```
 
 ---
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **P3 是架构决策先行**：先 recon scan 路径 + 写模型决策备忘 + 用户签字，**再**编码。别被「读码已存在」误导成「flip gate 就行」（DV-005 选项 c 已否决）。
-- 偏差先记 `deviations-log.md` 再改文档（本场记了 DV-005）。
-- commit message 沿用 `[feat|refactor|test|doc](connector) [P3-Tnn] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐，不再有 P2 那种错位）。
-- Maven：cwd=`fe/` 或 `-f fe/pom.xml`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`。rebase 后编译失败先 clean fe-core。
-- 不要乱碰 P1 fallback 中 hudi 之外的连接器 `instanceof` 分支。
+- **批 B 仍是 model-agnostic SPI 硬化**（gate 关，零 live 风险）；不要碰 `SPI_READY_TYPES`、不删 legacy、不动 hudi 之外的连接器 `instanceof` 分支。
+- **T05 先确认 SPI applyFilter 链路**：`ConnectorMetadata.applyFilter` 回传裁剪后的 handle（带 prunedPartitionPaths）→ `HudiScanPlanProvider.resolvePartitions` 已会消费它。对标 Hive 的真实 EQ/IN 裁剪。
+- **T06 大概率显式 unsupported**（与 T04 一致），别在批 B 做完整 MVCC（入批 E）。
+- 偏差先记 `deviations-log.md`（本场记了 DV-006）再改文档；架构/可行性 fork 先问用户（本场 T03 已问并签字）。
+- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 禁 static import**。
+```

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -9,7 +9,7 @@
 ## 📅 最后一次 handoff
 
 - **日期 / 时间**：2026-06-05
-- **本 session 主题**：**P3 批 D 完成（T08，design-only）**——`tableFormatType` 分流消费设计备忘 + **[D-020]**（用户签字 M2=方案 B per-table SPI provider）。**P3 hybrid in-scope（批 A–D）全部完成**；剩批 E（live cutover）并入 P7。
+- **本 session 主题**：**P3 批 D 完成（T08，design-only）**——`tableFormatType` 分流消费设计备忘 + **[D-020]**（用户签字 M2=方案 B per-table SPI provider）。**P3 hybrid in-scope（批 A–D）全部完成**；剩批 E（live cutover）并入 P7。**P3 PR [#64143](https://github.com/apache/doris/pull/64143) 已开**（base branch-catalog-spi）。
 - **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`）。工作树预期 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/`/`regression-conf.bak`；**`plan-doc/research/` 本 session 已纳入 git 跟踪**）。
 
 ---
@@ -28,10 +28,10 @@
 
 ## 🚧 未完成 / 待办（下一 session：三选一，待用户定）
 
-**P3 hybrid in-scope（批 A–D）已全部完成。** 没有"批 D 之后的批"——批 E 是 deferred、并入 P7。下一 session 是一个**分叉点**：
+**P3 hybrid in-scope（批 A–D）已全部完成，PR #64143 已开。** 没有"批 D 之后的批"——批 E 是 deferred、并入 P7。下一 session：
 
-1. **开 P3 PR**（推荐先确认）：把 `catalog-spi-04` 的批 A–D 工作开 PR，base = `apache/doris:branch-catalog-spi`。**git/push/PR 只在用户明确要求时做**（本 session 未开）。P3 无独立"开 PR"task（不同于 P2-T13），需用户拍板是否现在开、是否等批 E。
-2. **批 E 并入 P7**（不在 P3 编码）：live cutover——见下「批 E backlog」。属 hive/HMS migration（P7 或专门子阶段），不在 P3 PR 内。
+1. **监控 [PR #64143](https://github.com/apache/doris/pull/64143)**：base = `apache/doris:branch-catalog-spi`、head = `morningman:catalog-spi-04`，26 files +3065/−154、12 commits。盯 CI、处理 review comment（review 改动在本分支 `catalog-spi-04` 续 commit + push 即自动进 PR）。前序 P0/P1/P2 PR 均 **squash-merge**。
+2. **批 E 并入 P7**（不在 P3 编码）：live cutover——见下「批 E backlog」。属 hive/HMS migration（P7 或专门子阶段），不在本 PR 内。
 3. **启 P4**（maxcompute）：若 P3 告一段落，按 master plan 进下一连接器。
 
 > ⚠️ 三选项**都不应**在 P3 分支内碰 `SPI_READY_TYPES` / fe-core 消费实现 / legacy `datasource/hudi/` / 非 hudi 连接器——皆批 E。
@@ -85,10 +85,10 @@
    git status → clean（除 .audit-scratch/ conf.cmy/ regression-conf.bak；research/ 现已跟踪）
    Read PROGRESS.md §一/§三 + 本文件关键认知 1（M1⊥M2 + D-020）
 
-2. 与用户确认分叉（本文件「未完成/待办」三选一）：
-   (1) 开 P3 PR（base apache/doris:branch-catalog-spi）——需用户明确要求才 push/开 PR
-   (2) 批 E 并入 P7（live cutover；T08/D-020 已出 M1+M2 设计）
-   (3) 启 P4（maxcompute）
+2. PR #64143 已开（base apache/doris:branch-catalog-spi、head morningman:catalog-spi-04）：
+   gh pr view 64143 --repo apache/doris   → 盯 CI / review
+   review 改动在 catalog-spi-04 续 commit + push 即自动进 PR（前序均 squash-merge）
+   合入后：批 E 并入 P7（T08/D-020 已出 M1+M2 设计）或启 P4
    → P3 内不碰 SPI_READY_TYPES / fe-core 消费实现 / legacy / 非 hudi 连接器（皆批 E）
 
 3. 若走 (2) 批 E：实现序见本文件「批 E backlog」M1→M2→M4→翻闸；

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -9,129 +9,157 @@
 ## 📅 最后一次 handoff
 
 - **日期 / 时间**：2026-06-04
-- **本 session 主题**：**P2 批 C+D+E 连续完成**（T07 翻闸 → T08-T10 删 legacy → T11 单测 → T13 文档），**T12 推迟**，**PR 待开**（分支基线对齐由用户处理）
-- **分支**：`catalog-spi-03`
+- **本 session 主题**：**P2 已合入** `branch-catalog-spi`（#64096）；**P3 Hudi 两轮 recon + 定策略**——code-grounded 确认 HMS-over-SPI 现状（记 DV-005），用户定 **hybrid**（记 D-019），已建 [`tasks/P3-hudi-migration.md`](./tasks/P3-hudi-migration.md)
+- **分支**：`branch-catalog-spi`（P0 → P1 → P2 已干净 stack，工作树 clean）
 
 ---
 
 ## ✅ 本 session 完成项
 
-> 注：用户本 session 开始前把 `catalog-spi-03` **rebase 到了新 master**，所有旧 commit hash 已变。下方为 rebase 后的新 hash。
+### 1. P2 trino-connector 已合入主集成分支
 
-### 批 C — T07 翻闸（commit `0fe4b8a93d6`）
+`catalog-spi-03` 已 squash-merge 为单条 commit `0793f032662 [feat](connector) P2 migrate trino-connector to catalog SPI (T01-T13) (#64096)`，叠在 `2b1a3bb2197 [P1 #63641]` → `72d6d0109b9 [P0 #63582]` 之上。**旧 HANDOFF 的头号阻塞「PR base 错位（191-commit）」已消失**——`branch-catalog-spi` 已重建到新 master（P0/P1 hash 随之更新）。P2 阶段除 T12（回归测试，DV-003 推迟）外全部完成。
 
-`CatalogFactory.java:53` `SPI_READY_TYPES` 加 `"trino-connector"`（顺手删上方注释里过时的 trino 列举）。这一步把 `CREATE CATALOG type='trino-connector'` 路由到 SPI（`PluginDrivenExternalCatalog`），关闭了批 B→批 C 的 regression window。compile + checkstyle 绿。
+### 2. P3 Hudi 启动 recon（8-agent workflow，code-grounded + 对抗验证）
 
-### 批 D — 删 fe-core legacy trino 代码（commit `ed81a063fe8`，14 文件 / +1 −2508）
+用户准备启动 P3，要求**根据代码**确认 `fe-connector-hms` 的 SPI 元数据路径是否就绪。结论见下「关键认知 1」——简言之：**原计划「P3 需等 P5/P7 交付 HMS-over-SPI」的依赖假设与代码不符**（读码早已存在但 dormant），**真正阻塞是 catalog 模型错配 + gate 关闭**。verdict `hmsMetadataOverSpiReady=false`（high confidence，2 路对抗验证一致）。已记 **DV-005**，并同步 PROGRESS / connectors/hudi。
 
-- **T08** `PhysicalPlanTranslator`：删 `instanceof TrinoConnectorExternalTable` scan 分支 + 2 import（`PluginDrivenExternalTable` SPI 前置分支接管）。
-- **T09** `CatalogFactory`：删 `case "trino-connector"` + import。
-- **T10**：删 `datasource/trinoconnector/` 整目录（10 文件）+ 删 legacy 测试 `TrinoConnectorPredicateTest`。
-- **DV-001（HANDOFF 原计划漏项，recon 补回）**：`ExternalCatalog.java:948` `case TRINO_CONNECTOR` 改返 `PluginDrivenExternalDatabase`（照搬已迁移的 JDBC case，line 936）+ 删 import。
-- **有意保留**：`MetastoreProperties.Type.TRINO_CONNECTOR` + `TrinoConnectorPropertiesFactory`（属性子系统，不引用被删目录，SPI 路径可能仍需）；`InitCatalogLog.Type.TRINO_CONNECTOR` + `TableType.TRINO_CONNECTOR_EXTERNAL_TABLE` 枚举（image compat）；`GsonUtils` 3 个 label redirect（批 B 已处理，T10 **不碰** GsonUtils）。
-- 守门：fe-core `clean test-compile`（main+test）BUILD SUCCESS、checkstyle 0、fe-connector import-gate SUCCESS。
+### 3. 第二轮 scan/split recon + 定 hybrid 策略 + 建 tasks/P3
 
-### 批 E — T11 单测（commit `9bba12a44b2`，3 文件 / +441）
-
-3 个 JUnit5（Jupiter）纯转换器测试，**29 测试全绿**，checkstyle 0，本地 `mvn -pl fe-connector/fe-connector-trino -am test` 可跑：
-- `TrinoPredicateConverterTest`（14）— `ConnectorExpression` pushdown → Trino `TupleDomain`（EQ/range/NE/IN/NOT IN/IS [NOT] NULL/AND/OR、Slice 编码、null/unsupported 优雅降级到 `all()`）。
-- `TrinoTypeMappingTest`（11）— Trino type → Doris `ConnectorType`（标量、decimal 精度/scale、timestamp 精度 clamp 到 6、array/map/struct、unknown 抛错）。
-- `TrinoConnectorProviderTest`（4）— `validateProperties` 缺/空 `trino.connector.name` fail-fast（批 A T01）。
-- **DV-002**：fe-connector-trino 无 Mockito、`TrinoJsonSerializer` 非纯单元（需 plugin 的 HandleResolver+TypeRegistry）→ 砍 json/schema，用 `validateProperties` 替补第 3 类；plugin 依赖路径由现有 `external_table_p0/p2` trino_connector regression 套件覆盖。
-
-### T13 — 跟踪文档同步（本次提交）
-
-PROGRESS / tasks/P2 / connectors/trino-connector.md / deviations-log（DV-001..004）/ 本 HANDOFF 全部翻到 P2 完成态。
+第二轮 recon（scan/split 路径，verified）确认**混合 COW-native/MOR-JNI 不是问题**、plumbing 正确（详见关键认知 1b）。基于两轮 recon，用户拍板 **hybrid 策略**（记 **D-019**）：现做 (b) 连接器硬化+测试（behind 关闭的 gate，零 live-path 风险），推迟 (a) 模型落地+cutover 到 hive/HMS migration。已建 [`tasks/P3-hudi-migration.md`](./tasks/P3-hudi-migration.md)（hybrid 范围 + 批 A–E + file:line 锚点），批 A 待启动。
 
 ---
 
 ## 🚧 未完成 / 待办
 
-1. **PR 未开 —— 阻塞于分支基线错位（用户处理）**。`catalog-spi-03` 现基于**新 master**（含 `#63823 split fe-sql-parser`、`#64016 TLS` 等 master-only commit），而远端 `apache/doris:branch-catalog-spi` 仍停在 P1 merge `778c5dd610f`（旧 master 基线）；两者分叉于 `68d4eb308e5`（#63552）。`git rev-list --count upstream-apache/branch-catalog-spi..HEAD` = **191**（仅顶部 7 个是 P2）。**直接开 `catalog-spi-03 → branch-catalog-spi` 会是 191-commit 的错误巨型 PR**。等用户对齐分支后再开。
-2. **T12 回归测试推迟**（DV-003）——`trino_connector_migration_compat`（CREATE CATALOG→image→重启读回 + 旧 image 含 `TRINO_CONNECTOR` 枚举反序列化），需有 Trino plugin + docker/集群的环境。
+1. **P3 Hudi 批 A 待启动**——策略已定 **hybrid**（[D-019](./decisions-log.md)），已建 [`tasks/P3`](./tasks/P3-hudi-migration.md)。下一 session 第一件事见下（批 A T02 起）。批 E（live cutover/模型落地）deferred 到 hive/HMS migration。
+2. **T12 回归测试推迟**（DV-003）——`trino_connector_migration_compat`（CREATE CATALOG→image→重启读回 + 旧 image 含 `TRINO_CONNECTOR` 枚举反序列化），需有 Trino plugin + docker/集群环境。
+3. **DV-001 后续**：评估 `MetastoreProperties.Type.TRINO_CONNECTOR` + `TrinoConnectorPropertiesFactory` 是否真被 SPI 路径使用（纯死代码可清）。
+4. **DV-004 后续**：trino-connector 用户向安装文档在 doris-website 仓补（不在本仓）。
 
 ---
 
 ## ⚠️ 关键认知 / 临时发现
 
-1. **rebase 后 fe-core 编译坑（非代码问题）**：本场最大时间消耗。rebase 拉入 `#63823`（nereids 语法从 fe-core 拆到新模块 `fe-sql-parser`）后，`fe-core/target/generated-sources/.../DorisParser.java` 旧生成物残留（git 不管 target/），FQCN 撞名盖过 fe-sql-parser 依赖里的新版 → `LogicalPlanBuilder` 报 `cannot find symbol HOT()/expression()`。**修法：`clean` fe-core**（旧生成物删除、fe-core 已无 grammar 不会再生成）。只 clean fe-sql-parser 不够。任何 rebase 后遇此症状先 clean fe-core，别当代码 bug 查。
-2. **`MetastoreProperties` trino 条目有意保留**：它在 `property/metastore/` 子系统、不引用被删目录、删之不影响编译，但 SPI 建 catalog 可能仍走它解析属性。批 D 不动它；是否死代码留待后续评估（DV-001 后续动作）。
-3. **docs-next 不在本代码仓**：用户向文档在 doris-website 仓（DV-004）。本仓只有 `docs/`。
-4. （沿用）`tools/check-connector-imports.sh` import gate：fe-core 不能 import `org.apache.doris.connector.*`。
-5. （沿用）P1 fallback：`PhysicalPlanTranslator` 里其余 6 个连接器的 instanceof 分支待 P3-P7 各自迁完时删；本场只清了 trino 那一支（T08）。
+### 1. 【P3 核心】HMS-over-SPI「读码已存在但 dormant」；真正阻塞是 catalog 模型错配（DV-005，verified high-confidence）
+
+recon（8 agent，读真实方法体 + 2 路对抗验证）的关键事实：
+
+- **读码早已存在且非 stub**（在 `branch-catalog-spi` HEAD，源自更早的 #62183/#62821，一直 dormant 在 gate 后）：
+  - `fe-connector-hms` = 共享 **HMS Thrift 客户端库**（`HmsClient`/`ThriftHmsClient`，**不是** ConnectorMetadata）。
+  - `fe-connector-hive` = `HiveConnectorMetadata`(type `"hms"`)，真实读路径 + applyFilter 真分区裁剪。
+  - `fe-connector-hudi` = `HudiConnectorMetadata`(type `"hudi"`)，从 Hudi Avro MetaClient 读 schema（HMS fallback），COW/MOR 探测，`HudiScanPlanProvider` 快照扫描规划。
+  - D-005 区分符 `ConnectorTableSchema.tableFormatType` 已存在并被各连接器写入。
+- **但全部未接线（zero live caller）**：`CatalogFactory.SPI_READY_TYPES = {jdbc, es, trino-connector}`（`CatalogFactory.java:52`）不含 hms/hudi → 任何 HMS 系 catalog 永远走 legacy `HMSExternalCatalog`，不进 SPI。
+- **真正阻塞 = catalog 模型错配（架构级，用户/设计决策）**：现存连接器注册的是**独立 `"hudi"` catalog type**（`HudiConnectorProvider.getType()=="hudi"`），而 Doris 真实模型是 hudi **寄生**在 `"hms"` catalog 内、以 `HMSExternalTable.DLAType.HUDI` 暴露；fe-core **没有 `"hudi"` catalog type**，且 `PluginDrivenExternalTable` **从不消费** `tableFormatType`（只读 `getColumns()`，按 catalog TYPE 字串路由）。即单个 `"hms"` 连接器**没有 per-table HUDI/HIVE/ICEBERG 分流的 SPI 机制**。
+- **其他确认缺口**：增量读无 SPI 表示（P1-T04 的 `visitPhysicalHudiScan` SPI 分支丢弃 `getIncrementalRelation()`；MVCC trio 未实现；4 个 `*IncrementalRelation` 仍在 fe-core）；hive/hudi 未 override `listPartitions*`（Hudi applyFilter 列全部分区**不做**约束裁剪，Hive applyFilter **做** EQ/IN 裁剪）；三个连接器模块**零测试**。
+- **已验证非阻塞**：SPI scan/split **通用链路**（`PluginDrivenScanNode.planScan` → BE）已被合入的 trino-connector 走通；**hudi-specific** 的「单 ScanNode 混合 COW-native + MOR-JNI 每-split 格式」正确性才是待验证项。
+
+**→ catalog 模型决策【已定 2026-06-04 = hybrid，[D-019](./decisions-log.md)】**：现做 (b)（批 A–D，behind gate，零 live 风险），推迟 (a)（批 E，并入 hive/HMS migration）。原选项供回溯：
+
+- **(a) hms-first**：把 `HiveConnectorProvider(type="hms")` 接入 `PluginDrivenExternalCatalog` + fe-core 消费 `tableFormatType` 分流，hudi 作薄增量。一次命中真正架构阻塞、契合现存 `type="hms"` 设计；但把 P7(hive/HMS) 范围拉进 P3、触碰 **live 重度使用的 HMS 路径**、零测试网，回归风险大。
+- **(b) gate 后建脚手架**：先做 format-dispatch / 增量 SPI hook / MVCC + 补测试（design+stub，**不动 live 路径，零回归**）；但 hudi 不会单独端到端可用，推迟模型决策。
+- **(c) 直接 flip gate** —— **否决**（模型错配下 `"hudi"` provider 不可达；把 live hms catalog 推到未测 SPI；增量丢失；高回归）。
+- 对抗验证的 framing nit：**不要**在备忘里预设「推荐 (a)」——(a) 让 P3 依赖完成 P7 模型迁移、且在零测试的 live 路径上，是大而易回归的首交付；把 (a)/(b) 留给用户真实选择。
+
+### 1b. 【P3 scan 侧】scan/split 路径 recon 完成（verified；mixed-format 是非问题，parity gap 多数可在 SPI 层修）
+
+第二个 recon（4 reader + synthesis + 2 对抗验证，verdict `spiHudiCanReachBeModuloGate=false`——false **只因 gate/模型未解，不是 plumbing 问题**）：
+
+- **✅ 混合 COW-native + MOR-JNI 不是问题（之前最担心的点，已排除）**：单 `PluginDrivenScanNode` 能正确服务混合格式。node 级 `getFileFormatType()` 只是**默认种子**；真正生效的是 **per-range** `TFileRangeDesc.format_type`（`PlanNodes.thrift:566`），node 级 `TFileScanRangeParams.format_type`（:469）已标 **deprecated**。BE `file_scanner.h:291-295` per-range 优先于 node 级，且**每 range 新建 reader**（`_get_next_reader`），FORMAT_JNI+hudi→HudiJniReader / PARQUET/ORC→native。`HudiScanRange.populateRangeParams`(160-176) 自做 JNI→native 降级，与 legacy `HudiScanNode.setScanParams`(263-276) **逐行等价**。两路对抗验证确认，其中一路尝试 refute 失败。
+- **parity gap（FE 侧数据/特性缺口，多数可在 SPI surface 内修，不动 fe-core）**：
+  - **HIGH ① schema_id / history_schema_info 全缺**：legacy 每个 native split 设 `THudiFileDesc.schema_id` + `params.history_schema_info`；SPI 都没设 → BE 退化为**列名匹配**（`table_schema_change_helper.h:219-236`），重命名/schema-evolution/大小写不一致的列返 null/错列（**退化非崩溃**）。可经现有 SPI hook `ConnectorScanPlanProvider.populateScanLevelParams`（Paimon/ES 已 override，hudi 没）+ 在 `HudiScanRange` 设 schema_id 修复，**无需 fe-core 改动**。
+  - **HIGH ② column_types 双 bug**（对抗验证从 MEDIUM 升级）：(a) 用 `ConnectorType.getTypeName()` 返裸 `"DECIMAL"`/`"STRUCT"`，**丢精度/scale/子类型**（legacy 发 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 把 column_names/types/delta_logs 用**逗号 join 再 split**，而 Hive 类型串本身含逗号 → decimal/复杂类型元素被**打碎**、names 与 types 长度错位。命中**任何含 decimal/复杂列的 MOR-with-logs JNI split**。修：发完整 Hive 类型串 + 改 typed list 端到端（停止逗号 join/split）。
+  - **HIGH ③ time-travel 静默返最新**：snapshot 传到 node（`PhysicalPlanTranslator:835 setQueryTableSnapshot`）但 `HudiTableHandle` 无 snapshot 字段、`HudiScanPlanProvider` 永远用 `timeline.lastInstant` → `FOR TIME AS OF` 静默返最新。修：透传 snapshot，否则 fail-loud。
+  - **HIGH ④ 增量读无 SPI 表示**（代码已 defer）：失败模式未验证，**必须 fail-loud 而非静默全扫**。
+  - **MEDIUM**：MOR node（node=JNI）下 per-range 降级的 native split 继承 node 级 JNI location-props——很可能 parity（native reader 按 resolved format 派发、直接读 schema_id），但是唯一需 runtime 验证项。
+  - **LOW**：`forceJniScanner` 被忽略；runtime-filter 分区裁剪值缺；limit pushdown 被丢（4-arg vs 5-arg planScan，perf 非正确性）；`nested_fields` 两路都没设（at parity）。
+- **仍 false 的原因**：gate（`SPI_READY_TYPES` 不含 hms/hudi）+ 关键认知 1 的 catalog 模型错配。**scan plumbing 正确是必要非充分。**
+- **对 a/b 的影响**：scan 侧 HIGH 修复项（①schema_id/history、②column_types、④增量 fail-loud）**与模型选择无关、多数在 SPI surface 内可修**——正是选项 (b) 的高价值内容；无论 a/b 都要做。
+
+### 2.（沿用）rebase 后 fe-core 编译坑：stale `DorisParser`
+
+rebase 拉入 #63823（nereids 语法拆到 `fe-sql-parser`）后，`fe-core/target/generated-sources/.../DorisParser.java` 旧生成物残留导致 `LogicalPlanBuilder` 报 cannot find symbol。**修法：clean fe-core**（不是 fe-sql-parser）。任何 rebase 后遇此先 clean，别当代码 bug 查。
+
+### 3.（沿用）P1 fallback `instanceof` 分支
+
+`PhysicalPlanTranslator` 里其余连接器的 `instanceof` 分支待各自 P 阶段迁完再删；本场未动。hudi 的 `visitPhysicalHudiScan` 已有 SPI 分支（P1-T04）但 incrementalRelation 缺口见关键认知 1。**不要乱碰 hudi 之外的连接器分支。**
+
+### 4.（沿用）import gate
+
+`tools/check-connector-imports.sh`：fe-core 不能 import `org.apache.doris.connector.*`。
+
+### 5.（沿用）docs-next 不在本仓（DV-004）
+
+用户向文档在 doris-website 仓；本仓只有 `docs/`。
 
 ---
 
-## 🎯 下一个 session 第一件事
+## 🎯 下一个 session 第一件事（P3 Hudi）
 
 ```
 1. 自检：
-   git branch --show-current → catalog-spi-03
-   git log --oneline -8 → 顶层应是 9bba12a44b2 (T11) → ed81a063fe8 (T08-T10)
-                          → 0fe4b8a93d6 (T07) → 5e504a24883 (doc) → 9ed33f9a7a5 (批 B)
-                          → 69203b6418e (批 A) → 8f0b749bd06 (recon) → 3adabcaf54b (P1)
-   git status → 干净（本次文档 commit 之后）
+   git branch --show-current → branch-catalog-spi
+   git log --oneline -3 → 0793f032662 (P2 #64096) → 2b1a3bb2197 (P1 #63641) → 72d6d0109b9 (P0 #63582)
+   git status → clean（除 .audit-scratch/ conf.cmy/ 等本地未跟踪物）
+   Read plan-doc/tasks/P3-hudi-migration.md（hybrid 范围 + 批 A–E + file:line 锚点）
 
-2. 解决 PR base（核心待办）：
-   - git fetch upstream-apache branch-catalog-spi
-   - 确认 branch-catalog-spi 是否仍停在 778c5dd610f（P1）。
-   - 推荐做法：从远端 branch-catalog-spi 拉新分支（如 catalog-spi-03-pr），
-     cherry-pick 这 7 个 P2 commit（8f0b749bd06 recon → 69203b6418e A → 9ed33f9a7a5 B
-     → 5e504a24883 doc → 0fe4b8a93d6 C → ed81a063fe8 D → 9bba12a44b2 E）。
-     注意：branch-catalog-spi 没有 fe-sql-parser 拆分（#63823），但我们的改动与之正交，
-     cherry-pick 后应能编译；在该分支上重跑 fe-core compile + fe-connector-trino test 验证。
-   - 或：等 branch-catalog-spi 被刷新到 master 后直接用 catalog-spi-03。
-   - PR：gh pr create --repo apache/doris --base branch-catalog-spi --head morningman:<分支>
-     --title "[feat](connector) P2 trino-connector migration"
+2. 从 branch-catalog-spi 切 P3 工作分支（catalog-spi-04 / catalog-spi-p3-hudi）。
 
-3. T12 回归测试：在有 Trino plugin + docker/集群环境补（DV-003）。
+3. 启动【批 A】（全部 behind 关闭的 gate，零 live-path 风险；不要碰 SPI_READY_TYPES、不删 legacy）。
+   第一个 task = P3-T02（column_types 双 bug）：
+   - 读 fe-connector-hudi: HudiScanPlanProvider.java（getScanNodeProperties / collectMorSplits 塞 column_types 处）
+            HudiScanRange.java（~89/92/95 逗号 join、~194/199/202 split）
+            HudiTypeMapping.java（fromAvroSchema().getTypeName() —— 丢精度/子类型）
+     对照 fe-core legacy HudiUtils.convertAvroToHiveType（发完整 Hive 类型串）
+   - 关键：先读 BE hudi_jni_reader.cpp 确认 JNI scanner 期望的精确串格式（names ',' / types '#'），再改
+   - 改：发完整 Hive 类型串（decimal(10,2)/struct<...>）+ 停止逗号 join/split（typed list 端到端）+ 单测
 
-4. 之后启动 P3 Hudi 迁移（见 00-master-plan / connectors/hudi.md）。
-   注意 P1-T4 incrementalRelation 是 P3 Hudi SPI 缺口。
+4. 批 A 续：P3-T03（schema_id/history —— override populateScanLevelParams，无需动 fe-core）
+            → P3-T04（time-travel/增量 fail-loud）。
+   再 批 B（T05 partition 裁剪 / T06 MVCC）→ 批 C（T07 测试基线 + parity）→ 批 D（T08 dispatch 设计 design-only）。
+
+5. 守门 / 构建（每 task）：
+   mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false
+   （cwd=fe/ 或 -f fe/pom.xml）；fe-connector 编译 + checkstyle 0 + import-gate 通过；
+   rebase 后 fe-core 编译失败先 clean fe-core（关键认知 2）。
+
+6. 文档同步（每 task）：tasks/P3 状态 + PROGRESS §三 + connectors/hudi（playbook §5.1）。
+
+7. 批 E（T09–T11，deferred）不在本阶段编码——并入 hive/HMS migration（D-019）。
+   T12（trino 回归，DV-003）在有集群/plugin 环境补。
 ```
 
 ---
 
-## 📋 P2 commit 节奏（branch `catalog-spi-03`，rebase 到新 master 后）
+## 📂 P3 关键文件锚点（recon 已定位，附 file:line）
 
 ```
-9bba12a44b2  [test](connector) [P2-T11] add fe-connector-trino unit tests              ← 批 E
-ed81a063fe8  [refactor](connector) [P2-T08-T10] remove legacy trino-connector code      ← 批 D
-0fe4b8a93d6  [feat](connector) [P2-T07] enable trino-connector in SPI_READY_TYPES        ← 批 C
-5e504a24883  [doc](connector) refresh P2 HANDOFF for batch C kickoff
-9ed33f9a7a5  [feat](connector) [P2-T03-T06] bridge trino-connector through fe-core       ← 批 B
-69203b6418e  [feat](connector) [P2-T01-T02] complete trino-connector SPI surface         ← 批 A
-8f0b749bd06  [doc](connector) P2 trino-connector recon + task breakdown                  ← 批 0
-3adabcaf54b  [P1-T03-T05] route plugin-driven scans first (#63641)                       ← P1（rebase 后新 hash）
-```
-
-本次文档 commit（T13）将追加一条 `[doc](connector) [P2-T13] sync P2 tracking docs`。
-
-> ⚠️ 这 7 个 P2 commit 是干净的；问题只在 base（见 §未完成 1）。PR 不要在 base 对齐前开。
-
----
-
-## 📂 本场修改 / 新增的关键文件
-
-```
-批 C (0fe4b8a93d6):  fe-core/.../datasource/CatalogFactory.java (SPI_READY_TYPES)
-批 D (ed81a063fe8):  fe-core/.../nereids/glue/translator/PhysicalPlanTranslator.java (删 trino 分支+import)
-                     fe-core/.../datasource/CatalogFactory.java (删 case+import)
-                     fe-core/.../datasource/ExternalCatalog.java (TRINO_CONNECTOR db→PluginDrivenExternalDatabase, DV-001)
-                     删 fe-core/.../datasource/trinoconnector/ (10 文件)
-                     删 fe-core/src/test/.../trinoconnector/TrinoConnectorPredicateTest.java
-批 E (9bba12a44b2):  新建 fe-connector/fe-connector-trino/src/test/.../trino/
-                       TrinoPredicateConverterTest.java / TrinoTypeMappingTest.java / TrinoConnectorProviderTest.java
-T13:                 plan-doc/{PROGRESS, tasks/P2, connectors/trino-connector, deviations-log, HANDOFF}.md
+gate:          fe-core/.../datasource/CatalogFactory.java:52  (SPI_READY_TYPES，不含 hms/hudi)
+legacy 模型:   fe-core/.../datasource/hive/HMSExternalTable.java:208-210 (DLAType enum),
+                 250-281 / 297-306 (HUDI 探测), 722-759 (initHudiSchema 走 legacy)
+               fe-core/.../datasource/hive/HMSExternalCatalog.java:52 (extends ExternalCatalog，非 PluginDriven)
+               fe-core/.../datasource/hive/HudiDlaTable.java (dlaType=HUDI 表对象，在 hive/ 不在 hudi/)
+relation 分流: fe-core/.../nereids/rules/analysis/BindRelation.java:483-548
+                 (HMS_EXTERNAL_TABLE + dlaType==HUDI → LogicalHudiScan)
+scan 桥:       fe-core/.../nereids/glue/translator/PhysicalPlanTranslator.java:828-854
+                 (SPI 分支 828-838 丢 incrementalRelation；legacy 分支 840-854 传)
+legacy hudi:   fe-core/.../datasource/hudi/  15 文件 ~2403 LOC（top 9 + source/ 6），
+                 含 4 个 *IncrementalRelation + HudiScanNode(614 LOC)；live caller 仅 7 个 fe-core 文件，零测试
+SPI 已存在:    fe-connector/fe-connector-hms/  (HmsClient/ThriftHmsClient 客户端库，非 ConnectorMetadata)
+               fe-connector/fe-connector-hive/HiveConnectorMetadata.java  (type "hms")
+               fe-connector/fe-connector-hudi/HudiConnectorMetadata.java  (type "hudi")
+                 + HudiConnector(自建 ThriftHmsClient) + HudiScanPlanProvider
+               fe-connector/fe-connector-api/ConnectorTableSchema.java:33/58
+                 (tableFormatType；fe-core 从不消费 schema 级区分符)
 ```
 
 ---
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **分支 `catalog-spi-03`** 现基于 master；**开 PR 前务必先解决 base 错位**（§未完成 1），否则会是 191-commit 错误 PR。
-- rebase 后 fe-core 编译失败先想到 **clean fe-core**（stale DorisParser），别查代码（§关键认知 1）。
-- commit message 沿用 `[feat|refactor|test|doc](connector) [P2-Tnn] ...`。
-- Maven：cwd=`fe/` 或 `-f fe/pom.xml`；`-pl fe-core -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`。
-- **不要乱碰 P1 fallback 中 trino 之外的连接器分支**。
-- 偏差先记 `deviations-log.md` 再改文档（本场 DV-001..004 已记）。
+- **P3 是架构决策先行**：先 recon scan 路径 + 写模型决策备忘 + 用户签字，**再**编码。别被「读码已存在」误导成「flip gate 就行」（DV-005 选项 c 已否决）。
+- 偏差先记 `deviations-log.md` 再改文档（本场记了 DV-005）。
+- commit message 沿用 `[feat|refactor|test|doc](connector) [P3-Tnn] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐，不再有 P2 那种错位）。
+- Maven：cwd=`fe/` 或 `-f fe/pom.xml`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`。rebase 后编译失败先 clean fe-core。
+- 不要乱碰 P1 fallback 中 hudi 之外的连接器 `instanceof` 分支。

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -9,8 +9,8 @@
 ## 📅 最后一次 handoff
 
 - **日期 / 时间**：2026-06-05
-- **本 session 主题**：**P3 批 C 编码完成**——T07 三模块测试基线（hms/hive 零→有；hudi 扩）+ COW/MOR schema parity（golden-value）落地；列名 casing gap-1 **当场修**（用户签字），Hudi meta-field gap-2 推迟批 E（[DV-008]）。
-- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`；P0→P1→P2→recon→批 A/B/C 之上）。工作树预期 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/`/`plan-doc/research/`/`regression-conf.bak`）。
+- **本 session 主题**：**P3 批 D 完成（T08，design-only）**——`tableFormatType` 分流消费设计备忘 + **[D-020]**（用户签字 M2=方案 B per-table SPI provider）。**P3 hybrid in-scope（批 A–D）全部完成**；剩批 E（live cutover）并入 P7。
+- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`）。工作树预期 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/`/`regression-conf.bak`；**`plan-doc/research/` 本 session 已纳入 git 跟踪**）。
 
 ---
 
@@ -18,44 +18,49 @@
 
 | Task | 结果 | commits |
 |---|---|---|
-| **P3-T07** 三模块测试基线 + COW/MOR parity | ✅ 三模块 59 测全绿（hudi 33 + hms 12 + hive 14）；checkstyle 0（含 test 源）+ import-gate 通过 | `435065f`(feat) + 本 doc commit |
+| **P3-T08** tableFormatType 分流消费设计备忘 | ✅ design-only（零代码）；产出设计备忘 + [D-020]（M2=方案 B）；核心拆解 M1⊥M2 | 本 doc commit |
 
-**净产出** = 三连接器模块测试网从 {hudi 19, hms 0, hive 0} → {hudi 33, hms 12, hive 14} + COW/MOR schema golden parity + 1 个正确性修（gap-1 列名 casing 对齐 legacy，gate 后硬化、零 live 风险、零回归）。**批 A+B+C 编码完成**。
+**净产出** = 设计备忘 `designs/P3-T08-tableformat-dispatch-design.md` + 决策 D-020 + 把上 session 的 recon 研究文件纳入跟踪。**P3 hybrid 全部 in-scope（批 A–D）完成**：2 正确性修（T02/T05）+ 2 fail-loud/决策（T04/T06）+ 测试网零→59 测（T07）+ 模型 dispatch 设计（T08/D-020）。
 
-**commit stack**（新→旧）：本 doc commit→`435065f`(T07 feat)→`04f6576`(批 B handoff)→`10b72d4`(T05)→`301fe38`(批 A handoff)→`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2)→`2b1a3bb`(P1)→`72d6d01`(P0)。
+**commit stack**（新→旧）：本 doc commit→`76586b2`(批 C handoff)→`435065f`(T07 feat)→`04f6576`(批 B handoff)→`10b72d4`(T05)→`301fe38`(批 A handoff)→`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2)→`2b1a3bb`(P1)→`72d6d01`(P0)。
 
 ---
 
-## 🚧 未完成 / 待办（下一 session = 批 D）
+## 🚧 未完成 / 待办（下一 session：三选一，待用户定）
 
-1. **P3-T08（批 D，下一 session 第一件事）**：`tableFormatType` 分流消费**设计备忘（design-only，零代码）**。写清 `PluginDrivenExternalTable` 如何按 `ConnectorTableSchema.tableFormatType`（现 fe-core **从不消费**）把一个 `"hms"` catalog 的 per-table 路由到 HUDI/HIVE/ICEBERG。**不实现 fe-core 消费**（那是批 E）。作为 (a) 落地入口设计，可催生 D-NNN。
-   - **已有素材**：`plan-doc/research/spi-multi-format-hms-catalog-analysis.md`（28KB，本地未跟踪——上一 session 起草的多格式 HMS catalog 分析；T08 设计的直接输入，**先读**，避免重复 recon）。
-2. **批 E（deferred，不在 P3 hybrid 编码）**：见下「批 E backlog」。
-3. （沿用）T05 regression 推迟批 E（gate 关端到端不可触达；翻闸后断言带分区谓词查询仅扫匹配分区，explain/profile 校 partition 数；precedent DV-003）。
+**P3 hybrid in-scope（批 A–D）已全部完成。** 没有"批 D 之后的批"——批 E 是 deferred、并入 P7。下一 session 是一个**分叉点**：
 
-### 批 E backlog（登记，不在 P3 编码）
+1. **开 P3 PR**（推荐先确认）：把 `catalog-spi-04` 的批 A–D 工作开 PR，base = `apache/doris:branch-catalog-spi`。**git/push/PR 只在用户明确要求时做**（本 session 未开）。P3 无独立"开 PR"task（不同于 P2-T13），需用户拍板是否现在开、是否等批 E。
+2. **批 E 并入 P7**（不在 P3 编码）：live cutover——见下「批 E backlog」。属 hive/HMS migration（P7 或专门子阶段），不在 P3 PR 内。
+3. **启 P4**（maxcompute）：若 P3 告一段落，按 master plan 进下一连接器。
+
+> ⚠️ 三选项**都不应**在 P3 分支内碰 `SPI_READY_TYPES` / fe-core 消费实现 / legacy `datasource/hudi/` / 非 hudi 连接器——皆批 E。
+
+### 批 E backlog（登记，不在 P3 编码；T08/D-020 已为其出设计）
+- **M1**（T08 设计）：fe-core `PluginDrivenExternalTable` 消费 `tableFormatType`——`PluginDrivenSchemaCacheValue` 缓存格式 + `getEngine/getEngineTableTypeName` per-table 化（opaque 串、热路径不读）。
+- **M2**（T08/D-020 设计）：新增 default `ConnectorMetadata.getScanPlanProvider(handle)` + fe-core `PluginDrivenScanNode.getSplits` 优先 per-table 回落 per-catalog + hms 网关按 `handle.getTableType()` 委派。
 - T03 schema_id/history 完整 field-id evolution（DV-006）
-- T05 `listPartitions*` override（DV-007）
-- T06 完整 MVCC（`HudiMvccSnapshot` + snapshot 透传 + 增量时序，DV-007）
-- T04 完整 snapshot 透传 + 增量 SPI
-- **T07 gap-2**：Hudi meta-field 纳入（SPI 无参 `getTableAvroSchema()` vs legacy `(true)`）真实 fixture 实证（DV-008）
-- **T07 gap-1 余项**：`ThriftHmsClient` 源头防御性降字（与 hive 共享，DV-008）
-- T09–T11（模型落地/gate flip/删 legacy/集群验证）；端到端/集群验证（含 COW/MOR schema vs live legacy、BE JNI parse parity）
+- T05 `listPartitions*` override（DV-007）；T06 完整 MVCC（DV-007）；T04 完整 snapshot 透传 + 增量 SPI
+- **T07 gap-2**：Hudi meta-field 纳入（`getTableAvroSchema()` 无参 vs legacy `(true)`）真实 fixture 实证（DV-008）；gap-1 余项 `ThriftHmsClient` 源头防御降字（DV-008）
+- T09–T11（模型落地/gate flip/删 legacy/集群验证）；Iceberg-on-hms 经 SPI 依赖 **P6** 补 `IcebergScanPlanProvider`（M3）；探测共享化消 drift（M5，P7）
+- 端到端/集群验证（COW/MOR schema vs live legacy、BE JNI parse parity、混合多格式 catalog）
 
 ---
 
 ## ⚠️ 关键认知 / 临时发现
 
-### 1.【批 C 已用，批 D/E 仍需】parity 可行性 = golden-value（无跨模块编译路径）
-- `fe-core` 只依赖 `fe-connector-api` + `fe-connector-spi`，**不依赖**具体 `-hudi`/`-hms`/`-hive` 模块；连接器模块不依赖 fe-core。import-gate（`tools/check-connector-imports.sh`）**只扫 `*/src/main/java`、只禁 connector→fe-core 单向**（test 目录豁免，但无编译路径仍使跨模块 parity 不可行）。
-- → 任何 legacy↔SPI parity 用 **golden 值**（注 legacy `file:line`）。测试栈 **JUnit5 only，无 mockito**，替身手写（`FakeHmsClient` 先例：`tableExists`/`getTable`/`listPartitionNames`/`getPartitions` 按需实现，其余 throw）。checkstyle **含 test 源**（`fe/pom.xml:162` `includeTestSourceDirectory=true`）、**禁 static import**（用 `Assertions.assertX`），且 **test 阶段不跑 checkstyle**，需单独 `mvn -pl <module> checkstyle:check`。
+### 1.【T08/D-020 新结论】keystone gap = M1（身份消费）⊥ M2（scan 路由），可分离
+- `tableFormatType` **产而不用**：`HiveConnectorMetadata.getTableSchema` 设了它，但 `PluginDrivenExternalTable.initSchema:79-109` **只读 `getColumns()`**、丢 `getTableFormatType()`（本 session firsthand 核读确认）。第二缺口：`getEngine:195-215`/`getEngineTableTypeName:217-231` switch **catalog type** 非 per-table format。
+- **M1**（fe-core 读格式做 per-table 引擎名/身份，**opaque 串、热路径不读**）在 A/B/C **三方案通用**；**M2**（单 hms connector 产 Hudi/Iceberg scan plan）才是 A/B/C 分歧处。→ keystone 可控化。
+- **M2 = 方案 B**（[D-020]，用户签字）：新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`（默认 null→回落 per-catalog `Connector.getScanPlanProvider()`），fe-core `PluginDrivenScanNode.getSplits` 优先 per-table、回落 per-catalog。前提：`ConnectorScanPlanProvider.planScan:62-66` 入参已带 per-table handle（本 session 核实）。**A 备选**（连接器内 router，零 SPI churn）；**C 否决**（fe-core 长格式分派，违瘦 fe-core）。
+- **D-020 细化 D-005**（非推翻）：tableFormatType 区分符沿用；D-005 的"fe-core→PhysicalXxxScan"措辞早于 P1 scan-node 统一，由 per-table provider seam 取代。**批 E 实现别按 D-005 旧措辞做 PhysicalXxxScan**。
 
-### 2.【批 C 关键结论】COW/MOR schema = type-agnostic
-- legacy `HMSExternalTable.initHudiSchema` 与 SPI `HudiConnectorMetadata.getTableSchema`→`avroSchemaToColumns` 都从**同一 avro schema** 推导列表，**零表型分支**。COW/MOR 区别**只在 scan planning**（`HudiScanNode.canUseNativeReader` / `HudiScanPlanProvider.planScan:92`：COW=base files native、MOR=merged slices + delta logs JNI）。→ schema parity 是 avro→column 的纯函数；表型只影响 `detectHudiTableType` + split 收集。
+### 2.【批 C 已用，批 E 仍需】parity 可行性 = golden-value（无跨模块编译路径）
+- `fe-core` 只依赖 `fe-connector-api` + `fe-connector-spi`，**不依赖**具体 `-hudi`/`-hms`/`-hive` 模块；连接器模块不依赖 fe-core。import-gate（`tools/check-connector-imports.sh`）**只扫 `*/src/main/java`、只禁 connector→fe-core 单向**（test 豁免，但无编译路径仍使跨模块 parity 不可行）。
+- → legacy↔SPI parity 用 **golden 值**（注 legacy `file:line`）。测试栈 **JUnit5 only，无 mockito**，替身手写（`FakeHmsClient` 先例）。checkstyle **含 test 源**（`fe/pom.xml:162`）、**禁 static import**（用 `Assertions.assertX`）、**test 阶段不跑 checkstyle** → 单独 `mvn -pl <module> checkstyle:check`。
 
-### 3.【批 D 直接相关】tableFormatType 模型（T08 设计目标）
-- hudi **无独立 catalog**：寄生 `HMSExternalTable.dlaType=HUDI`（D-005）。SPI 侧 `ConnectorTableSchema.tableFormatType`（`getTableSchema` 设 `"HUDI"`）是区分符，但 **fe-core 从不消费**。
-- T08 = 设计 `PluginDrivenExternalTable` 如何按 tableFormatType per-table 路由到 HUDI/HIVE/ICEBERG（**design-only，不动 fe-core live 路径**）。legacy 对照：`HMSExternalTable.dlaType` + `initSchema` 分流（`initHudiSchema`/`initIcebergSchema`/`initHiveSchema`）。素材 `research/spi-multi-format-hms-catalog-analysis.md`。
+### 3.【批 C 关键结论】COW/MOR schema = type-agnostic
+- legacy `HMSExternalTable.initHudiSchema` 与 SPI `HudiConnectorMetadata.getTableSchema`→`avroSchemaToColumns` 都从**同一 avro schema** 推导列表，**零表型分支**。COW/MOR 区别**只在 scan planning**（`HudiScanPlanProvider.planScan:92`：COW=base files native、MOR=merged slices + delta logs JNI）。→ schema parity 是 avro→column 纯函数；表型只影响 `detectHudiTableType` + split 收集。
 
 ### 4.（沿用）SPI 分区裁剪链路 + Hive parity 基准（T05）
 - `PluginDrivenScanNode.applyFilter`→`currentHandle`→`getSplits`→`HudiScanPlanProvider.resolvePartitions` 读 `getPrunedPartitionPaths()`。Hudi `applyFilter` 镜像 `HiveConnectorMetadata.applyFilter`（7 步 + 7 helper duplicate，hudi 仅依赖 fe-connector-hms）。
@@ -64,33 +69,30 @@
 - `THudiFileDesc.{delta_logs,column_names,column_types}` thrift `list<string>`；**BE 自做 join**：names `,` / types **`#`** / delta `,`（`hudi_jni_reader.cpp:52-54`）。FE 传 typed list、类型串用 Hive 串（`HudiTypeMapping.toHiveTypeString`，非 `getTypeName()`）。
 
 ### 6.（沿用）批 E 去向 + 沿用坑
-- T03（DV-006）/ T04 完整 snapshot+增量 / T06 完整 MVCC / T05 list* / T07 gap-2 + ThriftHmsClient 降字：见批 E backlog。
 - rebase 后 fe-core `target/generated-sources/.../DorisParser.java` 残留 → cannot find symbol：**clean fe-core**（非 fe-sql-parser），别当代码 bug 查。
 - `PhysicalPlanTranslator` 里 hudi **之外**的连接器 `instanceof` 分支待各自 P 阶段迁完再删，**本场只动 hudi**。
 - 用户向文档在 doris-website 仓（DV-004）。
+- connectors/hudi.md 的 §关联「偏差：（暂无）」是 pre-existing 陈旧（实际 DV-005..008 相关），本场未顺手改（surgical）；下次清 kanban 时一并修。
 
 ---
 
-## 🎯 下一个 session 第一件事（P3 批 D / T08）
+## 🎯 下一个 session 第一件事
 
 ```
 1. 自检：
    git branch --show-current → catalog-spi-04
-   git log --oneline -6 → <doc>(批 C handoff) 435065f(T07 feat) 04f6576(批 B handoff) 10b72d4(T05) 301fe38 2758cf9
-   git status → clean（除 .audit-scratch/ conf.cmy/ plan-doc/research/ regression-conf.bak）
-   Read plan-doc/tasks/P3-hudi-migration.md（批 D = T08）+ 本文件关键认知 3
+   git log --oneline -6 → <本 doc>(T08/D-020) 76586b2(批 C handoff) 435065f(T07 feat) 04f6576 10b72d4 301fe38
+   git status → clean（除 .audit-scratch/ conf.cmy/ regression-conf.bak；research/ 现已跟踪）
+   Read PROGRESS.md §一/§三 + 本文件关键认知 1（M1⊥M2 + D-020）
 
-2. 启动【批 D / T08】（design-only，不动 fe-core；零代码）：
-   先读 plan-doc/research/spi-multi-format-hms-catalog-analysis.md（已有 28KB 分析，直接输入）。
-   recon 锚点：
-     fe-core 不消费处: PluginDrivenExternalTable（getEngine/schema 路径）、ConnectorTableSchema.tableFormatType（getTableSchema 设但无消费方）
-     legacy 模型:      HMSExternalTable.dlaType（HIVE/HUDI/ICEBERG）+ initSchema 分流（initHudiSchema/initIcebergSchema/initHiveSchema）
-     decision:         D-005（DLA 用 tableFormatType）
-   产出 = 设计备忘 plan-doc/tasks/designs/P3-T08-tableformat-dispatch-design.md（不动 fe-core live 路径），可催生 D-NNN。
+2. 与用户确认分叉（本文件「未完成/待办」三选一）：
+   (1) 开 P3 PR（base apache/doris:branch-catalog-spi）——需用户明确要求才 push/开 PR
+   (2) 批 E 并入 P7（live cutover；T08/D-020 已出 M1+M2 设计）
+   (3) 启 P4（maxcompute）
+   → P3 内不碰 SPI_READY_TYPES / fe-core 消费实现 / legacy / 非 hudi 连接器（皆批 E）
 
-3. 文档同步（playbook §5.1 五步）：tasks/P3 状态 + phase log + PROGRESS §三/四 + connectors/hudi（+ 新 D-NNN 如有）。
-
-4. commit：`[doc](connector) [P3-T08] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐）。
+3. 若走 (2) 批 E：实现序见本文件「批 E backlog」M1→M2→M4→翻闸；
+   设计直接读 designs/P3-T08-tableformat-dispatch-design.md（M1+M2 + Implementation Plan + Open）。
 ```
 
 ---
@@ -105,12 +107,15 @@ T05（已修）:  HudiConnectorMetadata.applyFilter（7 步 + 7 helper）/ HudiP
 T06（决策）:  ConnectorMetadata MVCC 三 default / 无 override（opt-out）
 T07（已修）:  HudiConnectorMetadata.avroSchemaToColumns（顶层降字 + package-private static）
               测试: hudi HudiTypeMappingTest/HudiSchemaParityTest/HudiTableTypeTest；hms HmsTypeMappingTest；hive HiveFileFormatTest/HiveConnectorMetadataPartitionPruningTest
-              legacy 锚: HMSExternalTable.initHudiSchema:734-758 / HudiUtils.convertAvroToHiveType / fromAvroHudiTypeToDorisType
               设计: designs/P3-T07-test-baseline-design.md
-T08（批 D 下一步）: PluginDrivenExternalTable / ConnectorTableSchema.tableFormatType / HMSExternalTable.dlaType+initSchema 分流 / D-005
-              素材: plan-doc/research/spi-multi-format-hms-catalog-analysis.md（未跟踪）
+T08（本场，设计）: 设计 designs/P3-T08-tableformat-dispatch-design.md；决策 D-020
+   keystone:   PluginDrivenExternalTable.initSchema:79-109（只读 columns）/ getEngine:195-215 / getEngineTableTypeName:217-231（switch catalog type）
+   M2 seam:    ConnectorMetadata:37-44（加 default getScanPlanProvider(handle)）/ Connector.getScanPlanProvider:40-42（per-catalog 回落）
+               ConnectorScanPlanProvider.planScan:62-66（入参带 handle）/ PluginDrivenScanNode.getSplits（~356-378，fe-core 改动点，批 E）
+   载体:       ConnectorTableSchema.getTableFormatType:58-60
+   素材:       plan-doc/research/spi-multi-format-hms-catalog-analysis.md（本场已跟踪）
 gate:         CatalogFactory.java:52（SPI_READY_TYPES，不含 hms/hudi——别动）
-设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / T04 / T05 / T06 / T07
+设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / T04 / T05 / T06 / T07 / T08
 scratch:      .audit-scratch/p3-t0X-*.workflow.js（本地 workflow 脚本，未跟踪）
 ```
 
@@ -118,7 +123,8 @@ scratch:      .audit-scratch/p3-t0X-*.workflow.js（本地 workflow 脚本，未
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **批 D 是 design-only**（T08）：**不动 fe-core live 路径、不实现 tableFormatType 消费（批 E）、不碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器**。产出是设计备忘 + 可能的 D-NNN。
-- **先读 `research/spi-multi-format-hms-catalog-analysis.md`**（已有 28KB 分析，避免重复 recon）；recon 可用 workflow（参 `.audit-scratch/p3-t0X-recon.workflow.js` 模板）。
-- 偏差先记 `deviations-log.md` 再改文档；架构/可行性 fork 先问用户（本场 T07 casing/baseline 两 fork 已签字 → DV-008）。
-- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 单独跑**（含 test 源）；**禁 static import**（用 `Assertions.assertX`）。
+- **P3 hybrid 收尾**：批 A–D 已全部 in-scope 完成。下一步是**分叉决策**（PR / 批 E→P7 / P4），**先问用户**，别默认开 PR 或自动进 P4。
+- **批 E 实现按 T08 设计走**（M1⊥M2，M2=方案 B），**别按 D-005 旧"PhysicalXxxScan"措辞**（已被 D-020 supersede）。新 default 方法保持 D-009（不破签名）。
+- 偏差先记 `deviations-log.md` 再改文档；架构/可行性 fork 先问用户（本场 M2 方案 B 已签字 → D-020）。
+- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 单独跑**（含 test 源）；**禁 static import**。
+```

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -9,8 +9,8 @@
 ## 📅 最后一次 handoff
 
 - **日期 / 时间**：2026-06-05
-- **本 session 主题**：**P3 批 A 编码完成**——T02（column_types 双 bug）✅ + T04（time-travel/增量 fail-loud）✅ 落地；T03（schema_id/history）经 code-grounded recon 证非 model-agnostic SPI 修复，**推迟批 E**（[DV-006]，用户签字）。
-- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`；P0→P1→P2→recon(D-019) 之上）。工作树 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/` 等）。
+- **本 session 主题**：**P3 批 B 编码完成**——T05（applyFilter 真实 EQ/IN 分区裁剪，镜像 Hive）✅ 落地；T06（MVCC/snapshot SPI）经 code-grounded recon + 用户签字定为 **keep default opt-out（零代码）**；两处 scope 校正记 [DV-007]（T05 `listPartitions*` override 推迟批 E、T06 不抛异常 override）。
+- **分支**：`catalog-spi-04`（P3 工作分支，基于 `branch-catalog-spi`；P0→P1→P2→recon(D-019) 之上）。工作树 clean（仅本地未跟踪 `.audit-scratch/`/`conf.cmy/`/`regression-conf.bak`）。
 
 ---
 
@@ -18,74 +18,77 @@
 
 | Task | 结果 | commits |
 |---|---|---|
-| **P3-T02** column_types 双 bug | ✅ 修复 + 模块首批 11 单测全绿 + 3-lens 对抗 review 零确认缺陷 | `95f23e9`(code) `ac0dc7c`(doc) |
-| **P3-T03** schema_id/history_schema_info | 🟡 **推迟批 E**（[DV-006]）——recon 证：连接器缺 field-id/InternalSchema/type→thrift；裸基线 BE 走 `ConstNode`(大小写敏感) 弱于现状 `by_parquet_name` = 净回归 | `517c9cf`(DV-006+doc) |
-| **P3-T04** time-travel/增量 fail-loud | ✅ `visitPhysicalHudiScan` SPI 分支抛 `AnalysisException`；fe-core 编译+checkstyle 0 | `feceabb`(code) `2758cf9`(doc) |
+| **P3-T05** applyFilter EQ/IN 分区裁剪 | ✅ 镜像 Hive 7 步 + 7 helper；`HudiPartitionPruningTest` 8 测全绿（模块 19）；checkstyle 0 + import-gate 通过 | `10b72d4`(code) + 本 doc commit |
+| **P3-T06** MVCC/snapshot SPI | ✅ **keep default opt-out 决策**（[DV-007]，零代码）——recon 证抛异常 override 错（破 opt-out 约定/死代码/T04 已 fail-loud）；完整 MVCC→批 E | 本 doc commit（含 `designs/P3-T06-*` + DV-007）|
 
-**commit stack**（新→旧）：`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2 #64096)→`2b1a3bb`(P1 #63641)→`72d6d01`(P0 #63582)。
+**commit stack**（新→旧）：本 doc commit→`10b72d4`(T05)→`301fe38`(批 A handoff)→`2758cf9`(T04 doc)→`feceabb`(T04)→`517c9cf`(T03 defer)→`ac0dc7c`(T02 doc)→`95f23e9`(T02)→`9fcf21a`(recon/D-019)→`0793f03`(P2 #64096)→`2b1a3bb`(P1 #63641)→`72d6d01`(P0 #63582)。
 
-**批 A 净产出** = 2 个正确性修复（gate 后硬化，零 live 风险，零回归）+ 1 个 code-grounded 推迟决策。每 task 走 design 备忘（`tasks/designs/P3-T0X-*.md`）→ impl → build → commit → 5 步文档同步。
+**批 B 净产出** = 1 个正确性/性能修复（分区裁剪 + 修复"分区来源静默切换"，gate 后硬化，零 live 风险，零回归）+ 1 个 code-grounded 决策（MVCC opt-out）。**批 A+B 编码完成**。每 task 走 design 备忘（`tasks/designs/P3-T0X-*.md`）→ impl → build → commit → 5 步文档同步。
 
 ---
 
-## 🚧 未完成 / 待办（下一 session = 批 B）
+## 🚧 未完成 / 待办（下一 session = 批 C）
 
-1. **P3-T05（批 B，下一 session 第一件事）**：`listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` EQ/IN 分区裁剪。现状：Hudi `applyFilter` 列**全部**分区不裁剪（`HudiScanPlanProvider.resolvePartitions` 用 `handle.getPrunedPartitionPaths()`，但没人 set 它 → 永远 null → 列全部）；Hive 已做 EQ/IN。**对标** `HiveConnectorMetadata.applyFilter`。
-2. **P3-T06（批 B）**：MVCC/snapshot SPI。`HudiConnectorMetadata` 未 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`（默认 `Optional.empty()`=unsupported）。与 T04 关联：大概率**显式 unsupported**（与 T04 fail-loud 一致）即可，完整 MVCC 入批 E。
-3. **批 C**（T07）：三模块（hms/hive/hudi）测试基线 + COW/MOR parity 测试（SPI `HudiConnectorMetadata` schema/partition vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`）。注：T07 parity 也该覆盖 T02 的 column_names/types 列集合+顺序 vs legacy。
-4. **批 D**（T08）：`tableFormatType` 分流消费设计备忘（design-only，不动 fe-core）。
-5. **批 E（deferred，不在 P3 hybrid 编码）**：T03（schema_id/history 完整 field-id evolution）、T04 的完整 snapshot 透传+增量 SPI+MVCC、T09–T11（模型落地/gate flip/删 legacy/集群验证）。并入 hive/HMS migration。
-6. **T04 单测推迟批 E**（dormant 分支不可 exercise；regression 断言 `FOR TIME AS OF`/增量→报错；precedent DV-003）。
+1. **P3-T07（批 C，下一 session 第一件事）**：三模块（hms/hive/hudi）测试基线 + **COW/MOR parity 测试**。当前 fe-connector-hms/hive/hudi **零测试**（hudi 已有 `HudiTypeMappingTest`/`HudiScanRangeTest`/`HudiPartitionPruningTest` 3 个；hms/hive 仍零）。parity = SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`（fe-core），COW & MOR 各一。注：parity 也该覆盖 T02 的 column_names/types 列集合+顺序 vs legacy。**Rule 9：测意图**（type-string 编码、裁剪正确、列集合一致）。
+2. **批 D（T08）**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core**）。
+3. **批 E（deferred，不在 P3 hybrid 编码）**：T03（schema_id/history 完整 field-id evolution，DV-006）、T05 的 `listPartitions*` override（DV-007）、T06 的完整 MVCC（`HudiMvccSnapshot`+snapshot 透传+增量时序，DV-007）、T04 的完整 snapshot 透传+增量 SPI、T09–T11（模型落地/gate flip/删 legacy/集群验证）。并入 hive/HMS migration。
+4. **T05 regression 推迟批 E**（gate 关，端到端不可触达；批 E 翻闸后断言带分区谓词查询仅扫匹配分区，explain/profile 校 partition 数；precedent DV-003）。
 
 ---
 
 ## ⚠️ 关键认知 / 临时发现
 
-### 1.【批 A 已用】BE Hudi JNI column_types/names/delta 契约（T02 已修，code-grounded 两点确认）
-- `THudiFileDesc.{delta_logs,column_names,column_types}` 是 thrift `list<string>`；**BE 自做 join**：names `,` / types **`#`** / delta `,`（`be/src/format/table/hudi_jni_reader.cpp:52-54`），Java `HadoopHudiJniScanner.java` split 同（types `#`@:113 / names `,`@:212 / delta `,`@:106）。types 用 `#` 正因类型串含逗号（`decimal(10,2)`/`struct<...>`）。**FE 永远传 typed list、不 join/split**；类型串用 Hive 串（`HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），**不是** Doris `getTypeName()`。
+### 1.【批 B 已用】SPI 分区裁剪链路 + Hive 是 parity 基准（T05 已修）
+- **链路**（end-to-end，spi-invoke recon 确认正确）：`PluginDrivenScanNode.convertPredicate` 调 `metadata.applyFilter` → `currentHandle = result.getHandle()`（:293）→ `getSplits` 把 `currentHandle` 传 `scanProvider.planScan`（:371）→ `HudiScanPlanProvider.planScan` 调 `resolvePartitions`（:137）→ 读 `handle.getPrunedPartitionPaths()`（:287-289）。**plumbing 一直正确，缺的是 applyFilter 里的裁剪逻辑**。
+- **T05 修法**：`HudiConnectorMetadata.applyFilter` 忠实镜像 `HiveConnectorMetadata.applyFilter`（:193-234 + 7 helper：extractPartitionPredicates/extractPredicatesRecursive/extractColumnName/extractLiteralValue/prunePartitionNames/parsePartitionName/matchesPredicates）。**关键差异**：Hudi 保留 `List<String> prunedPartitionPaths`（resolvePartitions 喂路径给 FileSystemView，非 HmsPartitionInfo）；上限保留 `-1`（不静默截断，安全于 Hive 100000）。**只裁 EQ/IN over partition cols**，范围/非分区谓词不裁、`remaining=全表达式`交 BE 复评（不漏行）。
+- **`ConnectorFilterConstraint.getColumnDomains()` 在 fe-core 侧为空**（`PluginDrivenScanNode.buildFilterConstraint` 传 `Collections.emptyMap()`）→ 唯一可用谓词表示是 `getExpression()`（与 Hive 同）。
+- **helper duplicate 不共享**：fe-connector-hudi 仅依赖 fe-connector-hms（**不依赖 fe-connector-hive**，pom 确认）；连接器互 import metadata 类错误分层；import-gate 禁连接器 import fe-core。故复刻，待 P7 hive migration consolidate（同 T02 `toHiveTypeString` 先例）。
 
-### 2.【批 E 必读】T03 schema_id/history 为何不是 SPI-surface 可修（DV-006，code-grounded）
-- BE `table_schema_change_helper.h:219-267`：`history_schema_info` **unset** → `by_parquet_name`/`by_orc_name`（鲁棒名匹配，处理大小写/缺列）= **现状**；`current==file` schema_id → **`ConstNode`**(`:92-121`，**identity-by-name，大小写敏感**)；id 不同 → `by_table_field_id`（唯一 field-id evolution 路径）。
-- **裸基线 `current==file==-1`→ConstNode 弱于现状名匹配 = 净回归**。faithful 需：`HudiColumnHandle` 加 field id（现无）+ Hudi `InternalSchema` 版本（`getCommitInstantInternalSchema`）+ 连接器内 type→`TColumnType` thrift（legacy 在 fe-core `ExternalUtil`，import-gate 禁复用）。legacy hudi baseline = `ExternalUtil.initSchemaInfo(params,-1L,table.getColumns())`（`HudiScanNode:240`）+ native split per-commit `InternalSchema.schemaId()`。**「Paimon/ES 已 override hook 设 schema」前提失真**——其 override 为 predicate/docvalue。
-- **结论**：批 E 与 hive/HMS migration 一并建机制。
+### 2.【批 C 必读】SPI partition/MVCC 方法零 live caller（决定批 C 测什么、批 E 做什么）
+- **`listPartitions/listPartitionNames/listPartitionValues`（SPI）在 fe-core 零 live caller**：`PluginDrivenScanNode` 不调用（分区走 applyFilter 链路）；`ShowPartitionsCommand`/`HudiExternalMetaCache`/`MetadataGenerator` 调的是 **legacy** metastore 路径（`dorisTable.getRemoteName()`）非 SPI。Hive 基准**也不 override** 这三方法。→ T05 只做 applyFilter 裁剪，`listPartitions*` override 推迟批 E（fe-core 长出 SPI 消费 + `SHOW PARTITIONS` 改走 SPI 时）。
+- **MVCC 三方法（`beginQuerySnapshot/getSnapshotAt/getSnapshotById`）无 production caller**（仅 `ConnectorMvccSnapshotAdapter` 测试用）；全体连接器（Iceberg/Paimon/Hive/Trino）**无一 override**，default `Optional.empty()`=opt-out（`FakeConnectorPluginTest` 断言）。→ T06 保持 default + 文档化，**不新增抛异常 override**（会破约定 + 死代码；T04 已在 time-travel fail-loud）。
 
-### 3.【批 E 必读】T04 fail-loud 位置 + 完整实现去向
-- 守卫在 `PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支（`:828-841` 附近）——**唯一**同时可见 `getTableSnapshot()` + `getIncrementalRelation()` 处（SPI surface 拿不到 incremental；`IncrementalRelation` 是 fe-core 概念，4 个 `*IncrementalRelation` 仍在 fe-core）。完整：snapshot 透传到 `HudiScanPlanProvider.planScan`（现永远用 `timeline.lastInstant()`@`:103`）+ 增量 SPI 表示 + MVCC（T06）。
+### 3.【沿用】BE Hudi JNI column_types/names/delta 契约（T02）
+- `THudiFileDesc.{delta_logs,column_names,column_types}` thrift `list<string>`；**BE 自做 join**：names `,` / types **`#`** / delta `,`（`hudi_jni_reader.cpp:52-54`），Java `HadoopHudiJniScanner` split 同。**FE 永远传 typed list、不 join/split**；类型串用 Hive 串（`HudiTypeMapping.toHiveTypeString`），**不是** `getTypeName()`。
 
-### 4.（沿用）rebase 后 fe-core 编译坑：stale `DorisParser`
-- rebase 拉入 nereids 语法拆分后，`fe-core/target/generated-sources/.../DorisParser.java` 残留导致 cannot find symbol。**修法：clean fe-core**（不是 fe-sql-parser），别当代码 bug 查。
+### 4.【沿用】T03 schema_id/history 为何批 E（DV-006）
+- BE `table_schema_change_helper.h:219-267`：`history_schema_info` unset → `by_parquet_name`（鲁棒名匹配）= 现状；裸 `current==file==-1`→`ConstNode`(大小写敏感) **弱于**现状 = 净回归。faithful 需连接器 field-id + Hudi `InternalSchema` + type→thrift（现无），批 E 与 hive/HMS 一并建。
 
-### 5.（沿用）import gate + P1 fallback + docs-next
-- `tools/check-connector-imports.sh`：fe-core 不能 import `org.apache.doris.connector.*`；连接器模块不能 import fe-core `org.apache.doris.(catalog|common|datasource|qe|analysis|nereids|planner)`。
-- `PhysicalPlanTranslator` 里 hudi **之外**的连接器 `instanceof` 分支待各自 P 阶段迁完再删，**本场只动了 hudi 的 SPI 分支**，别乱碰其他。
+### 5.【沿用】T04 fail-loud + 完整实现去向
+- 守卫在 `PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支（唯一同时可见 snapshot+incremental 处）。完整 snapshot 透传 + 增量 SPI + MVCC 入批 E。
+
+### 6.（沿用）rebase 后 fe-core 编译坑 + import gate + docs-next
+- rebase 后 `fe-core/target/generated-sources/.../DorisParser.java` 残留 → cannot find symbol。**修法：clean fe-core**（非 fe-sql-parser），别当代码 bug 查。
+- `tools/check-connector-imports.sh`：双向 import 守门（fe-core ↔ connector）。
+- `PhysicalPlanTranslator` 里 hudi **之外**的连接器 `instanceof` 分支待各自 P 阶段迁完再删，**本场只动 hudi 的 SPI 路径**，别乱碰其他。
 - 用户向文档在 doris-website 仓（DV-004），本仓只有 `docs/`。
 
 ---
 
-## 🎯 下一个 session 第一件事（P3 批 B / T05）
+## 🎯 下一个 session 第一件事（P3 批 C / T07）
 
 ```
 1. 自检：
    git branch --show-current → catalog-spi-04
-   git log --oneline -6 → 2758cf9(T04 doc) feceabb(T04) 517c9cf(T03 defer) ac0dc7c(T02 doc) 95f23e9(T02) 9fcf21a(recon)
+   git log --oneline -6 → <doc commit>(批 B handoff) 10b72d4(T05) 301fe38(批 A handoff) 2758cf9(T04 doc) feceabb(T04) 517c9cf(T03 defer)
    git status → clean（除 .audit-scratch/ conf.cmy/ regression-conf.bak）
-   Read plan-doc/tasks/P3-hudi-migration.md（批 B = T05/T06）+ 本文件关键认知
+   Read plan-doc/tasks/P3-hudi-migration.md（批 C = T07）+ 本文件关键认知 2/3
 
-2. 启动【批 B / T05】（仍 behind 关闭的 gate，零 live 风险）：listPartitions override + 真实 applyFilter EQ/IN 裁剪。
+2. 启动【批 C / T07】（仍 behind 关闭的 gate，零 live 风险）：三模块测试基线 + COW/MOR parity。
    recon 锚点：
-     fe-connector-hudi: HudiScanPlanProvider.resolvePartitions(:284-312)（用 handle.getPrunedPartitionPaths，永远 null）
-                        HudiConnectorMetadata（看有无 applyFilter；listPartitions* 默认空）
-                        HudiTableHandle（prunedPartitionPaths 字段 + toBuilder）
-     对标 fe-connector-hive: HiveConnectorMetadata.applyFilter（真 EQ/IN 分区裁剪——recon DV-005 已确认 Hive 做、Hudi 不做）
-     SPI: ConnectorMetadata.applyFilter / listPartitions* 签名（fe-connector-api）
-   先 recon（可用 workflow，参 .audit-scratch/p3-t03-recon.workflow.js 模板）→ 设计备忘 → 实现 → 单测 → 守门。
+     legacy parity 源: fe-core HiveMetaStoreClientHelper.getHudiTableSchema / HMSExternalTable.initHudiSchema(~722-759)
+     SPI 被测: HudiConnectorMetadata.getTableSchema / getColumnHandles / applyFilter（已有 3 测试类可扩展）
+     hms/hive 模块: 当前零测试——补 metadata/schema 单测基线
+   先 recon（可用 workflow，参 .audit-scratch/p3-t0X-recon.workflow.js 模板）→ 设计备忘 → 实现 → 单测 → 守门。
+   注意：parity 测试可能需 mock/fake HMS（HmsClient 是 8 方法 interface，可手写替身——见 HudiPartitionPruningTest.FakeHmsClient 先例）；
+        legacy 侧在 fe-core，import-gate 禁连接器直接调——parity 比对可能需在 fe-core test 或用固定 golden 值。
 
 3. 守门 / 构建（每 task）：
-   mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false
-   （cwd=fe/）；checkstyle 0 + import-gate 通过。**注意 Doris checkstyle 禁 static import**（用 `Assertions.assertX`，非 `import static`）。
-   若改 fe-core：mvn -pl fe-core -am compile（大；rebase 后失败先 clean fe-core）。
+   mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false（cwd=fe/）
+   checkstyle: mvn -pl <module> checkstyle:check（test 阶段不跑 checkstyle！需单独跑）+ import-gate（bash tools/check-connector-imports.sh）。
+   **Doris checkstyle 禁 static import**（用 Assertions.assertX）。HmsClient 有 9 方法（含 getDatabase + Closeable.close）。
 
-4. 文档同步（每 task，playbook §5.1 五步）：tasks/P3 状态+phase log + PROGRESS §一/三/四 + connectors/hudi（+ 新 DV/D 如有）。
+4. 文档同步（每 task，playbook §5.1 五步）：tasks/P3 状态+phase log + PROGRESS §一/三/四/六 + connectors/hudi（+ 新 DV/D 如有）。
 
 5. commit：`[feat|doc](connector) [P3-Tnn] ...`；PR base = `apache/doris:branch-catalog-spi`（base 已对齐）。
 ```
@@ -95,28 +98,28 @@
 ## 📂 P3 关键文件锚点
 
 ```
-T02（已修）:  fe-connector-hudi/HudiTypeMapping.java（toHiveTypeString）
-              HudiScanPlanProvider.java:118-120（用 toHiveTypeString）
-              HudiScanRange.java（typed list 字段 + populateRangeParams 直接 set）
-              BE: hudi_jni_reader.cpp:52-54 / be-java-extensions/.../HadoopHudiJniScanner.java:106/113/212
-T03（批 E）:  ExternalUtil.initSchemaInfo（fe-core:86-92）/ HudiScanNode:240,288-324（per-split schema_id）
-              BE: table_schema_change_helper.h:219-267（ConstNode vs by_parquet_name vs by_table_field_id）
-              HudiColumnHandle（无 field id）/ ConnectorScanPlanProvider.populateScanLevelParams（hook，:162-165）
-T04（已修）:  PhysicalPlanTranslator.visitPhysicalHudiScan SPI 分支（:828-841 附近，两守卫）
-T05（批 B 下一步）: HudiScanPlanProvider.resolvePartitions / HudiConnectorMetadata / HudiTableHandle.prunedPartitionPaths
-              对标 HiveConnectorMetadata.applyFilter
+T02（已修）:  fe-connector-hudi/HudiTypeMapping.toHiveTypeString / HudiScanPlanProvider:118-120 / HudiScanRange（typed list）
+              BE: hudi_jni_reader.cpp:52-54 / HadoopHudiJniScanner.java:106/113/212
+T03（批 E）:  ExternalUtil.initSchemaInfo / HudiScanNode:240,288-324 / BE table_schema_change_helper.h:219-267 / HudiColumnHandle（无 field id）
+T04（已修）:  PhysicalPlanTranslator.visitPhysicalHudiScan SPI 分支（两守卫）
+T05（已修）:  HudiConnectorMetadata.applyFilter（:144-209，7 步 + 7 helper）/ HudiTableHandle.prunedPartitionPaths
+              对标 HiveConnectorMetadata.applyFilter:193-234 + helpers / 链路 PluginDrivenScanNode:289-293,371 → HudiScanPlanProvider.resolvePartitions:287-289
+              测试: HudiPartitionPruningTest（FakeHmsClient 替身先例）
+T06（决策）:  ConnectorMetadata.java:60-77（MVCC 三 default）/ designs/P3-T06-mvcc-design.md / 无 override（opt-out）
+T07（批 C 下一步）: fe-core HiveMetaStoreClientHelper.getHudiTableSchema / HMSExternalTable.initHudiSchema
+              SPI HudiConnectorMetadata.getTableSchema/getColumnHandles；hms/hive 模块零测试待补
 gate:         CatalogFactory.java:52（SPI_READY_TYPES，不含 hms/hudi——别动）
-设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / P3-T04-*.md
-scratch:      .audit-scratch/p3-t02-review.workflow.js / p3-t03-recon.workflow.js（本地 workflow 脚本，未跟踪）
+设计备忘:     plan-doc/tasks/designs/P3-T02-*.md / T04 / T05 / T06
+scratch:      .audit-scratch/p3-t0X-*.workflow.js（本地 workflow 脚本，未跟踪）
 ```
 
 ---
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **批 B 仍是 model-agnostic SPI 硬化**（gate 关，零 live 风险）；不要碰 `SPI_READY_TYPES`、不删 legacy、不动 hudi 之外的连接器 `instanceof` 分支。
-- **T05 先确认 SPI applyFilter 链路**：`ConnectorMetadata.applyFilter` 回传裁剪后的 handle（带 prunedPartitionPaths）→ `HudiScanPlanProvider.resolvePartitions` 已会消费它。对标 Hive 的真实 EQ/IN 裁剪。
-- **T06 大概率显式 unsupported**（与 T04 一致），别在批 B 做完整 MVCC（入批 E）。
-- 偏差先记 `deviations-log.md`（本场记了 DV-006）再改文档；架构/可行性 fork 先问用户（本场 T03 已问并签字）。
-- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 禁 static import**。
+- **批 C 仍是 model-agnostic SPI 硬化/测试网**（gate 关，零 live 风险）；不要碰 `SPI_READY_TYPES`、不删 legacy、不动 hudi 之外的连接器 `instanceof` 分支。
+- **批 C 的难点是 parity 比对的可行性**：legacy 在 fe-core、SPI 在连接器模块、import-gate 隔离。先 recon 确认怎么拿 legacy 输出（fe-core test？golden 值？）再设计，别假设能直接跨模块调。
+- **测试基准**：hudi 模块已有 3 测试类 + FakeHmsClient 先例（`HmsClient` 8 方法 interface + close 易 fake）；hms/hive 模块零测试，先补 metadata 单测基线。
+- 偏差先记 `deviations-log.md`（本场记 DV-007）再改文档；架构/可行性 fork 先问用户（本场 T05 list*/T06 MVCC 两 fork 已问并签字）。
+- Maven：cwd=`fe/`；`-pl <module> -am`；`-Dmaven.build.cache.enabled=false`；测试 `-DfailIfNoTests=false`；**checkstyle 单独跑**（test 阶段不触发）；**禁 static import**。
 ```

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-06-04** | 当前阶段：**P2 trino-connector 代码完成**（T07–T11,T13 ✅；T12 推迟）；PR 待开（分支基线对齐中） | 项目总进度：**30%**
+> 最后更新：**2026-06-04** | 当前阶段：**P2 已合入 `branch-catalog-spi`（#64096）；P3 Hudi 启动 recon 完成，待 catalog 模型决策（DV-005）** | 项目总进度：**32%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -11,8 +11,8 @@
 |---|---|---|---|---|---|
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
-| **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 代码完成（T01-T11,T13；T12 推迟；PR 待开） | [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
+| **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▱▱▱▱▱▱▱▱▱ 5% | 🚧 hybrid（D-019）；批 A 待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -32,7 +32,7 @@
 | **jdbc** | ✅ | ✅ 100% | ✅ | 🟡 (13 个旧 client，P1 删) | n/a | **95%** | [详情](./connectors/jdbc.md) |
 | **es** | ✅ | ✅ 100% | ✅ | ✅ | ✅ | **100%** | [详情](./connectors/es.md) |
 | trino-connector | ✅ | ✅ 100% | ✅ | ✅ | ✅ | **100%** | [详情](./connectors/trino-connector.md) |
-| hudi | 🟡 | 🟨 50% | ❌ | ❌ | 0/0（寄生 hive） | **20%** | [详情](./connectors/hudi.md) |
+| hudi | 🟡（D-005；模型待定 DV-005）| 🟨 50%（读路径已存在但 dormant）| ❌（gate 关）| ❌ | 0/0（寄生 hms）| **20%** | [详情](./connectors/hudi.md) |
 | maxcompute | 🟡 | 🟨 60% | ❌ | ❌ | 0/12 | **25%** | [详情](./connectors/maxcompute.md) |
 | paimon | 🟡 | 🟨 50% | ❌ | ❌ | 0/10 | **20%** | [详情](./connectors/paimon.md) |
 | iceberg | 🟡 | 🟥 10% | ❌ | ❌ | 0/19 | **5%** | [详情](./connectors/iceberg.md) |
@@ -44,7 +44,21 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P2 — trino-connector 迁移（🚧 进行中）
+### P3 — hudi 迁移（🚧 hybrid 启动，批 A 待开工）
+
+> 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
+
+| 项 | 状态 | 备注 |
+|---|---|---|
+| HMS-over-SPI recon（#1 元数据 + #2 scan/split）| ✅ | code-grounded + 对抗验证；verdict `hmsMetadataOverSpiReady=false`（DV-005）|
+| catalog 模型决策（a/b/c）| ✅ hybrid（D-019）| 现做 (b)，推迟 (a)；真阻塞=独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`、fe-core 不消费 `tableFormatType` |
+| SPI scan/split 路径 recon | ✅ | **混合 COW-native/MOR-JNI 不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader；2 路对抗验证）；plumbing 正确但 verdict 仍 false（gate/模型未解）|
+| scan 侧 parity 修复（HIGH，多数 SPI 内可修）| ⏳ | ①schema_id/history 缺→退化名匹配 ②column_types 双 bug（丢精度+逗号破坏 decimal/复杂类型）③time-travel 静默返最新 ④增量读须 fail-loud；详见 [HANDOFF](./HANDOFF.md) 1b |
+| 增量读 SPI hook / MVCC | ⏳ | P1-T04 incrementalRelation gap；4 个 `*IncrementalRelation` 仍在 fe-core |
+| listPartitions override + 真实裁剪 | ⏳ | Hudi applyFilter 现列全部分区不裁剪 |
+| 三连接器模块测试 | ⏳ | fe-connector-hms/hive/hudi 当前零测试 |
+
+### P2 — trino-connector 迁移（✅ 已合入 #64096）
 | ID | Task | 批次 | Owner | 状态 | 启动 | 备注 |
 |---|---|---|---|---|---|---|
 | P2-T01 | `TrinoConnectorProvider.validateProperties` + `TrinoDorisConnector.preCreateValidation` | 批 A | @me | ✅ | 2026-05-25 | required-property check + preCreateValidation 触发 plugin loading；+20 LOC |
@@ -59,7 +73,7 @@
 | P2-T10 | 删 `datasource/trinoconnector/` 整目录 + legacy test | 批 D | @me | ✅ | 2026-06-04 | commit `ed81a063fe8`；GsonUtils 不碰（批 B 已处理）；+ExternalCatalog db case（DV-001）|
 | P2-T11 | fe-connector-trino 单元测试 | 批 E | @me | ✅ | 2026-06-04 | commit `9bba12a44b2`；3 类/29 测试；无 mock，json/schema 砍（DV-002）|
 | P2-T12 | regression-test `trino_connector_migration_compat`（image 兼容） | 批 E | @me | 🟡 | — | **推迟**（无集群/plugin；DV-003）|
-| P2-T13 | 同步跟踪文档 + 开 PR | 批 E | @me | ✅ | 2026-06-04 | 文档已同步；docs-next 不在本仓（DV-004）；**PR 待开**（分支对齐）|
+| P2-T13 | 同步跟踪文档 + 开 PR | 批 E | @me | ✅ | 2026-06-04 | 文档已同步；docs-next 不在本仓（DV-004）；**已合入 #64096**（squash `0793f032662`）|
 
 详细任务说明、阶段日志见 [tasks/P2-trino-connector-migration.md](./tasks/P2-trino-connector-migration.md)
 
@@ -113,6 +127,9 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-04** ✅ **P3 scan/split recon + 定 hybrid（D-019）+ 建 tasks/P3**：第二轮 recon（scan/split 路径，verified）——单 `PluginDrivenScanNode` 混合 COW-native/MOR-JNI **不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader）；plumbing 正确，剩 model-agnostic 正确性 gap（schema_id/history 缺、column_types 双 bug、time-travel 静默返最新、增量无表示、partition 裁剪缺、三模块零测试）。用户定 **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate，零 live 风险），推迟 (a) 模型落地+cutover 到 hive/HMS migration。已建 [tasks/P3](./tasks/P3-hudi-migration.md)，批 A 待启动
+- **2026-06-04** ✅ **P2 已合入 `branch-catalog-spi`**（#64096，squash `0793f032662`，叠在 P1 `2b1a3bb2197` / P0 `72d6d0109b9` 上）。旧「PR base 错位（191-commit）」阻塞消失——`branch-catalog-spi` 已重建到新 master（P0/P1 hash 随之更新）。P2 除 T12（回归，DV-003）外全部完成
+- **2026-06-04** 🚧 **P3 Hudi 启动 recon**（8-agent code-grounded workflow + 2 路对抗验证，verdict `hmsMetadataOverSpiReady=false` / high）：原计划「P3 需等 P5/P7 交付 HMS-over-SPI」与代码**不符**——HMS-over-SPI 读码（`fe-connector-hms` 客户端库 + `HiveConnectorMetadata`(type "hms") + `HudiConnectorMetadata`(type "hudi") + `ConnectorTableSchema.tableFormatType` 区分符）**早已存在但 dormant**（`SPI_READY_TYPES={jdbc,es,trino-connector}` 不含 hms/hudi，零 live caller，走 legacy `HMSExternalCatalog`）。**真正阻塞=catalog 模型错配**（独立 `"hudi"` catalog type vs Doris 真实的「寄生 `"hms"` 内以 `DLAType.HUDI` 暴露」；fe-core 不消费 `tableFormatType`）+ 增量读无 SPI 表示（P1-T04 gap）+ 三模块零测试。已验证非阻塞：SPI scan/split 通用链路被合入的 trino-connector 走通。记 **DV-005**；下一步=recon scan 路径 + 写 catalog 模型决策备忘（a/b；c 否决）+ 用户签字后编码
 - **2026-06-04** ✅ **P2 批 C+D+E 完成**（T07–T11,T13；T12 推迟；PR 待开）：批 C T07 翻闸（`0fe4b8a93d6`）；批 D 删 fe-core legacy trino 代码 14 文件 / −2508（`ed81a063fe8`，含 recon 补回的 `ExternalCatalog` db-case DV-001，保留 MetastoreProperties / 两个 image-compat 枚举 / GsonUtils redirect）；批 E T11 加 3 个纯转换器 JUnit5 测试 29 个全绿（`9bba12a44b2`，无 mock，DV-002）。T12 推迟（无集群/plugin，DV-003）；T13 文档同步本条。**rebase 构建坑**：fe-core 因 stale 生成的 `DorisParser`（grammar 随 #63823 拆到 `fe-sql-parser`）编译失败，clean fe-core 即解。**PR 待开**——`catalog-spi-03` 现基于 master、与 `branch-catalog-spi`（仍 P1，分叉于 #63552）错位（191-commit），分支对齐由用户处理
 - **2026-05-25（晚 ④）** ✅ **P2 批 B 完成**（T03+T04+T05+T06 fe-core 桥接）：recon 揭示 HANDOFF 三处描述误差并校正——(1) T03 不能"只加 redirect 不删旧"，必须 atomic replace 否则 `RuntimeTypeAdapterFactory.labelToSubtype` 撞名抛 IAE → FE 起不来；(2) T05 是 duplicate of T03，没有独立的 `ExternalCatalog.registerCompatibleSubtype` API；(3) T04 `name().toLowerCase()` 不通用——`Type.TRINO_CONNECTOR.name().toLowerCase()` 出 "trino_connector" 但 CatalogFactory 期望 "trino-connector"，新增 `legacyLogTypeToCatalogType` helper 做显式 case 映射；(4) T06 `TRINO_CONNECTOR_EXTERNAL_TABLE.toEngineName()` 返 null（switch 没 case，legacy 也是 null），保留此行为不修。3 files / +29 LOC 全在 fe-core。守门：fe-core compile + checkstyle + import gate 全绿。**重要**：批 B 后到批 C T07 翻闸前，新建 trino 目录无法序列化（registerSubtype 已删但 CatalogFactory 仍走 legacy）；不要在中间状态部署
 - **2026-05-25（晚 ③）** ✅ **P2 批 A 完成**（T01+T02 fe-connector-trino SPI 补齐）：`TrinoConnectorProvider.validateProperties` 校验 `trino.connector.name` 必填；`TrinoDorisConnector.preCreateValidation` 在 CREATE CATALOG 时触发 `ensureInitialized()` 完成 plugin 加载 + connector factory 解析，把延迟到首次查询的失败前移到 catalog 创建期。`TrinoConnectorDorisMetadata.applyFilter / applyProjection` 桥接 Trino 原生 push-down：复用现有 `TrinoPredicateConverter` 把 `ConnectorExpression` 转 `TupleDomain<ColumnHandle>`，调 Trino `metadata.applyFilter / applyProjection`，把回来的 trino-side `ConnectorTableHandle` 包成新的 `TrinoTableHandle`（保留 column maps）；`remainingFilter` 保守返回原表达式，匹配 legacy fe-core 行为（BE 端继续 re-evaluate）。+143 LOC 跨 3 文件，全部 `fe-connector-trino` 侧（**未触碰 fe-core**，严格守批 A 边界）；import gate + compile + checkstyle 全绿。单元测试推迟到 P2-T11 批 E 一起做
@@ -155,8 +172,8 @@
 
 | 类型 | 总数 | 最新条目 | 文档 |
 |---|---|---|---|
-| **决策**（D-NNN） | 18 | D-018（U6: ConnectorColumnStatistics 类型契约） | [decisions-log.md](./decisions-log.md) |
-| **偏差**（DV-NNN） | 0 | — | [deviations-log.md](./deviations-log.md) |
+| **决策**（D-NNN） | 19 | D-019（P3 hudi hybrid 推进策略）| [decisions-log.md](./decisions-log.md) |
+| **偏差**（DV-NNN） | 5 | DV-005（P3 HMS-over-SPI 依赖与代码不符；真阻塞=catalog 模型错配）| [deviations-log.md](./deviations-log.md) |
 | **风险**（R-NNN） | 14 | R-014（thrift sink 选择灵活性） | [risks.md](./risks.md) |
 
 ---
@@ -165,9 +182,9 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：P2 批 C（T07 翻闸 `0fe4b8a93d6`）+ 批 D（T08-T10 删 legacy `ed81a063fe8`）+ 批 E（T11 单测 `9bba12a44b2`）+ T13 文档同步。T12 推迟。本地 fe-core + fe-connector-trino 全绿（compile / test-compile / checkstyle / import-gate）。DV-001..004 已记
-- **下一个 session 应做**：(1) 解决 PR base 错位——`catalog-spi-03` 现基于 master，需从远端 `branch-catalog-spi` 拉新分支 cherry-pick 7 个 P2 commit 后开 PR；(2) T12 回归测试在有集群/plugin 的环境补；(3) 之后启动 P3 Hudi 迁移
-- **是否需要 handoff**：**是**——用户准备开新 session 跑批 C；本场已 rewrite [HANDOFF.md](./HANDOFF.md)（含 batch B→C regression window 警告 + T07/T08/T09/T10 详细 step-by-step）
+- **本 session 已完成**：确认 P2 已合入 `branch-catalog-spi`（#64096）；P3 Hudi 启动 recon（8-agent code-grounded workflow + 对抗验证）；记 DV-005；同步 HANDOFF / PROGRESS / deviations-log / connectors/hudi
+- **下一个 session 应做**：(1) 从 `branch-catalog-spi` 切 P3 工作分支；(2) recon SPI scan/split 路径（recon 唯一留白）；(3) 写 catalog 模型决策备忘（a/b；c 否决）交用户签字；(4) 签字后建 `tasks/P3-hudi-migration.md` 编码。**不要在签字前编码，更不要直接 flip `SPI_READY_TYPES`**
+- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（P3 起点 step-by-step + 模型决策选项 + file:line 锚点 + 沿用的 clean-fe-core / import-gate 认知）
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 
 ---

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -12,7 +12,7 @@
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
 | **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▰▱▱▱▱▱▱▱▱▱ 5% | 🚧 hybrid（D-019）；批 A 待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▱▱▱▱▱▱▱▱▱ 10% | 🚧 hybrid（D-019）；批 A 进行中（T02 ✅）| [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -44,7 +44,7 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P3 — hudi 迁移（🚧 hybrid 启动，批 A 待开工）
+### P3 — hudi 迁移（🚧 hybrid，批 A 进行中：T02 ✅）
 
 > 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
 
@@ -53,7 +53,7 @@
 | HMS-over-SPI recon（#1 元数据 + #2 scan/split）| ✅ | code-grounded + 对抗验证；verdict `hmsMetadataOverSpiReady=false`（DV-005）|
 | catalog 模型决策（a/b/c）| ✅ hybrid（D-019）| 现做 (b)，推迟 (a)；真阻塞=独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`、fe-core 不消费 `tableFormatType` |
 | SPI scan/split 路径 recon | ✅ | **混合 COW-native/MOR-JNI 不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader；2 路对抗验证）；plumbing 正确但 verdict 仍 false（gate/模型未解）|
-| scan 侧 parity 修复（HIGH，多数 SPI 内可修）| ⏳ | ①schema_id/history 缺→退化名匹配 ②column_types 双 bug（丢精度+逗号破坏 decimal/复杂类型）③time-travel 静默返最新 ④增量读须 fail-loud；详见 [HANDOFF](./HANDOFF.md) 1b |
+| scan 侧 parity 修复（HIGH，多数 SPI 内可修）| 🚧 | **②✅ column_types 双 bug（T02 `95f23e9`）**：发完整 Hive 类型串 + 弃逗号 join/split。余 ①schema_id/history（T03）③time-travel 静默返最新（T04）④增量读 fail-loud（T04）；详见 [HANDOFF](./HANDOFF.md) 1b |
 | 增量读 SPI hook / MVCC | ⏳ | P1-T04 incrementalRelation gap；4 个 `*IncrementalRelation` 仍在 fe-core |
 | listPartitions override + 真实裁剪 | ⏳ | Hudi applyFilter 现列全部分区不裁剪 |
 | 三连接器模块测试 | ⏳ | fe-connector-hms/hive/hudi 当前零测试 |
@@ -127,6 +127,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-04** ✅ **P3-T02（批 A 启动）column_types 双 bug 修复**（commit `95f23e9`）：硬化 dormant SPI hudi 连接器（gate 关，零 live caller）。(a) `HudiScanPlanProvider` 改发完整 **Hive 类型串**（新 `HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），不再用 `getTypeName()` 发 Doris 裸类型名（丢精度/scale/子类型）；(b) `HudiScanRange` 改 typed `List<String>` 直接设 thrift `list<string>`，弃逗号 join/split（曾打碎 `decimal(10,2)`/`struct<...>`），BE 自做 join（types `#` / names,delta `,`），与 Java `HadoopHudiJniScanner` split 契约一致（两点对抗确认）。建模块**首批**测试 11 个全绿；checkstyle 0 + import-gate 通过；3 路对抗 review 零确认缺陷。设计见 `tasks/designs/P3-T02-column-types-design.md`
 - **2026-06-04** ✅ **P3 scan/split recon + 定 hybrid（D-019）+ 建 tasks/P3**：第二轮 recon（scan/split 路径，verified）——单 `PluginDrivenScanNode` 混合 COW-native/MOR-JNI **不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader）；plumbing 正确，剩 model-agnostic 正确性 gap（schema_id/history 缺、column_types 双 bug、time-travel 静默返最新、增量无表示、partition 裁剪缺、三模块零测试）。用户定 **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate，零 live 风险），推迟 (a) 模型落地+cutover 到 hive/HMS migration。已建 [tasks/P3](./tasks/P3-hudi-migration.md)，批 A 待启动
 - **2026-06-04** ✅ **P2 已合入 `branch-catalog-spi`**（#64096，squash `0793f032662`，叠在 P1 `2b1a3bb2197` / P0 `72d6d0109b9` 上）。旧「PR base 错位（191-commit）」阻塞消失——`branch-catalog-spi` 已重建到新 master（P0/P1 hash 随之更新）。P2 除 T12（回归，DV-003）外全部完成
 - **2026-06-04** 🚧 **P3 Hudi 启动 recon**（8-agent code-grounded workflow + 2 路对抗验证，verdict `hmsMetadataOverSpiReady=false` / high）：原计划「P3 需等 P5/P7 交付 HMS-over-SPI」与代码**不符**——HMS-over-SPI 读码（`fe-connector-hms` 客户端库 + `HiveConnectorMetadata`(type "hms") + `HudiConnectorMetadata`(type "hudi") + `ConnectorTableSchema.tableFormatType` 区分符）**早已存在但 dormant**（`SPI_READY_TYPES={jdbc,es,trino-connector}` 不含 hms/hudi，零 live caller，走 legacy `HMSExternalCatalog`）。**真正阻塞=catalog 模型错配**（独立 `"hudi"` catalog type vs Doris 真实的「寄生 `"hms"` 内以 `DLAType.HUDI` 暴露」；fe-core 不消费 `tableFormatType`）+ 增量读无 SPI 表示（P1-T04 gap）+ 三模块零测试。已验证非阻塞：SPI scan/split 通用链路被合入的 trino-connector 走通。记 **DV-005**；下一步=recon scan 路径 + 写 catalog 模型决策备忘（a/b；c 否决）+ 用户签字后编码

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -12,7 +12,7 @@
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
 | **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▰▱▱▱▱▱▱▱▱▱ 10% | 🚧 hybrid（D-019）；批 A 进行中（T02 ✅）| [tasks/P3](./tasks/P3-hudi-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▰▱▱▱▱▱▱▱▱ 20% | 🚧 hybrid（D-019）；**批 A 编码完成**（T02 ✅ T04 ✅；T03→批 E）；批 B 待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -44,7 +44,7 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P3 — hudi 迁移（🚧 hybrid，批 A 进行中：T02 ✅）
+### P3 — hudi 迁移（🚧 hybrid，批 A 编码完成：T02 ✅ T04 ✅；T03→批 E；批 B 待启动）
 
 > 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
 
@@ -53,7 +53,7 @@
 | HMS-over-SPI recon（#1 元数据 + #2 scan/split）| ✅ | code-grounded + 对抗验证；verdict `hmsMetadataOverSpiReady=false`（DV-005）|
 | catalog 模型决策（a/b/c）| ✅ hybrid（D-019）| 现做 (b)，推迟 (a)；真阻塞=独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`、fe-core 不消费 `tableFormatType` |
 | SPI scan/split 路径 recon | ✅ | **混合 COW-native/MOR-JNI 不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader；2 路对抗验证）；plumbing 正确但 verdict 仍 false（gate/模型未解）|
-| scan 侧 parity 修复（HIGH）| 🚧 | **②✅ column_types 双 bug（T02 `95f23e9`）**。**①schema_id/history 推迟批 E（[DV-006]）**——非 model-agnostic SPI 修复（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）。余 ③time-travel 静默返最新（T04）④增量读 fail-loud（T04）；详见 [HANDOFF](./HANDOFF.md) 1b |
+| scan 侧 parity 修复（HIGH）| ✅ 批 A 范围 | **②✅ column_types（T02 `95f23e9`）**；**③④✅ time-travel/增量 fail-loud（T04 `feceabb`）**——`visitPhysicalHudiScan` SPI 分支抛 `AnalysisException`（不再静默）。**①schema_id/history 推迟批 E（[DV-006]）**（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）；详见 [HANDOFF](./HANDOFF.md) 1b |
 | 增量读 SPI hook / MVCC | ⏳ | P1-T04 incrementalRelation gap；4 个 `*IncrementalRelation` 仍在 fe-core |
 | listPartitions override + 真实裁剪 | ⏳ | Hudi applyFilter 现列全部分区不裁剪 |
 | 三连接器模块测试 | ⏳ | fe-connector-hms/hive/hudi 当前零测试 |
@@ -127,6 +127,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-05** ✅ **P3-T04 time-travel/增量读 fail-loud**（commit `feceabb`，批 A 编码收尾）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支对 `FOR TIME/VERSION AS OF`（曾静默返最新——provider 永远读 `lastInstant`）与增量读（曾静默全扫——SPI 无表示）抛 `AnalysisException`。唯一同时可见 snapshot+incremental 处。fe-core 编译 + checkstyle 0；dormant 分支 gate 关时不可达=零 live 风险；单测推迟批 E（不可 exercise，R12 显式登记）。**批 A 编码完成**：T02 + T04 两个正确性修复落地，T03 推迟批 E（DV-006）
 - **2026-06-05** 🟡 **P3-T03 推迟批 E**（[DV-006]，用户签字）：code-grounded recon（4-reader workflow + 主线核读 BE `table_schema_change_helper.h`）揭示 schema_id/history_schema_info **不是** 批 A 可做的 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override hook（设 schema）」前提失真（其 override 为 predicate/docvalue）；裸 `current==file==-1`→BE `ConstNode`(identity,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 = 净回归。faithful field-id evolution parity 与 hive/HMS migration 一并入批 E。批 A 保持现状名匹配（零回归），直进 T04
 - **2026-06-04** ✅ **P3-T02（批 A 启动）column_types 双 bug 修复**（commit `95f23e9`）：硬化 dormant SPI hudi 连接器（gate 关，零 live caller）。(a) `HudiScanPlanProvider` 改发完整 **Hive 类型串**（新 `HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），不再用 `getTypeName()` 发 Doris 裸类型名（丢精度/scale/子类型）；(b) `HudiScanRange` 改 typed `List<String>` 直接设 thrift `list<string>`，弃逗号 join/split（曾打碎 `decimal(10,2)`/`struct<...>`），BE 自做 join（types `#` / names,delta `,`），与 Java `HadoopHudiJniScanner` split 契约一致（两点对抗确认）。建模块**首批**测试 11 个全绿；checkstyle 0 + import-gate 通过；3 路对抗 review 零确认缺陷。设计见 `tasks/designs/P3-T02-column-types-design.md`
 - **2026-06-04** ✅ **P3 scan/split recon + 定 hybrid（D-019）+ 建 tasks/P3**：第二轮 recon（scan/split 路径，verified）——单 `PluginDrivenScanNode` 混合 COW-native/MOR-JNI **不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader）；plumbing 正确，剩 model-agnostic 正确性 gap（schema_id/history 缺、column_types 双 bug、time-travel 静默返最新、增量无表示、partition 裁剪缺、三模块零测试）。用户定 **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate，零 live 风险），推迟 (a) 模型落地+cutover 到 hive/HMS migration。已建 [tasks/P3](./tasks/P3-hudi-migration.md)，批 A 待启动

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -53,7 +53,7 @@
 | HMS-over-SPI recon（#1 元数据 + #2 scan/split）| ✅ | code-grounded + 对抗验证；verdict `hmsMetadataOverSpiReady=false`（DV-005）|
 | catalog 模型决策（a/b/c）| ✅ hybrid（D-019）| 现做 (b)，推迟 (a)；真阻塞=独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`、fe-core 不消费 `tableFormatType` |
 | SPI scan/split 路径 recon | ✅ | **混合 COW-native/MOR-JNI 不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader；2 路对抗验证）；plumbing 正确但 verdict 仍 false（gate/模型未解）|
-| scan 侧 parity 修复（HIGH，多数 SPI 内可修）| 🚧 | **②✅ column_types 双 bug（T02 `95f23e9`）**：发完整 Hive 类型串 + 弃逗号 join/split。余 ①schema_id/history（T03）③time-travel 静默返最新（T04）④增量读 fail-loud（T04）；详见 [HANDOFF](./HANDOFF.md) 1b |
+| scan 侧 parity 修复（HIGH）| 🚧 | **②✅ column_types 双 bug（T02 `95f23e9`）**。**①schema_id/history 推迟批 E（[DV-006]）**——非 model-agnostic SPI 修复（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）。余 ③time-travel 静默返最新（T04）④增量读 fail-loud（T04）；详见 [HANDOFF](./HANDOFF.md) 1b |
 | 增量读 SPI hook / MVCC | ⏳ | P1-T04 incrementalRelation gap；4 个 `*IncrementalRelation` 仍在 fe-core |
 | listPartitions override + 真实裁剪 | ⏳ | Hudi applyFilter 现列全部分区不裁剪 |
 | 三连接器模块测试 | ⏳ | fe-connector-hms/hive/hudi 当前零测试 |
@@ -127,6 +127,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-05** 🟡 **P3-T03 推迟批 E**（[DV-006]，用户签字）：code-grounded recon（4-reader workflow + 主线核读 BE `table_schema_change_helper.h`）揭示 schema_id/history_schema_info **不是** 批 A 可做的 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override hook（设 schema）」前提失真（其 override 为 predicate/docvalue）；裸 `current==file==-1`→BE `ConstNode`(identity,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 = 净回归。faithful field-id evolution parity 与 hive/HMS migration 一并入批 E。批 A 保持现状名匹配（零回归），直进 T04
 - **2026-06-04** ✅ **P3-T02（批 A 启动）column_types 双 bug 修复**（commit `95f23e9`）：硬化 dormant SPI hudi 连接器（gate 关，零 live caller）。(a) `HudiScanPlanProvider` 改发完整 **Hive 类型串**（新 `HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），不再用 `getTypeName()` 发 Doris 裸类型名（丢精度/scale/子类型）；(b) `HudiScanRange` 改 typed `List<String>` 直接设 thrift `list<string>`，弃逗号 join/split（曾打碎 `decimal(10,2)`/`struct<...>`），BE 自做 join（types `#` / names,delta `,`），与 Java `HadoopHudiJniScanner` split 契约一致（两点对抗确认）。建模块**首批**测试 11 个全绿；checkstyle 0 + import-gate 通过；3 路对抗 review 零确认缺陷。设计见 `tasks/designs/P3-T02-column-types-design.md`
 - **2026-06-04** ✅ **P3 scan/split recon + 定 hybrid（D-019）+ 建 tasks/P3**：第二轮 recon（scan/split 路径，verified）——单 `PluginDrivenScanNode` 混合 COW-native/MOR-JNI **不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader）；plumbing 正确，剩 model-agnostic 正确性 gap（schema_id/history 缺、column_types 双 bug、time-travel 静默返最新、增量无表示、partition 裁剪缺、三模块零测试）。用户定 **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate，零 live 风险），推迟 (a) 模型落地+cutover 到 hive/HMS migration。已建 [tasks/P3](./tasks/P3-hudi-migration.md)，批 A 待启动
 - **2026-06-04** ✅ **P2 已合入 `branch-catalog-spi`**（#64096，squash `0793f032662`，叠在 P1 `2b1a3bb2197` / P0 `72d6d0109b9` 上）。旧「PR base 错位（191-commit）」阻塞消失——`branch-catalog-spi` 已重建到新 master（P0/P1 hash 随之更新）。P2 除 T12（回归，DV-003）外全部完成
@@ -174,7 +175,7 @@
 | 类型 | 总数 | 最新条目 | 文档 |
 |---|---|---|---|
 | **决策**（D-NNN） | 19 | D-019（P3 hudi hybrid 推进策略）| [decisions-log.md](./decisions-log.md) |
-| **偏差**（DV-NNN） | 5 | DV-005（P3 HMS-over-SPI 依赖与代码不符；真阻塞=catalog 模型错配）| [deviations-log.md](./deviations-log.md) |
+| **偏差**（DV-NNN） | 6 | DV-006（P3-T03 schema_id 非批 A 可修，推迟批 E）| [deviations-log.md](./deviations-log.md) |
 | **风险**（R-NNN） | 14 | R-014（thrift sink 选择灵活性） | [risks.md](./risks.md) |
 
 ---

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -12,7 +12,7 @@
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
 | **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▰▰▰▱▱▱▱▱▱▱ 30% | 🚧 hybrid（D-019）；**批 A+B 编码完成**（T02/T04/T05 ✅ + T06 决策；T03→批 E）；批 C 待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▰▰▰▱▱▱▱▱▱ 40% | 🚧 hybrid（D-019）；**批 A+B+C 编码完成**（T02/T04/T05/T07 ✅ + T06 决策；T03→批 E）；批 D（T08 design-only）待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -32,7 +32,7 @@
 | **jdbc** | ✅ | ✅ 100% | ✅ | 🟡 (13 个旧 client，P1 删) | n/a | **95%** | [详情](./connectors/jdbc.md) |
 | **es** | ✅ | ✅ 100% | ✅ | ✅ | ✅ | **100%** | [详情](./connectors/es.md) |
 | trino-connector | ✅ | ✅ 100% | ✅ | ✅ | ✅ | **100%** | [详情](./connectors/trino-connector.md) |
-| hudi | 🟡（D-005；模型待定 DV-005）| 🟨 50%（读路径已存在但 dormant）| ❌（gate 关）| ❌ | 0/0（寄生 hms）| **20%** | [详情](./connectors/hudi.md) |
+| hudi | 🟡（D-005；模型待定 DV-005）| 🟨 55%（读路径 dormant + 批 C 测试基线）| ❌（gate 关）| ❌ | 0/0（寄生 hms）| **25%** | [详情](./connectors/hudi.md) |
 | maxcompute | 🟡 | 🟨 60% | ❌ | ❌ | 0/12 | **25%** | [详情](./connectors/maxcompute.md) |
 | paimon | 🟡 | 🟨 50% | ❌ | ❌ | 0/10 | **20%** | [详情](./connectors/paimon.md) |
 | iceberg | 🟡 | 🟥 10% | ❌ | ❌ | 0/19 | **5%** | [详情](./connectors/iceberg.md) |
@@ -44,7 +44,7 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P3 — hudi 迁移（🚧 hybrid，批 A+B 编码完成：T02/T04/T05 ✅ + T06 决策；T03→批 E；批 C 待启动）
+### P3 — hudi 迁移（🚧 hybrid，批 A+B+C 编码完成：T02/T04/T05/T07 ✅ + T06 决策；T03→批 E；批 D 待启动）
 
 > 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
 
@@ -56,7 +56,7 @@
 | scan 侧 parity 修复（HIGH）| ✅ 批 A 范围 | **②✅ column_types（T02 `95f23e9`）**；**③④✅ time-travel/增量 fail-loud（T04 `feceabb`）**——`visitPhysicalHudiScan` SPI 分支抛 `AnalysisException`（不再静默）。**①schema_id/history 推迟批 E（[DV-006]）**（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）；详见 [HANDOFF](./HANDOFF.md) 1b |
 | MVCC/snapshot SPI（T06）| ✅ 批 B 决策 | keep default opt-out（DV-007）——全体连接器无 override，T04 已 fail-loud time-travel；完整 MVCC + 增量读（P1-T04 gap，4 个 `*IncrementalRelation` 仍在 fe-core）入批 E |
 | listPartitions 真实裁剪（T05）| ✅ 批 B | applyFilter EQ/IN 裁剪（`10b72d4`，镜像 Hive）+ 修复"分区来源静默切换"；`listPartitions*` override→批 E（DV-007）|
-| 三连接器模块测试 | ⏳ 批 C | fe-connector-hms/hive/hudi 当前零测试；+ COW/MOR parity vs legacy |
+| 三连接器模块测试（T07）| ✅ 批 C | fe-connector-hms/hive/hudi 测试基线落地（hms 12 + hive 14 + hudi +18=33 全绿，golden-value）+ COW/MOR schema parity（schema type-agnostic）；列名 casing 当场修（DV-008，镜像 legacy）；gap-2 meta-field 推迟批 E |
 
 ### P2 — trino-connector 迁移（✅ 已合入 #64096）
 | ID | Task | 批次 | Owner | 状态 | 启动 | 备注 |
@@ -127,6 +127,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-05** ✅ **P3 批 C 编码完成（T07 三模块测试基线 + COW/MOR schema parity）**：feasibility recon（5-agent code-grounded workflow）定 **golden-value parity**（fe-core 只依赖 fe-connector-api/-spi、不依赖具体连接器模块，无跨模块编译路径；JUnit5 + 手写替身）；关键结论 **COW/MOR schema type-agnostic**（legacy/SPI 两侧 schema 推导都不按表型分支，差异只在 scan planning）。落地：**hudi**——`avroSchemaToColumns` 顶层列名 `toLowerCase` 修（gap-1，镜像 legacy `HMSExternalTable:745`，仅顶层、嵌套 struct 名保留）+ package-private static 可测；`HudiTypeMappingTest` 补 `fromAvroSchema`→ConnectorType golden（原零覆盖）；新 `HudiSchemaParityTest`（列名/序/类型/Hive 串/casing 边界 pin）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN 分类）。**hms**——新 `HmsTypeMappingTest`（hms+hive 共享的 Hive 类型串解析器，原零测试）。**hive**——新 `HiveFileFormatTest` + `HiveConnectorMetadataPartitionPruningTest`（镜像 T05 裁剪网）。三模块 test：hms 12 + hive 14 + hudi +18=33 全绿；checkstyle 0（含 test 源）；import-gate 通过。**两 parity gap**（[DV-008]）：gap-1 列名 casing 当场修（用户签字），gap-2 Hudi meta-field 纳入（`getTableAvroSchema(true)` vs 无参）推迟批 E（无真实 metaclient 不可单测）。下一步批 D（T08 design-only）。设计：`designs/P3-T07-test-baseline-design.md`
 - **2026-06-05** ✅ **P3 批 B 编码完成**（T05 ✅ + T06 决策，[DV-007]）：**T05**（commit `10b72d4`，feat）`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪——原占位实现列**全部** HMS 分区不裁剪、且无条件设 `prunedPartitionPaths` 静默把分区来源从 Hudi-metadata 切到 HMS；重写为忠实镜像 `HiveConnectorMetadata`（抽取 partition 列 EQ/IN 谓词→列候选→裁剪→仅有效果时回传 pruned handle，否则 `Optional.empty()` 回落 Hudi-metadata listing），保留 `List<String>` 路径表示 + `-1` 上限，7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿（模块 19 测）、checkstyle 0、import-gate 通过。**T06**（零代码决策，用户签字）MVCC/snapshot SPI **保持 default `Optional.empty()` opt-out**——recon 证「显式抛异常 override」错（破 SPI opt-out 约定、全体连接器无 override、无 production caller=死代码、T04 已 fail-loud time-travel）；完整 MVCC 入批 E。**scope 校正**（[DV-007]）：T05 `listPartitions*` override 推迟批 E（零 live caller、Hive 不 override）。批 A+B 编码完成，下一步批 C（三模块测试 + COW/MOR parity）。设计：`designs/P3-T05-*` / `P3-T06-*`
 - **2026-06-05** ✅ **P3-T04 time-travel/增量读 fail-loud**（commit `feceabb`，批 A 编码收尾）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支对 `FOR TIME/VERSION AS OF`（曾静默返最新——provider 永远读 `lastInstant`）与增量读（曾静默全扫——SPI 无表示）抛 `AnalysisException`。唯一同时可见 snapshot+incremental 处。fe-core 编译 + checkstyle 0；dormant 分支 gate 关时不可达=零 live 风险；单测推迟批 E（不可 exercise，R12 显式登记）。**批 A 编码完成**：T02 + T04 两个正确性修复落地，T03 推迟批 E（DV-006）
 - **2026-06-05** 🟡 **P3-T03 推迟批 E**（[DV-006]，用户签字）：code-grounded recon（4-reader workflow + 主线核读 BE `table_schema_change_helper.h`）揭示 schema_id/history_schema_info **不是** 批 A 可做的 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override hook（设 schema）」前提失真（其 override 为 predicate/docvalue）；裸 `current==file==-1`→BE `ConstNode`(identity,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 = 净回归。faithful field-id evolution parity 与 hive/HMS migration 一并入批 E。批 A 保持现状名匹配（零回归），直进 T04
@@ -177,7 +178,7 @@
 | 类型 | 总数 | 最新条目 | 文档 |
 |---|---|---|---|
 | **决策**（D-NNN） | 19 | D-019（P3 hudi hybrid 推进策略）| [decisions-log.md](./decisions-log.md) |
-| **偏差**（DV-NNN） | 7 | DV-007（P3 批 B scope 校正：T05 list* 推迟批 E、T06 MVCC keep-defaults）| [deviations-log.md](./deviations-log.md) |
+| **偏差**（DV-NNN） | 8 | DV-008（P3-T07 parity gap：列名 casing 当场修、Hudi meta-field 纳入推迟批 E）| [deviations-log.md](./deviations-log.md) |
 | **风险**（R-NNN） | 14 | R-014（thrift sink 选择灵活性） | [risks.md](./risks.md) |
 
 ---
@@ -186,9 +187,9 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：P3 批 B 编码（5-reader code-grounded recon workflow + 用户签字 2 个 scope fork）——T05 applyFilter 真实 EQ/IN 分区裁剪（`10b72d4`，镜像 Hive，8 单测全绿）+ T06 MVCC keep-defaults 决策（零代码）；记 DV-007；同步 tasks/P3 + PROGRESS + deviations-log + connectors/hudi + 2 设计备忘 + HANDOFF
-- **下一个 session 应做**：**批 C**（T07）——fe-connector-hms/hive/hudi 三模块测试基线 + COW/MOR parity（SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`）。**不要碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器**；批 D（T08 design-only）随后
-- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（批 C 起点 + T05/T06 认知 + 沿用的 clean-fe-core / import-gate / checkstyle 禁 static import 认知）
+- **本 session 已完成**：P3 批 C 编码（T07，5-agent code-grounded recon workflow + 用户签字 2 个 fork：casing 当场修 / focused baseline）——三模块测试基线（hms `HmsTypeMappingTest` 12 + hive `HiveFileFormatTest` 6/`HiveConnectorMetadataPartitionPruningTest` 8 + hudi `HudiTypeMappingTest`+7/`HudiSchemaParityTest` 3/`HudiTableTypeTest` 4 = 33 全绿）+ COW/MOR schema parity（golden-value）+ gap-1 列名 casing 修（镜像 legacy）；记 DV-008；同步 tasks/P3 + PROGRESS + deviations-log + connectors/hudi + 设计备忘 P3-T07 + HANDOFF
+- **下一个 session 应做**：**批 D**（T08）——`tableFormatType` 分流消费**设计备忘（design-only，不动 fe-core live 路径）**。**不要碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器 / fe-core 消费实现（批 E）**
+- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（批 D 起点 + T07 认知 + gap-2/casing 缩界 + 沿用 golden-value/import-gate/checkstyle 禁 static import 认知）
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 
 ---

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-06-05** | 当前阶段：**P3 Hudi hybrid（D-019）批 A–D 全部 in-scope 完成**（T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E）；剩批 E（cutover）并入 P7，P3 PR 待开 | 项目总进度：**33%**
+> 最后更新：**2026-06-05** | 当前阶段：**P3 Hudi hybrid（D-019）批 A–D 全部 in-scope 完成**（T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E）；剩批 E（cutover）并入 P7，P3 PR #64143 已开（CI 中） | 项目总进度：**33%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -12,7 +12,7 @@
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
 | **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▰▰▰▰▰▱▱▱▱▱ 45% | 🚧 hybrid（D-019）；**批 A–D 全部 in-scope 完成**（T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E）；剩批 E（cutover）并入 P7，P3 PR 待开 | [tasks/P3](./tasks/P3-hudi-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▰▰▰▰▱▱▱▱▱ 45% | 🚧 hybrid（D-019）；**批 A–D 全部 in-scope 完成**（T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E）；剩批 E（cutover）并入 P7，P3 PR #64143 已开（CI 中） | [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -44,7 +44,7 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P3 — hudi 迁移（🚧 hybrid，批 A–D 全部 in-scope 完成：T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E；剩批 E→P7，P3 PR 待开）
+### P3 — hudi 迁移（🚧 hybrid，批 A–D 全部 in-scope 完成：T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E；剩批 E→P7，P3 PR #64143 已开（CI 中））
 
 > 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
 
@@ -128,7 +128,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
-- **2026-06-05** ✅ **P3 批 D 完成（T08 `tableFormatType` 分流消费设计备忘，design-only）= P3 hybrid in-scope（批 A–D）全完成**：以上 session 的 6-reader recon（`research/spi-multi-format-hms-catalog-analysis.md`）为直接输入，本场不重复 recon、只 firsthand 核读 load-bearing 锚点（确认 keystone gap：`PluginDrivenExternalTable.initSchema` 只读 columns 丢 `tableFormatType`；新增第二缺口：`getEngine`/`getEngineTableTypeName` switch catalog type 非 per-table format；`planScan` 入参带 per-table handle）。**核心分析贡献**：把 keystone 拆成可分离的 **M1 身份消费 ⊥ M2 scan 路由**（M1 三方案通用，A/B/C 只在 M2 分歧）。M2 三方案评估后 **AskUserQuestion 用户签字 = 方案 B**（[D-020]）：新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`（默认 null→回落 per-catalog），fe-core `PluginDrivenScanNode.getSplits` 优先 per-table、回落 per-catalog；把 per-table 选 provider 升为一等 SPI 契约（满足 D-009 default-only）。A（连接器内 router，零 SPI churn）备选；C（fe-core 发现期分派）否决（违瘦 fe-core）。**细化 D-005**（区分符沿用；"PhysicalXxxScan" 措辞早于 P1 scan-node 统一，由 per-table provider seam 取代）。缩界：本场零代码、gate 不动；Iceberg-on-hms 经 SPI 依赖 P6/M3；M1+M2 实现登记批 E/P7。**P3 hybrid 净产出**=2 正确性修（T02/T05）+ 2 fail-loud/决策（T04/T06）+ 测试网零→59 测（T07）+ 模型 dispatch 设计（T08/D-020）。下一步=批 E 并入 P7 / 开 P3 PR / 启 P4。设计 `designs/P3-T08-tableformat-dispatch-design.md`
+- **2026-06-05** ✅ **P3 批 D 完成（T08 `tableFormatType` 分流消费设计备忘，design-only）= P3 hybrid in-scope（批 A–D）全完成**：以上 session 的 6-reader recon（`research/spi-multi-format-hms-catalog-analysis.md`）为直接输入，本场不重复 recon、只 firsthand 核读 load-bearing 锚点（确认 keystone gap：`PluginDrivenExternalTable.initSchema` 只读 columns 丢 `tableFormatType`；新增第二缺口：`getEngine`/`getEngineTableTypeName` switch catalog type 非 per-table format；`planScan` 入参带 per-table handle）。**核心分析贡献**：把 keystone 拆成可分离的 **M1 身份消费 ⊥ M2 scan 路由**（M1 三方案通用，A/B/C 只在 M2 分歧）。M2 三方案评估后 **AskUserQuestion 用户签字 = 方案 B**（[D-020]）：新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`（默认 null→回落 per-catalog），fe-core `PluginDrivenScanNode.getSplits` 优先 per-table、回落 per-catalog；把 per-table 选 provider 升为一等 SPI 契约（满足 D-009 default-only）。A（连接器内 router，零 SPI churn）备选；C（fe-core 发现期分派）否决（违瘦 fe-core）。**细化 D-005**（区分符沿用；"PhysicalXxxScan" 措辞早于 P1 scan-node 统一，由 per-table provider seam 取代）。缩界：本场零代码、gate 不动；Iceberg-on-hms 经 SPI 依赖 P6/M3；M1+M2 实现登记批 E/P7。**P3 hybrid 净产出**=2 正确性修（T02/T05）+ 2 fail-loud/决策（T04/T06）+ 测试网零→59 测（T07）+ 模型 dispatch 设计（T08/D-020）。**P3 PR [#64143](https://github.com/apache/doris/pull/64143) 已开**（base branch-catalog-spi，26 files +3065/−154，12 commits）；下一步=监控 CI / 处理 review，批 E 并入 P7 / 启 P4。设计 `designs/P3-T08-tableformat-dispatch-design.md`
 - **2026-06-05** ✅ **P3 批 C 编码完成（T07 三模块测试基线 + COW/MOR schema parity）**：feasibility recon（5-agent code-grounded workflow）定 **golden-value parity**（fe-core 只依赖 fe-connector-api/-spi、不依赖具体连接器模块，无跨模块编译路径；JUnit5 + 手写替身）；关键结论 **COW/MOR schema type-agnostic**（legacy/SPI 两侧 schema 推导都不按表型分支，差异只在 scan planning）。落地：**hudi**——`avroSchemaToColumns` 顶层列名 `toLowerCase` 修（gap-1，镜像 legacy `HMSExternalTable:745`，仅顶层、嵌套 struct 名保留）+ package-private static 可测；`HudiTypeMappingTest` 补 `fromAvroSchema`→ConnectorType golden（原零覆盖）；新 `HudiSchemaParityTest`（列名/序/类型/Hive 串/casing 边界 pin）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN 分类）。**hms**——新 `HmsTypeMappingTest`（hms+hive 共享的 Hive 类型串解析器，原零测试）。**hive**——新 `HiveFileFormatTest` + `HiveConnectorMetadataPartitionPruningTest`（镜像 T05 裁剪网）。三模块 test：hms 12 + hive 14 + hudi +18=33 全绿；checkstyle 0（含 test 源）；import-gate 通过。**两 parity gap**（[DV-008]）：gap-1 列名 casing 当场修（用户签字），gap-2 Hudi meta-field 纳入（`getTableAvroSchema(true)` vs 无参）推迟批 E（无真实 metaclient 不可单测）。下一步批 D（T08 design-only）。设计：`designs/P3-T07-test-baseline-design.md`
 - **2026-06-05** ✅ **P3 批 B 编码完成**（T05 ✅ + T06 决策，[DV-007]）：**T05**（commit `10b72d4`，feat）`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪——原占位实现列**全部** HMS 分区不裁剪、且无条件设 `prunedPartitionPaths` 静默把分区来源从 Hudi-metadata 切到 HMS；重写为忠实镜像 `HiveConnectorMetadata`（抽取 partition 列 EQ/IN 谓词→列候选→裁剪→仅有效果时回传 pruned handle，否则 `Optional.empty()` 回落 Hudi-metadata listing），保留 `List<String>` 路径表示 + `-1` 上限，7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿（模块 19 测）、checkstyle 0、import-gate 通过。**T06**（零代码决策，用户签字）MVCC/snapshot SPI **保持 default `Optional.empty()` opt-out**——recon 证「显式抛异常 override」错（破 SPI opt-out 约定、全体连接器无 override、无 production caller=死代码、T04 已 fail-loud time-travel）；完整 MVCC 入批 E。**scope 校正**（[DV-007]）：T05 `listPartitions*` override 推迟批 E（零 live caller、Hive 不 override）。批 A+B 编码完成，下一步批 C（三模块测试 + COW/MOR parity）。设计：`designs/P3-T05-*` / `P3-T06-*`
 - **2026-06-05** ✅ **P3-T04 time-travel/增量读 fail-loud**（commit `feceabb`，批 A 编码收尾）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支对 `FOR TIME/VERSION AS OF`（曾静默返最新——provider 永远读 `lastInstant`）与增量读（曾静默全扫——SPI 无表示）抛 `AnalysisException`。唯一同时可见 snapshot+incremental 处。fe-core 编译 + checkstyle 0；dormant 分支 gate 关时不可达=零 live 风险；单测推迟批 E（不可 exercise，R12 显式登记）。**批 A 编码完成**：T02 + T04 两个正确性修复落地，T03 推迟批 E（DV-006）
@@ -190,7 +190,7 @@
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
 - **本 session 已完成**：P3 批 D（T08 design-only，AskUserQuestion 用户签字 M2=方案 B）——`tableFormatType` 分流消费设计备忘 + [D-020]；核心拆解 **M1 身份消费 ⊥ M2 scan 路由**；细化 D-005；同步 tasks/P3（T08 ✅ + 阶段日志）+ PROGRESS（§一/§二/§三/§四/§六/§七）+ decisions-log（D-020）+ connectors/hudi + 设计备忘 P3-T08 + HANDOFF；研究输入 `research/spi-multi-format-hms-catalog-analysis.md` 一并纳入 git 跟踪（design 引用，避免悬空）
-- **下一个 session 应做**（**P3 hybrid in-scope 批 A–D 已全部完成**，三选一，待用户定）：(1) 开 **P3 PR**（base `apache/doris:branch-catalog-spi`）；(2) **批 E 并入 P7**（live cutover，不在 P3 编码）；(3) 启 **P4**（maxcompute）。**P3 内不要碰 `SPI_READY_TYPES` / fe-core 消费实现 / legacy / 非 hudi 连接器（皆批 E）**
+- **下一个 session 应做**（**P3 hybrid in-scope 批 A–D 完成，PR #64143 已开**）：监控 [PR #64143](https://github.com/apache/doris/pull/64143) CI / 处理 review；待合入后 **批 E 并入 P7**（live cutover，不在 P3 编码）或启 **P4**（maxcompute）。**P3 内不要碰 `SPI_READY_TYPES` / fe-core 消费实现 / legacy / 非 hudi 连接器（皆批 E）**
 - **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（P3 批 A–D 完成总结 + D-020/M1⊥M2 认知 + 批 E/PR/P4 三选项 + 沿用坑）
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-06-04** | 当前阶段：**P2 已合入 `branch-catalog-spi`（#64096）；P3 Hudi 启动 recon 完成，待 catalog 模型决策（DV-005）** | 项目总进度：**32%**
+> 最后更新：**2026-06-05** | 当前阶段：**P3 Hudi hybrid（D-019）批 A+B 编码完成**（T02/T04/T05 ✅ + T06 决策；T03→批 E）；下一步批 C 测试基线 | 项目总进度：**33%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -12,7 +12,7 @@
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
 | **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▰▰▱▱▱▱▱▱▱▱ 20% | 🚧 hybrid（D-019）；**批 A 编码完成**（T02 ✅ T04 ✅；T03→批 E）；批 B 待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▰▰▱▱▱▱▱▱▱ 30% | 🚧 hybrid（D-019）；**批 A+B 编码完成**（T02/T04/T05 ✅ + T06 决策；T03→批 E）；批 C 待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -44,7 +44,7 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P3 — hudi 迁移（🚧 hybrid，批 A 编码完成：T02 ✅ T04 ✅；T03→批 E；批 B 待启动）
+### P3 — hudi 迁移（🚧 hybrid，批 A+B 编码完成：T02/T04/T05 ✅ + T06 决策；T03→批 E；批 C 待启动）
 
 > 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
 
@@ -54,9 +54,9 @@
 | catalog 模型决策（a/b/c）| ✅ hybrid（D-019）| 现做 (b)，推迟 (a)；真阻塞=独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`、fe-core 不消费 `tableFormatType` |
 | SPI scan/split 路径 recon | ✅ | **混合 COW-native/MOR-JNI 不是问题**（per-range format，与 legacy 结构等价，BE 每 range 建 reader；2 路对抗验证）；plumbing 正确但 verdict 仍 false（gate/模型未解）|
 | scan 侧 parity 修复（HIGH）| ✅ 批 A 范围 | **②✅ column_types（T02 `95f23e9`）**；**③④✅ time-travel/增量 fail-loud（T04 `feceabb`）**——`visitPhysicalHudiScan` SPI 分支抛 `AnalysisException`（不再静默）。**①schema_id/history 推迟批 E（[DV-006]）**（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）；详见 [HANDOFF](./HANDOFF.md) 1b |
-| 增量读 SPI hook / MVCC | ⏳ | P1-T04 incrementalRelation gap；4 个 `*IncrementalRelation` 仍在 fe-core |
-| listPartitions override + 真实裁剪 | ⏳ | Hudi applyFilter 现列全部分区不裁剪 |
-| 三连接器模块测试 | ⏳ | fe-connector-hms/hive/hudi 当前零测试 |
+| MVCC/snapshot SPI（T06）| ✅ 批 B 决策 | keep default opt-out（DV-007）——全体连接器无 override，T04 已 fail-loud time-travel；完整 MVCC + 增量读（P1-T04 gap，4 个 `*IncrementalRelation` 仍在 fe-core）入批 E |
+| listPartitions 真实裁剪（T05）| ✅ 批 B | applyFilter EQ/IN 裁剪（`10b72d4`，镜像 Hive）+ 修复"分区来源静默切换"；`listPartitions*` override→批 E（DV-007）|
+| 三连接器模块测试 | ⏳ 批 C | fe-connector-hms/hive/hudi 当前零测试；+ COW/MOR parity vs legacy |
 
 ### P2 — trino-connector 迁移（✅ 已合入 #64096）
 | ID | Task | 批次 | Owner | 状态 | 启动 | 备注 |
@@ -127,6 +127,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-05** ✅ **P3 批 B 编码完成**（T05 ✅ + T06 决策，[DV-007]）：**T05**（commit `10b72d4`，feat）`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪——原占位实现列**全部** HMS 分区不裁剪、且无条件设 `prunedPartitionPaths` 静默把分区来源从 Hudi-metadata 切到 HMS；重写为忠实镜像 `HiveConnectorMetadata`（抽取 partition 列 EQ/IN 谓词→列候选→裁剪→仅有效果时回传 pruned handle，否则 `Optional.empty()` 回落 Hudi-metadata listing），保留 `List<String>` 路径表示 + `-1` 上限，7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿（模块 19 测）、checkstyle 0、import-gate 通过。**T06**（零代码决策，用户签字）MVCC/snapshot SPI **保持 default `Optional.empty()` opt-out**——recon 证「显式抛异常 override」错（破 SPI opt-out 约定、全体连接器无 override、无 production caller=死代码、T04 已 fail-loud time-travel）；完整 MVCC 入批 E。**scope 校正**（[DV-007]）：T05 `listPartitions*` override 推迟批 E（零 live caller、Hive 不 override）。批 A+B 编码完成，下一步批 C（三模块测试 + COW/MOR parity）。设计：`designs/P3-T05-*` / `P3-T06-*`
 - **2026-06-05** ✅ **P3-T04 time-travel/增量读 fail-loud**（commit `feceabb`，批 A 编码收尾）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支对 `FOR TIME/VERSION AS OF`（曾静默返最新——provider 永远读 `lastInstant`）与增量读（曾静默全扫——SPI 无表示）抛 `AnalysisException`。唯一同时可见 snapshot+incremental 处。fe-core 编译 + checkstyle 0；dormant 分支 gate 关时不可达=零 live 风险；单测推迟批 E（不可 exercise，R12 显式登记）。**批 A 编码完成**：T02 + T04 两个正确性修复落地，T03 推迟批 E（DV-006）
 - **2026-06-05** 🟡 **P3-T03 推迟批 E**（[DV-006]，用户签字）：code-grounded recon（4-reader workflow + 主线核读 BE `table_schema_change_helper.h`）揭示 schema_id/history_schema_info **不是** 批 A 可做的 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override hook（设 schema）」前提失真（其 override 为 predicate/docvalue）；裸 `current==file==-1`→BE `ConstNode`(identity,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 = 净回归。faithful field-id evolution parity 与 hive/HMS migration 一并入批 E。批 A 保持现状名匹配（零回归），直进 T04
 - **2026-06-04** ✅ **P3-T02（批 A 启动）column_types 双 bug 修复**（commit `95f23e9`）：硬化 dormant SPI hudi 连接器（gate 关，零 live caller）。(a) `HudiScanPlanProvider` 改发完整 **Hive 类型串**（新 `HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），不再用 `getTypeName()` 发 Doris 裸类型名（丢精度/scale/子类型）；(b) `HudiScanRange` 改 typed `List<String>` 直接设 thrift `list<string>`，弃逗号 join/split（曾打碎 `decimal(10,2)`/`struct<...>`），BE 自做 join（types `#` / names,delta `,`），与 Java `HadoopHudiJniScanner` split 契约一致（两点对抗确认）。建模块**首批**测试 11 个全绿；checkstyle 0 + import-gate 通过；3 路对抗 review 零确认缺陷。设计见 `tasks/designs/P3-T02-column-types-design.md`
@@ -176,7 +177,7 @@
 | 类型 | 总数 | 最新条目 | 文档 |
 |---|---|---|---|
 | **决策**（D-NNN） | 19 | D-019（P3 hudi hybrid 推进策略）| [decisions-log.md](./decisions-log.md) |
-| **偏差**（DV-NNN） | 6 | DV-006（P3-T03 schema_id 非批 A 可修，推迟批 E）| [deviations-log.md](./deviations-log.md) |
+| **偏差**（DV-NNN） | 7 | DV-007（P3 批 B scope 校正：T05 list* 推迟批 E、T06 MVCC keep-defaults）| [deviations-log.md](./deviations-log.md) |
 | **风险**（R-NNN） | 14 | R-014（thrift sink 选择灵活性） | [risks.md](./risks.md) |
 
 ---
@@ -185,9 +186,9 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：确认 P2 已合入 `branch-catalog-spi`（#64096）；P3 Hudi 启动 recon（8-agent code-grounded workflow + 对抗验证）；记 DV-005；同步 HANDOFF / PROGRESS / deviations-log / connectors/hudi
-- **下一个 session 应做**：(1) 从 `branch-catalog-spi` 切 P3 工作分支；(2) recon SPI scan/split 路径（recon 唯一留白）；(3) 写 catalog 模型决策备忘（a/b；c 否决）交用户签字；(4) 签字后建 `tasks/P3-hudi-migration.md` 编码。**不要在签字前编码，更不要直接 flip `SPI_READY_TYPES`**
-- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（P3 起点 step-by-step + 模型决策选项 + file:line 锚点 + 沿用的 clean-fe-core / import-gate 认知）
+- **本 session 已完成**：P3 批 B 编码（5-reader code-grounded recon workflow + 用户签字 2 个 scope fork）——T05 applyFilter 真实 EQ/IN 分区裁剪（`10b72d4`，镜像 Hive，8 单测全绿）+ T06 MVCC keep-defaults 决策（零代码）；记 DV-007；同步 tasks/P3 + PROGRESS + deviations-log + connectors/hudi + 2 设计备忘 + HANDOFF
+- **下一个 session 应做**：**批 C**（T07）——fe-connector-hms/hive/hudi 三模块测试基线 + COW/MOR parity（SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`）。**不要碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器**；批 D（T08 design-only）随后
+- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（批 C 起点 + T05/T06 认知 + 沿用的 clean-fe-core / import-gate / checkstyle 禁 static import 认知）
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 
 ---

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-06-05** | 当前阶段：**P3 Hudi hybrid（D-019）批 A+B 编码完成**（T02/T04/T05 ✅ + T06 决策；T03→批 E）；下一步批 C 测试基线 | 项目总进度：**33%**
+> 最后更新：**2026-06-05** | 当前阶段：**P3 Hudi hybrid（D-019）批 A–D 全部 in-scope 完成**（T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E）；剩批 E（cutover）并入 P7，P3 PR 待开 | 项目总进度：**33%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -12,7 +12,7 @@
 | **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR #63582 squash-merge `c6f056fa5bd`，T24-T25 流水线全绿）| [tasks/P0](./tasks/P0-spi-foundation.md) |
 | **P1** | scan-node 收口 + 重复清理 | 1 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 完成（PR [#63641](https://github.com/apache/doris/pull/63641) squash-merged `778c5dd610f`；T1 推迟 P8；T2 推迟 P4/P5）| [tasks/P1](./tasks/P1-scan-node-cleanup.md) |
 | **P2** | trino-connector 迁移 | 2 周 | ▰▰▰▰▰▰▰▰▰▰ 100% | ✅ 已合入 `branch-catalog-spi`（#64096，squash `0793f032662`；T12 回归推迟 DV-003）| [tasks/P2](./tasks/P2-trino-connector-migration.md) |
-| P3 | hudi 迁移 | 2 周 | ▰▰▰▰▱▱▱▱▱▱ 40% | 🚧 hybrid（D-019）；**批 A+B+C 编码完成**（T02/T04/T05/T07 ✅ + T06 决策；T03→批 E）；批 D（T08 design-only）待启动 | [tasks/P3](./tasks/P3-hudi-migration.md) |
+| P3 | hudi 迁移 | 2 周 | ▰▰▰▰▰▱▱▱▱▱ 45% | 🚧 hybrid（D-019）；**批 A–D 全部 in-scope 完成**（T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E）；剩批 E（cutover）并入 P7，P3 PR 待开 | [tasks/P3](./tasks/P3-hudi-migration.md) |
 | P4 | maxcompute 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P5 | paimon 迁移 | 3 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P6 | iceberg 迁移 | 5 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -32,7 +32,7 @@
 | **jdbc** | ✅ | ✅ 100% | ✅ | 🟡 (13 个旧 client，P1 删) | n/a | **95%** | [详情](./connectors/jdbc.md) |
 | **es** | ✅ | ✅ 100% | ✅ | ✅ | ✅ | **100%** | [详情](./connectors/es.md) |
 | trino-connector | ✅ | ✅ 100% | ✅ | ✅ | ✅ | **100%** | [详情](./connectors/trino-connector.md) |
-| hudi | 🟡（D-005；模型待定 DV-005）| 🟨 55%（读路径 dormant + 批 C 测试基线）| ❌（gate 关）| ❌ | 0/0（寄生 hms）| **25%** | [详情](./connectors/hudi.md) |
+| hudi | 🟡（D-005 区分符 + D-020 模型 dispatch 已设计；实现批 E）| 🟨 55%（读路径 dormant + 批 C 测试基线）| ❌（gate 关）| ❌ | 0/0（寄生 hms）| **25%** | [详情](./connectors/hudi.md) |
 | maxcompute | 🟡 | 🟨 60% | ❌ | ❌ | 0/12 | **25%** | [详情](./connectors/maxcompute.md) |
 | paimon | 🟡 | 🟨 50% | ❌ | ❌ | 0/10 | **20%** | [详情](./connectors/paimon.md) |
 | iceberg | 🟡 | 🟥 10% | ❌ | ❌ | 0/19 | **5%** | [详情](./connectors/iceberg.md) |
@@ -44,7 +44,7 @@
 
 > 状态非 ✅ 的项，按阶段聚合。详细见各阶段 task 文件。
 
-### P3 — hudi 迁移（🚧 hybrid，批 A+B+C 编码完成：T02/T04/T05/T07 ✅ + T06 决策；T03→批 E；批 D 待启动）
+### P3 — hudi 迁移（🚧 hybrid，批 A–D 全部 in-scope 完成：T02/T04/T05/T07 ✅ + T06/T08 决策；T03→批 E；剩批 E→P7，P3 PR 待开）
 
 > 策略 = **hybrid**（[D-019](./decisions-log.md)）：现做 (b) 连接器硬化+测试（behind gate），推迟 (a) 模型落地+cutover 到 hive/HMS migration。详细批次见 [tasks/P3](./tasks/P3-hudi-migration.md)；背景见 [DV-005](./deviations-log.md) / [HANDOFF](./HANDOFF.md) 关键认知 1+1b。
 
@@ -57,6 +57,7 @@
 | MVCC/snapshot SPI（T06）| ✅ 批 B 决策 | keep default opt-out（DV-007）——全体连接器无 override，T04 已 fail-loud time-travel；完整 MVCC + 增量读（P1-T04 gap，4 个 `*IncrementalRelation` 仍在 fe-core）入批 E |
 | listPartitions 真实裁剪（T05）| ✅ 批 B | applyFilter EQ/IN 裁剪（`10b72d4`，镜像 Hive）+ 修复"分区来源静默切换"；`listPartitions*` override→批 E（DV-007）|
 | 三连接器模块测试（T07）| ✅ 批 C | fe-connector-hms/hive/hudi 测试基线落地（hms 12 + hive 14 + hudi +18=33 全绿，golden-value）+ COW/MOR schema parity（schema type-agnostic）；列名 casing 当场修（DV-008，镜像 legacy）；gap-2 meta-field 推迟批 E |
+| tableFormatType 分流消费设计（T08）| ✅ 批 D | design-only 设计备忘 + [D-020]（用户签字）：**M1 身份消费 ⊥ M2 scan 路由**拆解（M1 三方案通用）；M2=**方案 B**（新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`，fe-core 优先 per-table、回落 per-catalog），细化 D-005；A 备选/C 否决；实现登记批 E/P7。设计 `designs/P3-T08-tableformat-dispatch-design.md` |
 
 ### P2 — trino-connector 迁移（✅ 已合入 #64096）
 | ID | Task | 批次 | Owner | 状态 | 启动 | 备注 |
@@ -127,6 +128,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-06-05** ✅ **P3 批 D 完成（T08 `tableFormatType` 分流消费设计备忘，design-only）= P3 hybrid in-scope（批 A–D）全完成**：以上 session 的 6-reader recon（`research/spi-multi-format-hms-catalog-analysis.md`）为直接输入，本场不重复 recon、只 firsthand 核读 load-bearing 锚点（确认 keystone gap：`PluginDrivenExternalTable.initSchema` 只读 columns 丢 `tableFormatType`；新增第二缺口：`getEngine`/`getEngineTableTypeName` switch catalog type 非 per-table format；`planScan` 入参带 per-table handle）。**核心分析贡献**：把 keystone 拆成可分离的 **M1 身份消费 ⊥ M2 scan 路由**（M1 三方案通用，A/B/C 只在 M2 分歧）。M2 三方案评估后 **AskUserQuestion 用户签字 = 方案 B**（[D-020]）：新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`（默认 null→回落 per-catalog），fe-core `PluginDrivenScanNode.getSplits` 优先 per-table、回落 per-catalog；把 per-table 选 provider 升为一等 SPI 契约（满足 D-009 default-only）。A（连接器内 router，零 SPI churn）备选；C（fe-core 发现期分派）否决（违瘦 fe-core）。**细化 D-005**（区分符沿用；"PhysicalXxxScan" 措辞早于 P1 scan-node 统一，由 per-table provider seam 取代）。缩界：本场零代码、gate 不动；Iceberg-on-hms 经 SPI 依赖 P6/M3；M1+M2 实现登记批 E/P7。**P3 hybrid 净产出**=2 正确性修（T02/T05）+ 2 fail-loud/决策（T04/T06）+ 测试网零→59 测（T07）+ 模型 dispatch 设计（T08/D-020）。下一步=批 E 并入 P7 / 开 P3 PR / 启 P4。设计 `designs/P3-T08-tableformat-dispatch-design.md`
 - **2026-06-05** ✅ **P3 批 C 编码完成（T07 三模块测试基线 + COW/MOR schema parity）**：feasibility recon（5-agent code-grounded workflow）定 **golden-value parity**（fe-core 只依赖 fe-connector-api/-spi、不依赖具体连接器模块，无跨模块编译路径；JUnit5 + 手写替身）；关键结论 **COW/MOR schema type-agnostic**（legacy/SPI 两侧 schema 推导都不按表型分支，差异只在 scan planning）。落地：**hudi**——`avroSchemaToColumns` 顶层列名 `toLowerCase` 修（gap-1，镜像 legacy `HMSExternalTable:745`，仅顶层、嵌套 struct 名保留）+ package-private static 可测；`HudiTypeMappingTest` 补 `fromAvroSchema`→ConnectorType golden（原零覆盖）；新 `HudiSchemaParityTest`（列名/序/类型/Hive 串/casing 边界 pin）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN 分类）。**hms**——新 `HmsTypeMappingTest`（hms+hive 共享的 Hive 类型串解析器，原零测试）。**hive**——新 `HiveFileFormatTest` + `HiveConnectorMetadataPartitionPruningTest`（镜像 T05 裁剪网）。三模块 test：hms 12 + hive 14 + hudi +18=33 全绿；checkstyle 0（含 test 源）；import-gate 通过。**两 parity gap**（[DV-008]）：gap-1 列名 casing 当场修（用户签字），gap-2 Hudi meta-field 纳入（`getTableAvroSchema(true)` vs 无参）推迟批 E（无真实 metaclient 不可单测）。下一步批 D（T08 design-only）。设计：`designs/P3-T07-test-baseline-design.md`
 - **2026-06-05** ✅ **P3 批 B 编码完成**（T05 ✅ + T06 决策，[DV-007]）：**T05**（commit `10b72d4`，feat）`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪——原占位实现列**全部** HMS 分区不裁剪、且无条件设 `prunedPartitionPaths` 静默把分区来源从 Hudi-metadata 切到 HMS；重写为忠实镜像 `HiveConnectorMetadata`（抽取 partition 列 EQ/IN 谓词→列候选→裁剪→仅有效果时回传 pruned handle，否则 `Optional.empty()` 回落 Hudi-metadata listing），保留 `List<String>` 路径表示 + `-1` 上限，7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿（模块 19 测）、checkstyle 0、import-gate 通过。**T06**（零代码决策，用户签字）MVCC/snapshot SPI **保持 default `Optional.empty()` opt-out**——recon 证「显式抛异常 override」错（破 SPI opt-out 约定、全体连接器无 override、无 production caller=死代码、T04 已 fail-loud time-travel）；完整 MVCC 入批 E。**scope 校正**（[DV-007]）：T05 `listPartitions*` override 推迟批 E（零 live caller、Hive 不 override）。批 A+B 编码完成，下一步批 C（三模块测试 + COW/MOR parity）。设计：`designs/P3-T05-*` / `P3-T06-*`
 - **2026-06-05** ✅ **P3-T04 time-travel/增量读 fail-loud**（commit `feceabb`，批 A 编码收尾）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支对 `FOR TIME/VERSION AS OF`（曾静默返最新——provider 永远读 `lastInstant`）与增量读（曾静默全扫——SPI 无表示）抛 `AnalysisException`。唯一同时可见 snapshot+incremental 处。fe-core 编译 + checkstyle 0；dormant 分支 gate 关时不可达=零 live 风险；单测推迟批 E（不可 exercise，R12 显式登记）。**批 A 编码完成**：T02 + T04 两个正确性修复落地，T03 推迟批 E（DV-006）
@@ -177,7 +179,7 @@
 
 | 类型 | 总数 | 最新条目 | 文档 |
 |---|---|---|---|
-| **决策**（D-NNN） | 19 | D-019（P3 hudi hybrid 推进策略）| [decisions-log.md](./decisions-log.md) |
+| **决策**（D-NNN） | 20 | D-020（单 `hms` 多格式 scan 路由=方案 B per-table provider；细化 D-005）| [decisions-log.md](./decisions-log.md) |
 | **偏差**（DV-NNN） | 8 | DV-008（P3-T07 parity gap：列名 casing 当场修、Hudi meta-field 纳入推迟批 E）| [deviations-log.md](./deviations-log.md) |
 | **风险**（R-NNN） | 14 | R-014（thrift sink 选择灵活性） | [risks.md](./risks.md) |
 
@@ -187,9 +189,9 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：P3 批 C 编码（T07，5-agent code-grounded recon workflow + 用户签字 2 个 fork：casing 当场修 / focused baseline）——三模块测试基线（hms `HmsTypeMappingTest` 12 + hive `HiveFileFormatTest` 6/`HiveConnectorMetadataPartitionPruningTest` 8 + hudi `HudiTypeMappingTest`+7/`HudiSchemaParityTest` 3/`HudiTableTypeTest` 4 = 33 全绿）+ COW/MOR schema parity（golden-value）+ gap-1 列名 casing 修（镜像 legacy）；记 DV-008；同步 tasks/P3 + PROGRESS + deviations-log + connectors/hudi + 设计备忘 P3-T07 + HANDOFF
-- **下一个 session 应做**：**批 D**（T08）——`tableFormatType` 分流消费**设计备忘（design-only，不动 fe-core live 路径）**。**不要碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器 / fe-core 消费实现（批 E）**
-- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（批 D 起点 + T07 认知 + gap-2/casing 缩界 + 沿用 golden-value/import-gate/checkstyle 禁 static import 认知）
+- **本 session 已完成**：P3 批 D（T08 design-only，AskUserQuestion 用户签字 M2=方案 B）——`tableFormatType` 分流消费设计备忘 + [D-020]；核心拆解 **M1 身份消费 ⊥ M2 scan 路由**；细化 D-005；同步 tasks/P3（T08 ✅ + 阶段日志）+ PROGRESS（§一/§二/§三/§四/§六/§七）+ decisions-log（D-020）+ connectors/hudi + 设计备忘 P3-T08 + HANDOFF；研究输入 `research/spi-multi-format-hms-catalog-analysis.md` 一并纳入 git 跟踪（design 引用，避免悬空）
+- **下一个 session 应做**（**P3 hybrid in-scope 批 A–D 已全部完成**，三选一，待用户定）：(1) 开 **P3 PR**（base `apache/doris:branch-catalog-spi`）；(2) **批 E 并入 P7**（live cutover，不在 P3 编码）；(3) 启 **P4**（maxcompute）。**P3 内不要碰 `SPI_READY_TYPES` / fe-core 消费实现 / legacy / 非 hudi 连接器（皆批 E）**
+- **是否需要 handoff**：**是**——本场已 rewrite [HANDOFF.md](./HANDOFF.md)（P3 批 A–D 完成总结 + D-020/M1⊥M2 认知 + 批 E/PR/P4 三选项 + 沿用坑）
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 
 ---

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -70,13 +70,16 @@
 ## 关联
 
 - 阶段 task：P3（待启动时建）
-- 决策：D-005（DLA 模型方案 A）
+- 决策：D-005（DLA 区分符方案 A）、D-020（多格式 scan 路由=方案 B per-table SPI provider，细化 D-005；T08 设计）
 - 偏差：（暂无）
 - 风险：（暂无独立的）
 
 ---
 
 ## 进度日志
+
+### 2026-06-05（批 D）
+- **P3-T08 ✅**（批 D，design-only 零代码，[D-020](../decisions-log.md)，用户签字）：`tableFormatType` 分流消费设计备忘。直接输入上 session recon `research/spi-multi-format-hms-catalog-analysis.md`；本场 firsthand 核读 keystone gap（`PluginDrivenExternalTable.initSchema` 只读 columns、丢 `getTableFormatType()`）。**核心拆解 M1 身份消费 ⊥ M2 scan 路由**（M1 三方案通用）。M2=**方案 B**（新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`，fe-core 优先 per-table、回落 per-catalog；hms 网关按 `handle.getTableType()` 委派 Hudi/Iceberg provider），把 per-table 选 provider 升为一等 SPI 契约（满足 D-009）。**细化 D-005**（区分符沿用；"PhysicalXxxScan" 措辞早于 P1 统一，由 per-table provider seam 取代）。Iceberg-on-hms 经 SPI 依赖 P6/M3；M1+M2 实现登记批 E/P7。**批 A–D（P3 hybrid in-scope）全部完成**。设计 [`../tasks/designs/P3-T08-tableformat-dispatch-design.md`](../tasks/designs/P3-T08-tableformat-dispatch-design.md)。
 
 ### 2026-06-05（批 C）
 - **P3-T07 ✅**（批 C，测试 + gap-1 修，[DV-008](../deviations-log.md)，用户签字）：三模块测试基线 + COW/MOR schema parity。feasibility = **golden-value**（fe-core 不依赖具体连接器模块，无跨模块编译路径）；关键结论 **COW/MOR schema type-agnostic**（两侧 schema 推导都不按表型分支，差异只在 scan planning）。**hudi** `avroSchemaToColumns` 顶层列名 `toLowerCase` 修（gap-1，镜像 legacy `HMSExternalTable:745`）+ package-private static 可测；`HudiTypeMappingTest` 补 `fromAvroSchema` golden（原零覆盖）；新 `HudiSchemaParityTest`（列名/序/类型/Hive 串/casing 边界）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN）。**hms** 新 `HmsTypeMappingTest`（共享 Hive 类型串解析器，原零测试）。**hive** 新 `HiveFileFormatTest` + `HiveConnectorMetadataPartitionPruningTest`（镜像 T05 裁剪网）。三模块 59 测全绿（hudi 33 + hms 12 + hive 14）；checkstyle 0；import-gate 通过；gate 保持关闭。gap-2 Hudi meta-field 纳入（`getTableAvroSchema(true)` vs 无参）推迟批 E。设计 [`../tasks/designs/P3-T07-test-baseline-design.md`](../tasks/designs/P3-T07-test-baseline-design.md)。

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -44,12 +44,12 @@
 | E2 Procedures | 🟡 | hudi 有 `archive_log` 等 procedure | 后续可考虑 |
 | E3 MetaInvalidator | 🟡 | 通过 HMS event 同步 | 复用 `fe-connector-hms` 的 invalidator |
 | E4 Transactions | 🟡 | hudi 有 timeline | 暂用 no-op |
-| E5 MvccSnapshot | ✅ 需要 | `HudiMvccSnapshot` 待迁移到 SPI | incremental query 时序 |
+| E5 MvccSnapshot | ✅ 需要 | 🟡 批 B 决策 keep default opt-out（T06/DV-007）；完整 `HudiMvccSnapshot` → 批 E | 全体连接器无 override，T04 已 fail-loud time-travel；incremental query 时序入批 E |
 | E6 VendedCredentials | ❌ | n/a | |
 | E7 SysTables | ❌ | n/a | |
 | E8 ColumnStatistics | 🟡 | hudi 有 column stats | 后续 |
 | E9 Delete/Merge sink | ❌ | hudi 写路径不在本计划范围 | 与 BE 强耦合 |
-| E10 listPartitions | ✅ 需要 | 走 HMS connector 的 listPartitions | |
+| E10 listPartitions | ✅ 需要 | 🟡 批 B：applyFilter EQ/IN 裁剪 ✅（T05 `10b72d4`，镜像 Hive）；`listPartitions*` override → 批 E（DV-007，零 live caller）| 分区裁剪经 applyFilter→prunedPartitionPaths→resolvePartitions 链路 |
 
 ---
 
@@ -78,7 +78,11 @@
 
 ## 进度日志
 
-### 2026-06-05
+### 2026-06-05（批 B）
+- **P3-T05 ✅**（批 B，commit `10b72d4`）：`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪。原占位实现列**全部** HMS 分区不裁剪、且无条件设 `prunedPartitionPaths`（静默把分区来源从 Hudi-metadata 切到 HMS）；重写为忠实镜像 `HiveConnectorMetadata`（抽取 partition 列 EQ/IN 谓词→列候选→裁剪→仅有效果时回传 pruned handle，否则 `Optional.empty()` 回落 Hudi-metadata listing）。保留 `List<String>` 路径表示 + `-1` 上限；7 helper duplicate from Hive（仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿；gate 保持关闭。`listPartitions*` override 推迟批 E（[DV-007](../deviations-log.md)：零 live caller、Hive 不 override）。设计 [`../tasks/designs/P3-T05-partition-pruning-design.md`](../tasks/designs/P3-T05-partition-pruning-design.md)。
+- **P3-T06 ✅**（批 B 决策，零代码，[DV-007](../deviations-log.md)，用户签字）：MVCC/snapshot SPI 保持 default `Optional.empty()` opt-out，不新增抛异常 override（破 SPI opt-out 约定、全体连接器无 override、无 production caller=死代码、T04 已 fail-loud time-travel）。完整 MVCC 入批 E。设计 [`../tasks/designs/P3-T06-mvcc-design.md`](../tasks/designs/P3-T06-mvcc-design.md)。
+
+### 2026-06-05（批 A）
 - **P3-T04 ✅**（批 A，commit `feceabb`）：`visitPhysicalHudiScan` SPI 分支 fail-loud——`FOR TIME/VERSION AS OF`（曾静默返最新）与增量读（曾静默全扫）抛 `AnalysisException`。dormant 分支零 live 风险；单测推迟批 E。**批 A 编码完成**（T02+T04 落地，T03→批 E）。
 - **P3-T03 🟡 推迟批 E**（[DV-006](../deviations-log.md)，用户签字）：schema_id/history_schema_info 非批 A 可做的 SPI-surface 修复——`HudiColumnHandle` 无 field id、SPI 无 Hudi `InternalSchema` 版本、连接器无 type→`TColumnType` thrift；裸 `current==file==-1`→BE `ConstNode`(大小写敏感) 弱于现状 `by_parquet_name` 名匹配（净回归）。批 A 保持现状名匹配（零回归，common 无 evolution 可用；改名/evolution 退化非崩溃），faithful parity 入批 E。
 

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -78,6 +78,9 @@
 
 ## 进度日志
 
+### 2026-06-05
+- **P3-T03 🟡 推迟批 E**（[DV-006](../deviations-log.md)，用户签字）：schema_id/history_schema_info 非批 A 可做的 SPI-surface 修复——`HudiColumnHandle` 无 field id、SPI 无 Hudi `InternalSchema` 版本、连接器无 type→`TColumnType` thrift；裸 `current==file==-1`→BE `ConstNode`(大小写敏感) 弱于现状 `by_parquet_name` 名匹配（净回归）。批 A 保持现状名匹配（零回归，common 无 evolution 可用；改名/evolution 退化非崩溃），faithful parity 入批 E。
+
 ### 2026-06-04
 - **P3-T02 ✅**（批 A，commit `95f23e9`）：修 JNI scanner `column_types` 双 bug——(a) 发完整 Hive 类型串（新 `HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），不再用 `getTypeName()` 丢精度/子类型；(b) `HudiScanRange` typed list 端到端，弃逗号 join/split（曾打碎 `decimal(10,2)`/`struct<...>`），BE 自做 join（types `#`）。建模块首批测试 11 个全绿；gate 保持关闭。设计见 [`../tasks/designs/P3-T02-column-types-design.md`](../tasks/designs/P3-T02-column-types-design.md)。
 - P3 启动 recon（8-agent code-grounded workflow + 对抗验证）。结论（[DV-005](../deviations-log.md)）：HMS-over-SPI 读码已存在但 **dormant**（gate 未开、零 live caller）；**真阻塞=catalog 模型错配**（独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`，fe-core 不消费 `tableFormatType`）+ 增量读无 SPI 表示（P1-T04 gap）+ 三模块零测试。P3 待 catalog 模型决策（a/b；c 否决）签字后开工。关键文件锚点见 HANDOFF。

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -79,6 +79,7 @@
 ## 进度日志
 
 ### 2026-06-05
+- **P3-T04 ✅**（批 A，commit `feceabb`）：`visitPhysicalHudiScan` SPI 分支 fail-loud——`FOR TIME/VERSION AS OF`（曾静默返最新）与增量读（曾静默全扫）抛 `AnalysisException`。dormant 分支零 live 风险；单测推迟批 E。**批 A 编码完成**（T02+T04 落地，T03→批 E）。
 - **P3-T03 🟡 推迟批 E**（[DV-006](../deviations-log.md)，用户签字）：schema_id/history_schema_info 非批 A 可做的 SPI-surface 修复——`HudiColumnHandle` 无 field id、SPI 无 Hudi `InternalSchema` 版本、连接器无 type→`TColumnType` thrift；裸 `current==file==-1`→BE `ConstNode`(大小写敏感) 弱于现状 `by_parquet_name` 名匹配（净回归）。批 A 保持现状名匹配（零回归，common 无 evolution 可用；改名/evolution 退化非崩溃），faithful parity 入批 E。
 
 ### 2026-06-04

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -63,6 +63,7 @@
   2. 把 `HudiScanNode` 删除，由 `PluginDrivenScanNode` + 增强后的 `HudiScanPlanProvider`（已存在）承接 incremental relation 逻辑。
   3. 改造 `PhysicalHudiScan` 让它走 SPI 路径。
 - **P3 启动前必须 P5 paimon 或 P7 hive 进入到至少完成 hms metadata 路径**，否则 hudi 拿不到底层 HMS 表元数据。**这是依赖序的隐藏约束**——见 master plan §3.4 第一段。
+- **⚠️ 2026-06-04 recon 更正（[DV-005](../deviations-log.md)）**：上一条「隐藏依赖」与代码不符。HMS-over-SPI 读路径（`fe-connector-hms` 客户端库 + `HiveConnectorMetadata`(type `"hms"`) + `HudiConnectorMetadata`(type `"hudi"`) + `ConnectorTableSchema.tableFormatType` 区分符）**早已存在但 dormant**（`CatalogFactory.SPI_READY_TYPES` 不含 hms/hudi，零 live caller）。**真正阻塞是 catalog 模型错配**：现存连接器是独立 `"hudi"` catalog type，而 Doris 真实模型是 hudi 寄生在 `"hms"` catalog 内、以 `DLAType.HUDI` 暴露，且 fe-core 不消费 `tableFormatType`。P3 改为：先 recon scan/split 路径 + 写 catalog 模型决策备忘（a/b；c 否决）→ 用户签字 → 编码。详见 [HANDOFF](../HANDOFF.md) 关键认知 1。
 
 ---
 
@@ -76,6 +77,9 @@
 ---
 
 ## 进度日志
+
+### 2026-06-04
+- P3 启动 recon（8-agent code-grounded workflow + 对抗验证）。结论（[DV-005](../deviations-log.md)）：HMS-over-SPI 读码已存在但 **dormant**（gate 未开、零 live caller）；**真阻塞=catalog 模型错配**（独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`，fe-core 不消费 `tableFormatType`）+ 增量读无 SPI 表示（P1-T04 gap）+ 三模块零测试。P3 待 catalog 模型决策（a/b；c 否决）签字后开工。关键文件锚点见 HANDOFF。
 
 ### 2026-05-24
 - 跟踪文件建立。50% 实现已就位，但 P3 依赖 hms-connector 路径先打通（D-005 模型）。

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -79,6 +79,7 @@
 ## 进度日志
 
 ### 2026-06-04
+- **P3-T02 ✅**（批 A，commit `95f23e9`）：修 JNI scanner `column_types` 双 bug——(a) 发完整 Hive 类型串（新 `HudiTypeMapping.toHiveTypeString` 复刻 legacy `HudiUtils.convertAvroToHiveType`），不再用 `getTypeName()` 丢精度/子类型；(b) `HudiScanRange` typed list 端到端，弃逗号 join/split（曾打碎 `decimal(10,2)`/`struct<...>`），BE 自做 join（types `#`）。建模块首批测试 11 个全绿；gate 保持关闭。设计见 [`../tasks/designs/P3-T02-column-types-design.md`](../tasks/designs/P3-T02-column-types-design.md)。
 - P3 启动 recon（8-agent code-grounded workflow + 对抗验证）。结论（[DV-005](../deviations-log.md)）：HMS-over-SPI 读码已存在但 **dormant**（gate 未开、零 live caller）；**真阻塞=catalog 模型错配**（独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`，fe-core 不消费 `tableFormatType`）+ 增量读无 SPI 表示（P1-T04 gap）+ 三模块零测试。P3 待 catalog 模型决策（a/b；c 否决）签字后开工。关键文件锚点见 HANDOFF。
 
 ### 2026-05-24

--- a/plan-doc/connectors/hudi.md
+++ b/plan-doc/connectors/hudi.md
@@ -11,8 +11,8 @@
 | **fe-core 旧路径** | `fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/` |
 | **共享依赖** | `fe-connector-hms`（通过 HMS 拿元数据） |
 | **计划迁移阶段** | **P3** |
-| **当前状态** | ⏸ 未启动 |
-| **完成度** | 20% |
+| **当前状态** | 🚧 dormant 硬化中（批 A–C；gate 关、零 live 风险）|
+| **完成度** | 25% |
 | **主 owner** | TBD |
 
 ---
@@ -31,7 +31,7 @@
 | 8-9 | 🚫 | hudi 无独立 catalog；走 D-005 的 `tableFormatType` 模型 |
 | 10 | ⏳ | 替换 `visitPhysicalHudiScan` 中 `HMSExternalTable.dlaType=HUDI` 检查 |
 | 11 | ⏳ | 删 `HudiScanNode`，由 `PluginDrivenScanNode` + `HudiScanPlanProvider` 承接 |
-| 12 | ⏳ | 0 个测试 |
+| 12 | 🟡 | 批 C/T07：三连接器模块测试基线 59 测（hudi 33 + hms 12 + hive 14；含 COW/MOR schema golden parity）；端到端/集群验证随批 E cutover |
 | 13 | ⏳ | 删 `datasource/hudi/` |
 
 ---
@@ -77,6 +77,9 @@
 ---
 
 ## 进度日志
+
+### 2026-06-05（批 C）
+- **P3-T07 ✅**（批 C，测试 + gap-1 修，[DV-008](../deviations-log.md)，用户签字）：三模块测试基线 + COW/MOR schema parity。feasibility = **golden-value**（fe-core 不依赖具体连接器模块，无跨模块编译路径）；关键结论 **COW/MOR schema type-agnostic**（两侧 schema 推导都不按表型分支，差异只在 scan planning）。**hudi** `avroSchemaToColumns` 顶层列名 `toLowerCase` 修（gap-1，镜像 legacy `HMSExternalTable:745`）+ package-private static 可测；`HudiTypeMappingTest` 补 `fromAvroSchema` golden（原零覆盖）；新 `HudiSchemaParityTest`（列名/序/类型/Hive 串/casing 边界）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN）。**hms** 新 `HmsTypeMappingTest`（共享 Hive 类型串解析器，原零测试）。**hive** 新 `HiveFileFormatTest` + `HiveConnectorMetadataPartitionPruningTest`（镜像 T05 裁剪网）。三模块 59 测全绿（hudi 33 + hms 12 + hive 14）；checkstyle 0；import-gate 通过；gate 保持关闭。gap-2 Hudi meta-field 纳入（`getTableAvroSchema(true)` vs 无参）推迟批 E。设计 [`../tasks/designs/P3-T07-test-baseline-design.md`](../tasks/designs/P3-T07-test-baseline-design.md)。
 
 ### 2026-06-05（批 B）
 - **P3-T05 ✅**（批 B，commit `10b72d4`）：`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪。原占位实现列**全部** HMS 分区不裁剪、且无条件设 `prunedPartitionPaths`（静默把分区来源从 Hudi-metadata 切到 HMS）；重写为忠实镜像 `HiveConnectorMetadata`（抽取 partition 列 EQ/IN 谓词→列候选→裁剪→仅有效果时回传 pruned handle，否则 `Optional.empty()` 回落 Hudi-metadata listing）。保留 `List<String>` 路径表示 + `-1` 上限；7 helper duplicate from Hive（仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿；gate 保持关闭。`listPartitions*` override 推迟批 E（[DV-007](../deviations-log.md)：零 live caller、Hive 不 override）。设计 [`../tasks/designs/P3-T05-partition-pruning-design.md`](../tasks/designs/P3-T05-partition-pruning-design.md)。

--- a/plan-doc/decisions-log.md
+++ b/plan-doc/decisions-log.md
@@ -15,6 +15,7 @@
 
 | 编号 | 别名 | 简述 | 日期 | 状态 |
 |---|---|---|---|---|
+| D-020 | — | 单 `hms` catalog 多格式 scan 路由 = 方案 B（`ConnectorMetadata.getScanPlanProvider(handle)` per-table default）；细化 D-005（design-only，实现批 E/P7）| 2026-06-05 | ✅ |
 | D-019 | — | P3 hudi 采用 hybrid：现做 model-agnostic 连接器硬化+测试（behind gate），推迟 catalog 模型落地+cutover 到 hive/HMS migration | 2026-06-04 | ✅ |
 | D-018 | U6 | `ConnectorColumnStatistics` 用 javadoc 类型映射表 + IAE 保证类型安全 | 2026-05-24 | ✅ |
 | D-017 | U5 | sys-table 命名统一 `$suffix`，别名机制留待未来 | 2026-05-24 | ✅ |
@@ -38,6 +39,18 @@
 ---
 
 ## 详细记录（时间倒序）
+
+### D-020 — 单 `hms` catalog 多格式 scan 路由 = 方案 B（per-table SPI provider）
+
+- **日期**：2026-06-05
+- **状态**：✅ 生效
+- **关联**：[D-005](#d-005)（被细化）、[D-009](#d-009)（default-only 约束）、[D-019](#d-019)（hybrid）、[tasks/P3 T08](./tasks/P3-hudi-migration.md)、[designs/P3-T08-tableformat-dispatch-design.md](./tasks/designs/P3-T08-tableformat-dispatch-design.md)、[research/spi-multi-format-hms-catalog-analysis.md](./research/spi-multi-format-hms-catalog-analysis.md)
+- **背景**：legacy 单 `hms` catalog 靠 `HMSExternalTable.dlaType` per-table tag + 处处 `switch(dlaType)` 同时暴露 Hive/Hudi/Iceberg。SPI 侧 `ConnectorTableSchema.tableFormatType` **产而不用**——`PluginDrivenExternalTable.initSchema:79-109` 只读 columns、`Connector.getScanPlanProvider:40-42` per-catalog 单点、`HiveScanPlanProvider` 硬编码 `tableFormatType="hive"`（research §6①②③ + 本场 firsthand 核读）。T08（批 D，design-only）须定 per-table 路由 seam；研究浮现三互斥方案（A 连接器内 router / B per-table SPI provider / C fe-core 发现期分派）。
+- **决策**：M2 scan 路由采 **方案 B**——在 `ConnectorMetadata` 新增**向后兼容 default** `getScanPlanProvider(ConnectorTableHandle handle)`（默认返 null → fe-core 回落 per-catalog `Connector.getScanPlanProvider()`）；fe-core `PluginDrivenScanNode.getSplits` 优先 per-table provider、回落 per-catalog；注册 `"hms"` 的连接器 override 之、按 `handle.getTableType()` 委派 Hudi/Iceberg provider。把"per-table 选 provider"升为一等 SPI 契约。配套 **M1**（fe-core 按缓存的 `tableFormatType` 做 per-table 引擎名/身份，作 opaque 串逐字上报、热路径不读）三方案通用。**design-only，实现 = 批 E/P7**。
+- **替代方案**：**A 连接器内 router**（`Connector.getScanPlanProvider()` 返回一个 `planScan` 按 `handle.getTableType()` 委派的 router）——零 SPI churn（`planScan` 已带 handle，本场核实），但路由藏进连接器、per-table 语义非一等契约；列为备选，批 E 实现期可据 iceberg 接入复杂度复核。**C fe-core 发现期分派**（fe-core 读 `tableFormatType` 建 format-specific 表对象，≈legacy DLAType→多态 DlaTable）——**否决**：fe-core 回退到 per-format 分派，违背瘦 fe-core 北极星（import-gate / D-003 / D-006）。
+- **影响**：**细化 [D-005]**——D-005 的"`tableFormatType` 区分符"结论沿用；但其"fe-core dispatch 到对应 `PhysicalXxxScan`"措辞（2026-05-24，**早于 P1 scan-node 统一**为单 `PluginDrivenScanNode` + per-range format）由 per-table provider seam 取代（SPI 路径已无 per-format `PhysicalXxxScan`）。批 E/P7 据此实现 M1+M2；新 default 方法满足 [D-009]（不破签名）。Iceberg-on-hms 经 SPI 依赖 **P6** 先补 `IcebergScanPlanProvider`（M3）；hms 网关引入对 `-hudi`/`-iceberg` 模块依赖边（A/B 同担）。**本场无代码改动**。
+
+---
 
 ### D-019 — P3 hudi 采用 hybrid 推进策略
 

--- a/plan-doc/decisions-log.md
+++ b/plan-doc/decisions-log.md
@@ -15,6 +15,7 @@
 
 | 编号 | 别名 | 简述 | 日期 | 状态 |
 |---|---|---|---|---|
+| D-019 | — | P3 hudi 采用 hybrid：现做 model-agnostic 连接器硬化+测试（behind gate），推迟 catalog 模型落地+cutover 到 hive/HMS migration | 2026-06-04 | ✅ |
 | D-018 | U6 | `ConnectorColumnStatistics` 用 javadoc 类型映射表 + IAE 保证类型安全 | 2026-05-24 | ✅ |
 | D-017 | U5 | sys-table 命名统一 `$suffix`，别名机制留待未来 | 2026-05-24 | ✅ |
 | D-016 | U4 | `getCredentialsForScans` 批量化，返回 `Map<Range, Credentials>` | 2026-05-24 | ✅ |
@@ -37,6 +38,18 @@
 ---
 
 ## 详细记录（时间倒序）
+
+### D-019 — P3 hudi 采用 hybrid 推进策略
+
+- **日期**：2026-06-04
+- **状态**：✅ 生效
+- **关联**：[DV-005](./deviations-log.md)、[D-005](#d-005)、[tasks/P3](./tasks/P3-hudi-migration.md)、master plan §3.4/§3.8
+- **背景**：两轮 code-grounded recon（+ 对抗验证）揭示：HMS-over-SPI 读码已存在但 dormant（gate 关、零 live caller）；scan/split plumbing 正确（单 `PluginDrivenScanNode` 混合 COW-native+MOR-JNI 非问题，与 legacy 结构等价）；真正阻塞是 catalog 模型错配（独立 `"hudi"` type vs 寄生 `"hms"` 的 `DLAType.HUDI`，fe-core 不消费 `tableFormatType`）+ 关闭的 gate；另有一批**与模型无关**的 SPI-surface 正确性缺口（`schema_id`/`history_schema_info` 缺、`column_types` 双 bug、time-travel 静默返最新、增量读无表示、partition 裁剪缺、三模块零测试）。
+- **决策**：P3 走 **hybrid**。**现在做 (b)**（批 A–D，全部 behind 关闭的 gate，零 live-path 风险）：hudi 连接器 model-agnostic 正确性修复 + metadata 补全 + 测试基线 + 模型 dispatch 设计（design-only）。**推迟 (a)**（批 E，登记不编码）：fe-core 消费 `tableFormatType` 的 per-table 分流、gate flip（`SPI_READY_TYPES` 加 hms/hudi）、live cutover、删 legacy `datasource/hudi/`、完整增量/time-travel、集群/runtime 验证 —— 并入一个 properly-scoped hive/HMS migration（P7 或专门子阶段）。
+- **替代方案**：(a) **hms-first 一次到位** —— 否决为 P3 首交付（把 P7 范围拉进 P3、re-route live 重度使用的 HMS 路径、零测试网，回归风险大）；(c) **直接 flip gate** —— 早已否决（模型错配下 `"hudi"` provider 不可达 + 高回归）。
+- **影响**：P3（hybrid）**不交付用户可见行为变化**（hudi 仍走 legacy，gate 不翻）；产出是连接器硬化 + 测试网 + 设计。批 A–C 验证为单测/设计级，端到端/集群验证随批 E cutover。tasks/P3 据此划批。
+
+---
 
 ### D-018 — `ConnectorColumnStatistics` 类型安全契约（原 U6）
 

--- a/plan-doc/deviations-log.md
+++ b/plan-doc/deviations-log.md
@@ -29,6 +29,32 @@
 
 ## 详细记录（时间倒序）
 
+### DV-008 — P3-T07 parity 暴露两处 SPI↔legacy 偏差：列名 casing 当场修；Hudi meta-field 纳入推迟批 E
+
+- **发现日期**：2026-06-05
+- **发现 session / agent**：P3 批 C session（T07 启动前 5-agent code-grounded recon workflow `p3-t07-recon`：cow-mor / legacy-types / spi-types / hms-surface / hive-surface + 主线核读 `HudiConnectorMetadata`/`HudiTypeMapping`/`HMSExternalTable.initHudiSchema`/`ThriftHmsClient`）
+- **当前状态**：🟢 已修正（gap-1 casing 已修 + 测；gap-2 meta-field 推迟批 E 实证）
+- **原计划位置**：[tasks/P3 §批 C/T07](./tasks/P3-hudi-migration.md)（「parity 测试——SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `getHudiTableSchema`」）——原计划隐含假定 SPI schema 输出与 legacy parity，仅需写测试验证
+- **偏差描述**：parity recon 实证 SPI avro→column 变换与 legacy `HMSExternalTable.initHudiSchema` 有两处偏差（其余逐类型一致，见设计备忘矩阵）：
+  1. **gap-1 列名 casing**：SPI `HudiConnectorMetadata.avroSchemaToColumns` 用 `field.name()` 原样；legacy 在 `HMSExternalTable.java:745` `toLowerCase(Locale.ROOT)`（**仅顶层列名**；嵌套 struct 字段名两侧均不降）。mixed-case avro 列名时 SPI 保留原 case → 破 parity（BE name-match 大小写敏感，见 DV-006 / T03）。
+  2. **gap-2 Hudi meta-field 纳入**：SPI `getSchemaFromMetaClient` 调无参 `TableSchemaResolver.getTableAvroSchema()`；legacy `getHudiTableSchema:852` 调 `getTableAvroSchema(true)`。`true` 很可能强制纳入 `_hoodie_*` meta 列，无参默认随 Hudi 版本/表配置（`populateMetaFields`）变 → 可能改变列集合。无真实 metaclient 不可单测判定（同 T03 族）。
+- **触发场景**：T07 parity recon（golden-value 法，因 fe-core 只依赖 fe-connector-api/-spi、不依赖具体连接器模块，无跨模块编译路径）+ 用户 AskUserQuestion 签字（2026-06-05，「Also fix casing now」+「Focused baseline」）。
+- **新方案**：
+  - **gap-1 当场修**（用户签字）：`avroSchemaToColumns` 顶层列名改 `toLowerCase(Locale.ROOT)`，镜像 legacy:745（仅顶层；嵌套 struct 名保持 raw，两侧一致）。已核安全：`ThriftHmsClient.convertFieldSchemas:303` 用 `fs.getName()` 不防御降字，但 Hive Metastore 自身存小写标识符 → 降 avro 路径列名与小写 HMS partition key 对齐（改善 `getColumnHandles` 匹配），无回归。`avroSchemaToColumns` 由 `private`→package-private `static`（零行为变更，使可单测）。
+  - **gap-2 推迟批 E**（DV-006 同族）：无真实 fixture 不可判定 + 属 schema-evolution/meta-field 机制，与 hive/HMS migration 一并实证。T07 parity 测不依赖该差异（测纯 avro→column 变换）。
+  - **缩界（R12 不静默）**：`ThriftHmsClient` 源头防御性降字（与 hive 模块共享）**不在 T07 改**——触碰 hive 行为属 P7/批 E。
+- **替代方案**：(gap-1) 不修、仅 pin 现状 + 记 DV 推批 E（precedent T03/T05）——用户否决，选当场修（trivially-correct，对齐 legacy + 小写 HMS）；(gap-2) 当场加 `(true)`——否决（无真实 metaclient 不可验证语义，脆测）。
+- **影响范围**：
+  - 文档：本条 + [tasks/P3](./tasks/P3-hudi-migration.md)（T07 ✅ + 验收 + 阶段日志）+ [PROGRESS](./PROGRESS.md)（§一/二/三/四/六/七）+ [connectors/hudi.md](./connectors/hudi.md)（概况 + playbook 12 + 进度日志）+ [HANDOFF](./HANDOFF.md)。
+  - 代码：gap-1 `HudiConnectorMetadata.avroSchemaToColumns`（降字 + 可见性）+ 6 测试文件（hudi 3 改/新 + hms 1 + hive 2）；gap-2 零代码。
+  - 计划：批 C = {三模块测试基线 ✅, COW/MOR schema parity ✅, gap-1 casing 修 ✅}；gap-2 meta-field 入批 E。
+- **关联**：P3-T07、DV-006（同族 schema-evolution 推批 E）、P3-T10/T11（批 E）、[D-019](./decisions-log.md)（hybrid）、[`designs/P3-T07-test-baseline-design.md`](./tasks/designs/P3-T07-test-baseline-design.md)
+- **后续动作**：
+  - [x] gap-1 casing 修 + `HudiSchemaParityTest` casing pin（顶层降、嵌套 struct 名保留）
+  - [x] 三模块测试基线（hms `HmsTypeMappingTest` 12 / hive `HiveFileFormatTest` 6 + `HiveConnectorMetadataPartitionPruningTest` 8 / hudi `HudiTypeMappingTest`+7 + `HudiSchemaParityTest` 3 + `HudiTableTypeTest` 4 = 33 全绿）
+  - [ ] 批 E：gap-2 meta-field 纳入（`getTableAvroSchema(true)` vs 无参）真实 fixture 实证
+  - [ ] 批 E/P7：`ThriftHmsClient` 源头防御性降字（与 hive 共享）
+
 ### DV-007 — P3 批 B scope 校正：T05 `listPartitions*` override 推迟批 E；T06 MVCC 保持 default opt-out（非抛异常 override）
 
 - **发现日期**：2026-06-05

--- a/plan-doc/deviations-log.md
+++ b/plan-doc/deviations-log.md
@@ -13,10 +13,11 @@
 
 ## 📋 索引
 
-> 时间倒序；当前共 **4** 项。
+> 时间倒序；当前共 **5** 项。
 
 | 编号 | 偏差主题 | 原计划位置 | 日期 | 当前状态 |
 |---|---|---|---|---|
+| DV-005 | P3 hudi「HMS-over-SPI 前置依赖」与代码不符；真阻塞=catalog 模型错配 | [connectors/hudi.md](./connectors/hudi.md) / [master plan §3.4](./00-connector-migration-master-plan.md) / D-005 | 2026-06-04 | 🟡 待修正（P3 模型决策）|
 | DV-004 | T13 用户向安装文档不在本代码仓（在 doris-website 仓） | [tasks/P2 T13](./tasks/P2-trino-connector-migration.md) | 2026-06-04 | 🟢 已修正 |
 | DV-003 | T12 回归测试引用不存在的先例/目录且本地不可运行 | [tasks/P2 T12](./tasks/P2-trino-connector-migration.md) | 2026-06-04 | 🟡 推迟 |
 | DV-002 | T11 无法 mock Trino plugin；JsonSerializer 非纯单元 | [tasks/P2 T11](./tasks/P2-trino-connector-migration.md) | 2026-06-04 | 🟢 已修正 |
@@ -25,6 +26,36 @@
 ---
 
 ## 详细记录（时间倒序）
+
+### DV-005 — P3 hudi 的「HMS-over-SPI 前置依赖」与代码实际状态不符；真正阻塞是 catalog 模型错配
+
+- **发现日期**：2026-06-04
+- **发现 session / agent**：P3 启动 recon session（8-agent code-grounded workflow + 2 路对抗验证；verdict `hmsMetadataOverSpiReady=false`, high confidence）
+- **当前状态**：🟡 待修正（P3 catalog 模型决策，待用户签字）
+- **原计划位置**：[connectors/hudi.md](./connectors/hudi.md)（「P3 启动前必须 P5 paimon 或 P7 hive 进入到至少完成 hms metadata 路径」）、[master plan §3.4/§3.8](./00-connector-migration-master-plan.md)、决策 D-005（用 `tableFormatType` 区分 DLA）
+- **偏差描述**：原计划假设 HMS-over-SPI 元数据读路径要等 P5/P7 才落地、是 P3 的前置硬依赖。recon 实测（`branch-catalog-spi` HEAD `0793f032662`）发现该读路径**代码早已存在且非 stub**（源自更早的 #62183/#62821，一直 dormant 在 gate 后）：
+  - `fe-connector-hms` = 共享 **HMS Thrift 客户端库**（`HmsClient`/`ThriftHmsClient`，**不是** ConnectorMetadata）；
+  - `fe-connector-hive` `HiveConnectorMetadata`(type `"hms"`) 真实读路径 + applyFilter 真分区裁剪；
+  - `fe-connector-hudi` `HudiConnectorMetadata`(type `"hudi"`) 从 Hudi Avro MetaClient 读 schema（HMS fallback）+ COW/MOR 探测 + `HudiScanPlanProvider` 快照扫描；
+  - D-005 区分符 `ConnectorTableSchema.tableFormatType`(`:33/:58`) 已存在并被各连接器写入。
+
+  但全部 **dormant**：`CatalogFactory.SPI_READY_TYPES = {jdbc, es, trino-connector}`(`CatalogFactory.java:52`) 不含 hms/hudi → HMS 系 catalog 永远走 legacy `HMSExternalCatalog`（零 live caller）。**真正阻塞不是缺 HMS 读码，而是 catalog 模型错配**：现存连接器注册独立 `"hudi"` catalog type（`HudiConnectorProvider.getType()=="hudi"`），而 Doris 真实模型是 hudi 寄生在 `"hms"` catalog 内、以 `HMSExternalTable.DLAType.HUDI` 暴露；fe-core 无 `"hudi"` catalog type，且 `PluginDrivenExternalTable` 从不消费 `tableFormatType`（只读 `getColumns()`，按 catalog TYPE 字串路由）→ 单个 `"hms"` 连接器没有 per-table HUDI/HIVE/ICEBERG 分流的 SPI 机制。附带确认缺口：增量读无 SPI 表示（P1-T04 `visitPhysicalHudiScan` SPI 分支丢弃 `getIncrementalRelation()`；MVCC trio 未实现；4 个 `*IncrementalRelation` 仍在 fe-core）；hive/hudi 未 override `listPartitions*`（Hudi applyFilter 列全部分区不裁剪，Hive applyFilter 做 EQ/IN 裁剪）；三模块零测试。**已验证非阻塞**：SPI scan/split 通用链路（`PluginDrivenScanNode.planScan`→BE）已被合入的 trino-connector 走通；hudi-specific 的「单 ScanNode 混合 COW-native + MOR-JNI 每-split 格式」正确性才是待验证项。
+- **触发场景**：用户准备启动 P3，要求 code-grounded 确认 HMS 就绪情况。
+- **新方案**：P3 不再以「等 P5/P7 交付 HMS-over-SPI」为前提；改为 (1) recon SPI scan/split 路径（hudi-specific 正确性），(2) 写 catalog 模型决策备忘（见下），用户签字后再编码。**不要直接 flip `SPI_READY_TYPES`**。
+- **替代方案（catalog 模型，待用户决策）**：
+  - **(a) hms-first**：`HiveConnectorProvider(type="hms")` 接入 `PluginDrivenExternalCatalog` + fe-core 消费 `tableFormatType` 分流，hudi 作薄增量。一次命中真正架构阻塞、契合现存 `type="hms"` 设计；但把 P7(hive/HMS) 范围拉进 P3、触碰 live 重度使用的 HMS 路径、零测试网，回归风险大。
+  - **(b) gate 后建脚手架**：先做 format-dispatch / 增量 SPI hook / MVCC + 补测试（design+stub，不动 live 路径、零回归）；但 hudi 不单独端到端可用，推迟模型决策。
+  - **(c) 直接 flip gate** —— **否决**（模型错配下 `"hudi"` provider 不可达；live hms catalog 推到未测 SPI；增量丢失；高回归）。
+- **影响范围**：
+  - 文档：本条 + [connectors/hudi.md](./connectors/hudi.md)（已加更正注）+ [PROGRESS.md](./PROGRESS.md)（§一 P3 / §二看板 / §四 / §六 / §七 已同步）+ [HANDOFF.md](./HANDOFF.md)（P3 起点）✅；master plan / hudi.md 章节正文待 P3 按选定模型重写。
+  - 代码：无（recon only）。
+  - 计划：P3 性质从「等依赖」变为「先定模型 + 补 SPI 分流/增量/测试」；可能与 P7(hive/HMS) 部分合并或重排序——待模型决策。
+- **关联**：D-005、P1-T04（incrementalRelation gap）、R-001（image 兼容）、P3、master plan §3.4/§3.8
+- **后续动作**：
+  - [x] P3 session：recon SPI scan/split —— **完成**（verdict：混合 COW-native/MOR-JNI 非问题、与 legacy 结构等价；plumbing 正确；parity gap 见下，详见 HANDOFF 1b）
+  - [ ] scan 侧 HIGH 修复（与模型无关、多在 SPI surface 内）：①`HudiScanPlanProvider` override `populateScanLevelParams` 设 current_schema_id+history_schema_info + `HudiScanRange` 设 `THudiFileDesc.schema_id`；②column_types 改发完整 Hive 类型串（弃 `getTypeName()`）+ 停止逗号 join/split（typed list 端到端）；③time-travel 透传 snapshot 否则 fail-loud；④增量读 fail-loud
+  - [x] 写 catalog 模型决策备忘（a/b），用户签字 —— **完成**：定 **hybrid**（[D-019](./decisions-log.md)），建 [tasks/P3](./tasks/P3-hudi-migration.md)（批 A 现做 b、批 E 推迟 a）
+  - [ ] 选定后：补 `tableFormatType` 分流消费、增量 SPI hook、`listPartitions` override + 真实 applyFilter 裁剪、三模块测试
 
 ### DV-004 — T13 用户向安装文档不在本代码仓（在 doris-website 仓）
 

--- a/plan-doc/deviations-log.md
+++ b/plan-doc/deviations-log.md
@@ -13,10 +13,11 @@
 
 ## 📋 索引
 
-> 时间倒序；当前共 **6** 项。
+> 时间倒序；当前共 **7** 项。
 
 | 编号 | 偏差主题 | 原计划位置 | 日期 | 当前状态 |
 |---|---|---|---|---|
+| DV-007 | P3 批 B scope 校正：T05 `listPartitions*` override 推迟批 E（零 live caller、Hive 不 override）；T06 MVCC 保持 default opt-out（非抛异常 override）| [HANDOFF 未完成 #1/#2](./HANDOFF.md) / [tasks/P3 T05/T06](./tasks/P3-hudi-migration.md) | 2026-06-05 | 🟢 已修正（T05 裁剪已落地；list*/MVCC 入批 E）|
 | DV-006 | P3-T03 schema_id/history 非批 A 可修（连接器缺 field-id/InternalSchema/type→thrift；裸基线会回归）；推迟批 E | [HANDOFF 1b ①](./HANDOFF.md) / [tasks/P3 T03](./tasks/P3-hudi-migration.md) | 2026-06-05 | 🟡 推迟（批 E）|
 | DV-005 | P3 hudi「HMS-over-SPI 前置依赖」与代码不符；真阻塞=catalog 模型错配 | [connectors/hudi.md](./connectors/hudi.md) / [master plan §3.4](./00-connector-migration-master-plan.md) / D-005 | 2026-06-04 | 🟡 待修正（P3 模型决策）|
 | DV-004 | T13 用户向安装文档不在本代码仓（在 doris-website 仓） | [tasks/P2 T13](./tasks/P2-trino-connector-migration.md) | 2026-06-04 | 🟢 已修正 |
@@ -27,6 +28,30 @@
 ---
 
 ## 详细记录（时间倒序）
+
+### DV-007 — P3 批 B scope 校正：T05 `listPartitions*` override 推迟批 E；T06 MVCC 保持 default opt-out（非抛异常 override）
+
+- **发现日期**：2026-06-05
+- **发现 session / agent**：P3 批 B session（T05/T06 启动前 5-reader code-grounded recon workflow：hudi-current / hudi-resolve / hive-ref / spi-invoke / mvcc-t06 + 主线核读 `HudiConnectorMetadata`/`HiveConnectorMetadata` 全文 + grep fe-core 调用方）
+- **当前状态**：🟢 已修正（T05 applyFilter EQ/IN 裁剪已落地 commit `10b72d4`；list*/MVCC 完整实现入批 E）
+- **原计划位置**：[HANDOFF.md 未完成 #1/#2](./HANDOFF.md)（「T05：`listPartitions/listPartitionNames/listPartitionValues` override + 真实 applyFilter EQ/IN 分区裁剪」；「T06：大概率**显式 unsupported**（与 T04 fail-loud 一致）」）+ [tasks/P3 §T05/T06](./tasks/P3-hudi-migration.md)
+- **偏差描述**：原计划把 T05 的「`listPartitions*` override」与「applyFilter 裁剪」并列为批 B 交付；并暗示 T06 应**新增抛异常的 MVCC override**。recon 实测两点前提失真：
+  1. **T05 `listPartitions*` 零 live caller + Hive 不 override**：SPI `ConnectorMetadata.listPartitionNames/listPartitions/listPartitionValues` 在 fe-core **无任何调用方**——`PluginDrivenScanNode` 不调用（分区经 `applyFilter`→`prunedPartitionPaths`→`resolvePartitions` 链路）；`ShowPartitionsCommand`/`HudiExternalMetaCache`/`MetadataGenerator` 调的是 **legacy** metastore 路径（`dorisTable.getRemoteName()`），非 SPI。对标 `HiveConnectorMetadata`（批 B 基准）**也不 override** 这三方法。→ 现 override = 不可测的死代码（违 R2 nothing speculative / R9 测意图）。
+  2. **T06「显式 unsupported」违 SPI opt-out 约定**：三个 MVCC 方法 default 即 `Optional.empty()`（= 不支持），`FakeConnectorPluginTest` 有显式断言；`Iceberg`/`Paimon`/`Hive`/`Trino` **全部依赖 default**，无一 override；MVCC 方法**无 production caller**（仅测试用 adapter）；且 T04 已在唯一可触发点（time-travel）`visitPhysicalHudiScan` 抛 `AnalysisException`。→ 新增抛异常 override = 唯一打破约定 + 不可达死代码（违 R11 conformance / R3 surgical）。
+- **触发场景**：T05/T06 启动前 recon + grep fe-core 调用方；用户 AskUserQuestion 签字（2026-06-05，「Pruning only, defer list*」+「Keep defaults + document」）。
+- **新方案**：
+  - **T05** = 仅 applyFilter 真实 EQ/IN 裁剪（忠实镜像 Hive 7 步 + 7 helper，保留 `List<String>` 路径表示与 `-1` 上限）；`listPartitions*` override **推迟批 E**（届时 fe-core 长出 SPI 消费 + `SHOW PARTITIONS` 改走 SPI 时一并做）。已落地 `10b72d4`（8 单测、checkstyle 0、import-gate 通过）。
+  - **T06** = **不 override，保持 default `Optional.empty()` opt-out + 文档化**（零代码）；正确的 fail-loud 已在 T04 的 translator 守卫。完整 MVCC（`HudiMvccSnapshot`、snapshot 透传、增量时序）入批 E。见 [`designs/P3-T06-mvcc-design.md`](./tasks/designs/P3-T06-mvcc-design.md)。
+- **替代方案**：(T05) 现 override 三方法委托 HMS——否决（死代码、无可测意图、Hive 无先例）；(T06) 新增抛异常 override——否决（破 opt-out 约定、不可达、与全体连接器分叉、T04 已覆盖）。
+- **影响范围**：
+  - 文档：本条 + [tasks/P3](./tasks/P3-hudi-migration.md)（T05 ✅ 裁剪 + T06 ✅ 决策 + 验收标准 + 阶段日志）+ [PROGRESS](./PROGRESS.md)（§一 P3 / §三 / §四 / §六计数）+ [connectors/hudi.md](./connectors/hudi.md)（E5/E10 + 进度日志）。
+  - 代码：T05 已合入 `10b72d4`（applyFilter 裁剪 + 单测）；T06 零代码。
+  - 计划：批 B 范围由 {T05 裁剪+list* override, T06 throwing override} 收为 {T05 裁剪 ✅, T06 keep-defaults ✅}；list*/完整 MVCC 与 T03/T09–T11 同批 E。
+- **关联**：[DV-005](#dv-005--p3-hudi-的hms-over-spi-前置依赖与代码实际状态不符真正阻塞是-catalog-模型错配)（其后续动作「listPartitions override + 真实 applyFilter 裁剪」本条落地裁剪部分）、P3-T05、P3-T06、P3-T10/T11（批 E）、[D-019](./decisions-log.md)（hybrid）、[P3-T04](./tasks/designs/P3-T04-fail-loud-design.md)
+- **后续动作**：
+  - [x] T05 applyFilter EQ/IN 裁剪 + 单测（`10b72d4`）
+  - [ ] 批 E：`listPartitions*` override（fe-core SPI 消费就绪 + `SHOW PARTITIONS` 走 SPI 后）
+  - [ ] 批 E：完整 MVCC（`HudiMvccSnapshot` + snapshot 透传 + 增量时序），time-travel 从 T04 fail-loud 转为正确快照
 
 ### DV-006 — P3-T03（schema_id / history_schema_info）不是 model-agnostic 的批 A SPI-surface 修复；推迟到批 E
 

--- a/plan-doc/deviations-log.md
+++ b/plan-doc/deviations-log.md
@@ -13,10 +13,11 @@
 
 ## 📋 索引
 
-> 时间倒序；当前共 **5** 项。
+> 时间倒序；当前共 **6** 项。
 
 | 编号 | 偏差主题 | 原计划位置 | 日期 | 当前状态 |
 |---|---|---|---|---|
+| DV-006 | P3-T03 schema_id/history 非批 A 可修（连接器缺 field-id/InternalSchema/type→thrift；裸基线会回归）；推迟批 E | [HANDOFF 1b ①](./HANDOFF.md) / [tasks/P3 T03](./tasks/P3-hudi-migration.md) | 2026-06-05 | 🟡 推迟（批 E）|
 | DV-005 | P3 hudi「HMS-over-SPI 前置依赖」与代码不符；真阻塞=catalog 模型错配 | [connectors/hudi.md](./connectors/hudi.md) / [master plan §3.4](./00-connector-migration-master-plan.md) / D-005 | 2026-06-04 | 🟡 待修正（P3 模型决策）|
 | DV-004 | T13 用户向安装文档不在本代码仓（在 doris-website 仓） | [tasks/P2 T13](./tasks/P2-trino-connector-migration.md) | 2026-06-04 | 🟢 已修正 |
 | DV-003 | T12 回归测试引用不存在的先例/目录且本地不可运行 | [tasks/P2 T12](./tasks/P2-trino-connector-migration.md) | 2026-06-04 | 🟡 推迟 |
@@ -26,6 +27,29 @@
 ---
 
 ## 详细记录（时间倒序）
+
+### DV-006 — P3-T03（schema_id / history_schema_info）不是 model-agnostic 的批 A SPI-surface 修复；推迟到批 E
+
+- **发现日期**：2026-06-05
+- **发现 session / agent**：P3 批 A session（T03 启动前 code-grounded recon：4-reader workflow 读 SPI hook + Paimon/ES 参照 + legacy 路径 + thrift/BE 消费端；主线对 BE `table_schema_change_helper.h` 二次核读）
+- **当前状态**：🟡 推迟（批 E，并入 hive/HMS migration）
+- **原计划位置**：[HANDOFF.md 关键认知 1b HIGH ①](./HANDOFF.md) + [DV-005 后续动作 ①](#dv-005--p3-hudi-的hms-over-spi-前置依赖与代码实际状态不符真正阻塞是-catalog-模型错配) + [tasks/P3 §P3-T03](./tasks/P3-hudi-migration.md)：「schema_id/history 缺→退化名匹配；可经现有 SPI hook `populateScanLevelParams`（Paimon/ES 已 override）+ `HudiScanRange` 设 schema_id 修复，**无需 fe-core 改动**」
+- **偏差描述**：原评估认为 ① 是「多在 SPI surface 内可修」的 model-agnostic 修复。recon 实测发现**前提不成立**：
+  1. **BE 语义**（`be/src/format/table/table_schema_change_helper.h:219-267`）：`history_schema_info` **unset** → `by_parquet_name`/`by_orc_name`（**鲁棒名匹配**，处理大小写 / 缺列）——**即当前 SPI hudi 路径行为**；`current_schema_id == file_schema_id` → **`ConstNode`**（`:92-121`）= **纯 identity-by-name**、**大小写敏感**、假设精确匹配（其注释自陈需注意大小写）；id 不同 → `by_table_field_id`（**唯一**做 field-id / 改名 / evolution 的路径）。
+  2. **「Paimon/ES 已 override」前提失真**：二者 override `populateScanLevelParams` 是为 **predicate / docvalue**，**并不设** schema evolution 元数据（recon 实证）——**无任何 SPI 先例**发 schema_id/history。
+  3. **连接器缺料**：`HudiColumnHandle` **无 field id**（仅 `name`/`typeName` 串/`isPartitionKey`）；SPI hudi 连接器**无 Hudi `InternalSchema` 版本跟踪**（legacy 走 `getCommitInstantInternalSchema`）；连接器模块**无 type→`TColumnType` thrift 转换**（legacy 在 fe-core `ExternalUtil.getExternalSchema`，import gate 禁止复用）。
+  4. **裸基线会回归**：若仅设 `current==file==-1`（→ ConstNode）= identity-by-name 大小写敏感，**严格弱于**当前名匹配（丢大小写 / 缺列处理）——**净回归**；而真正的 field-id evolution 路径需上述全部缺料。
+- **触发场景**：T03 启动前 recon + 主线核读 BE `gen_table_info_node_by_field_id` / `ConstNode` / `StructNode`。
+- **新方案**：**T03 推迟到批 E**，与 hive/HMS migration 一次性建齐机制（column-handle field id + Hudi `InternalSchema` 版本 + Avro/ConnectorType→`TColumnType` thrift + `populateScanLevelParams` 设 current+history + 每-split `THudiFileDesc.schema_id`）。批 A 不发任何 schema 元数据（保持现状名匹配，**零回归**），不 ship 裸 ConstNode 基线。用户已签字（2026-06-05，AskUserQuestion「Defer T03 to batch E」）。
+- **替代方案**：(a) 批 A 内建全套 field-id/InternalSchema/type→thrift 机制——否决（大、与批 E 重叠、触碰 live 可读 schema 路径、回归风险）；(b) 裸 ConstNode 基线——否决（净回归大小写/缺列）。
+- **影响范围**：
+  - 文档：本条 + [tasks/P3](./tasks/P3-hudi-migration.md)（T03 移入批 E、备注现状名匹配 + evolution gap）+ [PROGRESS](./PROGRESS.md)（§三 parity 行 / §六计数）+ [connectors/hudi.md](./connectors/hudi.md)。
+  - 代码：无（recon + 决策，零改动）。
+  - 计划：批 A 范围由 {T02,T03,T04} 收为 {T02 ✅, T04}；T03 与 T09–T11 同批 E。
+- **关联**：[DV-005](#dv-005--p3-hudi-的hms-over-spi-前置依赖与代码实际状态不符真正阻塞是-catalog-模型错配)（其后续 ① 本条修正）、P3-T03、P3-T10/T11（批 E）、[D-019](./decisions-log.md)（hybrid）、R-001
+- **后续动作**：
+  - [ ] 批 E：连接器 schema field-id + InternalSchema 版本 + type→thrift + `populateScanLevelParams` + per-split `schema_id`（faithful field-id evolution parity）
+  - [x] 现状行为登记：SPI hudi 走 BE 名匹配（`by_parquet_name`/`by_orc_name`），common 无 evolution 可用；改名 / reorder-with-evolution 退化（非崩溃）
 
 ### DV-005 — P3 hudi 的「HMS-over-SPI 前置依赖」与代码实际状态不符；真正阻塞是 catalog 模型错配
 

--- a/plan-doc/research/spi-multi-format-hms-catalog-analysis.md
+++ b/plan-doc/research/spi-multi-format-hms-catalog-analysis.md
@@ -1,0 +1,349 @@
+# 独立调研：SPI 体系下「单 HMS catalog 同时访问 Hive / Iceberg / Hudi」的现状分析
+
+> **性质**：独立调研快照（read-only），不修改任何现有文档。结论仅引用、不改写 [PROGRESS](../PROGRESS.md) / [tasks/P3](../tasks/P3-hudi-migration.md) / [DV-005](../deviations-log.md) / [D-019](../decisions-log.md)。
+> **方法**：6-reader code-grounded recon workflow（legacy-model / spi-catalog-gate / connector-providers / format-dispatch / scan-split-path / module-deps-reuse）+ 主线核读。所有结论带 `file:line` 锚点。
+> **调研日期**：2026-06-05　**分支**：`catalog-spi-04`（基于 `branch-catalog-spi`）
+> **范围**：只回答「legacy 单 `hms` catalog 同时暴露 Hive+Iceberg+Hudi」这一能力在 SPI 体系下的现状、依赖、复用、调用关系、阶段、缺口、后续步骤。**未做任何代码改动。**
+
+---
+
+## 0. TL;DR（一句话结论）
+
+**当前 SPI 体系「尚未」端到端支持单个 `hms` catalog 同时访问 Hive/Iceberg/Hudi。** 三件事已就位：①连接器模块齐全（hive 注册 `"hms"` 类型、hudi 注册 `"hudi"`、iceberg 注册 `"iceberg"`）；②**per-table 格式探测已忠实复刻 legacy**（`HiveTableFormatDetector` 与 `HMSExternalTable.makeSureInitialized` 同序同集）；③探测结果已写入 `HiveTableHandle.tableType` + `ConnectorTableSchema.tableFormatType`。
+
+但**三处关键链路断裂**，使其仍不可用：
+
+1. **`tableFormatType` 产而不用**——fe-core `PluginDrivenExternalTable.initSchema()` 拿到 `ConnectorTableSchema` 后**只读 columns、从不读 `getTableFormatType()`**（`PluginDrivenExternalTable.java:~93`/`~210`），per-table 格式信号在 fe-core 边界被丢弃。
+2. **scan 派发按连接器硬编码、非按表格式**——`HiveScanPlanProvider.planScan` 对所有表都发 `HiveScanRange` 且 `tableFormatType="hive"`（`HiveScanRange.java:120-122,195`），**从不读 `handle.getTableType()`**；hms 里的 Hudi/Iceberg 表会被当成 Hive 误扫。
+3. **一个 `Connector` 只有一个 `ScanPlanProvider`（per-catalog 非 per-format）**——`Connector.getScanPlanProvider()` 默认返 null、`HiveConnector` 恒返 `HiveScanPlanProvider`；没有按 `HiveTableType` 选 `HudiScanPlanProvider`/`IcebergScanPlanProvider` 的 router。
+
+加之 **gate 关闭**（`SPI_READY_TYPES={jdbc,es,trino-connector}`，不含 hms/hudi/iceberg，`CatalogFactory.java:52`），**整个 HMS 家族当前一律走 legacy `HMSExternalCatalog`**——SPI 路径是 dormant 的。
+
+> 这与项目既有判断 [DV-005](../deviations-log.md)（真阻塞=catalog 模型错配 + fe-core 不消费 `tableFormatType`）、[D-019](../decisions-log.md)（hybrid：先硬化连接器、推迟模型落地到 P7/批 E）**完全吻合**——本调研在代码层面进一步坐实了"缺什么"。
+
+---
+
+## 1. Legacy 模型（目标行为：SPI 必须复刻它）
+
+单个 `HMSExternalCatalog`（type=`"hms"`）同时暴露 Hive/Iceberg/Hudi 表，靠**per-table 一次性格式探测 + 多态分派**：
+
+| 环节 | 位置 | 行为 |
+|---|---|---|
+| catalog | `HMSExternalCatalog.java:52-106` | 单实例，无 per-format 子类；所有表走 `HMSExternalTable` |
+| 格式枚举 | `HMSExternalTable.java:208-210` | `DLAType { UNKNOWN, HIVE, HUDI, ICEBERG }` |
+| **一次性探测** | `HMSExternalTable.java:250-307` | `makeSureInitialized()` 顺序：①Iceberg（`table_type=ICEBERG` 参数）→ ②Hudi（input format 或 `flink.connector=hudi`）→ ③Hive（支持的 input format）；设 `dlaType` + 建多态 `dlaTable`（`IcebergDlaTable`/`HudiDlaTable`/`HiveDlaTable`）|
+| schema 分派 | `HMSExternalTable.java:384-408` | `getFullSchema()` switch(dlaType)：HUDI→`HudiDlaTable.getHudiSchemaCacheValue()`、ICEBERG→`IcebergUtils.getIcebergSchema()`、else→Hive |
+| cache 引擎分派 | `HMSExternalTable.java:226-240` | `getMetaCacheEngine()` switch：`Hive/Hudi/IcebergExternalMetaCache.ENGINE` |
+| **scan 分派** | `PhysicalPlanTranslator.java:~724-770` | `visitPhysicalFileScan` switch(`getDlaType()`)：ICEBERG→`IcebergScanNode`、HIVE→`HiveScanNode`、HUDI→抛异常（须走 `visitPhysicalHudiScan`→`HudiScanNode`，`:819`）|
+| 多态基类 | `HMSDlaTable.java:36-87` | 抽象基类定义 per-format 的 partition/snapshot/MTMV 操作；3 个实现 `Hive/Hudi/IcebergDlaTable` |
+
+**要点**：legacy 的"同时多格式"靠 **`DLAType` 这个 per-table tag + 处处 switch(dlaType)**。SPI 必须复刻这个 per-table tag 的产生 **与** 消费（switch）。当前**只复刻了产生，没复刻消费**（见 §4.3 / §6）。
+
+---
+
+## 2. 模块全景与依赖图
+
+### 2.1 依赖图（已 code/pom 确认，箭头 = "依赖")
+
+```
+                         fe-thrift (provided)
+                              ▲
+                       fe-connector-api ──────────────┐ (SPI 接口: Connector / ConnectorMetadata /
+                              ▲                        │  ConnectorTableSchema / handle / pushdown / scan)
+                       fe-extension-spi                │
+                              ▲                        │
+                       fe-connector-spi ───────────────┤ (ConnectorProvider / ConnectorContext)
+                         ▲         ▲                    │
+        ┌────────────────┘         └───────────┐       │
+ fe-connector-hms              fe-connector-iceberg     │
+ (共享 HMS Thrift 客户端库,       (type="iceberg";        │
+  非 plugin: HmsClient /          iceberg-core/-aws,     │
+  ThriftHmsClient / HmsTableInfo  hadoop; **不依赖 hms,   │
+  / HmsPartitionInfo /            也不依赖 api!**)        │
+  HmsTypeMapping;                 + iceberg-api          │
+  hive-catalog-shade,             + iceberg-backend-     │
+  hadoop, commons-pool2)            {rest,hms,glue,dlf,  │
+   ▲           ▲                     hadoop,s3tables}     │
+   │           │                                         │
+fe-connector- fe-connector-                              │
+  hive          hudi                                     │
+ (type="hms")  (type="hudi";                             │
+               + hudi-common,                            │
+               hudi-hadoop-mr)                           │
+   │           │            │                            │
+   └───────────┴────────────┴──── 均依赖 fe-connector-api/-spi ┘
+
+ fe-core ── 仅依赖 ──> fe-connector-api + fe-connector-spi
+   （拥有 CatalogFactory / ConnectorFactory / ConnectorPluginManager /
+     PluginDrivenExternalCatalog·Database·Table / PluginDrivenScanNode）
+   **绝不依赖任何 fe-connector 实现模块**（hms/hive/hudi/iceberg/jdbc/es...）
+```
+
+### 2.2 依赖边清单（pom 实证）
+
+| 模块 | 依赖 | 锚点 |
+|---|---|---|
+| `fe-connector-api` | `fe-thrift`(provided) | `fe-connector-api/pom.xml:45-51` |
+| `fe-connector-spi` | `fe-connector-api` + `fe-extension-spi` | `fe-connector-spi/pom.xml:42-52` |
+| `fe-connector-hms` | `fe-connector-spi` + `hive-catalog-shade` + `hadoop-common` + `commons-pool2`（**库，非 plugin**）| `fe-connector-hms/pom.xml:43-96` |
+| `fe-connector-hive` | `fe-connector-spi` + `fe-connector-api`(provided) + `fe-thrift`(provided) + **`fe-connector-hms`** | `fe-connector-hive/pom.xml:43-82` |
+| `fe-connector-hudi` | `fe-connector-spi` + `fe-connector-api`(provided) + `fe-thrift`(provided) + **`fe-connector-hms`** + `hudi-common` + `hudi-hadoop-mr` | `fe-connector-hudi/pom.xml:44-96` |
+| `fe-connector-iceberg` | `fe-connector-spi` + `iceberg-core` + `iceberg-aws` + `hadoop-common`（**无 hms，且 pom 未见 api**）| `fe-connector-iceberg/pom.xml:43-81` |
+| `fe-core` | `fe-connector-api` + `fe-connector-spi`（仅此）| 由 import-gate 保证 |
+
+**关键结构观察**：
+- **依赖脊柱**：`api ← spi ← hms ← {hive, hudi}`；`iceberg` 走另一条线（Iceberg SDK，**不复用 hms**）。
+- **Hudi 不依赖 Hive**（pom 确认）——这印证了 P3-T05 里"分区裁剪 helper 只能从 Hive 复刻、不能跨模块共享"的判断。
+- **单向隔离**：`tools/check-connector-imports.sh:30-60` 禁止连接器 import fe-core `{catalog,common,datasource,qe,analysis,nereids,planner}`；fe-core 只 import `connector.api.*`/`connector.spi.*`。这是整个 SPI 解耦的护栏。
+
+### 2.3 各连接器完成度（LOC / 阶段，recon 实测）
+
+| 连接器 | LOC / 类数 | 注册 type | 实现范围 | 缺 |
+|---|---|---|---|---|
+| **fe-connector-hms** | 1461 / 9 | —（共享库）| HMS Thrift 客户端 + 类型映射 | n/a |
+| **fe-connector-hive** | 2010 / 12 | `"hms"` | metadata + scan + 分区裁剪 + **格式探测** | 非-Hive 格式的 scan 派发 |
+| **fe-connector-hudi** | 1854 / 11 | `"hudi"` | metadata + COW/MOR scan（T02/T04/T05 已硬化）| 接入 `hms` catalog 的 per-table 路径；MVCC/增量(批 E) |
+| **fe-connector-iceberg** | 596 / 6 | `"iceberg"` | **metadata-only**（list/getTableHandle/getTableSchema，用 Iceberg SDK）| **无 `ScanPlanProvider`**；pom 未依赖 `fe-connector-api` |
+
+---
+
+## 3. SPI 接口契约 & 调用关系（call chains）
+
+### 3.1 关键 SPI 类型
+
+- `Connector`（`fe-connector-api/Connector.java:34-121`）：`getMetadata(session)` + `getScanPlanProvider()`（默认返 null，`:40-42`，**per-catalog 一个**）。
+- `ConnectorMetadata`（`ConnectorMetadata.java:37-44`）= `ConnectorSchemaOps + ConnectorTableOps + ConnectorPushdownOps + ConnectorStatisticsOps + ConnectorWriteOps + ConnectorIdentifierOps + Closeable`。
+- `ConnectorProvider`（`fe-connector-spi/.../ConnectorProvider.java:40-98`）：`getType()` / `supports(type,props)`（默认 `type.equalsIgnoreCase(getType())`）/ `create(props,ctx)` / `apiVersion()`。
+- `ConnectorTableSchema`（`fe-connector-api/.../ConnectorTableSchema.java:29-92`）：`tableName + columns + **tableFormatType(String)** + properties`。**承载 per-table 格式信号的载体**。
+- `ConnectorScanPlanProvider`（`.../scan/ConnectorScanPlanProvider.java:38-196`）：`planScan(session, handle, columns, filter, limit) → List<ConnectorScanRange>`。
+- `ConnectorScanRange.getTableFormatType()`（`.../scan/ConnectorScanRange.java:96-98`）：默认 `"plugin_driven"`，各连接器 override（Hive→`"hive"`、Hudi→`"hudi"`）。
+
+### 3.2 catalog 创建链路
+
+```
+CREATE CATALOG
+ → CatalogFactory.createCatalog()  (CatalogFactory.java:71-184)
+   → if (SPI_READY_TYPES.contains(type))        // 当前仅 jdbc/es/trino-connector
+       ConnectorFactory.createConnector(type, props, ctx)
+        → ConnectorPluginManager.createConnector()  (:126-144)
+           → 遍历 providers, 第一个 provider.supports(type,props)==true
+           → provider.create(props, ctx) → Connector
+       → new PluginDrivenExternalCatalog(..., connector)
+     else  // hms/iceberg/paimon/hudi/max_compute 走这里
+       new HMSExternalCatalog(...) / IcebergExternalCatalogFactory.createCatalog(...) ...   ← legacy
+ → (FE 重启/反序列化) PluginDrivenExternalCatalog.initLocalObjectsImpl()  (:87-145)
+       → 用带 auth 的 DefaultConnectorContext 重新 createConnector（连接器生命周期 = 2 次创建）
+```
+
+### 3.3 元数据 / schema 链路（per-table 格式在此"产生"）
+
+```
+PluginDrivenExternalTable.initSchema()  (PluginDrivenExternalTable.java:79-109)
+ → metadata.getTableHandle(session, db, tbl)
+     → [Hive] HiveConnectorMetadata.getTableHandle()  (:105-131)
+         → HiveTableFormatDetector.detect(HmsTableInfo)  (:77-100)  ← 产生 HiveTableType{HIVE|HUDI|ICEBERG|UNKNOWN}
+         → new HiveTableHandle(..., tableType)            ← 格式写入 handle
+ → metadata.getTableSchema(handle)
+     → [Hive] HiveConnectorMetadata.getTableSchema()  (:134-154)
+         → detectFormatType(tableInfo)  (:282-294)  ← 产生 tableFormatType 字符串("HIVE_*"/"HUDI"/"ICEBERG")
+         → return new ConnectorTableSchema(name, cols, **formatType**, props)
+ → ❗ initSchema 只迭代 tableSchema.getColumns()，**从不读 getTableFormatType()** ← 信号在此丢弃（见 §6 缺口①）
+```
+
+### 3.4 scan / split 链路（per-table 格式在此"本应被消费"却未）
+
+```
+PhysicalPlanTranslator.visitPhysicalFileScan()  (:~735-740)
+ → if (table instanceof PluginDrivenExternalTable)  → PluginDrivenScanNode   // 先于 HMSExternalTable 匹配
+PluginDrivenScanNode.getSplits()  (:356-378)
+ → connector.getScanPlanProvider()        // per-catalog 一个；Hive 恒返 HiveScanPlanProvider
+ → scanProvider.planScan(session, currentHandle, cols, filter, limit)
+     → [Hive] HiveScanPlanProvider.planScan()  (:95-132)
+         → resolvePartitions(handle) → listAndSplitFiles(...)
+         → 每 split: HiveScanRange{ ..., tableFormatType="hive" }  (:268-296)  ← ❗ 不读 handle.getTableType()
+     → [Hudi] HudiScanPlanProvider.planScan()  (:85-162)   // 但 hms catalog 不会路由到它
+         → HoodieTableMetaClient → resolvePartitions → COW/MOR split → HudiScanRange{tableFormatType="hudi"}
+ → PluginDrivenScanNode.setScanParams()  (:381-395)
+     → TTableFormatFileDesc.setTableFormatType(scanRange.getTableFormatType())  ← BE 按此 string 选 reader
+```
+
+> **断点可视化**：格式信号有两条独立通道——(1) `ConnectorTableSchema.tableFormatType`（metadata 阶段产生，**fe-core 不消费**）；(2) `ConnectorScanRange.getTableFormatType()`（scan 阶段产生，**被消费但 per-connector 硬编码**）。两条都无法让"一个 hms catalog 把某张表当 Hudi/Iceberg 扫"。
+
+---
+
+## 4. per-table 格式探测：已就位的部分
+
+SPI 侧 `HiveTableFormatDetector.detect(HmsTableInfo)`（`fe-connector-hive/.../HiveTableFormatDetector.java:77-100`）**逐条镜像** legacy `HMSExternalTable.supportedIcebergTable/supportedHoodieTable/supportedHiveTable`：
+
+```
+(1) params["table_type"] == "ICEBERG"                         → ICEBERG
+(2) params["flink.connector"] == "hudi"
+    || inputFormat ∈ {HoodieParquetInputFormat, HoodieParquetRealtimeInputFormat, ...}  → HUDI
+(3) inputFormat ∈ {MapredParquetInputFormat, OrcInputFormat, TextInputFormat, ...}      → HIVE
+(4) else                                                       → UNKNOWN
+```
+
+- 同序、同集，与 fe-core 检测**不漂移**（两套各一份，recon 已比对一致；潜在 drift 风险见 §8）。
+- 结果落两处：`HiveTableHandle.tableType`（handle，`HiveTableHandle.java:~41`）+ `ConnectorTableSchema.tableFormatType`（schema，`HiveConnectorMetadata.java:153`）。
+
+**所以"探测"这一步已具备 legacy 的全部能力**——问题在下游"消费/路由"。
+
+---
+
+## 5. 复用地图（哪些可复用）
+
+| 可复用资产 | 位置 | 谁在用 / 可被谁用 |
+|---|---|---|
+| **HMS Thrift 客户端**（`HmsClient`/`ThriftHmsClient`，池化）| `fe-connector-hms` | hive + hudi 已复用；iceberg-HMS-backend **未**复用（用 Iceberg SDK）|
+| `HmsTableInfo` / `HmsPartitionInfo` DTO | `fe-connector-hms` | hive + hudi |
+| `HmsTypeMapping`（HMS→ConnectorType）| `fe-connector-hms` | hive + hudi |
+| **`HiveTableFormatDetector`**（per-table 格式探测）| `fe-connector-hive` | 仅 hive 内部；**应抽到共享层**供 router 复用 |
+| `ConnectorScanRange.populateRangeParams()` 钩子 | `fe-connector-api` | 各连接器写 per-split BE thrift（Hive ACID、Hudi JNI）|
+| **`PluginDrivenScanNode`** 通用 split/pushdown/limit/projection | `fe-core` | 任何新 provider 插入 `getScanPlanProvider()` 即免费获得 |
+| `ConnectorMetadata.applyFilter()` 下推钩子 | `fe-connector-api` | Hive/Hudi 分区裁剪；Iceberg/Hudi 可 override 加格式特定下推 |
+| 分区裁剪 helper（extractPartitionPredicates 等）| hive ↔ hudi **重复**（P3-T05 登记）| 待 P7 consolidate |
+| `ConnectorFactory.createConnector()` null-fallback | `fe-core` | legacy↔SPI 共存的 feature-flag（`SPI_READY_TYPES`）|
+
+---
+
+## 6. 关键缺口（为什么还不能端到端）
+
+> 按"阻断性"排序。①②③是机制断点，④⑤是模块缺失，⑥是开关。
+
+**① `tableFormatType` 产而不用（keystone gap）**
+`HiveConnectorMetadata` 正确地 per-table 设置了 `ConnectorTableSchema.tableFormatType`，但 `PluginDrivenExternalTable.initSchema()`（`:79-109`）**只读 columns、从不读 `getTableFormatType()`**。legacy 的 `DLAType` tag 在 SPI 里有"产生"无"消费"。→ fe-core 无从得知一张 SPI 表是 Hive/Hudi/Iceberg，也就无法把它路由到对的 scan/cache 路径。
+
+**② scan 派发 per-connector 硬编码、非 per-table**
+`HiveScanPlanProvider.planScan` 对所有表恒发 `tableFormatType="hive"`（`HiveScanRange.java:120-122,195`），**从不读 `handle.getTableType()`**（`HiveScanPlanProvider` 取 inputFormat/serde 但不分支格式）。→ hms 里的 Hudi/Iceberg 表会被 BE 当 Hive 文件误扫。
+
+**③ 一个 `Connector` 只有一个 `ScanPlanProvider`**
+`Connector.getScanPlanProvider()` 是 per-catalog（`Connector.java:40`），`HiveConnector` 恒返 `HiveScanPlanProvider`（`HiveConnector.java:60-62`）。没有"按 `HiveTableType` 选 `HudiScanPlanProvider`/`IcebergScanPlanProvider`"的 router/strategy。
+
+**④ Iceberg SPI 仅 metadata、无 scan provider**
+`IcebergConnectorMetadata` 仅 167 LOC（list/getTableHandle/getTableSchema，用 Iceberg SDK）；`IcebergConnector` **无 `getScanPlanProvider()` override → 返 null**（`IcebergConnector.java`，scan 仍在 fe-core `IcebergScanNode`）。且 `fe-connector-iceberg` pom **未依赖 `fe-connector-api`**（仅 spi），是接入 scan SPI 前必须补的结构缺口。
+
+**⑤ Hudi 的 metadata/scan 未接入 `hms` catalog 的 per-table 路径**
+`HudiConnectorProvider` 注册的是**独立** `"hudi"` 类型（面向专用 Hudi catalog），不在 `hms` catalog 的 per-table 分派内。hms 里探测为 HUDI 的表，目前 SPI 无法把它交给 `HudiConnectorMetadata`/`HudiScanPlanProvider`。
+
+**⑥ gate 关闭**
+`SPI_READY_TYPES={jdbc,es,trino-connector}`（`CatalogFactory.java:52`）不含 hms/hudi/iceberg → 整个 HMS 家族走 legacy `HMSExternalCatalog`。即便①–⑤补齐，也需翻闸 + legacy 兼容/cutover + image 反序列化兼容（R-001）。
+
+**附：测试缺口**　多格式分派零测试（`HMSExternalTableTest` 仅测 view）；三连接器模块 parity 测试为 P3 批 C 待补项。
+
+---
+
+## 7. 当前阶段定位
+
+> 引用 [PROGRESS.md](../PROGRESS.md)（不改写）：
+
+- **P0 SPI 基座 ✅ / P1 scan-node 收口 ✅ / P2 trino-connector ✅**（已合入 `branch-catalog-spi`）。
+- **P3 hudi（hybrid，D-019）进行中**：批 A（T02 column_types、T04 time-travel/增量 fail-loud）+ 批 B（T05 分区裁剪、T06 MVCC keep-defaults）**编码完成**，**gate 仍关**；批 C（三模块测试 + COW/MOR parity）、批 D（T08 `tableFormatType` 分流消费**设计**）待启动；批 E（模型落地/翻闸/删 legacy/集群验证）deferred 并入 P7。
+- **P4 maxcompute / P5 paimon / P6 iceberg / P7 hive(+HMS) / P8 收尾**：未启动。
+- **Iceberg / Hive 连接器**：iceberg=metadata-only（596 LOC），hive=metadata+scan+探测（2010 LOC），**均 dormant**（gate 关）。
+- **真阻塞（[DV-005](../deviations-log.md)）= catalog 模型错配 + fe-core 不消费 `tableFormatType`**——本调研在 §6 逐条坐实。
+
+**一句话定位**：底座（SPI 接口、PluginDriven* 框架、HMS 共享库、per-table 探测、各连接器骨架）已就位且各连接器在 gate 后逐个硬化；**但"单 hms catalog 多格式分派"这条主干尚未接通，且其设计（批 D / T08）尚未落笔、落地在 P7/批 E**。
+
+---
+
+## 8. 还缺哪些模块 / 机制
+
+| # | 缺失项 | 类型 | 落点（项目计划）|
+|---|---|---|---|
+| M1 | **fe-core 消费 `tableFormatType`**：`PluginDrivenExternalTable`（或一个 table 工厂）读 `ConnectorTableSchema.tableFormatType`，驱动 per-table 的 scan 路径 + cache 引擎选择 | fe-core 机制 | **批 D 设计(T08) → 批 E/P7 实现** |
+| M2 | **per-table scan-provider router**：让单个 `hms` 连接器按 `HiveTableType` 选 Hive/Hudi/Iceberg 的 scan 规划（见下"3 选项"）| SPI/连接器机制 | 批 D 设计 → P7 |
+| M3 | **`IcebergScanPlanProvider`** + `fe-connector-iceberg` 依赖 `fe-connector-api` | iceberg 模块 | **P6** |
+| M4 | **Hudi metadata/scan 接入 hms catalog**（hms 探测为 HUDI 的表交给 Hudi 路径）| 连接器组合 | 批 E/P7 |
+| M5 | **格式探测共享化**：把 `HiveTableFormatDetector` 抽到共享层，消除 fe-core / SPI 两份 drift 风险 | 复用重构 | P7 |
+| M6 | **gate flip** `SPI_READY_TYPES += hms` + legacy `HMSExternalCatalog` cutover/兼容 + image 反序列化兼容（R-001）| 翻闸/迁移 | 批 E/P7 |
+| M7 | **多格式分派测试网**（parity：SPI 输出 vs legacy；混合 Hive/Hudi/Iceberg catalog 端到端）| 测试 | P3 批 C + P7 |
+| M8 | Paimon / MaxCompute 的 ConnectorProvider（与本问题相关性低，但同属 HMS 家族外的并行迁移）| 连接器 | P4 / P5 |
+
+### M2 的关键未决设计决策（"3 选项"，recon 浮现，**项目尚未拍板**）
+
+单个 `hms` catalog 如何把 per-table 路由到 Hive/Hudi/Iceberg？三条路线（互斥）：
+
+- **(A) 连接器内 router**：`HiveConnector`（type=`"hms"`）作为网关，`getScanPlanProvider()` 返回一个按 `handle.getTableType()` 选子 provider 的 router；metadata 侧同理 `HiveConnectorMetadata` 委托 `Hudi/IcebergConnectorMetadata`。**优点**：贴合"hive 模块已注册 `hms`"现状、单 catalog 单 connector 不变。**缺点**：把 hive 连接器变成三格式聚合体，模块边界变重。
+- **(B) SPI 改为 per-table 选 provider**：把 `getScanPlanProvider()` 从 `Connector`（per-catalog）下移到 `ConnectorMetadata.getScanPlanProvider(handle)`（per-table，按 handle 类型）。**优点**：最干净的 per-table 语义。**缺点**：改 SPI 接口，影响所有连接器。
+- **(C) fe-core 发现期分派**：fe-core 读 `tableFormatType`，在建表时产出 format-specific 的表对象（最接近 legacy `DLAType`→多态 `DlaTable`）。**优点**：与 legacy 心智一致、改动集中在 fe-core。**缺点**：fe-core 需重新长出 per-format 分派（部分回到 legacy 形态），与"瘦 fe-core"目标张力。
+
+> 这正是 [D-019](../decisions-log.md) 把 (a)模型落地推迟到 P7/批 E 的核心待决项；[tasks/P3 T08](../tasks/P3-hudi-migration.md)（批 D，design-only）是其设计入口。本调研建议把"M1+M2 的 (A/B/C) 选型"作为 T08 设计备忘的核心命题。
+
+---
+
+## 9. 后续开发步骤（建议 roadmap）
+
+> 与既有阶段计划（P3 hybrid → P6 iceberg → P7 hive/HMS）和 D-019/DV-005 对齐；不替代项目计划，作为"打通单 hms 多格式"的依赖序梳理。
+
+```
+[已完成] SPI 基座(P0) · scan-node 收口(P1) · trino 迁移(P2) · hudi 连接器硬化(P3 批A+B)
+   │
+   ├─[P3 批C]  三模块测试基线 + COW/MOR parity（SPI 输出 vs legacy）           ← 正在路上
+   │
+   ├─[P3 批D / T08]  ★keystone 设计★：`tableFormatType` 分流消费 + M2(A/B/C)选型   ← 设计 only
+   │                 产出 D-NNN（模型决策），明确 M1+M2 的接口形态
+   │
+   ├─[P6]  Iceberg scan SPI：补 IcebergScanPlanProvider + iceberg 依赖 api(M3)     ← 让 iceberg 可走 SPI
+   │
+   └─[P7 / 批E]  模型落地（live cutover）：
+        1. M1  fe-core 消费 tableFormatType（PluginDrivenExternalTable / table 工厂）
+        2. M2  落地选定的 router 方案（A/B/C 之一）
+        3. M4  hms catalog 内 per-table 把 HUDI→Hudi 路径、ICEBERG→Iceberg 路径
+        4. M5  抽共享格式探测，消 drift
+        5. M6  SPI_READY_TYPES += hms 翻闸 + legacy HMSExternalCatalog cutover + image 兼容(R-001)
+        6. 删 legacy datasource/{hive,hudi,iceberg}/ + 清反向 instanceof
+        7. M7  混合 Hive/Hudi/Iceberg catalog 端到端/集群验证
+```
+
+**最短关键路径**（让单 hms catalog 多格式"先能跑通"）：**T08 设计(M1+M2 选型) → M1 fe-core 消费 tableFormatType → M2 router → M4 hms 内 Hudi 路径 →（Iceberg 需 M3 先行）→ M6 翻闸**。其中 **M1+M2 是真正的 keystone**：没有它，per-table 探测的成果无法兑现。
+
+---
+
+## 10. 开放问题（留给 T08 设计 / 后续决策）
+
+1. **M2 选型**：(A) 连接器内 router / (B) `ConnectorMetadata.getScanPlanProvider(handle)` per-table / (C) fe-core 发现期分派——哪条？（§8）
+2. **Iceberg 归属**：hms 里的 Iceberg 表是由 hms 连接器委托 `IcebergConnectorMetadata`，还是 fe-core 仍回落 legacy `IcebergScanNode`？Iceberg 不依赖 hms（用 SDK），跨界委托如何拼装？
+3. **Hudi time-travel/增量**：`planScan` 只读最新快照（`HudiScanPlanProvider.java:100-108`），`visitPhysicalHudiScan` 对 `AS OF`/增量已 fail-loud（P3-T04）。snapshot/timestamp 如何经 SPI 传入 `planScan`？（批 E）
+4. **连接器生命周期**：catalog 创建期 + `initLocalObjectsImpl` 期各创建一次 connector（`PluginDrivenExternalCatalog.java:87-145`）——首个是否被丢弃？`HmsClient` 是否重复建（池泄漏风险）？
+5. **`tableFormatType` 去留**：它是面向未来 per-table 分派的前瞻字段（应被 M1 消费），不是技术债——T08 须明确其消费契约。
+6. **fe-core ↔ SPI 探测 drift**：`HMSExternalTable.makeSureInitialized` 与 `HiveTableFormatDetector` 两份逻辑，长期是否抽共享（M5）以防漂移？
+
+---
+
+## 附录 A：核心 file:line 锚点索引
+
+**Legacy 模型**
+- `fe-core/.../datasource/hive/HMSExternalCatalog.java:52-106`
+- `fe-core/.../datasource/hive/HMSExternalTable.java:208-210`(DLAType) `:250-307`(探测) `:226-240`(cache 分派) `:384-408`(schema 分派)
+- `fe-core/.../datasource/hive/{Hive,Hudi,Iceberg}DlaTable.java` / `HMSDlaTable.java:36-87`
+- `fe-core/.../nereids/glue/translator/PhysicalPlanTranslator.java:~724-770`(scan 分派) `:819`(visitPhysicalHudiScan)
+
+**SPI catalog / gate / 框架**
+- `fe-core/.../datasource/CatalogFactory.java:52`(SPI_READY_TYPES) `:71-184`(createCatalog)
+- `fe-core/.../connector/ConnectorFactory.java:53-75` / `ConnectorPluginManager.java:74-144`
+- `fe-core/.../datasource/PluginDrivenExternalCatalog.java:57-145` / `PluginDrivenExternalTable.java:79-109`(❗不读 tableFormatType) / `PluginDrivenScanNode.java:85-100,356-395`
+
+**SPI 接口**
+- `fe-connector-api/.../Connector.java:34-121` / `ConnectorMetadata.java:37-44` / `ConnectorTableSchema.java:29-92`
+- `fe-connector-api/.../scan/ConnectorScanPlanProvider.java:38-196` / `ConnectorScanRange.java:96-98`
+- `fe-connector-spi/.../ConnectorProvider.java:40-98`
+
+**连接器实现**
+- hive: `HiveConnectorProvider.java:32-43`(type="hms") / `HiveConnector.java:54-73` / `HiveConnectorMetadata.java:105-131,134-154,282-294,193-234` / `HiveTableFormatDetector.java:77-100` / `HiveTableType.java:28-41` / `HiveTableHandle.java:35-196` / `HiveScanPlanProvider.java:95-132` / `HiveScanRange.java:120-122,195`
+- hudi: `HudiConnectorProvider.java:36`(type="hudi") / `HudiConnector.java:46-110` / `HudiConnectorMetadata.java:69-214` / `HudiScanPlanProvider.java:85-162` / `HudiScanRange.java:140-142`
+- iceberg: `IcebergConnectorProvider.java:34-45`(type="iceberg") / `IcebergConnector.java:51-150`(无 scan provider) / `IcebergConnectorMetadata.java:57-167`(metadata-only)
+- hms: `fe-connector-hms/.../HmsClient.java:40-78`
+
+**护栏 / 项目文档**
+- `tools/check-connector-imports.sh:30-60`
+- `plan-doc/deviations-log.md`(DV-005) / `plan-doc/decisions-log.md`(D-019) / `plan-doc/tasks/P3-hudi-migration.md`(T08 批 D)
+
+---
+
+## 附录 B：调研方法与可信度
+
+- 6 个 read-only `Explore` agent 并行（areas：legacy-model / spi-catalog-gate / connector-providers / format-dispatch / scan-split-path / module-deps-reuse），合计读 ~286 次工具调用、~469K token；结论经 6 reader 交叉印证（§0 三断点、gate、依赖图均多 reader 一致）。
+- **可信度高的结论**：`tableFormatType` 产而不用、scan 硬编码 `"hive"`、Iceberg 无 ScanPlanProvider、依赖图、type 注册（hms/hudi/iceberg）、gate 内容——多 reader + 主线核读一致。
+- **行号为近似锚点**：个别文件不同 reader 报的行段略有出入（如 `PhysicalPlanTranslator` ~724-795），已取交集并标"~"。落地修改前应按附录 A 重新精确定位。
+- **本调研未运行构建/测试**（纯静态阅读）；未改动任何代码或现有文档。
+```

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -9,7 +9,7 @@
 
 ## 元信息
 
-- **状态**：🚧 进行中（批 0 ✅；批 A 编码完成 T02 ✅/T04 ✅/T03→批 E；批 B 编码完成 T05 ✅/T06 决策 ✅（[DV-007]）；**批 C 编码完成**：T07 三模块测试基线 + COW/MOR schema parity ✅（[DV-008]，列名 casing 当场修、meta-field→批 E）；下一步批 D：T08 `tableFormatType` 分流设计备忘 design-only）
+- **状态**：🚧 进行中（批 0 ✅；批 A 编码完成 T02 ✅/T04 ✅/T03→批 E；批 B 编码完成 T05 ✅/T06 决策 ✅（[DV-007]）；批 C 编码完成 T07 三模块测试基线 + COW/MOR schema parity ✅（[DV-008]）；**批 D 设计完成**：T08 `tableFormatType` 分流消费设计备忘 ✅（[D-020]，M2=方案 B per-table SPI provider，design-only）。**批 A–D（P3 hybrid 全部 in-scope）完成**，剩批 E（deferred，并入 P7/hive·HMS migration））
 - **启动日期**：2026-06-04
 - **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
 - **实际完成**：—
@@ -45,7 +45,7 @@
 - [x] **批 B / T05**：真实 `applyFilter` EQ/IN 约束裁剪 ✅（`10b72d4`，镜像 Hive）；`listPartitions*` override **推迟批 E**（[DV-007]，零 live caller、Hive 不 override）
 - [x] **批 B / T06**：MVCC/snapshot SPI **保持 default opt-out + 文档化** ✅（[DV-007]，非抛异常 override——破 opt-out 约定/不可达；T04 已 fail-loud time-travel）；完整 MVCC 入批 E
 - [x] **批 C / T07**：fe-connector-hms/hive/hudi 测试基线 ✅（hms 12 + hive 14 + hudi +18=33 全绿，golden-value）；**parity 测试** ✅——COW/MOR schema **type-agnostic**（差异只在 scan planning），SPI avro→column 变换 golden 对标 legacy `getHudiTableSchema`/`initHudiSchema`（列名/序/类型/Hive 串/casing）+ `detectHudiTableType` COW/MOR 分类。列名 casing 当场修（[DV-008]）；meta-field 纳入推迟批 E
-- [ ] **批 D**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core live 路径**）
+- [x] **批 D / T08**：`tableFormatType` 分流消费设计备忘 ✅（design-only，零代码，**未动 fe-core live 路径**）——M1（fe-core opaque-串身份消费）⊥ M2（scan 路由）拆解；M2=**方案 B** per-table SPI provider（[D-020]，用户签字），细化 D-005；实现登记批 E/P7。设计：[`designs/P3-T08-tableformat-dispatch-design.md`](./designs/P3-T08-tableformat-dispatch-design.md)
 - [ ] 全程 fe-connector 编译 + checkstyle 0 + import-gate 通过；新增单测全绿
 - [ ] gate 保持关闭（`SPI_READY_TYPES` 不含 hms/hudi）；legacy `datasource/hudi/` 不删（批 A–D 内）
 - [ ] 批 E 各项作为 deferred 明确登记，不在 P3 PR 内编码
@@ -66,7 +66,7 @@
 | P3-T05 | 真实 `applyFilter` EQ/IN 分区裁剪 + 单测（`listPartitions*` override 推迟批 E）| 批 B | @me | ✅ | `10b72d4` | 2026-06-05 | 2026-06-05 | applyFilter 原是占位（列全部分区不裁剪 + 无条件设 `prunedPartitionPaths` → 静默把分区来源从 Hudi-metadata 切到 HMS）。重写为**忠实镜像 `HiveConnectorMetadata`**：抽取 partition 列 EQ/IN 谓词 → 列候选 → 裁剪 → 仅在有效果时回传 pruned handle，否则 `Optional.empty()`（handle 不变，回落 Hudi-metadata listing）。保留 `List<String>` 路径表示 + `-1` 上限（不静默截断）；7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿、checkstyle 0、import-gate 通过。**`listPartitions*` override 推迟批 E**（[DV-007]：零 live caller、Hive 不 override）。设计：[`designs/P3-T05-partition-pruning-design.md`](./designs/P3-T05-partition-pruning-design.md) |
 | P3-T06 | MVCC/snapshot SPI：保持 default opt-out + 文档化（完整 MVCC→批 E）| 批 B | @me | ✅ | — | 2026-06-05 | 2026-06-05 | **决策（[DV-007]，用户签字「Keep defaults + document」）**：不 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`，保持 SPI default `Optional.empty()`（= opt-out）。recon 证「显式抛异常 override」错——破 SPI opt-out 约定（全体连接器含 Iceberg/Paimon/Hive/Trino 均依赖 default，`FakeConnectorPluginTest` 断言）、不可达死代码（MVCC 无 production caller）、且 T04 已在唯一可触发点（time-travel）fail-loud。**零代码**。完整 MVCC（`HudiMvccSnapshot`+snapshot 透传+增量时序）入批 E。设计：[`designs/P3-T06-mvcc-design.md`](./designs/P3-T06-mvcc-design.md) |
 | P3-T07 | 三模块测试基线 + parity 测试 | 批 C | @me | ✅ | — | 2026-06-05 | 2026-06-05 | golden-value parity（无跨模块编译路径：fe-core 不依赖具体连接器模块）。**hudi**：`avroSchemaToColumns` 列名 `toLowerCase` 修（gap-1）+ package-private static；`HudiTypeMappingTest`+`fromAvroSchema` golden；新 `HudiSchemaParityTest`（列集合/序/类型/Hive 串/casing 边界）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN）。**hms**：新 `HmsTypeMappingTest`（共享解析器）。**hive**：新 `HiveFileFormatTest`+`HiveConnectorMetadataPartitionPruningTest`（镜像 T05）。33 测全绿、checkstyle 0、import-gate 通过。COW/MOR schema **type-agnostic**。gap-2 meta-field→批 E（[DV-008]）。设计 [`designs/P3-T07-test-baseline-design.md`](./designs/P3-T07-test-baseline-design.md) |
-| P3-T08 | `tableFormatType` 分流消费设计备忘（design-only） | 批 D | @me | ⏳ | — | — | — | 写清 `PluginDrivenExternalTable` 如何按 `ConnectorTableSchema.tableFormatType`（现 fe-core 从不消费）把一个 `"hms"` catalog 的 per-table 路由到 HUDI/HIVE/ICEBERG。**不实现 fe-core 消费**（那是批 E）。作为 (a) 落地入口设计，可催生 D-NNN |
+| P3-T08 | `tableFormatType` 分流消费设计备忘（design-only） | 批 D | @me | ✅ | — | 2026-06-05 | 2026-06-05 | 设计备忘落地（零代码，未动 fe-core）。核心拆解 **M1 身份消费 ⊥ M2 scan 路由**（M1 三方案通用）。M2 三方案（A 连接器内 router / B per-table SPI provider / C fe-core 发现期分派）评估后用户签字 **方案 B**（[D-020]）：新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`，fe-core 优先 per-table、回落 per-catalog。**细化 D-005**（区分符沿用；"PhysicalXxxScan" 措辞早于 P1 统一，由 per-table provider seam 取代）。Iceberg-on-hms 依赖 P6/M3。实现登记批 E/P7。设计：[`designs/P3-T08-tableformat-dispatch-design.md`](./designs/P3-T08-tableformat-dispatch-design.md) |
 | P3-T09 | [deferred] fe-core 消费 `tableFormatType` + hudi 表产出为 `PluginDrivenExternalTable` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**；并入 hive/HMS migration（D-019）。catalog 模型落地 |
 | P3-T10 | [deferred] gate flip（`SPI_READY_TYPES` 加 hms/hudi）+ live cutover + 删 legacy `datasource/hudi/` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**。15 文件 ~2403 LOC + `HudiDlaTable`(在 hive/)，live caller 仅 7 个 fe-core 文件。cutover 经验证后再删 |
 | P3-T11 | [deferred] 集群/runtime 验证 + 完整增量/time-travel + image 兼容 | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**。混合格式 MOR regression、BE JNI parse parity、name-match 精确性、image 反序列化兼容（R-001） |
@@ -76,6 +76,15 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-06-05（批 D：T08 ✅ `tableFormatType` 分流消费设计备忘，批 D 完成 = P3 hybrid in-scope 全完成）
+- **P3-T08 ✅**（design-only，零代码，[D-020]，用户签字 AskUserQuestion「M2=方案 B per-table SPI provider」）：
+  - **直接输入** `research/spi-multi-format-hms-catalog-analysis.md`（上 session 6-reader recon）；本场**不重复 recon**，只 firsthand 核读 load-bearing 锚点（避免按 research 的近似行号误设计）：keystone gap 确认（`PluginDrivenExternalTable.initSchema:79-109` 只读 `getColumns()`、丢 `getTableFormatType()`）；新增第二缺口（`getEngine:195-215`/`getEngineTableTypeName:217-231` switch catalog type 非 per-table format）；`ConnectorScanPlanProvider.planScan:62-66` 入参带 per-table handle（三方案落脚前提）；`ConnectorMetadata:37-44` 无 per-table provider（B 的新增点）。
+  - **核心分析贡献**：把 keystone 拆成**可分离**两子问题——**M1 身份消费**（fe-core 读 `tableFormatType` 做 per-table 引擎名/身份，opaque 串、热路径不读）**⊥ M2 scan 路由**（单 hms connector 产 Hudi/Iceberg scan plan）。**M1 三方案通用**；A/B/C 只在 M2 分歧 → keystone 可控化。
+  - **M2 决策 = 方案 B**（[D-020]）：新增向后兼容 default `ConnectorMetadata.getScanPlanProvider(handle)`（默认 null→回落 per-catalog），fe-core `PluginDrivenScanNode.getSplits` 优先 per-table、回落 per-catalog；hms 网关按 `handle.getTableType()` 委派。把 per-table 选 provider 升为一等 SPI 契约，满足 D-009（default-only）。A（连接器内 router，零 SPI churn）列备选；C（fe-core 发现期分派）否决（违瘦 fe-core）。
+  - **细化 D-005**（留痕，非偏差）：tableFormatType 区分符沿用；"fe-core→PhysicalXxxScan"措辞早于 P1 scan-node 统一，由 per-table provider seam 取代。
+  - **缩界（R12 不静默）**：本场零代码、gate 不动；Iceberg-on-hms 经 SPI 依赖 **P6/M3**（iceberg 现无 ScanPlanProvider、pom 未依赖 api），P6 前 ICEBERG 表回落 legacy 或 fail-loud（不误扫 Hive）；探测共享化（M5）留 P7；M1+M2 实现登记批 E。设计：[`designs/P3-T08-tableformat-dispatch-design.md`](./designs/P3-T08-tableformat-dispatch-design.md)。
+- **批 D 小结**：T08 设计备忘落地 + D-020。**P3 hybrid 全部 in-scope（批 A–D）完成**：2 正确性修（T02/T05）+ 2 fail-loud/决策（T04/T06）+ 测试网零→59 测（T07）+ 模型 dispatch 设计（T08）。剩批 E（T03/T09–T11 + 各 deferred）并入 P7/hive·HMS migration，不在 P3 PR 编码。
 
 ### 2026-06-05（批 C：T07 ✅ 三模块测试基线 + COW/MOR schema parity，批 C 编码完成）
 - **P3-T07 ✅**（测试 + gap-1 修，[DV-008]，用户签字 AskUserQuestion「Also fix casing now」+「Focused baseline」）：

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -9,7 +9,7 @@
 
 ## 元信息
 
-- **状态**：🚧 进行中（批 0 ✅；批 A 进行中：T02 ✅，T03/T04 待启动）
+- **状态**：🚧 进行中（批 0 ✅；批 A：T02 ✅，T03 推迟批 E（[DV-006]），T04 待启动）
 - **启动日期**：2026-06-04
 - **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
 - **实际完成**：—
@@ -39,7 +39,9 @@
 
 ## 验收标准
 
-- [ ] **批 A**：`column_types` 双 bug 修复（发完整 Hive 类型串 + 弃逗号 join/split）；native split 的 `schema_id` + `params.history_schema_info` 填充；time-travel / 增量读 **fail-loud**（不静默返最新 / 不静默全扫）
+- [x] **批 A / T02**：`column_types` 双 bug 修复（发完整 Hive 类型串 + 弃逗号 join/split）✅（`95f23e9`）
+- [ ] **批 A / T04**：time-travel / 增量读 **fail-loud**（不静默返最新 / 不静默全扫）
+- [~] **批 A→E / T03**：native split `schema_id` + `params.history_schema_info` 填充 —— **推迟批 E（[DV-006]）**，非 model-agnostic SPI 修复（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）
 - [ ] **批 B**：`listPartitions*` override + 真实 `applyFilter` 约束裁剪；MVCC/snapshot SPI 实现或显式 unsupported
 - [ ] **批 C**：fe-connector-hms/hive/hudi 测试基线（当前零测试）；**parity 测试**——SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`，COW & MOR 各一
 - [ ] **批 D**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core live 路径**）
@@ -58,7 +60,7 @@
 |---|---|---|---|---|---|---|---|---|
 | P3-T01 | 两轮 code-grounded recon + hybrid 决策（D-019）+ 本 task 文件 | 批 0 | @me | ✅ | — | 2026-06-04 | 2026-06-04 | recon #1（元数据）+ #2（scan/split）均含对抗验证；DV-005 记依赖更正；D-019 定 hybrid。锚点见 HANDOFF「P3 关键文件锚点」 |
 | P3-T02 | `column_types` 双 bug 修复 + 单测 | 批 A | @me | ✅ | `95f23e9` | 2026-06-04 | 2026-06-04 | (a) `HudiScanPlanProvider` 弃 `ConnectorType.getTypeName()`（丢精度/scale/子类型），改发完整 Hive 类型串（对标 legacy `HudiUtils.convertAvroToHiveType`，如 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 停止 column_names/column_types/delta_logs 的逗号 join/split（含逗号的类型串会被打碎），改 typed list 端到端。**先读 BE `hudi_jni_reader.cpp` 确认 JNI scanner 期望的精确串格式**（names `,` / types `#`），再改。命中含 decimal/复杂列的 MOR-with-logs JNI split |
-| P3-T03 | native split `schema_id` + `history_schema_info` 填充 + 单测 | 批 A | @me | ⏳ | — | — | — | `HudiScanPlanProvider` override `ConnectorScanPlanProvider.populateScanLevelParams` 设 `current_schema_id` + `history_schema_info`（对标 legacy `ExternalUtil.initSchemaInfo` + `putHistorySchemaInfo`）；`HudiScanRange` 在 native COW/MOR-RO split 设 `THudiFileDesc.schema_id`。**无需 fe-core 改动**（Paimon/ES 已用此 hook）。修复 BE 退化为名匹配 → 丢 field-id / schema-evolution / 大小写处理 |
+| P3-T03 | native split `schema_id` + `history_schema_info` 填充 + 单测 | ~~批 A~~→**批 E** | TBD | 🟡 推迟 | — | — | — | **[DV-006] 推迟批 E**：recon 实证非 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override」前提失真（其 override 为 predicate/docvalue，**不设** schema 元数据）；裸 `current==file==-1`→BE `ConstNode`(identity-by-name,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 → **净回归**。faithful field-id evolution parity 需批 E 一次性建机制。批 A 保持现状名匹配（零回归） |
 | P3-T04 | time-travel + 增量读 fail-loud 守卫 + 单测 | 批 A | @me | ⏳ | — | — | — | 当前 `HudiScanPlanProvider` 永远用 `timeline.lastInstant`、`HudiTableHandle` 无 snapshot 字段 → `FOR TIME AS OF` 静默返最新；增量读无 SPI 表示。本 task 仅做**显式报错**（不静默），完整实现入批 E。透传 snapshot 的完整 wiring 也可在此起步 |
 | P3-T05 | `listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` 裁剪 + 单测 | 批 B | @me | ⏳ | — | — | — | 现 Hudi `applyFilter` 列**全部**分区不做约束裁剪（Hive 已做 EQ/IN）；SPI partition 方法默认空。补真实裁剪 + override 分区方法 |
 | P3-T06 | MVCC/snapshot SPI（实现或显式 unsupported） | 批 B | @me | ⏳ | — | — | — | `HudiConnectorMetadata` 未 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`（默认 `Optional.empty()`）。与 T04 关联：要么接 `HudiMvccSnapshot` 语义，要么显式 unsupported |
@@ -73,6 +75,13 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-06-05（批 A 续：T03 推迟决策）
+- **P3-T03 🟡 推迟批 E**（[DV-006]，用户签字 AskUserQuestion「Defer T03 to batch E」）：T03 启动前 4-reader code-grounded recon + 主线核读 BE `table_schema_change_helper.h:219-267` 揭示——schema_id/history **不是** 批 A 可做的 model-agnostic SPI-surface 修复：
+  - **连接器缺料**：`HudiColumnHandle` 无 field id；SPI 无 Hudi `InternalSchema` 版本跟踪；连接器模块无 type→`TColumnType` thrift 转换（legacy 在 fe-core `ExternalUtil`，import-gate 禁复用）。
+  - **「Paimon/ES 已 override hook」前提失真**：二者 override `populateScanLevelParams` 为 predicate/docvalue，**不设** schema 元数据（无 SPI 先例）。
+  - **裸基线净回归**：仅设 `current==file==-1` → BE 走 `ConstNode`（identity-by-name，大小写敏感），**弱于**当前 unset→`by_parquet_name`（鲁棒名匹配，处理大小写/缺列）。faithful field-id evolution parity 需批 E 与 hive/HMS migration 一次性建机制。
+  - **批 A 动作**：不发 schema 元数据，保持现状名匹配（**零回归**），不 ship 裸 ConstNode。→ 直接进 **T04**。
 
 ### 2026-06-04（批 A 启动）
 - **P3-T02 ✅**（commit `95f23e9`，feat）：修 hudi JNI `column_types` 双 bug。

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -1,0 +1,96 @@
+# P3 — hudi 迁移
+
+> 阶段总览见 [00-master-plan §3.4](../00-connector-migration-master-plan.md)。
+> 协作规范见 [AGENT-PLAYBOOK.md](../AGENT-PLAYBOOK.md)。
+> 连接器看板：[connectors/hudi.md](../connectors/hudi.md)。
+> 关键前情：[DV-005](../deviations-log.md)（依赖假设更正）、[D-019](../decisions-log.md)（hybrid 策略）、[HANDOFF 关键认知 1 / 1b](../HANDOFF.md)。
+
+---
+
+## 元信息
+
+- **状态**：🚧 进行中（批 0 ✅ recon + 决策完成；批 A 待启动）
+- **启动日期**：2026-06-04
+- **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
+- **实际完成**：—
+- **阻塞**：无（P0 ✅ / P1 ✅ / P2 ✅ 已合入 #64096）
+- **阻塞下游**：批 E（live cutover）与 P7 hive/HMS migration 合并；P3 批 A–D 不阻塞任何下游
+- **主 owner**：@me
+- **分支**：从 `branch-catalog-spi` 切（建议 `catalog-spi-04` / `catalog-spi-p3-hudi`）；PR base = `apache/doris:branch-catalog-spi`
+
+---
+
+## 策略：hybrid（D-019）
+
+两轮 code-grounded recon（+ 对抗验证）的结论（详见 [DV-005](../deviations-log.md) / HANDOFF 关键认知 1+1b）：
+
+- HMS-over-SPI **读码已存在但 dormant**（`fe-connector-hms` 客户端库 + `HiveConnectorMetadata`(type `"hms"`) + `HudiConnectorMetadata`(type `"hudi"`)，gate 关闭、零 live caller）。
+- scan/split **plumbing 正确**：单 `PluginDrivenScanNode` 能混合 COW-native + MOR-JNI（per-range format，BE 每 range 建 reader），与 legacy `HudiScanNode` 结构等价 —— **混合格式不是问题**。
+- **真正阻塞 = catalog 模型错配 + gate**（架构级）；另有一批**与模型无关**的 SPI-surface 正确性缺口。
+
+**hybrid = 现在做 (b)，推迟 (a)**：
+
+- **(b) 现在做（批 A–D，全部 behind 关闭的 gate，零 live-path 风险）**：把 dormant 的 hudi 连接器**硬化到正确性 parity** + 补 metadata 缺口 + 建**测试基线** + 出**模型 dispatch 设计**。这些都与最终选哪种模型无关，且无论如何都要做。
+- **(a) 推迟（批 E，登记不编码）**：fe-core 消费 `tableFormatType` 的 per-table 分流、gate flip（`SPI_READY_TYPES` 加 hms/hudi）、live 路径 cutover、删 legacy `datasource/hudi/`、完整增量/time-travel、集群/runtime 验证 —— 并入一个 **properly-scoped hive/HMS migration**（P7 或专门子阶段），避免把 P7 范围与 live 重度 HMS 路径风险压进 P3。
+
+> ⚠️ **P3（hybrid）不交付用户可见行为变化**：hudi 查询仍走 legacy 路径（gate 不翻）。P3 的产出是**连接器硬化 + 测试网 + 设计**，为后续 live cutover 扫清正确性障碍。批 A–C 的验证是**单测 + 设计级**；端到端/集群验证随批 E cutover 一起做（recon 的 open questions 见关联）。
+
+---
+
+## 验收标准
+
+- [ ] **批 A**：`column_types` 双 bug 修复（发完整 Hive 类型串 + 弃逗号 join/split）；native split 的 `schema_id` + `params.history_schema_info` 填充；time-travel / 增量读 **fail-loud**（不静默返最新 / 不静默全扫）
+- [ ] **批 B**：`listPartitions*` override + 真实 `applyFilter` 约束裁剪；MVCC/snapshot SPI 实现或显式 unsupported
+- [ ] **批 C**：fe-connector-hms/hive/hudi 测试基线（当前零测试）；**parity 测试**——SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`，COW & MOR 各一
+- [ ] **批 D**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core live 路径**）
+- [ ] 全程 fe-connector 编译 + checkstyle 0 + import-gate 通过；新增单测全绿
+- [ ] gate 保持关闭（`SPI_READY_TYPES` 不含 hms/hudi）；legacy `datasource/hudi/` 不删（批 A–D 内）
+- [ ] 批 E 各项作为 deferred 明确登记，不在 P3 PR 内编码
+- [ ] 同步看板 + PROGRESS + connectors/hudi
+
+---
+
+## 任务清单
+
+> ID 永不复用。批次：批 0=recon/决策；批 A=scan 正确性；批 B=metadata 补全；批 C=测试；批 D=模型设计；批 E=deferred（登记）。
+
+| ID | 任务 | 批次 | Owner | 状态 | PR | 启动 | 完成 | 备注 |
+|---|---|---|---|---|---|---|---|---|
+| P3-T01 | 两轮 code-grounded recon + hybrid 决策（D-019）+ 本 task 文件 | 批 0 | @me | ✅ | — | 2026-06-04 | 2026-06-04 | recon #1（元数据）+ #2（scan/split）均含对抗验证；DV-005 记依赖更正；D-019 定 hybrid。锚点见 HANDOFF「P3 关键文件锚点」 |
+| P3-T02 | `column_types` 双 bug 修复 + 单测 | 批 A | @me | ⏳ | — | — | — | (a) `HudiScanPlanProvider` 弃 `ConnectorType.getTypeName()`（丢精度/scale/子类型），改发完整 Hive 类型串（对标 legacy `HudiUtils.convertAvroToHiveType`，如 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 停止 column_names/column_types/delta_logs 的逗号 join/split（含逗号的类型串会被打碎），改 typed list 端到端。**先读 BE `hudi_jni_reader.cpp` 确认 JNI scanner 期望的精确串格式**（names `,` / types `#`），再改。命中含 decimal/复杂列的 MOR-with-logs JNI split |
+| P3-T03 | native split `schema_id` + `history_schema_info` 填充 + 单测 | 批 A | @me | ⏳ | — | — | — | `HudiScanPlanProvider` override `ConnectorScanPlanProvider.populateScanLevelParams` 设 `current_schema_id` + `history_schema_info`（对标 legacy `ExternalUtil.initSchemaInfo` + `putHistorySchemaInfo`）；`HudiScanRange` 在 native COW/MOR-RO split 设 `THudiFileDesc.schema_id`。**无需 fe-core 改动**（Paimon/ES 已用此 hook）。修复 BE 退化为名匹配 → 丢 field-id / schema-evolution / 大小写处理 |
+| P3-T04 | time-travel + 增量读 fail-loud 守卫 + 单测 | 批 A | @me | ⏳ | — | — | — | 当前 `HudiScanPlanProvider` 永远用 `timeline.lastInstant`、`HudiTableHandle` 无 snapshot 字段 → `FOR TIME AS OF` 静默返最新；增量读无 SPI 表示。本 task 仅做**显式报错**（不静默），完整实现入批 E。透传 snapshot 的完整 wiring 也可在此起步 |
+| P3-T05 | `listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` 裁剪 + 单测 | 批 B | @me | ⏳ | — | — | — | 现 Hudi `applyFilter` 列**全部**分区不做约束裁剪（Hive 已做 EQ/IN）；SPI partition 方法默认空。补真实裁剪 + override 分区方法 |
+| P3-T06 | MVCC/snapshot SPI（实现或显式 unsupported） | 批 B | @me | ⏳ | — | — | — | `HudiConnectorMetadata` 未 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`（默认 `Optional.empty()`）。与 T04 关联：要么接 `HudiMvccSnapshot` 语义，要么显式 unsupported |
+| P3-T07 | 三模块测试基线 + parity 测试 | 批 C | @me | ⏳ | — | — | — | fe-connector-hms/hive/hudi 当前**零测试**。补单测 + **parity**：SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`（fe-core），COW & MOR 各一。Rule 9：测意图（type-string 编码、schema_id、裁剪正确） |
+| P3-T08 | `tableFormatType` 分流消费设计备忘（design-only） | 批 D | @me | ⏳ | — | — | — | 写清 `PluginDrivenExternalTable` 如何按 `ConnectorTableSchema.tableFormatType`（现 fe-core 从不消费）把一个 `"hms"` catalog 的 per-table 路由到 HUDI/HIVE/ICEBERG。**不实现 fe-core 消费**（那是批 E）。作为 (a) 落地入口设计，可催生 D-NNN |
+| P3-T09 | [deferred] fe-core 消费 `tableFormatType` + hudi 表产出为 `PluginDrivenExternalTable` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**；并入 hive/HMS migration（D-019）。catalog 模型落地 |
+| P3-T10 | [deferred] gate flip（`SPI_READY_TYPES` 加 hms/hudi）+ live cutover + 删 legacy `datasource/hudi/` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**。15 文件 ~2403 LOC + `HudiDlaTable`(在 hive/)，live caller 仅 7 个 fe-core 文件。cutover 经验证后再删 |
+| P3-T11 | [deferred] 集群/runtime 验证 + 完整增量/time-travel + image 兼容 | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**。混合格式 MOR regression、BE JNI parse parity、name-match 精确性、image 反序列化兼容（R-001） |
+
+**状态图例**：⏳ pending / 🚧 in_progress / ✅ done / ❌ blocked / 🚫 deleted
+
+---
+
+## 阶段日志（倒序）
+
+### 2026-06-04
+- **批 0 完成**：两轮 recon（#1 元数据路径就绪 / #2 scan-split 路径，均 8/7-agent code-grounded workflow + 对抗验证）。结论改写原计划依赖假设 → 记 **DV-005**；用户定 **hybrid** 策略 → 记 **D-019**；建本 task 文件。
+- 关键结论：HMS-over-SPI 读码 dormant、scan plumbing 正确（混合格式非问题）、真阻塞=模型错配+gate；批 A–D 与模型无关，先做。
+
+---
+
+## 关联
+
+- Master plan 章节：[§3.4 P3 hudi](../00-connector-migration-master-plan.md)、[§3.8 P7 hive+HMS](../00-connector-migration-master-plan.md)（批 E 并入处）
+- RFC 章节：tableFormatType / DLA 模型（D-005 相关）
+- 决策：[D-005](../decisions-log.md)（DLA 用 tableFormatType）、[D-019](../decisions-log.md)（hybrid 策略）、D-002（PluginDrivenScanNode extends FileQueryScanNode）
+- 偏差：[DV-005](../deviations-log.md)（依赖假设更正 + scan 侧 parity gap）
+- 风险：R-001（image 兼容，批 E）
+- 连接器：[connectors/hudi.md](../connectors/hudi.md)
+
+---
+
+## 当前阻塞项
+
+无。批 A 可立即启动（gate 关闭，零 live-path 风险）。批 E 待 hive/HMS migration 排期。

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -16,7 +16,7 @@
 - **阻塞**：无（P0 ✅ / P1 ✅ / P2 ✅ 已合入 #64096）
 - **阻塞下游**：批 E（live cutover）与 P7 hive/HMS migration 合并；P3 批 A–D 不阻塞任何下游
 - **主 owner**：@me
-- **分支**：从 `branch-catalog-spi` 切（建议 `catalog-spi-04` / `catalog-spi-p3-hudi`）；PR base = `apache/doris:branch-catalog-spi`
+- **分支**：`catalog-spi-04`（从 `branch-catalog-spi` 切）；**PR [#64143](https://github.com/apache/doris/pull/64143)**（base `apache/doris:branch-catalog-spi`，2026-06-05 开，26 files +3065/−154、12 commits）
 
 ---
 

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -9,7 +9,7 @@
 
 ## 元信息
 
-- **状态**：🚧 进行中（批 0 ✅；批 A 编码完成 T02 ✅/T04 ✅/T03→批 E；**批 B 编码完成**：T05 applyFilter EQ/IN 裁剪 ✅、T06 MVCC keep-defaults 决策 ✅（[DV-007]）；下一步批 C：三模块测试基线 + COW/MOR parity）
+- **状态**：🚧 进行中（批 0 ✅；批 A 编码完成 T02 ✅/T04 ✅/T03→批 E；批 B 编码完成 T05 ✅/T06 决策 ✅（[DV-007]）；**批 C 编码完成**：T07 三模块测试基线 + COW/MOR schema parity ✅（[DV-008]，列名 casing 当场修、meta-field→批 E）；下一步批 D：T08 `tableFormatType` 分流设计备忘 design-only）
 - **启动日期**：2026-06-04
 - **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
 - **实际完成**：—
@@ -44,7 +44,7 @@
 - [~] **批 A→E / T03**：native split `schema_id` + `params.history_schema_info` 填充 —— **推迟批 E（[DV-006]）**，非 model-agnostic SPI 修复（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）
 - [x] **批 B / T05**：真实 `applyFilter` EQ/IN 约束裁剪 ✅（`10b72d4`，镜像 Hive）；`listPartitions*` override **推迟批 E**（[DV-007]，零 live caller、Hive 不 override）
 - [x] **批 B / T06**：MVCC/snapshot SPI **保持 default opt-out + 文档化** ✅（[DV-007]，非抛异常 override——破 opt-out 约定/不可达；T04 已 fail-loud time-travel）；完整 MVCC 入批 E
-- [ ] **批 C**：fe-connector-hms/hive/hudi 测试基线（当前零测试）；**parity 测试**——SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`，COW & MOR 各一
+- [x] **批 C / T07**：fe-connector-hms/hive/hudi 测试基线 ✅（hms 12 + hive 14 + hudi +18=33 全绿，golden-value）；**parity 测试** ✅——COW/MOR schema **type-agnostic**（差异只在 scan planning），SPI avro→column 变换 golden 对标 legacy `getHudiTableSchema`/`initHudiSchema`（列名/序/类型/Hive 串/casing）+ `detectHudiTableType` COW/MOR 分类。列名 casing 当场修（[DV-008]）；meta-field 纳入推迟批 E
 - [ ] **批 D**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core live 路径**）
 - [ ] 全程 fe-connector 编译 + checkstyle 0 + import-gate 通过；新增单测全绿
 - [ ] gate 保持关闭（`SPI_READY_TYPES` 不含 hms/hudi）；legacy `datasource/hudi/` 不删（批 A–D 内）
@@ -65,7 +65,7 @@
 | P3-T04 | time-travel + 增量读 fail-loud 守卫 | 批 A | @me | ✅ | `feceabb` | 2026-06-05 | 2026-06-05 | `visitPhysicalHudiScan` SPI 分支加两守卫：`getIncrementalRelation().isPresent()` / `getTableSnapshot().isPresent()` → 抛 `AnalysisException`（不再静默返最新/全扫）。唯一同时可见 snapshot+incremental 的位置（SPI surface 拿不到 incremental）。删 dead `setQueryTableSnapshot`。dormant 分支 gate 关时不可达 → 零 live 风险。**单测推迟批 E**（dormant 不可 exercise；regression 断言 FOR TIME AS OF/增量→报错，precedent DV-003）。完整 snapshot 透传/增量 SPI/MVCC 入批 E |
 | P3-T05 | 真实 `applyFilter` EQ/IN 分区裁剪 + 单测（`listPartitions*` override 推迟批 E）| 批 B | @me | ✅ | `10b72d4` | 2026-06-05 | 2026-06-05 | applyFilter 原是占位（列全部分区不裁剪 + 无条件设 `prunedPartitionPaths` → 静默把分区来源从 Hudi-metadata 切到 HMS）。重写为**忠实镜像 `HiveConnectorMetadata`**：抽取 partition 列 EQ/IN 谓词 → 列候选 → 裁剪 → 仅在有效果时回传 pruned handle，否则 `Optional.empty()`（handle 不变，回落 Hudi-metadata listing）。保留 `List<String>` 路径表示 + `-1` 上限（不静默截断）；7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿、checkstyle 0、import-gate 通过。**`listPartitions*` override 推迟批 E**（[DV-007]：零 live caller、Hive 不 override）。设计：[`designs/P3-T05-partition-pruning-design.md`](./designs/P3-T05-partition-pruning-design.md) |
 | P3-T06 | MVCC/snapshot SPI：保持 default opt-out + 文档化（完整 MVCC→批 E）| 批 B | @me | ✅ | — | 2026-06-05 | 2026-06-05 | **决策（[DV-007]，用户签字「Keep defaults + document」）**：不 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`，保持 SPI default `Optional.empty()`（= opt-out）。recon 证「显式抛异常 override」错——破 SPI opt-out 约定（全体连接器含 Iceberg/Paimon/Hive/Trino 均依赖 default，`FakeConnectorPluginTest` 断言）、不可达死代码（MVCC 无 production caller）、且 T04 已在唯一可触发点（time-travel）fail-loud。**零代码**。完整 MVCC（`HudiMvccSnapshot`+snapshot 透传+增量时序）入批 E。设计：[`designs/P3-T06-mvcc-design.md`](./designs/P3-T06-mvcc-design.md) |
-| P3-T07 | 三模块测试基线 + parity 测试 | 批 C | @me | ⏳ | — | — | — | fe-connector-hms/hive/hudi 当前**零测试**。补单测 + **parity**：SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`（fe-core），COW & MOR 各一。Rule 9：测意图（type-string 编码、schema_id、裁剪正确） |
+| P3-T07 | 三模块测试基线 + parity 测试 | 批 C | @me | ✅ | — | 2026-06-05 | 2026-06-05 | golden-value parity（无跨模块编译路径：fe-core 不依赖具体连接器模块）。**hudi**：`avroSchemaToColumns` 列名 `toLowerCase` 修（gap-1）+ package-private static；`HudiTypeMappingTest`+`fromAvroSchema` golden；新 `HudiSchemaParityTest`（列集合/序/类型/Hive 串/casing 边界）+ `HudiTableTypeTest`（COW/MOR/UNKNOWN）。**hms**：新 `HmsTypeMappingTest`（共享解析器）。**hive**：新 `HiveFileFormatTest`+`HiveConnectorMetadataPartitionPruningTest`（镜像 T05）。33 测全绿、checkstyle 0、import-gate 通过。COW/MOR schema **type-agnostic**。gap-2 meta-field→批 E（[DV-008]）。设计 [`designs/P3-T07-test-baseline-design.md`](./designs/P3-T07-test-baseline-design.md) |
 | P3-T08 | `tableFormatType` 分流消费设计备忘（design-only） | 批 D | @me | ⏳ | — | — | — | 写清 `PluginDrivenExternalTable` 如何按 `ConnectorTableSchema.tableFormatType`（现 fe-core 从不消费）把一个 `"hms"` catalog 的 per-table 路由到 HUDI/HIVE/ICEBERG。**不实现 fe-core 消费**（那是批 E）。作为 (a) 落地入口设计，可催生 D-NNN |
 | P3-T09 | [deferred] fe-core 消费 `tableFormatType` + hudi 表产出为 `PluginDrivenExternalTable` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**；并入 hive/HMS migration（D-019）。catalog 模型落地 |
 | P3-T10 | [deferred] gate flip（`SPI_READY_TYPES` 加 hms/hudi）+ live cutover + 删 legacy `datasource/hudi/` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**。15 文件 ~2403 LOC + `HudiDlaTable`(在 hive/)，live caller 仅 7 个 fe-core 文件。cutover 经验证后再删 |
@@ -76,6 +76,16 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-06-05（批 C：T07 ✅ 三模块测试基线 + COW/MOR schema parity，批 C 编码完成）
+- **P3-T07 ✅**（测试 + gap-1 修，[DV-008]，用户签字 AskUserQuestion「Also fix casing now」+「Focused baseline」）：
+  - **feasibility（golden-value）**：fe-core 只依赖 `fe-connector-api`/`-spi`、**不依赖**具体连接器模块；连接器不依赖 fe-core；import-gate 只扫 `src/main`、只禁 connector→fe-core 单向 → **无跨模块编译路径同时见 legacy `HudiUtils` 与 SPI `HudiTypeMapping`**。parity 用 golden 值（注 legacy file:line），JUnit5 + 手写替身（无 mockito，`FakeHmsClient` 先例）。
+  - **COW/MOR schema type-agnostic**（recon 关键结论）：legacy `initHudiSchema` 与 SPI `getTableSchema`→`avroSchemaToColumns` 都从同一 avro schema 推导、**零表型分支**；COW/MOR 区别只在 scan planning（split 收集 + reader 格式）。→「COW & MOR 各一」= (a) avro→column 变换 golden（COW≡MOR 恒等）+ (b) `detectHudiTableType` 分类。
+  - **gap-1 列名 casing 当场修**：`HudiConnectorMetadata.avroSchemaToColumns` 顶层列名改 `toLowerCase(Locale.ROOT)`，镜像 legacy `HMSExternalTable:745`（**仅顶层**；嵌套 struct 名两侧均保留）；改 package-private `static` 可测（零行为变更）。已核安全（HMS 自身存小写标识符 → 与小写 HMS partition key 对齐，改善 `getColumnHandles` 匹配，无回归）。`ThriftHmsClient` 源头防御降字（与 hive 共享）缩界推 P7/批 E。
+  - **gap-2 Hudi meta-field 纳入推迟批 E**（[DV-008]）：SPI 无参 `getTableAvroSchema()` vs legacy `(true)`，可能改变列集合；无真实 metaclient 不可单测，同 T03 族。
+  - **测试**：**hudi**（+18）`HudiTypeMappingTest`+7（`fromAvroSchema`→ConnectorType golden，原零覆盖）/ 新 `HudiSchemaParityTest` 3（列名小写+序+ConnectorType+nullable+Hive 串，casing 边界 pin）/ 新 `HudiTableTypeTest` 4（COW/MOR/UNKNOWN）。**hms**（+12）新 `HmsTypeMappingTest`（共享 Hive 类型串解析器：嵌套 array/map/struct、decimal 精度/scale、char/varchar 长度、Options、大小写、`findNextNestedField`）。**hive**（+14）新 `HiveFileFormatTest` 6 + `HiveConnectorMetadataPartitionPruningTest` 8（镜像 `HudiPartitionPruningTest`，含 `getPartitions` 跳；consolidation 信号注 javadoc，P7 处理）。
+  - 三模块 33 测全绿；checkstyle 0（含 test 源，`includeTestSourceDirectory=true`）；import-gate 通过。gate 保持关闭，唯一 main 改动 = hudi `avroSchemaToColumns`（dormant、零 live 风险）。设计：[`designs/P3-T07-test-baseline-design.md`](./designs/P3-T07-test-baseline-design.md)。
+- **批 C 编码小结**：T07 测试网（三模块零→33 测）+ COW/MOR schema parity + gap-1 casing 修落地；gap-2 meta-field 登记批 E。**批 A+B+C 编码完成**，下一步批 D（T08 `tableFormatType` 分流设计备忘 design-only，不动 fe-core）。
 
 ### 2026-06-05（批 B：T05 ✅ 裁剪、T06 ✅ 决策，批 B 编码完成）
 - **P3-T05 ✅**（commit `10b72d4`，feat）：`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪。

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -9,7 +9,7 @@
 
 ## 元信息
 
-- **状态**：🚧 进行中（批 0 ✅；批 A：T02 ✅，T03 推迟批 E（[DV-006]），T04 待启动）
+- **状态**：🚧 进行中（批 0 ✅；**批 A 编码完成**：T02 ✅、T04 ✅、T03 推迟批 E（[DV-006]）；下一步批 B：T05 partition 裁剪 / T06 MVCC）
 - **启动日期**：2026-06-04
 - **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
 - **实际完成**：—
@@ -40,7 +40,7 @@
 ## 验收标准
 
 - [x] **批 A / T02**：`column_types` 双 bug 修复（发完整 Hive 类型串 + 弃逗号 join/split）✅（`95f23e9`）
-- [ ] **批 A / T04**：time-travel / 增量读 **fail-loud**（不静默返最新 / 不静默全扫）
+- [x] **批 A / T04**：time-travel / 增量读 **fail-loud**（不静默返最新 / 不静默全扫）✅（`feceabb`，单测推迟批 E）
 - [~] **批 A→E / T03**：native split `schema_id` + `params.history_schema_info` 填充 —— **推迟批 E（[DV-006]）**，非 model-agnostic SPI 修复（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）
 - [ ] **批 B**：`listPartitions*` override + 真实 `applyFilter` 约束裁剪；MVCC/snapshot SPI 实现或显式 unsupported
 - [ ] **批 C**：fe-connector-hms/hive/hudi 测试基线（当前零测试）；**parity 测试**——SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`，COW & MOR 各一
@@ -61,7 +61,7 @@
 | P3-T01 | 两轮 code-grounded recon + hybrid 决策（D-019）+ 本 task 文件 | 批 0 | @me | ✅ | — | 2026-06-04 | 2026-06-04 | recon #1（元数据）+ #2（scan/split）均含对抗验证；DV-005 记依赖更正；D-019 定 hybrid。锚点见 HANDOFF「P3 关键文件锚点」 |
 | P3-T02 | `column_types` 双 bug 修复 + 单测 | 批 A | @me | ✅ | `95f23e9` | 2026-06-04 | 2026-06-04 | (a) `HudiScanPlanProvider` 弃 `ConnectorType.getTypeName()`（丢精度/scale/子类型），改发完整 Hive 类型串（对标 legacy `HudiUtils.convertAvroToHiveType`，如 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 停止 column_names/column_types/delta_logs 的逗号 join/split（含逗号的类型串会被打碎），改 typed list 端到端。**先读 BE `hudi_jni_reader.cpp` 确认 JNI scanner 期望的精确串格式**（names `,` / types `#`），再改。命中含 decimal/复杂列的 MOR-with-logs JNI split |
 | P3-T03 | native split `schema_id` + `history_schema_info` 填充 + 单测 | ~~批 A~~→**批 E** | TBD | 🟡 推迟 | — | — | — | **[DV-006] 推迟批 E**：recon 实证非 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override」前提失真（其 override 为 predicate/docvalue，**不设** schema 元数据）；裸 `current==file==-1`→BE `ConstNode`(identity-by-name,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 → **净回归**。faithful field-id evolution parity 需批 E 一次性建机制。批 A 保持现状名匹配（零回归） |
-| P3-T04 | time-travel + 增量读 fail-loud 守卫 + 单测 | 批 A | @me | ⏳ | — | — | — | 当前 `HudiScanPlanProvider` 永远用 `timeline.lastInstant`、`HudiTableHandle` 无 snapshot 字段 → `FOR TIME AS OF` 静默返最新；增量读无 SPI 表示。本 task 仅做**显式报错**（不静默），完整实现入批 E。透传 snapshot 的完整 wiring 也可在此起步 |
+| P3-T04 | time-travel + 增量读 fail-loud 守卫 | 批 A | @me | ✅ | `feceabb` | 2026-06-05 | 2026-06-05 | `visitPhysicalHudiScan` SPI 分支加两守卫：`getIncrementalRelation().isPresent()` / `getTableSnapshot().isPresent()` → 抛 `AnalysisException`（不再静默返最新/全扫）。唯一同时可见 snapshot+incremental 的位置（SPI surface 拿不到 incremental）。删 dead `setQueryTableSnapshot`。dormant 分支 gate 关时不可达 → 零 live 风险。**单测推迟批 E**（dormant 不可 exercise；regression 断言 FOR TIME AS OF/增量→报错，precedent DV-003）。完整 snapshot 透传/增量 SPI/MVCC 入批 E |
 | P3-T05 | `listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` 裁剪 + 单测 | 批 B | @me | ⏳ | — | — | — | 现 Hudi `applyFilter` 列**全部**分区不做约束裁剪（Hive 已做 EQ/IN）；SPI partition 方法默认空。补真实裁剪 + override 分区方法 |
 | P3-T06 | MVCC/snapshot SPI（实现或显式 unsupported） | 批 B | @me | ⏳ | — | — | — | `HudiConnectorMetadata` 未 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`（默认 `Optional.empty()`）。与 T04 关联：要么接 `HudiMvccSnapshot` 语义，要么显式 unsupported |
 | P3-T07 | 三模块测试基线 + parity 测试 | 批 C | @me | ⏳ | — | — | — | fe-connector-hms/hive/hudi 当前**零测试**。补单测 + **parity**：SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`（fe-core），COW & MOR 各一。Rule 9：测意图（type-string 编码、schema_id、裁剪正确） |
@@ -75,6 +75,10 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-06-05（批 A 续：T04 ✅，批 A 编码收尾）
+- **P3-T04 ✅**（commit `feceabb`，feat）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支加 fail-loud 守卫——`getIncrementalRelation().isPresent()` → 抛 `AnalysisException`（曾静默全扫）；`getTableSnapshot().isPresent()` → 抛（曾静默返最新，因 `HudiScanPlanProvider` 永远用 `timeline.lastInstant()`）。该分支是**唯一**同时可见 snapshot + incrementalRelation 处（SPI surface 拿不到 incremental）。删 dead `setQueryTableSnapshot`。fe-core 编译 + checkstyle 0。**dormant 分支 gate 关时运行期不可达 → 零 live 风险**；**单测推迟批 E**（不可 exercise；批 E regression 断言 FOR TIME AS OF/增量→报错，precedent DV-003，R12 显式登记不静默跳过）。完整 snapshot 透传 + 增量 SPI 表示 + MVCC 入批 E（与 T06/T03/T09–T11 同批 E）。设计：[`designs/P3-T04-fail-loud-design.md`](./designs/P3-T04-fail-loud-design.md)。
+- **批 A 编码小结**：T02（column_types 双 bug）✅ + T04（fail-loud）✅ 落地；T03（schema_id/history）推迟批 E（[DV-006]，证非 model-agnostic SPI 修复）。批 A 净产出 = 2 个正确性修复（gate 后硬化，零回归）+ 1 个 code-grounded 推迟决策。
 
 ### 2026-06-05（批 A 续：T03 推迟决策）
 - **P3-T03 🟡 推迟批 E**（[DV-006]，用户签字 AskUserQuestion「Defer T03 to batch E」）：T03 启动前 4-reader code-grounded recon + 主线核读 BE `table_schema_change_helper.h:219-267` 揭示——schema_id/history **不是** 批 A 可做的 model-agnostic SPI-surface 修复：

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -9,7 +9,7 @@
 
 ## 元信息
 
-- **状态**：🚧 进行中（批 0 ✅ recon + 决策完成；批 A 待启动）
+- **状态**：🚧 进行中（批 0 ✅；批 A 进行中：T02 ✅，T03/T04 待启动）
 - **启动日期**：2026-06-04
 - **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
 - **实际完成**：—
@@ -57,7 +57,7 @@
 | ID | 任务 | 批次 | Owner | 状态 | PR | 启动 | 完成 | 备注 |
 |---|---|---|---|---|---|---|---|---|
 | P3-T01 | 两轮 code-grounded recon + hybrid 决策（D-019）+ 本 task 文件 | 批 0 | @me | ✅ | — | 2026-06-04 | 2026-06-04 | recon #1（元数据）+ #2（scan/split）均含对抗验证；DV-005 记依赖更正；D-019 定 hybrid。锚点见 HANDOFF「P3 关键文件锚点」 |
-| P3-T02 | `column_types` 双 bug 修复 + 单测 | 批 A | @me | ⏳ | — | — | — | (a) `HudiScanPlanProvider` 弃 `ConnectorType.getTypeName()`（丢精度/scale/子类型），改发完整 Hive 类型串（对标 legacy `HudiUtils.convertAvroToHiveType`，如 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 停止 column_names/column_types/delta_logs 的逗号 join/split（含逗号的类型串会被打碎），改 typed list 端到端。**先读 BE `hudi_jni_reader.cpp` 确认 JNI scanner 期望的精确串格式**（names `,` / types `#`），再改。命中含 decimal/复杂列的 MOR-with-logs JNI split |
+| P3-T02 | `column_types` 双 bug 修复 + 单测 | 批 A | @me | ✅ | `95f23e9` | 2026-06-04 | 2026-06-04 | (a) `HudiScanPlanProvider` 弃 `ConnectorType.getTypeName()`（丢精度/scale/子类型），改发完整 Hive 类型串（对标 legacy `HudiUtils.convertAvroToHiveType`，如 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 停止 column_names/column_types/delta_logs 的逗号 join/split（含逗号的类型串会被打碎），改 typed list 端到端。**先读 BE `hudi_jni_reader.cpp` 确认 JNI scanner 期望的精确串格式**（names `,` / types `#`），再改。命中含 decimal/复杂列的 MOR-with-logs JNI split |
 | P3-T03 | native split `schema_id` + `history_schema_info` 填充 + 单测 | 批 A | @me | ⏳ | — | — | — | `HudiScanPlanProvider` override `ConnectorScanPlanProvider.populateScanLevelParams` 设 `current_schema_id` + `history_schema_info`（对标 legacy `ExternalUtil.initSchemaInfo` + `putHistorySchemaInfo`）；`HudiScanRange` 在 native COW/MOR-RO split 设 `THudiFileDesc.schema_id`。**无需 fe-core 改动**（Paimon/ES 已用此 hook）。修复 BE 退化为名匹配 → 丢 field-id / schema-evolution / 大小写处理 |
 | P3-T04 | time-travel + 增量读 fail-loud 守卫 + 单测 | 批 A | @me | ⏳ | — | — | — | 当前 `HudiScanPlanProvider` 永远用 `timeline.lastInstant`、`HudiTableHandle` 无 snapshot 字段 → `FOR TIME AS OF` 静默返最新；增量读无 SPI 表示。本 task 仅做**显式报错**（不静默），完整实现入批 E。透传 snapshot 的完整 wiring 也可在此起步 |
 | P3-T05 | `listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` 裁剪 + 单测 | 批 B | @me | ⏳ | — | — | — | 现 Hudi `applyFilter` 列**全部**分区不做约束裁剪（Hive 已做 EQ/IN）；SPI partition 方法默认空。补真实裁剪 + override 分区方法 |
@@ -74,7 +74,15 @@
 
 ## 阶段日志（倒序）
 
-### 2026-06-04
+### 2026-06-04（批 A 启动）
+- **P3-T02 ✅**（commit `95f23e9`，feat）：修 hudi JNI `column_types` 双 bug。
+  - **(a)** `HudiScanPlanProvider` 原用 `HudiTypeMapping.fromAvroSchema(..).getTypeName()` 发 **Doris** 裸类型名（`DECIMALV3`/`STRUCT`，丢精度/scale/子类型）；BE Hudi JNI scanner 期望 **Hive 类型串**。新增 `HudiTypeMapping.toHiveTypeString`（忠实复刻 legacy `HudiUtils.convertAvroToHiveType`，import-gate 禁止直接复用 fe-core）。`fromAvroSchema`（→Doris ConnectorType，服务 schema 上报）不动；删 dead `unwrapNullable`。
+  - **(b)** `HudiScanRange` 原把 column_names/types/delta_logs 逗号 join 再 split，打碎含逗号的 Hive 类型串（`decimal(10,2)`/`struct<a:int,b:string>`）并使 names↔types 错位。改为 typed `List<String>` 字段直接设 thrift `list<string>`；BE（`hudi_jni_reader.cpp`）自做 join（names `,` / types `#` / delta `,`），与 Java `HadoopHudiJniScanner` split 契约一致（两点 code-grounded 对抗确认）。
+  - **测试**：建模块**首批**测试（`HudiTypeMappingTest` 9 + `HudiScanRangeTest` 2 = 11 全绿）。断言旧码会失败的行为（Rule 9）：decimal 精度、struct/array/map 逗号存活、union unwrap、不支持类型 fail-loud、typed-list 对齐 + native 降级。
+  - **守门**：fe-connector-hudi 编译 + checkstyle 0 + import-gate 通过；BUILD SUCCESS。**3 路对抗 review（parity / BE-contract / style+test）零确认缺陷**。
+  - 设计备忘：[`designs/P3-T02-column-types-design.md`](./designs/P3-T02-column-types-design.md)。gate 保持关闭，零 fe-core/BE/thrift 改动。
+
+### 2026-06-04（批 0）
 - **批 0 完成**：两轮 recon（#1 元数据路径就绪 / #2 scan-split 路径，均 8/7-agent code-grounded workflow + 对抗验证）。结论改写原计划依赖假设 → 记 **DV-005**；用户定 **hybrid** 策略 → 记 **D-019**；建本 task 文件。
 - 关键结论：HMS-over-SPI 读码 dormant、scan plumbing 正确（混合格式非问题）、真阻塞=模型错配+gate；批 A–D 与模型无关，先做。
 

--- a/plan-doc/tasks/P3-hudi-migration.md
+++ b/plan-doc/tasks/P3-hudi-migration.md
@@ -9,7 +9,7 @@
 
 ## 元信息
 
-- **状态**：🚧 进行中（批 0 ✅；**批 A 编码完成**：T02 ✅、T04 ✅、T03 推迟批 E（[DV-006]）；下一步批 B：T05 partition 裁剪 / T06 MVCC）
+- **状态**：🚧 进行中（批 0 ✅；批 A 编码完成 T02 ✅/T04 ✅/T03→批 E；**批 B 编码完成**：T05 applyFilter EQ/IN 裁剪 ✅、T06 MVCC keep-defaults 决策 ✅（[DV-007]）；下一步批 C：三模块测试基线 + COW/MOR parity）
 - **启动日期**：2026-06-04
 - **目标完成**：—（hybrid 范围，估时按批 A–C 约 1–1.5 周；批 D 设计 0.5 周；批 E deferred 不计入 P3）
 - **实际完成**：—
@@ -42,7 +42,8 @@
 - [x] **批 A / T02**：`column_types` 双 bug 修复（发完整 Hive 类型串 + 弃逗号 join/split）✅（`95f23e9`）
 - [x] **批 A / T04**：time-travel / 增量读 **fail-loud**（不静默返最新 / 不静默全扫）✅（`feceabb`，单测推迟批 E）
 - [~] **批 A→E / T03**：native split `schema_id` + `params.history_schema_info` 填充 —— **推迟批 E（[DV-006]）**，非 model-agnostic SPI 修复（连接器缺 field-id/InternalSchema/type→thrift；裸基线净回归）
-- [ ] **批 B**：`listPartitions*` override + 真实 `applyFilter` 约束裁剪；MVCC/snapshot SPI 实现或显式 unsupported
+- [x] **批 B / T05**：真实 `applyFilter` EQ/IN 约束裁剪 ✅（`10b72d4`，镜像 Hive）；`listPartitions*` override **推迟批 E**（[DV-007]，零 live caller、Hive 不 override）
+- [x] **批 B / T06**：MVCC/snapshot SPI **保持 default opt-out + 文档化** ✅（[DV-007]，非抛异常 override——破 opt-out 约定/不可达；T04 已 fail-loud time-travel）；完整 MVCC 入批 E
 - [ ] **批 C**：fe-connector-hms/hive/hudi 测试基线（当前零测试）；**parity 测试**——SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`，COW & MOR 各一
 - [ ] **批 D**：`tableFormatType` 分流消费设计备忘（design-only，**不动 fe-core live 路径**）
 - [ ] 全程 fe-connector 编译 + checkstyle 0 + import-gate 通过；新增单测全绿
@@ -62,8 +63,8 @@
 | P3-T02 | `column_types` 双 bug 修复 + 单测 | 批 A | @me | ✅ | `95f23e9` | 2026-06-04 | 2026-06-04 | (a) `HudiScanPlanProvider` 弃 `ConnectorType.getTypeName()`（丢精度/scale/子类型），改发完整 Hive 类型串（对标 legacy `HudiUtils.convertAvroToHiveType`，如 `decimal(10,2)`/`struct<...>`）；(b) `HudiScanRange` 停止 column_names/column_types/delta_logs 的逗号 join/split（含逗号的类型串会被打碎），改 typed list 端到端。**先读 BE `hudi_jni_reader.cpp` 确认 JNI scanner 期望的精确串格式**（names `,` / types `#`），再改。命中含 decimal/复杂列的 MOR-with-logs JNI split |
 | P3-T03 | native split `schema_id` + `history_schema_info` 填充 + 单测 | ~~批 A~~→**批 E** | TBD | 🟡 推迟 | — | — | — | **[DV-006] 推迟批 E**：recon 实证非 model-agnostic SPI-surface 修复——连接器缺 field-id（`HudiColumnHandle` 无）/ Hudi `InternalSchema` 版本 / type→`TColumnType` thrift；「Paimon/ES 已 override」前提失真（其 override 为 predicate/docvalue，**不设** schema 元数据）；裸 `current==file==-1`→BE `ConstNode`(identity-by-name,大小写敏感) **弱于**当前 `by_parquet_name` 名匹配 → **净回归**。faithful field-id evolution parity 需批 E 一次性建机制。批 A 保持现状名匹配（零回归） |
 | P3-T04 | time-travel + 增量读 fail-loud 守卫 | 批 A | @me | ✅ | `feceabb` | 2026-06-05 | 2026-06-05 | `visitPhysicalHudiScan` SPI 分支加两守卫：`getIncrementalRelation().isPresent()` / `getTableSnapshot().isPresent()` → 抛 `AnalysisException`（不再静默返最新/全扫）。唯一同时可见 snapshot+incremental 的位置（SPI surface 拿不到 incremental）。删 dead `setQueryTableSnapshot`。dormant 分支 gate 关时不可达 → 零 live 风险。**单测推迟批 E**（dormant 不可 exercise；regression 断言 FOR TIME AS OF/增量→报错，precedent DV-003）。完整 snapshot 透传/增量 SPI/MVCC 入批 E |
-| P3-T05 | `listPartitions/listPartitionNames/listPartitionValues` override + 真实 `applyFilter` 裁剪 + 单测 | 批 B | @me | ⏳ | — | — | — | 现 Hudi `applyFilter` 列**全部**分区不做约束裁剪（Hive 已做 EQ/IN）；SPI partition 方法默认空。补真实裁剪 + override 分区方法 |
-| P3-T06 | MVCC/snapshot SPI（实现或显式 unsupported） | 批 B | @me | ⏳ | — | — | — | `HudiConnectorMetadata` 未 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`（默认 `Optional.empty()`）。与 T04 关联：要么接 `HudiMvccSnapshot` 语义，要么显式 unsupported |
+| P3-T05 | 真实 `applyFilter` EQ/IN 分区裁剪 + 单测（`listPartitions*` override 推迟批 E）| 批 B | @me | ✅ | `10b72d4` | 2026-06-05 | 2026-06-05 | applyFilter 原是占位（列全部分区不裁剪 + 无条件设 `prunedPartitionPaths` → 静默把分区来源从 Hudi-metadata 切到 HMS）。重写为**忠实镜像 `HiveConnectorMetadata`**：抽取 partition 列 EQ/IN 谓词 → 列候选 → 裁剪 → 仅在有效果时回传 pruned handle，否则 `Optional.empty()`（handle 不变，回落 Hudi-metadata listing）。保留 `List<String>` 路径表示 + `-1` 上限（不静默截断）；7 helper duplicate from Hive（hudi 仅依赖 fe-connector-hms）。`HudiPartitionPruningTest` 8 测全绿、checkstyle 0、import-gate 通过。**`listPartitions*` override 推迟批 E**（[DV-007]：零 live caller、Hive 不 override）。设计：[`designs/P3-T05-partition-pruning-design.md`](./designs/P3-T05-partition-pruning-design.md) |
+| P3-T06 | MVCC/snapshot SPI：保持 default opt-out + 文档化（完整 MVCC→批 E）| 批 B | @me | ✅ | — | 2026-06-05 | 2026-06-05 | **决策（[DV-007]，用户签字「Keep defaults + document」）**：不 override `beginQuerySnapshot/getSnapshotAt/getSnapshotById`，保持 SPI default `Optional.empty()`（= opt-out）。recon 证「显式抛异常 override」错——破 SPI opt-out 约定（全体连接器含 Iceberg/Paimon/Hive/Trino 均依赖 default，`FakeConnectorPluginTest` 断言）、不可达死代码（MVCC 无 production caller）、且 T04 已在唯一可触发点（time-travel）fail-loud。**零代码**。完整 MVCC（`HudiMvccSnapshot`+snapshot 透传+增量时序）入批 E。设计：[`designs/P3-T06-mvcc-design.md`](./designs/P3-T06-mvcc-design.md) |
 | P3-T07 | 三模块测试基线 + parity 测试 | 批 C | @me | ⏳ | — | — | — | fe-connector-hms/hive/hudi 当前**零测试**。补单测 + **parity**：SPI `HudiConnectorMetadata` schema/partition 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema`（fe-core），COW & MOR 各一。Rule 9：测意图（type-string 编码、schema_id、裁剪正确） |
 | P3-T08 | `tableFormatType` 分流消费设计备忘（design-only） | 批 D | @me | ⏳ | — | — | — | 写清 `PluginDrivenExternalTable` 如何按 `ConnectorTableSchema.tableFormatType`（现 fe-core 从不消费）把一个 `"hms"` catalog 的 per-table 路由到 HUDI/HIVE/ICEBERG。**不实现 fe-core 消费**（那是批 E）。作为 (a) 落地入口设计，可催生 D-NNN |
 | P3-T09 | [deferred] fe-core 消费 `tableFormatType` + hudi 表产出为 `PluginDrivenExternalTable` | 批 E | TBD | ⏳ | — | — | — | **不在 P3 hybrid 编码范围**；并入 hive/HMS migration（D-019）。catalog 模型落地 |
@@ -75,6 +76,16 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-06-05（批 B：T05 ✅ 裁剪、T06 ✅ 决策，批 B 编码完成）
+- **P3-T05 ✅**（commit `10b72d4`，feat）：`HudiConnectorMetadata.applyFilter` 真实 EQ/IN 分区裁剪。
+  - **根因**：原 applyFilter 是占位——对任何分区表 (a) 列**全部** HMS 分区名、忽略谓词，(b) 无条件设 `prunedPartitionPaths`。后果：无裁剪扫全分区；且无条件设 `prunedPartitionPaths` **短路** `HudiScanPlanProvider.resolvePartitions`（:287-289），把分区来源从 Hudi-metadata（`getAllPartitionPaths`）**静默切到 HMS**（仅对带 WHERE 的查询）——未声明的行为分叉。
+  - **修复**：忠实镜像 `HiveConnectorMetadata.applyFilter`（7 步）——抽取 partition 列 EQ/IN 谓词（解析 `getExpression()`，`columnDomains` 在 fe-core 侧为空）→ 列候选 → `prunePartitionNames` 匹配 → 仅在 `matched.size() != all.size()`（真有效果）时回传 pruned handle，否则 `Optional.empty()`（handle 不变 → resolvePartitions 回落 Hudi-metadata listing，修复来源切换）。**保留 Hudi `List<String>` 路径表示**（resolvePartitions 喂路径给 FileSystemView，非 HmsPartitionInfo）+ `-1` 上限（不静默截断，严格安全于 Hive 的 100000）。7 个 private helper duplicate from Hive（hudi 仅依赖 fe-connector-hms 非 -hive；P7 hive migration 时 consolidate，同 T02 `toHiveTypeString` 先例）。
+  - **测试**：`HudiPartitionPruningTest` 8 测（EQ/IN/AND 裁剪、非分区谓词忽略、命中全部/0 分区、unpartitioned），手写 `HmsClient` 测试替身（接口 8 方法+close）。模块 19 测全绿；checkstyle 0；import-gate 通过。
+  - **`listPartitions*` override 推迟批 E**（[DV-007]）：SPI 三方法零 live caller（`SHOW PARTITIONS` 等走 legacy metastore 路径，非 SPI）、Hive 基准不 override → 现 override = 不可测死代码。批 E（fe-core SPI 消费就绪）再做。
+  - 设计：[`designs/P3-T05-partition-pruning-design.md`](./designs/P3-T05-partition-pruning-design.md)。gate 保持关闭，零 fe-core/BE/thrift/Hive 改动。
+- **P3-T06 ✅**（决策，零代码，[DV-007]，用户签字 AskUserQuestion「Keep defaults + document」）：MVCC/snapshot SPI **保持 default `Optional.empty()` opt-out**，不新增抛异常 override。recon（mvcc-t06 reader + grep fe-core）证「显式 unsupported override」错：① SPI 约定 default=opt-out（`FakeConnectorPluginTest` 断言）；② 全体连接器（Iceberg/Paimon/Hive/Trino）无一 override；③ MVCC 方法无 production caller（仅测试 adapter）→ override 是死代码；④ T04 已在唯一可触发点（time-travel `visitPhysicalHudiScan`）抛 `AnalysisException`。正确「unsupported」=保持 default + T04 守卫。完整 MVCC 入批 E。设计：[`designs/P3-T06-mvcc-design.md`](./designs/P3-T06-mvcc-design.md)。
+- **批 B 编码小结**：T05（applyFilter 真实裁剪）✅ 落地 + T06（MVCC keep-defaults）✅ 决策。批 B 净产出 = 1 个正确性/性能修复（分区裁剪 + 修复来源切换，gate 后硬化，零回归）+ 1 个 code-grounded 决策（MVCC opt-out）。批 A+B 编码完成，下一步批 C（三模块测试基线 + COW/MOR parity）。
 
 ### 2026-06-05（批 A 续：T04 ✅，批 A 编码收尾）
 - **P3-T04 ✅**（commit `feceabb`，feat）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支加 fail-loud 守卫——`getIncrementalRelation().isPresent()` → 抛 `AnalysisException`（曾静默全扫）；`getTableSnapshot().isPresent()` → 抛（曾静默返最新，因 `HudiScanPlanProvider` 永远用 `timeline.lastInstant()`）。该分支是**唯一**同时可见 snapshot + incrementalRelation 处（SPI surface 拿不到 incremental）。删 dead `setQueryTableSnapshot`。fe-core 编译 + checkstyle 0。**dormant 分支 gate 关时运行期不可达 → 零 live 风险**；**单测推迟批 E**（不可 exercise；批 E regression 断言 FOR TIME AS OF/增量→报错，precedent DV-003，R12 显式登记不静默跳过）。完整 snapshot 透传 + 增量 SPI 表示 + MVCC 入批 E（与 T06/T03/T09–T11 同批 E）。设计：[`designs/P3-T04-fail-loud-design.md`](./designs/P3-T04-fail-loud-design.md)。

--- a/plan-doc/tasks/designs/P3-T02-column-types-design.md
+++ b/plan-doc/tasks/designs/P3-T02-column-types-design.md
@@ -1,0 +1,131 @@
+# P3-T02 设计 — `column_types` 双 bug 修复
+
+> 批 A / scan 正确性 · behind 关闭的 gate（`SPI_READY_TYPES` 不含 hms/hudi）· 零 live-path 风险
+> 关联：[tasks/P3](../P3-hudi-migration.md) · [HANDOFF 关键认知 1b HIGH ②](../../HANDOFF.md) · [DV-005](../../deviations-log.md)
+> 状态：设计完成（code-grounded，BE↔Java 契约两点对抗确认）
+
+---
+
+## Problem
+
+MOR-with-logs 的 JNI split 在 SPI 路径下，传给 BE Hudi JNI scanner 的 `hudi_column_types`（以及与之配对的 `hudi_column_names`）**被破坏**，命中**任何含 decimal / 复杂类型（array/map/struct）列**的表会读出错列 / 类型，或 names↔types 长度错位。
+
+两个独立 bug 叠加：
+
+- **(a) 类型系统错 + 丢精度**：`HudiScanPlanProvider.planScan`（`HudiScanPlanProvider.java:118-120`）用 `HudiTypeMapping.fromAvroSchema(...).getTypeName()` 生成 column_types。`fromAvroSchema` 产出的是 **Doris** `ConnectorType`（`DECIMALV3`/`DATETIMEV2`/`STRING`...），`.getTypeName()` 只取**裸类型名**，丢失 precision/scale/子类型。而 BE Hudi JNI scanner 期望的是 **Hive 类型串**（`decimal(10,2)`/`struct<a:int,b:string>`/`timestamp`/`date`...）——是另一套类型系统。
+- **(b) 逗号 join→split 打碎类型串**：`HudiScanRange` 把 `columnNames`/`columnTypes`/`deltaLogs` 三个 `List<String>` 用 `String.join(",")` 压成单串存进 `properties` map（`HudiScanRange.java:89/92/95`），再在 `populateRangeParams` 里 `split(",")` 还原（`HudiScanRange.java:194/199/204`）。Hive 类型串**本身含逗号**（`decimal(10,2)`、`struct<a:int,b:string>`、`map<string,int>`）→ 一个类型被打碎成多个 list 元素，column_types 长度膨胀、与 column_names 错位。
+
+---
+
+## Root Cause
+
+### BE ↔ Java JNI scanner 的精确契约（已对抗确认，两处独立代码）
+
+`THudiFileDesc.{delta_logs, column_names, column_types}` 是 thrift **`list<string>`**（`gensrc/thrift/PlanNodes.thrift:396-398`）。**join 由 BE 做，不是 FE 做**：
+
+| 字段 | BE cpp join（`be/src/format/table/hudi_jni_reader.cpp`）| Java scanner split（`fe/be-java-extensions/hadoop-hudi-scanner/.../HadoopHudiJniScanner.java`）|
+|---|---|---|
+| `delta_file_paths` | `join(delta_logs, ",")` (:52) | `.split(",")` (:106) |
+| `hudi_column_names` | `join(column_names, ",")` (:53) | `.split(",")` (:212) |
+| `hudi_column_types` | `join(column_types, **"#"**)` (:54) | `.split(**"#"**)` (:113) |
+
+**关键**：column_types 用 `#` 分隔，正是**因为**类型串里含逗号（`decimal(10,2)`/`struct<...>`）；names 是标识符（无逗号）用 `,` 安全。所以 FE 的正确做法是：**把每个列类型作为一个完整 Hive 类型串、整体作为 list 的一个元素塞进 `THudiFileDesc.column_types`，绝不在 FE 端 join/split**。BE join `#`、Java split `#`，类型串里的逗号天然保留。
+
+### legacy 参照（确认设计方向）
+
+- legacy `HudiScanNode.java:299-301` 直接 `fileDesc.setDeltaLogs(...)/setColumnNames(...)/setColumnTypes(...)` 设 thrift list —— **不 join**。
+- legacy column_types 来源：`HMSExternalTable.java:752` `colTypes.add(HudiUtils.convertAvroToHiveType(hudiAvroField.schema()))` → 完整 Hive 类型串。`HudiUtils.convertAvroToHiveType`（`HudiUtils.java:68-135`）是 canonical Avro→Hive-type-string 转换器。
+
+### 当前 SPI bug 的连锁后果
+
+`columnTypes = [..., "decimal(10,2)", "struct<a:int,b:string>"]`
+→ 构造器 `String.join(",")` → `"...,decimal(10,2),struct<a:int,b:string>"`
+→ `populateRangeParams` `split(",")` → `[..., "decimal(10", "2)", "struct<a:int", "b:string>"]`（元素数膨胀 + 串被打碎）
+→ BE `join("#")` → `...#decimal(10#2)#struct<a:int#b:string>` → Java `split("#")` 得到无意义的类型片段 → JNI reader 解析失败 / 错列。
+叠加 bug (a)：即便不打碎，`getTypeName()` 也只给 `DECIMALV3`（无 `(10,2)`）/`STRUCT`（无子字段）——BE 无法用。
+
+---
+
+## Design
+
+三处改动，全部在 `fe-connector-hudi` 模块内（**不动 fe-core，不动 BE，不动 thrift**），gate 保持关闭。
+
+### 改动 1 — `HudiTypeMapping.java`：新增 Avro→Hive 类型串方法
+
+新增 `public static String toHiveTypeString(Schema schema)`，**逐行 mirror** legacy `HudiUtils.convertAvroToHiveType`（fe-core，import gate 禁止直接复用，故在连接器模块内复刻）。语义完全对齐，包括：
+- `decimal(p,s)`、`array<...>`、`struct<name:type,...>`、`map<string,...>`、`timestamp`/`date`、primitives；
+- UNION 单一非空类型递归 unwrap；
+- 不支持类型（TimeMillis/TimeMicros/多类型 union/空 record）**抛 `IllegalArgumentException`**（与 legacy 一致，fail-loud）。
+
+保留现有 `fromAvroSchema`（Avro→Doris `ConnectorType`）**不动**——它服务 schema 上报（`HudiConnectorMetadata.java:240`），是正确的、另一条路径。
+
+### 改动 2 — `HudiScanPlanProvider.java`：用 Hive 类型串生成 column_types
+
+`planScan` 中 column_types 生成（:118-120）：
+```java
+// before
+columnTypes = avroSchema.getFields().stream()
+        .map(f -> HudiTypeMapping.fromAvroSchema(unwrapNullable(f.schema())).getTypeName())
+        .collect(Collectors.toList());
+// after
+columnTypes = avroSchema.getFields().stream()
+        .map(f -> HudiTypeMapping.toHiveTypeString(f.schema()))
+        .collect(Collectors.toList());
+```
+（`toHiveTypeString` 自己处理 union unwrap，直接传 `f.schema()`，对齐 legacy `convertAvroToHiveType(field.schema())`。）若此改动使私有 `unwrapNullable`（:350-359）变为未引用，则一并删除。
+
+### 改动 3 — `HudiScanRange.java`：三个 list 字段端到端 typed，弃逗号 join/split
+
+- 新增三个 `List<String>` 字段：`deltaLogs`、`columnNames`、`columnTypes`（不可变副本）。
+- 构造器：**移除** `props.put("hudi.delta_logs"/"hudi.column_names"/"hudi.column_types", String.join(",", ...))`（:88-96 三处），改为赋值字段。标量 JNI 字段（instant_time/serde/input_format/base_path/data_file_path/data_file_length）**保持原样存 props map**（无逗号问题，最小改动）。
+- `populateRangeParams`：
+  - JNI 降级判定的 delta-logs 空检查（:161-162）改用 `deltaLogs` 字段（`deltaLogs == null || deltaLogs.isEmpty()`）。
+  - 直接 `fileDesc.setDeltaLogs(deltaLogs)/setColumnNames(columnNames)/setColumnTypes(columnTypes)`（保留 null/empty 守卫），**不再 split**。
+
+> `getProperties()` 仅被 `HudiScanRange.populateRangeParams` 自身消费（`PluginDrivenScanNode.java:392` 调 `populateRangeParams`，且 `HudiScanRange` override 了该方法、不走 `ConnectorScanRange` 默认 generic 路径）——故三个 list key 从 map 移除对外部零影响。
+
+---
+
+## Implementation Plan
+
+1. `HudiTypeMapping.java`：加 `toHiveTypeString(Schema)` + 递归 helper（mirror legacy）。
+2. `HudiScanPlanProvider.java`：改 :118-120；若 `unwrapNullable` 变 dead 则删。
+3. `HudiScanRange.java`：加 3 字段、改构造器、改 `populateRangeParams`。
+4. 新增单测（见下）。
+5. 构建守门：`mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false`（cwd=fe/）；checkstyle 0；import-gate 通过。
+
+---
+
+## Risk Analysis
+
+- **回归面**：gate 关闭，hudi 查询仍走 legacy 路径；SPI `HudiScanRange`/`HudiScanPlanProvider` **零 live caller**（trino-connector 之外的 SPI 表才会触达，hudi 未翻闸）。改动纯属硬化 dormant 代码，**零 live-path 风险**。
+- **契约风险**：BE↔Java 的 `#`/`,` 分隔已两点确认；不改 BE/thrift，契约不变。
+- **parity 残留（不在 T02 范围，登记）**：
+  - column_names/types 的**列集合与顺序**是否与 legacy（meta 列 `_hoodie_*`、partition 列）完全一致 → 由 **T07 parity 测试**校验。
+  - schema 解析失败时 `planScan` try/catch 吞成空 list（:121-126）的 fail-loud 问题 → **T04** 处理，本 task 不动控制流。
+  - `toHiveTypeString` 对不支持类型抛异常，会被上述 try/catch 吞 → 同属 T04 范畴。
+- **simplicity（CLAUDE.md R2/R3）**：仅 3 文件、新增一个 mirror 方法 + 字段化三个 list；标量保持原样，最小 diff。
+
+---
+
+## Test Plan
+
+### Unit Tests（本 task 交付；建立 fe-connector-hudi 首个测试）
+
+`HudiTypeMappingTest`（验证 Avro→Hive 串编码意图，Rule 9）：
+- `decimal` logical type → `"decimal(10,2)"`（**精度/scale 不丢** —— 直击 bug a）。
+- record → `"struct<a:int,b:string>"`（**含逗号的复杂类型** —— 串里必须保留逗号）。
+- `array<int>`、`map<string,bigint>`、嵌套 `array<struct<...>>`。
+- primitives：int/bigint/boolean/float/double/string/date/timestamp。
+- nullable union（`["null", T]`）→ unwrap 为 T。
+- 不支持类型（TimeMillis）→ 抛 `IllegalArgumentException`（fail-loud parity）。
+
+`HudiScanRangeTest`（验证 typed-list 端到端不被打碎，Rule 9 —— 直击 bug b）：
+- 构造 range：`columnNames=["x","y","z"]`、`columnTypes=["int","decimal(10,2)","struct<a:int,b:string>"]`、`deltaLogs=["s3://.../.log.1","s3://.../.log.2"]`、含 delta logs（→ JNI）。
+- 调 `populateRangeParams`，断言 `THudiFileDesc.getColumnTypes()` **恰为 3 个元素且逐元素未变**（不是被逗号打碎成 5 个），`getColumnNames()` 3 元素，`getDeltaLogs()` 2 元素，names↔types **长度一致**。
+- 断言 `decimal(10,2)`、`struct<a:int,b:string>` 作为**单个 list 元素**完整保留（编码"类型串里的逗号必须存活到 BE，否则 JNI scanner split('#') 读错类型"这一 WHY）。
+- 降级用例：无 delta logs 的 `.parquet` data file → format 降为 `FORMAT_PARQUET`、不设 JNI 列字段（验证 :160-176 降级逻辑用 field 后仍正确）。
+
+### E2E Tests
+
+**不适用 / 推迟批 E**：gate 关闭，hudi 查询不走 SPI 路径，无法在 regression-test 中端到端触达本代码（需 batch E 翻闸 + Hudi 集群）。按 [tasks/P3 §策略](../P3-hudi-migration.md) 批 A–C 验证为「单测 + 设计级」，端到端随批 E cutover 做。**显式登记，不静默跳过（CLAUDE.md R12）**。

--- a/plan-doc/tasks/designs/P3-T04-fail-loud-design.md
+++ b/plan-doc/tasks/designs/P3-T04-fail-loud-design.md
@@ -1,0 +1,69 @@
+# P3-T04 设计 — time-travel + 增量读 fail-loud 守卫
+
+> 批 A / scan 正确性 · behind 关闭的 gate · 零 live-path 风险（SPI hudi 分支 dormant，gate 关时不可达）
+> 关联：[tasks/P3](../P3-hudi-migration.md) · [HANDOFF 1b HIGH ③④](../../HANDOFF.md) · [DV-005](../../deviations-log.md)
+> 状态：设计完成（code-grounded）
+
+---
+
+## Problem
+
+SPI hudi 路径对两类查询**静默给错结果**：
+
+- **time-travel**（`FOR TIME AS OF` / `FOR VERSION AS OF`）：`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支（`PhysicalPlanTranslator.java:835`）把 snapshot 经 `setQueryTableSnapshot` 设到 node，但 `HudiScanPlanProvider.planScan`（`HudiScanPlanProvider.java:103`）**永远用 `timeline.lastInstant()`**、忽略 snapshot → **静默返最新**。
+- **增量读**（incremental relation）：SPI 分支（`:828-838`）**根本不传** `hudiScan.getIncrementalRelation()`（仅 legacy 分支 `:848` 传）；SPI 无任何增量表示 → **静默全量扫描**。
+
+二者都是**正确性 bug（静默错结果）**，不是性能问题。
+
+## Root Cause
+
+- snapshot 透传链路未接：node 拿到 snapshot 但 provider 不消费。
+- 增量读在 SPI 层无模型（`IncrementalRelation` 是 fe-core 概念，4 个 `*IncrementalRelation` 类仍在 fe-core；P1-T04 已知 gap）。
+- 完整实现（snapshot 透传到 provider + 增量 SPI 表示 + MVCC）属**批 E**（与 hive/HMS migration、模型落地一并），见 T06/批 E。
+
+## Design
+
+**仅做 fail-loud（task 范围）**：在 `visitPhysicalHudiScan` 的 SPI 分支**顶部**显式报错，绝不静默。这是**唯一**同时可见 snapshot + incrementalRelation 的位置（SPI surface 拿不到 incrementalRelation），故守卫只能落在该 dormant 分支（gate 关时不可达，零 live 风险）。
+
+```java
+if (table instanceof PluginDrivenExternalTable) {
+    // Fail loud: SPI hudi 路径尚不支持 time travel / 增量读（provider 永远读最新，
+    // 增量 relation 无 SPI 表示）。静默返最新/全扫会给错结果。完整支持推迟批 E。
+    if (hudiScan.getIncrementalRelation().isPresent()) {
+        throw new AnalysisException("Hudi incremental read is not yet supported via the "
+                + "catalog SPI; it is deferred to the Hudi connector migration.");
+    }
+    if (hudiScan.getTableSnapshot().isPresent()) {
+        throw new AnalysisException("Hudi time travel (FOR TIME/VERSION AS OF) is not yet "
+                + "supported via the catalog SPI; it is deferred to the Hudi connector migration.");
+    }
+    ... // 原 node 创建逻辑；删去已被守卫覆盖为 dead 的 setQueryTableSnapshot 行
+}
+```
+
+- 守卫只在**真有** time-travel/增量时触发；普通快照查询 `Optional.empty()` → 正常通过，零影响。
+- `AnalysisException`（`org.apache.doris.nereids.exceptions.AnalysisException`，unchecked，已 import `:76`）= nereids 用户向错误的惯用类型。
+- 守卫后 `hudiScan.getTableSnapshot()` 必为空 → 原 `:835` 的 `ifPresent(setQueryTableSnapshot)` 成 dead，删除（surgical）。更新 `:825-827` 注释为新行为 + 批 E 指向。
+
+## Implementation Plan
+
+1. `PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支加两守卫 + 删 dead `setQueryTableSnapshot` 行 + 更新注释。
+2. 守门：`mvn -pl fe-core -am compile`（fe-core 大，rebase 后失败先 clean fe-core，关键认知 2）；checkstyle 0。
+
+## Risk Analysis
+
+- **零 live 风险**：SPI 分支仅当 `table instanceof PluginDrivenExternalTable`（即 hudi 走 SPI）才进；gate 关（`SPI_READY_TYPES` 不含 hms/hudi）→ hudi 永远是 `HMSExternalTable`，**该分支运行期不可达**。改动是硬化 dormant 代码。
+- **不碰** SPI_READY_TYPES / legacy / 其他连接器 `instanceof` 分支（HANDOFF 关键认知 3）。
+- **行为改进**：从「静默错结果」→「显式报错」。对 legacy 路径（line 844+）零影响。
+
+## Test Plan
+
+### Unit Tests
+
+**不适用（显式登记，不静默——CLAUDE.md R12）**：守卫在 fe-core nereids translator 的 **dormant 分支**，gate 关时**运行期不可达**；单测需构造 `PhysicalHudiScan` + `PlanTranslatorContext` + `PluginDrivenExternalTable`（重 nereids 脚手架），且无法真正 exercise（分支不可达）。抽 boolean-helper 仅为测一个近乎恒真的 2-行守卫 = 为单用代码加抽象（违 R2）、测试近同义反复（违 R9）。
+
+**验证推迟批 E**（与 T03/DV-006、T11 一致；precedent DV-003）：批 E 翻闸后在 regression-test 加 `FOR TIME AS OF <ts>` / 增量查询 → **断言报错**（而非静默最新/全扫）。本 task 的正确性由 code review + 编译保证；运行期断言入批 E。
+
+### E2E Tests
+
+同上：推迟批 E（gate 关，端到端不可触达）。

--- a/plan-doc/tasks/designs/P3-T05-partition-pruning-design.md
+++ b/plan-doc/tasks/designs/P3-T05-partition-pruning-design.md
@@ -1,0 +1,132 @@
+# P3-T05 设计 — `applyFilter` 真实 EQ/IN 分区裁剪
+
+> 批 B / metadata 补全 · behind 关闭的 gate（`SPI_READY_TYPES` 不含 hms/hudi）· 零 live-path 风险（SPI hudi 分支 dormant，零 live caller）
+> 关联：[tasks/P3](../P3-hudi-migration.md) · [HANDOFF 未完成 #1](../../HANDOFF.md) · [DV-005](../../deviations-log.md) · [DV-007](../../deviations-log.md)（批 B scope 校正）
+> 对标参照：`HiveConnectorMetadata.applyFilter`（`fe-connector-hive`，:193-234 + 7 个 helper）
+> 状态：设计完成（code-grounded，5-reader recon workflow + 主线核读 Hive/Hudi 全文）
+
+---
+
+## Problem
+
+SPI Hudi 路径**不做分区裁剪**，且附带一个**静默的分区来源切换** bug。
+
+`HudiConnectorMetadata.applyFilter`（`HudiConnectorMetadata.java:144-167`）当前对**任何**带 partition key 的表：
+
+1. **完全忽略谓词**：直接 `hmsClient.listPartitionNames(db, table, -1)` 拉**全部**分区名，不解析 `constraint.getExpression()`，不抽取 EQ/IN，不裁剪。
+2. **无条件**把全量列表塞进 `prunedPartitionPaths`（`:162-164`）。
+
+两个后果：
+
+- **(perf/正确性) 无分区裁剪**：`year='2024' AND month='01'` 仍扫全部分区 → 性能塌方 + 无谓 HMS/文件系统压力。
+- **(隐蔽) 分区来源静默切换**：`prunedPartitionPaths` 一旦非 null，`HudiScanPlanProvider.resolvePartitions`（`:287-289`）就**短路**、直接用它，**绕过** `:307` 的 `HoodieTableMetadata.getAllPartitionPaths()`（Hudi 元数据表，Hudi 的权威分区来源）。即：**只要查询带任意 WHERE（触发 applyFilter），分区来源就从 Hudi-metadata 偷偷换成 HMS**；无 WHERE 时又回到 Hudi-metadata。两个来源对已同步表通常一致，但这是**未声明的行为分叉**，且把"裁剪入口"和"来源选择"耦合在了一起。
+
+**对标**：`HiveConnectorMetadata.applyFilter`（`:193-234`）做真实 EQ/IN 裁剪，且**仅在裁剪真正生效时**才回传修改后的 handle，其余情况 `Optional.empty()`（handle 不变，下游用默认 listing）。Hudi 缺这套逻辑。
+
+---
+
+## Root Cause
+
+Hudi 的 `applyFilter` 是个**占位实现**：从未移植 Hive 的「抽取分区谓词 → 列候选 → 匹配 → 缩减集」链路，也没有 Hive 的「无效裁剪即 `Optional.empty()`」短路守卫，于是退化成"无条件设全量"。
+
+> `ConnectorFilterConstraint.getColumnDomains()` 在 fe-core 侧由 `PluginDrivenScanNode.buildFilterConstraint` 传入**空 map**（`Collections.emptyMap()`），唯一可用的谓词表示是 `getExpression()`（完整表达式树）——与 Hive 一致。故裁剪必须解析 `getExpression()`。
+
+---
+
+## Design
+
+把 `HudiConnectorMetadata.applyFilter` **重写为忠实镜像 `HiveConnectorMetadata.applyFilter`**，但**保留 Hudi 的 `List<String> prunedPartitionPaths` 表示**（不改用 Hive 的 `List<HmsPartitionInfo>`）——因为 `HudiScanPlanProvider.resolvePartitions` 消费的是**相对分区路径串**（喂给 Hudi `HoodieTableFileSystemView`，:208/:237），不是 HMS 分区元数据。HMS 分区**名**（`year=2024/month=01`，Hive 约定）即 Hudi 相对分区**路径**，二者同形，无需转换（现有 `parsePartitionValues` :317-332 已按 `/`+`=` 解析，证明同形假设）。
+
+全部改动在 `fe-connector-hudi` 模块内（**不动 fe-core、不动 BE、不动 thrift、不动 Hive**），gate 保持关闭。
+
+### 改动 1 — `HudiConnectorMetadata.applyFilter` 重写（mirror Hive 7 步）
+
+```java
+HudiTableHandle hudiHandle = (HudiTableHandle) handle;
+List<String> partKeyNames = hudiHandle.getPartitionKeyNames();
+if (partKeyNames == null || partKeyNames.isEmpty()) {
+    return Optional.empty();                                    // ① 无分区列 → 不裁剪
+}
+Map<String, List<String>> partitionPredicates = extractPartitionPredicates(
+        constraint.getExpression(), partKeyNames);
+if (partitionPredicates.isEmpty()) {
+    return Optional.empty();                                    // ② 无分区谓词 → handle 不变，
+}                                                              //    resolvePartitions 回落 Hudi-metadata listing（修复来源切换 bug）
+List<String> allPartNames = hmsClient.listPartitionNames(
+        hudiHandle.getDbName(), hudiHandle.getTableName(), -1); // ③ 列候选（保留现有 -1=unlimited，见下）
+if (allPartNames == null || allPartNames.isEmpty()) {
+    return Optional.empty();                                    // 无分区可裁
+}
+List<String> matchedPartNames = prunePartitionNames(
+        allPartNames, partKeyNames, partitionPredicates);       // ④ 按谓词匹配
+if (matchedPartNames.size() == allPartNames.size()) {
+    return Optional.empty();                                    // ⑤ 裁剪无效果 → 不回传
+}
+HudiTableHandle updatedHandle = hudiHandle.toBuilder()
+        .prunedPartitionPaths(matchedPartNames)                 // ⑥ 仅缩减集（可为空=裁光）
+        .build();
+return Optional.of(new FilterApplicationResult<>(
+        updatedHandle, constraint.getExpression(), false));     // ⑦ remaining=全表达式（BE 复评，与 Hive 同）
+```
+
+**与 Hive 的两处有意差异（surgical，登记）**：
+
+- **③ HMS listPartitionNames 上限**：Hive 用 `100000`（硬上限，超出静默丢分区 → 潜在漏裁/错结果）；Hudi **保留现状 `-1`（unlimited）**——**严格更安全**（不静默截断），且是 Hudi 占位实现的既有取值，不引入新行为。**不跟 Hive 的 100000**。
+- **分区表示**：Hive `List<HmsPartitionInfo>`（含 location/format）；Hudi `List<String>`（路径串）——Hudi 下游不需要 HMS 元数据（Hudi 自己从 FileSystemView 解析文件），保持现状字段，最小 diff。
+
+### 改动 2 — 移植 7 个 private helper（duplicate from Hive）
+
+逐行复刻 `HiveConnectorMetadata` 的：`extractPartitionPredicates`、`extractPredicatesRecursive`、`extractColumnName`、`extractLiteralValue`、`prunePartitionNames`、`parsePartitionName`、`matchesPredicates`。语义完全一致：
+
+- 递归下降识别 `ConnectorAnd`（遍历 conjuncts）/ `ConnectorComparison`（仅 `Operator.EQ`）/ `ConnectorIn`（非 negated）；列名经 `ConnectorColumnRef`、字面值经 `ConnectorLiteral`（`String.valueOf`）。
+- `parsePartitionName` 按 `/` 再 `=` 解析；`matchesPredicates` 要求每个分区谓词列在分区值中命中 allowed 集合。
+- 只对 **partition key 集合内**的列累积谓词（非分区列谓词被忽略 → 由 BE 复评，正确）。
+
+**为何 duplicate 而非共享**：`fe-connector-hudi` 仅依赖 `fe-connector-hms`，**不依赖 `fe-connector-hive`**（pom 确认）；连接器模块互相 import 对方 metadata 类是错误分层；import-gate 禁连接器 import fe-core。抽到 `fe-connector-hms` 共享需**改 Hive**（移其 private 副本）= 触碰其它连接器工作码（本场只动 hudi，HANDOFF 关键认知 5）。故复刻，**登记 Hive/Hudi 重复**，待 P7 hive migration 时一并 consolidate（届时两模块同改）。与 T02 复刻 `toHiveTypeString`（而非跨模块共享）一脉相承。
+
+### 新增 import
+
+`ConnectorAnd`/`ConnectorComparison`/`ConnectorExpression`/`ConnectorIn`/`ConnectorLiteral`（`connector.api.pushdown`）、`java.util.HashMap`、`java.util.Set`。`FilterApplicationResult`/`ConnectorFilterConstraint` 已 import。
+
+---
+
+## Implementation Plan
+
+1. `HudiConnectorMetadata.java`：重写 `applyFilter`（:144-167）为 7 步；新增 7 个 helper；补 import。
+2. 新增 `HudiPartitionPruningTest`（见 Test Plan）：手写 `HmsClient` 测试替身（接口 8 方法，仅实现 `listPartitionNames`，余抛 `UnsupportedOperationException`）。
+3. 守门：`mvn -pl fe-connector/fe-connector-hudi -am test -Dmaven.build.cache.enabled=false -DfailIfNoTests=false`（cwd=`fe/`）；checkstyle 0（**禁 static import**，用 `Assertions.assertX`）；import-gate 通过。
+
+---
+
+## Risk Analysis
+
+- **零 live 风险**：gate 关闭，hudi 查询走 legacy `HudiScanNode`；SPI `HudiConnectorMetadata.applyFilter` **零 live caller**（仅 SPI 表触达，hudi 未翻闸）。改动纯硬化 dormant 代码。
+- **行为改进**：(a) 真实 EQ/IN 裁剪（性能）；(b) 修复"分区来源静默切换"——无分区谓词时回 `Optional.empty()`，`resolvePartitions` 回落 Hudi-metadata listing，与无 WHERE 路径一致（消除分叉）。
+- **正确性边界**：
+  - 只裁剪 **EQ/IN over partition columns**；范围谓词（`>`/`<`/`BETWEEN`）、非分区列谓词**不裁剪**（保守），`remaining=全表达式` 交 BE 复评 → **不会漏行**（与 Hive 同语义）。
+  - `matched` 为空（谓词命中 0 分区）→ `prunedPartitionPaths=[]` → 扫 0 分区（正确）。
+  - 分区名/路径同形假设：现有 `parsePartitionValues` 已依赖，T05 不新增假设。
+- **不碰** `SPI_READY_TYPES` / legacy / 其它连接器（含 Hive）/ thrift（HANDOFF 关键认知 3+5）。
+- **simplicity（R2/R3）**：单文件 + 镜像 Hive 既证实现，最小 diff；保留 `List<String>` 字段与 `-1` 上限（不引入新行为）。
+
+---
+
+## Test Plan
+
+### Unit Tests（本 task 交付；模块第三个测试类）
+
+`HudiPartitionPruningTest`（**测意图 / Rule 9**：编码「分区裁剪必须正确缩减集合、且绝不在非分区列或范围谓词上误裁」这一 WHY）。手写 `FakeHmsClient implements HmsClient`，`listPartitionNames` 返固定列表如 `["year=2023/month=12","year=2024/month=01","year=2024/month=02"]`，余方法抛 `UnsupportedOperationException`。构造真实 `ConnectorExpression` 树（`ConnectorComparison(EQ,…)` / `ConnectorIn` / `ConnectorAnd` / `ConnectorColumnRef` / `ConnectorLiteral`）：
+
+- **EQ on partition col**：`year='2024'` → handle 含 2 分区（`year=2024/*`），断言**恰为**那 2 个、顺序保留。
+- **IN on partition col**：`month IN ('01','12')` → 跨 year 命中 `…/month=01` + `…/month=12`。
+- **AND（分区谓词 + 非分区谓词）**：`year='2024' AND price>100` → 仅按 `year` 裁（2 分区），`price>100` 被忽略（非分区列）→ 断言不误裁、不抛。
+- **非分区谓词 only**：`price>100` → `Optional.empty()`（**不裁剪、handle 不变**——直击"来源切换"修复）。
+- **谓词命中全部分区**：`year IN ('2023','2024')`（覆盖全集）→ `Optional.empty()`（裁剪无效果，不回传）。
+- **谓词命中 0 分区**：`year='1999'` → handle 含**空** `prunedPartitionPaths`（扫 0 分区，非 empty-optional）。
+- **无分区列表**：`partKeyNames` 空 → `Optional.empty()`（unpartitioned 表，applyFilter 不介入）。
+
+每用例断言 `result.isPresent()` 与（present 时）`((HudiTableHandle)result.getHandle()).getPrunedPartitionPaths()` 的**精确集合**——断言旧占位码（设全量）会失败的行为。
+
+### E2E Tests
+
+**不适用 / 推迟批 E**（与 T02/T04、`tasks/P3 §策略` 一致；precedent DV-003）：gate 关闭，hudi 查询不走 SPI，无法在 regression-test 端到端触达。批 E 翻闸后加 regression：带分区谓词查询 → 断言**仅扫匹配分区**（explain/profile 校 partition 数）。**显式登记，不静默跳过（R12）**。

--- a/plan-doc/tasks/designs/P3-T06-mvcc-design.md
+++ b/plan-doc/tasks/designs/P3-T06-mvcc-design.md
@@ -1,0 +1,39 @@
+# P3-T06 设计 — MVCC / snapshot SPI（保持 default opt-out，无代码）
+
+> 批 B / metadata 补全 · behind 关闭的 gate · 零 live-path 风险
+> 关联：[tasks/P3](../P3-hudi-migration.md) · [HANDOFF 未完成 #2](../../HANDOFF.md) · [DV-007](../../deviations-log.md)（批 B scope 校正）· [P3-T04 设计](./P3-T04-fail-loud-design.md)
+> 状态：决策完成（code-grounded，用户签字 2026-06-05「Keep defaults + document」）
+
+---
+
+## Problem
+
+`HudiConnectorMetadata` 未 override SPI 的三个 MVCC/snapshot 方法（`ConnectorMetadata.java:60-77`）：
+`beginQuerySnapshot` / `getSnapshotAt(timestampMillis)` / `getSnapshotById(snapshotId)`，均默认返 `Optional.empty()`。
+
+HANDOFF 原提示 T06「**大概率显式 unsupported（与 T04 fail-loud 一致）**」——暗示**新增抛异常的 override**。
+
+## 决策：**不 override，保持 SPI default（`Optional.empty()` = opt-out）+ 文档化**（无代码改动）
+
+code-grounded recon（5-reader workflow，mvcc-t06 reader）证明「新增抛异常 override」是**错的**：
+
+1. **SPI 约定 = default opt-out**：三方法 default 即 `Optional.empty()`，语义是「连接器**不支持** MVCC」。`FakeConnectorPluginTest`（fe-core）有显式断言「all three mvcc defaults return Optional.empty() — connector opts out of MVCC」。
+2. **无任何连接器 override**：`Iceberg` / `Paimon`（均 MVCC-capable 表格式）/ `Hive` / `Trino` **全部依赖 default**，无一 override。Hudi 若新增抛异常 override = **唯一打破 opt-out 约定**的连接器。
+3. **无 production caller**：全仓 `beginQuerySnapshot`/`getSnapshotAt`/`getSnapshotById` 仅出现在 SPI 接口、`ConnectorMvccSnapshot` 类型、`ConnectorMvccSnapshotAdapter`（fe-core，仅测试用）——**fe-core 查询路径从不调用**。抛异常的 override = **不可达死代码**。
+4. **T04 已在唯一可触发点 fail-loud**：Hudi 唯一可能请求 snapshot 的位置是 time-travel（`FOR TIME/VERSION AS OF`），`PhysicalPlanTranslator.visitPhysicalHudiScan` SPI 分支（T04，`feceabb`）**已抛 `AnalysisException`**。即便批 E 接通 MVCC 调用链，请求也在到达 metadata 前被 T04 拦截。重复在 metadata 层抛 = 冗余。
+
+**结论**：正确的「unsupported」表达 = **保持 default `Optional.empty()`（与全体连接器一致）+ T04 的 translator 守卫**。T06 是**文档化决策**，非代码任务。完整 MVCC（`HudiMvccSnapshot` 语义、snapshot 透传、增量时序）入**批 E**（与 T03/T04 完整实现、T09–T11、hive/HMS migration 一并），见 [DV-007](../../deviations-log.md)。
+
+## Why no code
+
+- 新增 override 违反 SPI opt-out 约定（R11 conformance）、是不可达死代码（R2 nothing speculative）、与全体连接器分叉（R7 surface conflicts—此处选更一致的一方）。
+- T04 已提供唯一可触发路径的 fail-loud；不重复（R3 surgical）。
+
+## Risk Analysis
+
+- **零改动 → 零回归 / 零 live 风险**。
+- 行为正确性：gate 关时 MVCC 方法不可达；批 E 翻闸后，time-travel 被 T04 拦截（fail-loud），非 time-travel 查询不请求 snapshot → `Optional.empty()` 的 opt-out 语义正确（连接器不参与 MVCC，走默认 latest 快照语义由 provider 的 `timeline.lastInstant()` 承接，与当前一致）。
+
+## Test Plan
+
+**不适用（无代码）**。SPI default opt-out 行为已由 fe-core `FakeConnectorPluginTest`（T08 三方法返 empty）覆盖。批 E 接通 MVCC 调用链 + 实现 `HudiMvccSnapshot` 后，于 regression 验证 time-travel 语义（与 T04 的批 E regression 同套：`FOR TIME AS OF` 当前 fail-loud，批 E 后返正确快照）。**显式登记，不静默（R12）**。

--- a/plan-doc/tasks/designs/P3-T07-test-baseline-design.md
+++ b/plan-doc/tasks/designs/P3-T07-test-baseline-design.md
@@ -1,0 +1,116 @@
+# P3-T07 设计 — 三模块测试基线 + COW/MOR schema parity（golden-value）
+
+> 关联：[tasks/P3-hudi-migration.md](../P3-hudi-migration.md)（批 C / T07）、[HANDOFF 关键认知 2/3](../../HANDOFF.md)。
+> recon：5-agent code-grounded workflow（`p3-t07-recon`，2026-06-05），结论见下。
+> 用户签字（AskUserQuestion，2026-06-05）：① **casing 当场修**；② baseline **focused intent-driven set**。
+
+---
+
+## Problem
+
+批 C 目标：为三个连接器模块建**测试基线** + 证 SPI hudi schema 输出与 legacy parity。
+
+- `fe-connector-hms` / `fe-connector-hive`：**当前零测试**；`fe-connector-hudi`：已有 3 测试类（`HudiTypeMappingTest` / `HudiScanRangeTest` / `HudiPartitionPruningTest`）。
+- parity 要求（T07 验收 + HANDOFF）：SPI `HudiConnectorMetadata` schema / column-type 输出 vs legacy `HiveMetaStoreClientHelper.getHudiTableSchema` + `HMSExternalTable.initHudiSchema`，**COW & MOR 各一**；覆盖 column_names / types **列集合 + 顺序 + casing**。Rule 9：测意图。
+
+---
+
+## Recon 结论（决定整个设计）
+
+### 1. parity 可行性 = **golden-value（唯一可行）**
+- import-gate（`tools/check-connector-imports.sh`）只扫 `*/src/main/java` 且只禁 connector→fe-core 单向；**test 目录豁免**。但真正约束是 **Maven 依赖图**：`fe-core` 只依赖 `fe-connector-api`/`-spi`，**不依赖** 具体 `-hudi`/`-hms`/`-hive` 模块；连接器模块不依赖 fe-core。→ **无任何编译路径能同时见 legacy `HudiUtils` 与 SPI `HudiTypeMapping`**。直接跨模块 parity 断言不可行（除非新增依赖 = 架构倒退）。
+- → parity 用 **golden 值**：把 legacy `HudiUtils.convertAvroToHiveType` / `fromAvroHudiTypeToDorisType` / `initHudiSchema` 的契约读出，作为带 `file:line` 注释的 golden 常量，断言 SPI 复现。与 T02 `HudiTypeMappingTest` golden 断言 `toHiveTypeString` 一脉相承。
+- 测试栈：**JUnit 5 only，无 mockito/jmockit**；替身全手写（`FakeHmsClient` 先例）。checkstyle **禁 static import**。
+
+### 2. COW/MOR schema = **type-agnostic**（关键简化）
+- legacy（`HMSExternalTable.initHudiSchema:734-758`）与 SPI（`HudiConnectorMetadata.getTableSchema → avroSchemaToColumns:262`）都从**同一份 Hudi avro schema** 推导列表/名/类型，**零** COW/MOR 分支。COW/MOR 区别只在 **scan planning**（split 收集 + reader 格式：`HudiScanNode.canUseNativeReader` / `HudiScanPlanProvider.planScan:92`）。
+- → "COW & MOR 各一" **不需两份真实 Hudi 表 fixture**，降解为：
+  - (a) **一份纯 avro→column 变换**（真实 parity 面：名/序/类型/Hive 串/nullable），golden 对标 legacy 契约 —— COW≡MOR 恒等；
+  - (b) **`detectHudiTableType` 分类**（`HudiConnectorMetadata:301`，COW vs MOR vs UNKNOWN）—— metadata SPI 中唯一区分表型处，经 `getTableHandle` + `FakeHmsClient` 喂 `HmsTableInfo` 测。
+
+### 3. legacy↔SPI 类型映射 = **逐类型一致**（recon 矩阵）
+- `HudiTypeMapping.toHiveTypeString` ≡ `HudiUtils.convertAvroToHiveType`；`HudiTypeMapping.fromAvroSchema` ≡ `HudiUtils.fromAvroHudiTypeToDorisType`，**每个 avro 类型** Hive 串 + Doris 类型均一致。例外见下两 gap。
+
+---
+
+## 两处 parity gap
+
+### gap-1（confirmed）column 名 casing —— **当场修（用户签字）**
+- SPI `avroSchemaToColumns:270` 用 `field.name()` **原样**；legacy 在 `HMSExternalTable:745` `toLowerCase(Locale.ROOT)`（**仅顶层列名**；嵌套 struct 字段名 legacy/SPI 均不降，保持一致）。
+- **修法**：`avroSchemaToColumns` 顶层列名改 `field.name().toLowerCase(Locale.ROOT)`，镜像 legacy:745。**仅顶层**，不动 `HudiTypeMapping` 嵌套 struct 名（两侧本就一致）。
+- **安全性**（已核）：`ThriftHmsClient.convertFieldSchemas:303-304` 用 `fs.getName()` 不防御性降字，但 **Hive Metastore 自身存小写标识符** → HMS 来源的 partition key 名到手即小写。降 avro 路径列名 → 与小写 HMS partition key **对齐**（改善 `getColumnHandles:142` 对 mixed-case Hudi 表的匹配），**无回归**。
+- **明确缩界（Rule 12 不静默）**：`ThriftHmsClient` 源头的防御性降字（与 hive 模块共享）**不在 T07 改** —— 触碰 hive 行为属 P7/批 E。本场只对齐 hudi 的 metaclient-avro schema 路径。
+
+### gap-2（open）Hudi meta-field 纳入 —— **登记 DV，推迟批 E**
+- legacy `getHudiTableSchema:852` 调 `getTableAvroSchema(true)`；SPI `getSchemaFromMetaClient:235` 调无参 `getTableAvroSchema()`。`true` 很可能强制纳入 `_hoodie_*` meta 列；无参默认随 Hudi 版本/表配置（`populateMetaFields`）变。可能改变**列集合**。
+- 无真实 metaclient 不可单测判定（recon 未能从库源解析），且属 T03 同族（schema-evolution/field-id 已推批 E）。→ 记 **DV-008**，批 E 用真实 fixture 实证。本场 parity 测**不依赖该差异**（测纯 avro→column 变换，不经 metaclient）。
+
+---
+
+## Design（focused intent-driven set）
+
+### 模块 hudi（task 3）
+
+**改动（main）**：
+1. `HudiConnectorMetadata.avroSchemaToColumns` 顶层列名 `toLowerCase(Locale.ROOT)`（gap-1 修），加 `import java.util.Locale`。
+2. `avroSchemaToColumns` 由 `private` 改 **package-private `static`**（仅可见性/static 化，**零行为变更**）——使测试可直接喂手造 avro record schema 断言完整列变换（名/序/类型/nullable）。`getSchemaFromMetaClient:236` 的静态调用不变。
+
+**测试**：
+- **扩 `HudiTypeMappingTest`**：补 `fromAvroSchema`→`ConnectorType` golden（**当前零覆盖**）——primitives / DATEV2 / DATETIMEV2(3/6) / DECIMALV3(p,s) / array / map / struct / nullable-unwrap / ENUM→STRING / multi-union→UNSUPPORTED。对标 legacy `fromAvroHudiTypeToDorisType`。
+- **新 `HudiSchemaParityTest`**（纯 avro，无 HMS）：核心 parity 交付。
+  - `avroSchemaToColumns(代表性 record)` → 断言 **小写列名 + 原序 + 每列 ConnectorType + nullable**（golden 注 legacy `initHudiSchema`/`HudiUtils` file:line）。
+  - 同 schema 每列 `toHiveTypeString` = golden Hive 串（= legacy `colTypes`）。
+  - **casing pin**：mixed-case avro 字段（如 `Amount`）→ 列名 `amount`（gap-1 修的回归网）。
+  - javadoc 写明 **COW≡MOR schema 恒等**（变换是 schema 的纯函数，不取表型）。
+- **新 `HudiTableTypeTest`**（`FakeHmsClient`）：`detectHudiTableType` 经 `getTableHandle` → COW（`HoodieParquetInputFormat` / `spark.sql.sources.provider=hudi`）、MOR（`...RealtimeInputFormat` / `realtime`）、UNKNOWN。= "COW & MOR 各一" 分类面。
+
+### 模块 hms（task 4）
+
+- **新 `HmsTypeMappingTest`**（最高价值——`HmsTypeMapping` 是 hms+hive **共享** 的 Hive-类型串解析器，零测试，真解析逻辑）：primitives（boolean/tinyint/smallint/int/bigint/float/double/string/date/timestamp/binary）、`char(N)`/`varchar(N)`（含无长度默认）、`decimal`/`decimal(p)`/`decimal(p,s)`（默认精度）、`array<>`/`map<,>`/`struct<:,:>`/嵌套、Options（timeScale / mapBinaryToVarbinary / mapTimestampTz）、`timestamp with local time zone`、unsupported→UNSUPPORTED、大小写不敏感。golden 值对标解析逻辑。
+- **缩界**：DTO 不可变/getter/config 常量等 ~60 低意图测**不做**（Rule 2/9），记为 backlog。
+
+### 模块 hive（task 4）
+
+- **新 `HiveConnectorMetadataPartitionPruningTest`**：镜像 `HudiPartitionPruningTest` 测 `HiveConnectorMetadata.applyFilter`（T05 裁剪逻辑的 Hive 原型）。手写 `FakeHmsClient`。pin EQ/IN 裁剪、非分区谓词忽略、全/零匹配、unpartitioned。**javadoc 注明与 hudi 的结构性重复**（consolidation 信号，P7 处理）。
+- **新 `HiveFileFormatTest`**：`HiveFileFormat.fromInputFormat`/`fromSerDeLib`/`detect`/`isSplittable`——纯逻辑（drive BE reader 选择）：parquet/orc/text/json 大小写子串匹配、SerDe 回退、inputFormat 优先、splittable。
+- **缩界**：`HiveTableFormatDetector`/`HiveTextProperties`/`HiveColumnHandle`/`HiveScanRange` 等记 backlog（择期或 P7）。
+
+---
+
+## Implementation Plan
+
+1. hudi：改 `avroSchemaToColumns`（降字 + package-private static）→ 扩 `HudiTypeMappingTest` → 新 `HudiSchemaParityTest` + `HudiTableTypeTest` → `mvn -pl ...-hudi -am test` 绿。
+2. hms：新 `HmsTypeMappingTest` →（先读 `HmsTypeMapping.java` 定 golden）→ test 绿。
+3. hive：新 `HiveConnectorMetadataPartitionPruningTest` + `HiveFileFormatTest` →（先读 `HiveConnectorMetadata.applyFilter` + `HiveFileFormat` + 各 handle builder）→ test 绿。
+4. 守门（每模块）：`checkstyle:check`（单独跑）+ `bash tools/check-connector-imports.sh`。
+5. 文档同步（playbook §5.1 五步）+ DV-008 + commit。
+
+---
+
+## Risk Analysis
+
+- **gate 保持关闭**（`SPI_READY_TYPES` 不动）；零 fe-core/BE/thrift 改动；唯一 main 改动 = hudi `avroSchemaToColumns`（降字 + 可见性），dormant、零 live 风险。
+- casing 修：已核 HMS 来源小写 → 无回归；缩界明确（不动 `ThriftHmsClient`/hive）。
+- golden 漂移：每 golden 注 legacy `file:line`，legacy 变则人工核（无跨模块编译耦合，这是 golden 法的固有代价，已登记）。
+- gap-2 不在本场测面，避免基于未判定语义写脆测。
+
+---
+
+## Test Plan
+
+### Unit Tests（本 task 交付）
+- hudi：`HudiTypeMappingTest`(+fromAvroSchema) / `HudiSchemaParityTest` / `HudiTableTypeTest`。
+- hms：`HmsTypeMappingTest`。
+- hive：`HiveConnectorMetadataPartitionPruningTest` / `HiveFileFormatTest`。
+- 三模块编译 + checkstyle 0 + import-gate 通过；全绿。
+
+### E2E / parity-vs-live
+**推迟批 E**（gate 关，端到端不可触达；precedent DV-003）：批 E 翻闸后用真实 COW/MOR fixture 实证 (a) schema 列集合/类型/casing vs legacy，(b) gap-2 meta-field 纳入，(c) BE name-match 精确性。**显式登记，不静默跳过（R12）**。
+
+---
+
+## Decisions / Deviations
+
+- **DV-008**（本场新增）：SPI hudi `getTableAvroSchema()` 无参 vs legacy `(true)` 的 meta-field 纳入差异，推迟批 E 实证（同 T03 族）。
+- casing gap-1：**当场修**（用户签字），仅 hudi metaclient-avro 路径顶层列名；`ThriftHmsClient` 源头防御降字推 P7/批 E。
+- baseline：**focused**（用户签字）；DTO/config/detector/textprops 等记 backlog。

--- a/plan-doc/tasks/designs/P3-T08-tableformat-dispatch-design.md
+++ b/plan-doc/tasks/designs/P3-T08-tableformat-dispatch-design.md
@@ -1,0 +1,137 @@
+# P3-T08 设计 — `tableFormatType` 分流消费（design-only，单 `hms` catalog 多格式路由）
+
+> 关联：[tasks/P3-hudi-migration.md](../P3-hudi-migration.md)（批 D / T08）、[D-005](../../decisions-log.md)（DLA 用 tableFormatType）、[D-019](../../decisions-log.md)（hybrid）、[HANDOFF 关键认知 3](../../HANDOFF.md)。
+> 直接输入：[research/spi-multi-format-hms-catalog-analysis.md](../../research/spi-multi-format-hms-catalog-analysis.md)（6-reader code-grounded recon，本场未重复 recon，只核读 load-bearing 锚点）。
+> 用户签字（AskUserQuestion，2026-06-05）：M2 路由 = **方案 B（per-table SPI provider）** → 本场记 **[D-020](../../decisions-log.md)**。
+> **性质 = design-only**：不动 fe-core live 路径、不实现消费（实现 = 批 E/P7）、不碰 `SPI_READY_TYPES` / legacy / 非 hudi 连接器。
+
+---
+
+## Problem
+
+批 D 目标：写清**单个 `hms` catalog 如何按 per-table `tableFormatType` 把表路由到 HUDI/HIVE/ICEBERG**，明确 fe-core 的消费契约与 SPI seam，作为 (a) 模型落地（批 E/P7）的入口设计。
+
+legacy 用 `HMSExternalTable.dlaType`（per-table tag）+ 处处 `switch(dlaType)` 实现"同一 hms catalog 多格式"。SPI 侧 **只复刻了 tag 的产生，没复刻消费**（research §1/§6①）。T08 = 设计这个消费。
+
+---
+
+## Recon 结论（load-bearing 锚点本场已核读，非沿用近似行号）
+
+### 1. keystone gap = `tableFormatType` 产而不用（firsthand 确认）
+- `HiveConnectorMetadata.getTableSchema` per-table 探测并设 `ConnectorTableSchema.tableFormatType`（research §3.3，`HiveConnectorMetadata.java:134-154` / `detectFormatType:282-294`）——**产生端就位**。
+- 但 `PluginDrivenExternalTable.initSchema`（`PluginDrivenExternalTable.java:79-109`）拿到 `tableSchema` 后**只迭代 `getColumns()`**（`:96-105`）、返回 `SchemaCacheValue(columns)`（`:107-108`），**从不调 `tableSchema.getTableFormatType()`**——格式信号在 fe-core 边界丢弃。✅ 确认 research §6①。
+- `ConnectorTableSchema.getTableFormatType()`（`ConnectorTableSchema.java:58-60`）存在、是 final 不可变字段——载体就绪，缺消费。
+
+### 2. 第二个 fe-core 消费缺口 = 身份/引擎名 per-catalog 而非 per-table（firsthand 新增）
+- `PluginDrivenExternalTable.getEngine()`（`:195-215`）/ `getEngineTableTypeName()`（`:217-231`）**switch 的是 catalog type**（`jdbc`/`es`/`trino-connector`），多格式 `hms` catalog 一律落 `default`。→ 一个 hms catalog 里的 hudi/hive/iceberg 表对用户显示同一引擎名，与 legacy（per-table 引擎）不符。这是 M1 的第二处落点。
+
+### 3. scan 侧 SPI 是 per-catalog 单 provider（firsthand 确认）
+- `Connector.getScanPlanProvider()`（`Connector.java:40-42`）默认返 null、**per-catalog 一个**；`HiveConnector` 恒返 `HiveScanPlanProvider`（research §6③）。
+- 但 `ConnectorScanPlanProvider.planScan(session, handle, columns, filter)`（`ConnectorScanPlanProvider.java:62-66`，+5-arg limit 重载 `:82-89`）**入参带 per-table `ConnectorTableHandle handle`**——即 per-table 信息在 scan 规划时**可得**（handle 已携 `HiveTableHandle.tableType`）。这是 M2 三方案都能落脚的前提。
+- `ConnectorMetadata`（`ConnectorMetadata.java:37-44`）**当前无** `getScanPlanProvider(handle)`——方案 B 的新增点。
+
+### 4. 关键拆解：M1（身份消费）⊥ M2（scan 路由）
+本设计的核心分析贡献——keystone gap 拆成两个**可分离**子问题：
+
+| | M1 身份消费 | M2 scan 路由 |
+|---|---|---|
+| 是什么 | fe-core 读 `tableFormatType` 做 per-table **引擎名/表身份/information_schema** | 单 `hms` connector 为非-Hive 表产出 **Hudi/Iceberg scan plan** |
+| 落点 | `PluginDrivenExternalTable`（initSchema 缓存 + getEngine 消费）| SPI seam（A/B/C 三方案分歧处）|
+| 是否随 A/B/C 变 | **否**——三方案 M1 设计相同 | **是**——这是 D-020 的命题 |
+| fe-core 是否需懂格式语义 | 否（opaque string，逐字上报）| 否（经 handle 路由，热路径不读字符串）|
+
+→ M1 在所有方案中一致；A/B/C 只在 M2 分歧。**这是把"keystone"可控化的关键**。
+
+---
+
+## 决策：M2 = 方案 B（[D-020]，用户签字）
+
+研究浮现三条互斥路由方案（research §8）。本场逐条 code-grounded 评估后由用户拍板 **B**：
+
+| 方案 | 机制 | SPI churn | fe-core 是否长格式分派 | 网关依赖代价 | 裁决 |
+|---|---|---|---|---|---|
+| **A** 连接器内 router | `Connector.getScanPlanProvider()` 返回一个 `planScan` 按 `handle.getTableType()` 委派的 router | **零**（现 SPI 即可，planScan 已带 handle）| 否 | hive→hudi/iceberg 依赖边 | 备选 |
+| **B** ✅ per-table SPI provider | 新增 **backward-compat default** `ConnectorMetadata.getScanPlanProvider(handle)`；fe-core 优先用它、回落 `Connector` 的 | 一个 default 方法（D-009 合规）| 否 | 同 A（网关 impl 仍需多格式依赖）| **选定** |
+| **C** fe-core 发现期分派 | fe-core 读 `tableFormatType` 建 format-specific 表对象（≈legacy DLAType→多态 DlaTable）| —（fe-core 侧）| **是**（与 import-gate/D-003/D-006 瘦 fe-core 北极星相悖）| — | 否决 |
+
+**B 选定理由**（用户决策）：把 per-table 选 provider 升为**一等 SPI 契约**（最干净的 per-table 语义），优于 A 把路由藏进连接器 router；同时以**向后兼容 default 方法**落地（满足 [D-009]：本计划只新增 default、不破签名），不构成 breaking change。代价（网关 impl 需多格式依赖）A/B 同担，非 B 独有。C 因 fe-core 回退到 per-format 分派、违背瘦 fe-core 目标被否决。
+
+> **与 D-005 的关系（须留痕）**：[D-005] 定"用 `tableFormatType` 区分 + fe-core 据此 dispatch 到对应 `PhysicalXxxScan`"。其**区分符**结论 D-020 完全沿用；但"dispatch 到 `PhysicalXxxScan`"措辞写于 2026-05-24，**早于 P1 的 scan-node 统一**（`visitPhysicalFileScan`→单 `PluginDrivenScanNode` + per-range format，P1-T03/T04）——SPI 路径已无 per-format `PhysicalXxxScan`。D-020 = 在统一后的 SPI 架构下**操作化** D-005 的区分符消费，scan dispatch seam 由"fe-core→PhysicalXxxScan"改为"`ConnectorMetadata.getScanPlanProvider(handle)`→per-table provider"。D-020 不推翻 D-005，是其机制细化。
+
+---
+
+## M1 设计 — `PluginDrivenExternalTable` 消费 `tableFormatType`（design-only）
+
+> fe-core 侧，**所有 M2 方案通用**。实现 = 批 E。
+
+1. **缓存 per-table 格式（与 schema 同生命周期）**：`initSchema`（`:93` 之后）读 `tableSchema.getTableFormatType()`，随 schema 一并缓存。**推荐**新 `PluginDrivenSchemaCacheValue extends SchemaCacheValue`（plugin 私有，不污染其他 external table 的 `SchemaCacheValue`），携 `Optional<String> tableFormatType`。备选：(b) 用时经 `metadata.getTableSchema(handle)` 重取（无状态但多 round-trip）；(c) transient 字段（缓存淘汰/反序列化丢失，否决）。
+2. **身份/引擎名 per-table 化**：`getEngine()` / `getEngineTableTypeName()` 在 catalog type 为多格式族（如 `hms`）时，改用缓存的 `tableFormatType` 作 per-table 引擎名。**fe-core 保持格式无关**——`tableFormatType` 作 **opaque 连接器选定串逐字上报**（连接器选规范值），**禁止** fe-core 长出 `switch("HUDI"→...)`。
+3. **能力门控不进 fe-core**：legacy 按 dlaType 门控 time-travel/MTMV/snapshot；SPI 侧这些已是连接器职责（`ConnectorMetadata` MVCC default opt-out=T06、time-travel fail-loud=T04 在 `visitPhysicalHudiScan`）。→ M1 **不需要** fe-core 按格式门控，进一步减 fe-core 格式知识。
+4. **热路径不读字符串**：scan 路由走 M2（经 handle），**不**经 fe-core 读 `tableFormatType` 字符串再分支——M1 的 fe-core 字符串消费**仅服务身份/上报**，热路径零格式 switch。
+
+---
+
+## M2 设计 — 方案 B per-table provider seam（design-only）
+
+> 实现 = 批 E（+ iceberg 部分依赖 P6/M3）。
+
+1. **SPI 新增**（`fe-connector-api`，backward-compat default）：
+   ```
+   // ConnectorMetadata
+   default ConnectorScanPlanProvider getScanPlanProvider(ConnectorTableHandle handle) {
+       return null;   // 默认回落 per-catalog Connector.getScanPlanProvider()
+   }
+   ```
+   默认 null → 现有所有连接器（jdbc/es/trino/iceberg/独立 hudi/hive）**零影响**（满足 [D-009]）。
+2. **fe-core scan 路径**（唯一 scan 侧改动）：`PluginDrivenScanNode.getSplits()`（research `:356-378`）由 `connector.getScanPlanProvider()` 改为**优先** `metadata.getScanPlanProvider(currentHandle)`、为 null 时**回落** `connector.getScanPlanProvider()`（保留现行为）。
+3. **hms 网关实现**：注册 `"hms"` 的连接器 override `getScanPlanProvider(handle)`，按 `handle.getTableType()`（`HiveTableType{HIVE|HUDI|ICEBERG|UNKNOWN}`）返 Hive/Hudi/Iceberg provider；metadata 侧同理委派 `Hudi/IcebergConnectorMetadata`。→ 引入 hms-网关模块对 `-hudi`/`-iceberg` 的依赖边（A/B 同担的结构代价）。
+4. **per-range 格式仍是 BE 选 reader 的最终依据**：各 provider 产出的 `ConnectorScanRange.getTableFormatType()`（Hive→`"hive"`/Hudi→`"hudi"`）→ `TTableFormatFileDesc.setTableFormatType`，BE 每 range 建对应 reader（与 legacy 等价，research §3.4 / 批 0 结论）。M2 只决定"哪个 provider 规划 split"，per-range 契约不变。
+
+---
+
+## 边界 / 缩界（Rule 12 不静默）
+
+- **本场零代码**：以上 M1/M2 均设计，**不动** fe-core/SPI/连接器任何 live 文件。
+- **Iceberg-on-hms 经 SPI 依赖 P6/M3**：`fe-connector-iceberg` 现**无 `ScanPlanProvider`** 且 pom **未依赖 `fe-connector-api`**（research §6④/§2.3）。B 的 `getScanPlanProvider(handle)` 对 ICEBERG 表落地需 P6 先补 `IcebergScanPlanProvider` + api 依赖。批 E/P7 落地 hms 多格式时：ICEBERG 表在 P6 前**回落 legacy `IcebergScanNode` 或 fail-loud**，不静默误扫为 Hive。
+- **格式探测共享化（M5）非本场**：fe-core `HMSExternalTable.makeSureInitialized` 与 SPI `HiveTableFormatDetector` 两份逻辑的 drift 防护（抽共享层）留 P7。
+- **gate 不动**：`SPI_READY_TYPES` 不含 hms/hudi/iceberg（`CatalogFactory.java:52`），整族走 legacy；B 落地后仍需批 E 翻闸 + cutover + image 兼容（R-001）。
+
+---
+
+## Implementation Plan（批 E/P7，非本场）
+
+> 登记依赖序，供批 E 接手；本场不执行。
+
+1. **M1**：`PluginDrivenSchemaCacheValue` + `initSchema` 缓存 `tableFormatType` + `getEngine/getEngineTableTypeName` per-table 化（fe-core，opaque 串）。
+2. **M2-SPI**：`ConnectorMetadata.getScanPlanProvider(handle)` default null（`fe-connector-api`，default 方法）。
+3. **M2-fe-core**：`PluginDrivenScanNode.getSplits` 优先 metadata-per-table provider、回落 connector-per-catalog。
+4. **M2-网关**：hms 连接器 override `getScanPlanProvider(handle)` + metadata 委派；加 `-hudi`/`-iceberg` 依赖边。
+5. **M4**：hms 探测为 HUDI 的表交 Hudi 路径（+ ICEBERG 待 P6/M3）。
+6. **翻闸/cutover/删 legacy/集群验证**：T09–T11（批 E），含 image 兼容（R-001）。
+
+---
+
+## Risk Analysis
+
+- **本场零 live 风险**：design-only，gate 关，无代码改动。
+- **B 的 SPI 表面演进**：新 default 方法是向后兼容（D-009），但把"scan provider 来源"从 per-catalog 单点变为 per-table 优先+回落，**所有连接器的 scan plumbing 经此分叉**——批 E 实现时需回归全连接器（jdbc/es/trino 走 null 回落路径必须等价）。已登记。
+- **网关依赖边**：hms→hudi/iceberg 耦合模块 build/release（A/B 同担）；批 E 落地前评估是否反而触发 M2 的 (A) 更轻。**本设计记录 B 为方向，实现期可据 iceberg 接入复杂度复核**（D-020 关联 open question）。
+- **D-005 机制措辞陈旧**：已在 D-020 留痕 supersede，避免下游按 `PhysicalXxxScan` 旧措辞误实现。
+
+---
+
+## Test Plan
+
+- **本场无单测**（design-only，零代码）。
+- **批 E 落地时**（登记，R12 不静默跳过）：
+  - fe-core 单测：`PluginDrivenExternalTable` per-table `getEngine` = 缓存 `tableFormatType`；多格式 hms catalog 下 hudi/hive/iceberg 表引擎名各异。
+  - SPI 回归：现有连接器（jdbc/es/trino）`getScanPlanProvider(handle)` 返 null → 回落 per-catalog provider，行为等价（防 B 的 plumbing 分叉回归）。
+  - 端到端（翻闸后）：单 hms catalog 混合 Hive+Hudi(+Iceberg) 表，per-table 走对的 scan/reader，vs legacy parity。
+
+---
+
+## Decisions / Deviations
+
+- **[D-020]**（本场新增，用户签字）：M2 路由 = 方案 B（`ConnectorMetadata.getScanPlanProvider(handle)` per-table default），design-only，实现批 E/P7。**细化 D-005**（沿用 tableFormatType 区分符；机制由"fe-core→PhysicalXxxScan"更新为 per-table provider seam，因 P1 已统一 scan-node）。
+- 无新 DV：B 与 D-005/D-009 一致，D-005 机制措辞更新已收于 D-020 留痕（非偏差，是决策细化）。
+- Open（转批 E/P7，承自 research §10）：Iceberg-on-hms 委派 vs 回落 legacy（依赖 P6/M3）；连接器生命周期双创建（`PluginDrivenExternalCatalog:87-145`，`HmsClient` 是否重复建）；探测 drift 共享化（M5）。


### PR DESCRIPTION
## Proposed changes

testing with #64146

P3 of the catalog-SPI migration (base: `branch-catalog-spi`). Migrates the **hudi** connector following the **hybrid** strategy (D-019): harden the dormant HMS-over-SPI hudi connector to correctness parity, build a test baseline, and write the per-table dispatch design — **all behind the closed gate** (`SPI_READY_TYPES` unchanged).

> ⚠️ **No user-visible behavior change.** The SPI hudi path stays dormant (gate closed); hudi queries continue to use the legacy `HMSExternalTable.dlaType=HUDI` path. This PR removes correctness blockers ahead of the live cutover (deferred to P7 / batch E).

### What's included

**Correctness fixes (hardening dormant code, behind gate):**
- **T02** — fix hudi JNI `column_types` double bug: emit full Hive type strings (was Doris bare type names, losing precision/scale/subtypes) and send `column_names`/`column_types`/`delta_logs` as typed lists end-to-end (was comma join/split, which shattered `decimal(10,2)` / `struct<...>`). Matches the BE `hudi_jni_reader.cpp` contract (names `,` / types `#` / delta `,`).
- **T04** — fail loud on time-travel / incremental read in the SPI `visitPhysicalHudiScan` branch (was silently returning the latest snapshot / silently full-scanning).
- **T05** — real EQ/IN partition pruning in `HudiConnectorMetadata.applyFilter` (was a placeholder that ignored predicates and unconditionally switched the partition source from Hudi-metadata to HMS); faithfully mirrors `HiveConnectorMetadata.applyFilter`.
- **T07** — column-name casing fix in `avroSchemaToColumns` (top-level lowercase, mirroring legacy `HMSExternalTable`).

**Test baseline (all three connector modules started P3 with 0 tests):**
- `fe-connector-hudi` (33): type-mapping / schema-parity (COW/MOR golden) / table-type / partition-pruning / scan-range.
- `fe-connector-hms` (12): shared Hive-type-string parser tests.
- `fe-connector-hive` (14): file-format / partition-pruning (mirrors T05).
- COW/MOR schema is **type-agnostic** (golden parity vs legacy `initHudiSchema`); table type only affects scan planning.

**Decisions / design (code-grounded, design-only):**
- **T03** — defer `schema_id`/`history_schema_info` field-id evolution to batch E (DV-006; not a model-agnostic SPI fix).
- **T06** — keep MVCC/snapshot SPI defaults (opt-out) + document (DV-007).
- **T08** — `tableFormatType` dispatch design memo + **D-020**: single `hms` catalog per-table routing via a new backward-compatible `ConnectorMetadata.getScanPlanProvider(handle)` (per-table provider seam); refines D-005. The keystone gap is split into M1 (identity consumption, fe-core reads `tableFormatType` as an opaque string) and M2 (scan routing).

### Deferred to batch E / P7 (not in this PR)
Gate flip (`SPI_READY_TYPES += hms/hudi`), fe-core `tableFormatType` consumption (M1+M2 implementation), live cutover, delete legacy `datasource/hudi/`, full incremental/time-travel/MVCC, Iceberg-on-hms via SPI (needs P6 `IcebergScanPlanProvider`), cluster/runtime validation.

### Verification
Per task tracking, each code batch landed with: per-module compile + checkstyle 0 (incl. test sources) + connector import-gate pass + new unit tests green. The two most recent commits are docs-only (`plan-doc/`); the code is unchanged since the last green batch. Gate stays closed → the dormant SPI path is unreachable at runtime → zero live-path risk. CI re-verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
