### PR TITLE
[fix](meta cache) Invalidate external row count cache after metadata changes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -21,10 +21,11 @@ import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
-import org.apache.doris.connector.spi.Connector;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.log.CatalogLog;
 import org.apache.doris.datasource.log.ExternalObjectLog;
@@ -99,37 +100,44 @@ public class RefreshManager {
         ExternalCatalog catalog = (ExternalCatalog) Env.getCurrentEnv().getCatalogMgr().getCatalog(log.getCatalogId());
         if (catalog == null) {
             LOG.warn("failed to find catalog when replaying refresh db: {}", log.debugForRefreshDb());
+            return;
         }
-        boolean hasDbName = !Strings.isNullOrEmpty(log.getDbName());
-        String localDbName = hasDbName
-                ? log.getDbName()
-                : catalog.getDbNameForReplay(log.getDbId()).orElse(null);
-        Optional<ExternalDatabase<? extends ExternalTable>> db =
-                localDbName == null ? Optional.empty() : catalog.getDbForReplay(localDbName);
+        String localDbName = log.getDbName();
+        if (Strings.isNullOrEmpty(localDbName)) {
+            LOG.warn("refresh database replay log has no local name: {}", log.debugForRefreshDb());
+            return;
+        }
+        long dbId = Util.genIdByName(catalog.getName(), localDbName);
+        Optional<ExternalDatabase<? extends ExternalTable>> db = catalog.getDbForReplay(localDbName);
 
         if (!db.isPresent()) {
-            if (localDbName != null) {
-                Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDb(catalog.getId(), localDbName);
+            ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
+            try {
                 invalidateAllConnectorCachesIfPresent(catalog);
-                LOG.info("database object cache is cold when replaying refresh database; invalidated caches by "
-                                + "local name {} from {}: {}",
-                        localDbName, hasDbName ? "edit log" : "retained ID mapping", log.debugForRefreshDb());
-                return;
+            } finally {
+                cacheMgr.invalidateDb(log.getCatalogId(), dbId, localDbName);
             }
-            LOG.warn("failed to find db when replaying refresh db: {}", log.debugForRefreshDb());
-        } else {
-            refreshDbInternal(db.get());
+            LOG.info("database object cache is cold when replaying refresh database; invalidated caches by "
+                            + "local name {}: {}",
+                    localDbName, log.debugForRefreshDb());
+            return;
         }
+        refreshDbInternal(db.get());
     }
 
     private void refreshDbInternal(ExternalDatabase db) {
-        db.resetMetaToUninitialized();
-        // Also drop any connector-side caches for every table in this db (e.g. hive's metastore + directory-listing
-        // caches) so a subsequent read reflects the latest external state — otherwise REFRESH DATABASE would reset
-        // only the engine-side meta and leave the connector serving stale partition/file listings up to its TTL.
-        // Connector-agnostic (generic SPI no-op default); keyed by the REMOTE db name. Mirrors refreshTableInternal.
-        if (db.getCatalog() instanceof PluginDrivenExternalCatalog) {
-            ((PluginDrivenExternalCatalog) db.getCatalog()).getConnector().invalidateDb(db.getRemoteName());
+        // Connector metadata is the row-count source, so invalidate it before engine and row-count caches.
+        try {
+            if (db.getCatalog() instanceof PluginDrivenExternalCatalog) {
+                ((PluginDrivenExternalCatalog) db.getCatalog()).getConnector().invalidateDb(db.getRemoteName());
+            }
+        } finally {
+            try {
+                db.resetMetaToUninitialized();
+            } finally {
+                Env.getCurrentEnv().getExtMetaCacheMgr()
+                        .invalidateDbRowCountCache(db.getCatalog().getId(), db.getId());
+            }
         }
         LOG.info("refresh database {} in catalog {}", db.getFullName(), db.getCatalog().getName());
     }
@@ -163,9 +171,19 @@ public class RefreshManager {
         }
         long updateTime = System.currentTimeMillis();
         refreshTableInternal((ExternalDatabase) db, (ExternalTable) table, updateTime);
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(catalog.getId(), db.getFullName(),
-                table.getName(), updateTime);
+        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
+                catalog.getId(), db.getFullName(), table.getName(), updateTime);
+        env.getEditLog().logRefreshExternalTable(log);
+    }
+
+    /** Records a committed remote mutation for replay before any fallible local cache refresh. */
+    public void refreshTableAfterExternalMutation(ExternalTable table) {
+        ExternalDatabase db = table.getDb();
+        long updateTime = System.currentTimeMillis();
+        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
+                table.getCatalog().getId(), db.getFullName(), table.getName(), updateTime);
         Env.getCurrentEnv().getEditLog().logRefreshExternalTable(log);
+        refreshTableInternal(db, table, updateTime);
     }
 
     public void replayRefreshTable(ExternalObjectLog log) {
@@ -174,100 +192,85 @@ public class RefreshManager {
             LOG.warn("failed to find catalog when replaying refresh table: {}", log.debugForRefreshTable());
             return;
         }
-        boolean hasDbName = !Strings.isNullOrEmpty(log.getDbName());
-        String localDbName = hasDbName
-                ? log.getDbName()
-                : catalog.getDbNameForReplay(log.getDbId()).orElse(null);
-        Optional<ExternalDatabase<? extends ExternalTable>> db =
-                localDbName == null ? Optional.empty() : catalog.getDbForReplay(localDbName);
-        // See comment in refreshDbInternal for why db and table may be null.
-        if (!db.isPresent()) {
-            if (!catalog.isInitialized()) {
-                LOG.info("catalog is uninitialized when replaying refresh table; skip cache invalidation: {}",
-                        log.debugForRefreshTable());
-                return;
-            }
-            if (localDbName != null) {
-                if (hasDbName && !Strings.isNullOrEmpty(log.getTableName())) {
-                    Env.getCurrentEnv().getExtMetaCacheMgr()
-                            .invalidateTable(catalog.getId(), localDbName, log.getTableName());
-                    LOG.info("database object cache is cold when replaying refresh table; "
-                                    + "invalidated caches by local names {}.{} from edit log: {}",
-                            localDbName, log.getTableName(), log.debugForRefreshTable());
-                } else {
-                    // Doris 2.1/3.0 edit logs contain only database/table IDs. Once the database object is cold,
-                    // its table ID map is unreachable, so invalidate the database scope conservatively.
-                    Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDb(catalog.getId(), localDbName);
-                    LOG.info("database object cache is cold when replaying legacy ID-only refresh table; "
-                                    + "invalidated database caches by local name {} from retained ID mapping: {}",
-                            localDbName, log.debugForRefreshTable());
-                }
-                invalidateAllConnectorCachesIfPresent(catalog);
-                return;
-            }
-            LOG.warn("failed to find db when replaying refresh table: {}", log.debugForRefreshTable());
+        String localDbName = log.getDbName();
+        String localTableName = log.getTableName();
+        if (Strings.isNullOrEmpty(localDbName) || Strings.isNullOrEmpty(localTableName)) {
+            LOG.warn("refresh table replay log has no local name: {}", log.debugForRefreshTable());
             return;
         }
-        String localTableName;
-        String tableNameSource;
-        boolean hasTableName = !Strings.isNullOrEmpty(log.getTableName());
-        if (hasTableName) {
-            localTableName = log.getTableName();
-            tableNameSource = "edit log";
-        } else {
-            localTableName = db.get().getTableNameForReplay(log.getTableId()).orElse(null);
-            tableNameSource = "retained ID mapping";
-        }
-        Optional<? extends ExternalTable> table = hasTableName
-                ? db.get().getTableForReplay(log.getTableName())
-                : db.get().getTableForReplay(log.getTableId());
+        long dbId = Util.genIdByName(catalog.getName(), localDbName);
+        long tableId = Util.genIdByName(catalog.getName(), localDbName, localTableName);
+        Optional<ExternalDatabase<? extends ExternalTable>> db = catalog.getDbForReplay(localDbName);
         if (!Strings.isNullOrEmpty(log.getNewTableName())) {
-            if (localTableName == null) {
-                LOG.warn("failed to resolve local table name when replaying rename table, skip rename: {}",
-                        log.debugForRefreshTable());
-                return;
-            }
-            // Keep connector caches aligned with the FE rename replay. A hot object provides the precise remote
-            // source key; if the object is cold, invalidate the connector's database cache because the retained
-            // FE ID mapping contains only the local table name.
-            if (catalog instanceof PluginDrivenExternalCatalog) {
-                Connector connector = ((PluginDrivenExternalCatalog) catalog).getConnector();
-                String remoteDbName = db.get().getRemoteName();
-                if (table.isPresent()) {
-                    connector.invalidateTable(remoteDbName, table.get().getRemoteName());
-                } else {
-                    connector.invalidateDb(remoteDbName);
-                }
-                connector.invalidateTable(remoteDbName, log.getNewTableName());
-            }
-            db.get().unregisterTable(localTableName);
-            db.get().resetMetaCacheNames();
-            Env.getCurrentEnv().getConstraintManager().renameTable(
-                    new TableNameInfo(catalog.getName(), db.get().getFullName(), localTableName),
-                    new TableNameInfo(catalog.getName(), db.get().getFullName(), log.getNewTableName()));
+            replayRenameTable(log, catalog, db);
             return;
         }
+        if (!db.isPresent()) {
+            try {
+                invalidateAllConnectorCachesIfPresent(catalog);
+            } finally {
+                Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(
+                        log.getCatalogId(), dbId, localDbName, tableId, localTableName);
+            }
+            LOG.info("database object cache is cold when replaying refresh table; "
+                            + "invalidated caches by local names {}.{}: {}",
+                    localDbName, localTableName, log.debugForRefreshTable());
+            return;
+        }
+        Optional<? extends ExternalTable> table = db.get().getTableForReplay(localTableName);
         if (!table.isPresent()) {
-            if (localTableName == null) {
-                LOG.warn("failed to resolve local table name when replaying refresh table, skip refresh: {}",
-                        log.debugForRefreshTable());
-                return;
+            try {
+                if (catalog instanceof PluginDrivenExternalCatalog) {
+                    // A cold table object cannot provide the mapped remote table name.
+                    ((PluginDrivenExternalCatalog) catalog).getConnector().invalidateDb(db.get().getRemoteName());
+                }
+            } finally {
+                Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(
+                        log.getCatalogId(), dbId, db.get().getFullName(), tableId, localTableName);
             }
-            Env.getCurrentEnv().getExtMetaCacheMgr()
-                    .invalidateTable(catalog.getId(), db.get().getFullName(), localTableName);
-            if (catalog instanceof PluginDrivenExternalCatalog) {
-                // The retained ID mapping cannot recover a mapped remote table name without loading metadata.
-                // Invalidate the connector's database cache to preserve replay correctness without remote I/O.
-                ((PluginDrivenExternalCatalog) catalog).getConnector().invalidateDb(db.get().getRemoteName());
-            }
-            LOG.info("table object cache is cold when replaying refresh table; "
-                            + "invalidated engine caches by local name {} from {}: {}",
-                    localTableName, tableNameSource, log.debugForRefreshTable());
+            LOG.info("table object cache is cold when replaying refresh table; invalidated caches by local name {}: {}",
+                    localTableName, log.debugForRefreshTable());
             return;
         }
-        // Legacy partition-bearing refresh logs are conservatively replayed as a full table invalidation now that
-        // connector plugins own their partition caches.
         refreshTableInternal(db.get(), table.get(), log.getLastUpdateTime());
+    }
+
+    private void replayRenameTable(ExternalObjectLog log, ExternalCatalog catalog,
+            Optional<ExternalDatabase<? extends ExternalTable>> db) {
+        ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
+        String localDbName = log.getDbName();
+        String localTableName = log.getTableName();
+        long dbId = Util.genIdByName(catalog.getName(), localDbName);
+        long sourceTableId = Util.genIdByName(catalog.getName(), localDbName, localTableName);
+        long destinationTableId = Util.genIdByName(catalog.getName(), localDbName, log.getNewTableName());
+        try {
+            if (!db.isPresent()) {
+                invalidateAllConnectorCachesIfPresent(catalog);
+                LOG.info("database object cache is cold when replaying rename table; invalidated connector caches for "
+                                + "{}: {}",
+                        localDbName, log.debugForRefreshTable());
+            } else {
+                ExternalDatabase<? extends ExternalTable> database = db.get();
+                try {
+                    if (catalog instanceof PluginDrivenExternalCatalog) {
+                        // Persisted names are local identities, so database scope is the replay-safe connector key.
+                        ((PluginDrivenExternalCatalog) catalog).getConnector()
+                                .invalidateDb(database.getRemoteName());
+                    }
+                } finally {
+                    database.invalidateTableRename(localTableName, log.getNewTableName());
+                }
+            }
+        } finally {
+            try {
+                Env.getCurrentEnv().getConstraintManager().renameTable(
+                        new TableNameInfo(catalog.getName(), localDbName, localTableName),
+                        new TableNameInfo(catalog.getName(), localDbName, log.getNewTableName()));
+            } finally {
+                cacheMgr.invalidateTableRename(log.getCatalogId(), dbId, localDbName,
+                        sourceTableId, localTableName, destinationTableId, log.getNewTableName());
+            }
+        }
     }
 
     private void invalidateAllConnectorCachesIfPresent(ExternalCatalog catalog) {
@@ -276,7 +279,7 @@ public class RefreshManager {
         }
     }
 
-    public void refreshExternalTableFromEvent(String catalogName, String dbName, String tableName,
+    public void refreshExternalTableFromEvent(String catalogName, String localDbName, String localTableName,
             long updateTime) throws DdlException {
         CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(catalogName);
         if (catalog == null) {
@@ -285,12 +288,12 @@ public class RefreshManager {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support refresh ExternalCatalog Tables");
         }
-        DatabaseIf db = catalog.getDbNullable(dbName);
+        DatabaseIf db = catalog.getDbNullable(localDbName);
         if (db == null) {
             return;
         }
 
-        TableIf table = db.getTableNullable(tableName);
+        TableIf table = db.getTableNullable(localTableName);
         if (table == null) {
             return;
         }
@@ -302,56 +305,49 @@ public class RefreshManager {
         if (updateTime > 0) {
             table.setUpdateTime(updateTime);
         }
-        Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(table);
-        // FIX-4: also drop any connector-side per-table cache (e.g. paimon's latest-snapshot cache) so the
-        // next read reflects the latest external state. Connector-agnostic (generic SPI no-op default); keyed
-        // by the REMOTE db/table names the connector uses.
-        if (table.getCatalog() instanceof PluginDrivenExternalCatalog) {
-            ((PluginDrivenExternalCatalog) table.getCatalog()).getConnector()
-                    .invalidateTable(db.getRemoteName(), table.getRemoteName());
+        // Connector metadata is the row-count source, so invalidate it before engine and row-count caches.
+        try {
+            if (table.getCatalog() instanceof PluginDrivenExternalCatalog) {
+                ((PluginDrivenExternalCatalog) table.getCatalog()).getConnector()
+                        .invalidateTable(db.getRemoteName(), table.getRemoteName());
+            }
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(table);
         }
         LOG.info("refresh table {}, id {} from db {} in catalog {}, update time: {}",
                 table.getName(), table.getId(), db.getFullName(), db.getCatalog().getName(), updateTime);
     }
 
     // Refresh partition
-    public void refreshPartitions(String catalogName, String dbName, String tableName,
-            List<String> partitionNames, long updateTime, boolean ignoreIfNotExists)
-            throws DdlException {
+    public void refreshPartitionsFromEvent(String catalogName, String localDbName, String localTableName,
+            List<String> partitionNames, long updateTime) throws DdlException {
         CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(catalogName);
         if (catalog == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("No catalog found with name: " + catalogName);
-            }
             return;
         }
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support ExternalCatalog");
         }
-        DatabaseIf db = catalog.getDbNullable(dbName);
+        DatabaseIf db = catalog.getDbNullable(localDbName);
         if (db == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
-            }
             return;
         }
 
-        TableIf table = db.getTableNullable(tableName);
+        TableIf table = db.getTableNullable(localTableName);
         if (table == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
-            }
             return;
         }
 
         ExternalTable externalTable = (ExternalTable) table;
-        if (externalTable.getCatalog() instanceof PluginDrivenExternalCatalog) {
-            // The connector owns the partition cache (pull-through); invalidate by name. Mirrors
-            // refreshTableInternal's connector hook.
-            ((PluginDrivenExternalCatalog) externalTable.getCatalog()).getConnector().invalidatePartition(
-                    ((ExternalDatabase<?>) db).getRemoteName(), externalTable.getRemoteName(), partitionNames);
+        try {
+            if (externalTable.getCatalog() instanceof PluginDrivenExternalCatalog) {
+                ((PluginDrivenExternalCatalog) externalTable.getCatalog()).getConnector().invalidatePartition(
+                        ((ExternalDatabase<?>) db).getRemoteName(), externalTable.getRemoteName(), partitionNames);
+            }
+            externalTable.setUpdateTime(updateTime);
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableRowCountCache(externalTable);
         }
-        externalTable.setUpdateTime(updateTime);
     }
 
     public void addToRefreshMap(long catalogId, Integer[] sec) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -700,8 +700,9 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         return () -> { };
     }
 
-    public void unregisterExternalTable(String dbName, String tableName, String catalogName, boolean ignoreIfExists)
-            throws DdlException {
+    /** Applies a table drop event using canonical FE-local identities. */
+    public void unregisterExternalTableFromEvent(
+            String localDbName, String localTableName, String catalogName) throws DdlException {
         CatalogIf<?> catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
             throw new DdlException("No catalog found with name: " + catalogName);
@@ -709,39 +710,23 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support drop ExternalCatalog Tables");
         }
-        ExternalDatabase<?> db = ((ExternalCatalog) catalog).getDbNullable(dbName);
+        ExternalDatabase<?> db = ((ExternalCatalog) catalog).getDbNullable(localDbName);
         if (db == null) {
-            if (!ignoreIfExists) {
-                throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
-            }
             return;
         }
 
-        String tableNameToInvalidate;
-        if (ignoreIfExists) {
-            tableNameToInvalidate = db.canonicalLocalTableNameFromRemote(tableName);
-        } else {
-            TableIf table = db.getTableNullable(tableName);
-            if (table == null) {
-                throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
-            }
-            tableNameToInvalidate = table.getName();
-        }
-
-        // All current production callers with ignoreIfExists=true are HMS event paths. Skip load-through table
-        // existence validation so local names/object/ID/engine cache cleanup still runs after the table has already
-        // disappeared remotely. Resolve the event's remote name to the same canonical local key used by CREATE_TABLE.
+        // The remote table may already be gone, so do not perform a load-through existence check.
         db.writeLock();
         try {
-            db.unregisterTable(tableNameToInvalidate);
+            db.unregisterTable(localTableName);
         } finally {
             db.writeUnlock();
         }
     }
 
-    public void registerExternalTableFromEvent(String dbName, String tableName,
-            String catalogName, long updateTime,
-            boolean ignoreIfExists) throws DdlException {
+    /** Applies a table create event while preserving both its remote and canonical FE-local identities. */
+    public void registerExternalTableFromEvent(String localDbName,
+            String remoteTableName, String localTableName, String catalogName, long updateTime) throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
             throw new DdlException("No catalog found with name: " + catalogName);
@@ -749,24 +734,20 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support create ExternalCatalog Tables");
         }
-        DatabaseIf db = catalog.getDbNullable(dbName);
+        DatabaseIf db = catalog.getDbNullable(localDbName);
         if (db == null) {
-            if (!ignoreIfExists) {
-                throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
-            }
             return;
         }
 
         ExternalDatabase<?> externalDatabase = (ExternalDatabase<?>) db;
-        String localTableName = externalDatabase.canonicalLocalTableNameFromRemote(tableName);
         long tblId = Util.genIdByName(catalogName, db.getFullName(), localTableName);
 
         db.writeLock();
         try {
             // buildTableForInit dispatches to the catalog's own table type, so connector events do not depend
             // on a connector-specific ExternalDatabase subtype.
-            ExternalTable namedTable = externalDatabase.buildTableForInit(tableName, localTableName, tblId,
-                    (ExternalCatalog) catalog, externalDatabase, false);
+            ExternalTable namedTable = externalDatabase.buildTableForInit(
+                    remoteTableName, localTableName, tblId, (ExternalCatalog) catalog, externalDatabase, false);
             namedTable.setUpdateTime(updateTime);
             db.registerTable(namedTable);
         } finally {
@@ -774,7 +755,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         }
     }
 
-    public void unregisterExternalDatabase(String dbName, String catalogName)
+    public void unregisterExternalDatabaseFromEvent(String localDbName, String catalogName)
             throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
@@ -783,11 +764,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support drop ExternalCatalog databases");
         }
-        ((ExternalCatalog) catalog).unregisterDatabase(dbName);
+        ((ExternalCatalog) catalog).unregisterDatabase(localDbName);
     }
 
-    public void registerExternalDatabaseFromEvent(String dbName, String catalogName)
-            throws DdlException {
+    public void registerExternalDatabaseFromEvent(
+            String remoteDbName, String localDbName, String catalogName) throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
             throw new DdlException("No catalog found with name: " + catalogName);
@@ -798,11 +779,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
 
         // Plugin-driven catalogs implement event registration; the generic ExternalCatalog base throws
         // (fail-loud for catalogs that cannot register).
-        ((ExternalCatalog) catalog).registerDatabase(dbName);
+        ((ExternalCatalog) catalog).registerDatabaseFromEvent(remoteDbName, localDbName);
     }
 
-    public void addExternalPartitions(String catalogName, String dbName, String tableName,
-            List<String> partitionNames, long updateTime, boolean ignoreIfNotExists)
+    public void addExternalPartitionsFromEvent(String catalogName,
+            String localDbName, String localTableName, List<String> partitionNames, long updateTime)
             throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
@@ -811,33 +792,29 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support ExternalCatalog");
         }
-        DatabaseIf db = catalog.getDbNullable(dbName);
+        DatabaseIf db = catalog.getDbNullable(localDbName);
         if (db == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
-            }
             return;
         }
 
-        TableIf table = db.getTableNullable(tableName);
+        TableIf table = db.getTableNullable(localTableName);
         if (table == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
-            }
             return;
         }
-        if (catalog instanceof PluginDrivenExternalCatalog) {
-            // The connector owns the partition cache (pull-through), so invalidating by name is enough for
-            // the added partitions to show up on the next listing. Mirrors refreshTableInternal's connector hook.
-            ((PluginDrivenExternalCatalog) catalog).getConnector().invalidatePartition(
-                    ((ExternalDatabase<?>) db).getRemoteName(), ((ExternalTable) table).getRemoteName(),
-                    partitionNames);
-            ((ExternalTable) table).setUpdateTime(updateTime);
+        try {
+            if (catalog instanceof PluginDrivenExternalCatalog) {
+                ((PluginDrivenExternalCatalog) catalog).getConnector().invalidatePartition(
+                        ((ExternalDatabase<?>) db).getRemoteName(), ((ExternalTable) table).getRemoteName(),
+                        partitionNames);
+                ((ExternalTable) table).setUpdateTime(updateTime);
+            }
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableRowCountCache((ExternalTable) table);
         }
     }
 
-    public void dropExternalPartitions(String catalogName, String dbName, String tableName,
-            List<String> partitionNames, long updateTime, boolean ignoreIfNotExists)
+    public void dropExternalPartitionsFromEvent(String catalogName,
+            String localDbName, String localTableName, List<String> partitionNames, long updateTime)
             throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
@@ -846,28 +823,25 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support ExternalCatalog");
         }
-        DatabaseIf db = catalog.getDbNullable(dbName);
+        DatabaseIf db = catalog.getDbNullable(localDbName);
         if (db == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
-            }
             return;
         }
 
-        TableIf table = db.getTableNullable(tableName);
+        TableIf table = db.getTableNullable(localTableName);
         if (table == null) {
-            if (!ignoreIfNotExists) {
-                throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
-            }
             return;
         }
 
-        if (catalog instanceof PluginDrivenExternalCatalog) {
-            // The connector owns the partition cache (pull-through); invalidate by name.
-            ((PluginDrivenExternalCatalog) catalog).getConnector().invalidatePartition(
-                    ((ExternalDatabase<?>) db).getRemoteName(), ((ExternalTable) table).getRemoteName(),
-                    partitionNames);
-            ((ExternalTable) table).setUpdateTime(updateTime);
+        try {
+            if (catalog instanceof PluginDrivenExternalCatalog) {
+                ((PluginDrivenExternalCatalog) catalog).getConnector().invalidatePartition(
+                        ((ExternalDatabase<?>) db).getRemoteName(), ((ExternalTable) table).getRemoteName(),
+                        partitionNames);
+                ((ExternalTable) table).setUpdateTime(updateTime);
+            }
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableRowCountCache((ExternalTable) table);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -630,9 +630,12 @@ public abstract class ExternalCatalog
      */
     public void onRefreshCache(boolean invalidCache) {
         setLastUpdateTime(System.currentTimeMillis());
-        refreshMetaCacheOnly();
-        if (invalidCache) {
-            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateCatalog(id);
+        try {
+            refreshMetaCacheOnly();
+        } finally {
+            if (invalidCache) {
+                Env.getCurrentEnv().getExtMetaCacheMgr().invalidateCatalog(id);
+            }
         }
     }
 
@@ -854,21 +857,37 @@ public abstract class ExternalCatalog
      */
     public Runnable modifyCatalogPropsWithDeferredAccessControllerCleanup(Map<String, String> props) {
         catalogProperty.modifyCatalogProps(props);
-        Runnable accessControllerCleanup = resetToUninitialized(false, true);
-        try {
-            String schemaCacheTtl = props.getOrDefault(SCHEMA_CACHE_TTL_SECOND, null);
-            if (java.util.Objects.nonNull(schemaCacheTtl)) {
-                Env.getCurrentEnv().getExtMetaCacheMgr().removeCatalog(id);
-            }
-            return accessControllerCleanup;
-        } catch (RuntimeException | Error e) {
-            accessControllerCleanup.run();
-            throw e;
-        }
+        return resetAfterPropertyUpdate(props, true);
     }
 
     public void tryModifyCatalogProps(Map<String, String> props) {
         catalogProperty.modifyCatalogProps(props);
+    }
+
+    private void invalidateCachesAfterPropertyUpdate(Map<String, String> updatedProps) {
+        ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
+        if (updatedProps.get(SCHEMA_CACHE_TTL_SECOND) != null) {
+            cacheMgr.removeCatalog(id);
+        } else {
+            cacheMgr.invalidateCatalog(id);
+        }
+    }
+
+    private Runnable resetAfterPropertyUpdate(Map<String, String> updatedProps,
+            boolean deferAccessControllerCleanup) {
+        Runnable accessControllerCleanup = () -> { };
+        // Property and connector state may already have changed when reset fails, so cache invalidation is mandatory.
+        try {
+            accessControllerCleanup = resetToUninitialized(false, deferAccessControllerCleanup);
+        } finally {
+            try {
+                invalidateCachesAfterPropertyUpdate(updatedProps);
+            } catch (RuntimeException | Error e) {
+                accessControllerCleanup.run();
+                throw e;
+            }
+        }
+        return accessControllerCleanup;
     }
 
     public void rollBackCatalogProps(Map<String, String> props) {
@@ -1160,8 +1179,7 @@ public abstract class ExternalCatalog
     }
 
     public void replayCreateDb(String dbName) {
-        // Invalidate the FE cache directly so follower FEs reflect the create on edit-log replay.
-        resetMetaCacheNames();
+        invalidateCreatedDatabase(dbName);
     }
 
     @Override
@@ -1171,7 +1189,6 @@ public abstract class ExternalCatalog
     }
 
     public void replayDropDb(String dbName) {
-        // Drop the db from the cache on replay.
         unregisterDatabase(dbName);
     }
 
@@ -1182,8 +1199,56 @@ public abstract class ExternalCatalog
     }
 
     public void replayCreateTable(String dbName, String tblName) {
-        // Refresh the db's table-name cache on replay.
-        getDbForReplay(dbName).ifPresent(db -> db.resetMetaCacheNames());
+        invalidateCreatedTable(dbName, tblName);
+    }
+
+    protected final void invalidateCreatedDatabase(String dbName) {
+        ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
+        String previousLocalDbName = dbName;
+        try {
+            previousLocalDbName = resolveDatabaseNameForInvalidation(dbName);
+            invalidateDatabaseCache(previousLocalDbName);
+        } finally {
+            try {
+                resetMetaCacheNames();
+            } finally {
+                if (previousLocalDbName.equals(dbName)) {
+                    cacheMgr.invalidateDb(getId(), Util.genIdByName(getName(), dbName), dbName);
+                } else {
+                    // A case-equivalent owner may have a different deterministic identity.
+                    try {
+                        cacheMgr.invalidateDb(getId(),
+                                Util.genIdByName(getName(), previousLocalDbName), previousLocalDbName);
+                    } finally {
+                        cacheMgr.invalidateDb(getId(), Util.genIdByName(getName(), dbName), dbName);
+                    }
+                }
+            }
+        }
+    }
+
+    protected final void invalidateCreatedTable(String dbName, String tableName) {
+        ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
+        try {
+            Optional<ExternalDatabase<? extends ExternalTable>> db = getDbForReplay(dbName);
+            if (db.isPresent() && db.get().isInitialized()) {
+                db.get().invalidateTableForCreate(tableName);
+            }
+        } finally {
+            cacheMgr.invalidateTable(getId(), Util.genIdByName(getName(), dbName), dbName,
+                    Util.genIdByName(getName(), dbName, tableName), tableName);
+        }
+    }
+
+    protected final void invalidateDroppedTable(String dbName, String tableName) {
+        Optional<ExternalDatabase<? extends ExternalTable>> db = getDbForReplay(dbName);
+        if (db.isPresent() && db.get().isInitialized()) {
+            db.get().unregisterTable(tableName);
+            return;
+        }
+        Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(
+                getId(), Util.genIdByName(getName(), dbName), dbName,
+                Util.genIdByName(getName(), dbName, tableName), tableName);
     }
 
     @Override
@@ -1200,29 +1265,26 @@ public abstract class ExternalCatalog
     }
 
     public void replayDropTable(String dbName, String tblName) {
-        // Remove the table from the cache on replay.
-        getDbForReplay(dbName).ifPresent(db -> db.unregisterTable(tblName));
+        invalidateDroppedTable(dbName, tblName);
     }
 
-    /**
-     * Unregisters a database from the catalog.
-     * Internally, remove the database meta from cache
-     *
-     * @param dbName
-     */
+    /** Removes a database from local metadata and invalidates its FE caches. */
     public void unregisterDatabase(String dbName) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("unregister database [{}]", dbName);
         }
-        String localDbName = resolveDatabaseNameForInvalidation(dbName);
-        if (isInitialized()) {
+        String localDbName = dbName;
+        try {
+            localDbName = resolveDatabaseNameForInvalidation(dbName);
             invalidateDatabaseCache(localDbName);
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDb(
+                    getId(), Util.genIdByName(getName(), localDbName), localDbName);
         }
-        Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDb(getId(), localDbName);
     }
 
-    public void registerDatabase(String dbName) {
-        throw new NotImplementedException("registerDatabase not implemented");
+    public void registerDatabaseFromEvent(String remoteDbName, String localDbName) {
+        throw new NotImplementedException("registerDatabaseFromEvent not implemented");
     }
 
     protected Map<String, Boolean> getIncludeDatabaseMap() {
@@ -1321,6 +1383,20 @@ public abstract class ExternalCatalog
             return remoteDbName;
         }
         return localDbName;
+    }
+
+    /** Converts a remote table identity to the canonical local name used by FE metadata and caches. */
+    protected final String canonicalLocalTableNameFromRemote(String remoteDbName, String remoteTableName) {
+        String localTableName = fromRemoteTableName(remoteDbName, remoteTableName);
+        int mode = getLowerCaseTableNames();
+        if (mode == 1) {
+            return localTableName.toLowerCase(Locale.ROOT);
+        }
+        if (mode == 2) {
+            // Mode 2 preserves the original remote case for display and object-cache keys.
+            return remoteTableName;
+        }
+        return localTableName;
     }
 
     /**
@@ -1557,12 +1633,7 @@ public abstract class ExternalCatalog
     @Override
     public void notifyPropertiesUpdated(Map<String, String> updatedProps) {
         CatalogIf.super.notifyPropertiesUpdated(updatedProps);
-        resetToUninitialized(false);
-        String schemaCacheTtl = updatedProps.getOrDefault(SCHEMA_CACHE_TTL_SECOND, null);
-        if (java.util.Objects.nonNull(schemaCacheTtl)) {
-            ExternalMetaCacheMgr extMetaCacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
-            extMetaCacheMgr.removeCatalog(id);
-        }
+        resetAfterPropertyUpdate(updatedProps, false);
     }
 
     public CatalogProperty getCatalogProperty() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -125,7 +125,8 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             this.initialized = false;
             invalidateAllTableCache();
         }
-        Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDb(extCatalog.getId(), getFullName());
+        Env.getCurrentEnv().getExtMetaCacheMgr()
+                .invalidateDbMetadataCache(extCatalog.getId(), getFullName());
     }
 
     public boolean isInitialized() {
@@ -768,18 +769,62 @@ public abstract class ExternalDatabase<T extends ExternalTable>
 
     @Override
     public void unregisterTable(String tableName) {
-        makeSureInitialized();
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("unregister table {}.{}", this.name, tableName);
-        }
-        setLastUpdateTime(System.currentTimeMillis());
-        String localTableName = resolveTableNameForInvalidation(tableName);
-        // Always clean local names/object/ID state, even when the object entry is cold or already evicted.
-        if (isInitialized()) {
+        String localTableName = tableName;
+        try {
+            makeSureInitialized();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("unregister table {}.{}", this.name, tableName);
+            }
+            setLastUpdateTime(System.currentTimeMillis());
+            localTableName = resolveTableNameForInvalidation(tableName);
+            // Always clean local names/object/ID state, even when the object entry is cold or already evicted.
             invalidateTableCache(localTableName);
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(
+                    extCatalog.getId(), id, getFullName(),
+                    Util.genIdByName(extCatalog.getName(), getFullName(), localTableName), localTableName);
         }
-        Env.getCurrentEnv().getExtMetaCacheMgr()
-                .invalidateTable(extCatalog.getId(), getFullName(), localTableName);
+    }
+
+    /** Removes a previous local name owner while reconciling a CREATE target. */
+    void invalidateTableForCreate(String tableName) {
+        if (!isInitialized()) {
+            return;
+        }
+        String previousLocalTableName = resolveTableNameForInvalidation(tableName);
+        try {
+            invalidateTableCache(previousLocalTableName);
+        } finally {
+            try {
+                resetMetaCacheNames();
+            } finally {
+                // A case-equivalent owner may have a different deterministic identity.
+                if (!previousLocalTableName.equals(tableName)) {
+                    Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(
+                            extCatalog.getId(), id, getFullName(),
+                            Util.genIdByName(extCatalog.getName(), getFullName(), previousLocalTableName),
+                            previousLocalTableName);
+                }
+            }
+        }
+    }
+
+    /** Removes both local name owners after rename without loading remote metadata. */
+    public void invalidateTableRename(String oldTableName, String newTableName) {
+        if (!isInitialized()) {
+            return;
+        }
+        String localOldTableName = resolveTableNameForInvalidation(oldTableName);
+        String localNewTableName = resolveTableNameForInvalidation(newTableName);
+        try {
+            invalidateTableCache(localOldTableName);
+        } finally {
+            try {
+                invalidateTableCache(localNewTableName);
+            } finally {
+                resetMetaCacheNames();
+            }
+        }
     }
 
     @Override
@@ -787,19 +832,23 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         return extCatalog;
     }
 
-    // Only used for sync hive metastore event
+    // Used by incremental metastore-event registration.
     @Override
     public boolean registerTable(TableIf tableIf) {
-        makeSureInitialized();
         T table = (T) tableIf;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("create table [{}]", table.getName());
+        try {
+            makeSureInitialized();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("create table [{}]", table.getName());
+            }
+            if (isInitialized()) {
+                updateTableCache(table, table.getRemoteName(), table.getName());
+            }
+            setLastUpdateTime(System.currentTimeMillis());
+            return true;
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTable(table);
         }
-        if (isInitialized()) {
-            updateTableCache(table, table.getRemoteName(), table.getName());
-        }
-        setLastUpdateTime(System.currentTimeMillis());
-        return true;
     }
 
     private boolean isStoredTableNamesLowerCase() {
@@ -817,16 +866,9 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                 || !Strings.isNullOrEmpty(extCatalog.getMetaNamesMapping());
     }
 
-    String canonicalLocalTableNameFromRemote(String remoteTableName) {
-        String localTableName = extCatalog.fromRemoteTableName(remoteName, remoteTableName);
-        if (isStoredTableNamesLowerCase()) {
-            return localTableName.toLowerCase(Locale.ROOT);
-        }
-        if (isTableNamesCaseInsensitive()) {
-            // Mode 2 preserves the original remote case for display and object-cache keys.
-            return remoteTableName;
-        }
-        return localTableName;
+    /** Returns the canonical local identity used for a remote table name. */
+    public String canonicalLocalTableNameFromRemote(String remoteTableName) {
+        return extCatalog.canonicalLocalTableNameFromRemote(remoteName, remoteTableName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -178,13 +178,18 @@ public class ExternalMetaCacheMgr {
     }
 
     public void invalidateCatalog(long catalogId) {
-        routeCatalogEngines(catalogId, cache -> safeInvalidate(
-                cache, catalogId, "invalidateCatalog",
-                () -> cache.invalidateCatalogEntries(catalogId)));
-        // Cache B (Nereids sorted-partition-ranges) has no db/catalog-scoped eviction, so a catalog-level
-        // REFRESH must drop ALL of its entries -- else binary-search pruning could serve ranges older than
-        // the refreshed metadata. Coarse but correct (a rebuild is cheap and lazy). Mirrors invalidateTable.
-        invalidateSortedPartitionsCache();
+        try {
+            try {
+                routeCatalogEngines(catalogId, cache -> safeInvalidate(
+                        cache, catalogId, "invalidateCatalog",
+                        () -> cache.invalidateCatalogEntries(catalogId)));
+            } finally {
+                // This cache has no catalog-scoped key, so catalog invalidation must clear it globally.
+                invalidateSortedPartitionsCache();
+            }
+        } finally {
+            rowCountCache.invalidateCatalog(catalogId);
+        }
     }
 
     public void invalidateCatalogByEngine(long catalogId, String engine) {
@@ -194,12 +199,17 @@ public class ExternalMetaCacheMgr {
     }
 
     public void removeCatalog(long catalogId) {
-        routeCatalogEngines(catalogId, cache -> safeInvalidate(
-                cache, catalogId, "removeCatalog",
-                () -> cache.invalidateCatalog(catalogId)));
-        // Drop ALL Cache B entries: the catalog is going away and Cache B has no catalog-scoped eviction.
-        // (invalidateAll needs no catalog name, so this is safe even after the catalog was already removed.)
-        invalidateSortedPartitionsCache();
+        try {
+            try {
+                routeCatalogEngines(catalogId, cache -> safeInvalidate(
+                        cache, catalogId, "removeCatalog",
+                        () -> cache.invalidateCatalog(catalogId)));
+            } finally {
+                invalidateSortedPartitionsCache();
+            }
+        } finally {
+            rowCountCache.invalidateCatalog(catalogId);
+        }
     }
 
     public void removeCatalogByEngine(long catalogId, String engine) {
@@ -208,24 +218,75 @@ public class ExternalMetaCacheMgr {
                 () -> cache.invalidateCatalog(catalogId)));
     }
 
-    public void invalidateDb(long catalogId, String dbName) {
-        routeCatalogEngines(catalogId, cache -> safeInvalidate(
-                cache, catalogId, "invalidateDb", () -> cache.invalidateDb(catalogId, dbName)));
-        // Cache B has no db-scoped eviction key, so a db-level REFRESH drops ALL entries (coarse but
-        // correct -- a rebuild is cheap and lazy). Mirrors invalidateTable's Cache B wiring.
-        invalidateSortedPartitionsCache();
+    /**
+     * Invalidates database metadata without evicting row counts. Passive object-cache resets use this directly;
+     * mutation paths must add their row-count barrier after upstream metadata has been invalidated.
+     */
+    public void invalidateDbMetadataCache(long catalogId, String dbName) {
+        try {
+            routeCatalogEngines(catalogId, cache -> safeInvalidate(
+                    cache, catalogId, "invalidateDbMetadataCache", () -> cache.invalidateDb(catalogId, dbName)));
+        } finally {
+            // This cache has no database-scoped key, so database invalidation must clear it globally.
+            invalidateSortedPartitionsCache();
+        }
     }
 
-    public void invalidateTable(long catalogId, String dbName, String tableName) {
-        routeCatalogEngines(catalogId, cache -> safeInvalidate(
-                cache, catalogId, "invalidateTable",
-                () -> cache.invalidateTable(catalogId, dbName, tableName)));
-        // Also drop the Nereids sorted-partition-ranges cache for this external table so binary-search
-        // pruning does not serve ranges older than the refreshed metadata.
-        CatalogIf<?> ctl = getCatalog(catalogId);
-        if (ctl != null) {
-            Env.getCurrentEnv().getSortedPartitionsCacheManager().invalidateTable(ctl.getName(), dbName, tableName);
+    public void invalidateDb(long catalogId, long dbId, String dbName) {
+        try {
+            invalidateDbMetadataCache(catalogId, dbName);
+        } finally {
+            // Keep row-count invalidation last: it fences loads published before the metadata invalidation.
+            rowCountCache.invalidateDb(catalogId, dbId);
         }
+    }
+
+    private void invalidateTableMetadataCache(long catalogId, String dbName, String tableName) {
+        try {
+            routeCatalogEngines(catalogId, cache -> safeInvalidate(
+                    cache, catalogId, "invalidateTableMetadataCache",
+                    () -> cache.invalidateTable(catalogId, dbName, tableName)));
+        } finally {
+            CatalogIf<?> catalog = getCatalog(catalogId);
+            if (catalog != null) {
+                Env.getCurrentEnv().getSortedPartitionsCacheManager()
+                        .invalidateTable(catalog.getName(), dbName, tableName);
+            }
+        }
+    }
+
+    public void invalidateTable(long catalogId, long dbId, String dbName,
+            long tableId, String tableName) {
+        try {
+            invalidateTableMetadataCache(catalogId, dbName, tableName);
+        } finally {
+            // Keep row-count invalidation last: it fences loads published before the metadata invalidation.
+            rowCountCache.invalidateTable(catalogId, dbId, tableId);
+        }
+    }
+
+    public void invalidateTableRename(long catalogId, long dbId, String dbName,
+            long sourceTableId, String sourceTableName,
+            long destinationTableId, String destinationTableName) {
+        try {
+            invalidateTable(catalogId, dbId, dbName, sourceTableId, sourceTableName);
+        } finally {
+            // The destination ID may belong to an earlier incarnation, so its row-count barrier must run last.
+            invalidateTable(catalogId, dbId, dbName, destinationTableId, destinationTableName);
+        }
+    }
+
+    public void invalidateTable(ExternalTable table) {
+        invalidateTable(table.getCatalog().getId(), table.getDb().getId(), table.getDbName(),
+                table.getId(), table.getName());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("invalidated table caches for {}.{} in catalog {}", table.getRemoteDbName(),
+                    table.getRemoteName(), table.getCatalog().getName());
+        }
+    }
+
+    public void invalidateDbRowCountCache(long catalogId, long dbId) {
+        rowCountCache.invalidateDb(catalogId, dbId);
     }
 
     /**
@@ -242,6 +303,12 @@ public class ExternalMetaCacheMgr {
         if (mgr != null) {
             mgr.invalidateAll();
         }
+    }
+
+    /** Evicts only row count for partition changes that do not invalidate table-level FE metadata. */
+    public void invalidateTableRowCountCache(ExternalTable table) {
+        rowCountCache.invalidateTable(
+                table.getCatalog().getId(), table.getDb().getId(), table.getId());
     }
 
     public void invalidateTableByEngine(long catalogId, String engine, String dbName, String tableName) {
@@ -379,16 +446,6 @@ public class ExternalMetaCacheMgr {
 
     public ExternalRowCountCache getRowCountCache() {
         return rowCountCache;
-    }
-
-    public void invalidateTableCache(ExternalTable dorisTable) {
-        invalidateTable(dorisTable.getCatalog().getId(),
-                dorisTable.getDbName(),
-                dorisTable.getName());
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("invalid table cache for {}.{} in catalog {}", dorisTable.getRemoteDbName(),
-                    dorisTable.getRemoteName(), dorisTable.getCatalog().getName());
-        }
     }
 
     public ExecutorService commonRefreshExecutor() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
@@ -33,11 +33,15 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class ExternalRowCountCache {
 
     private static final Logger LOG = LogManager.getLogger(ExternalRowCountCache.class);
     private final AsyncLoadingCache<RowCountKey, Optional<Long>> rowCountCache;
+    // Serialize future publication with explicit invalidation. The read lock ends as soon as Caffeine has
+    // published the future, before this class waits for the row-count result.
+    private final ReentrantReadWriteLock publicationLock = new ReentrantReadWriteLock();
 
     public ExternalRowCountCache(ExecutorService executor) {
         // 1. set expireAfterWrite to 1 day, avoid too many entries
@@ -122,10 +126,16 @@ public class ExternalRowCountCache {
     public long getCachedRowCount(long catalogId, long dbId, long tableId, boolean fillMetaCache) {
         RowCountKey key = new RowCountKey(catalogId, dbId, tableId);
         try {
-            CompletableFuture<Optional<Long>> f = fillMetaCache
-                    ? rowCountCache.get(key, (rowCountKey, executor) -> CompletableFuture.supplyAsync(
-                            () -> loadRowCount(rowCountKey, true), executor))
-                    : rowCountCache.get(key);
+            CompletableFuture<Optional<Long>> f;
+            publicationLock.readLock().lock();
+            try {
+                f = fillMetaCache
+                        ? rowCountCache.get(key, (rowCountKey, executor) -> CompletableFuture.supplyAsync(
+                                () -> loadRowCount(rowCountKey, true), executor))
+                        : rowCountCache.get(key);
+            } finally {
+                publicationLock.readLock().unlock();
+            }
             // Get row count synchronously by default.
             if (ConnectContext.get() == null
                     || ConnectContext.get().getSessionVariable().fetchHiveRowCountSync) {
@@ -160,6 +170,35 @@ public class ExternalRowCountCache {
             LOG.warn("Unexpected exception while returning row count if present", e);
         }
         return -1;
+    }
+
+    // Catalog/db invalidation is O(N): row-count keys are numeric ids, and Caffeine
+    // does not support prefix invalidation by catalog or database id.
+    void invalidateCatalog(long catalogId) {
+        publicationLock.writeLock().lock();
+        try {
+            rowCountCache.asMap().keySet().removeIf(key -> key.catalogId == catalogId);
+        } finally {
+            publicationLock.writeLock().unlock();
+        }
+    }
+
+    void invalidateDb(long catalogId, long dbId) {
+        publicationLock.writeLock().lock();
+        try {
+            rowCountCache.asMap().keySet().removeIf(key -> key.catalogId == catalogId && key.dbId == dbId);
+        } finally {
+            publicationLock.writeLock().unlock();
+        }
+    }
+
+    void invalidateTable(long catalogId, long dbId, long tableId) {
+        publicationLock.writeLock().lock();
+        try {
+            rowCountCache.synchronous().invalidate(new RowCountKey(catalogId, dbId, tableId));
+        } finally {
+            publicationLock.writeLock().unlock();
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/MetastoreEventSyncDriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/MetastoreEventSyncDriver.java
@@ -247,51 +247,63 @@ public class MetastoreEventSyncDriver extends MasterDaemon {
     // legacy event.process() bodies called, now generalized to work on a flipped catalog.
     private void applyOne(PluginDrivenExternalCatalog catalog, Connector connector,
             MetastoreChangeDescriptor descriptor) throws Exception {
+        EventIdentity before = EventIdentity.from(
+                catalog, descriptor.getDbName(), descriptor.getTableName());
+        EventIdentity after = descriptor.getDbNameAfter() == null ? null : EventIdentity.from(
+                catalog, descriptor.getDbNameAfter(), descriptor.getTableNameAfter());
         String catalogName = catalog.getName();
         CatalogMgr catalogMgr = Env.getCurrentEnv().getCatalogMgr();
-        invalidateStructuralEventCaches(connector, descriptor);
+        invalidateStructuralEventCaches(connector, descriptor.getOp(), before, after);
         switch (descriptor.getOp()) {
             case REGISTER_DATABASE:
-                catalogMgr.registerExternalDatabaseFromEvent(descriptor.getDbName(), catalogName);
+                catalogMgr.registerExternalDatabaseFromEvent(
+                        before.remoteDbName, before.localDbName, catalogName);
                 break;
             case UNREGISTER_DATABASE:
-                catalogMgr.unregisterExternalDatabase(descriptor.getDbName(), catalogName);
+                catalogMgr.unregisterExternalDatabaseFromEvent(before.localDbName, catalogName);
                 break;
             case RENAME_DATABASE:
                 // Always converge to "old removed, new registered". A normal lookup may already have warmed the
                 // target after the remote rename; treating that as a reason to skip would retain stale old state.
-                catalogMgr.unregisterExternalDatabase(descriptor.getDbName(), catalogName);
-                catalogMgr.registerExternalDatabaseFromEvent(descriptor.getDbNameAfter(), catalogName);
+                catalogMgr.unregisterExternalDatabaseFromEvent(before.localDbName, catalogName);
+                catalogMgr.registerExternalDatabaseFromEvent(
+                        after.remoteDbName, after.localDbName, catalogName);
                 break;
             case REGISTER_TABLE:
-                catalogMgr.registerExternalTableFromEvent(descriptor.getDbName(), descriptor.getTableName(),
-                        catalogName, descriptor.getUpdateTime(), true);
+                catalogMgr.registerExternalTableFromEvent(before.localDbName,
+                        before.remoteTableName, before.localTableName, catalogName, descriptor.getUpdateTime());
                 break;
             case UNREGISTER_TABLE:
-                catalogMgr.unregisterExternalTable(descriptor.getDbName(), descriptor.getTableName(),
-                        catalogName, true);
+                catalogMgr.unregisterExternalTableFromEvent(
+                        before.localDbName, before.localTableName, catalogName);
                 break;
             case RENAME_TABLE:
-                applyRenameTable(catalog, descriptor);
+                // Always converge to "old removed, new registered". The target may already be hot because a normal
+                // lookup raced with the event after the remote rename; it must not prevent cleanup of the old identity.
+                catalogMgr.unregisterExternalTableFromEvent(
+                        before.localDbName, before.localTableName, catalogName);
+                catalogMgr.registerExternalTableFromEvent(after.localDbName,
+                        after.remoteTableName, after.localTableName,
+                        catalogName, descriptor.getUpdateTime());
                 break;
             case REFRESH_TABLE:
-                Env.getCurrentEnv().getRefreshManager().refreshExternalTableFromEvent(catalogName,
-                        descriptor.getDbName(), descriptor.getTableName(), descriptor.getUpdateTime());
+                Env.getCurrentEnv().getRefreshManager().refreshExternalTableFromEvent(
+                        catalogName, before.localDbName, before.localTableName, descriptor.getUpdateTime());
                 break;
             case ADD_PARTITIONS:
-                catalogMgr.addExternalPartitions(catalogName, descriptor.getDbName(),
-                        descriptor.getTableName(), descriptor.getPartitionNames(),
-                        descriptor.getUpdateTime(), true);
+                catalogMgr.addExternalPartitionsFromEvent(catalogName,
+                        before.localDbName, before.localTableName,
+                        descriptor.getPartitionNames(), descriptor.getUpdateTime());
                 break;
             case DROP_PARTITIONS:
-                catalogMgr.dropExternalPartitions(catalogName, descriptor.getDbName(),
-                        descriptor.getTableName(), descriptor.getPartitionNames(),
-                        descriptor.getUpdateTime(), true);
+                catalogMgr.dropExternalPartitionsFromEvent(catalogName,
+                        before.localDbName, before.localTableName,
+                        descriptor.getPartitionNames(), descriptor.getUpdateTime());
                 break;
             case REFRESH_PARTITIONS:
-                Env.getCurrentEnv().getRefreshManager().refreshPartitions(catalogName,
-                        descriptor.getDbName(), descriptor.getTableName(),
-                        descriptor.getPartitionNames(), descriptor.getUpdateTime(), true);
+                Env.getCurrentEnv().getRefreshManager().refreshPartitionsFromEvent(catalogName,
+                        before.localDbName, before.localTableName,
+                        descriptor.getPartitionNames(), descriptor.getUpdateTime());
                 break;
             default:
                 break;
@@ -300,32 +312,30 @@ public class MetastoreEventSyncDriver extends MasterDaemon {
 
     /**
      * Invalidates connector-owned caches for structural events before publishing the corresponding FE mutation.
-     * Descriptor names are remote identities, which is the contract of the connector invalidation SPI. Rename
-     * invalidates both exact keys because case-only changes can address distinct cache entries; same-key
-     * view-recreate invalidates once. Refresh and partition descriptors already invalidate through their existing
-     * engine mutators and are deliberately not duplicated here.
+     * Connector cache keys use remote identities; FE mutators below use the local identities from the same values.
      */
-    private void invalidateStructuralEventCaches(Connector connector, MetastoreChangeDescriptor descriptor) {
-        switch (descriptor.getOp()) {
+    private void invalidateStructuralEventCaches(Connector connector,
+            MetastoreChangeDescriptor.Op op, EventIdentity before, EventIdentity after) {
+        switch (op) {
             case REGISTER_DATABASE:
             case UNREGISTER_DATABASE:
-                connector.invalidateDb(descriptor.getDbName());
+                connector.invalidateDb(before.remoteDbName);
                 break;
             case RENAME_DATABASE:
-                connector.invalidateDb(descriptor.getDbName());
-                if (!Objects.equals(descriptor.getDbName(), descriptor.getDbNameAfter())) {
-                    connector.invalidateDb(descriptor.getDbNameAfter());
+                connector.invalidateDb(before.remoteDbName);
+                if (!Objects.equals(before.remoteDbName, after.remoteDbName)) {
+                    connector.invalidateDb(after.remoteDbName);
                 }
                 break;
             case REGISTER_TABLE:
             case UNREGISTER_TABLE:
-                connector.invalidateTable(descriptor.getDbName(), descriptor.getTableName());
+                connector.invalidateTable(before.remoteDbName, before.remoteTableName);
                 break;
             case RENAME_TABLE:
-                connector.invalidateTable(descriptor.getDbName(), descriptor.getTableName());
-                if (!Objects.equals(descriptor.getDbName(), descriptor.getDbNameAfter())
-                        || !Objects.equals(descriptor.getTableName(), descriptor.getTableNameAfter())) {
-                    connector.invalidateTable(descriptor.getDbNameAfter(), descriptor.getTableNameAfter());
+                connector.invalidateTable(before.remoteDbName, before.remoteTableName);
+                if (!Objects.equals(before.remoteDbName, after.remoteDbName)
+                        || !Objects.equals(before.remoteTableName, after.remoteTableName)) {
+                    connector.invalidateTable(after.remoteDbName, after.remoteTableName);
                 }
                 break;
             default:
@@ -333,16 +343,29 @@ public class MetastoreEventSyncDriver extends MasterDaemon {
         }
     }
 
-    private void applyRenameTable(PluginDrivenExternalCatalog catalog, MetastoreChangeDescriptor descriptor)
-            throws Exception {
-        String catalogName = catalog.getName();
-        CatalogMgr catalogMgr = Env.getCurrentEnv().getCatalogMgr();
-        // Always converge to "old removed, new registered". The target may already be hot because a normal
-        // lookup raced with the event after the remote rename; it must not prevent cleanup of the old identity.
-        catalogMgr.unregisterExternalTable(descriptor.getDbName(), descriptor.getTableName(),
-                catalogName, true);
-        catalogMgr.registerExternalTableFromEvent(descriptor.getDbNameAfter(),
-                descriptor.getTableNameAfter(), catalogName, descriptor.getUpdateTime(), true);
+    /** One remote connector identity and its canonical FE-local counterpart. */
+    private static final class EventIdentity {
+        private final String remoteDbName;
+        private final String localDbName;
+        private final String remoteTableName;
+        private final String localTableName;
+
+        private EventIdentity(String remoteDbName, String localDbName,
+                String remoteTableName, String localTableName) {
+            this.remoteDbName = remoteDbName;
+            this.localDbName = localDbName;
+            this.remoteTableName = remoteTableName;
+            this.localTableName = localTableName;
+        }
+
+        private static EventIdentity from(PluginDrivenExternalCatalog catalog,
+                String remoteDbName, String remoteTableName) {
+            Objects.requireNonNull(remoteDbName, "remote database name");
+            String localDbName = catalog.canonicalLocalDatabaseNameFromRemote(remoteDbName);
+            String localTableName = remoteTableName == null
+                    ? null : catalog.canonicalLocalTableNameFromRemote(remoteDbName, remoteTableName);
+            return new EventIdentity(remoteDbName, localDbName, remoteTableName, localTableName);
+        }
     }
 
     // Writes the synced-event-id cursor to the edit-log so followers advance to it (the log's only live

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalog.java
@@ -60,6 +60,7 @@ import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.ExternalFunctionRules;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.datasource.connector.converter.ConnectorBranchTagConverter;
@@ -313,33 +314,26 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
     }
 
     /**
-     * {@code REFRESH CATALOG} must also drop the connector's OWN caches (e.g. the iceberg latest-snapshot
-     * cache, default TTL 24h, and the manifest cache). The base {@link #onRefreshCache} only invalidates the
-     * registered engine caches via the route resolver — which for a plugin catalog resolves to the schema-only
-     * {@code ENGINE_DEFAULT} bucket and never reaches the connector-owned caches. And {@code REFRESH CATALOG}
-     * does NOT rebuild the connector (that only happens on {@code ADD}/{@code MODIFY CATALOG} via
-     * {@link #resetToUninitialized}), so without this the connector keeps serving stale metadata until TTL.
-     *
-     * <p>Connector-agnostic: {@link Connector#invalidateAll()} is a generic SPI (no-op default; paimon clears
-     * its own latest-snapshot cache too). Reads the {@code connector} field directly (no forced init, mirroring
-     * {@link #overlayMetaCacheConfig}): an uninitialized catalog — or one whose connector was just nulled by
-     * {@code resetToUninitialized}'s {@code onClose()} before this runs — has no connector caches to drop, and
-     * the next access lazily rebuilds the connector with empty caches.
+     * Invalidates connector-owned metadata before FE caches because connector metadata feeds row-count loading.
+     * The connector field is read directly so refreshing an uninitialized catalog does not initialize it.
      */
     @Override
     public void onRefreshCache(boolean invalidCache) {
-        super.onRefreshCache(invalidCache);
-        if (invalidCache) {
+        if (!invalidCache) {
+            super.onRefreshCache(false);
+            return;
+        }
+        try {
             invalidateAllConnectorCachesIfPresent();
+        } finally {
+            super.onRefreshCache(true);
         }
     }
 
     /**
      * Invalidates connector-owned caches without initializing or rebuilding the connector.
      *
-     * <p>This is also used by edit-log replay when only a retained local database name is available. Without a
-     * database object, replay cannot recover the remote database/table identity, so whole-connector invalidation is
-     * the conservative cache-only fallback.
+     * <p>Replay also uses this when no database object is cached and remote cache keys cannot be recovered.
      */
     public void invalidateAllConnectorCachesIfPresent() {
         Connector localConnector = connector;
@@ -483,23 +477,22 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
      * (buildDbForInit + the shared metadata-cache update protocol) and mirrors the legacy HMS implementation.
      */
     @Override
-    public void registerDatabase(String dbName) {
-        String localDbName = canonicalLocalDatabaseNameFromRemote(dbName);
+    public void registerDatabaseFromEvent(String remoteDbName, String localDbName) {
         long dbId = Util.genIdByName(getName(), localDbName);
-        ExternalDatabase<? extends ExternalTable> db =
-                buildDbForInit(dbName, localDbName, dbId, logType, false);
-        if (isInitialized()) {
-            updateDatabaseCache(db.getRemoteName(), db.getFullName(), db);
+        try {
+            ExternalDatabase<? extends ExternalTable> db =
+                    buildDbForInit(remoteDbName, localDbName, dbId, logType, false);
+            if (isInitialized()) {
+                updateDatabaseCache(db.getRemoteName(), db.getFullName(), db);
+            }
+        } finally {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDb(getId(), dbId, localDbName);
         }
     }
 
     /**
-     * FIX-4: let the connector's own cache knob also govern the schema cache (restoring the legacy single-knob
-     * semantics — e.g. paimon's {@code meta.cache.paimon.table.ttl-second} sized the whole table cache, schema
-     * included). Applied to the engine's EPHEMERAL cache-sizing property copy only (never persisted). An
-     * explicit user {@code schema.cache.ttl-second} wins. Uses the {@code connector} field directly (no forced
-     * init / no throw): this hook only runs during a cache read, by which point the catalog is already
-     * initialized; a null connector (uninitialized or concurrently dropped) simply leaves the engine default.
+     * Applies a connector-provided schema-cache TTL to the ephemeral cache configuration. An explicit schema TTL
+     * takes precedence, and an unavailable connector leaves the engine default unchanged.
      */
     @Override
     public void overlayMetaCacheConfig(Map<String, String> metaCacheProperties) {
@@ -517,69 +510,34 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
     }
 
     /**
-     * Routes {@code CREATE TABLE} through the SPI's
-     * {@code ConnectorTableOps.createTable(session, request)} instead of the
-     * legacy {@code metadataOps} path used by other {@link ExternalCatalog}
-     * subclasses.
-     *
-     * <p>Connectors that have not overridden the new SPI default fall through
-     * to the SPI's "CREATE TABLE not supported" exception, which is wrapped
-     * here as a {@link DdlException} to match the existing caller contract.</p>
-     *
-     * <p>The SPI {@code createTable} is {@code void} and this override has no
-     * {@code metadataOps}, so it mirrors legacy
-     * {@code MaxComputeMetadataOps.createTableImpl}: when the table already exists
-     * and {@code IF NOT EXISTS} was given it returns {@code true} and skips the
-     * connector create + edit log + cache reset (so a {@code CREATE TABLE IF NOT
-     * EXISTS ... AS SELECT} short-circuits per the {@code Env.createTable} contract
-     * instead of INSERTing into the existing table); otherwise it creates the table,
-     * writes the edit log, resets the cache, and returns {@code false}.</p>
+     * Routes CREATE TABLE through the connector SPI. Returning {@code true} for an existing table preserves
+     * the caller's CTAS short-circuit contract. A newly created table persists canonical local names; every
+     * successful path invalidates connector, metadata, and row-count caches in that order.
      */
     @Override
     public boolean createTable(CreateTableInfo createTableInfo) throws UserException {
         makeSureInitialized();
-        // Resolve the local db name to its remote (ODPS) name before handing it to the connector,
-        // mirroring legacy MaxComputeMetadataOps.createTableImpl (db.getRemoteName()). Without this,
-        // name-mapped catalogs (lower_case_meta_names / meta_names_mapping, where the local display
-        // name differs from the remote name) would address the wrong remote schema. The table name
-        // is intentionally NOT remote-resolved (legacy parity: the table does not exist yet, so
-        // there is no local->remote mapping for it).
+        // The database already has a remote identity; the new table name is itself the remote target.
         ExternalDatabase<? extends ExternalTable> db = getDbNullable(createTableInfo.getDbName());
         if (db == null) {
             throw new DdlException("Failed to get database: '" + createTableInfo.getDbName()
                     + "' in catalog: " + getName());
         }
+        String localTableName = db.canonicalLocalTableNameFromRemote(createTableInfo.getTableName());
         ConnectorSession session = buildConnectorSession();
         ConnectorMetadata metadata = PluginDrivenMetadata.get(session, connector);
-        // Mirror legacy MaxComputeMetadataOps.createTableImpl:178-197 -- probe BOTH the remote
-        // (connector) and the local FE cache for an existing table. On IF NOT EXISTS this lets CTAS
-        // short-circuit (Env.createTable contract: return true when the table already exists), so a
-        // "CREATE TABLE IF NOT EXISTS ... AS SELECT" does NOT fall through to an INSERT into the
-        // pre-existing table. The table name is intentionally NOT remote-resolved (legacy parity).
+        // Both views matter: name folding can expose a local conflict that the remote lookup does not see.
         boolean remoteExists = metadata.getTableHandle(session, db.getRemoteName(),
                 createTableInfo.getTableName()).isPresent();
-        boolean localExists = db.getTableNullable(createTableInfo.getTableName()) != null;
+        boolean localExists = db.getTableNullable(localTableName) != null;
         if (remoteExists || localExists) {
             if (createTableInfo.isIfNotExists()) {
                 LOG.info("create table[{}.{}.{}] which already exists; skipping (IF NOT EXISTS)",
                         getName(), createTableInfo.getDbName(), createTableInfo.getTableName());
-                // #66112 (ported from the legacy paimon arm): an existing-table success returns BEFORE the
-                // post-create cache invalidation below, so this FE would keep a table-name cache that predates
-                // the table -- a table created out-of-band (another engine / another FE) stays invisible to
-                // SHOW TABLES and to a subsequent SELECT until an unrelated refresh. Every successful no-op
-                // must refresh the names, exactly like the created-here path.
-                getDbForReplay(createTableInfo.getDbName()).ifPresent(d -> d.resetMetaCacheNames());
+                invalidateCreatedTableCaches(db, createTableInfo.getTableName(), localTableName);
                 return true;
             }
-            // !IF NOT EXISTS: a table that already exists -- whether remotely (connector) OR only in the
-            // local FE cache (a case-variant name folded onto an existing table under lower_case_meta_names
-            // while the case-sensitive remote has no such table) -- must be rejected HERE with MySQL errno
-            // 1050 (ERR_TABLE_EXISTS_ERROR / SQLSTATE 42S01). Mirrors legacy {Paimon,MaxCompute}MetadataOps,
-            // which report ERR_TABLE_EXISTS_ERROR for BOTH the remote arm (PaimonMetadataOps:195 /
-            // MaxComputeMetadataOps:184) and the local arm (:212 / :195). Reporting before
-            // metadata.createTable also keeps a local-cache-only conflict from being CREATED remotely
-            // (the connector would otherwise create a duplicate). Reaching here already guarantees
-            // (remoteExists || localExists) && !isIfNotExists; reportDdlException throws.
+            // Report the established MySQL error before a local-only conflict can create a remote duplicate.
             ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR,
                     createTableInfo.getTableName());
         }
@@ -588,88 +546,62 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         try {
             metadata.createTable(session, request);
         } catch (DorisConnectorException e) {
-            // #66112: the existence probe above and the remote create are not atomic, so a concurrent
-            // creator (another FE, another engine) can win the race in between and the connector then
-            // fails with its own already-exists error. Under IF NOT EXISTS the statement's contract is
-            // "ensure it is there", so a re-probe that finds the table makes this a successful no-op.
-            // Returning TRUE (not false) is the load-bearing part: it tells CreateTableCommand that this
-            // statement did not create the table, so a CTAS neither INSERTs into the winner's table nor
-            // claims rollback ownership of it.
+            // The probe and create are not atomic. A successful re-probe turns a lost IF NOT EXISTS race into
+            // the same CTAS-short-circuit result as an initially existing table.
             if (createTableInfo.isIfNotExists()
                     && metadata.getTableHandle(session, db.getRemoteName(),
                             createTableInfo.getTableName()).isPresent()) {
                 LOG.info("create table[{}.{}.{}] lost the race to a concurrent creator; "
                                 + "treating as an IF NOT EXISTS no-op", getName(),
                         createTableInfo.getDbName(), createTableInfo.getTableName());
-                getDbForReplay(createTableInfo.getDbName()).ifPresent(d -> d.resetMetaCacheNames());
+                invalidateCreatedTableCaches(db, createTableInfo.getTableName(), localTableName);
                 return true;
             }
             throw new DdlException(e.getMessage(), e);
         }
-        // Drop any stale connector-owned cache entry for this name before the new table goes live
-        // (belt-and-suspenders with the DROP path, which is the load-bearing invalidation for drop+recreate).
-        // Connector-agnostic: invalidateTable is a no-op SPI default; hive/iceberg/paimon drop their own
-        // per-table caches (metastore/file-listing, latest-snapshot pin). The table name is intentionally NOT
-        // remote-resolved (a new table has no local->remote mapping — parity with the create request + editlog).
-        connector.invalidateTable(db.getRemoteName(), createTableInfo.getTableName());
         org.apache.doris.persist.CreateTableInfo persistInfo =
                 new org.apache.doris.persist.CreateTableInfo(
-                        getName(),
-                        createTableInfo.getDbName(),
-                        createTableInfo.getTableName());
+                        getName(), db.getFullName(), localTableName);
         Env.getCurrentEnv().getEditLog().logCreateTable(persistInfo);
-        // Invalidate the FE-side table-name cache so the new table is immediately visible on
-        // this FE. The legacy metadataOps path did this via afterCreateTable(); since
-        // PluginDrivenExternalCatalog has no metadataOps, the override must do it here.
-        // (Edit log and cache invalidation deliberately use the LOCAL db/table names for
-        // follower-replay consistency; only the connector-bound name is remote-resolved.)
-        getDbForReplay(createTableInfo.getDbName()).ifPresent(d -> d.resetMetaCacheNames());
+        invalidateCreatedTableCaches(db, createTableInfo.getTableName(), localTableName);
         LOG.info("finished to create table {}.{}.{}", getName(),
                 createTableInfo.getDbName(), createTableInfo.getTableName());
         return false;
     }
 
-    /**
-     * Routes {@code CREATE DATABASE} through the SPI's
-     * {@code ConnectorSchemaOps.createDatabase(session, dbName, properties)}.
-     *
-     * <p>The SPI signature carries no {@code ifNotExists}; this override honors it
-     * FE-side. It short-circuits on the local FE cache and then on the remote
-     * {@code databaseExists}, so {@code CREATE DATABASE IF NOT EXISTS} on a database
-     * that exists remotely but is not yet in this FE's cache cleanly no-ops instead of
-     * surfacing a remote "already exists" error (mirroring legacy
-     * {@code MaxComputeMetadataOps.createDbImpl}, which checked both). On success it
-     * writes the edit log and invalidates the cached db-name list (mirroring the
-     * legacy {@code metadataOps.afterCreateDb()} the plugin path no longer has).</p>
-     */
+    /** Routes CREATE DATABASE through the connector SPI while enforcing IF NOT EXISTS on both FE and remote state. */
     @Override
     public void createDb(String dbName, boolean ifNotExists, Map<String, String> properties) throws DdlException {
         makeSureInitialized();
-        // Fast path: FE-cache hit + IF NOT EXISTS => no-op (legacy createDbImpl: dorisDb != null).
-        if (ifNotExists && getDbNullable(dbName) != null) {
-            return;
+        if (ifNotExists) {
+            ExternalDatabase<? extends ExternalTable> existingDb = getDbNullable(dbName);
+            if (existingDb != null) {
+                invalidateCreatedDatabaseCaches(existingDb.getRemoteName(), existingDb.getFullName());
+                return;
+            }
         }
+        String localDbName = canonicalLocalDatabaseNameFromRemote(dbName);
         ConnectorSession session = buildConnectorSession();
         ConnectorMetadata metadata = PluginDrivenMetadata.get(session, connector);
-        // FE-cache miss but the db may already exist REMOTELY (created on another FE / before this
-        // FE's db-name cache was populated). Legacy MaxComputeMetadataOps.createDbImpl consulted
-        // BOTH getDbNullable AND the remote databaseExist, and IF NOT EXISTS then no-oped. Mirror
-        // that remote check. Asked of EVERY connector, mirroring Trino's CreateSchemaTask: IF NOT
-        // EXISTS means "ensure it is there", so a connector that cannot create databases but reports
-        // this one as existing has already satisfied the request and must not be made to fail.
-        // A connector that answers neither question keeps the default databaseExists() == false and
-        // falls through to createDatabase() -> "CREATE DATABASE not supported", as before.
+        // A remote hit also satisfies IF NOT EXISTS, including for connectors that cannot create databases.
         if (ifNotExists && metadata.databaseExists(session, dbName)) {
             LOG.info("create database[{}] which already exists remotely, skip", dbName);
+            invalidateCreatedDatabaseCaches(dbName, localDbName);
             return;
         }
         try {
             metadata.createDatabase(session, dbName, properties);
         } catch (DorisConnectorException e) {
+            if (ifNotExists && metadata.databaseExists(session, dbName)) {
+                LOG.info("create database[{}] lost the race to a concurrent creator; "
+                        + "treating as an IF NOT EXISTS no-op", dbName);
+                invalidateCreatedDatabaseCaches(dbName, localDbName);
+                return;
+            }
             throw new DdlException(e.getMessage(), e);
         }
-        Env.getCurrentEnv().getEditLog().logCreateDb(new CreateDbInfo(getName(), dbName, null));
-        resetMetaCacheNames();
+        Env.getCurrentEnv().getEditLog().logCreateDb(new CreateDbInfo(getName(), localDbName, null));
+        invalidateCreatedDatabaseCaches(dbName, localDbName);
         LOG.info("finished to create database {}.{}", getName(), dbName);
     }
 
@@ -705,16 +637,12 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         } catch (DorisConnectorException e) {
             throw new DdlException(e.getMessage(), e);
         }
-        // Drop the connector's own caches for every table in this db so a subsequent same-name CREATE
-        // DATABASE and the next reads go live rather than serving dropped tables up to the connector TTL.
-        // Connector-agnostic (no-op SPI default); keyed by the REMOTE db name, mirroring
-        // RefreshManager.refreshDbInternal. (createDb is intentionally NOT hooked: a brand-new db has no
-        // table-keyed connector entries that this dropDb did not already clear.)
-        connector.invalidateDb(db.getRemoteName());
-        // Edit log + cache invalidation intentionally use the LOCAL name: followers replay the
-        // persisted DropDbInfo and the on-FE cache is keyed by local name (follower-replay parity).
-        Env.getCurrentEnv().getEditLog().logDropDb(new DropDbInfo(getName(), dbName));
-        unregisterDatabase(dbName);
+        Env.getCurrentEnv().getEditLog().logDropDb(new DropDbInfo(getName(), db.getFullName()));
+        try {
+            connector.invalidateDb(db.getRemoteName());
+        } finally {
+            unregisterDatabase(db.getFullName());
+        }
         LOG.info("finished to drop database {}.{}", getName(), dbName);
     }
 
@@ -762,11 +690,7 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
             } catch (DorisConnectorException e) {
                 throw new DdlException(e.getMessage(), e);
             }
-            // Uniform with the table branch: drop the connector's own caches for this name (harmless no-op
-            // for a view, which carries no snapshot pin). Keyed by the REMOTE names.
-            connector.invalidateTable(dorisTable.getRemoteDbName(), dorisTable.getRemoteName());
-            Env.getCurrentEnv().getEditLog().logDropTable(new DropInfo(getName(), dbName, tableName));
-            getDbForReplay(dbName).ifPresent(d -> d.unregisterTable(tableName));
+            finishDropTable(db, dorisTable);
             LOG.info("finished to drop view {}.{}.{}", getName(), dbName, tableName);
             return;
         }
@@ -776,6 +700,7 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         // side; preserve the existing IF EXISTS handling for that case.
         if (!handle.isPresent()) {
             if (ifExists) {
+                finishDropTable(db, dorisTable);
                 return;
             }
             throw new DdlException("Failed to get table: '" + tableName + "' in database: " + dbName);
@@ -785,16 +710,7 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         } catch (DorisConnectorException e) {
             throw new DdlException(e.getMessage(), e);
         }
-        // Drop the connector's own caches for this table (paimon/iceberg latest-snapshot pin, hive
-        // metastore + file-listing) so a subsequent same-name CREATE and the next read go live rather than
-        // serving the dropped table up to the connector TTL — the load-bearing fix for drop+recreate.
-        // Connector-agnostic (no-op SPI default); keyed by the REMOTE db/table names the connector caches
-        // under, mirroring RefreshManager.refreshTableInternal.
-        connector.invalidateTable(dorisTable.getRemoteDbName(), dorisTable.getRemoteName());
-        // Edit log and cache invalidation deliberately use the LOCAL db/table names for
-        // follower-replay consistency; only the connector-bound names are remote-resolved.
-        Env.getCurrentEnv().getEditLog().logDropTable(new DropInfo(getName(), dbName, tableName));
-        getDbForReplay(dbName).ifPresent(d -> d.unregisterTable(tableName));
+        finishDropTable(db, dorisTable);
         LOG.info("finished to drop table {}.{}.{}", getName(), dbName, tableName);
     }
 
@@ -823,20 +739,13 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         ConnectorSession session = buildConnectorSession();
         ConnectorMetadata metadata = PluginDrivenMetadata.get(session, connector);
         ConnectorTableHandle handle = resolveAlterHandle(dorisTable, session, metadata);
+        String localNewTableName = db.canonicalLocalTableNameFromRemote(newTableName);
         try {
             metadata.renameTable(session, handle, newTableName);
         } catch (DorisConnectorException e) {
             throw new DdlException(e.getMessage(), e);
         }
-        // R4: drop the connector's OWN caches for BOTH the source and target names so an atomic swap
-        // (RENAME t->t_arch; RENAME t_new->t) doesn't serve the pre-rename pinned snapshot under either name —
-        // afterExternalRename only fixes the FE name cache. Same drop+recreate class the dropTable hook covers.
-        // Connector-agnostic (no-op SPI default); the source is keyed by its resolved REMOTE names, the target
-        // by the new name in the same remote db (parity with createTable: a rename target has no prior
-        // local->remote mapping). Followers propagate this via RefreshManager.replayRefreshTable's rename branch.
-        connector.invalidateTable(dorisTable.getRemoteDbName(), dorisTable.getRemoteName());
-        connector.invalidateTable(dorisTable.getRemoteDbName(), newTableName);
-        afterExternalRename(dbName, oldTableName, newTableName);
+        afterExternalRename(db, dorisTable, newTableName, localNewTableName);
     }
 
     /**
@@ -873,74 +782,108 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
             throw new DdlException(e.getMessage(), e);
         }
         long updateTime = System.currentTimeMillis();
-        // Cache refresh + edit log use the LOCAL db/table names for follower-replay parity (only the
-        // connector-bound handle is remote-resolved), mirroring base ExternalCatalog.truncateTable.
-        Env.getCurrentEnv().getRefreshManager().refreshTableInternal(db, dorisTable, updateTime);
         Env.getCurrentEnv().getEditLog().logTruncateTable(
-                new TruncateTableInfo(getName(), dbName, tableName, partitions, updateTime));
+                new TruncateTableInfo(getName(), db.getFullName(), dorisTable.getName(), partitions, updateTime));
+        Env.getCurrentEnv().getRefreshManager().refreshTableInternal(db, dorisTable, updateTime);
         LOG.info("finished to truncate table {}.{}.{}", getName(), dbName, tableName);
     }
 
     /**
-     * Refreshes the local table cache on edit-log replay of a connector-driven truncate. The base
-     * {@link ExternalCatalog#replayTruncateTable} delegates to {@code metadataOps.afterTruncateTable}, which is a
-     * no-op for PluginDriven ({@code metadataOps == null}); this override re-resolves the cached table by the
-     * replayed LOCAL names and runs {@code refreshTableInternal} (the same effect the master path applied),
-     * mirroring legacy {@code HiveMetadataOps.afterTruncateTable}.
+     * Replays cache invalidation for a connector-driven truncate without loading remote metadata. A cached table
+     * follows the normal refresh path. Otherwise canonical local names identify engine and row-count caches, while
+     * connector invalidation widens to the database or catalog scope when the remote table name is unavailable.
      */
     @Override
     public void replayTruncateTable(TruncateTableInfo info) {
-        getDbForReplay(info.getDb()).ifPresent(db ->
-                db.getTableForReplay(info.getTable()).ifPresent(tbl ->
-                        Env.getCurrentEnv().getRefreshManager().refreshTableInternal(db, tbl, info.getUpdateTime())));
+        Optional<ExternalDatabase<? extends ExternalTable>> db = getDbForReplay(info.getDb());
+        Optional<? extends ExternalTable> table = db.flatMap(database -> database.getTableForReplay(info.getTable()));
+        if (table.isPresent()) {
+            Env.getCurrentEnv().getRefreshManager()
+                    .refreshTableInternal(db.get(), table.get(), info.getUpdateTime());
+            return;
+        }
+        ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
+        try {
+            Connector replayConnector = connector;
+            if (isInitialized() && replayConnector != null) {
+                if (db.isPresent()) {
+                    replayConnector.invalidateDb(db.get().getRemoteName());
+                } else {
+                    replayConnector.invalidateAll();
+                }
+            }
+        } finally {
+            long dbId = Util.genIdByName(getName(), info.getDb());
+            cacheMgr.invalidateTable(getId(), dbId, info.getDb(),
+                    Util.genIdByName(getName(), info.getDb(), info.getTable()), info.getTable());
+        }
     }
 
-    /**
-     * Propagates the coordinator {@link #dropTable} hook's connector-cache invalidation to followers/observers
-     * on edit-log replay. The base {@link ExternalCatalog#replayDropTable} plugin branch only touches the FE
-     * name cache ({@code unregisterTable}); without this, a follower that had queried a paimon/iceberg table
-     * keeps its latest-snapshot pin (and paimon's schema memo) for the dropped name until the 24h access-TTL —
-     * the coordinator-only half of the drop+recreate fix. Resolves the REMOTE names from the still-cached
-     * table BEFORE the base unregisters it, keyed exactly like the coordinator (mirrors
-     * {@code RefreshManager.replayRefreshTable → refreshTableInternal}'s connector hook).
-     *
-     * <p><b>Never force-initializes during replay:</b> {@code getConnector()} runs only inside the
-     * {@code getDbForReplay}/{@code getTableForReplay} match, which is present only when this catalog is
-     * already initialized on this FE (both return empty otherwise). A never-initialized catalog has no
-     * connector cache to drop, so skipping it is correct — mirroring {@code HiveConnector.forEachBuiltSibling}
-     * ("a never-built sibling has no cache") and preserving the base's no-force-init replay behavior.
-     */
     @Override
     public void replayDropTable(String dbName, String tblName) {
-        getDbForReplay(dbName).ifPresent(db ->
-                db.getTableForReplay(tblName).ifPresent(tbl ->
-                        getConnector().invalidateTable(db.getRemoteName(), tbl.getRemoteName())));
-        super.replayDropTable(dbName, tblName);
+        try {
+            invalidateTableConnectorCacheForReplay(dbName, tblName);
+        } finally {
+            super.replayDropTable(dbName, tblName);
+        }
     }
 
-    /**
-     * Replay analogue of the coordinator {@link #dropDb} hook's connector-cache invalidation — clears every
-     * table's connector cache for the dropped database on followers/observers (the base
-     * {@link ExternalCatalog#replayDropDb} plugin branch only unregisters the FE db). Resolves the REMOTE db
-     * name BEFORE the base unregisters the database. See {@link #replayDropTable} for the no-force-init
-     * rationale.
-     */
     @Override
     public void replayDropDb(String dbName) {
-        getDbForReplay(dbName).ifPresent(db -> getConnector().invalidateDb(db.getRemoteName()));
-        super.replayDropDb(dbName);
+        try {
+            invalidateDatabaseConnectorCacheForReplay(dbName);
+        } finally {
+            super.replayDropDb(dbName);
+        }
     }
 
-    /**
-     * Replay analogue of the coordinator {@link #createTable} hook's belt-and-suspenders connector-cache
-     * invalidation (uniform with the drop path). The table name is NOT remote-resolved — parity with the
-     * coordinator, where a brand-new table has no local→remote mapping. See {@link #replayDropTable} for the
-     * no-force-init rationale.
-     */
     @Override
     public void replayCreateTable(String dbName, String tblName) {
-        super.replayCreateTable(dbName, tblName);
-        getDbForReplay(dbName).ifPresent(db -> getConnector().invalidateTable(db.getRemoteName(), tblName));
+        try {
+            invalidateDatabaseConnectorCacheForReplay(dbName);
+        } finally {
+            super.replayCreateTable(dbName, tblName);
+        }
+    }
+
+    @Override
+    public void replayCreateDb(String dbName) {
+        try {
+            invalidateDatabaseConnectorCacheForReplay(dbName);
+        } finally {
+            super.replayCreateDb(dbName);
+        }
+    }
+
+    // Replay never initializes a cold catalog; missing local-to-remote identity widens the live connector scope.
+    private void invalidateDatabaseConnectorCacheForReplay(String localDbName) {
+        Connector replayConnector = connector;
+        if (isInitialized() && replayConnector != null) {
+            Optional<ExternalDatabase<? extends ExternalTable>> db = getDbForReplay(localDbName);
+            if (db.isPresent()) {
+                replayConnector.invalidateDb(db.get().getRemoteName());
+            } else {
+                replayConnector.invalidateAll();
+            }
+        }
+    }
+
+    private void invalidateTableConnectorCacheForReplay(String localDbName, String localTableName) {
+        Connector replayConnector = connector;
+        if (!isInitialized() || replayConnector == null) {
+            return;
+        }
+        Optional<ExternalDatabase<? extends ExternalTable>> db = getDbForReplay(localDbName);
+        if (!db.isPresent()) {
+            replayConnector.invalidateAll();
+            return;
+        }
+        Optional<? extends ExternalTable> table = db.get().getTableForReplay(localTableName);
+        if (table.isPresent()) {
+            replayConnector.invalidateTable(db.get().getRemoteName(), table.get().getRemoteName());
+        } else {
+            replayConnector.invalidateDb(db.get().getRemoteName());
+        }
     }
 
     /**
@@ -1320,46 +1263,75 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         return ConnectorColumnPath.of(columnPath.getParts());
     }
 
-    /**
-     * Replays the base {@link ExternalCatalog} per-op bookkeeping for a connector-driven schema change.
-     *
-     * <p>The base column ops only emit the editlog ({@code logRefreshExternalTable}); the actual cache
-     * invalidation is delegated INTO {@code metadataOps.refreshTable -> RefreshManager.refreshTableInternal}.
-     * Since PluginDrivenExternalCatalog has no {@code metadataOps}, this helper does BOTH explicitly: the
-     * {@code createForRefreshTable} editlog (LOCAL names, replay-neutral) and a {@code refreshTableInternal}
-     * (re-resolving the local cached table by its REMOTE names, mirroring legacy
-     * {@code IcebergMetadataOps.refreshTable}). {@code refreshTableInternal} is the single source of truth for
-     * the cache work ({@code unsetObjectCreated} + {@code setUpdateTime} + {@code invalidateTableCache} + the
-     * connector-side per-table cache drop), so it must NOT be re-inlined here.
-     */
+    /** Persists replay identity, then refreshes the cached table when present or the resolved transient table. */
     protected void afterExternalDdl(ExternalTable externalTable, long updateTime) {
         Env.getCurrentEnv().getEditLog().logRefreshExternalTable(
-                ExternalObjectLog.createForRefreshTable(getId(),
-                        externalTable.getDbName(), externalTable.getName(), updateTime));
-        getDbForReplay(externalTable.getRemoteDbName()).ifPresent(db ->
-                db.getTableForReplay(externalTable.getRemoteName()).ifPresent(tbl ->
-                        Env.getCurrentEnv().getRefreshManager().refreshTableInternal(db, tbl, updateTime)));
+                ExternalObjectLog.createForRefreshTable(
+                        getId(), externalTable.getDbName(), externalTable.getName(), updateTime));
+        ExternalTable refreshTarget = getDbForReplay(externalTable.getDbName())
+                .<ExternalTable>flatMap(db -> db.getTableForReplay(externalTable.getName()))
+                .orElse(externalTable);
+        Env.getCurrentEnv().getRefreshManager()
+                .refreshTableInternal(refreshTarget.getDb(), refreshTarget, updateTime);
     }
 
-    /**
-     * Replays the base {@link ExternalCatalog#renameTable} bookkeeping for a connector-driven rename, since
-     * PluginDriven has no {@code metadataOps}: the table-name cache fix ({@code unregisterTable(old)} +
-     * {@code resetMetaCacheNames()}, mirroring legacy {@code IcebergMetadataOps.afterRenameTable}), the
-     * {@code constraintManager} rename, and the {@code createForRenameTable} editlog (whose replay,
-     * {@code RefreshManager.replayRefreshTable}, is already metadataOps-neutral). All use LOCAL names, matching
-     * the base op + the editlog payload, so followers replay consistently. Order mirrors the base op
-     * (cache &rarr; constraint &rarr; editlog).
-     */
-    protected void afterExternalRename(String dbName, String oldTableName, String newTableName) {
-        getDbForReplay(dbName).ifPresent(db -> {
-            db.unregisterTable(oldTableName);
-            db.resetMetaCacheNames();
-        });
-        Env.getCurrentEnv().getConstraintManager().renameTable(
-                new TableNameInfo(getName(), dbName, oldTableName),
-                new TableNameInfo(getName(), dbName, newTableName));
+    private void invalidateCreatedDatabaseCaches(String remoteDbName, String localDbName) {
+        try {
+            connector.invalidateDb(remoteDbName);
+        } finally {
+            invalidateCreatedDatabase(localDbName);
+        }
+    }
+
+    private void invalidateCreatedTableCaches(ExternalDatabase<? extends ExternalTable> db,
+            String remoteTableName, String localTableName) {
+        try {
+            connector.invalidateTable(db.getRemoteName(), remoteTableName);
+        } finally {
+            invalidateCreatedTable(db.getFullName(), localTableName);
+        }
+    }
+
+    private void finishDropTable(ExternalDatabase<? extends ExternalTable> db, ExternalTable table) {
+        Env.getCurrentEnv().getEditLog().logDropTable(
+                new DropInfo(getName(), db.getFullName(), table.getName()));
+        try {
+            connector.invalidateTable(table.getRemoteDbName(), table.getRemoteName());
+        } finally {
+            invalidateDroppedTable(db.getFullName(), table.getName());
+        }
+    }
+
+    protected void afterExternalRename(ExternalDatabase<? extends ExternalTable> db,
+            ExternalTable table, String remoteNewTableName, String localNewTableName) {
+        String dbName = db.getFullName();
+        String oldTableName = table.getName();
+        // The remote rename has committed; persist replay identity before fallible local bookkeeping.
         Env.getCurrentEnv().getEditLog().logRefreshExternalTable(
-                ExternalObjectLog.createForRenameTable(getId(), dbName, oldTableName, newTableName));
+                ExternalObjectLog.createForRenameTable(
+                        getId(), dbName, oldTableName, localNewTableName));
+        try {
+            try {
+                connector.invalidateTable(table.getRemoteDbName(), table.getRemoteName());
+            } finally {
+                connector.invalidateTable(table.getRemoteDbName(), remoteNewTableName);
+            }
+        } finally {
+            try {
+                getDbForReplay(dbName).ifPresent(
+                        cachedDb -> cachedDb.invalidateTableRename(oldTableName, localNewTableName));
+            } finally {
+                try {
+                    Env.getCurrentEnv().getConstraintManager().renameTable(
+                            new TableNameInfo(getName(), dbName, oldTableName),
+                            new TableNameInfo(getName(), dbName, localNewTableName));
+                } finally {
+                    Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableRename(
+                            getId(), db.getId(), dbName, table.getId(), oldTableName,
+                            Util.genIdByName(getName(), dbName, localNewTableName), localNewTableName);
+                }
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteActionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteActionCommand.java
@@ -28,7 +28,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.ExternalTable;
-import org.apache.doris.datasource.log.ExternalObjectLog;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.execute.ExecuteAction;
@@ -94,7 +93,6 @@ public class ExecuteActionCommand extends Command implements ForwardWithSync {
         if (!(table instanceof ExternalTable)) {
             throw new AnalysisException("ALTER TABLE EXECUTE is currently only supported for external tables");
         }
-
         try {
             ExecuteAction action = ExecuteActionFactory.createAction(
                     actionName, properties, partitionNamesInfo, whereCondition, table);
@@ -105,7 +103,6 @@ public class ExecuteActionCommand extends Command implements ForwardWithSync {
 
             action.validate(tableNameInfo, ctx.getCurrentUserIdentity());
             ResultSet resultSet = action.execute(table);
-            logRefreshTable(table, System.currentTimeMillis());
             if (resultSet != null) {
                 executor.sendResultSet(resultSet);
             }
@@ -142,26 +139,5 @@ public class ExecuteActionCommand extends Command implements ForwardWithSync {
 
     public Optional<Expression> getWhereCondition() {
         return whereCondition;
-    }
-
-    /**
-     * Log refresh table to make follow fe metadata cache refresh.
-     *
-     * @param table the table to log
-     * @throws UserException if the table type is not supported
-     */
-    private void logRefreshTable(TableIf table, long updateTime) throws UserException {
-        if (table instanceof ExternalTable) {
-            ExternalTable externalTable = (ExternalTable) table;
-            Env.getCurrentEnv().getEditLog()
-                    .logRefreshExternalTable(
-                            ExternalObjectLog.createForRefreshTable(
-                                    externalTable.getCatalog().getId(),
-                                    externalTable.getDbName(),
-                                    externalTable.getName(), updateTime));
-        } else {
-            // support more table in future
-            throw new UserException("Unsupported table type: " + table.getClass().getName() + " for refresh table");
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorExecuteAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorExecuteAction.java
@@ -38,7 +38,6 @@ import org.apache.doris.connector.spi.procedure.ConnectorProcedureOps;
 import org.apache.doris.connector.spi.procedure.ConnectorProcedureResult;
 import org.apache.doris.connector.spi.procedure.ProcedureExecutionMode;
 import org.apache.doris.connector.spi.pushdown.ConnectorPredicate;
-import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.connector.converter.ConnectorColumnConverter;
 import org.apache.doris.datasource.connector.converter.UnboundExpressionToConnectorPredicateConverter;
 import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
@@ -68,10 +67,11 @@ import java.util.Optional;
  * then wraps the engine-neutral {@link ConnectorProcedureResult} back into a {@code ResultSet}.</p>
  *
  * <p><b>Engine/connector split (D-062 §2).</b> The engine keeps the command shell — this adapter performs
- * the {@code ALTER} privilege check ({@link #validate}) and the single-row {@code CommonResultSet} wrapping
- * ({@link #execute}); {@code ExecuteActionCommand} keeps the edit-log refresh. The connector owns the
- * procedure body — per-argument validation (the {@code NamedArguments} framework is not reachable across the
- * import gate), the underlying SDK call and the result schema/rows. The connector signals failures with an
+ * the {@code ALTER} privilege check ({@link #validate}), the committed-mutation fence, and the single-row
+ * {@code CommonResultSet} wrapping ({@link #execute}). The connector owns the procedure body — per-argument
+ * validation (the {@code NamedArguments} framework is not reachable across the import gate), the underlying SDK
+ * call and the result schema/rows. The fence persists follower replay identity and refreshes leader caches before
+ * result conversion. The connector signals failures with an
  * unchecked {@link DorisConnectorException}; this adapter converts it to a {@code UserException} so
  * {@code ExecuteActionCommand.run()} re-wraps it with the legacy {@code "Failed to execute action:"} prefix.</p>
  *
@@ -164,42 +164,28 @@ public class ConnectorExecuteAction implements ExecuteAction {
                     loweredWhere);
             try {
                 ConnectorProcedureResult result = driver.run();
-                refreshTableCachesAfterMutation();
                 return wrapResult(result);
             } catch (DorisConnectorException e) {
                 throw new UserException(e.getMessage(), e);
             }
         }
 
-        // SINGLE_CALL: a synchronous single-result procedure.
+        // SINGLE_CALL: the connector call is the mutation boundary. Fence the completed mutation before
+        // converting its result, which can still fail on an invalid connector result.
+        ConnectorProcedureResult result;
         try {
-            ConnectorProcedureResult result = procedureOps.execute(
+            result = procedureOps.execute(
                     session, tableHandle, actionType, properties, null, partitionNames);
-            refreshTableCachesAfterMutation();
-            return wrapResult(result);
+            Env.getCurrentEnv().getRefreshManager().refreshTableAfterExternalMutation(table);
         } catch (DorisConnectorException e) {
-            // Surface the connector's unchecked exception as a checked UserException so
-            // ExecuteActionCommand.run() catches it and re-wraps it with the legacy "Failed to execute action:"
-            // prefix. Use the plain UserException type the legacy action bodies threw (e.g.
-            // IcebergRollbackToSnapshotAction.executeAction), so getMessage() formats identically; the message is
-            // kept verbatim (the connector preserves the legacy text byte-for-byte — T08 byte-parity).
+            // Surface connector failures from either the procedure or post-commit connector cache invalidation as
+            // a checked UserException so ExecuteActionCommand.run() re-wraps them with the legacy
+            // "Failed to execute action:" prefix. Use the plain UserException type the legacy action bodies threw
+            // (e.g. IcebergRollbackToSnapshotAction.executeAction), so getMessage() formats identically; the message
+            // is kept verbatim (the connector preserves the legacy text byte-for-byte — T08 byte-parity).
             throw new UserException(e.getMessage(), e);
         }
-    }
-
-    /**
-     * After a successful procedure commit, drop this FE's caches for the mutated table through the standard
-     * refresh-table path — exactly what a follower FE does when it replays the refresh-table journal that
-     * {@code ExecuteActionCommand} writes after this returns. {@code refreshTableInternal} clears BOTH the
-     * engine meta cache (keyed by the table's LOCAL names) and the connector's own per-table cache (keyed by
-     * the REMOTE names), resolving both from the {@link PluginDrivenExternalTable}. Without this, the FE that
-     * ran the procedure keeps serving stale connector metadata (the iceberg latest-snapshot cache, default TTL
-     * 24h) until expiry — a leader/follower split. Connector-agnostic: {@code refreshTableInternal}'s connector
-     * arm is a generic SPI call (no-op default).
-     */
-    private void refreshTableCachesAfterMutation() {
-        Env.getCurrentEnv().getRefreshManager()
-                .refreshTableInternal((ExternalDatabase) table.getDatabase(), table, System.currentTimeMillis());
+        return wrapResult(result);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorRewriteDriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorRewriteDriver.java
@@ -172,6 +172,10 @@ public class ConnectorRewriteDriver {
         // failed commit needs no rollback (it would find nothing) — surface it directly.
         txnManager.commit(txnId);
 
+        // The rewrite is committed. Persist follower replay identity and refresh leader caches before the
+        // post-commit statistics and result construction below, which can fail independently of the mutation.
+        Env.getCurrentEnv().getRefreshManager().refreshTableAfterExternalMutation(table);
+
         // STEP 5: post-commit statistics. The added-files count is only valid after commit (it is
         // materialized from the BE commit fragments during commit); the other three are summed from the
         // planning groups (the connector exposes them on each ConnectorRewriteGroup).

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
@@ -54,7 +54,6 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
     private static final Logger LOG = LogManager.getLogger(BaseExternalTableInsertExecutor.class);
     protected TransactionStatus txnStatus = TransactionStatus.ABORTED;
     protected final TransactionManager transactionManager;
-    protected final String catalogName;
     protected Optional<SummaryProfile> summaryProfile = Optional.empty();
 
     /**
@@ -65,7 +64,6 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
                                            Optional<InsertCommandContext> insertCtx,
                                            boolean emptyInsert, long jobId) {
         super(ctx, table, labelName, planner, insertCtx, emptyInsert, jobId);
-        catalogName = table.getCatalog().getName();
         transactionManager = table.getCatalog().getTransactionManager();
 
         if (ConnectContext.get().getExecutor() != null) {
@@ -143,15 +141,10 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
     /**
      * Called after transaction commit.
      * Subclasses can override this to customize post-commit behavior.
-     * Default: full table refresh.
+     * Default: persist the mutation for replay, then refresh the full table.
      */
     protected void doAfterCommit() throws DdlException {
-        // Default: full table refresh
-        Env.getCurrentEnv().getRefreshManager().handleRefreshTable(
-                catalogName,
-                table.getDatabase().getFullName(),
-                table.getName(),
-                true);
+        Env.getCurrentEnv().getRefreshManager().refreshTableAfterExternalMutation((ExternalTable) table);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/PluginDrivenInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/PluginDrivenInsertExecutor.java
@@ -166,9 +166,9 @@ public class PluginDrivenInsertExecutor extends BaseExternalTableInsertExecutor 
      * <p>By the time this runs, the remote write is already durably committed and FE cannot roll
      * it back: for jdbc the BE commits directly via PreparedStatement; for the connector-transaction
      * path (maxcompute) the write session is committed by the transaction manager in onComplete,
-     * before this step. {@code super.doAfterCommit()} only refreshes FE-side metadata cache and
-     * writes an external-table refresh edit log (a cache-invalidation hint to followers); it never
-     * touches the already-committed remote data.</p>
+     * before this step. {@code super.doAfterCommit()} records a refresh hint for followers, then
+     * invalidates connector, metadata, and row-count caches; it never touches the already-committed
+     * remote data.</p>
      *
      * <p>If that refresh fails (e.g., catalog dropped concurrently, edit log I/O error), reporting
      * the INSERT as failed would mislead the user into retrying and writing duplicate data. The

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshManagerRenameReplayTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshManagerRenameReplayTest.java
@@ -18,9 +18,11 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.catalog.constraint.ConstraintManager;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.log.ExternalObjectLog;
 import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
@@ -28,37 +30,51 @@ import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.Optional;
 
-/**
- * Tests {@link RefreshManager#replayRefreshTable}'s RENAME branch (R4). A connector-driven RENAME TABLE is
- * logged as a {@code createForRenameTable} external-object log and replayed here on followers/observers.
- *
- * <p>Before R4 the replay only fixed the FE name cache ({@code unregisterTable} + {@code resetMetaCacheNames}
- * + constraint rename) — it never dropped the connector's OWN caches, so a follower that had queried the
- * source table kept its latest-snapshot pin (and paimon's schema memo) to the 24h TTL after an atomic table
- * swap. This pins that the replay now propagates {@code connector.invalidateTable} for BOTH the source and
- * target names, keyed exactly like the coordinator {@code PluginDrivenExternalCatalog.renameTable} hook.
- */
+/** Tests connector and local-cache invalidation during external table rename replay. */
 public class RefreshManagerRenameReplayTest {
 
     private MockedStatic<Env> mockedEnv;
     private CatalogMgr catalogMgr;
+    private ExternalMetaCacheMgr metaCacheMgr;
+    private ConstraintManager constraintManager;
     private RefreshManager refreshManager;
+    private PluginDrivenExternalCatalog catalog;
+    private Connector connector;
+    private ExternalDatabase<? extends ExternalTable> db;
+    private long dbId;
+    private long sourceTableId;
+    private long destinationTableId;
 
     @BeforeEach
     public void setUp() {
         Env mockEnv = Mockito.mock(Env.class);
         catalogMgr = Mockito.mock(CatalogMgr.class);
-        ConstraintManager constraintManager = Mockito.mock(ConstraintManager.class);
+        metaCacheMgr = Mockito.mock(ExternalMetaCacheMgr.class);
+        constraintManager = Mockito.mock(ConstraintManager.class);
         mockedEnv = Mockito.mockStatic(Env.class);
         mockedEnv.when(Env::getCurrentEnv).thenReturn(mockEnv);
         Mockito.when(mockEnv.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(mockEnv.getExtMetaCacheMgr()).thenReturn(metaCacheMgr);
         Mockito.when(mockEnv.getConstraintManager()).thenReturn(constraintManager);
         refreshManager = new RefreshManager();
+
+        catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
+        connector = Mockito.mock(Connector.class);
+        db = mockDb();
+        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(7L);
+        Mockito.when(catalog.getName()).thenReturn("c");
+        Mockito.when(catalog.getConnector()).thenReturn(connector);
+        Mockito.doReturn(Optional.of(db)).when(catalog).getDbForReplay("db1");
+        Mockito.when(db.getRemoteName()).thenReturn("DB1");
+        dbId = Util.genIdByName("c", "db1");
+        sourceTableId = Util.genIdByName("c", "db1", "t1");
+        destinationTableId = Util.genIdByName("c", "db1", "t2");
     }
 
     @AfterEach
@@ -74,51 +90,31 @@ public class RefreshManagerRenameReplayTest {
     }
 
     @Test
-    public void testRenameReplayInvalidatesConnectorSourceAndTargetOnFollower() {
-        // local db1.t1 -> t2, mapping to remote DB1.TBL1 (source). The source table is still in the replay
-        // cache when the rename replays (getDbForReplay/getTableForReplay resolve it), so the catalog is
-        // already initialized on this FE and getConnector() does not force-init.
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Connector connector = Mockito.mock(Connector.class);
-        ExternalDatabase<? extends ExternalTable> db = mockDb();
-        ExternalTable table = Mockito.mock(ExternalTable.class);
-        // doReturn (not when().thenReturn) because getCatalog returns a wildcard CatalogIf<? extends ...>
-        // whose capture rejects a concrete PluginDrivenExternalCatalog in the typed stubbing form.
-        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(7L);
-        Mockito.when(catalog.getName()).thenReturn("c");
-        Mockito.when(catalog.getConnector()).thenReturn(connector);
-        Mockito.doReturn(Optional.of(db)).when(catalog).getDbForReplay("db1");
-        Mockito.when(db.getRemoteName()).thenReturn("DB1");
-        Mockito.doReturn(Optional.of(table)).when(db).getTableForReplay("t1");
-        Mockito.when(table.getRemoteName()).thenReturn("TBL1");
+    public void testRenameReplayInvalidatesConnectorDatabaseOnFollower() {
+        replayRename();
 
-        refreshManager.replayRefreshTable(ExternalObjectLog.createForRenameTable(7L, "db1", "t1", "t2"));
-
-        // WHY (Rule 9 / R4): both the source (REMOTE DB1.TBL1) and the target (DB1.t2, new name NOT
-        // remote-resolved — parity with the coordinator) connector caches must be dropped so an atomic swap
-        // doesn't serve the pre-rename pin. MUTATION: removing the rename-branch invalidation, or passing the
-        // LOCAL names, turns this red.
-        Mockito.verify(connector).invalidateTable("DB1", "TBL1");
-        Mockito.verify(connector).invalidateTable("DB1", "t2");
-        // Base bookkeeping is preserved: the source name is unregistered and the db's name cache reset.
-        Mockito.verify(db).unregisterTable("t1");
-        Mockito.verify(db).resetMetaCacheNames();
+        InOrder order = Mockito.inOrder(connector, db, metaCacheMgr);
+        order.verify(connector).invalidateDb("DB1");
+        order.verify(db).invalidateTableRename("t1", "t2");
+        order.verify(metaCacheMgr).invalidateTableRename(
+                7L, dbId, "db1", sourceTableId, "t1", destinationTableId, "t2");
     }
 
     @Test
-    public void testRenameReplayUninitializedCatalogSkipsInvalidate() {
-        // A follower that never initialized this catalog: getDbForReplay returns empty, so the replay resolves
-        // no db/table and returns early — the connector is never consulted (no force-init, no cache to drop).
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Connector connector = Mockito.mock(Connector.class);
-        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(7L);
+    public void testRenameReplayWithoutDatabaseObjectInvalidatesBothIdentitiesWithoutConnectorInit() {
         Mockito.doReturn(Optional.empty()).when(catalog).getDbForReplay("db1");
 
-        refreshManager.replayRefreshTable(ExternalObjectLog.createForRenameTable(7L, "db1", "t1", "t2"));
+        replayRename();
 
-        // WHY (R4 no-force-init): an uninitialized catalog has no connector cache to drop; the replay must not
-        // touch (or force-build) the connector. MUTATION: force-initializing / invalidating here -> red.
+        Mockito.verify(metaCacheMgr).invalidateTableRename(
+                7L, dbId, "db1", sourceTableId, "t1", destinationTableId, "t2");
+        Mockito.verify(catalog).invalidateAllConnectorCachesIfPresent();
         Mockito.verify(catalog, Mockito.never()).getConnector();
         Mockito.verifyNoInteractions(connector);
+    }
+
+    private void replayRename() {
+        refreshManager.replayRefreshTable(ExternalObjectLog.createForRenameTable(
+                7L, "db1", "t1", "t2"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshManagerTest.java
@@ -20,15 +20,16 @@ package org.apache.doris.catalog;
 import org.apache.doris.catalog.constraint.ConstraintManager;
 import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.ExternalMetaCacheMgr;
+import org.apache.doris.datasource.ExternalRowCountCache;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.log.ExternalObjectLog;
-import org.apache.doris.datasource.metacache.CacheSpec;
 import org.apache.doris.datasource.metacache.ExternalMetaCache;
 import org.apache.doris.datasource.metacache.ExternalMetaCacheRegistry;
 import org.apache.doris.datasource.metacache.MetaCacheEntry;
@@ -37,41 +38,55 @@ import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalDatabase;
 import org.apache.doris.datasource.test.TestExternalTable;
+import org.apache.doris.persist.EditLog;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class RefreshManagerTest {
     private static final long CATALOG_ID = 10L;
-    private static final long DATABASE_ID = 20L;
-    private static final long TABLE_ID = 30L;
+    private static final String CATALOG_NAME = "test_catalog";
     private static final String DATABASE_NAME = "db1";
     private static final String TABLE_NAME = "tbl1";
     private static final String NEW_TABLE_NAME = "tbl2";
+    private static final long DATABASE_ID = Util.genIdByName(CATALOG_NAME, DATABASE_NAME);
+    private static final long TABLE_ID = Util.genIdByName(CATALOG_NAME, DATABASE_NAME, TABLE_NAME);
 
-    private Env originalEnv;
+    private MockedStatic<Env> mockedEnv;
     private TestExternalCatalog catalog;
     private CountingDatabase database;
     private RecordingExternalMetaCache engineCache;
+    private ExternalMetaCacheMgr metaCacheMgr;
     private RecordingConstraintManager constraintManager;
-    private AtomicInteger databaseObjectLoadCalls;
+    private EditLog editLog;
     private TestingCatalogMgr testingCatalogMgr;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Map<String, String> properties = Collections.singletonMap(
                 "catalog_provider.class", EmptyCatalogProvider.class.getName());
-        catalog = new TestExternalCatalog(CATALOG_ID, "test_catalog", "", properties, "");
+        catalog = new TestExternalCatalog(CATALOG_ID, CATALOG_NAME, "", properties, "");
         catalog.setInitializedForTest(true);
 
         database = new CountingDatabase(catalog, DATABASE_ID, DATABASE_NAME, DATABASE_NAME);
@@ -79,22 +94,60 @@ public class RefreshManagerTest {
         catalog.addDatabaseForTest(database);
 
         engineCache = new RecordingExternalMetaCache();
-        databaseObjectLoadCalls = new AtomicInteger();
-        ExternalMetaCacheMgr metaCacheMgr = new ExternalMetaCacheMgr(true);
+        metaCacheMgr = Mockito.spy(new ExternalMetaCacheMgr(true));
         ExternalMetaCacheRegistry cacheRegistry = Deencapsulation.getField(metaCacheMgr, "cacheRegistry");
         cacheRegistry.resetForTest(Collections.singletonList(engineCache));
         constraintManager = new RecordingConstraintManager();
         testingCatalogMgr = new TestingCatalogMgr(catalog);
-        originalEnv = replaceEnvSingleton(
-                new TestingEnv(testingCatalogMgr, metaCacheMgr, constraintManager));
+        TestingEnv testingEnv = new TestingEnv(testingCatalogMgr, metaCacheMgr, constraintManager);
+        editLog = Mockito.mock(EditLog.class);
+        testingEnv.setEditLog(editLog);
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(testingEnv);
     }
 
     @After
-    public void tearDown() throws Exception {
-        if (originalEnv != null) {
-            replaceEnvSingleton(originalEnv);
-            originalEnv = null;
+    public void tearDown() {
+        if (mockedEnv != null) {
+            mockedEnv.close();
+            mockedEnv = null;
         }
+    }
+
+    @Test
+    public void testReplayRefreshDbReturnsWhenCatalogIsMissing() {
+        testingCatalogMgr.setCatalog(null);
+        Mockito.clearInvocations(metaCacheMgr);
+
+        new RefreshManager().replayRefreshDb(
+                ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME));
+
+        Mockito.verifyNoInteractions(metaCacheMgr);
+    }
+
+    @Test
+    public void testReplayHotRefreshDbInvalidatesMetadataThenRowCountOnce() {
+        ExternalObjectLog log = ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME);
+
+        new RefreshManager().replayRefreshDb(log);
+
+        InOrder order = Mockito.inOrder(metaCacheMgr);
+        order.verify(metaCacheMgr).invalidateDbMetadataCache(CATALOG_ID, DATABASE_NAME);
+        order.verify(metaCacheMgr).invalidateDbRowCountCache(CATALOG_ID, DATABASE_ID);
+        Mockito.verify(metaCacheMgr, Mockito.never()).invalidateDb(
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString());
+    }
+
+    @Test
+    public void testReplayHotRefreshDbKeepsRowCountBarrierWhenMetadataInvalidationFails() {
+        engineCache.failDbInvalidation = true;
+        ExternalObjectLog log = ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME);
+
+        Assert.assertThrows(IllegalStateException.class, () -> new RefreshManager().replayRefreshDb(log));
+
+        InOrder order = Mockito.inOrder(metaCacheMgr);
+        order.verify(metaCacheMgr).invalidateDbMetadataCache(CATALOG_ID, DATABASE_NAME);
+        order.verify(metaCacheMgr).invalidateDbRowCountCache(CATALOG_ID, DATABASE_ID);
     }
 
     @Test
@@ -106,149 +159,163 @@ public class RefreshManagerTest {
         new RefreshManager().replayRefreshTable(log);
 
         assertColdTableInvalidatedByName();
+        Mockito.verify(metaCacheMgr).invalidateTable(
+                CATALOG_ID, DATABASE_ID, DATABASE_NAME, TABLE_ID, TABLE_NAME);
     }
 
     @Test
-    public void testReplayNameBasedRefreshDbInvalidatesEngineCacheWhenDatabaseObjectCacheHasTtlZero() {
-        disableDatabaseObjectCacheWithTtlZero();
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME);
-
-        new RefreshManager().replayRefreshDb(log);
-
-        Assert.assertEquals(1, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(CATALOG_ID, engineCache.lastCatalogId);
-        Assert.assertEquals(DATABASE_NAME, engineCache.lastDatabaseName);
-        Assert.assertEquals(0, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(0, databaseObjectLoadCalls.get());
-    }
-
-    @Test
-    public void testReplayNameBasedRefreshTableInvalidatesEngineCacheWhenDatabaseObjectCacheHasTtlZero() {
-        disableDatabaseObjectCacheWithTtlZero();
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
-                CATALOG_ID, DATABASE_NAME, TABLE_NAME, 123L);
-
-        new RefreshManager().replayRefreshTable(log);
-
-        Assert.assertEquals(0, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(1, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(CATALOG_ID, engineCache.lastCatalogId);
-        Assert.assertEquals(DATABASE_NAME, engineCache.lastDatabaseName);
-        Assert.assertEquals(TABLE_NAME, engineCache.lastTableName);
-        Assert.assertEquals(0, databaseObjectLoadCalls.get());
-    }
-
-    @Test
-    public void testReplayIdOnlyRefreshDbInvalidatesDatabaseScopeWhenDatabaseObjectCacheHasTtlZero() {
-        Connector connector = usePluginCatalogWithDisabledDatabaseObjectCache();
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME);
-        log.setDbName(null);
-        log.setDbId(DATABASE_ID);
-
-        new RefreshManager().replayRefreshDb(log);
-
-        Assert.assertEquals(1, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(0, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(CATALOG_ID, engineCache.lastCatalogId);
-        Assert.assertEquals(DATABASE_NAME, engineCache.lastDatabaseName);
-        Assert.assertEquals(0, databaseObjectLoadCalls.get());
-        Mockito.verify(connector).invalidateAll();
-    }
-
-    @Test
-    public void testReplayIdOnlyRefreshTableInvalidatesDatabaseScopeWhenDatabaseObjectCacheHasTtlZero() {
-        Connector connector = usePluginCatalogWithDisabledDatabaseObjectCache();
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
-                CATALOG_ID, DATABASE_NAME, TABLE_NAME, 123L);
-        log.setDbName(null);
-        log.setTableName(null);
-        log.setDbId(DATABASE_ID);
-        log.setTableId(TABLE_ID);
-
-        new RefreshManager().replayRefreshTable(log);
-
-        Assert.assertEquals(1, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(0, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(CATALOG_ID, engineCache.lastCatalogId);
-        Assert.assertEquals(DATABASE_NAME, engineCache.lastDatabaseName);
-        Assert.assertEquals(0, databaseObjectLoadCalls.get());
-        Mockito.verify(connector).invalidateAll();
-    }
-
-    @Test
-    public void testReplayIdOnlyRefreshTableInvalidatesPluginDatabaseWhenTableObjectIsCold() {
+    public void testRefreshTableRemovesRowCountLoadedDuringConnectorInvalidation() throws Exception {
         PluginCatalogFixture fixture = usePluginCatalog();
-        ExternalTable table = new ExternalTable(
-                TABLE_ID, TABLE_NAME, TABLE_NAME, fixture.catalog, fixture.database,
-                TableIf.TableType.PLUGIN_EXTERNAL_TABLE);
-        fixture.database.addTableForTest(table);
-        fixture.database.evictTableObjectForTest(TABLE_NAME);
-        Assert.assertTrue(fixture.catalog.getDbForReplay(DATABASE_NAME).isPresent());
-        Assert.assertFalse(fixture.database.getTableForReplay(TABLE_NAME).isPresent());
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getCatalog()).thenReturn(fixture.catalog);
+        Mockito.when(table.getDb()).thenReturn(fixture.database);
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
+        Mockito.when(table.getDbName()).thenReturn(DATABASE_NAME);
+        Mockito.when(table.getName()).thenReturn(TABLE_NAME);
+        Mockito.when(table.getRemoteName()).thenReturn(TABLE_NAME);
+        AtomicLong sourceRowCount = new AtomicLong(100L);
+        Mockito.when(table.fetchRowCountWithMetaCache(false)).thenAnswer(inv -> sourceRowCount.get());
 
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
-                CATALOG_ID, DATABASE_NAME, TABLE_NAME, 123L);
-        log.setDbName(null);
-        log.setTableName(null);
-        log.setDbId(DATABASE_ID);
-        log.setTableId(TABLE_ID);
+        CountDownLatch connectorInvalidationStarted = new CountDownLatch(1);
+        CountDownLatch finishConnectorInvalidation = new CountDownLatch(1);
+        Mockito.doAnswer(inv -> {
+            connectorInvalidationStarted.countDown();
+            Assert.assertTrue(finishConnectorInvalidation.await(3L, TimeUnit.SECONDS));
+            sourceRowCount.set(200L);
+            return null;
+        }).when(fixture.connector).invalidateTable(DATABASE_NAME, TABLE_NAME);
 
-        new RefreshManager().replayRefreshTable(log);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (MockedConstruction<ExternalRowCountCache.RowCountCacheLoader> mocked =
+                Mockito.mockConstruction(ExternalRowCountCache.RowCountCacheLoader.class,
+                        (loader, context) -> Mockito.when(loader.asyncLoad(Mockito.any(), Mockito.any()))
+                                .thenAnswer(inv -> CompletableFuture.completedFuture(
+                                        Optional.of(sourceRowCount.get()))))) {
+            ExternalRowCountCache rowCountCache =
+                    new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+            Deencapsulation.setField(metaCacheMgr, "rowCountCache", rowCountCache);
 
-        Assert.assertEquals(0, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(1, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(CATALOG_ID, engineCache.lastCatalogId);
-        Assert.assertEquals(DATABASE_NAME, engineCache.lastDatabaseName);
-        Assert.assertEquals(TABLE_NAME, engineCache.lastTableName);
-        Assert.assertEquals(0, fixture.database.buildTableCalls.get());
-        Mockito.verify(fixture.connector).invalidateDb(DATABASE_NAME);
-        Mockito.verify(fixture.connector, Mockito.never()).invalidateAll();
+            Future<Long> loadDuringConnectorInvalidation = executor.submit(() -> {
+                Assert.assertTrue(connectorInvalidationStarted.await(3L, TimeUnit.SECONDS));
+                try {
+                    return rowCountCache.getCachedRowCount(CATALOG_ID, DATABASE_ID, TABLE_ID, false);
+                } finally {
+                    finishConnectorInvalidation.countDown();
+                }
+            });
+            new RefreshManager().refreshTableInternal(fixture.database, table, 123L);
+
+            Assert.assertEquals(100L, loadDuringConnectorInvalidation.get(3L, TimeUnit.SECONDS).longValue());
+            Assert.assertEquals(TableIf.UNKNOWN_ROW_COUNT,
+                    rowCountCache.getCachedRowCountIfPresent(CATALOG_ID, DATABASE_ID, TABLE_ID));
+            Assert.assertEquals(200L,
+                    rowCountCache.getCachedRowCount(CATALOG_ID, DATABASE_ID, TABLE_ID, false));
+            Mockito.verify(metaCacheMgr).invalidateTable(
+                    CATALOG_ID, DATABASE_ID, DATABASE_NAME, TABLE_ID, TABLE_NAME);
+        } finally {
+            finishConnectorInvalidation.countDown();
+            executor.shutdownNow();
+        }
     }
 
     @Test
-    public void testReplayIdOnlyRefreshDbDoesNothingWhenRetainedDatabaseMappingIsMissing() {
-        Assert.assertFalse(catalog.getDbNameForReplay(DATABASE_ID + 1).isPresent());
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME);
-        log.setDbName(null);
-        log.setDbId(DATABASE_ID + 1);
+    public void testRefreshTableKeepsLocalBarrierWhenConnectorInvalidationFails() {
+        PluginCatalogFixture fixture = usePluginCatalog();
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getCatalog()).thenReturn(fixture.catalog);
+        Mockito.when(table.getDb()).thenReturn(fixture.database);
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
+        Mockito.when(table.getDbName()).thenReturn(DATABASE_NAME);
+        Mockito.when(table.getName()).thenReturn(TABLE_NAME);
+        Mockito.when(table.getRemoteName()).thenReturn(TABLE_NAME);
+        Mockito.doThrow(new IllegalStateException("connector invalidation failed"))
+                .when(fixture.connector).invalidateTable(DATABASE_NAME, TABLE_NAME);
 
-        new RefreshManager().replayRefreshDb(log);
+        Assert.assertThrows(IllegalStateException.class,
+                () -> new RefreshManager().refreshTableInternal(fixture.database, table, 123L));
 
-        Assert.assertEquals(0, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(0, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(0, databaseObjectLoadCalls.get());
+        Mockito.verify(metaCacheMgr).invalidateTable(table);
     }
 
     @Test
-    public void testReplayIdOnlyRefreshTableDoesNothingWhenRetainedDatabaseMappingIsMissing() {
-        Assert.assertFalse(catalog.getDbNameForReplay(DATABASE_ID + 1).isPresent());
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
-                CATALOG_ID, DATABASE_NAME, TABLE_NAME, 123L);
-        log.setDbName(null);
-        log.setTableName(null);
-        log.setDbId(DATABASE_ID + 1);
-        log.setTableId(TABLE_ID);
+    public void testRefreshTableAfterExternalMutationLogsBeforeFallibleInvalidation() {
+        ExternalCatalog externalCatalog = Mockito.mock(ExternalCatalog.class);
+        ExternalDatabase database = Mockito.mock(ExternalDatabase.class);
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(externalCatalog.getId()).thenReturn(CATALOG_ID);
+        Mockito.when(database.getFullName()).thenReturn(DATABASE_NAME);
+        Mockito.when(table.getCatalog()).thenReturn(externalCatalog);
+        Mockito.when(table.getDb()).thenReturn(database);
+        Mockito.when(table.getName()).thenReturn(TABLE_NAME);
+        RefreshManager refreshManager = Mockito.spy(new RefreshManager());
+        IllegalStateException refreshFailure = new IllegalStateException("cache invalidation failed");
+        Mockito.doThrow(refreshFailure).when(refreshManager)
+                .refreshTableInternal(Mockito.eq(database), Mockito.eq(table), Mockito.anyLong());
 
-        new RefreshManager().replayRefreshTable(log);
+        IllegalStateException thrown = Assert.assertThrows(IllegalStateException.class,
+                () -> refreshManager.refreshTableAfterExternalMutation(table));
+        Assert.assertSame(refreshFailure, thrown);
 
-        Assert.assertEquals(0, engineCache.invalidateDbCalls.get());
-        Assert.assertEquals(0, engineCache.invalidateTableCalls.get());
-        Assert.assertEquals(0, databaseObjectLoadCalls.get());
+        InOrder order = Mockito.inOrder(editLog, refreshManager);
+        ArgumentCaptor<ExternalObjectLog> logCaptor = ArgumentCaptor.forClass(ExternalObjectLog.class);
+        order.verify(editLog).logRefreshExternalTable(logCaptor.capture());
+        ExternalObjectLog log = logCaptor.getValue();
+        Assert.assertEquals(CATALOG_ID, log.getCatalogId());
+        Assert.assertEquals(DATABASE_NAME, log.getDbName());
+        Assert.assertEquals(TABLE_NAME, log.getTableName());
+        order.verify(refreshManager).refreshTableInternal(database, table, log.getLastUpdateTime());
     }
 
     @Test
-    public void testReplayIdOnlyRefreshInvalidatesColdTableByRetainedName() {
-        seedAndEvictTableObject();
-        ExternalObjectLog log = ExternalObjectLog.createForRefreshTable(
-                CATALOG_ID, DATABASE_NAME, TABLE_NAME, 123L);
-        log.setDbName(null);
-        log.setTableName(null);
-        log.setDbId(DATABASE_ID);
-        log.setTableId(TABLE_ID);
+    public void testReplayRefreshDbKeepsLocalBarrierWhenConnectorInvalidationFails() {
+        PluginCatalogFixture fixture = usePluginCatalog();
+        Mockito.doThrow(new IllegalStateException("connector invalidation failed"))
+                .when(fixture.connector).invalidateDb(DATABASE_NAME);
 
-        new RefreshManager().replayRefreshTable(log);
+        Assert.assertThrows(IllegalStateException.class,
+                () -> new RefreshManager().replayRefreshDb(
+                        ExternalObjectLog.createForRefreshDb(CATALOG_ID, DATABASE_NAME)));
 
-        assertColdTableInvalidatedByName();
+        Assert.assertFalse(fixture.database.isInitialized());
+        Mockito.verify(metaCacheMgr).invalidateDbMetadataCache(CATALOG_ID, DATABASE_NAME);
+        Mockito.verify(metaCacheMgr).invalidateDbRowCountCache(CATALOG_ID, DATABASE_ID);
+    }
+
+    @Test
+    public void testReplayRenameEvictsPreexistingSourceAndDestinationRowCounts() {
+        long sourceTableId = Util.genIdByName(catalog.getName(), DATABASE_NAME, TABLE_NAME);
+        long destinationTableId = Util.genIdByName(catalog.getName(), DATABASE_NAME, NEW_TABLE_NAME);
+        try (MockedConstruction<ExternalRowCountCache.RowCountCacheLoader> mocked =
+                Mockito.mockConstruction(ExternalRowCountCache.RowCountCacheLoader.class,
+                        (loader, context) -> Mockito.when(loader.asyncLoad(Mockito.any(), Mockito.any()))
+                                .thenAnswer(inv -> {
+                                    ExternalRowCountCache.RowCountKey key = inv.getArgument(0);
+                                    long rowCount = key.getTableId() == sourceTableId ? 100L : 200L;
+                                    return CompletableFuture.completedFuture(Optional.of(rowCount));
+                                }))) {
+            ExternalRowCountCache rowCountCache =
+                    new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+            Deencapsulation.setField(metaCacheMgr, "rowCountCache", rowCountCache);
+            Assert.assertEquals(100L,
+                    rowCountCache.getCachedRowCount(CATALOG_ID, DATABASE_ID, sourceTableId, false));
+            Assert.assertEquals(200L,
+                    rowCountCache.getCachedRowCount(CATALOG_ID, DATABASE_ID, destinationTableId, false));
+
+            database.addTableForTest(
+                    new TestExternalTable(sourceTableId, TABLE_NAME, TABLE_NAME, catalog, database));
+            database.addTableForTest(
+                    new TestExternalTable(destinationTableId, NEW_TABLE_NAME, NEW_TABLE_NAME, catalog, database));
+            Assert.assertNotNull(database.getCachedTableForTest(NEW_TABLE_NAME));
+            new RefreshManager().replayRefreshTable(ExternalObjectLog.createForRenameTable(
+                    CATALOG_ID, DATABASE_NAME, TABLE_NAME, NEW_TABLE_NAME));
+
+            Assert.assertNull(database.getCachedTableForTest(TABLE_NAME));
+            Assert.assertNull(database.getCachedTableForTest(NEW_TABLE_NAME));
+            Assert.assertEquals(TableIf.UNKNOWN_ROW_COUNT,
+                    rowCountCache.getCachedRowCountIfPresent(CATALOG_ID, DATABASE_ID, sourceTableId));
+            Assert.assertEquals(TableIf.UNKNOWN_ROW_COUNT,
+                    rowCountCache.getCachedRowCountIfPresent(CATALOG_ID, DATABASE_ID, destinationTableId));
+        }
     }
 
     @Test
@@ -262,21 +329,6 @@ public class RefreshManagerTest {
         assertColdRenameMigrated();
     }
 
-    @Test
-    public void testReplayIdOnlyRenameMigratesColdLocalState() {
-        seedAndEvictTableObject();
-        ExternalObjectLog log = ExternalObjectLog.createForRenameTable(
-                CATALOG_ID, DATABASE_NAME, TABLE_NAME, NEW_TABLE_NAME);
-        log.setDbName(null);
-        log.setTableName(null);
-        log.setDbId(DATABASE_ID);
-        log.setTableId(TABLE_ID);
-
-        new RefreshManager().replayRefreshTable(log);
-
-        assertColdRenameMigrated();
-    }
-
     private void seedAndEvictTableObject() {
         TestExternalTable table = new TestExternalTable(TABLE_ID, TABLE_NAME, TABLE_NAME, catalog, database);
         database.addTableForTest(table);
@@ -284,36 +336,11 @@ public class RefreshManagerTest {
         Assert.assertFalse(database.getTableForReplay(TABLE_NAME).isPresent());
     }
 
-    private void disableDatabaseObjectCacheWithTtlZero() {
-        disableDatabaseObjectCacheWithTtlZero(catalog, database);
-    }
-
-    private void disableDatabaseObjectCacheWithTtlZero(
-            ExternalCatalog targetCatalog, ExternalDatabase<? extends ExternalTable> targetDatabase) {
-        MetaCacheEntry<String, ExternalDatabase<? extends ExternalTable>> disabledDatabases = new MetaCacheEntry<>(
-                "ttl_zero_databases",
-                ignored -> {
-                    databaseObjectLoadCalls.incrementAndGet();
-                    return targetDatabase;
-                },
-                CacheSpec.of(true, 0L, 10L),
-                Env.getCurrentEnv().getExtMetaCacheMgr().commonRefreshExecutor(),
-                false);
-        Deencapsulation.setField(targetCatalog, "databases", disabledDatabases);
-        Assert.assertFalse(targetCatalog.getDbForReplay(DATABASE_NAME).isPresent());
-    }
-
-    private Connector usePluginCatalogWithDisabledDatabaseObjectCache() {
-        PluginCatalogFixture fixture = usePluginCatalog();
-        disableDatabaseObjectCacheWithTtlZero(fixture.catalog, fixture.database);
-        return fixture.connector;
-    }
-
     private PluginCatalogFixture usePluginCatalog() {
         Connector connector = Mockito.mock(Connector.class);
         Map<String, String> properties = Collections.singletonMap("type", "test");
         PluginDrivenExternalCatalog pluginCatalog = new PluginDrivenExternalCatalog(
-                CATALOG_ID, "test_catalog", null, properties, "", connector);
+                CATALOG_ID, CATALOG_NAME, null, properties, "", connector);
         pluginCatalog.setInitializedForTest(true);
         PluginDatabase pluginDatabase =
                 new PluginDatabase(pluginCatalog, DATABASE_ID, DATABASE_NAME, DATABASE_NAME);
@@ -333,11 +360,10 @@ public class RefreshManagerTest {
     }
 
     private void assertColdRenameMigrated() {
-        Assert.assertEquals(1, engineCache.invalidateTableCalls.get());
         Assert.assertEquals(CATALOG_ID, engineCache.lastCatalogId);
         Assert.assertEquals(DATABASE_NAME, engineCache.lastDatabaseName);
-        Assert.assertEquals(TABLE_NAME, engineCache.lastTableName);
-        Assert.assertFalse(database.getTableNameForReplay(TABLE_ID).isPresent());
+        Assert.assertEquals(NEW_TABLE_NAME, engineCache.lastTableName);
+        Assert.assertNull(database.getCachedTableNameByIdForTest(TABLE_ID));
         Assert.assertFalse(database.getTableForReplay(TABLE_NAME).isPresent());
         Assert.assertNull(database.getCachedTableNamesForTest());
         Assert.assertEquals(0, database.buildTableCalls.get());
@@ -348,24 +374,6 @@ public class RefreshManagerTest {
         Assert.assertEquals("test_catalog", constraintManager.newTableName.getCtl());
         Assert.assertEquals(DATABASE_NAME, constraintManager.newTableName.getDb());
         Assert.assertEquals(NEW_TABLE_NAME, constraintManager.newTableName.getTbl());
-    }
-
-    private static Env replaceEnvSingleton(Env newInstance) throws Exception {
-        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
-        unsafeField.setAccessible(true);
-        Object unsafe = unsafeField.get(null);
-        Class<?> singletonHolder = Class.forName("org.apache.doris.catalog.Env$SingletonHolder");
-        Field instanceField = singletonHolder.getDeclaredField("INSTANCE");
-        Method staticFieldOffset = unsafeClass.getMethod("staticFieldOffset", Field.class);
-        Method staticFieldBase = unsafeClass.getMethod("staticFieldBase", Field.class);
-        Method getObject = unsafeClass.getMethod("getObject", Object.class, long.class);
-        Method putObject = unsafeClass.getMethod("putObject", Object.class, long.class, Object.class);
-        long offset = (long) staticFieldOffset.invoke(unsafe, instanceField);
-        Object base = staticFieldBase.invoke(unsafe, instanceField);
-        Env old = (Env) getObject.invoke(unsafe, base, offset);
-        putObject.invoke(unsafe, base, offset, newInstance);
-        return old;
     }
 
     public static class EmptyCatalogProvider implements TestExternalCatalog.TestCatalogProvider {
@@ -432,7 +440,7 @@ public class RefreshManagerTest {
 
         @Override
         public CatalogIf<? extends DatabaseIf<? extends TableIf>> getCatalog(long id) {
-            return id == catalog.getId() ? catalog : null;
+            return catalog != null && id == catalog.getId() ? catalog : null;
         }
     }
 
@@ -481,6 +489,7 @@ public class RefreshManagerTest {
     private static class RecordingExternalMetaCache implements ExternalMetaCache {
         private final AtomicInteger invalidateDbCalls = new AtomicInteger();
         private final AtomicInteger invalidateTableCalls = new AtomicInteger();
+        private boolean failDbInvalidation;
         private long lastCatalogId;
         private String lastDatabaseName;
         private String lastTableName;
@@ -523,6 +532,9 @@ public class RefreshManagerTest {
             lastCatalogId = catalogId;
             lastDatabaseName = dbName;
             invalidateDbCalls.incrementAndGet();
+            if (failDbInvalidation) {
+                throw new IllegalStateException("database metadata invalidation failed");
+            }
         }
 
         @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManagerExternalTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManagerExternalTest.java
@@ -235,13 +235,7 @@ public class NereidsSortedPartitionsCacheManagerExternalTest {
         PluginDrivenMvccSnapshot pinT1 = new PluginDrivenMvccSnapshot(
                 connectorSnapshotT1, pinnedPartsT1, Maps.newHashMap());
 
-        // A DIFFERENT pin for the SAME table at a second @tag reference. With two non-default versions
-        // pinned and no default ("") entry, the version-BLIND lookup (StatementContext#getSnapshot(TableIf))
-        // is ambiguous and gives up (see its javadoc); only the version-AWARE lookup that the
-        // LogicalFileScan branch of pinnedSnapshot uses resolves the exact t1 reference. MUTATION:
-        // collapsing pinnedSnapshot to the version-blind fallback makes this test observably diverge
-        // (an unresolved pin sends getOrMaterialize to materializeLatest() on a field-less mock, or the
-        // assertions below simply see the wrong values).
+        // A second version makes the version-blind lookup ambiguous; the scan must resolve its exact reference.
         ConnectorMvccSnapshot connectorSnapshotT2 = ConnectorMvccSnapshot.builder()
                 .snapshotId(99L).schemaId(3L).build();
         PluginDrivenMvccSnapshot pinT2 = new PluginDrivenMvccSnapshot(
@@ -515,12 +509,12 @@ public class NereidsSortedPartitionsCacheManagerExternalTest {
         ExternalMetaCacheMgr metaCacheMgr = new ExternalMetaCacheMgr(true);
         try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
             envStatic.when(Env::getCurrentEnv).thenReturn(env);
-            metaCacheMgr.invalidateTable(catalogId, DB, TBL);
+            metaCacheMgr.invalidateTable(catalogId, 8L, DB, 9L, TBL);
         }
 
         Assertions.assertEquals(0, rangesCacheMgr.getPartitionCaches().estimatedSize(),
                 "ExternalMetaCacheMgr.invalidateTable must also drop the "
-                        + "NereidsSortedPartitionsCacheManager entry (ExternalMetaCacheMgr.java:217-220)");
+                        + "NereidsSortedPartitionsCacheManager entry");
     }
 
     // ── db/catalog-level invalidation also drops Cache B (§10 completeness) ──
@@ -566,7 +560,7 @@ public class NereidsSortedPartitionsCacheManagerExternalTest {
 
     @Test
     public void testInvalidateDbDropsRangesCache() throws Exception {
-        assertDropsAllRangesCache(m -> m.invalidateDb(CATALOG_ID, DB));
+        assertDropsAllRangesCache(m -> m.invalidateDbMetadataCache(CATALOG_ID, DB));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -42,12 +42,16 @@ import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -524,6 +528,23 @@ public class ExternalCatalogTest extends TestWithFeService {
     }
 
     @Test
+    public void testReplayCreateDbRemovesCaseEquivalentPreviousIncarnation() {
+        IncrementalUpdateCatalog catalog = new IncrementalUpdateCatalog(2);
+        catalog.setInitializedForTest(true);
+        long previousDbId = Util.genIdByName(catalog.getName(), "MixedDb");
+        long createdDbId = Util.genIdByName(catalog.getName(), "mixeddb");
+        TestExternalDatabase previousDb =
+                new TestExternalDatabase(catalog, previousDbId, "MixedDb", "MixedDb");
+        catalog.addDatabaseForTest(previousDb);
+
+        catalog.replayCreateDb("mixeddb");
+
+        Assertions.assertNotEquals(previousDbId, createdDbId);
+        Assertions.assertNull(catalog.getCachedDatabaseForTest("MixedDb"));
+        Assertions.assertNull(catalog.getCachedDatabaseNameByIdForTest(previousDbId));
+    }
+
+    @Test
     public void testCaseInsensitiveDatabaseUnregisterClearsCanonicalColdIdMap() {
         IncrementalUpdateCatalog catalog = new IncrementalUpdateCatalog(2);
         catalog.setInitializedForTest(true);
@@ -953,7 +974,7 @@ public class ExternalCatalogTest extends TestWithFeService {
                     Util.genIdByName(catalog.getName(), db.getFullName(), "MixedTbl")));
             Assertions.assertEquals(0, db.getTableLookupCount());
 
-            mgr.unregisterExternalTable("db_ci", "MixedTbl", catalog.getName(), true);
+            mgr.unregisterExternalTableFromEvent("db_ci", "MixedTbl", catalog.getName());
 
             Assertions.assertNull(schemaEntry.getIfPresent(exactCaseKey));
             Assertions.assertEquals(0, db.getTableLookupCount());
@@ -985,8 +1006,24 @@ public class ExternalCatalogTest extends TestWithFeService {
         Map<String, CatalogIf> nameToCatalog = Deencapsulation.getField(mgr, "nameToCatalog");
         nameToCatalog.put(catalog.getName(), catalog);
         mgr.getIdToCatalog().put(catalog.getId(), catalog);
+        ExternalMetaCacheMgr cacheMgr = env.getExtMetaCacheMgr();
+        ExternalRowCountCache originalRowCountCache = cacheMgr.getRowCountCache();
+        ExternalRowCountCache rowCountCache = new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+        Deencapsulation.setField(cacheMgr, "rowCountCache", rowCountCache);
         try {
-            mgr.registerExternalTableFromEvent("db1", "tbl1", catalog.getName(), 123L, true);
+            ExternalTable statsTable = Mockito.mock(ExternalTable.class);
+            Mockito.when(statsTable.fetchRowCountWithMetaCache(false)).thenReturn(100L);
+            try (MockedStatic<StatisticsUtil> statisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+                statisticsUtil.when(() -> StatisticsUtil.findTable(catalog.getId(), db.getId(), tableId))
+                        .thenReturn(statsTable);
+                Assertions.assertEquals(100L,
+                        rowCountCache.getCachedRowCount(catalog.getId(), db.getId(), tableId, false));
+
+                mgr.registerExternalTableFromEvent("db1", "tbl1", "tbl1", catalog.getName(), 123L);
+
+                Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT,
+                        rowCountCache.getCachedRowCountIfPresent(catalog.getId(), db.getId(), tableId));
+            }
 
             TestExternalTable eventTable = db.getCachedTableForTest("tbl1");
             Assertions.assertNotNull(eventTable);
@@ -996,6 +1033,7 @@ public class ExternalCatalogTest extends TestWithFeService {
             Assertions.assertEquals("tbl1", db.getCachedTableNameByIdForTest(tableId));
             Assertions.assertEquals(0, db.getTableLookupCount());
         } finally {
+            Deencapsulation.setField(cacheMgr, "rowCountCache", originalRowCountCache);
             nameToCatalog.remove(catalog.getName());
             mgr.getIdToCatalog().remove(catalog.getId());
         }
@@ -1015,7 +1053,8 @@ public class ExternalCatalogTest extends TestWithFeService {
         nameToCatalog.put(catalog.getName(), catalog);
         mgr.getIdToCatalog().put(catalog.getId(), catalog);
         try {
-            mgr.registerExternalTableFromEvent("db_ci", "MixedTbl", catalog.getName(), 123L, true);
+            mgr.registerExternalTableFromEvent(
+                    "db_ci", "MixedTbl", "MixedTbl", catalog.getName(), 123L);
 
             long mixedCaseId = Util.genIdByName(catalog.getName(), db.getFullName(), "MixedTbl");
             long lowerCaseId = Util.genIdByName(catalog.getName(), db.getFullName(), "mixedtbl");
@@ -1027,7 +1066,7 @@ public class ExternalCatalogTest extends TestWithFeService {
 
             // Hive treats table names case-insensitively. A later DROP event may use another spelling, but mode 2
             // must still resolve it to the exact retained CREATE identity and remove that ID mapping.
-            mgr.unregisterExternalTable("db_ci", "mixedTBL", catalog.getName(), true);
+            mgr.unregisterExternalTableFromEvent("db_ci", "mixedTBL", catalog.getName());
 
             Assertions.assertNull(db.getCachedTableNameByIdForTest(mixedCaseId));
             Assertions.assertNull(db.getCachedTableNameByIdForTest(lowerCaseId));
@@ -1050,7 +1089,8 @@ public class ExternalCatalogTest extends TestWithFeService {
         nameToCatalog.put(catalog.getName(), catalog);
         mgr.getIdToCatalog().put(catalog.getId(), catalog);
         try {
-            mgr.registerExternalTableFromEvent("db_ci", remoteTableName, catalog.getName(), 1L, true);
+            mgr.registerExternalTableFromEvent(
+                    "db_ci", remoteTableName, localTableName, catalog.getName(), 1L);
             long tableId = Util.genIdByName(catalog.getName(), db.getFullName(), localTableName);
 
             Assertions.assertEquals(0, db.getTableLookupCount());
@@ -1060,7 +1100,9 @@ public class ExternalCatalogTest extends TestWithFeService {
 
             // The remote table has already disappeared when DROP_TABLE is delivered. The ignored event path must
             // still resolve the canonical local key without a load-through lookup and remove the cold ID mapping.
-            mgr.unregisterExternalTable("db_ci", dropTableName, catalog.getName(), true);
+            String localDropTableName = catalog.canonicalLocalTableNameFromRemote(
+                    db.getRemoteName(), dropTableName);
+            mgr.unregisterExternalTableFromEvent("db_ci", localDropTableName, catalog.getName());
 
             Assertions.assertEquals(0, db.getTableLookupCount());
             Assertions.assertNull(db.getCachedTableNamesForTest());
@@ -1633,15 +1675,6 @@ public class ExternalCatalogTest extends TestWithFeService {
         public TestExternalTable getTableNullable(String tableName) {
             tableLookupCount.incrementAndGet();
             return null;
-        }
-
-        @Override
-        public boolean registerTable(TableIf tableIf) {
-            makeSureInitialized();
-            TestExternalTable table = (TestExternalTable) tableIf;
-            updateTableCache(table, table.getRemoteName(), table.getName(), false);
-            setLastUpdateTime(System.currentTimeMillis());
-            return true;
         }
 
         int getTableLookupCount() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseTest.java
@@ -178,6 +178,27 @@ public class ExternalDatabaseTest extends TestWithFeService {
     }
 
     @Test
+    public void testReplayCreateTableRemovesCaseEquivalentPreviousIncarnation() {
+        CaseInsensitiveCatalog catalog = new CaseInsensitiveCatalog();
+        catalog.setInitializedForTest(true);
+        long dbId = Util.genIdByName(catalog.getName(), "db_ci");
+        InspectableDatabase db = new InspectableDatabase(catalog, dbId, "db_ci", "db_ci");
+        db.setInitializedForTest(true);
+        long previousTableId = Util.genIdByName(catalog.getName(), "db_ci", "MixedTbl");
+        long createdTableId = Util.genIdByName(catalog.getName(), "db_ci", "mixedtbl");
+        TestExternalTable previousTable =
+                new TestExternalTable(previousTableId, "MixedTbl", "MixedTbl", catalog, db);
+        db.addTableForTest(previousTable);
+        catalog.addDatabaseForTest(db);
+
+        catalog.replayCreateTable("db_ci", "mixedtbl");
+
+        Assertions.assertNotEquals(previousTableId, createdTableId);
+        Assertions.assertNull(db.getCachedTableForTest("MixedTbl"));
+        Assertions.assertNull(db.getCachedTableNameByIdForTest(previousTableId));
+    }
+
+    @Test
     public void testCaseInsensitiveTableUnregisterClearsCanonicalColdIdMap() {
         CaseInsensitiveCatalog catalog = new CaseInsensitiveCatalog();
         InspectableDatabase db = new InspectableDatabase(catalog, 231L, "db_ci", "db_ci");

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
@@ -17,20 +17,40 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.ThreadPoolManager;
+import org.apache.doris.common.cache.NereidsSortedPartitionsCacheManager;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.metacache.ExternalMetaCache;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.datasource.test.TestExternalDatabase;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ExternalRowCountCacheTest {
@@ -78,6 +98,287 @@ public class ExternalRowCountCacheTest {
 
         Mockito.verify(table).fetchRowCountWithMetaCache(true);
         Mockito.verify(table).fetchRowCountWithMetaCache(false);
+    }
+
+    @Test
+    public void testInvalidateTableReloadsRowCount() {
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        AtomicLong rowCount = new AtomicLong(100L);
+        Mockito.when(table.fetchRowCountWithMetaCache(false)).thenAnswer(inv -> rowCount.get());
+
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+            mockedStatisticsUtil.when(() -> StatisticsUtil.findTable(1, 2, 3)).thenReturn(table);
+
+            ExternalRowCountCache cache = new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+            Assertions.assertEquals(100L, cache.getCachedRowCount(1, 2, 3, false));
+
+            rowCount.set(200L);
+            Assertions.assertEquals(100L, cache.getCachedRowCount(1, 2, 3, false));
+
+            cache.invalidateTable(1, 2, 3);
+            Assertions.assertEquals(200L, cache.getCachedRowCount(1, 2, 3, false));
+        }
+
+        Mockito.verify(table, Mockito.times(2)).fetchRowCountWithMetaCache(false);
+    }
+
+    @Test
+    public void testCatalogAndDbInvalidationKeepUnrelatedRowCounts() {
+        ExternalTable firstTable = Mockito.mock(ExternalTable.class);
+        ExternalTable secondTable = Mockito.mock(ExternalTable.class);
+        ExternalTable otherCatalogTable = Mockito.mock(ExternalTable.class);
+        AtomicLong firstRowCount = new AtomicLong(100L);
+        AtomicLong secondRowCount = new AtomicLong(200L);
+        AtomicLong otherCatalogRowCount = new AtomicLong(300L);
+        Mockito.when(firstTable.fetchRowCountWithMetaCache(false)).thenAnswer(inv -> firstRowCount.get());
+        Mockito.when(secondTable.fetchRowCountWithMetaCache(false)).thenAnswer(inv -> secondRowCount.get());
+        Mockito.when(otherCatalogTable.fetchRowCountWithMetaCache(false))
+                .thenAnswer(inv -> otherCatalogRowCount.get());
+
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+            mockedStatisticsUtil.when(() -> StatisticsUtil.findTable(1, 11, 111)).thenReturn(firstTable);
+            mockedStatisticsUtil.when(() -> StatisticsUtil.findTable(1, 12, 112)).thenReturn(secondTable);
+            mockedStatisticsUtil.when(() -> StatisticsUtil.findTable(2, 11, 211)).thenReturn(otherCatalogTable);
+
+            ExternalRowCountCache cache = new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+            Assertions.assertEquals(100L, cache.getCachedRowCount(1, 11, 111, false));
+            Assertions.assertEquals(200L, cache.getCachedRowCount(1, 12, 112, false));
+            Assertions.assertEquals(300L, cache.getCachedRowCount(2, 11, 211, false));
+
+            firstRowCount.set(101L);
+            secondRowCount.set(202L);
+            otherCatalogRowCount.set(303L);
+            cache.invalidateDb(1, 11);
+            Assertions.assertEquals(101L, cache.getCachedRowCount(1, 11, 111, false));
+            Assertions.assertEquals(200L, cache.getCachedRowCount(1, 12, 112, false));
+            Assertions.assertEquals(300L, cache.getCachedRowCount(2, 11, 211, false));
+
+            firstRowCount.set(111L);
+            cache.invalidateCatalog(1);
+            Assertions.assertEquals(111L, cache.getCachedRowCount(1, 11, 111, false));
+            Assertions.assertEquals(202L, cache.getCachedRowCount(1, 12, 112, false));
+            Assertions.assertEquals(300L, cache.getCachedRowCount(2, 11, 211, false));
+        }
+    }
+
+    @Test
+    public void testTableInvalidationWaitsForFuturePublication() throws Exception {
+        ExecutorService loadExecutor = Mockito.mock(ExecutorService.class);
+        CountDownLatch loadSubmitted = new CountDownLatch(1);
+        CountDownLatch allowPublication = new CountDownLatch(1);
+        Mockito.doAnswer(inv -> {
+            loadSubmitted.countDown();
+            Assertions.assertTrue(allowPublication.await(3L, TimeUnit.SECONDS));
+            ((Runnable) inv.getArgument(0)).run();
+            return null;
+        }).when(loadExecutor).execute(Mockito.any());
+        ExecutorService callers = Executors.newFixedThreadPool(2);
+        try (MockedConstruction<ExternalRowCountCache.RowCountCacheLoader> mocked =
+                Mockito.mockConstruction(ExternalRowCountCache.RowCountCacheLoader.class,
+                        Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                        (loader, context) -> Mockito.doReturn(Optional.of(100L))
+                                .when(loader).doLoad(Mockito.any()))) {
+            ExternalRowCountCache cache = new ExternalRowCountCache(loadExecutor);
+
+            Future<Long> load = callers.submit(() -> cache.getCachedRowCount(1, 2, 3, false));
+            Assertions.assertTrue(loadSubmitted.await(3L, TimeUnit.SECONDS));
+            CountDownLatch invalidationStarted = new CountDownLatch(1);
+            Future<?> invalidation = callers.submit(() -> {
+                invalidationStarted.countDown();
+                cache.invalidateTable(1, 2, 3);
+            });
+            Assertions.assertTrue(invalidationStarted.await(3L, TimeUnit.SECONDS));
+            Assertions.assertThrows(TimeoutException.class,
+                    () -> invalidation.get(200L, TimeUnit.MILLISECONDS));
+
+            allowPublication.countDown();
+            Assertions.assertEquals(100L, load.get(3L, TimeUnit.SECONDS));
+            invalidation.get(3L, TimeUnit.SECONDS);
+            Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT, cache.getCachedRowCountIfPresent(1, 2, 3));
+        } finally {
+            allowPublication.countDown();
+            callers.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testTableInvalidationDiscardsPendingLoadCompletion() throws Exception {
+        CompletableFuture<Optional<Long>> loadedRowCount = new CompletableFuture<>();
+        CountDownLatch loadStarted = new CountDownLatch(1);
+        ExecutorService callers = Executors.newSingleThreadExecutor();
+        try (MockedConstruction<ExternalRowCountCache.RowCountCacheLoader> mocked =
+                Mockito.mockConstruction(ExternalRowCountCache.RowCountCacheLoader.class,
+                        (loader, context) -> Mockito.when(loader.asyncLoad(Mockito.any(), Mockito.any()))
+                                .thenAnswer(inv -> {
+                                    loadStarted.countDown();
+                                    return loadedRowCount;
+                                }))) {
+            ExternalRowCountCache cache =
+                    new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+
+            Future<Long> load = callers.submit(() -> cache.getCachedRowCount(1, 2, 3, false));
+            Assertions.assertTrue(loadStarted.await(3L, TimeUnit.SECONDS));
+            cache.invalidateTable(1, 2, 3);
+
+            loadedRowCount.complete(Optional.of(100L));
+            Assertions.assertEquals(100L, load.get(3L, TimeUnit.SECONDS));
+            Assertions.assertEquals(
+                    TableIf.UNKNOWN_ROW_COUNT, cache.getCachedRowCountIfPresent(1, 2, 3));
+        } finally {
+            loadedRowCount.complete(Optional.empty());
+            callers.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testUnregisterMissingIdentityInvalidatesDeterministicScopes() {
+        Map<String, String> properties = Collections.singletonMap(
+                "catalog_provider.class", EmptyCatalogProvider.class.getName());
+        TestExternalCatalog catalog = new TestExternalCatalog(1L, "catalog1", "", properties, "");
+        catalog.setInitializedForTest(true);
+        long dbId = Util.genIdByName("catalog1", "db1");
+        TestExternalDatabase db = new TestExternalDatabase(catalog, dbId, "db1", "db1");
+        db.setInitializedForTest(true);
+
+        ExternalMetaCacheMgr metaCacheMgr = Mockito.mock(ExternalMetaCacheMgr.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getExtMetaCacheMgr()).thenReturn(metaCacheMgr);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            db.unregisterTable("tbl1");
+            catalog.unregisterDatabase("db1");
+        }
+
+        Mockito.verify(metaCacheMgr).invalidateTable(
+                1L, dbId, "db1", Util.genIdByName("catalog1", "db1", "tbl1"), "tbl1");
+        Mockito.verify(metaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("catalog1", "db1"), "db1");
+    }
+
+    @Test
+    public void testTableHelpersUseOwningDatabaseIdentityBeforeTableInitialization() {
+        ExternalCatalog catalog = Mockito.mock(ExternalCatalog.class);
+        Mockito.when(catalog.getId()).thenReturn(1L);
+        ExternalDatabase database = Mockito.mock(ExternalDatabase.class);
+        Mockito.when(database.getId()).thenReturn(11L);
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getCatalog()).thenReturn(catalog);
+        Mockito.when(table.getDb()).thenReturn(database);
+        Mockito.when(table.getDbId()).thenReturn(0L);
+        Mockito.when(table.getDbName()).thenReturn("db1");
+        Mockito.when(table.getId()).thenReturn(22L);
+        Mockito.when(table.getName()).thenReturn("tbl1");
+
+        ExternalMetaCacheMgr metaCacheMgr = new ExternalMetaCacheMgr(true);
+        ExternalRowCountCache rowCountCache = Mockito.mock(ExternalRowCountCache.class);
+        Deencapsulation.setField(metaCacheMgr, "rowCountCache", rowCountCache);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            metaCacheMgr.invalidateTable(table);
+            metaCacheMgr.invalidateTableRowCountCache(table);
+        }
+
+        Mockito.verify(rowCountCache, Mockito.times(2)).invalidateTable(1L, 11L, 22L);
+        Mockito.verify(rowCountCache, Mockito.never()).invalidateTable(1L, 0L, 22L);
+    }
+
+    @Test
+    public void testRenameInvalidationCompletesDestinationBarrierWhenSourceMetadataFails() {
+        ExternalMetaCache engineCache = Mockito.mock(ExternalMetaCache.class);
+        Mockito.when(engineCache.engine()).thenReturn("default");
+        Mockito.when(engineCache.aliases()).thenReturn(Collections.emptySet());
+        Mockito.when(engineCache.isCatalogInitialized(1L)).thenReturn(true);
+        Mockito.doThrow(new IllegalStateException("metadata invalidation failed"))
+                .when(engineCache).invalidateTable(1L, "db1", "tbl1");
+
+        ExternalMetaCacheMgr metaCacheMgr = new ExternalMetaCacheMgr(true);
+        metaCacheMgr.replaceEngineCachesForTest(Collections.singletonList(engineCache));
+        ExternalRowCountCache rowCountCache = Mockito.mock(ExternalRowCountCache.class);
+        Deencapsulation.setField(metaCacheMgr, "rowCountCache", rowCountCache);
+        ExternalCatalog catalog = Mockito.mock(ExternalCatalog.class);
+        Mockito.when(catalog.getName()).thenReturn("catalog1");
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(1L);
+        NereidsSortedPartitionsCacheManager sortedPartitionsCacheManager =
+                Mockito.mock(NereidsSortedPartitionsCacheManager.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(env.getSortedPartitionsCacheManager()).thenReturn(sortedPartitionsCacheManager);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Assertions.assertThrows(IllegalStateException.class,
+                    () -> metaCacheMgr.invalidateTableRename(
+                            1L, 11L, "db1", 22L, "tbl1", 23L, "tbl2"));
+        }
+
+        InOrder inOrder = Mockito.inOrder(engineCache, sortedPartitionsCacheManager, rowCountCache);
+        inOrder.verify(engineCache).invalidateTable(1L, "db1", "tbl1");
+        inOrder.verify(sortedPartitionsCacheManager).invalidateTable("catalog1", "db1", "tbl1");
+        inOrder.verify(rowCountCache).invalidateTable(1L, 11L, 22L);
+        inOrder.verify(engineCache).invalidateTable(1L, "db1", "tbl2");
+        inOrder.verify(sortedPartitionsCacheManager).invalidateTable("catalog1", "db1", "tbl2");
+        inOrder.verify(rowCountCache).invalidateTable(1L, 11L, 23L);
+    }
+
+    @Test
+    public void testCatalogRefreshScansRowCountCacheOnceForMultipleHotDatabases() {
+        Map<String, String> properties = Collections.singletonMap(
+                "catalog_provider.class", EmptyCatalogProvider.class.getName());
+        TestExternalCatalog catalog = new TestExternalCatalog(1L, "catalog1", "", properties, "");
+        catalog.setInitializedForTest(true);
+        catalog.addDatabaseForTest(new TestExternalDatabase(catalog, 11L, "db1", "db1"));
+        catalog.addDatabaseForTest(new TestExternalDatabase(catalog, 12L, "db2", "db2"));
+
+        ExternalMetaCacheMgr metaCacheMgr = new ExternalMetaCacheMgr(true);
+        ExternalRowCountCache rowCountCache = Mockito.spy(
+                new ExternalRowCountCache(MoreExecutors.newDirectExecutorService()));
+        Deencapsulation.setField(metaCacheMgr, "rowCountCache", rowCountCache);
+
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(1L);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getExtMetaCacheMgr()).thenReturn(metaCacheMgr);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(env.getSortedPartitionsCacheManager())
+                .thenReturn(Mockito.mock(NereidsSortedPartitionsCacheManager.class));
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            catalog.onRefreshCache(true);
+        }
+
+        Mockito.verify(rowCountCache).invalidateCatalog(1L);
+        Mockito.verify(rowCountCache, Mockito.never()).invalidateDb(Mockito.anyLong(), Mockito.anyLong());
+    }
+
+    @Test
+    public void testInvalidateDbMetadataCacheDoesNotAccessDbForRowCount() {
+        ExternalCatalog catalog = Mockito.mock(ExternalCatalog.class);
+        Mockito.when(catalog.getId()).thenReturn(1L);
+
+        ExternalMetaCacheMgr metaCacheMgr = new ExternalMetaCacheMgr(true);
+        ExternalRowCountCache rowCountCache = Mockito.spy(
+                new ExternalRowCountCache(MoreExecutors.newDirectExecutorService()));
+        Deencapsulation.setField(metaCacheMgr, "rowCountCache", rowCountCache);
+
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(1L);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            metaCacheMgr.invalidateDbMetadataCache(1L, "db1");
+        }
+
+        Mockito.verify(catalog, Mockito.never()).getDbNullable("db1");
+        Mockito.verify(rowCountCache, Mockito.never()).invalidateDb(Mockito.anyLong(), Mockito.anyLong());
     }
 
     @Test
@@ -151,6 +452,13 @@ public class ExternalRowCountCacheTest {
                 Thread.sleep(1000);
             }
             Assertions.assertEquals(3, counter.get());
+        }
+    }
+
+    public static class EmptyCatalogProvider implements TestExternalCatalog.TestCatalogProvider {
+        @Override
+        public Map<String, Map<String, List<Column>>> getMetadata() {
+            return Collections.emptyMap();
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/MetastoreEventSyncDriverClassLoaderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/MetastoreEventSyncDriverClassLoaderTest.java
@@ -203,11 +203,12 @@ public class MetastoreEventSyncDriverClassLoaderTest {
             PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
             Mockito.when(catalog.getId()).thenReturn(1L);
             Mockito.when(catalog.getName()).thenReturn("test_catalog");
+            Mockito.when(catalog.canonicalLocalDatabaseNameFromRemote("db1")).thenReturn("db1");
             CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
             Mockito.doAnswer(invocation -> {
                 mutationClassLoader.set(Thread.currentThread().getContextClassLoader());
                 return null;
-            }).when(catalogMgr).registerExternalDatabaseFromEvent("db1", "test_catalog");
+            }).when(catalogMgr).registerExternalDatabaseFromEvent("db1", "db1", "test_catalog");
             Env env = Mockito.mock(Env.class);
             Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
             Mockito.when(env.isMaster()).thenReturn(false);
@@ -226,7 +227,7 @@ public class MetastoreEventSyncDriverClassLoaderTest {
                     Deencapsulation.invoke(new MetastoreEventSyncDriver(), "syncCatalog",
                             catalog, connector, eventSource);
                     Mockito.verify(catalogMgr)
-                            .registerExternalDatabaseFromEvent("db1", "test_catalog");
+                            .registerExternalDatabaseFromEvent("db1", "db1", "test_catalog");
                 }
 
                 Assertions.assertSame(eventSourceLoader, pollClassLoader.get());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/MetastoreEventSyncDriverMappedNameTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/MetastoreEventSyncDriverMappedNameTest.java
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.RefreshManager;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.connector.spi.Connector;
+import org.apache.doris.connector.spi.event.MetastoreChangeDescriptor;
+import org.apache.doris.connector.spi.event.MetastoreChangeDescriptor.Op;
+import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class MetastoreEventSyncDriverMappedNameTest {
+
+    @Test
+    public void databaseRenameKeepsRemoteConnectorKeysAndUsesLocalFeNames() throws Exception {
+        Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new MappingEventCatalog(connector);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        MetastoreChangeDescriptor descriptor = MetastoreChangeDescriptor.forDatabase(
+                Op.RENAME_DATABASE, "OldDb", "NewDb", 1L, 2L);
+
+        apply(catalog, connector, descriptor, env);
+
+        InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
+        inOrder.verify(connector).invalidateDb("OldDb");
+        inOrder.verify(connector).invalidateDb("NewDb");
+        inOrder.verify(catalogMgr).unregisterExternalDatabaseFromEvent("local_OldDb", "test_catalog");
+        inOrder.verify(catalogMgr).registerExternalDatabaseFromEvent(
+                "NewDb", "local_NewDb", "test_catalog");
+        Mockito.verifyNoMoreInteractions(connector, catalogMgr);
+    }
+
+    @Test
+    public void tableRenameKeepsRemoteConnectorKeysAndUsesBothTableIdentities() throws Exception {
+        Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new MappingEventCatalog(connector);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        MetastoreChangeDescriptor descriptor = MetastoreChangeDescriptor.forTableRename(
+                "OldDb", "OldTable", "NewDb", "NewTable", 1L, 2L);
+
+        apply(catalog, connector, descriptor, env);
+
+        InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
+        inOrder.verify(connector).invalidateTable("OldDb", "OldTable");
+        inOrder.verify(connector).invalidateTable("NewDb", "NewTable");
+        inOrder.verify(catalogMgr).unregisterExternalTableFromEvent(
+                "local_OldDb", "local_OldDb_OldTable", "test_catalog");
+        inOrder.verify(catalogMgr).registerExternalTableFromEvent(
+                "local_NewDb", "NewTable", "local_NewDb_NewTable", "test_catalog", 2L);
+        Mockito.verifyNoMoreInteractions(connector, catalogMgr);
+    }
+
+    @Test
+    public void refreshAndPartitionEventsUseMappedLocalNames() throws Exception {
+        Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new MappingEventCatalog(connector);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        RefreshManager refreshManager = Mockito.mock(RefreshManager.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(env.getRefreshManager()).thenReturn(refreshManager);
+        MetastoreChangeDescriptor refreshTable = MetastoreChangeDescriptor.forTable(
+                Op.REFRESH_TABLE, "RemoteDb", "RemoteTable", null, 1L, 2L);
+        MetastoreChangeDescriptor addPartitions = MetastoreChangeDescriptor.forPartitions(
+                Op.ADD_PARTITIONS, "RemoteDb", "RemoteTable",
+                Collections.singletonList("p=1"), 2L, 3L);
+        MetastoreChangeDescriptor dropPartitions = MetastoreChangeDescriptor.forPartitions(
+                Op.DROP_PARTITIONS, "RemoteDb", "RemoteTable",
+                Collections.singletonList("p=1"), 3L, 4L);
+        MetastoreChangeDescriptor refreshPartitions = MetastoreChangeDescriptor.forPartitions(
+                Op.REFRESH_PARTITIONS, "RemoteDb", "RemoteTable",
+                Collections.singletonList("p=1"), 4L, 5L);
+
+        apply(catalog, connector, refreshTable, env);
+        apply(catalog, connector, addPartitions, env);
+        apply(catalog, connector, dropPartitions, env);
+        apply(catalog, connector, refreshPartitions, env);
+
+        Mockito.verify(refreshManager).refreshExternalTableFromEvent(
+                "test_catalog", "local_RemoteDb", "local_RemoteDb_RemoteTable", 2L);
+        Mockito.verify(catalogMgr).addExternalPartitionsFromEvent(
+                "test_catalog", "local_RemoteDb", "local_RemoteDb_RemoteTable",
+                Collections.singletonList("p=1"), 3L);
+        Mockito.verify(catalogMgr).dropExternalPartitionsFromEvent(
+                "test_catalog", "local_RemoteDb", "local_RemoteDb_RemoteTable",
+                Collections.singletonList("p=1"), 4L);
+        Mockito.verify(refreshManager).refreshPartitionsFromEvent(
+                "test_catalog", "local_RemoteDb", "local_RemoteDb_RemoteTable",
+                Collections.singletonList("p=1"), 5L);
+        Mockito.verifyNoInteractions(connector);
+    }
+
+    private static void apply(PluginDrivenExternalCatalog catalog, Connector connector,
+            MetastoreChangeDescriptor descriptor, Env env) throws Exception {
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Deencapsulation.invoke(
+                    new MetastoreEventSyncDriver(), "applyOne", catalog, connector, descriptor);
+        }
+    }
+
+    private static class MappingEventCatalog extends PluginDrivenExternalCatalog {
+        MappingEventCatalog(Connector connector) {
+            super(1L, "test_catalog", null, Collections.singletonMap("type", "iceberg"), "", connector);
+        }
+
+        @Override
+        public String fromRemoteDatabaseName(String remoteDatabaseName) {
+            return "local_" + remoteDatabaseName;
+        }
+
+        @Override
+        public String fromRemoteTableName(String remoteDatabaseName, String remoteTableName) {
+            return "local_" + remoteDatabaseName + "_" + remoteTableName;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/MetastoreEventSyncDriverRenameTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/MetastoreEventSyncDriverRenameTest.java
@@ -29,13 +29,14 @@ import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Collections;
+
 public class MetastoreEventSyncDriverRenameTest {
 
     @Test
     public void databaseRenameAlwaysCleansOldNameAndRegistersNewName() throws Exception {
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Mockito.when(catalog.getName()).thenReturn("test_catalog");
         Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new IdentityEventCatalog(connector);
         CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         Env env = Mockito.mock(Env.class);
         Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
@@ -51,16 +52,15 @@ public class MetastoreEventSyncDriverRenameTest {
         InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
         inOrder.verify(connector).invalidateDb("OldDb");
         inOrder.verify(connector).invalidateDb("NewDb");
-        inOrder.verify(catalogMgr).unregisterExternalDatabase("OldDb", "test_catalog");
-        inOrder.verify(catalogMgr).registerExternalDatabaseFromEvent("NewDb", "test_catalog");
+        inOrder.verify(catalogMgr).unregisterExternalDatabaseFromEvent("OldDb", "test_catalog");
+        inOrder.verify(catalogMgr).registerExternalDatabaseFromEvent("NewDb", "NewDb", "test_catalog");
         Mockito.verifyNoMoreInteractions(connector, catalogMgr);
     }
 
     @Test
     public void tableRenameAlwaysCleansOldNameAndRegistersNewName() throws Exception {
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Mockito.when(catalog.getName()).thenReturn("test_catalog");
         Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new IdentityEventCatalog(connector);
         CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         Env env = Mockito.mock(Env.class);
         Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
@@ -76,18 +76,17 @@ public class MetastoreEventSyncDriverRenameTest {
         InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
         inOrder.verify(connector).invalidateTable("OldDb", "OldTable");
         inOrder.verify(connector).invalidateTable("NewDb", "NewTable");
-        inOrder.verify(catalogMgr).unregisterExternalTable(
-                "OldDb", "OldTable", "test_catalog", true);
+        inOrder.verify(catalogMgr).unregisterExternalTableFromEvent(
+                "OldDb", "OldTable", "test_catalog");
         inOrder.verify(catalogMgr).registerExternalTableFromEvent(
-                "NewDb", "NewTable", "test_catalog", 2L, true);
+                "NewDb", "NewTable", "NewTable", "test_catalog", 2L);
         Mockito.verifyNoMoreInteractions(connector, catalogMgr);
     }
 
     @Test
     public void sameNameViewRecreateInvalidatesConnectorOnceBeforeReplacement() throws Exception {
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Mockito.when(catalog.getName()).thenReturn("test_catalog");
         Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new IdentityEventCatalog(connector);
         CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         Env env = Mockito.mock(Env.class);
         Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
@@ -102,18 +101,17 @@ public class MetastoreEventSyncDriverRenameTest {
 
         InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
         inOrder.verify(connector).invalidateTable("db1", "view1");
-        inOrder.verify(catalogMgr).unregisterExternalTable(
-                "db1", "view1", "test_catalog", true);
+        inOrder.verify(catalogMgr).unregisterExternalTableFromEvent(
+                "db1", "view1", "test_catalog");
         inOrder.verify(catalogMgr).registerExternalTableFromEvent(
-                "db1", "view1", "test_catalog", 2L, true);
+                "db1", "view1", "view1", "test_catalog", 2L);
         Mockito.verifyNoMoreInteractions(connector, catalogMgr);
     }
 
     @Test
     public void sameNameTableDropCreateInvalidatesBothIncarnations() throws Exception {
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Mockito.when(catalog.getName()).thenReturn("test_catalog");
         Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new IdentityEventCatalog(connector);
         CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         Env env = Mockito.mock(Env.class);
         Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
@@ -131,19 +129,18 @@ public class MetastoreEventSyncDriverRenameTest {
 
         InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
         inOrder.verify(connector).invalidateTable("db1", "tbl1");
-        inOrder.verify(catalogMgr).unregisterExternalTable(
-                "db1", "tbl1", "test_catalog", true);
+        inOrder.verify(catalogMgr).unregisterExternalTableFromEvent(
+                "db1", "tbl1", "test_catalog");
         inOrder.verify(connector).invalidateTable("db1", "tbl1");
         inOrder.verify(catalogMgr).registerExternalTableFromEvent(
-                "db1", "tbl1", "test_catalog", 3L, true);
+                "db1", "tbl1", "tbl1", "test_catalog", 3L);
         Mockito.verifyNoMoreInteractions(connector, catalogMgr);
     }
 
     @Test
     public void sameNameDatabaseDropCreateInvalidatesBothIncarnations() throws Exception {
-        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
-        Mockito.when(catalog.getName()).thenReturn("test_catalog");
         Connector connector = Mockito.mock(Connector.class);
+        PluginDrivenExternalCatalog catalog = new IdentityEventCatalog(connector);
         CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         Env env = Mockito.mock(Env.class);
         Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
@@ -161,9 +158,25 @@ public class MetastoreEventSyncDriverRenameTest {
 
         InOrder inOrder = Mockito.inOrder(connector, catalogMgr);
         inOrder.verify(connector).invalidateDb("db1");
-        inOrder.verify(catalogMgr).unregisterExternalDatabase("db1", "test_catalog");
+        inOrder.verify(catalogMgr).unregisterExternalDatabaseFromEvent("db1", "test_catalog");
         inOrder.verify(connector).invalidateDb("db1");
-        inOrder.verify(catalogMgr).registerExternalDatabaseFromEvent("db1", "test_catalog");
+        inOrder.verify(catalogMgr).registerExternalDatabaseFromEvent("db1", "db1", "test_catalog");
         Mockito.verifyNoMoreInteractions(connector, catalogMgr);
+    }
+
+    private static class IdentityEventCatalog extends PluginDrivenExternalCatalog {
+        IdentityEventCatalog(Connector connector) {
+            super(1L, "test_catalog", null, Collections.singletonMap("type", "iceberg"), "", connector);
+        }
+
+        @Override
+        public String fromRemoteDatabaseName(String remoteDatabaseName) {
+            return remoteDatabaseName;
+        }
+
+        @Override
+        public String fromRemoteTableName(String remoteDatabaseName, String remoteTableName) {
+            return remoteTableName;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogCacheTest.java
@@ -23,19 +23,14 @@ import org.apache.doris.datasource.ExternalMetaCacheMgr;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Pins {@link PluginDrivenExternalCatalog#onRefreshCache} (H-5): {@code REFRESH CATALOG} with cache
- * invalidation must also drop the connector's OWN caches (e.g. the iceberg latest-snapshot cache, default TTL
- * 24h), which the base engine route resolver never reaches for a plugin catalog. {@code REFRESH CATALOG} does
- * not rebuild the connector (only {@code ADD}/{@code MODIFY CATALOG} does), so this override is the only thing
- * that drops the connector caches on refresh.
- */
+/** Verifies connector-owned caches follow catalog refresh semantics. */
 public class PluginDrivenExternalCatalogCacheTest {
 
     private static PluginDrivenExternalCatalog catalogWith(Connector connector) {
@@ -55,13 +50,10 @@ public class PluginDrivenExternalCatalogCacheTest {
             envStatic.when(Env::getCurrentEnv).thenReturn(env);
             catalog.onRefreshCache(true);
         }
-        // H-5 has TWO halves; pin both. (a) the base engine invalidation must STILL run: super.onRefreshCache(true)
-        // -> Env...getExtMetaCacheMgr().invalidateCatalog(id) flushes the engine route-resolver/schema cache for
-        // this plugin catalog. MUTATION: dropping the super.onRefreshCache(...) delegation -> verify fails.
-        Mockito.verify(cacheMgr).invalidateCatalog(1L);
-        // (b) the connector's OWN caches must be dropped too (the part the base path never reaches). MUTATION:
-        // removing connector.invalidateAll() -> the connector keeps serving stale snapshots up to 24h -> fails.
-        Mockito.verify(connector, Mockito.times(1)).invalidateAll();
+        // Connector state must be cleared before the engine invalidates row counts derived from it.
+        InOrder order = Mockito.inOrder(connector, cacheMgr);
+        order.verify(connector).invalidateAll();
+        order.verify(cacheMgr).invalidateCatalog(1L);
     }
 
     @Test
@@ -71,8 +63,6 @@ public class PluginDrivenExternalCatalogCacheTest {
         Env env = Mockito.mock(Env.class);
         try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
             envStatic.when(Env::getCurrentEnv).thenReturn(env);
-            // invalidCache=false (the plain "reload metadata, keep caches" refresh) must NOT drop connector
-            // caches. MUTATION: dropping the invalidCache guard -> connector cleared unconditionally -> fails.
             catalog.onRefreshCache(false);
         }
         Mockito.verify(connector, Mockito.never()).invalidateAll();
@@ -80,8 +70,7 @@ public class PluginDrivenExternalCatalogCacheTest {
 
     @Test
     public void refreshCatalogWithNullConnectorIsSafe() {
-        // resetToUninitialized() nulls the connector (onClose) BEFORE calling onRefreshCache, and an
-        // uninitialized catalog has no connector yet. The override must be a safe no-op, not an NPE.
+        // A reset catalog has no connector to invalidate.
         PluginDrivenExternalCatalog catalog = catalogWith(null);
         Env env = Mockito.mock(Env.class);
         Mockito.when(env.getExtMetaCacheMgr()).thenReturn(Mockito.mock(ExternalMetaCacheMgr.class));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogConcurrencyTest.java
@@ -17,15 +17,22 @@
 
 package org.apache.doris.datasource.plugin;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.FileFormatConstants;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorMetadata;
 import org.apache.doris.connector.spi.ConnectorSession;
+import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.SessionContext;
+import org.apache.doris.mysql.privilege.AccessControllerManager;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -50,6 +57,27 @@ import java.util.function.Supplier;
  */
 public class PluginDrivenExternalCatalogConcurrencyTest {
 
+    private MockedStatic<Env> mockedEnv;
+    private ExternalMetaCacheMgr cacheMgr;
+
+    @BeforeEach
+    public void setUp() {
+        Env env = Mockito.mock(Env.class);
+        cacheMgr = Mockito.mock(ExternalMetaCacheMgr.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        Mockito.when(env.getExtMetaCacheMgr()).thenReturn(cacheMgr);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(accessManager.detachAccessController(Mockito.anyString(), Mockito.anyLong()))
+                .thenReturn(() -> { });
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockedEnv.close();
+    }
+
     @Test
     public void testAlterRejectsInvalidHiveParquetTimezone() {
         Map<String, String> properties = new HashMap<>();
@@ -62,6 +90,42 @@ public class PluginDrivenExternalCatalogConcurrencyTest {
         DdlException exception = Assertions.assertThrows(DdlException.class,
                 () -> catalog.validatePropertiesBeforeUpdate(properties, updates));
         Assertions.assertTrue(exception.getMessage().contains("short timezone aliases are not supported"));
+    }
+
+    @Test
+    public void testPropertyUpdateInvalidatesCatalogCaches() throws Exception {
+        TestablePluginCatalog catalog = new TestablePluginCatalog(
+                mockConnector("old", new ConcurrentLinkedQueue<>()));
+
+        catalog.notifyPropertiesUpdated(Collections.singletonMap("endpoint", "new-source"));
+
+        Mockito.verify(cacheMgr).invalidateCatalog(1L);
+        Mockito.verify(cacheMgr, Mockito.never()).removeCatalog(Mockito.anyLong());
+    }
+
+    @Test
+    public void testDeferredPropertyUpdateInvalidatesCatalogCaches() throws Exception {
+        TestablePluginCatalog catalog = new TestablePluginCatalog(
+                mockConnector("old", new ConcurrentLinkedQueue<>()));
+
+        Runnable cleanup = catalog.modifyCatalogPropsWithDeferredAccessControllerCleanup(
+                Collections.singletonMap("endpoint", "new-source"));
+        cleanup.run();
+
+        Mockito.verify(cacheMgr).invalidateCatalog(1L);
+        Mockito.verify(cacheMgr, Mockito.never()).removeCatalog(Mockito.anyLong());
+    }
+
+    @Test
+    public void testSchemaCachePropertyUsesSingleCatalogInvalidation() throws Exception {
+        TestablePluginCatalog catalog = new TestablePluginCatalog(
+                mockConnector("old", new ConcurrentLinkedQueue<>()));
+
+        catalog.notifyPropertiesUpdated(Collections.singletonMap(
+                ExternalCatalog.SCHEMA_CACHE_TTL_SECOND, "10"));
+
+        Mockito.verify(cacheMgr).removeCatalog(1L);
+        Mockito.verify(cacheMgr, Mockito.never()).invalidateCatalog(Mockito.anyLong());
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogDdlRoutingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogDdlRoutingTest.java
@@ -33,6 +33,8 @@ import org.apache.doris.catalog.info.TagOptions;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.connector.ddl.CreateTableInfoToConnectorRequestConverter;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorColumn;
@@ -48,48 +50,49 @@ import org.apache.doris.connector.spi.ddl.PartitionFieldChange;
 import org.apache.doris.connector.spi.ddl.TagChange;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
+import org.apache.doris.datasource.ExternalRowCountCache;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.log.ExternalObjectLog;
 import org.apache.doris.nereids.trees.plans.commands.info.AddPartitionFieldOp;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateTableInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.DropPartitionFieldOp;
 import org.apache.doris.nereids.trees.plans.commands.info.ReplacePartitionFieldOp;
+import org.apache.doris.persist.CreateDbInfo;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.TruncateTableInfo;
+import org.apache.doris.statistics.util.StatisticsUtil;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * Tests for {@link PluginDrivenExternalCatalog}'s DDL overrides (createDb / dropDb /
- * dropTable) added by P4-T06c, and the cache-invalidation fix to the existing
- * createTable override.
- *
- * <p><b>Why these tests matter:</b> after the MaxCompute SPI cutover (T06b), a
- * {@code max_compute} catalog is a {@link PluginDrivenExternalCatalog} whose
- * {@code metadataOps} is always {@code null}. Without these overrides every DDL
- * would hit the base class and throw "… is not supported for catalog". These tests
- * lock in that DDL is routed to the connector SPI instead, that connector failures
- * are surfaced as {@link DdlException} (caller contract), that the SPI's missing
- * {@code ifNotExists}/{@code ifExists} semantics are enforced FE-side, and that the
- * FE metadata cache is invalidated after each op so the change is visible on the
- * same FE — exactly what the legacy {@code MaxComputeMetadataOps.afterX()} hooks did.</p>
- */
+/** Tests connector-routed external DDL, persistence, and local cache invalidation. */
 public class PluginDrivenExternalCatalogDdlRoutingTest {
 
+    private static final String CATALOG_NAME = "test-catalog";
+    private static final String DATABASE_NAME = "db1";
+    private static final long DATABASE_ID = Util.genIdByName(CATALOG_NAME, DATABASE_NAME);
+    private static final long TABLE_ID = Util.genIdByName(CATALOG_NAME, DATABASE_NAME, "t1");
     private MockedStatic<Env> mockedEnv;
+    private Env mockEnv;
     private EditLog mockEditLog;
     private RefreshManager mockRefreshManager;
     private ConstraintManager mockConstraintManager;
+    private ExternalMetaCacheMgr mockMetaCacheMgr;
     private Connector connector;
     private ConnectorMetadata metadata;
     private ConnectorSession session;
@@ -102,21 +105,27 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         session = Mockito.mock(ConnectorSession.class);
         Mockito.when(session.getStatementScope()).thenReturn(ConnectorStatementScope.NONE);
         Mockito.when(connector.getMetadata(Mockito.any())).thenReturn(metadata);
+        Mockito.when(metadata.fromRemoteDatabaseName(Mockito.eq(session), Mockito.anyString()))
+                .thenAnswer(inv -> inv.getArgument(1));
+        Mockito.when(metadata.fromRemoteTableName(Mockito.eq(session), Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(inv -> inv.getArgument(2));
 
         // Construct with the real Env singleton (the constructor is Env-safe), then
         // activate the static Env mock so the DDL overrides' edit-log writes are no-ops.
         catalog = new TestablePluginCatalog(connector);
         catalog.sessionMock = session;
 
-        Env mockEnv = Mockito.mock(Env.class);
+        mockEnv = Mockito.mock(Env.class);
         mockEditLog = Mockito.mock(EditLog.class);
         mockRefreshManager = Mockito.mock(RefreshManager.class);
         mockConstraintManager = Mockito.mock(ConstraintManager.class);
+        mockMetaCacheMgr = Mockito.mock(ExternalMetaCacheMgr.class);
         mockedEnv = Mockito.mockStatic(Env.class);
         mockedEnv.when(Env::getCurrentEnv).thenReturn(mockEnv);
         Mockito.when(mockEnv.getEditLog()).thenReturn(mockEditLog);
         Mockito.when(mockEnv.getRefreshManager()).thenReturn(mockRefreshManager);
         Mockito.when(mockEnv.getConstraintManager()).thenReturn(mockConstraintManager);
+        Mockito.when(mockEnv.getExtMetaCacheMgr()).thenReturn(mockMetaCacheMgr);
     }
 
     @AfterEach
@@ -137,31 +146,39 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         Mockito.verify(metadata).createDatabase(session, "db1", props);
         Mockito.verify(mockEditLog).logCreateDb(Mockito.any());
-        Assertions.assertEquals(1, catalog.resetMetaCacheNamesCount,
-                "createDb must invalidate the catalog db-name cache (legacy afterCreateDb parity)");
+        Assertions.assertEquals(1, catalog.resetMetaCacheNamesCount);
+        InOrder order = Mockito.inOrder(connector, mockMetaCacheMgr);
+        order.verify(connector).invalidateDb("db1");
+        order.verify(mockMetaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("test-catalog", "db1"), "db1");
     }
 
     @Test
-    public void testCreateDbDoesNotInvalidateConnectorCache() throws Exception {
-        catalog.createDb("db1", false, new HashMap<>());
+    public void testCreateDbPersistsCanonicalLocalName() throws Exception {
+        Mockito.when(metadata.fromRemoteDatabaseName(session, "REMOTE_DB")).thenReturn("local_db");
 
-        // WHY (Rule 9): createDb is DELIBERATELY not hooked to connector.invalidate* — a brand-new database
-        // has no table-keyed connector cache entries to clear that a prior dropDb did not already clear (the
-        // db-name-list is refreshed via resetMetaCacheNames, asserted above). This pins that scoping choice:
-        // a mutation that adds connector.invalidateDb/invalidateTable to createDb turns this red.
-        Mockito.verify(connector, Mockito.never()).invalidateDb(Mockito.any());
-        Mockito.verify(connector, Mockito.never()).invalidateTable(Mockito.any(), Mockito.any());
+        catalog.createDb("REMOTE_DB", false, new HashMap<>());
+
+        ArgumentCaptor<CreateDbInfo> log = ArgumentCaptor.forClass(CreateDbInfo.class);
+        Mockito.verify(mockEditLog).logCreateDb(log.capture());
+        Assertions.assertEquals("local_db", log.getValue().getDbName());
+        Mockito.verify(connector).invalidateDb("REMOTE_DB");
+        Mockito.verify(mockMetaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("test-catalog", "local_db"), "local_db");
     }
 
     @Test
-    public void testCreateDbIfNotExistsShortCircuitsWhenDbExists() throws Exception {
-        catalog.dbNullableResult = Mockito.mock(ExternalDatabase.class);
+    public void testCreateDbIfNotExistsRefreshesCachesWhenDbExists() throws Exception {
+        catalog.dbNullableResult = mockExternalDatabase();
 
         catalog.createDb("db1", true, new HashMap<>());
 
         Mockito.verify(metadata, Mockito.never()).createDatabase(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(mockEditLog, Mockito.never()).logCreateDb(Mockito.any());
-        Assertions.assertEquals(0, catalog.resetMetaCacheNamesCount);
+        Mockito.verify(connector).invalidateDb("DB1");
+        Assertions.assertEquals(1, catalog.resetMetaCacheNamesCount);
+        Mockito.verify(mockMetaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("test-catalog", "db1"), "db1");
     }
 
     @Test
@@ -181,14 +198,12 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.createDb("db1", true, new HashMap<>());
 
-        // WHY (Rule 9): DG-4 regression -- a db that exists REMOTELY but is not yet in this FE's
-        // cache must make CREATE DATABASE IF NOT EXISTS a clean no-op (legacy createDbImpl consulted
-        // the remote databaseExist), NOT surface a remote "already exists" error. A mutation that
-        // removes the remote precheck calls createDatabase/logCreateDb -> these never() asserts red.
         Mockito.verify(metadata).databaseExists(session, "db1");
         Mockito.verify(metadata, Mockito.never()).createDatabase(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(mockEditLog, Mockito.never()).logCreateDb(Mockito.any());
-        Assertions.assertEquals(0, catalog.resetMetaCacheNamesCount);
+        Assertions.assertEquals(1, catalog.resetMetaCacheNamesCount);
+        Mockito.verify(mockMetaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("test-catalog", "db1"), "db1");
     }
 
     @Test
@@ -199,13 +214,25 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.createDb("db1", true, props);
 
-        // WHY: remote-absent must still create + editlog + cache reset -- proves the fix did not
-        // degrade IF NOT EXISTS into "never create". Paired with the test above (exists<->absent),
-        // this pins both sides of legacy createDbImpl's existence branch.
         Mockito.verify(metadata).databaseExists(session, "db1");
         Mockito.verify(metadata).createDatabase(session, "db1", props);
         Mockito.verify(mockEditLog).logCreateDb(Mockito.any());
         Assertions.assertEquals(1, catalog.resetMetaCacheNamesCount);
+    }
+
+    @Test
+    public void testCreateDbIfNotExistsLosingTheCreateRaceReturnsWithoutEditLog() throws Exception {
+        Mockito.when(metadata.databaseExists(session, "db1")).thenReturn(false, true);
+        Mockito.doThrow(new DorisConnectorException("database already exists"))
+                .when(metadata).createDatabase(session, "db1", Collections.emptyMap());
+
+        catalog.createDb("db1", true, Collections.emptyMap());
+
+        Mockito.verify(metadata, Mockito.times(2)).databaseExists(session, "db1");
+        Mockito.verify(mockEditLog, Mockito.never()).logCreateDb(Mockito.any());
+        Mockito.verify(connector).invalidateDb("db1");
+        Mockito.verify(mockMetaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("test-catalog", "db1"), "db1");
     }
 
     @Test
@@ -219,12 +246,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.createDb("db1", true, new HashMap<>());
 
-        // WHY (Rule 9): the existence precheck is asked of EVERY connector, not only those that can
-        // create -- IF NOT EXISTS means "ensure it is there", and it is, so the statement must
-        // succeed instead of reporting "CREATE DATABASE not supported" (this is Trino's
-        // CreateSchemaTask behavior; it replaced a supportsCreateDatabase() gate that could only
-        // restate whether createDatabase was overridden). MUTATION: re-gating the precheck on any
-        // capability sends this through createDatabase -> the stubbed throw fails the test.
         Mockito.verify(metadata).databaseExists(session, "db1");
         Mockito.verify(metadata, Mockito.never()).createDatabase(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(mockEditLog, Mockito.never()).logCreateDb(Mockito.any());
@@ -241,8 +262,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         DdlException ex = Assertions.assertThrows(DdlException.class,
                 () -> catalog.createDb("db1", true, new HashMap<>()));
 
-        // WHY: the precheck must not degrade IF NOT EXISTS into "never fail" -- an absent db on a
-        // connector that cannot create one still surfaces the connector's refusal.
         Assertions.assertTrue(ex.getMessage().contains("CREATE DATABASE not supported"));
     }
 
@@ -260,6 +279,7 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Mockito.verify(mockEditLog).logDropDb(Mockito.any());
         Assertions.assertEquals("db1", catalog.unregisteredDb,
                 "dropDb must remove the db from the cache (legacy afterDropDb parity)");
+        Mockito.verify(mockMetaCacheMgr).invalidateDb(1L, DATABASE_ID, "db1");
     }
 
     @Test
@@ -300,10 +320,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.dropDb("db1", false, true);
 
-        // WHY (Rule 9 / Rule 12): the regression (DG-3) is that the user's FORCE intent was
-        // silently dropped at the FE→SPI boundary, so DROP DB FORCE stopped cascading table
-        // drops. This asserts force=true actually reaches the connector. A mutation reverting
-        // PluginDrivenExternalCatalog.dropDb to the 3-arg / hardcoded-false call makes it red.
         Mockito.verify(metadata).dropDatabase(session, "db1", false, true);
     }
 
@@ -315,8 +331,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.dropDb("db1", false, false);
 
-        // WHY: guards that the fix does NOT over-correct into always-cascading -- a plain
-        // (non-FORCE) DROP DB must forward force=false so the connector never deletes tables.
         Mockito.verify(metadata).dropDatabase(session, "db1", false, false);
     }
 
@@ -329,14 +343,8 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.dropDb("db1", false, true);
 
-        // WHY (Rule 9): the connector must receive the REMOTE db name so name-mapped catalogs hit the
-        // real remote namespace -- the regression forwarded the bare LOCAL "db1", which on a mapped
-        // catalog drops/cascades the wrong (or nonexistent) namespace. A mutation reverting to the
-        // local dbName makes this verify red. Mirrors the dropTable remote-name resolution.
         Mockito.verify(metadata).dropDatabase(session, "REMOTE_DB1", false, true);
-        // WHY: edit log + cache invalidation MUST keep the LOCAL name -- followers replay the persisted
-        // DropDbInfo and the on-FE cache is keyed by local name. A mutation persisting the remote name
-        // into DropDbInfo / unregisterDatabase must turn these red.
+        // Connector calls use remote names; edit-log and FE cache identities stay local.
         ArgumentCaptor<org.apache.doris.persist.DropDbInfo> dropDbInfo =
                 ArgumentCaptor.forClass(org.apache.doris.persist.DropDbInfo.class);
         Mockito.verify(mockEditLog).logDropDb(dropDbInfo.capture());
@@ -344,45 +352,35 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
                 "edit-log DropDbInfo must carry the LOCAL db name for follower replay");
         Assertions.assertEquals("db1", catalog.unregisteredDb,
                 "cache invalidation must use the LOCAL db name");
-        // WHY (Rule 9): the connector's own caches for every table in this db must be dropped on DROP
-        // DATABASE with the REMOTE db name (mirrors RefreshManager.refreshDbInternal). A mutation dropping
-        // the call — or passing the LOCAL "db1" — makes this red.
         Mockito.verify(connector).invalidateDb("REMOTE_DB1");
     }
 
     // ==================== DROP TABLE ====================
-    // FIX-DDL-REMOTE: dropTable now resolves the local db/table names to their REMOTE (ODPS)
-    // names (via getDbNullable + db.getTableNullable + getRemoteDbName/getRemoteName) before
-    // calling the connector, mirroring base ExternalCatalog.dropTable / legacy
-    // MaxComputeMetadataOps.dropTableImpl. Every drop test therefore stubs dbNullableResult and
-    // db.getTableNullable; edit log / cache invalidation still use the LOCAL names.
-
     @Test
-    public void testDropTableResolvesRemoteNamesRoutesAndUnregisters() throws Exception {
+    public void testDropTableKeepsExactCleanupAfterDatabaseCacheEviction() throws Exception {
         // local db1.t1 maps to remote DB1.TBL1 (name mapping enabled).
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();   // resolution db (getDbNullable)
         ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getName()).thenReturn("t1");
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
         Mockito.when(table.getRemoteDbName()).thenReturn("DB1");
         Mockito.when(table.getRemoteName()).thenReturn("TBL1");
-        Mockito.doReturn(table).when(db).getTableNullable("t1");
+        Mockito.doReturn(table).when(db).getTableNullable("T1");
         catalog.dbNullableResult = db;
-        // Distinct replay db: locks that cache invalidation uses the getDbForReplay lookup, NOT
-        // the resolution db (a refactor routing unregister through the resolution db must go red).
         ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
         catalog.dbForReplayResult = Optional.of(replayDb);
 
         ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
         Mockito.when(metadata.getTableHandle(session, "DB1", "TBL1")).thenReturn(Optional.of(handle));
+        Mockito.doAnswer(inv -> {
+            catalog.dbForReplayResult = Optional.empty();
+            return null;
+        }).when(metadata).dropTable(session, handle);
 
-        catalog.dropTable("db1", "t1", false, false, false, false, false, false);
+        catalog.dropTable("DB1", "T1", false, false, false, false, false, false);
 
-        // WHY: the connector must receive the REMOTE names so name-mapped catalogs hit the real
-        // ODPS object; a mutation that passes the local "db1"/"t1" makes this verify red.
         Mockito.verify(metadata).getTableHandle(session, "DB1", "TBL1");
         Mockito.verify(metadata).dropTable(session, handle);
-        // WHY: edit log + cache invalidation MUST use the LOCAL names -- followers replay the
-        // persisted DropInfo and the on-FE cache is keyed by local name. A mutation building
-        // DropInfo / looking up getDbForReplay with the remote names must turn these red.
         ArgumentCaptor<org.apache.doris.persist.DropInfo> dropInfo =
                 ArgumentCaptor.forClass(org.apache.doris.persist.DropInfo.class);
         Mockito.verify(mockEditLog).logDropTable(dropInfo.capture());
@@ -390,15 +388,11 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
                 "edit-log DropInfo must carry the LOCAL db name for follower replay");
         Assertions.assertEquals("t1", dropInfo.getValue().getTableName(),
                 "edit-log DropInfo must carry the LOCAL table name for follower replay");
-        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg,
-                "cache invalidation must look up the LOCAL db name");
-        Mockito.verify(replayDb).unregisterTable("t1");
+        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg);
+        Mockito.verify(replayDb, Mockito.never()).unregisterTable(Mockito.anyString());
         Mockito.verify(db, Mockito.never()).unregisterTable(Mockito.anyString());
-        // WHY (Rule 9): the connector's OWN caches (paimon/iceberg latest-snapshot pin, hive metastore +
-        // file-listing) must be dropped on DROP TABLE with the REMOTE names, so a subsequent same-name
-        // CREATE + read go live instead of serving the dropped table up to the connector TTL (the LIVE
-        // paimon/iceberg drop+recreate stale-pin fix). A mutation dropping the call — or passing the LOCAL
-        // "db1"/"t1" — makes this verify red.
+        Mockito.verify(mockMetaCacheMgr).invalidateTable(1L, DATABASE_ID, "db1", TABLE_ID, "t1");
+        // Connector caches are keyed by the remote identity.
         Mockito.verify(connector).invalidateTable("DB1", "TBL1");
     }
 
@@ -406,9 +400,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     public void testDropTableMissingDbThrowsEvenWithIfExists() {
         catalog.dbNullableResult = null; // db not present
 
-        // WHY: mirror base ExternalCatalog.dropTable -- a missing db ALWAYS throws, even with
-        // IF EXISTS (only a missing TABLE honors IF EXISTS). A mutation that ifExists-gates the
-        // db==null branch makes this test red.
         Assertions.assertThrows(DdlException.class,
                 () -> catalog.dropTable("missing", "t1", false, false, false, true, false, false));
         Mockito.verifyNoInteractions(metadata);
@@ -422,7 +413,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.dropTable("db1", "missing", false, false, false, true, false, false);
 
-        // Table missing + IF EXISTS => no-op; the connector is never even consulted.
         Mockito.verifyNoInteractions(metadata);
         Mockito.verify(mockEditLog, Mockito.never()).logDropTable(Mockito.any());
     }
@@ -439,11 +429,11 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     }
 
     @Test
-    public void testDropTableHandleAbsentAfterLocalResolveIsNoopWithIfExists() throws Exception {
-        // FE cache has the table (resolves locally), but it was dropped out-of-band remotely:
-        // getTableHandle returns empty. IF EXISTS must still no-op.
+    public void testDropTableHandleAbsentAfterLocalResolveCleansLocalStateWithIfExists() throws Exception {
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getName()).thenReturn("t1");
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
         Mockito.when(table.getRemoteDbName()).thenReturn("DB1");
         Mockito.when(table.getRemoteName()).thenReturn("TBL1");
         Mockito.doReturn(table).when(db).getTableNullable("t1");
@@ -454,7 +444,9 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         Mockito.verify(metadata).getTableHandle(session, "DB1", "TBL1");
         Mockito.verify(metadata, Mockito.never()).dropTable(Mockito.any(), Mockito.any());
-        Mockito.verify(mockEditLog, Mockito.never()).logDropTable(Mockito.any());
+        Mockito.verify(connector).invalidateTable("DB1", "TBL1");
+        Mockito.verify(mockEditLog).logDropTable(Mockito.any());
+        Mockito.verify(mockMetaCacheMgr).invalidateTable(1L, DATABASE_ID, "db1", TABLE_ID, "t1");
     }
 
     @Test
@@ -489,41 +481,27 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         DdlException ex = Assertions.assertThrows(DdlException.class,
                 () -> catalog.dropTable("db1", "t1", false, false, false, false, false, false));
         Assertions.assertTrue(ex.getMessage().contains("boom"));
-        // WHY (Rule 9 / Rule 12): a remote drop failure must abort BEFORE the cache is invalidated — the
-        // invalidate sits AFTER the successful metadata.dropTable, so the connector cache stays consistent
-        // with the (unchanged) remote. A mutation moving invalidateTable ahead of the mutation goes red.
         Mockito.verify(connector, Mockito.never()).invalidateTable(Mockito.any(), Mockito.any());
     }
-
-    // B2: DROP on a flipped iceberg VIEW must route to metadata.dropView (mirroring legacy
-    // IcebergMetadataOps.dropTableImpl's viewExists -> performDropView dispatch). The connector's
-    // getTableHandle/tableExists is false for a view, so without this routing the handle path would no-op
-    // (IF EXISTS) / throw (no such table). Edit log + cache invalidation use the LOCAL names like the table path.
 
     @Test
     public void testDropTableRoutesViewToDropViewAndUnregisters() throws Exception {
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         ExternalTable view = Mockito.mock(ExternalTable.class);
+        Mockito.when(view.getName()).thenReturn("v1");
         Mockito.when(view.getRemoteDbName()).thenReturn("DB1");
         Mockito.when(view.getRemoteName()).thenReturn("V1");
         Mockito.doReturn(view).when(db).getTableNullable("v1");
         catalog.dbNullableResult = db;
         ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
         catalog.dbForReplayResult = Optional.of(replayDb);
-        // The connector reports the (remote) object as a view.
         Mockito.when(metadata.viewExists(session, "DB1", "V1")).thenReturn(true);
 
         catalog.dropTable("db1", "v1", false, false, false, false, false, false);
 
-        // WHY: a view must be dropped via dropView with the REMOTE names, and the table-handle path must be
-        // skipped entirely (getTableHandle/dropTable never consulted) -- legacy dropTableImpl checks viewExists
-        // BEFORE resolving the table. A mutation that drops the routing makes the dropView verify red (and the
-        // getTableHandle would be reached on a non-existent table).
         Mockito.verify(metadata).dropView(session, "DB1", "V1");
         Mockito.verify(metadata, Mockito.never()).getTableHandle(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(metadata, Mockito.never()).dropTable(Mockito.any(), Mockito.any());
-        // WHY: edit log + cache invalidation MUST use the LOCAL names (follower replay parity), identical to
-        // the table path. A mutation persisting the remote names turns these red.
         ArgumentCaptor<org.apache.doris.persist.DropInfo> dropInfo =
                 ArgumentCaptor.forClass(org.apache.doris.persist.DropInfo.class);
         Mockito.verify(mockEditLog).logDropTable(dropInfo.capture());
@@ -531,10 +509,8 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
                 "edit-log DropInfo must carry the LOCAL db name for follower replay");
         Assertions.assertEquals("v1", dropInfo.getValue().getTableName(),
                 "edit-log DropInfo must carry the LOCAL view name for follower replay");
-        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg,
-                "cache invalidation must look up the LOCAL db name");
+        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg);
         Mockito.verify(replayDb).unregisterTable("v1");
-        // The view branch drops the connector caches too (uniform with the table branch), keyed by REMOTE names.
         Mockito.verify(connector).invalidateTable("DB1", "V1");
     }
 
@@ -549,8 +525,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Mockito.when(metadata.viewExists(session, "DB1", "V1")).thenReturn(true);
         Mockito.doThrow(new DorisConnectorException("boom")).when(metadata).dropView(session, "DB1", "V1");
 
-        // WHY: a remote view-drop failure must surface as a DdlException (same as the table path) and abort
-        // BEFORE any bookkeeping -- no editlog, no unregister, so the FE cache stays consistent with the remote.
         DdlException ex = Assertions.assertThrows(DdlException.class,
                 () -> catalog.dropTable("db1", "v1", false, false, false, false, false, false));
         Assertions.assertTrue(ex.getMessage().contains("boom"));
@@ -558,56 +532,96 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     }
 
     // ==================== RENAME TABLE ====================
-    // renameTable resolves the SOURCE by REMOTE names (like dropTable) and passes the new name through
-    // (legacy renameTableImpl parity); afterExternalRename does the cache fix (unregister old + reset names)
-    // + constraintManager rename + createForRenameTable editlog, all with LOCAL names for follower replay.
+    @Test
+    public void testRenameTableKeepsCanonicalExactCleanupAfterDatabaseCacheEviction() throws Exception {
+        // local db1.t1 maps to remote DB1.TBL1 (name mapping enabled).
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getName()).thenReturn("t1");
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
+        Mockito.when(table.getRemoteDbName()).thenReturn("DB1");
+        Mockito.when(table.getRemoteName()).thenReturn("TBL1");
+        Mockito.doReturn(table).when(db).getTableNullable("t1");
+        Mockito.when(db.canonicalLocalTableNameFromRemote("REMOTE_T2")).thenReturn("local_t2");
+        catalog.dbNullableResult = db;
+        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
+        catalog.dbForReplayResult = Optional.of(replayDb);
+        ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
+        Mockito.when(metadata.getTableHandle(session, "DB1", "TBL1")).thenReturn(Optional.of(handle));
+        Mockito.doAnswer(inv -> {
+            catalog.dbForReplayResult = Optional.empty();
+            return null;
+        }).when(metadata).renameTable(session, handle, "REMOTE_T2");
+
+        catalog.renameTable("db1", "t1", "REMOTE_T2");
+
+        Mockito.verify(metadata).getTableHandle(session, "DB1", "TBL1");
+        Mockito.verify(metadata).renameTable(session, handle, "REMOTE_T2");
+        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg);
+        Mockito.verify(replayDb, Mockito.never()).invalidateTableRename(Mockito.anyString(), Mockito.anyString());
+        ArgumentCaptor<TableNameInfo> oldName = ArgumentCaptor.forClass(TableNameInfo.class);
+        ArgumentCaptor<TableNameInfo> newName = ArgumentCaptor.forClass(TableNameInfo.class);
+        Mockito.verify(mockConstraintManager).renameTable(oldName.capture(), newName.capture());
+        Assertions.assertEquals("t1", oldName.getValue().getTbl());
+        Assertions.assertEquals("local_t2", newName.getValue().getTbl());
+        ArgumentCaptor<ExternalObjectLog> logCap = ArgumentCaptor.forClass(ExternalObjectLog.class);
+        Mockito.verify(mockEditLog).logRefreshExternalTable(logCap.capture());
+        Assertions.assertEquals("db1", logCap.getValue().getDbName());
+        Assertions.assertEquals("t1", logCap.getValue().getTableName());
+        Assertions.assertEquals("local_t2", logCap.getValue().getNewTableName());
+        // The destination has no pre-rename mapping, so its remote name is the requested new name.
+        Mockito.verify(connector).invalidateTable("DB1", "TBL1");
+        Mockito.verify(connector).invalidateTable("DB1", "REMOTE_T2");
+        Mockito.verify(mockMetaCacheMgr).invalidateTableRename(
+                1L, DATABASE_ID, "db1", TABLE_ID, "t1",
+                Util.genIdByName("test-catalog", "db1", "local_t2"), "local_t2");
+    }
 
     @Test
-    public void testRenameTableResolvesRemoteSourceRoutesAndFixesCache() throws Exception {
-        // local db1.t1 maps to remote DB1.TBL1 (name mapping enabled).
+    public void testRenameResolvesDestinationIdentityBeforeRemoteMutation() throws Exception {
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         ExternalTable table = Mockito.mock(ExternalTable.class);
         Mockito.when(table.getRemoteDbName()).thenReturn("DB1");
         Mockito.when(table.getRemoteName()).thenReturn("TBL1");
         Mockito.doReturn(table).when(db).getTableNullable("t1");
+        Mockito.when(db.canonicalLocalTableNameFromRemote("TBL2"))
+                .thenThrow(new IllegalStateException("name mapping failed"));
         catalog.dbNullableResult = db;
-        // Distinct replay db: locks that the cache fix uses the getDbForReplay lookup (LOCAL name), not the
-        // resolution db.
-        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
-        catalog.dbForReplayResult = Optional.of(replayDb);
+        ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
+        Mockito.when(metadata.getTableHandle(session, "DB1", "TBL1")).thenReturn(Optional.of(handle));
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> catalog.renameTable("db1", "t1", "TBL2"));
+
+        Mockito.verify(metadata, Mockito.never()).renameTable(Mockito.any(), Mockito.any(), Mockito.anyString());
+        Mockito.verify(mockEditLog, Mockito.never()).logRefreshExternalTable(Mockito.any());
+    }
+
+    @Test
+    public void testRenameTableUsesStructuralSourceInvalidationAndDestinationBarrier() throws Exception {
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getName()).thenReturn("t1");
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
+        Mockito.when(table.getRemoteDbName()).thenReturn("DB1");
+        Mockito.when(table.getRemoteName()).thenReturn("TBL1");
+        Mockito.doReturn(table).when(db).getTableNullable("t1");
+        catalog.dbNullableResult = db;
+        ExternalDatabase<? extends ExternalTable> cachedDb = mockExternalDatabase();
+        catalog.dbForReplayResult = Optional.of(cachedDb);
         ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
         Mockito.when(metadata.getTableHandle(session, "DB1", "TBL1")).thenReturn(Optional.of(handle));
 
         catalog.renameTable("db1", "t1", "t2");
 
-        // WHY: the connector must receive the REMOTE source names + the new name; a mutation passing the
-        // local "db1"/"t1" makes this verify red.
-        Mockito.verify(metadata).getTableHandle(session, "DB1", "TBL1");
-        Mockito.verify(metadata).renameTable(session, handle, "t2");
-        // WHY (Rule 9): cache fix + constraint + editlog MUST use LOCAL names (followers replay the
-        // createForRenameTable entry and the cache is keyed by local name). A mutation using remote names
-        // for the bookkeeping turns these red.
-        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg,
-                "cache fix must look up the LOCAL db name");
-        Mockito.verify(replayDb).unregisterTable("t1");
-        Mockito.verify(replayDb).resetMetaCacheNames();
-        ArgumentCaptor<TableNameInfo> oldName = ArgumentCaptor.forClass(TableNameInfo.class);
-        ArgumentCaptor<TableNameInfo> newName = ArgumentCaptor.forClass(TableNameInfo.class);
-        Mockito.verify(mockConstraintManager).renameTable(oldName.capture(), newName.capture());
-        Assertions.assertEquals("t1", oldName.getValue().getTbl());
-        Assertions.assertEquals("t2", newName.getValue().getTbl());
-        ArgumentCaptor<ExternalObjectLog> logCap = ArgumentCaptor.forClass(ExternalObjectLog.class);
-        Mockito.verify(mockEditLog).logRefreshExternalTable(logCap.capture());
-        Assertions.assertEquals("db1", logCap.getValue().getDbName());
-        Assertions.assertEquals("t1", logCap.getValue().getTableName());
-        Assertions.assertEquals("t2", logCap.getValue().getNewTableName());
-        // WHY (Rule 9 / R4): the connector's own caches for BOTH the source (REMOTE DB1.TBL1) and the target
-        // (DB1.t2, new name NOT remote-resolved) must be dropped so an atomic swap (RENAME t->t_arch;
-        // RENAME t_new->t) doesn't serve the pre-rename pinned snapshot under either name. Before R4
-        // afterExternalRename fixed only the FE name cache. MUTATION: dropping either call — or passing the
-        // LOCAL names — turns this red.
-        Mockito.verify(connector).invalidateTable("DB1", "TBL1");
-        Mockito.verify(connector).invalidateTable("DB1", "t2");
+        long destinationId = Util.genIdByName("test-catalog", "db1", "t2");
+        InOrder order = Mockito.inOrder(mockEditLog, connector, cachedDb, mockMetaCacheMgr);
+        order.verify(mockEditLog).logRefreshExternalTable(Mockito.any());
+        order.verify(connector).invalidateTable("DB1", "TBL1");
+        order.verify(connector).invalidateTable("DB1", "t2");
+        order.verify(cachedDb).invalidateTableRename("t1", "t2");
+        order.verify(mockMetaCacheMgr).invalidateTableRename(
+                1L, DATABASE_ID, "db1", TABLE_ID, "t1", destinationId, "t2");
     }
 
     @Test
@@ -636,6 +650,8 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Mockito.when(table.getRemoteName()).thenReturn("TBL1");
         Mockito.doReturn(table).when(db).getTableNullable("t1");
         catalog.dbNullableResult = db;
+        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
+        catalog.dbForReplayResult = Optional.of(replayDb);
         ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
         Mockito.when(metadata.getTableHandle(session, "DB1", "TBL1")).thenReturn(Optional.of(handle));
         Mockito.doThrow(new DorisConnectorException("boom")).when(metadata).renameTable(session, handle, "t2");
@@ -643,28 +659,20 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         DdlException ex = Assertions.assertThrows(DdlException.class,
                 () -> catalog.renameTable("db1", "t1", "t2"));
         Assertions.assertTrue(ex.getMessage().contains("boom"));
-        // WHY: a remote rename failure must abort BEFORE any bookkeeping (no editlog, no constraint rename),
-        // so the FE cache + constraints stay consistent with the unchanged remote.
         Mockito.verify(mockEditLog, Mockito.never()).logRefreshExternalTable(Mockito.any());
         Mockito.verifyNoInteractions(mockConstraintManager);
-        // WHY (R4): the connector-cache invalidation sits AFTER the successful renameTable, so a remote
-        // failure must NOT drop the connector cache — it stays consistent with the unchanged remote.
         Mockito.verify(connector, Mockito.never()).invalidateTable(Mockito.any(), Mockito.any());
     }
 
     // ==================== CREATE TABLE ====================
-    // FIX-DDL-REMOTE: createTable now resolves the local db name to its REMOTE (ODPS) name (via
-    // getDbNullable + db.getRemoteName()) and passes THAT to the converter; the table name is
-    // intentionally NOT remote-resolved (legacy parity). Edit log / cache invalidation still use
-    // the local names.
-
     @Test
     public void testCreateTablePassesRemoteDbNameToConverter() throws UserException {
         // local db1 maps to remote DB1.
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         Mockito.when(db.getRemoteName()).thenReturn("DB1");
         catalog.dbNullableResult = db;
-        catalog.dbForReplayResult = Optional.of(db);
+        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
+        catalog.dbForReplayResult = Optional.of(replayDb);
 
         try (MockedStatic<CreateTableInfoToConnectorRequestConverter> conv =
                 Mockito.mockStatic(CreateTableInfoToConnectorRequestConverter.class)) {
@@ -677,11 +685,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
             catalog.createTable(info);
 
-            // WHY: the converter (and thus the connector) must receive the REMOTE db name "DB1",
-            // not the local "db1", so name-mapped catalogs address the real ODPS schema. We assert
-            // on the SECOND argument actually passed to convert() -- NOT on req.getDbName(), which
-            // would be vacuous here because the converter is mocked and returns a stub unaffected
-            // by the dbName argument. A mutation that passes info.getDbName() makes this red.
             conv.verify(() -> CreateTableInfoToConnectorRequestConverter.convert(info, "DB1"));
         }
     }
@@ -717,9 +720,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
             catalog.createTable(info);
 
             Mockito.verify(metadata).createTable(session, req);
-            // WHY: edit log MUST carry the LOCAL names (followers replay this persist entry), even
-            // though the connector got the remote "DB1". A mutation persisting db.getRemoteName()
-            // must turn these red.
             ArgumentCaptor<org.apache.doris.persist.CreateTableInfo> persist =
                     ArgumentCaptor.forClass(org.apache.doris.persist.CreateTableInfo.class);
             Mockito.verify(mockEditLog).logCreateTable(persist.capture());
@@ -727,27 +727,47 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
                     "edit-log CreateTableInfo must carry the LOCAL db name for follower replay");
             Assertions.assertEquals("t1", persist.getValue().getTblName(),
                     "edit-log CreateTableInfo must carry the LOCAL table name for follower replay");
-            // Cache invalidation must look up the LOCAL db name and act on the replay db.
-            Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg,
-                    "cache invalidation must look up the LOCAL db name");
-            Mockito.verify(replayDb).resetMetaCacheNames();
-            // WHY (Rule 9): CREATE TABLE also drops any stale connector cache entry for the new name
-            // (belt-and-suspenders with the DROP path). Keyed by the REMOTE db name "DB1" but the
-            // (non-remote-resolved) table name "t1" — a mutation flipping the table name to remote, or
-            // dropping the call, makes this red.
+            Mockito.verify(mockMetaCacheMgr).invalidateTable(
+                    1L, DATABASE_ID, "db1", Util.genIdByName("test-catalog", "db1", "t1"), "t1");
             Mockito.verify(connector).invalidateTable("DB1", "t1");
         }
     }
 
     @Test
-    public void testCreateTableIfNotExistsExistingRemoteTableReturnsTrueAndSkipsSideEffects() throws Exception {
+    public void testCreateTablePersistsCanonicalLocalTableName() throws UserException {
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         Mockito.when(db.getRemoteName()).thenReturn("DB1");
+        Mockito.when(db.canonicalLocalTableNameFromRemote("REMOTE_T1")).thenReturn("local_t1");
         catalog.dbNullableResult = db;
-        // Distinct replay db: production resets the cache via getDbForReplay(...).resetMetaCacheNames()
-        // on the REPLAY db object (NOT catalog.resetMetaCacheNames()), so we must assert on it.
-        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
-        catalog.dbForReplayResult = Optional.of(replayDb);
+
+        try (MockedStatic<CreateTableInfoToConnectorRequestConverter> converter =
+                Mockito.mockStatic(CreateTableInfoToConnectorRequestConverter.class)) {
+            ConnectorCreateTableRequest request = Mockito.mock(ConnectorCreateTableRequest.class);
+            CreateTableInfo info = Mockito.mock(CreateTableInfo.class);
+            Mockito.when(info.getDbName()).thenReturn("db1");
+            Mockito.when(info.getTableName()).thenReturn("REMOTE_T1");
+            converter.when(() -> CreateTableInfoToConnectorRequestConverter.convert(info, "DB1"))
+                    .thenReturn(request);
+
+            catalog.createTable(info);
+
+            Mockito.verify(db).getTableNullable("local_t1");
+            ArgumentCaptor<org.apache.doris.persist.CreateTableInfo> log =
+                    ArgumentCaptor.forClass(org.apache.doris.persist.CreateTableInfo.class);
+            Mockito.verify(mockEditLog).logCreateTable(log.capture());
+            Assertions.assertEquals("db1", log.getValue().getDbName());
+            Assertions.assertEquals("local_t1", log.getValue().getTblName());
+            Mockito.verify(connector).invalidateTable("DB1", "REMOTE_T1");
+            Mockito.verify(mockMetaCacheMgr).invalidateTable(
+                    1L, DATABASE_ID, "db1", Util.genIdByName("test-catalog", "db1", "local_t1"), "local_t1");
+        }
+    }
+
+    @Test
+    public void testCreateTableIfNotExistsEvictsPreexistingRowCount() throws Exception {
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        catalog.dbNullableResult = db;
+        catalog.dbForReplayResult = Optional.of(db);
         ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
         Mockito.when(metadata.getTableHandle(session, "DB1", "t1")).thenReturn(Optional.of(handle));
         CreateTableInfo info = Mockito.mock(CreateTableInfo.class);
@@ -755,20 +775,29 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Mockito.when(info.getTableName()).thenReturn("t1");
         Mockito.when(info.isIfNotExists()).thenReturn(true);
 
-        boolean res = catalog.createTable(info);
+        long tableId = Util.genIdByName("test-catalog", "db1", "t1");
+        AtomicLong rowCount = new AtomicLong(100L);
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.fetchRowCountWithMetaCache(false)).thenAnswer(inv -> rowCount.get());
+        ExternalMetaCacheMgr realMetaCacheMgr = new ExternalMetaCacheMgr(true);
+        ExternalRowCountCache rowCountCache = new ExternalRowCountCache(
+                MoreExecutors.newDirectExecutorService());
+        Deencapsulation.setField(realMetaCacheMgr, "rowCountCache", rowCountCache);
+        Mockito.when(mockEnv.getExtMetaCacheMgr()).thenReturn(realMetaCacheMgr);
 
-        // WHY (Rule 9 / DG-6): returning false here makes CreateTableCommand:103 not short-circuit,
-        // so CTAS (CREATE TABLE IF NOT EXISTS ... AS SELECT) runs an INSERT into the pre-existing
-        // table -- a SILENT DATA CHANGE. The fix must return true and skip create/editlog/cache-reset.
-        Assertions.assertTrue(res,
-                "IF NOT EXISTS on an existing table must return true so CTAS short-circuits (no INSERT)");
-        Mockito.verify(metadata, Mockito.never()).createTable(Mockito.any(), Mockito.any());
-        Mockito.verify(mockEditLog, Mockito.never()).logCreateTable(Mockito.any());
-        // WHY (#66112): the no-op returns BEFORE the created-here bookkeeping, so without an explicit
-        // reset this FE keeps a table-name cache that predates the table -- a table created out-of-band
-        // (another engine / another FE) stays invisible to SHOW TABLES and to a following SELECT. No edit
-        // log though: nothing changed on the remote, so followers have nothing to replay.
-        Mockito.verify(replayDb).resetMetaCacheNames();
+        try (MockedStatic<StatisticsUtil> statisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+            statisticsUtil.when(() -> StatisticsUtil.findTable(1L, DATABASE_ID, tableId)).thenReturn(table);
+            Assertions.assertEquals(100L, rowCountCache.getCachedRowCount(1L, DATABASE_ID, tableId, false));
+
+            rowCount.set(200L);
+            boolean result = catalog.createTable(info);
+
+            Assertions.assertTrue(result);
+            Mockito.verify(metadata, Mockito.never()).createTable(Mockito.any(), Mockito.any());
+            Mockito.verify(mockEditLog, Mockito.never()).logCreateTable(Mockito.any());
+            Mockito.verify(connector).invalidateTable("DB1", "t1");
+            Assertions.assertEquals(200L, rowCountCache.getCachedRowCount(1L, DATABASE_ID, tableId, false));
+        }
     }
 
     @Test
@@ -793,14 +822,11 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         boolean res = catalog.createTable(info);
 
-        // WHY (#66112): IF NOT EXISTS means "ensure it is there", so losing the race is a successful
-        // no-op -- and it must answer TRUE, not false: false would tell CreateTableCommand that THIS
-        // statement created the table, so a CTAS would INSERT into the winner's table and, on failure,
-        // drop it. No edit log / no connector-cache invalidation: this statement changed nothing remotely.
         Assertions.assertTrue(res, "losing the create race under IF NOT EXISTS must return true");
         Mockito.verify(mockEditLog, Mockito.never()).logCreateTable(Mockito.any());
-        Mockito.verify(connector, Mockito.never()).invalidateTable(Mockito.any(), Mockito.any());
-        Mockito.verify(replayDb).resetMetaCacheNames();
+        Mockito.verify(connector).invalidateTable("DB1", "t1");
+        Mockito.verify(mockMetaCacheMgr).invalidateTable(
+                1L, DATABASE_ID, "db1", Util.genIdByName("test-catalog", "db1", "t1"), "t1");
     }
 
     @Test
@@ -810,7 +836,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         Mockito.when(db.getRemoteName()).thenReturn("DB1");
         catalog.dbNullableResult = db;
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
         ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
         Mockito.when(metadata.getTableHandle(session, "DB1", "t1"))
                 .thenReturn(Optional.empty(), Optional.of(handle));
@@ -842,19 +867,15 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         boolean res = catalog.createTable(info);
 
-        // WHY: legacy checks BOTH remote AND local; this pins the local arm so a refactor that drops
-        // the `|| db.getTableNullable(...) != null` probe (keeping only getTableHandle) goes red.
         Assertions.assertTrue(res, "existing local table + IF NOT EXISTS must return true");
         Mockito.verify(metadata, Mockito.never()).createTable(Mockito.any(), Mockito.any());
         Mockito.verify(mockEditLog, Mockito.never()).logCreateTable(Mockito.any());
+        Mockito.verify(mockMetaCacheMgr).invalidateTable(
+                1L, DATABASE_ID, "db1", Util.genIdByName("test-catalog", "db1", "t1"), "t1");
     }
 
     @Test
     public void testCreateTableExistingRemoteTableWithoutIfNotExistsReportsErrno1050() {
-        // FIX-R1-TABLE: a table that exists REMOTELY but is absent from this FE's cache (stale cache /
-        // other-FE / external create), created without IF NOT EXISTS, must be rejected with MySQL errno
-        // 1050 (ERR_TABLE_EXISTS_ERROR / SQLSTATE 42S01) -- legacy parity ({Paimon,MaxCompute}MetadataOps
-        // both report 1050 for the remote arm). The connector is NOT consulted (the FE short-circuits).
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         Mockito.when(db.getRemoteName()).thenReturn("DB1");
         catalog.dbNullableResult = db;
@@ -865,13 +886,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Mockito.when(info.getTableName()).thenReturn("t1");
         Mockito.when(info.isIfNotExists()).thenReturn(false);
 
-        // WHY (Rule 9 / Rule 12): pre-fix the bridge gated the 1050 report on localExists only, so a
-        // remote-ONLY conflict fell through to metadata.createTable and surfaced a GENERIC DdlException
-        // (errno ERR_UNKNOWN_ERROR = 0) -- silently dropping the documented MySQL 1050 contract some
-        // ORMs branch on. The fix reports 1050 at the FE before the connector. MUTATION: restoring the
-        // `if (localExists)` guard makes this remote-only case (localExists=false) fall through -> errno
-        // reverts to 0 and metadata.createTable IS called -> the errno assertion AND the never().createTable
-        // verify both go red.
         DdlException ex = Assertions.assertThrows(DdlException.class, () -> catalog.createTable(info));
         Assertions.assertEquals(ErrorCode.ERR_TABLE_EXISTS_ERROR, ex.getMysqlErrorCode(),
                 "remote-existing table without IF NOT EXISTS must surface MySQL errno 1050 (legacy parity)");
@@ -882,12 +896,7 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
     @Test
     public void testCreateTableLocalConflictWithoutIfNotExistsRejects() throws Exception {
-        // Remote says ABSENT (getTableHandle empty) but the FE cache HAS the table -- the local arm of the
-        // legacy remote-then-local probe (PaimonMetadataOps.performCreateTable:206-214). Under
-        // lower_case_meta_names a case-variant name folds onto an existing local table while the
-        // case-sensitive remote has no such table. Legacy throws ERR_TABLE_EXISTS_ERROR here; the bridge
-        // must NOT fall through to metadata.createTable, which would CREATE a duplicate remote table
-        // (silent metadata corruption).
+        // A case-folded local name may conflict even when the case-sensitive remote name is absent.
         ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
         Mockito.when(db.getRemoteName()).thenReturn("DB1");
         Mockito.doReturn(Mockito.mock(ExternalTable.class)).when(db).getTableNullable("t1");
@@ -904,13 +913,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
             Mockito.when(info.getTableName()).thenReturn("t1");
             Mockito.when(info.isIfNotExists()).thenReturn(false);
 
-            // WHY (Rule 9 / Rule 12): a local-ONLY conflict without IF NOT EXISTS must be REJECTED at the FE
-            // level with MySQL errno 1050 (ERR_TABLE_EXISTS_ERROR), never handed to connector.createTable
-            // (which would create a duplicate remote table under lower_case_meta_names case-folding). Paired
-            // with testCreateTableExistingRemoteTableWithoutIfNotExistsReportsErrno1050, this pins that the
-            // existence rejection covers EITHER arm: MUTATION re-narrowing the report to the remote arm only
-            // (e.g. `if (remoteExists)`) lets this local-only case (remoteExists=false) fall through ->
-            // createTable called + errno reverts to ERR_UNKNOWN_ERROR -> the asserts below go red.
             DdlException ex = Assertions.assertThrows(DdlException.class, () -> catalog.createTable(info));
             Assertions.assertEquals(ErrorCode.ERR_TABLE_EXISTS_ERROR, ex.getMysqlErrorCode(),
                     "local-cache conflict without IF NOT EXISTS must surface MySQL errno 1050");
@@ -920,14 +922,74 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         }
     }
 
-    // ==================== EDIT-LOG REPLAY (follower / observer propagation) ====================
-    // R1: the coordinator dropTable/createTable/dropDb hooks drop the connector's OWN cache, but editlog
-    // replay on followers/observers went through the base ExternalCatalog.replay* plugin branch, which only
-    // touched the FE name cache — so a follower kept the dropped/renamed object's snapshot pin to the TTL.
-    // These overrides propagate connector.invalidate* on replay too, keyed like the coordinator, WITHOUT
-    // force-initializing a catalog (the getDbForReplay/getTableForReplay match is present only when already
-    // initialized on this FE).
+    // ==================== TRUNCATE TABLE ====================
 
+    @Test
+    public void testTruncateTablePersistsCanonicalLocalNames() throws Exception {
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        Mockito.when(db.getId()).thenReturn(DATABASE_ID);
+        ExternalTable table = mockAlterTable();
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
+        Mockito.when(db.getFullName()).thenReturn("db1");
+        Mockito.doReturn(table).when(db).getTableNullable("T1");
+        catalog.dbNullableResult = db;
+        ConnectorTableHandle handle = Mockito.mock(ConnectorTableHandle.class);
+        Mockito.when(metadata.getTableHandle(session, "DB1", "TBL1")).thenReturn(Optional.of(handle));
+
+        catalog.truncateTable("DB1", "T1", null, false, "");
+
+        Mockito.verify(metadata).truncateTable(session, handle, null);
+        ArgumentCaptor<TruncateTableInfo> log = ArgumentCaptor.forClass(TruncateTableInfo.class);
+        Mockito.verify(mockEditLog).logTruncateTable(log.capture());
+        Assertions.assertEquals("db1", log.getValue().getDb());
+        Assertions.assertEquals("t1", log.getValue().getTable());
+        Mockito.verify(mockRefreshManager).refreshTableInternal(Mockito.eq(db), Mockito.eq(table), Mockito.anyLong());
+    }
+
+    @Test
+    public void testReplayTruncateUsesNormalRefreshWhenTableObjectIsCached() {
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        ExternalTable table = mockAlterTable();
+        Mockito.doReturn(Optional.of(table)).when(db).getTableForReplay("t1");
+        catalog.dbForReplayResult = Optional.of(db);
+        TruncateTableInfo info = new TruncateTableInfo("test-catalog", "db1", "t1", null, 123L);
+
+        catalog.replayTruncateTable(info);
+
+        Mockito.verify(mockRefreshManager).refreshTableInternal(db, table, 123L);
+        Mockito.verifyNoInteractions(mockMetaCacheMgr);
+    }
+
+    @Test
+    public void testReplayTruncateInvalidatesByCanonicalNameWhenTableObjectIsCold() {
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        Mockito.when(db.getRemoteName()).thenReturn("DB1");
+        Mockito.doReturn(Optional.empty()).when(db).getTableForReplay("t1");
+        catalog.dbForReplayResult = Optional.of(db);
+
+        catalog.replayTruncateTable(new TruncateTableInfo("test-catalog", "db1", "t1", null, 123L));
+
+        InOrder order = Mockito.inOrder(connector, mockMetaCacheMgr);
+        order.verify(connector).invalidateDb("DB1");
+        order.verify(mockMetaCacheMgr).invalidateTable(
+                1L, Util.genIdByName("test-catalog", "db1"), "db1",
+                Util.genIdByName("test-catalog", "db1", "t1"), "t1");
+    }
+
+    @Test
+    public void testReplayTruncateInvalidatesAllConnectorCachesWhenDatabaseObjectIsCold() {
+        catalog.dbForReplayResult = Optional.empty();
+
+        catalog.replayTruncateTable(new TruncateTableInfo("test-catalog", "db1", "t1", null, 123L));
+
+        InOrder order = Mockito.inOrder(connector, mockMetaCacheMgr);
+        order.verify(connector).invalidateAll();
+        order.verify(mockMetaCacheMgr).invalidateTable(
+                1L, Util.genIdByName("test-catalog", "db1"), "db1",
+                Util.genIdByName("test-catalog", "db1", "t1"), "t1");
+    }
+
+    // ==================== EDIT-LOG REPLAY (follower / observer propagation) ====================
     @Test
     public void testReplayDropTableInvalidatesConnectorOnFollower() {
         // local db1.t1 maps to remote DB1.TBL1; the table is still in the replay cache when the drop replays.
@@ -940,26 +1002,56 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.replayDropTable("db1", "t1");
 
-        // WHY (Rule 9 / R1): without the override a follower kept the dropped table's latest-snapshot pin (and
-        // paimon schema memo) to the 24h TTL — the coordinator-only half of the drop+recreate fix. Replay must
-        // drop it, keyed by the REMOTE names resolved from the still-cached table BEFORE unregister. MUTATION:
-        // removing the override, or passing the LOCAL names, turns this red.
         Mockito.verify(connector).invalidateTable("DB1", "TBL1");
-        // Base bookkeeping is preserved: the table is still unregistered from the FE name cache.
         Mockito.verify(replayDb).unregisterTable("t1");
     }
 
     @Test
-    public void testReplayDropTableUninitializedCatalogSkipsInvalidate() {
-        // A follower that never initialized this catalog: getDbForReplay returns empty -> no connector cache
-        // exists to drop, and the override must NOT force-initialize the catalog (no invalidate, no throw).
+    public void testReplayDropTableDoesNotInitializeColdDatabase() {
+        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
+        Mockito.when(replayDb.isInitialized()).thenReturn(false);
+        Mockito.doReturn(Optional.empty()).when(replayDb).getTableForReplay("t1");
+        catalog.dbForReplayResult = Optional.of(replayDb);
+
+        catalog.replayDropTable("db1", "t1");
+
+        Mockito.verify(replayDb, Mockito.never()).unregisterTable(Mockito.anyString());
+        verifyDeterministicTableInvalidation("db1", "t1");
+    }
+
+    @Test
+    public void testReplayDropTableInvalidatesDatabaseConnectorCacheWhenTableObjectIsCold() {
+        ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
+        Mockito.when(replayDb.getRemoteName()).thenReturn("DB1");
+        Mockito.doReturn(Optional.empty()).when(replayDb).getTableForReplay("t1");
+        catalog.dbForReplayResult = Optional.of(replayDb);
+
+        catalog.replayDropTable("db1", "t1");
+
+        Mockito.verify(connector).invalidateDb("DB1");
+        Mockito.verify(replayDb).unregisterTable("t1");
+    }
+
+    @Test
+    public void testReplayDropTableInvalidatesAllConnectorCachesWhenDatabaseObjectIsCold() {
         catalog.dbForReplayResult = Optional.empty();
 
         catalog.replayDropTable("db1", "t1");
 
-        // WHY (R1 no-force-init): the connector is untouched when the catalog is not initialized on this FE.
-        // MUTATION: using getConnector() unconditionally (force-init) would invoke the connector here -> red.
-        Mockito.verify(connector, Mockito.never()).invalidateTable(Mockito.any(), Mockito.any());
+        Mockito.verify(connector).invalidateAll();
+        verifyDeterministicTableInvalidation("db1", "t1");
+    }
+
+    @Test
+    public void testReplayDropTableUninitializedCatalogSkipsInvalidate() {
+        // Replay must not initialize a catalog solely to invalidate connector state.
+        catalog.setInitializedForTest(false);
+        catalog.dbForReplayResult = Optional.empty();
+
+        catalog.replayDropTable("db1", "t1");
+
+        Mockito.verifyNoInteractions(connector);
+        verifyDeterministicTableInvalidation("db1", "t1");
     }
 
     @Test
@@ -970,12 +1062,20 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.replayDropDb("db1");
 
-        // WHY (R1): DROP DATABASE replay must drop every table's connector cache for the db (keyed by the
-        // REMOTE db name), mirroring the coordinator dropDb hook. MUTATION: removing the override or passing
-        // the LOCAL "db1" turns this red.
         Mockito.verify(connector).invalidateDb("DB1");
-        // Base bookkeeping is preserved (the db is unregistered by the LOCAL name).
         Assertions.assertEquals("db1", catalog.unregisteredDb);
+        verifyDeterministicDatabaseInvalidation("db1");
+    }
+
+    @Test
+    public void testReplayDropDbInvalidatesAllWhenDatabaseObjectIsCold() {
+        catalog.dbForReplayResult = Optional.empty();
+
+        catalog.replayDropDb("db1");
+
+        Mockito.verify(connector).invalidateAll();
+        Assertions.assertEquals("db1", catalog.unregisteredDb);
+        verifyDeterministicDatabaseInvalidation("db1");
     }
 
     @Test
@@ -986,20 +1086,30 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
 
         catalog.replayCreateTable("db1", "t1");
 
-        // WHY (R1): belt-and-suspenders parity with the coordinator createTable hook — keyed by the REMOTE db
-        // name "DB1" but the (non-remote-resolved) table name "t1". MUTATION: flipping the table name to remote
-        // or dropping the call turns this red.
-        Mockito.verify(connector).invalidateTable("DB1", "t1");
-        // Base bookkeeping is preserved (the db's table-name cache is refreshed).
-        Mockito.verify(replayDb).resetMetaCacheNames();
+        Mockito.verify(connector).invalidateDb("DB1");
+        verifyDeterministicTableInvalidation("db1", "t1");
     }
 
-    // ==================== COLUMN EVOLUTION (B2) ====================
-    // The 6 column-op overrides resolve the connector handle by REMOTE names (like dropTable), convert the
-    // Doris Column/ColumnPosition to the neutral SPI types, dispatch, wrap DorisConnectorException as
-    // DdlException, and run afterExternalDdl (editlog with LOCAL names + RefreshManager.refreshTableInternal
-    // re-resolving by REMOTE names). PluginDriven has no metadataOps, so without these overrides the base ops
-    // would throw "not supported".
+    @Test
+    public void testReplayCreateTableInvalidatesAllWhenDatabaseObjectIsCold() {
+        catalog.dbForReplayResult = Optional.empty();
+
+        catalog.replayCreateTable("db1", "t1");
+
+        Mockito.verify(connector).invalidateAll();
+        verifyDeterministicTableInvalidation("db1", "t1");
+    }
+
+    @Test
+    public void testReplayCreateDbInvalidatesDatabaseCaches() {
+        catalog.replayCreateDb("db1");
+
+        Assertions.assertEquals(1, catalog.resetMetaCacheNamesCount);
+        Mockito.verify(connector).invalidateAll();
+        verifyDeterministicDatabaseInvalidation("db1");
+    }
+
+    // ==================== COLUMN EVOLUTION ====================
 
     @Test
     public void testAddColumnRoutesConvertsAndLogsRefresh() throws Exception {
@@ -1013,11 +1123,7 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Mockito.verify(metadata).addColumn(Mockito.eq(session), Mockito.eq(handle),
                 colCap.capture(), posCap.capture());
         Assertions.assertEquals("age", colCap.getValue().getName());
-        // WHY: position FIRST must be neutralized to ConnectorColumnPosition.FIRST (toConnectorPosition); a
-        // mutation dropping the isFirst() branch makes this red.
         Assertions.assertTrue(posCap.getValue().isFirst());
-        // WHY (Rule 9): the editlog MUST carry the LOCAL names for follower replay (base
-        // logRefreshExternalTable parity); a mutation persisting the remote names turns these red.
         ArgumentCaptor<ExternalObjectLog> logCap = ArgumentCaptor.forClass(ExternalObjectLog.class);
         Mockito.verify(mockEditLog).logRefreshExternalTable(logCap.capture());
         Assertions.assertEquals("db1", logCap.getValue().getDbName());
@@ -1069,8 +1175,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         ArgumentCaptor<ConnectorColumnPosition> posCap = ArgumentCaptor.forClass(ConnectorColumnPosition.class);
         Mockito.verify(metadata).modifyColumn(Mockito.eq(session), Mockito.eq(handle),
                 Mockito.any(ConnectorColumn.class), posCap.capture());
-        // WHY: AFTER <col> must be neutralized to ConnectorColumnPosition.after(col); a mutation that drops
-        // the afterColumn or flips it to FIRST makes these red.
         Assertions.assertFalse(posCap.getValue().isFirst());
         Assertions.assertEquals("id", posCap.getValue().getAfterColumn());
     }
@@ -1095,8 +1199,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         ArgumentCaptor<ConnectorColumnPosition> posCap = ArgumentCaptor.forClass(ConnectorColumnPosition.class);
         Mockito.verify(metadata).addColumn(Mockito.any(), Mockito.any(),
                 Mockito.any(ConnectorColumn.class), posCap.capture());
-        // WHY: a null ColumnPosition (no position clause) must stay null across the SPI (toConnectorPosition
-        // null-guard); a mutation returning FIRST/after for null would change append semantics.
         Assertions.assertNull(posCap.getValue());
     }
 
@@ -1104,26 +1206,30 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     public void testColumnOpRefreshesTableCacheViaRefreshManager() throws Exception {
         ExternalTable table = mockAlterTable();
         stubAlterHandle();
-        // afterExternalDdl re-resolves the cached table by the REMOTE names (legacy IcebergMetadataOps.refreshTable
-        // parity), then calls RefreshManager.refreshTableInternal — the cache-invalidation the base column op
-        // delegated into metadataOps and PluginDriven (metadataOps == null) must reproduce explicitly.
         ExternalDatabase<? extends ExternalTable> replayDb = mockExternalDatabase();
         ExternalTable cached = Mockito.mock(ExternalTable.class);
-        Mockito.doReturn(Optional.of(cached)).when(replayDb).getTableForReplay("TBL1");
+        Mockito.doReturn(replayDb).when(cached).getDb();
+        Mockito.doReturn(Optional.of(cached)).when(replayDb).getTableForReplay("t1");
         catalog.dbForReplayResult = Optional.of(replayDb);
 
         catalog.dropColumn(table, "age");
 
-        // WHY (Rule 9 / BLOCKER-2): the base column ops do NOT invalidate the cache themselves — they delegate it
-        // into metadataOps.refreshTable -> RefreshManager.refreshTableInternal. A helper that only writes the
-        // editlog (the literal "copy the base op" reading) would SILENTLY lose cache invalidation after every
-        // connector-driven schema change. These asserts pin that the refresh actually runs, re-resolving by the
-        // REMOTE names. A mutation dropping the refreshTableInternal call goes red.
-        Assertions.assertEquals("DB1", catalog.lastGetDbForReplayArg,
-                "afterExternalDdl must re-resolve the cached table by the REMOTE db name (legacy parity)");
-        Mockito.verify(replayDb).getTableForReplay("TBL1");
+        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg);
+        Mockito.verify(replayDb).getTableForReplay("t1");
         Mockito.verify(mockRefreshManager)
                 .refreshTableInternal(Mockito.eq(replayDb), Mockito.eq(cached), Mockito.anyLong());
+    }
+
+    @Test
+    public void testColumnOpRefreshesTransientTableWhenSharedCacheIsCold() throws Exception {
+        ExternalTable transientTable = mockAlterTable();
+        stubAlterHandle();
+
+        catalog.dropColumn(transientTable, "age");
+
+        Assertions.assertEquals("db1", catalog.lastGetDbForReplayArg);
+        Mockito.verify(mockRefreshManager).refreshTableInternal(
+                Mockito.eq(transientTable.getDb()), Mockito.eq(transientTable), Mockito.anyLong());
     }
 
     @Test
@@ -1146,25 +1252,16 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Assertions.assertTrue(ex.getMessage().contains("boom"));
     }
 
-    // Branch/tag ALTERs resolve the handle by REMOTE names (like the column ops), neutralize the nereids info
-    // type to the SPI carrier (ConnectorBranchTagConverter), wrap a DorisConnectorException as a DdlException,
-    // and run afterExternalDdl (editlog with LOCAL names + refreshTableInternal). PluginDriven has no
-    // metadataOps, so without these overrides the base ops would throw "branching operation is not supported".
-
     @Test
     public void testCreateOrReplaceBranchRoutesConvertsAndRefreshes() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         CreateOrReplaceBranchInfo info = new CreateOrReplaceBranchInfo("b1", true, false, true,
                 new BranchOptions(Optional.of(42L), Optional.of(86400000L),
                         Optional.of(5), Optional.of(172800000L)));
         catalog.createOrReplaceBranch(table, info);
 
-        // WHY (Rule 9): the converter must map every field of the nereids info/options to the neutral carrier
-        // (incl. the legacy retain->maxSnapshotAge / numSnapshots->minSnapshotsToKeep / retention->maxRefAge
-        // mapping). A mutation dropping any field makes one of these asserts red.
         ArgumentCaptor<BranchChange> cap = ArgumentCaptor.forClass(BranchChange.class);
         Mockito.verify(metadata).createOrReplaceBranch(Mockito.eq(session), Mockito.eq(handle), cap.capture());
         BranchChange b = cap.getValue();
@@ -1176,21 +1273,16 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Assertions.assertEquals(86400000L, b.getMaxSnapshotAgeMs().longValue());
         Assertions.assertEquals(5, b.getMinSnapshotsToKeep().intValue());
         Assertions.assertEquals(172800000L, b.getMaxRefAgeMs().longValue());
-        // WHY: branch/tag share the column-op bookkeeping (afterExternalDdl) — editlog with LOCAL names + cache
-        // refresh re-resolving by REMOTE names. A mutation dropping the bookkeeping turns these red.
         ArgumentCaptor<ExternalObjectLog> logCap = ArgumentCaptor.forClass(ExternalObjectLog.class);
         Mockito.verify(mockEditLog).logRefreshExternalTable(logCap.capture());
         Assertions.assertEquals("db1", logCap.getValue().getDbName());
         Assertions.assertEquals("t1", logCap.getValue().getTableName());
-        Assertions.assertEquals("DB1", catalog.lastGetDbForReplayArg,
-                "afterExternalDdl must re-resolve the cached table by the REMOTE db name");
     }
 
     @Test
     public void testCreateOrReplaceBranchEmptyOptionsConvertToNulls() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.createOrReplaceBranch(table, new CreateOrReplaceBranchInfo("b1", true, false, false,
                 BranchOptions.EMPTY));
@@ -1215,7 +1307,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         DdlException ex = Assertions.assertThrows(DdlException.class, () -> catalog.createOrReplaceBranch(table,
                 new CreateOrReplaceBranchInfo("b1", true, false, false, BranchOptions.EMPTY)));
         Assertions.assertTrue(ex.getMessage().contains("boom"));
-        // A remote failure must abort BEFORE bookkeeping (no editlog).
         Mockito.verify(mockEditLog, Mockito.never()).logRefreshExternalTable(Mockito.any());
     }
 
@@ -1223,7 +1314,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     public void testCreateOrReplaceTagRoutesConvertsAndRefreshes() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.createOrReplaceTag(table, new CreateOrReplaceTagInfo("v1", false, true, false,
                 new TagOptions(Optional.of(9L), Optional.of(99000L))));
@@ -1243,7 +1333,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     public void testDropBranchRoutesConvertsAndRefreshes() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.dropBranch(table, new DropBranchInfo("b1", true));
 
@@ -1258,7 +1347,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     public void testDropTagRoutesConvertsAndRefreshes() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.dropTag(table, new DropTagInfo("v1", false));
 
@@ -1279,18 +1367,13 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
                 .dropTag(Mockito.any(), Mockito.any(), Mockito.any());
     }
 
-    // ---------- Partition evolution (B5): route by handle, convert op -> DTO, bookkeep ----------
-
     @Test
     public void testAddPartitionFieldRoutesConvertsAndRefreshes() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.addPartitionField(table, new AddPartitionFieldOp("bucket", 8, "id", "id_b"));
 
-        // WHY (Rule 9): the op's transform spec must reach the connector as a neutral PartitionFieldChange; a
-        // mutation dropping any field makes one of these asserts red.
         ArgumentCaptor<PartitionFieldChange> cap = ArgumentCaptor.forClass(PartitionFieldChange.class);
         Mockito.verify(metadata).addPartitionField(Mockito.eq(session), Mockito.eq(handle), cap.capture());
         PartitionFieldChange c = cap.getValue();
@@ -1299,21 +1382,16 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Assertions.assertEquals("id", c.getColumnName());
         Assertions.assertEquals("id_b", c.getPartitionFieldName());
         Assertions.assertNull(c.getOldColumnName());
-        // WHY: a partition spec change shares the column-op bookkeeping (afterExternalDdl) — editlog with LOCAL
-        // names + cache refresh re-resolving by REMOTE names. A mutation dropping it turns these red.
         ArgumentCaptor<ExternalObjectLog> logCap = ArgumentCaptor.forClass(ExternalObjectLog.class);
         Mockito.verify(mockEditLog).logRefreshExternalTable(logCap.capture());
         Assertions.assertEquals("db1", logCap.getValue().getDbName());
         Assertions.assertEquals("t1", logCap.getValue().getTableName());
-        Assertions.assertEquals("DB1", catalog.lastGetDbForReplayArg,
-                "afterExternalDdl must re-resolve the cached table by the REMOTE db name");
     }
 
     @Test
     public void testDropPartitionFieldRoutesByName() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.dropPartitionField(table, new DropPartitionFieldOp("p_id"));
 
@@ -1328,7 +1406,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     public void testReplacePartitionFieldRoutesMapsOldAndNew() throws Exception {
         ExternalTable table = mockAlterTable();
         ConnectorTableHandle handle = stubAlterHandle();
-        catalog.dbForReplayResult = Optional.of(mockExternalDatabase());
 
         catalog.replacePartitionField(table,
                 new ReplacePartitionFieldOp("p", null, null, null, "bucket", 4, "id", "p2"));
@@ -1336,7 +1413,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         ArgumentCaptor<PartitionFieldChange> cap = ArgumentCaptor.forClass(PartitionFieldChange.class);
         Mockito.verify(metadata).replacePartitionField(Mockito.eq(session), Mockito.eq(handle), cap.capture());
         PartitionFieldChange c = cap.getValue();
-        // new* maps to the primary field, old* to the old side (Rule 9).
         Assertions.assertEquals("bucket", c.getTransformName());
         Assertions.assertEquals(4, c.getTransformArg().intValue());
         Assertions.assertEquals("id", c.getColumnName());
@@ -1355,7 +1431,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         DdlException ex = Assertions.assertThrows(DdlException.class, () -> catalog.addPartitionField(table,
                 new AddPartitionFieldOp(null, null, "id", null)));
         Assertions.assertTrue(ex.getMessage().contains("boom"));
-        // A remote failure must abort BEFORE bookkeeping (no editlog).
         Mockito.verify(mockEditLog, Mockito.never()).logRefreshExternalTable(Mockito.any());
     }
 
@@ -1375,10 +1450,13 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     /** A mock external table whose LOCAL names are db1.t1 and REMOTE names DB1.TBL1 (name mapping enabled). */
     private ExternalTable mockAlterTable() {
         ExternalTable table = Mockito.mock(ExternalTable.class);
+        Mockito.when(table.getId()).thenReturn(TABLE_ID);
         Mockito.when(table.getDbName()).thenReturn("db1");
         Mockito.when(table.getName()).thenReturn("t1");
         Mockito.when(table.getRemoteDbName()).thenReturn("DB1");
         Mockito.when(table.getRemoteName()).thenReturn("TBL1");
+        ExternalDatabase<? extends ExternalTable> db = mockExternalDatabase();
+        Mockito.doReturn(db).when(table).getDb();
         return table;
     }
 
@@ -1390,13 +1468,32 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
     }
 
     /** A nullable INT Doris column (iceberg add/modify reject non-nullable adds). */
+    private void verifyDeterministicDatabaseInvalidation(String dbName) {
+        Mockito.verify(mockMetaCacheMgr).invalidateDb(
+                1L, Util.genIdByName("test-catalog", dbName), dbName);
+    }
+
+    private void verifyDeterministicTableInvalidation(String dbName, String tableName) {
+        Mockito.verify(mockMetaCacheMgr).invalidateTable(
+                1L, Util.genIdByName("test-catalog", dbName), dbName,
+                Util.genIdByName("test-catalog", dbName, tableName), tableName);
+    }
+
     private static Column nullableIntColumn(String name) {
         return new Column(name, Type.INT, false, null, true, null, "");
     }
 
     @SuppressWarnings("unchecked")
     private ExternalDatabase<? extends ExternalTable> mockExternalDatabase() {
-        return (ExternalDatabase<? extends ExternalTable>) Mockito.mock(ExternalDatabase.class);
+        ExternalDatabase<? extends ExternalTable> db =
+                (ExternalDatabase<? extends ExternalTable>) Mockito.mock(ExternalDatabase.class);
+        Mockito.when(db.getFullName()).thenReturn("db1");
+        Mockito.when(db.getRemoteName()).thenReturn("DB1");
+        Mockito.when(db.getId()).thenReturn(DATABASE_ID);
+        Mockito.when(db.isInitialized()).thenReturn(true);
+        Mockito.when(db.canonicalLocalTableNameFromRemote(Mockito.anyString()))
+                .thenAnswer(inv -> inv.getArgument(0));
+        return db;
     }
 
     /**
@@ -1410,8 +1507,6 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         Optional<ExternalDatabase<? extends ExternalTable>> dbForReplayResult = Optional.empty();
         int resetMetaCacheNamesCount;
         String unregisteredDb;
-        // Records the arg passed to getDbForReplay so tests can assert the cache-invalidation
-        // lookup uses the LOCAL db name (follower-replay parity), not the remote-resolved one.
         String lastGetDbForReplayArg;
 
         TestablePluginCatalog(Connector initial) {
@@ -1442,17 +1537,19 @@ public class PluginDrivenExternalCatalogDdlRoutingTest {
         @Override
         public Optional<ExternalDatabase<? extends ExternalTable>> getDbForReplay(String dbName) {
             lastGetDbForReplayArg = dbName;
-            return dbForReplayResult;
+            return dbForReplayResult.filter(db -> dbName.equals(db.getFullName()));
         }
 
         @Override
         public void resetMetaCacheNames() {
             resetMetaCacheNamesCount++;
+            super.resetMetaCacheNames();
         }
 
         @Override
         public void unregisterDatabase(String dbName) {
             unregisteredDb = dbName;
+            super.unregisterDatabase(dbName);
         }
 
         private static Map<String, String> testProps() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogIdentityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogIdentityTest.java
@@ -17,15 +17,18 @@
 
 package org.apache.doris.datasource.plugin;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.log.InitCatalogLog;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
@@ -61,8 +64,14 @@ public class PluginDrivenExternalCatalogIdentityTest {
     private static void assertRegisteredIdentity(
             int mode, String remoteName, String mappedName, String expectedLocalName) {
         RecordingCatalog catalog = new RecordingCatalog(mode, mappedName);
+        Env env = Mockito.mock(Env.class);
+        ExternalMetaCacheMgr cacheMgr = Mockito.mock(ExternalMetaCacheMgr.class);
+        Mockito.when(env.getExtMetaCacheMgr()).thenReturn(cacheMgr);
 
-        catalog.registerDatabase(remoteName);
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            catalog.registerDatabaseFromEvent(remoteName, catalog.canonicalNameForTest(remoteName));
+        }
 
         Assertions.assertEquals(remoteName, catalog.registeredRemoteName);
         Assertions.assertEquals(expectedLocalName, catalog.registeredLocalName);
@@ -71,6 +80,8 @@ public class PluginDrivenExternalCatalogIdentityTest {
         Assertions.assertFalse(catalog.registeredCheckExists);
         Assertions.assertEquals(expectedLocalName, catalog.canonicalNameForTest(remoteName));
         Assertions.assertFalse(catalog.hasMetaCacheEntriesForTest());
+        Mockito.verify(cacheMgr).invalidateDb(
+                catalog.getId(), Util.genIdByName(catalog.getName(), expectedLocalName), expectedLocalName);
     }
 
     private static class RecordingCatalog extends PluginDrivenExternalCatalog {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteActionCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteActionCommandTest.java
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.RefreshManager;
+import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.CatalogMgr;
+import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.ExternalTable;
+import org.apache.doris.nereids.trees.plans.commands.execute.ExecuteAction;
+import org.apache.doris.nereids.trees.plans.commands.execute.ExecuteActionFactory;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.StmtExecutor;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class ExecuteActionCommandTest {
+
+    @Test
+    public void testCommandDoesNotRepeatActionOwnedMutationFence() throws Exception {
+        Fixture fixture = new Fixture();
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ExecuteActionFactory> factoryStatic = Mockito.mockStatic(ExecuteActionFactory.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(fixture.env);
+            factoryStatic.when(() -> ExecuteActionFactory.createAction(
+                            Mockito.anyString(), Mockito.anyMap(), Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(fixture.action);
+
+            fixture.command.run(fixture.context, fixture.executor);
+
+            Mockito.verify(fixture.action).execute(fixture.table);
+            Mockito.verifyNoInteractions(fixture.refreshManager, fixture.executor);
+        }
+    }
+
+    @Test
+    public void testFailedMutationSkipsPostCommitRefresh() throws Exception {
+        Fixture fixture = new Fixture();
+        Mockito.when(fixture.action.execute(fixture.table)).thenThrow(new UserException("remote failure"));
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ExecuteActionFactory> factoryStatic = Mockito.mockStatic(ExecuteActionFactory.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(fixture.env);
+            factoryStatic.when(() -> ExecuteActionFactory.createAction(
+                            Mockito.anyString(), Mockito.anyMap(), Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(fixture.action);
+
+            DdlException thrown = Assertions.assertThrows(
+                    DdlException.class, () -> fixture.command.run(fixture.context, fixture.executor));
+            Assertions.assertTrue(thrown.getMessage().contains("remote failure"));
+            Mockito.verifyNoInteractions(fixture.refreshManager, fixture.executor);
+        }
+    }
+
+    private static final class Fixture {
+        private final Env env = Mockito.mock(Env.class);
+        private final CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        private final RefreshManager refreshManager = Mockito.mock(RefreshManager.class);
+        private final ExternalCatalog catalog = Mockito.mock(ExternalCatalog.class);
+        private final ExternalDatabase database = Mockito.mock(ExternalDatabase.class);
+        private final ExternalTable table = Mockito.mock(ExternalTable.class);
+        private final ExecuteAction action = Mockito.mock(ExecuteAction.class);
+        private final ConnectContext context = Mockito.mock(ConnectContext.class);
+        private final StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        private final ExecuteActionCommand command = new ExecuteActionCommand(
+                new TableNameInfo("ctl", "db", "tbl"), "action", Collections.emptyMap(),
+                Optional.empty(), Optional.empty());
+
+        private Fixture() throws UserException {
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(env.getRefreshManager()).thenReturn(refreshManager);
+            Mockito.when(catalogMgr.getCatalog("ctl")).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable("db")).thenReturn(database);
+            Mockito.when(database.getTableNullable("tbl")).thenReturn(table);
+            Mockito.when(action.isSupported(table)).thenReturn(true);
+            Mockito.when(action.execute(table)).thenReturn(null);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorExecuteActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorExecuteActionTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -77,7 +78,7 @@ import java.util.Optional;
  * <p><b>WHY this matters:</b> at the P6.6 iceberg cutover, {@code ALTER TABLE t EXECUTE proc(...)} on an
  * iceberg table (then a {@code PluginDrivenExternalTable}) must route through the connector's
  * {@link ConnectorProcedureOps} instead of the legacy fe-core actions, while the engine keeps the
- * {@code ALTER} privilege check, the single-row {@code CommonResultSet} wrapping and the edit-log refresh
+ * {@code ALTER} privilege check, the committed-mutation fence and the single-row result wrapping
  * (D-062 §2). These tests pin that the dispatch threads the catalog's session/handle into
  * {@code getProcedureOps().execute(...)}, wraps the engine-neutral {@link ConnectorProcedureResult} back
  * into a {@code ResultSet}, surfaces the connector's {@link DorisConnectorException} as a
@@ -89,9 +90,6 @@ public class ConnectorExecuteActionTest {
     private static final String REMOTE_DB = "remote_db";
     private static final String REMOTE_TBL = "remote_tbl";
 
-    // execute() now refreshes the table's caches after a successful commit (H-6) via
-    // Env.getCurrentEnv().getRefreshManager().refreshTableInternal(...). Stub that statically for every test so
-    // the dispatch paths don't NPE, and so the refresh can be verified.
     private MockedStatic<Env> envStatic;
     private Env env;
     private RefreshManager refreshManager;
@@ -258,6 +256,7 @@ public class ConnectorExecuteActionTest {
                 .getLeft()).getColumnName());
         // The engine passes the connector's rendered rows straight through to the ResultSet.
         Assertions.assertEquals(Collections.singletonList(Arrays.asList("0", "0", "0", "0")), rs.getResultRows());
+        Mockito.verifyNoInteractions(refreshManager);
     }
 
     @Test
@@ -278,6 +277,23 @@ public class ConnectorExecuteActionTest {
         Assertions.assertEquals(UserException.class, e.getClass(),
                 "Re-wrap must use the plain UserException type the legacy action body threw (no extra errCode layer)");
         Assertions.assertEquals("Snapshot 7 not found in table remote_tbl", e.getDetailMessage());
+        Mockito.verifyNoInteractions(refreshManager);
+    }
+
+    @Test
+    public void executeReWrapsPostCommitRefreshConnectorException() {
+        Fixture f = new Fixture();
+        Mockito.when(f.procedureOps.execute(Mockito.any(), Mockito.any(), Mockito.anyString(),
+                        Mockito.anyMap(), Mockito.any(), Mockito.anyList()))
+                .thenReturn(twoColumnResult(Arrays.asList("100", "200")));
+        Mockito.doThrow(new DorisConnectorException("connector cache invalidation failed"))
+                .when(refreshManager).refreshTableAfterExternalMutation(f.table);
+
+        ConnectorExecuteAction action = new ConnectorExecuteAction("rollback_to_snapshot",
+                f.props, Optional.empty(), Optional.empty(), f.table);
+
+        UserException e = Assertions.assertThrows(UserException.class, () -> action.execute(f.table));
+        Assertions.assertEquals("connector cache invalidation failed", e.getDetailMessage());
     }
 
     @Test
@@ -332,9 +348,9 @@ public class ConnectorExecuteActionTest {
     }
 
     @Test
-    public void executeEnforcesSingleRowWidthInvariant() {
+    public void executeFencesCommittedSingleCallBeforeResultValidation() {
         Fixture f = new Fixture();
-        // Two declared columns but a one-wide row -> the single-row contract (BaseExecuteAction:106-108) must trip.
+        // Two declared columns but a one-wide row: the connector call completed, then result validation fails.
         Mockito.when(f.procedureOps.execute(Mockito.any(), Mockito.any(), Mockito.anyString(),
                         Mockito.anyMap(), Mockito.any(), Mockito.anyList()))
                 .thenReturn(twoColumnResult(Collections.singletonList("only-one")));
@@ -342,6 +358,12 @@ public class ConnectorExecuteActionTest {
         ConnectorExecuteAction action = new ConnectorExecuteAction("rollback_to_snapshot",
                 f.props, Optional.empty(), Optional.empty(), f.table);
         Assertions.assertThrows(IllegalStateException.class, () -> action.execute(f.table));
+
+        InOrder order = Mockito.inOrder(f.procedureOps, refreshManager);
+        order.verify(f.procedureOps).execute(Mockito.eq(f.session), Mockito.eq(f.handle),
+                Mockito.eq("rollback_to_snapshot"), Mockito.eq(f.props),
+                Mockito.isNull(), Mockito.eq(Collections.emptyList()));
+        order.verify(refreshManager).refreshTableAfterExternalMutation(f.table);
     }
 
     @Test
@@ -373,69 +395,6 @@ public class ConnectorExecuteActionTest {
                 f.props, Optional.empty(), Optional.empty(), f.table);
         Assertions.assertNull(action.execute(f.table),
                 "A non-empty schema with zero rows (connector's null-row encoding) wraps to null, like legacy");
-    }
-
-    // -------- execute(): leader-side cache refresh after a successful commit (H-6) --------
-
-    @Test
-    public void executeRefreshesTableCachesAfterSuccessfulSingleCall() throws Exception {
-        Fixture f = new Fixture();
-        Mockito.when(f.procedureOps.execute(Mockito.any(), Mockito.any(), Mockito.anyString(),
-                        Mockito.anyMap(), Mockito.any(), Mockito.anyList()))
-                .thenReturn(twoColumnResult(Arrays.asList("100", "200")));
-
-        ConnectorExecuteAction action = new ConnectorExecuteAction("rollback_to_snapshot",
-                f.props, Optional.empty(), Optional.empty(), f.table);
-        action.execute(f.table);
-
-        // H-6: the FE that ran the procedure must refresh the mutated table through the standard refresh-table
-        // path — the only path that clears BOTH the engine meta cache (LOCAL names) and the connector's own
-        // per-table cache (REMOTE names, the iceberg latest-snapshot cache, default TTL 24h). Without this the
-        // leader keeps serving the pre-procedure snapshot up to 24h (leader/follower split). MUTATION: dropping
-        // the refreshTableCachesAfterMutation() call -> verify fails.
-        Mockito.verify(refreshManager).refreshTableInternal(
-                Mockito.eq(f.db), Mockito.eq(f.table), Mockito.anyLong());
-    }
-
-    @Test
-    public void executeRefreshesTableCachesAfterSuccessfulDistributedRewrite() throws Exception {
-        // The DISTRIBUTED rewrite also produces a new snapshot, so it must refresh too. No groups -> the driver
-        // takes the early return without opening a transaction, but the refresh still runs on a normal return.
-        Fixture f = new Fixture();
-        Mockito.when(f.procedureOps.getExecutionMode("rewrite_data_files"))
-                .thenReturn(ProcedureExecutionMode.DISTRIBUTED);
-        Mockito.when(f.procedureOps.planRewrite(Mockito.any(), Mockito.any(), Mockito.anyString(),
-                        Mockito.anyMap(), Mockito.any(), Mockito.anyList()))
-                .thenReturn(Collections.emptyList());
-        // Without this the mock returns null and the engine NPEs while wrapping the result.
-        Mockito.when(f.procedureOps.buildRewriteResult(Mockito.anyString(), Mockito.any()))
-                .thenReturn(rewriteResult("0", "0", "0", "0"));
-
-        Expression where = new GreaterThan(new UnboundSlot("a"), new IntegerLiteral(5));
-        ConnectorExecuteAction action = new ConnectorExecuteAction("rewrite_data_files",
-                f.props, Optional.empty(), Optional.of(where), f.table);
-        action.execute(f.table);
-
-        Mockito.verify(refreshManager).refreshTableInternal(
-                Mockito.eq(f.db), Mockito.eq(f.table), Mockito.anyLong());
-    }
-
-    @Test
-    public void executeDoesNotRefreshWhenProcedureFails() {
-        Fixture f = new Fixture();
-        Mockito.when(f.procedureOps.execute(Mockito.any(), Mockito.any(), Mockito.anyString(),
-                        Mockito.anyMap(), Mockito.any(), Mockito.anyList()))
-                .thenThrow(new DorisConnectorException("Snapshot 7 not found in table remote_tbl"));
-
-        ConnectorExecuteAction action = new ConnectorExecuteAction("rollback_to_snapshot",
-                f.props, Optional.empty(), Optional.empty(), f.table);
-
-        Assertions.assertThrows(UserException.class, () -> action.execute(f.table));
-        // A failed procedure committed nothing, so it must not refresh (no spurious cache churn; mirrors follower
-        // replay which only runs on a logged success). MUTATION: refreshing unconditionally / in a finally -> the
-        // never-verify fails.
-        Mockito.verify(refreshManager, Mockito.never())
-                .refreshTableInternal(Mockito.any(), Mockito.any(), Mockito.anyLong());
     }
 
     // -------- validate(): engine keeps the ALTER privilege check --------

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorRewriteDriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/execute/ConnectorRewriteDriverTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.trees.plans.commands.execute;
 
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.RefreshManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.connector.spi.ConnectorColumn;
 import org.apache.doris.connector.spi.ConnectorMetadata;
@@ -24,6 +26,8 @@ import org.apache.doris.connector.spi.ConnectorSession;
 import org.apache.doris.connector.spi.ConnectorType;
 import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
+import org.apache.doris.connector.spi.handle.ConnectorTransaction;
+import org.apache.doris.connector.spi.handle.RewriteCapableTransaction;
 import org.apache.doris.connector.spi.procedure.ConnectorProcedureOps;
 import org.apache.doris.connector.spi.procedure.ConnectorProcedureResult;
 import org.apache.doris.connector.spi.procedure.ConnectorRewriteGroup;
@@ -33,16 +37,23 @@ import org.apache.doris.connector.spi.pushdown.ConnectorPredicate;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.scheduler.manager.TransientTaskManager;
+import org.apache.doris.transaction.PluginDrivenTransactionManager;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Guards the engine-neutral parts of {@link ConnectorRewriteDriver} that are unit-testable without a live
@@ -139,6 +150,69 @@ public class ConnectorRewriteDriverTest {
         UserException ex = Assertions.assertThrows(UserException.class, driver::run);
         Assertions.assertTrue(ex.getMessage().contains("plan boom"),
                 "the connector failure text must be preserved, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void committedRewriteFencesBeforeResultConstruction() throws Exception {
+        ConnectorProcedureOps procedureOps = Mockito.mock(ConnectorProcedureOps.class);
+        ConnectorMetadata metadata = Mockito.mock(ConnectorMetadata.class);
+        ConnectorSession session = Mockito.mock(ConnectorSession.class);
+        ConnectorTableHandle tableHandle = Mockito.mock(ConnectorTableHandle.class);
+        ConnectorTransaction connectorTx = Mockito.mock(ConnectorTransaction.class,
+                Mockito.withSettings().extraInterfaces(RewriteCapableTransaction.class));
+        RewriteCapableTransaction rewriteTx = (RewriteCapableTransaction) connectorTx;
+        PluginDrivenTransactionManager txnManager = Mockito.mock(PluginDrivenTransactionManager.class);
+        PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
+        ExternalTable table = Mockito.mock(ExternalTable.class);
+        ConnectContext context = Mockito.mock(ConnectContext.class);
+        SessionVariable sessionVariable = Mockito.mock(SessionVariable.class);
+        ConnectorRewriteGroup group = new ConnectorRewriteGroup(
+                ImmutableSet.of("s3://bucket/table/a.parquet"), 1, 1024L, 0);
+
+        Mockito.when(procedureOps.planRewrite(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any())).thenReturn(Collections.singletonList(group));
+        Mockito.when(metadata.beginTransaction(session, tableHandle)).thenReturn(connectorTx);
+        Mockito.when(catalog.getTransactionManager()).thenReturn(txnManager);
+        Mockito.when(txnManager.begin(connectorTx)).thenReturn(7L);
+        Mockito.when(context.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.getInsertTimeoutS()).thenReturn(1);
+        Mockito.when(rewriteTx.getRewriteAddedDataFilesCount()).thenReturn(1);
+        Mockito.when(procedureOps.buildRewriteResult(Mockito.eq("rewrite_data_files"), Mockito.any()))
+                .thenThrow(new IllegalStateException("invalid committed result"));
+
+        Env env = Mockito.mock(Env.class);
+        RefreshManager refreshManager = Mockito.mock(RefreshManager.class);
+        TransientTaskManager transientTaskManager = Mockito.mock(TransientTaskManager.class);
+        Mockito.when(env.getRefreshManager()).thenReturn(refreshManager);
+        Mockito.when(env.getTransientTaskManager()).thenReturn(transientTaskManager);
+        AtomicReference<ConnectorRewriteGroupTask.RewriteResultCallback> callback = new AtomicReference<>();
+
+        ConnectorRewriteDriver driver = new ConnectorRewriteDriver(
+                context, table, catalog, metadata, procedureOps, session, tableHandle,
+                "rewrite_data_files", Collections.emptyMap(), Collections.emptyList(), null);
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedConstruction<ConnectorRewriteGroupTask> taskConstruction = Mockito.mockConstruction(
+                        ConnectorRewriteGroupTask.class, (task, constructionContext) -> {
+                            callback.set((ConnectorRewriteGroupTask.RewriteResultCallback)
+                                    constructionContext.arguments().get(5));
+                            Mockito.when(task.getId()).thenReturn(11L);
+                        })) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(transientTaskManager.addMemoryTask(Mockito.any())).thenAnswer(invocation -> {
+                ConnectorRewriteGroupTask task = invocation.getArgument(0);
+                callback.get().onTaskCompleted(task.getId());
+                return task.getId();
+            });
+
+            Assertions.assertThrows(IllegalStateException.class, driver::run);
+
+            Assertions.assertEquals(1, taskConstruction.constructed().size());
+            InOrder order = Mockito.inOrder(txnManager, refreshManager, procedureOps);
+            order.verify(txnManager).commit(7L);
+            order.verify(refreshManager).refreshTableAfterExternalMutation(table);
+            order.verify(procedureOps).buildRewriteResult(Mockito.eq("rewrite_data_files"), Mockito.any());
+        }
     }
 
     @Test


### PR DESCRIPTION
### Problem Summary
External table row counts are cached separately from metadata caches. Some metadata mutation and replay paths did not invalidate row counts, allowing stale values to surviverefreshes,
DML/DDL operations, cold-cache replay, and table renames until cache expiration, which could affect statistics estimation.

### Solution
Add scoped invalidation and concurrent-load fencing to ExternalRowCountCache, and integrate it with unified metadata invalidation paths. Cover external metadata mutations and replay,
including cold deterministic identities and both sides of a rename. Add real-cache tests to verify eviction and reload behavior.