### PR TITLE
[test](regression) Move Iceberg REST HDFS case to P2 (cherry-pick to 4.0)

### DIFF
--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_on_hdfs.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_on_hdfs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_rest_on_hdfs", "external,iceberg,external_docker,external_docker_iceberg_rest,new_catalog_property") {
+suite("iceberg_rest_on_hdfs", "p2,external") {
 
     def testQueryAndInsert = { String catalogProperties, String prefix ->
 


### PR DESCRIPTION
Cherry-pick of #63367 to branch-4.0.

Move `iceberg_rest_on_hdfs` out of the P0 external suite because it requires the dedicated `iceberg-rest` Docker environment, which is not started by the default community external pipeline.

Original PR: https://github.com/apache/doris/pull/63367
Original commit: 0500b5aaa13420f237d8be422abb4194df9c5206