### PR TITLE
[fix](be) Fix duplicate symbol __lsan_ignore_object when build be ut in LSAN

### DIFF
--- a/be/src/common/phdr_cache.cpp
+++ b/be/src/common/phdr_cache.cpp
@@ -106,13 +106,7 @@ extern "C"
 }
 */
 
-extern "C" {
-#ifdef ADDRESS_SANITIZER
-void __lsan_ignore_object(const void*);
-#else
-void __lsan_ignore_object(const void*) {} // NOLINT
-#endif
-}
+#include "util/debug/leak_annotations.h"
 
 void updatePHDRCache() {
     // Fill out ELF header cache for access without locking.
@@ -132,7 +126,7 @@ void updatePHDRCache() {
     phdr_cache.store(new_phdr_cache);
 
     /// Memory is intentionally leaked.
-    __lsan_ignore_object(new_phdr_cache);
+    ANNOTATE_LEAKING_OBJECT_PTR(new_phdr_cache);
 }
 
 bool hasPHDRCache() {

--- a/be/src/util/debug/leak_annotations.h
+++ b/be/src/util/debug/leak_annotations.h
@@ -21,16 +21,24 @@
 // Does nothing if LeakSanitizer is not enabled.
 #define ANNOTATE_LEAKING_OBJECT_PTR(p)
 
+// Check if LeakSanitizer is enabled
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#if defined(__linux__)
+#if __has_feature(address_sanitizer) || __has_feature(leak_sanitizer)
+#define DORIS_LSAN_ENABLED 1
+#endif
+#endif
+
+#if !defined(DORIS_LSAN_ENABLED) && (defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER))
+#define DORIS_LSAN_ENABLED 1
+#endif
+
+// DORIS_LSAN_ENABLED && __linux__
+#if defined(DORIS_LSAN_ENABLED) && defined(__linux__)
 
 #undef ANNOTATE_LEAKING_OBJECT_PTR
 #define ANNOTATE_LEAKING_OBJECT_PTR(p) __lsan_ignore_object(p);
 
-#endif
-#endif
-#endif
+#endif // DORIS_LSAN_ENABLED && __linux__
 
 // API definitions from LLVM lsan_interface.h
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64163

error log:
[master_LSAN.log](https://github.com/user-attachments/files/28677514/master_LSAN.log)
log after fix:
[lsan_duplicate_symbol_LSAN.log](https://github.com/user-attachments/files/28677527/lsan_duplicate_symbol_LSAN.log)
[doris_be_test.xml](https://github.com/user-attachments/files/28677529/doris_be_test.xml)

Related PR: #

Problem Summary: When building BE unit tests in LSAN mode, the linker reports a duplicate symbol error for `__lsan_ignore_object`. The root cause is that `phdr_cache.cpp` manually declares and defines `__lsan_ignore_object`, which conflicts with the LSAN runtime library that already provides this symbol. Additionally, `leak_annotations.h` only enables `ANNOTATE_LEAKING_OBJECT_PTR` under `address_sanitizer` but not under `leak_sanitizer` independently.

The fix:
1. Replace the manual `__lsan_ignore_object` declaration/definition in `phdr_cache.cpp` with the existing `ANNOTATE_LEAKING_OBJECT_PTR` macro from `leak_annotations.h`
2. Extend `leak_annotations.h` to also enable `ANNOTATE_LEAKING_OBJECT_PTR` when `leak_sanitizer` is detected (not just `address_sanitizer`)
3. fix LocalFileSystemTest.TestGlob hardcoded path incompatible with non-ASAN builds, I found this when testing, and fix it btw

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test: BE UT runs successfully in LSAN mode after the fix
    - [ ] Regression test
    - [ ] Manual test
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label