### PR TITLE
[feat](routine_load) Support SHOW ROUTINE LOAD TASK FOR <db>.<job_name>

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -9846,16 +9846,30 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     @Override
     public LogicalPlan visitShowRoutineLoadTask(DorisParser.ShowRoutineLoadTaskContext ctx) {
+        if (ctx.label != null) {
+            List<String> labelParts = visitMultipartIdentifier(ctx.label);
+            String jobName;
+            String dbName = null;
+            if (labelParts.size() == 1) {
+                jobName = labelParts.get(0);
+            } else if (labelParts.size() == 2) {
+                dbName = labelParts.get(0);
+                jobName = labelParts.get(1);
+            } else {
+                throw new ParseException("only support [<db>.]<job_name>", ctx.label);
+            }
+            LabelNameInfo labelNameInfo = new LabelNameInfo(dbName, jobName);
+            return new ShowRoutineLoadTaskCommand(labelNameInfo);
+        }
+
         String dbName = null;
         if (ctx.database != null) {
             dbName = ctx.database.getText();
         }
-
         Expression whereClause = null;
         if (ctx.wildWhere() != null) {
             whereClause = getWildWhere(ctx.wildWhere());
         }
-
         return new ShowRoutineLoadTaskCommand(dbName, whereClause);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowRoutineLoadTaskCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowRoutineLoadTaskCommand.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
 import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
@@ -68,14 +69,24 @@ public class ShowRoutineLoadTaskCommand extends ShowCommand {
             .build();
 
     private final String dbName;
+    private final LabelNameInfo labelNameInfo;
     private final Expression whereClause;
 
     private String jobName;
     private String dbFullName;
 
     public ShowRoutineLoadTaskCommand(String dbName, Expression whereClause) {
+        this(dbName, null, whereClause);
+    }
+
+    public ShowRoutineLoadTaskCommand(LabelNameInfo labelNameInfo) {
+        this(null, labelNameInfo, null);
+    }
+
+    private ShowRoutineLoadTaskCommand(String dbName, LabelNameInfo labelNameInfo, Expression whereClause) {
         super(PlanType.SHOW_ROUTINE_LOAD_TASK_COMMAND);
         this.dbName = dbName;
+        this.labelNameInfo = labelNameInfo;
         this.whereClause = whereClause;
     }
 
@@ -89,11 +100,17 @@ public class ShowRoutineLoadTaskCommand extends ShowCommand {
      * validate
      */
     public void validate(ConnectContext ctx) throws AnalysisException {
-        if (Strings.isNullOrEmpty(dbName)) {
+        dbFullName = labelNameInfo == null ? dbName : labelNameInfo.getDb();
+        if (Strings.isNullOrEmpty(dbFullName)) {
             if (Strings.isNullOrEmpty(ctx.getDatabase())) {
                 throw new AnalysisException("please designate a database in show stmt");
             }
             dbFullName = ctx.getDatabase();
+        }
+
+        if (labelNameInfo != null && !Strings.isNullOrEmpty(labelNameInfo.getLabel())) {
+            jobName = labelNameInfo.getLabel();
+            return;
         }
 
         if (!isWhereClauseValid(whereClause)) {

--- a/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -517,7 +517,8 @@ supportedLoadStatement
     | RESUME ALL ROUTINE LOAD                                                       #resumeAllRoutineLoad
     | STOP ROUTINE LOAD FOR label=multipartIdentifier                               #stopRoutineLoad
     | SHOW ALL? ROUTINE LOAD ((FOR label=multipartIdentifier) | (LIKE STRING_LITERAL)?)         #showRoutineLoad
-    | SHOW ROUTINE LOAD TASK ((FROM | IN) database=identifier)? wildWhere?          #showRoutineLoadTask
+    | SHOW ROUTINE LOAD TASK ((FOR label=multipartIdentifier)
+        | (((FROM | IN) database=identifier)? wildWhere?))                           #showRoutineLoadTask
     | SHOW INVERTED INDEX ANALYZER                                                  #showIndexAnalyzer
     | SHOW INVERTED INDEX TOKENIZER                                                 #showIndexTokenizer
     | SHOW INVERTED INDEX TOKEN_FILTER                                              #showIndexTokenFilter

--- a/regression-test/suites/load_p0/routine_load/test_show_routine_load.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_show_routine_load.groovy
@@ -163,8 +163,20 @@ suite("test_show_routine_load","p0") {
                 sleep(5000)
                 count++
             }
-            res = sql "SHOW ROUTINE LOAD TASK WHERE JobName = \"testShow1\";"
-            log.info("SHOW ROUTINE LOAD task result: ${res}".toString())
+            res = sql "SHOW ROUTINE LOAD TASK WHERE JobName = \"testShow1\""
+            assertTrue(res.size() == 1)
+
+            res = sql "SHOW ROUTINE LOAD TASK FROM ${db} WHERE JobName = \"testShow1\""
+            assertTrue(res.size() == 1)
+
+            res = sql "SHOW ROUTINE LOAD TASK IN ${db} WHERE JobName = \"testShow1\""
+            assertTrue(res.size() == 1)
+
+            res = sql "SHOW ROUTINE LOAD TASK FOR testShow1"
+            assertTrue(res.size() == 1)
+
+            res = sql "SHOW ROUTINE LOAD TASK FOR ${db}.testShow1"
+            log.info("SHOW ROUTINE LOAD TASK result: ${res}".toString())
             assertTrue(res.size() == 1)
         } finally {
             sql "stop routine load for testShow"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The current `SHOW ROUTINE LOAD TASK` statement only accepts a `WHERE`-based syntax to specify the job:

    SHOW ROUTINE LOAD TASK [FROM|IN <db>] WHERE JobName = "xxx"

This is inconsistent with other routine-load related statements, which all use the shorter `FOR` form, e.g. `SHOW ROUTINE LOAD FOR <job>`, `STOP ROUTINE LOAD FOR <job>`, `PAUSE ROUTINE LOAD FOR <job>`, `RESUME ROUTINE LOAD FOR <job>`. The `WHERE JobName = "xxx"` form is verbose and rarely seen in load-related grammar.

This PR adds the `FOR` clause to `SHOW ROUTINE LOAD TASK` to align with the rest of the routine-load syntax:

    SHOW ROUTINE LOAD TASK FOR <job_name>
    SHOW ROUTINE LOAD TASK FOR <db>.<job_name>

The original `WHERE`-based syntax is fully preserved for backward compatibility.

### Release note

Support `SHOW ROUTINE LOAD TASK FOR <job_name>` syntax.

### Check List (For Author)

- Test
    - [x] Regression test

- Behavior changed:
    - [x] Yes. Adds a new `FOR` clause to `SHOW ROUTINE LOAD TASK`. The original `WHERE`-based syntax is preserved.