### PR TITLE
[feature](be) Add OLAP scan filter profile counters

### DIFF
--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -628,9 +628,10 @@ bool OlapScanLocalState::_read_mor_as_dup() {
 }
 
 void OlapScanLocalState::_register_key_range_scan_filter() {
-    if (_scan_filter_profile == nullptr || _key_range_scan_filter) {
+    if (_scan_filter_profile == nullptr) {
         return;
     }
+    DORIS_CHECK(!_key_range_scan_filter);
 
     std::vector<int32_t> source_filter_ids;
     for (const auto& [_, filter_ids] : _slot_id_to_scan_filter_ids_for_key_range) {
@@ -1275,13 +1276,11 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
                         new_predicates.push_back(it);
                     } else if (_scan_filter_profile != nullptr) {
                         const auto& handle = it->scan_filter_handle();
-                        if (handle.has_filter_id()) {
-                            auto& source_ids =
-                                    _slot_id_to_scan_filter_ids_for_key_range[*key_to_erase];
-                            if (std::find(source_ids.begin(), source_ids.end(), handle.filter_id) ==
-                                source_ids.end()) {
-                                source_ids.push_back(handle.filter_id);
-                            }
+                        DORIS_CHECK(handle.has_filter_id());
+                        auto& source_ids = _slot_id_to_scan_filter_ids_for_key_range[*key_to_erase];
+                        if (std::find(source_ids.begin(), source_ids.end(), handle.filter_id) ==
+                            source_ids.end()) {
+                            source_ids.push_back(handle.filter_id);
                         }
                     }
                 }

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -59,6 +59,9 @@ namespace {
 
 constexpr int64_t MAX_PROFILE_KEY_RANGES = 32;
 
+/// Count the number of real key ranges, excluding full-scan placeholders.
+/// A key range is considered real if it has a lower bound, which implies it
+/// also has an upper bound because they are always set together.
 int64_t key_range_count(const std::vector<std::unique_ptr<OlapScanRange>>& ranges) {
     int64_t count = 0;
     for (const auto& range : ranges) {
@@ -628,7 +631,7 @@ bool OlapScanLocalState::_read_mor_as_dup() {
 }
 
 void OlapScanLocalState::_register_key_range_scan_filter() {
-    if (_scan_filter_profile == nullptr) {
+    if (!enable_scan_filter_profile()) {
         return;
     }
     DORIS_CHECK(!_key_range_scan_filter);
@@ -1274,7 +1277,7 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
                 for (const auto& it : _slot_id_to_predicates[*key_to_erase]) {
                     if (!can_erase_predicate(*it)) {
                         new_predicates.push_back(it);
-                    } else if (_scan_filter_profile != nullptr) {
+                    } else if (enable_scan_filter_profile()) {
                         const auto& handle = it->scan_filter_handle();
                         DORIS_CHECK(handle.has_filter_id());
                         auto& source_ids = _slot_id_to_scan_filter_ids_for_key_range[*key_to_erase];
@@ -1302,9 +1305,6 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
     }
 
     if (state()->enable_profile()) {
-        if (_scan_filter_profile == nullptr) {
-            custom_profile()->add_info_string("KeyRanges", _scan_keys.debug_string());
-        }
         custom_profile()->add_info_string("TabletIds", tablets_id_to_string(_scan_ranges));
     }
     VLOG_CRITICAL << _scan_keys.debug_string();

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -53,6 +54,50 @@
 #include "util/to_string.h"
 
 namespace doris {
+
+namespace {
+
+constexpr int64_t MAX_PROFILE_KEY_RANGES = 32;
+
+int64_t key_range_count(const std::vector<std::unique_ptr<OlapScanRange>>& ranges) {
+    int64_t count = 0;
+    for (const auto& range : ranges) {
+        if (range->has_lower_bound) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::string scan_keys_profile_string(const std::vector<std::unique_ptr<OlapScanRange>>& ranges) {
+    fmt::memory_buffer scan_keys_buffer;
+    int64_t range_count = 0;
+    int64_t printed = 0;
+    for (const auto& range : ranges) {
+        if (!range->has_lower_bound) {
+            continue;
+        }
+        if (printed < MAX_PROFILE_KEY_RANGES) {
+            if (printed > 0) {
+                fmt::format_to(scan_keys_buffer, "; ");
+            }
+            fmt::format_to(scan_keys_buffer, "{}{} : {}{}", range->begin_include ? "[" : "(",
+                           range->begin_scan_range.debug_string(),
+                           range->end_scan_range.debug_string(), range->end_include ? "]" : ")");
+            ++printed;
+        }
+        ++range_count;
+    }
+    if (range_count > printed) {
+        if (printed > 0) {
+            fmt::format_to(scan_keys_buffer, "; ");
+        }
+        fmt::format_to(scan_keys_buffer, "... {} more", range_count - printed);
+    }
+    return fmt::to_string(scan_keys_buffer);
+}
+
+} // namespace
 
 Status OlapScanLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     const TOlapScanNode& olap_scan_node = _parent->cast<OlapScanOperatorX>()._olap_scan_node;
@@ -582,6 +627,27 @@ bool OlapScanLocalState::_read_mor_as_dup() {
     return p._olap_scan_node.__isset.read_mor_as_dup && p._olap_scan_node.read_mor_as_dup;
 }
 
+void OlapScanLocalState::_register_key_range_scan_filter() {
+    if (_scan_filter_profile == nullptr || _key_range_scan_filter) {
+        return;
+    }
+
+    std::vector<int32_t> source_filter_ids;
+    for (const auto& [_, filter_ids] : _slot_id_to_scan_filter_ids_for_key_range) {
+        source_filter_ids.insert(source_filter_ids.end(), filter_ids.begin(), filter_ids.end());
+    }
+    std::ranges::sort(source_filter_ids);
+    source_filter_ids.erase(std::ranges::unique(source_filter_ids).begin(),
+                            source_filter_ids.end());
+
+    ScanFilterDesc desc;
+    desc.kind = ScanFilterKind::KEY_RANGE;
+    desc.compact_info = scan_keys_profile_string(_cond_ranges);
+    desc.source_filter_ids = std::move(source_filter_ids);
+    desc.range_count = key_range_count(_cond_ranges);
+    _key_range_scan_filter = _scan_filter_profile->register_filter(std::move(desc));
+}
+
 Status OlapScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
     if (_scan_ranges.empty()) {
         _eos = true;
@@ -604,6 +670,10 @@ Status OlapScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
     // key range to the tablet reader.
     if (_cond_ranges.empty()) {
         _cond_ranges.emplace_back(new doris::OlapScanRange());
+    }
+    if (std::ranges::any_of(_cond_ranges,
+                            [](const auto& range) { return range->has_lower_bound; })) {
+        _register_key_range_scan_filter();
     }
 
     // Filter out tablets whose partitions have been pruned by runtime filters.
@@ -1204,6 +1274,16 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
                 for (const auto& it : _slot_id_to_predicates[*key_to_erase]) {
                     if (!can_erase_predicate(*it)) {
                         new_predicates.push_back(it);
+                    } else if (_scan_filter_profile != nullptr) {
+                        const auto& handle = it->scan_filter_handle();
+                        if (handle) {
+                            auto& source_ids =
+                                    _slot_id_to_scan_filter_ids_for_key_range[*key_to_erase];
+                            if (std::find(source_ids.begin(), source_ids.end(), handle.filter_id) ==
+                                source_ids.end()) {
+                                source_ids.push_back(handle.filter_id);
+                            }
+                        }
                     }
                 }
                 if (new_predicates.empty()) {
@@ -1224,7 +1304,9 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
     }
 
     if (state()->enable_profile()) {
-        custom_profile()->add_info_string("KeyRanges", _scan_keys.debug_string());
+        if (_scan_filter_profile == nullptr) {
+            custom_profile()->add_info_string("KeyRanges", _scan_keys.debug_string());
+        }
         custom_profile()->add_info_string("TabletIds", tablets_id_to_string(_scan_ranges));
     }
     VLOG_CRITICAL << _scan_keys.debug_string();
@@ -1291,6 +1373,13 @@ void OlapScanLocalState::_attach_partition_boundaries() {
         return;
     }
     COUNTER_SET(_total_partitions_rf_counter, parsed->total_partitions());
+}
+
+ScanRuntimeFilterPartitionPruningStats OlapScanLocalState::_runtime_filter_partition_pruning_stats()
+        const {
+    auto stats = ScanLocalStateBase::_runtime_filter_partition_pruning_stats();
+    stats.pruned_tablets = _tablets_pruned_by_rf_counter->value();
+    return stats;
 }
 
 } // namespace doris

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -640,12 +640,11 @@ void OlapScanLocalState::_register_key_range_scan_filter() {
     source_filter_ids.erase(std::ranges::unique(source_filter_ids).begin(),
                             source_filter_ids.end());
 
-    ScanFilterDesc desc;
-    desc.kind = ScanFilterKind::KEY_RANGE;
-    desc.compact_info = scan_keys_profile_string(_cond_ranges);
-    desc.source_filter_ids = std::move(source_filter_ids);
-    desc.range_count = key_range_count(_cond_ranges);
-    _key_range_scan_filter = _scan_filter_profile->register_filter(std::move(desc));
+    ScanKeyRangeInfo key_range;
+    key_range.scan_keys = scan_keys_profile_string(_cond_ranges);
+    key_range.source_filter_ids = std::move(source_filter_ids);
+    key_range.range_count = key_range_count(_cond_ranges);
+    _key_range_scan_filter = _scan_filter_profile->register_key_range(std::move(key_range));
 }
 
 Status OlapScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
@@ -1276,7 +1275,7 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
                         new_predicates.push_back(it);
                     } else if (_scan_filter_profile != nullptr) {
                         const auto& handle = it->scan_filter_handle();
-                        if (handle) {
+                        if (handle.has_filter_id()) {
                             auto& source_ids =
                                     _slot_id_to_scan_filter_ids_for_key_range[*key_to_erase];
                             if (std::find(source_ids.begin(), source_ids.end(), handle.filter_id) ==

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -123,6 +123,7 @@ private:
     Status _init_scanners(std::list<ScannerSPtr>* scanners) override;
 
     Status _build_key_ranges_and_filters();
+    void _register_key_range_scan_filter();
 
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
     std::vector<SyncRowsetStats> _sync_statistics;
@@ -134,6 +135,7 @@ private:
     std::atomic_bool _sync_tablet = false;
     std::vector<std::unique_ptr<doris::OlapScanRange>> _cond_ranges;
     OlapScanKeys _scan_keys;
+    ScanFilterHandle _key_range_scan_filter;
     // If column id in this set, indicate that we need to read data after index filtering
     std::set<int32_t> _output_column_ids;
 
@@ -333,6 +335,7 @@ private:
     // OlapScanOperatorX (parsed once in OperatorX::prepare()). Cheap: pointer
     // assignment plus a counter set, no parsing work.
     void _attach_partition_boundaries();
+    ScanRuntimeFilterPartitionPruningStats _runtime_filter_partition_pruning_stats() const override;
 
     RuntimeProfile::Counter* _tablets_pruned_by_rf_counter = nullptr;
 };

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -82,8 +82,8 @@ Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* stat
         for (size_t i = conjuncts_before; i < _conjuncts.size(); ++i) {
             DCHECK(_conjuncts[i]->root() != nullptr);
             if (!_conjuncts[i]->scan_filter_handle()) {
-                _conjuncts[i]->attach_scan_filter(
-                        _register_scan_filter(_conjuncts[i]->root(), nullptr));
+                _conjuncts[i]->attach_scan_filter(_register_scan_filter(
+                        _conjuncts[i]->root(), nullptr, state->profile_level()));
             }
         }
     }
@@ -227,9 +227,11 @@ static std::string predicates_to_string(
 }
 
 ScanFilterHandle ScanLocalStateBase::_register_scan_filter(const VExprSPtr& root,
-                                                           const SlotDescriptor* slot) {
+                                                           const SlotDescriptor* slot,
+                                                           int profile_level) {
     DCHECK(_scan_filter_profile != nullptr);
     DCHECK(root != nullptr);
+    DCHECK_GE(profile_level, 1);
 
     ScanFilterDesc desc;
     desc.kind = ScanFilterKind::NORMAL;
@@ -244,7 +246,9 @@ ScanFilterHandle ScanLocalStateBase::_register_scan_filter(const VExprSPtr& root
         desc.column_name = slot->col_name();
         desc.column_id = _parent->intermediate_row_desc().get_column_id(slot->id());
     }
-    desc.expr_debug_string = root->debug_string();
+    if (profile_level >= 3) {
+        desc.expr_debug_string = root->debug_string();
+    }
     return _scan_filter_profile->register_filter(std::move(desc));
 }
 
@@ -396,7 +400,8 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
             if (new_root) {
                 conjunct->set_root(new_root);
                 if (_scan_filter_profile != nullptr && !conjunct->scan_filter_handle()) {
-                    conjunct->attach_scan_filter(_register_scan_filter(conjunct->root(), nullptr));
+                    conjunct->attach_scan_filter(_register_scan_filter(conjunct->root(), nullptr,
+                                                                       state->profile_level()));
                 }
                 if (_should_push_down_common_expr(conjunct->root())) {
                     _common_expr_ctxs_push_down.emplace_back(conjunct);
@@ -530,7 +535,7 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
         if (pdt != PushDownType::UNACCEPTABLE && _scan_filter_profile != nullptr) {
             auto handle = context->scan_filter_handle();
             if (!handle) {
-                handle = _register_scan_filter(root, slot);
+                handle = _register_scan_filter(root, slot, state()->profile_level());
                 context->attach_scan_filter(handle);
             }
             DCHECK(handle);
@@ -635,7 +640,8 @@ Status ScanLocalStateBase::_normalize_function_filters(VExprContext* expr_ctx, S
             if (_scan_filter_profile != nullptr) {
                 handle = expr_ctx->scan_filter_handle();
                 if (!handle) {
-                    handle = _register_scan_filter(expr_ctx->root(), slot);
+                    handle =
+                            _register_scan_filter(expr_ctx->root(), slot, state()->profile_level());
                     expr_ctx->attach_scan_filter(handle);
                 }
                 DCHECK(handle);

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -80,7 +80,8 @@ Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* stat
                                                                    arrived_rf_num, _conjuncts));
     if (_scan_filter_profile != nullptr) {
         for (size_t i = conjuncts_before; i < _conjuncts.size(); ++i) {
-            if (_conjuncts[i]->root() != nullptr && !_conjuncts[i]->scan_filter_handle()) {
+            DCHECK(_conjuncts[i]->root() != nullptr);
+            if (!_conjuncts[i]->scan_filter_handle()) {
                 _conjuncts[i]->attach_scan_filter(
                         _register_scan_filter(_conjuncts[i]->root(), nullptr));
             }
@@ -227,9 +228,8 @@ static std::string predicates_to_string(
 
 ScanFilterHandle ScanLocalStateBase::_register_scan_filter(const VExprSPtr& root,
                                                            const SlotDescriptor* slot) {
-    if (_scan_filter_profile == nullptr || root == nullptr) {
-        return {};
-    }
+    DCHECK(_scan_filter_profile != nullptr);
+    DCHECK(root != nullptr);
 
     ScanFilterDesc desc;
     desc.kind = ScanFilterKind::NORMAL;
@@ -395,7 +395,7 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
             RETURN_IF_ERROR(_normalize_predicate(conjunct.get(), conjunct->root(), new_root));
             if (new_root) {
                 conjunct->set_root(new_root);
-                if (!conjunct->scan_filter_handle()) {
+                if (_scan_filter_profile != nullptr && !conjunct->scan_filter_handle()) {
                     conjunct->attach_scan_filter(_register_scan_filter(conjunct->root(), nullptr));
                 }
                 if (_should_push_down_common_expr(conjunct->root())) {
@@ -532,16 +532,15 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
                 },
                 *range);
         RETURN_IF_ERROR(status);
-        if (pdt != PushDownType::UNACCEPTABLE) {
+        if (pdt != PushDownType::UNACCEPTABLE && _scan_filter_profile != nullptr) {
             auto handle = context->scan_filter_handle();
             if (!handle) {
                 handle = _register_scan_filter(root, slot);
                 context->attach_scan_filter(handle);
             }
-            if (handle) {
-                for (size_t i = predicates_before; i < slot_predicates.size(); ++i) {
-                    slot_predicates[i]->attach_scan_filter(handle);
-                }
+            DCHECK(handle);
+            for (size_t i = predicates_before; i < slot_predicates.size(); ++i) {
+                slot_predicates[i]->attach_scan_filter(handle);
             }
         }
     }
@@ -637,10 +636,14 @@ Status ScanLocalStateBase::_normalize_function_filters(VExprContext* expr_ctx, S
                                                           expr_ctx, &val, &fn_ctx, temp_pdt));
         if (temp_pdt != PushDownType::UNACCEPTABLE) {
             std::string col = slot->col_name();
-            auto handle = expr_ctx->scan_filter_handle();
-            if (!handle) {
-                handle = _register_scan_filter(expr_ctx->root(), slot);
-                expr_ctx->attach_scan_filter(handle);
+            ScanFilterHandle handle;
+            if (_scan_filter_profile != nullptr) {
+                handle = expr_ctx->scan_filter_handle();
+                if (!handle) {
+                    handle = _register_scan_filter(expr_ctx->root(), slot);
+                    expr_ctx->attach_scan_filter(handle);
+                }
+                DCHECK(handle);
             }
             _push_down_functions.emplace_back(opposite, col, fn_ctx, val, handle);
             *pdt = temp_pdt;

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -510,11 +510,6 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
                                                     status);
                             }
                             break;
-                        case TExprNodeType::BITMAP_PRED:
-                            RETURN_IF_PUSH_DOWN(_normalize_bitmap_filter(context, root, slot,
-                                                                         slot_predicates, &pdt),
-                                                status);
-                            break;
                         case TExprNodeType::BLOOM_PRED:
                             RETURN_IF_PUSH_DOWN(_normalize_bloom_filter(context, root, slot,
                                                                         slot_predicates, &pdt),

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -78,7 +78,7 @@ Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* stat
     size_t conjuncts_before = _conjuncts.size();
     RETURN_IF_ERROR(_helper.try_append_late_arrival_runtime_filter(state, _parent->row_descriptor(),
                                                                    arrived_rf_num, _conjuncts));
-    if (_scan_filter_profile != nullptr) {
+    if (enable_scan_filter_profile()) {
         for (size_t i = conjuncts_before; i < _conjuncts.size(); ++i) {
             DCHECK(_conjuncts[i]->root() != nullptr);
             if (!_conjuncts[i]->scan_filter_handle()) {
@@ -209,23 +209,6 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     return Status::OK();
 }
 
-static std::string predicates_to_string(
-        const phmap::flat_hash_map<int, std::vector<std::shared_ptr<ColumnPredicate>>>&
-                slot_id_to_predicates) {
-    fmt::memory_buffer debug_string_buffer;
-    for (const auto& [slot_id, predicates] : slot_id_to_predicates) {
-        if (predicates.empty()) {
-            continue;
-        }
-        fmt::format_to(debug_string_buffer, "Slot ID: {}: [", slot_id);
-        for (const auto& predicate : predicates) {
-            fmt::format_to(debug_string_buffer, "{{{}}}, ", predicate->debug_string());
-        }
-        fmt::format_to(debug_string_buffer, "] ");
-    }
-    return fmt::to_string(debug_string_buffer);
-}
-
 ScanFilterHandle ScanLocalStateBase::_register_scan_filter(const VExprSPtr& root,
                                                            const SlotDescriptor* slot,
                                                            int profile_level) {
@@ -295,11 +278,6 @@ Status ScanLocalState<Derived>::open(RuntimeState* state) {
     }
 
     RETURN_IF_ERROR(_process_conjuncts(state));
-
-    if (state->enable_profile() && _scan_filter_profile == nullptr) {
-        custom_profile()->add_info_string("PushDownPredicates",
-                                          predicates_to_string(_slot_id_to_predicates));
-    }
 
     auto status = _eos ? Status::OK() : _prepare_scanners();
     RETURN_IF_ERROR(status);
@@ -399,7 +377,7 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
             RETURN_IF_ERROR(_normalize_predicate(conjunct.get(), conjunct->root(), new_root));
             if (new_root) {
                 conjunct->set_root(new_root);
-                if (_scan_filter_profile != nullptr && !conjunct->scan_filter_handle()) {
+                if (enable_scan_filter_profile() && !conjunct->scan_filter_handle()) {
                     conjunct->attach_scan_filter(_register_scan_filter(conjunct->root(), nullptr,
                                                                        state->profile_level()));
                 }
@@ -416,19 +394,6 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
             }
         }
         ++it;
-    }
-
-    if (state->enable_profile() && _scan_filter_profile == nullptr) {
-        std::string message;
-        for (auto& conjunct : _conjuncts) {
-            if (conjunct->root()) {
-                if (!message.empty()) {
-                    message += ", ";
-                }
-                message += conjunct->root()->debug_string();
-            }
-        }
-        custom_profile()->add_info_string("RemainedPredicates", message);
     }
 
     for (auto& it : _slot_id_to_value_range) {
@@ -532,7 +497,7 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
                 },
                 *range);
         RETURN_IF_ERROR(status);
-        if (pdt != PushDownType::UNACCEPTABLE && _scan_filter_profile != nullptr) {
+        if (pdt != PushDownType::UNACCEPTABLE && enable_scan_filter_profile()) {
             auto handle = context->scan_filter_handle();
             if (!handle) {
                 handle = _register_scan_filter(root, slot, state()->profile_level());
@@ -637,7 +602,7 @@ Status ScanLocalStateBase::_normalize_function_filters(VExprContext* expr_ctx, S
         if (temp_pdt != PushDownType::UNACCEPTABLE) {
             std::string col = slot->col_name();
             ScanFilterHandle handle;
-            if (_scan_filter_profile != nullptr) {
+            if (enable_scan_filter_profile()) {
                 handle = expr_ctx->scan_filter_handle();
                 if (!handle) {
                     handle =
@@ -1376,7 +1341,7 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
     COUNTER_SET(_wait_for_dependency_timer, _scan_dependency->watcher_elapse_time());
     COUNTER_SET(_wait_for_rf_timer, rf_time);
     _helper.collect_realtime_profile(custom_profile(), _scan_filter_profile.get());
-    if (_scan_filter_profile != nullptr) {
+    if (enable_scan_filter_profile()) {
         _scan_filter_profile->set_runtime_filter_partition_pruning_stats(
                 _runtime_filter_partition_pruning_stats());
         _scan_filter_profile->materialize(custom_profile(), state->profile_level());

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -21,6 +21,7 @@
 #include <gen_cpp/Exprs_types.h>
 #include <gen_cpp/Metrics_types.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 
@@ -77,6 +78,14 @@ Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* stat
     size_t conjuncts_before = _conjuncts.size();
     RETURN_IF_ERROR(_helper.try_append_late_arrival_runtime_filter(state, _parent->row_descriptor(),
                                                                    arrived_rf_num, _conjuncts));
+    if (_scan_filter_profile != nullptr) {
+        for (size_t i = conjuncts_before; i < _conjuncts.size(); ++i) {
+            if (_conjuncts[i]->root() != nullptr && !_conjuncts[i]->scan_filter_handle()) {
+                _conjuncts[i]->attach_scan_filter(
+                        _register_scan_filter(_conjuncts[i]->root(), nullptr));
+            }
+        }
+    }
     if (state->enable_adjust_conjunct_order_by_cost()) {
         std::ranges::sort(_conjuncts, [](const auto& a, const auto& b) {
             return a->execute_cost() < b->execute_cost();
@@ -134,6 +143,12 @@ Status ScanLocalStateBase::_do_partition_pruning_by_rf() {
     return Status::OK();
 }
 
+ScanRuntimeFilterPartitionPruningStats ScanLocalStateBase::_runtime_filter_partition_pruning_stats()
+        const {
+    return {.total_partitions = _total_partitions_rf_counter->value(),
+            .pruned_partitions = _partitions_pruned_by_rf_counter->value()};
+}
+
 int ScanLocalStateBase::max_scanners_concurrency(RuntimeState* state) const {
     // For select * from table limit 10; should just use one thread.
     if (should_run_serial()) {
@@ -180,6 +195,9 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     SCOPED_TIMER(_init_timer);
     auto& p = _parent->cast<typename Derived::Parent>();
     _max_pushdown_conditions_per_column = p._max_pushdown_conditions_per_column;
+    if (state->enable_profile() && state->profile_level() >= 1) {
+        _scan_filter_profile = std::make_shared<ScanFilterProfile>();
+    }
     RETURN_IF_ERROR(_helper.init(state, p.is_serial_operator(), p.node_id(), p.operator_id(),
                                  _filter_dependencies, p.get_name() + "_FILTER_DEPENDENCY"));
     RETURN_IF_ERROR(_init_profile());
@@ -205,6 +223,31 @@ static std::string predicates_to_string(
         fmt::format_to(debug_string_buffer, "] ");
     }
     return fmt::to_string(debug_string_buffer);
+}
+
+ScanFilterHandle ScanLocalStateBase::_register_scan_filter(const VExprSPtr& root,
+                                                           const SlotDescriptor* slot) {
+    if (_scan_filter_profile == nullptr || root == nullptr) {
+        return {};
+    }
+
+    ScanFilterDesc desc;
+    desc.kind = ScanFilterKind::NORMAL;
+    if (root->is_rf_wrapper()) {
+        desc.kind = ScanFilterKind::RUNTIME_FILTER;
+        desc.runtime_filter_id = assert_cast<RuntimeFilterExpr*>(root.get())->filter_id();
+    } else if (root->is_topn_filter()) {
+        desc.kind = ScanFilterKind::TOPN_FILTER;
+        desc.topn_filter_source_node_id = assert_cast<VTopNPred*>(root.get())->source_node_id();
+    }
+    if (slot != nullptr) {
+        desc.slot_id = slot->id();
+        desc.column_name = slot->col_name();
+        desc.column_id = _parent->intermediate_row_desc().get_column_id(slot->id());
+    }
+    desc.debug_string = root->debug_string();
+    desc.compact_info = desc.debug_string;
+    return _scan_filter_profile->register_filter(std::move(desc));
 }
 
 template <typename Derived>
@@ -251,7 +294,7 @@ Status ScanLocalState<Derived>::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(_process_conjuncts(state));
 
-    if (state->enable_profile()) {
+    if (state->enable_profile() && _scan_filter_profile == nullptr) {
         custom_profile()->add_info_string("PushDownPredicates",
                                           predicates_to_string(_slot_id_to_predicates));
     }
@@ -354,6 +397,9 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
             RETURN_IF_ERROR(_normalize_predicate(conjunct.get(), conjunct->root(), new_root));
             if (new_root) {
                 conjunct->set_root(new_root);
+                if (!conjunct->scan_filter_handle()) {
+                    conjunct->attach_scan_filter(_register_scan_filter(conjunct->root(), nullptr));
+                }
                 if (_should_push_down_common_expr(conjunct->root())) {
                     _common_expr_ctxs_push_down.emplace_back(conjunct);
                     it = _conjuncts.erase(it);
@@ -369,7 +415,7 @@ Status ScanLocalState<Derived>::_normalize_conjuncts(RuntimeState* state) {
         ++it;
     }
 
-    if (state->enable_profile()) {
+    if (state->enable_profile() && _scan_filter_profile == nullptr) {
         std::string message;
         for (auto& conjunct : _conjuncts) {
             if (conjunct->root()) {
@@ -424,6 +470,8 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
     }
     if (_is_predicate_acting_on_slot(expr_root->children(), &slot, &range)) {
         Status status = Status::OK();
+        auto& slot_predicates = _slot_id_to_predicates[slot->id()];
+        const size_t predicates_before = slot_predicates.size();
         std::visit(
                 [&](auto& value_range) {
                     auto expr = root->is_rf_wrapper() ? root->get_impl() : root;
@@ -431,7 +479,7 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
                         Defer attach_defer = [&]() {
                             if (pdt != PushDownType::UNACCEPTABLE && root->is_rf_wrapper()) {
                                 auto* rf_expr = assert_cast<RuntimeFilterExpr*>(root.get());
-                                _slot_id_to_predicates[slot->id()].back()->attach_profile_counter(
+                                slot_predicates.back()->attach_profile_counter(
                                         rf_expr->filter_id(),
                                         rf_expr->predicate_filtered_rows_counter(),
                                         rf_expr->predicate_input_rows_counter(),
@@ -442,37 +490,36 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
                         switch (expr->node_type()) {
                         case TExprNodeType::IN_PRED:
                             RETURN_IF_PUSH_DOWN(
-                                    _normalize_in_predicate(context, expr, slot,
-                                                            _slot_id_to_predicates[slot->id()],
+                                    _normalize_in_predicate(context, expr, slot, slot_predicates,
                                                             value_range, &pdt),
                                     status);
                             break;
                         case TExprNodeType::BINARY_PRED:
                             RETURN_IF_PUSH_DOWN(
                                     _normalize_binary_predicate(context, expr, slot,
-                                                                _slot_id_to_predicates[slot->id()],
-                                                                value_range, &pdt),
+                                                                slot_predicates, value_range, &pdt),
                                     status);
                             break;
                         case TExprNodeType::FUNCTION_CALL:
                             if (expr->is_topn_filter()) {
-                                RETURN_IF_PUSH_DOWN(
-                                        _normalize_topn_filter(context, expr, slot,
-                                                               _slot_id_to_predicates[slot->id()],
-                                                               &pdt),
-                                        status);
+                                RETURN_IF_PUSH_DOWN(_normalize_topn_filter(context, expr, slot,
+                                                                           slot_predicates, &pdt),
+                                                    status);
                             } else {
                                 RETURN_IF_PUSH_DOWN(_normalize_is_null_predicate(
-                                                            context, expr, slot,
-                                                            _slot_id_to_predicates[slot->id()],
+                                                            context, expr, slot, slot_predicates,
                                                             value_range, &pdt),
                                                     status);
                             }
                             break;
+                        case TExprNodeType::BITMAP_PRED:
+                            RETURN_IF_PUSH_DOWN(_normalize_bitmap_filter(context, root, slot,
+                                                                         slot_predicates, &pdt),
+                                                status);
+                            break;
                         case TExprNodeType::BLOOM_PRED:
-                            RETURN_IF_PUSH_DOWN(_normalize_bloom_filter(
-                                                        context, root, slot,
-                                                        _slot_id_to_predicates[slot->id()], &pdt),
+                            RETURN_IF_PUSH_DOWN(_normalize_bloom_filter(context, root, slot,
+                                                                        slot_predicates, &pdt),
                                                 status);
                             break;
                         default:
@@ -487,6 +534,18 @@ Status ScanLocalState<Derived>::_normalize_predicate(VExprContext* context, cons
                 },
                 *range);
         RETURN_IF_ERROR(status);
+        if (pdt != PushDownType::UNACCEPTABLE) {
+            auto handle = context->scan_filter_handle();
+            if (!handle) {
+                handle = _register_scan_filter(root, slot);
+                context->attach_scan_filter(handle);
+            }
+            if (handle) {
+                for (size_t i = predicates_before; i < slot_predicates.size(); ++i) {
+                    slot_predicates[i]->attach_scan_filter(handle);
+                }
+            }
+        }
     }
     if (pdt == PushDownType::ACCEPTABLE && slotref != nullptr &&
         slotref->data_type()->get_primitive_type() == PrimitiveType::TYPE_VARIANT) {
@@ -580,7 +639,12 @@ Status ScanLocalStateBase::_normalize_function_filters(VExprContext* expr_ctx, S
                                                           expr_ctx, &val, &fn_ctx, temp_pdt));
         if (temp_pdt != PushDownType::UNACCEPTABLE) {
             std::string col = slot->col_name();
-            _push_down_functions.emplace_back(opposite, col, fn_ctx, val);
+            auto handle = expr_ctx->scan_filter_handle();
+            if (!handle) {
+                handle = _register_scan_filter(expr_ctx->root(), slot);
+                expr_ctx->attach_scan_filter(handle);
+            }
+            _push_down_functions.emplace_back(opposite, col, fn_ctx, val, handle);
             *pdt = temp_pdt;
         }
     }
@@ -1309,7 +1373,12 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
     std::list<std::shared_ptr<ScannerDelegate>> {}.swap(_scanners);
     COUNTER_SET(_wait_for_dependency_timer, _scan_dependency->watcher_elapse_time());
     COUNTER_SET(_wait_for_rf_timer, rf_time);
-    _helper.collect_realtime_profile(custom_profile());
+    _helper.collect_realtime_profile(custom_profile(), _scan_filter_profile.get());
+    if (_scan_filter_profile != nullptr) {
+        _scan_filter_profile->set_runtime_filter_partition_pruning_stats(
+                _runtime_filter_partition_pruning_stats());
+        _scan_filter_profile->materialize(custom_profile(), state->profile_level());
+    }
     return PipelineXLocalState<>::close(state);
 }
 

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -241,12 +241,10 @@ ScanFilterHandle ScanLocalStateBase::_register_scan_filter(const VExprSPtr& root
         desc.topn_filter_source_node_id = assert_cast<VTopNPred*>(root.get())->source_node_id();
     }
     if (slot != nullptr) {
-        desc.slot_id = slot->id();
         desc.column_name = slot->col_name();
         desc.column_id = _parent->intermediate_row_desc().get_column_id(slot->id());
     }
-    desc.debug_string = root->debug_string();
-    desc.compact_info = desc.debug_string;
+    desc.expr_debug_string = root->debug_string();
     return _scan_filter_profile->register_filter(std::move(desc));
 }
 

--- a/be/src/exec/operator/scan_operator.h
+++ b/be/src/exec/operator/scan_operator.h
@@ -35,6 +35,7 @@
 #include "exprs/vectorized_fn_call.h"
 #include "exprs/vin_predicate.h"
 #include "runtime/descriptors.h"
+#include "runtime/scan_filter_profile.h"
 #include "storage/predicate/filter_olap_param.h"
 
 namespace doris {
@@ -98,6 +99,8 @@ public:
 
     Status clone_conjunct_ctxs(VExprContextSPtrs& scanner_conjuncts);
 
+    std::shared_ptr<ScanFilterProfile> scan_filter_profile() const { return _scan_filter_profile; }
+
 protected:
     friend class ScannerContext;
     friend class Scanner;
@@ -110,6 +113,7 @@ protected:
     virtual Status _on_runtime_filter_update();
 
     Status _do_partition_pruning_by_rf();
+    virtual ScanRuntimeFilterPartitionPruningStats _runtime_filter_partition_pruning_stats() const;
 
     std::atomic<bool> _opened {false};
 
@@ -130,6 +134,8 @@ protected:
     RuntimeProfile::Counter* _filter_timer = nullptr;
     // rows read from the scanner (including those discarded by (pre)filters)
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
+
+    std::shared_ptr<ScanFilterProfile> _scan_filter_profile;
 
     RuntimeProfile::Counter* _num_scanners = nullptr;
 
@@ -185,6 +191,8 @@ protected:
         pdt = PushDownType::UNACCEPTABLE;
         return Status::OK();
     }
+
+    ScanFilterHandle _register_scan_filter(const VExprSPtr& root, const SlotDescriptor* slot);
 
     // Non-templated normalize methods, moved here to avoid re-compilation per Derived type.
     Status _eval_const_conjuncts(VExprContext* expr_ctx, PushDownType* pdt);
@@ -338,6 +346,7 @@ protected:
     // Parsed from conjuncts
     phmap::flat_hash_map<int, ColumnValueRangeType> _slot_id_to_value_range;
     phmap::flat_hash_map<int, std::vector<std::shared_ptr<ColumnPredicate>>> _slot_id_to_predicates;
+    phmap::flat_hash_map<int, std::vector<int32_t>> _slot_id_to_scan_filter_ids_for_key_range;
     std::vector<std::shared_ptr<MutilColumnBlockPredicate>> _or_predicates;
 
     std::vector<std::shared_ptr<Dependency>> _filter_dependencies;

--- a/be/src/exec/operator/scan_operator.h
+++ b/be/src/exec/operator/scan_operator.h
@@ -192,7 +192,8 @@ protected:
         return Status::OK();
     }
 
-    ScanFilterHandle _register_scan_filter(const VExprSPtr& root, const SlotDescriptor* slot);
+    ScanFilterHandle _register_scan_filter(const VExprSPtr& root, const SlotDescriptor* slot,
+                                           int profile_level);
 
     // Non-templated normalize methods, moved here to avoid re-compilation per Derived type.
     Status _eval_const_conjuncts(VExprContext* expr_ctx, PushDownType* pdt);

--- a/be/src/exec/operator/scan_operator.h
+++ b/be/src/exec/operator/scan_operator.h
@@ -100,6 +100,7 @@ public:
     Status clone_conjunct_ctxs(VExprContextSPtrs& scanner_conjuncts);
 
     std::shared_ptr<ScanFilterProfile> scan_filter_profile() const { return _scan_filter_profile; }
+    bool enable_scan_filter_profile() const { return _scan_filter_profile != nullptr; }
 
 protected:
     friend class ScannerContext;

--- a/be/src/exec/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_consumer.cpp
@@ -247,7 +247,7 @@ void RuntimeFilterConsumer::collect_scan_filter_profile(ScanFilterProfile* scan_
              .filtered_rows = _rf_filter->value(),
              .wait_time_ns = _wait_timer->value(),
              .always_true_filter_rows = _always_true_counter->value(),
-             .debug_string = debug_string()});
+             .debug_string = _debug_string_internal()});
 }
 
 } // namespace doris

--- a/be/src/exec/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_consumer.cpp
@@ -22,6 +22,7 @@
 #include "exprs/vbloom_predicate.h"
 #include "exprs/vdirect_in_predicate.h"
 #include "runtime/runtime_profile.h"
+#include "runtime/scan_filter_profile.h"
 
 namespace doris {
 Status RuntimeFilterConsumer::_apply_ready_expr(std::vector<RuntimeFilterExprPtr>& push_exprs) {
@@ -235,6 +236,18 @@ void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_oper
     c = parent_operator_profile->add_counter(fmt::format("RF{} AlwaysTrueFilterRows", filter_id),
                                              TUnit::UNIT, "RuntimeFilterInfo", 1);
     c->update(_always_true_counter->value());
+}
+
+void RuntimeFilterConsumer::collect_scan_filter_profile(ScanFilterProfile* scan_filter_profile) {
+    std::unique_lock<std::recursive_mutex> l(_rmtx);
+    DCHECK(scan_filter_profile != nullptr);
+    scan_filter_profile->set_runtime_filter_profile_stats(
+            {.runtime_filter_id = _wrapper->filter_id(),
+             .input_rows = _rf_input->value(),
+             .filtered_rows = _rf_filter->value(),
+             .wait_time_ns = _wait_timer->value(),
+             .always_true_filter_rows = _always_true_counter->value(),
+             .debug_string = debug_string()});
 }
 
 } // namespace doris

--- a/be/src/exec/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/exec/runtime_filter/runtime_filter_consumer.h
@@ -28,6 +28,8 @@
 #include "runtime/runtime_profile.h"
 
 namespace doris {
+class ScanFilterProfile;
+
 // Work on ScanNode or MultiCastDataStreamSource, RuntimeFilterConsumerHelper will manage all RuntimeFilterConsumer
 // Used to create RuntimeFilterExpr to filter data
 class RuntimeFilterConsumer : public RuntimeFilter {
@@ -68,6 +70,7 @@ public:
 
     // Called by RuntimeFilterConsumerHelper
     void collect_realtime_profile(RuntimeProfile* parent_operator_profile);
+    void collect_scan_filter_profile(ScanFilterProfile* scan_filter_profile);
 
     static std::string to_string(const State& state) {
         switch (state) {

--- a/be/src/exec/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/exec/runtime_filter/runtime_filter_consumer.h
@@ -61,9 +61,7 @@ public:
 
     std::string debug_string() override {
         std::unique_lock<std::recursive_mutex> l(_rmtx);
-        return fmt::format("Consumer: ({}, state: {}, reached_timeout: {}, timeout_limit: {}ms)",
-                           _debug_string(), to_string(_rf_state),
-                           _reached_timeout ? "true" : "false", std::to_string(_rf_wait_time_ms));
+        return _debug_string_internal();
     }
 
     bool is_applied() const { return _rf_state == State::APPLIED; }
@@ -107,6 +105,11 @@ private:
     Status _apply_ready_expr(std::vector<RuntimeFilterExprPtr>& push_exprs);
 
     Status _get_push_exprs(std::vector<RuntimeFilterExprPtr>& container, const TExpr& probe_expr);
+    std::string _debug_string_internal() const {
+        return fmt::format("Consumer: ({}, state: {}, reached_timeout: {}, timeout_limit: {}ms)",
+                           _debug_string(), to_string(_rf_state),
+                           _reached_timeout ? "true" : "false", std::to_string(_rf_wait_time_ms));
+    }
     void _check_state(std::vector<State> assumed_states) {
         if (!check_state_impl<RuntimeFilterConsumer>(_rf_state, assumed_states)) {
             throw Exception(ErrorCode::INTERNAL_ERROR,

--- a/be/src/exec/runtime_filter/runtime_filter_consumer_helper.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_consumer_helper.cpp
@@ -19,6 +19,7 @@
 
 #include "exec/runtime_filter/runtime_filter_consumer.h"
 #include "runtime/runtime_profile.h"
+#include "runtime/scan_filter_profile.h"
 
 namespace doris {
 RuntimeFilterConsumerHelper::RuntimeFilterConsumerHelper(
@@ -129,8 +130,21 @@ Status RuntimeFilterConsumerHelper::try_append_late_arrival_runtime_filter(
     return Status::OK();
 }
 
-void RuntimeFilterConsumerHelper::collect_realtime_profile(
-        RuntimeProfile* parent_operator_profile) {
+void RuntimeFilterConsumerHelper::collect_realtime_profile(RuntimeProfile* parent_operator_profile,
+                                                           ScanFilterProfile* scan_filter_profile) {
+    if (_consumers.empty()) {
+        return;
+    }
+
+    if (scan_filter_profile != nullptr) {
+        scan_filter_profile->set_runtime_filter_acquire_time(
+                _acquire_runtime_filter_timer->value());
+        for (const auto& consumer : _consumers) {
+            consumer->collect_scan_filter_profile(scan_filter_profile);
+        }
+        return;
+    }
+
     std::ignore = parent_operator_profile->add_counter("RuntimeFilterInfo", TUnit::NONE,
                                                        RuntimeProfile::ROOT_COUNTER, 1);
     RuntimeProfile::Counter* c = parent_operator_profile->add_counter(

--- a/be/src/exec/runtime_filter/runtime_filter_consumer_helper.h
+++ b/be/src/exec/runtime_filter/runtime_filter_consumer_helper.h
@@ -24,6 +24,8 @@
 #include "runtime/runtime_profile.h"
 
 namespace doris {
+class ScanFilterProfile;
+
 // this class used in ScanNode or MultiCastDataStreamSource
 /**
  * init -> acquire_runtime_filter -> try_append_late_arrival_runtime_filter
@@ -49,7 +51,8 @@ public:
 
     // Called by XXXLocalState::close()
     // parent_operator_profile is owned by LocalState so update it is safe at here.
-    void collect_realtime_profile(RuntimeProfile* parent_operator_profile);
+    void collect_realtime_profile(RuntimeProfile* parent_operator_profile,
+                                  ScanFilterProfile* scan_filter_profile = nullptr);
 
     size_t runtime_filter_nums() const { return _runtime_filter_descs.size(); }
 

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -92,6 +92,8 @@ OlapScanner::OlapScanner(ScanLocalStateBase* parent, OlapScanner::Params&& param
                                  .rs_splits {},
                                  .return_columns {},
                                  .output_columns {},
+                                 .scan_filter_profile {},
+                                 .key_range_scan_filter {},
                                  .common_expr_ctxs_push_down {},
                                  .topn_filter_source_node_ids {},
                                  .key_group_cluster_key_idxes {},
@@ -400,9 +402,9 @@ Status OlapScanner::_init_tablet_reader_params(
     _tablet_reader_params.vir_cid_to_idx_in_block = _vir_cid_to_idx_in_block;
     _tablet_reader_params.vir_col_idx_to_type = _vir_col_idx_to_type;
     _tablet_reader_params.score_runtime = _score_runtime;
-    _tablet_reader_params.output_columns = ((OlapScanLocalState*)_local_state)->_output_column_ids;
+    _tablet_reader_params.output_columns = olap_local_state->_output_column_ids;
     _tablet_reader_params.ann_topn_runtime = _ann_topn_runtime;
-    for (const auto& ele : ((OlapScanLocalState*)_local_state)->_cast_types_for_variants) {
+    for (const auto& ele : olap_local_state->_cast_types_for_variants) {
         _tablet_reader_params.target_cast_type_for_variants[ele.first] = ele.second;
     };
     auto& tablet_schema = _tablet_reader_params.tablet_schema;
@@ -447,6 +449,8 @@ Status OlapScanner::_init_tablet_reader_params(
 
     _tablet_reader_params.profile = _local_state->custom_profile();
     _tablet_reader_params.runtime_state = _state;
+    _tablet_reader_params.scan_filter_profile = _local_state->scan_filter_profile();
+    _tablet_reader_params.key_range_scan_filter = olap_local_state->_key_range_scan_filter;
 
     _tablet_reader_params.origin_return_columns = &_return_columns;
     _tablet_reader_params.tablet_columns_convert_to_null_set = &_tablet_columns_convert_to_null_set;

--- a/be/src/exec/scan/scanner.cpp
+++ b/be/src/exec/scan/scanner.cpp
@@ -197,7 +197,8 @@ Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
 
 Status Scanner::_filter_output_block(Block* block) {
     auto old_rows = block->rows();
-    Status st = VExprContext::filter_block(_conjuncts, block, block->columns());
+    Status st = VExprContext::filter_block(_conjuncts, block, block->columns(),
+                                           ScanFilterStage::EXEC_RESIDUAL);
     _counter.num_rows_unselected += old_rows - block->rows();
     return st;
 }

--- a/be/src/exprs/function_filter.h
+++ b/be/src/exprs/function_filter.h
@@ -17,20 +17,24 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "core/string_ref.h" // IWYU pragma: keep
 #include "exprs/function_context.h"
+#include "runtime/scan_filter_profile.h"
 
 namespace doris {
 
 class FunctionFilter {
 public:
     FunctionFilter(bool opposite, const std::string& col_name, doris::FunctionContext* fn_ctx,
-                   doris::StringRef string_param)
+                   doris::StringRef string_param,
+                   ScanFilterHandle scan_filter_handle = ScanFilterHandle())
             : _opposite(opposite),
               _col_name(col_name),
               _fn_ctx(fn_ctx),
-              _string_param(string_param) {}
+              _string_param(string_param),
+              _scan_filter_handle(std::move(scan_filter_handle)) {}
 
     bool _opposite;
     std::string _col_name;
@@ -38,6 +42,7 @@ public:
     doris::FunctionContext* _fn_ctx = nullptr;
     // only one param from conjunct, because now only support like predicate
     doris::StringRef _string_param;
+    ScanFilterHandle _scan_filter_handle;
 };
 
 } // namespace doris

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -162,6 +162,7 @@ Status VExprContext::clone(RuntimeState* state, VExprContextSPtr& new_ctx) {
     // segment_v2::AnnRangeSearchRuntime should be cloned as well.
     // The object of segment_v2::AnnRangeSearchRuntime is not shared by threads.
     new_ctx->_ann_range_search_runtime = this->_ann_range_search_runtime;
+    new_ctx->_scan_filter_handle = _scan_filter_handle;
 
     return _root->open(state, new_ctx.get(), FunctionContext::THREAD_LOCAL);
 }
@@ -203,7 +204,8 @@ Status VExprContext::filter_block(VExprContext* vexpr_ctx, Block* block) {
 }
 
 Status VExprContext::filter_block(const VExprContextSPtrs& expr_contexts, Block* block,
-                                  size_t column_to_keep) {
+                                  size_t column_to_keep,
+                                  std::optional<ScanFilterStage> scan_filter_stage) {
     if (expr_contexts.empty() || block->rows() == 0) {
         return Status::OK();
     }
@@ -212,13 +214,15 @@ Status VExprContext::filter_block(const VExprContextSPtrs& expr_contexts, Block*
     std::iota(columns_to_filter.begin(), columns_to_filter.end(), 0);
 
     return execute_conjuncts_and_filter_block(expr_contexts, block, columns_to_filter,
-                                              static_cast<int>(column_to_keep));
+                                              static_cast<int>(column_to_keep), scan_filter_stage);
 }
 
 Status VExprContext::execute_conjuncts(const VExprContextSPtrs& ctxs,
                                        const std::vector<IColumn::Filter*>* filters, Block* block,
-                                       IColumn::Filter* result_filter, bool* can_filter_all) {
-    return execute_conjuncts(ctxs, filters, false, block, result_filter, can_filter_all);
+                                       IColumn::Filter* result_filter, bool* can_filter_all,
+                                       std::optional<ScanFilterStage> scan_filter_stage) {
+    return execute_conjuncts(ctxs, filters, false, block, result_filter, can_filter_all,
+                             scan_filter_stage);
 }
 
 Status VExprContext::execute_filter(const Block* block, uint8_t* __restrict result_filter_data,
@@ -230,14 +234,27 @@ Status VExprContext::execute_filter(const Block* block, uint8_t* __restrict resu
 Status VExprContext::execute_conjuncts(const VExprContextSPtrs& ctxs,
                                        const std::vector<IColumn::Filter*>* filters,
                                        bool accept_null, const Block* block,
-                                       IColumn::Filter* result_filter, bool* can_filter_all) {
+                                       IColumn::Filter* result_filter, bool* can_filter_all,
+                                       std::optional<ScanFilterStage> scan_filter_stage) {
     size_t rows = block->rows();
     DCHECK_EQ(result_filter->size(), rows);
     *can_filter_all = false;
     auto* __restrict result_filter_data = result_filter->data();
     for (const auto& ctx : ctxs) {
+        const bool collect_scan_filter_stats =
+                scan_filter_stage.has_value() && ctx->scan_filter_handle();
+        const int64_t input_rows =
+                collect_scan_filter_stats
+                        ? std::count(result_filter_data, result_filter_data + rows, 1)
+                        : 0;
         RETURN_IF_ERROR(
                 ctx->execute_filter(block, result_filter_data, rows, accept_null, can_filter_all));
+        if (collect_scan_filter_stats) {
+            const int64_t output_rows =
+                    *can_filter_all ? 0
+                                    : std::count(result_filter_data, result_filter_data + rows, 1);
+            ctx->scan_filter_handle().stats->record(*scan_filter_stage, input_rows, output_rows);
+        }
         if (*can_filter_all) {
             return Status::OK();
         }
@@ -311,16 +328,16 @@ Status VExprContext::execute_conjuncts(const VExprContextSPtrs& conjuncts, const
 
 // TODO Performance Optimization
 // need exception safety
-Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs& ctxs, Block* block,
-                                                        std::vector<uint32_t>& columns_to_filter,
-                                                        int column_to_keep) {
+Status VExprContext::execute_conjuncts_and_filter_block(
+        const VExprContextSPtrs& ctxs, Block* block, std::vector<uint32_t>& columns_to_filter,
+        int column_to_keep, std::optional<ScanFilterStage> scan_filter_stage) {
     IColumn::Filter result_filter(block->rows(), 1);
     bool can_filter_all;
 
     _reset_memory_usage(ctxs);
 
-    RETURN_IF_ERROR(
-            execute_conjuncts(ctxs, nullptr, false, block, &result_filter, &can_filter_all));
+    RETURN_IF_ERROR(execute_conjuncts(ctxs, nullptr, false, block, &result_filter, &can_filter_all,
+                                      scan_filter_stage));
 
     // Accumulate the usage of `result_filter` into the first context.
     if (!ctxs.empty()) {
@@ -356,14 +373,15 @@ Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs&
     return Status::OK();
 }
 
-Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs& ctxs, Block* block,
-                                                        std::vector<uint32_t>& columns_to_filter,
-                                                        int column_to_keep,
-                                                        IColumn::Filter& filter) {
+Status VExprContext::execute_conjuncts_and_filter_block(
+        const VExprContextSPtrs& ctxs, Block* block, std::vector<uint32_t>& columns_to_filter,
+        int column_to_keep, IColumn::Filter& filter,
+        std::optional<ScanFilterStage> scan_filter_stage) {
     _reset_memory_usage(ctxs);
     filter.resize_fill(block->rows(), 1);
     bool can_filter_all;
-    RETURN_IF_ERROR(execute_conjuncts(ctxs, nullptr, false, block, &filter, &can_filter_all));
+    RETURN_IF_ERROR(execute_conjuncts(ctxs, nullptr, false, block, &filter, &can_filter_all,
+                                      scan_filter_stage));
 
     // Accumulate the usage of `result_filter` into the first context.
     if (!ctxs.empty()) {

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -35,6 +36,7 @@
 #include "exprs/function_context.h"
 #include "exprs/vexpr_fwd.h"
 #include "runtime/runtime_state.h"
+#include "runtime/scan_filter_profile.h"
 #include "storage/index/ann/ann_range_search_runtime.h"
 #include "storage/index/ann/ann_search_params.h"
 #include "storage/index/inverted/inverted_index_reader.h"
@@ -263,6 +265,10 @@ public:
 
     std::shared_ptr<IndexExecContext> get_index_context() const { return _index_context; }
 
+    void attach_scan_filter(ScanFilterHandle handle) { _scan_filter_handle = std::move(handle); }
+
+    const ScanFilterHandle& scan_filter_handle() const { return _scan_filter_handle; }
+
     /// Creates a FunctionContext, and returns the index that's passed to fn_context() to
     /// retrieve the created context. Exprs that need a FunctionContext should call this in
     /// Prepare() and save the returned index. 'varargs_buffer_size', if specified, is the
@@ -293,30 +299,32 @@ public:
 
     [[nodiscard]] static Status filter_block(VExprContext* vexpr_ctx, Block* block);
 
-    [[nodiscard]] static Status filter_block(const VExprContextSPtrs& expr_contexts, Block* block,
-                                             size_t column_to_keep);
+    [[nodiscard]] static Status filter_block(
+            const VExprContextSPtrs& expr_contexts, Block* block, size_t column_to_keep,
+            std::optional<ScanFilterStage> scan_filter_stage = std::nullopt);
 
-    [[nodiscard]] static Status execute_conjuncts(const VExprContextSPtrs& ctxs,
-                                                  const std::vector<IColumn::Filter*>* filters,
-                                                  bool accept_null, const Block* block,
-                                                  IColumn::Filter* result_filter,
-                                                  bool* can_filter_all);
+    [[nodiscard]] static Status execute_conjuncts(
+            const VExprContextSPtrs& ctxs, const std::vector<IColumn::Filter*>* filters,
+            bool accept_null, const Block* block, IColumn::Filter* result_filter,
+            bool* can_filter_all, std::optional<ScanFilterStage> scan_filter_stage = std::nullopt);
 
     [[nodiscard]] static Status execute_conjuncts(const VExprContextSPtrs& conjuncts,
                                                   const Block* block, ColumnUInt8& null_map,
                                                   IColumn::Filter& result_filter);
 
-    static Status execute_conjuncts(const VExprContextSPtrs& ctxs,
-                                    const std::vector<IColumn::Filter*>* filters, Block* block,
-                                    IColumn::Filter* result_filter, bool* can_filter_all);
+    static Status execute_conjuncts(
+            const VExprContextSPtrs& ctxs, const std::vector<IColumn::Filter*>* filters,
+            Block* block, IColumn::Filter* result_filter, bool* can_filter_all,
+            std::optional<ScanFilterStage> scan_filter_stage = std::nullopt);
 
     [[nodiscard]] static Status execute_conjuncts_and_filter_block(
             const VExprContextSPtrs& ctxs, Block* block, std::vector<uint32_t>& columns_to_filter,
-            int column_to_keep);
+            int column_to_keep, std::optional<ScanFilterStage> scan_filter_stage = std::nullopt);
 
-    static Status execute_conjuncts_and_filter_block(const VExprContextSPtrs& ctxs, Block* block,
-                                                     std::vector<uint32_t>& columns_to_filter,
-                                                     int column_to_keep, IColumn::Filter& filter);
+    static Status execute_conjuncts_and_filter_block(
+            const VExprContextSPtrs& ctxs, Block* block, std::vector<uint32_t>& columns_to_filter,
+            int column_to_keep, IColumn::Filter& filter,
+            std::optional<ScanFilterStage> scan_filter_stage = std::nullopt);
 
     [[nodiscard]] static Status get_output_block_after_execute_exprs(const VExprContextSPtrs&,
                                                                      const Block&, Block*,
@@ -356,6 +364,7 @@ public:
 
         _last_result_column_id = other._last_result_column_id;
         _depth_num = other._depth_num;
+        _scan_filter_handle = other._scan_filter_handle;
         return *this;
     }
 
@@ -368,6 +377,7 @@ public:
         _fn_contexts = std::move(other._fn_contexts);
         _last_result_column_id = other._last_result_column_id;
         _depth_num = other._depth_num;
+        _scan_filter_handle = other._scan_filter_handle;
         return *this;
     }
 
@@ -421,6 +431,7 @@ private:
     int _depth_num = 0;
 
     std::shared_ptr<IndexExecContext> _index_context;
+    ScanFilterHandle _scan_filter_handle;
     size_t _memory_usage = 0;
 
     segment_v2::AnnRangeSearchRuntime _ann_range_search_runtime;

--- a/be/src/runtime/scan_filter_profile.cpp
+++ b/be/src/runtime/scan_filter_profile.cpp
@@ -103,6 +103,13 @@ std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot
         const auto stage = static_cast<ScanFilterStage>(i);
         const auto& stage_stats = snapshot.stage_snapshots[static_cast<size_t>(stage)];
         if (stage_stats.participated()) {
+            if (profile_level >= 3) {
+                stages.emplace_back(
+                        fmt::format("{}(input={}, filtered={})", scan_filter_stage_name(stage),
+                                    PrettyPrinter::print(stage_stats.input_rows, TUnit::UNIT),
+                                    PrettyPrinter::print(stage_stats.filtered_rows, TUnit::UNIT)));
+                continue;
+            }
             if (profile_level >= 2) {
                 stages.emplace_back(
                         fmt::format("{}({})", scan_filter_stage_name(stage),

--- a/be/src/runtime/scan_filter_profile.cpp
+++ b/be/src/runtime/scan_filter_profile.cpp
@@ -18,10 +18,11 @@
 #include "runtime/scan_filter_profile.h"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <sstream>
+#include <unordered_set>
 
 #include "runtime/runtime_profile.h"
 
@@ -32,28 +33,17 @@ namespace {
 constexpr const char* SCAN_FILTER_INFO = "ScanFilterInfo";
 constexpr const char* KEY_RANGE_INFO = "KeyRangeInfo";
 constexpr const char* RUNTIME_FILTER_PARTITION_PRUNING = "RuntimeFilterPartitionPruning";
+constexpr int NOT_APPLIED_PROFILE_ORDER = static_cast<int>(ScanFilterStage::NUM_STAGES);
 
 bool is_index_stage(ScanFilterStage stage) {
-    return stage == ScanFilterStage::INDEX_INVERTED ||
-           stage == ScanFilterStage::INDEX_BLOOM_FILTER ||
-           stage == ScanFilterStage::INDEX_ZONE_MAP || stage == ScanFilterStage::INDEX_DICT ||
-           stage == ScanFilterStage::INDEX_ANN;
+    return stage == ScanFilterStage::INDEX_INVERTED || stage == ScanFilterStage::INDEX_ANN ||
+           stage == ScanFilterStage::INDEX_DICT || stage == ScanFilterStage::INDEX_BLOOM_FILTER ||
+           stage == ScanFilterStage::INDEX_ZONE_MAP;
 }
 
 bool is_exec_stage(ScanFilterStage stage) {
     return stage == ScanFilterStage::EXEC_VECTOR || stage == ScanFilterStage::EXEC_SHORT_CIRCUIT ||
            stage == ScanFilterStage::EXEC_COMMON_EXPR || stage == ScanFilterStage::EXEC_RESIDUAL;
-}
-
-std::string join_ids(const std::vector<int32_t>& ids) {
-    std::stringstream ss;
-    for (size_t i = 0; i < ids.size(); ++i) {
-        if (i != 0) {
-            ss << ",";
-        }
-        ss << ids[i];
-    }
-    return ss.str();
 }
 
 void set_counter(RuntimeProfile* profile, const std::string& name, TUnit::type type,
@@ -82,38 +72,6 @@ void add_info_string_if_not_empty(RuntimeProfile* profile, const std::string& ke
     }
 }
 
-int stage_display_order(ScanFilterStage stage) {
-    switch (stage) {
-    case ScanFilterStage::KEY_RANGE:
-        return 1;
-    case ScanFilterStage::INDEX_INVERTED:
-        return 2;
-    case ScanFilterStage::INDEX_ANN:
-        return 3;
-    case ScanFilterStage::INDEX_DICT:
-        return 4;
-    case ScanFilterStage::INDEX_BLOOM_FILTER:
-        return 5;
-    case ScanFilterStage::INDEX_ZONE_MAP:
-        return 6;
-    case ScanFilterStage::EXEC_VECTOR:
-        return 7;
-    case ScanFilterStage::EXEC_SHORT_CIRCUIT:
-        return 8;
-    case ScanFilterStage::EXEC_COMMON_EXPR:
-        return 9;
-    case ScanFilterStage::EXEC_RESIDUAL:
-        return 10;
-    case ScanFilterStage::NUM_STAGES:
-        break;
-    }
-    return 99;
-}
-
-const char* stage_profile_name(ScanFilterStage stage) {
-    return scan_filter_stage_name(stage);
-}
-
 const char* scan_filter_source_name(ScanFilterKind kind) {
     switch (kind) {
     case ScanFilterKind::NORMAL:
@@ -128,29 +86,11 @@ const char* scan_filter_source_name(ScanFilterKind kind) {
     return "Unknown";
 }
 
-bool contains_id(const std::vector<int32_t>& ids, int32_t id) {
-    return std::find(ids.begin(), ids.end(), id) != ids.end();
-}
-
-bool has_runtime_filter_partition_pruning_stats(
-        const ScanRuntimeFilterPartitionPruningStats& stats) {
-    return stats.total_partitions > 0 || stats.pruned_partitions > 0 || stats.pruned_tablets > 0;
-}
-
-constexpr std::array<ScanFilterStage, static_cast<size_t>(ScanFilterStage::NUM_STAGES)>
-ordered_stages() {
-    return {ScanFilterStage::KEY_RANGE,          ScanFilterStage::INDEX_INVERTED,
-            ScanFilterStage::INDEX_ANN,          ScanFilterStage::INDEX_DICT,
-            ScanFilterStage::INDEX_BLOOM_FILTER, ScanFilterStage::INDEX_ZONE_MAP,
-            ScanFilterStage::EXEC_VECTOR,        ScanFilterStage::EXEC_SHORT_CIRCUIT,
-            ScanFilterStage::EXEC_COMMON_EXPR,   ScanFilterStage::EXEC_RESIDUAL};
-}
-
 struct SummaryStats {
     bool participated = false;
     bool has_filtering_stage = false;
     bool has_time = false;
-    int first_stage = 99;
+    int first_stage = NOT_APPLIED_PROFILE_ORDER;
     int last_stage = -1;
     int64_t input_rows = 0;
     int64_t output_rows = 0;
@@ -163,7 +103,7 @@ void update_summary(SummaryStats* summary, ScanFilterStage stage,
     if (!stats.participated()) {
         return;
     }
-    const auto order = stage_display_order(stage);
+    const auto order = static_cast<int>(stage);
     if (stats.filtered_rows > 0) {
         if (!summary->has_filtering_stage || order < summary->first_stage) {
             summary->first_stage = order;
@@ -201,7 +141,7 @@ struct MaterializedFilterSnapshot {
 
 void materialize_filter_stage(RuntimeProfile* filter_profile, ScanFilterStage stage,
                               const ScanFilterStageStatsSnapshot& stats) {
-    auto* stage_profile = get_or_create_child(filter_profile, stage_profile_name(stage));
+    auto* stage_profile = get_or_create_child(filter_profile, scan_filter_stage_name(stage));
     set_root_counter(stage_profile, "InputRows", TUnit::UNIT, 2, stats.input_rows);
     set_root_counter(stage_profile, "FilteredRows", TUnit::UNIT, 2, stats.filtered_rows);
     if (stats.has_time) {
@@ -212,37 +152,27 @@ void materialize_filter_stage(RuntimeProfile* filter_profile, ScanFilterStage st
 std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot,
                                       bool is_key_range_source) {
     std::vector<std::string> stages;
-    for (const auto stage : ordered_stages()) {
+    for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
+        const auto stage = static_cast<ScanFilterStage>(i);
         if (snapshot.stage_snapshots[static_cast<size_t>(stage)].participated()) {
-            stages.emplace_back(stage_profile_name(stage));
+            stages.emplace_back(scan_filter_stage_name(stage));
         }
     }
     if (stages.empty()) {
         return is_key_range_source ? "KeyRangeInfo" : "NotApplied";
     }
-
-    std::stringstream ss;
-    for (size_t i = 0; i < stages.size(); ++i) {
-        if (i != 0) {
-            ss << " -> ";
-        }
-        ss << stages[i];
-    }
-    return ss.str();
+    return fmt::format("{}", fmt::join(stages, " -> "));
 }
 
 std::string target_string(const ScanFilterDesc& desc) {
-    std::stringstream ss;
+    std::vector<std::string> parts;
     if (desc.column_id >= 0) {
-        ss << "column_id=" << desc.column_id;
+        parts.emplace_back(fmt::format("column_id={}", desc.column_id));
     }
     if (!desc.column_name.empty()) {
-        if (ss.tellp() > 0) {
-            ss << ", ";
-        }
-        ss << "column=" << desc.column_name;
+        parts.emplace_back(fmt::format("column={}", desc.column_name));
     }
-    return ss.str();
+    return fmt::format("{}", fmt::join(parts, ", "));
 }
 
 std::string source_string(const ScanFilterDesc& desc) {
@@ -298,7 +228,8 @@ void materialize_filter_counters(RuntimeProfile* filter_profile,
     if (profile_level < 2) {
         return;
     }
-    for (const auto stage : ordered_stages()) {
+    for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
+        const auto stage = static_cast<ScanFilterStage>(i);
         const auto& stage_stats = snapshot.stage_snapshots[static_cast<size_t>(stage)];
         if (!stage_stats.participated()) {
             continue;
@@ -324,23 +255,6 @@ void materialize_runtime_filter_partition_pruning(
     }
 }
 
-int first_profile_order(const MaterializedFilterSnapshot& snapshot, bool is_key_range_source) {
-    if (snapshot.total.participated) {
-        return snapshot.total.first_stage;
-    }
-    if (is_key_range_source) {
-        return 1;
-    }
-    return 99;
-}
-
-int64_t first_profile_input_rows(const MaterializedFilterSnapshot& snapshot, int order) {
-    if (snapshot.total.participated && snapshot.total.first_stage == order) {
-        return snapshot.total.input_rows;
-    }
-    return snapshot.total.input_rows;
-}
-
 } // namespace
 
 const char* scan_filter_kind_name(ScanFilterKind kind) {
@@ -363,14 +277,14 @@ const char* scan_filter_stage_name(ScanFilterStage stage) {
         return "KeyRange";
     case ScanFilterStage::INDEX_INVERTED:
         return "IndexInverted";
+    case ScanFilterStage::INDEX_ANN:
+        return "IndexAnn";
+    case ScanFilterStage::INDEX_DICT:
+        return "IndexDict";
     case ScanFilterStage::INDEX_BLOOM_FILTER:
         return "IndexBloomFilter";
     case ScanFilterStage::INDEX_ZONE_MAP:
         return "IndexZoneMap";
-    case ScanFilterStage::INDEX_DICT:
-        return "IndexDict";
-    case ScanFilterStage::INDEX_ANN:
-        return "IndexAnn";
     case ScanFilterStage::EXEC_VECTOR:
         return "ExecuteVector";
     case ScanFilterStage::EXEC_SHORT_CIRCUIT:
@@ -529,8 +443,9 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
         const auto& key_range = *key_range_snapshot;
         const auto key_range_stats = key_range.handle.stats->snapshot(ScanFilterStage::KEY_RANGE);
         if (!key_range.source_filter_ids.empty()) {
-            key_range_profile->add_info_string("SourceFilterIds",
-                                               join_ids(key_range.source_filter_ids));
+            key_range_profile->add_info_string(
+                    "SourceFilterIds",
+                    fmt::format("{}", fmt::join(key_range.source_filter_ids, ",")));
         }
         if (profile_level >= 2) {
             add_info_string_if_not_empty(key_range_profile, "ScanKeys", key_range.scan_keys);
@@ -544,32 +459,19 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
     }
 
     const bool has_partition_pruning_stats =
-            has_runtime_filter_partition_pruning_stats(runtime_filter_partition_pruning_stats);
+            runtime_filter_partition_pruning_stats.total_partitions > 0;
     if (scan_filter_snapshots.empty() && !has_partition_pruning_stats &&
         runtime_filter_acquire_time_ns <= 0) {
         return;
     }
 
-    std::vector<int32_t> key_range_source_filter_ids;
+    std::unordered_set<int32_t> key_range_source_filter_ids;
     if (key_range_snapshot.has_value()) {
-        key_range_source_filter_ids = key_range_snapshot->source_filter_ids;
+        key_range_source_filter_ids.insert(key_range_snapshot->source_filter_ids.begin(),
+                                           key_range_snapshot->source_filter_ids.end());
     }
 
-    std::ranges::sort(scan_filter_snapshots, [&](const auto& left, const auto& right) {
-        const bool left_key_range_source =
-                contains_id(key_range_source_filter_ids, left.desc.filter_id);
-        const bool right_key_range_source =
-                contains_id(key_range_source_filter_ids, right.desc.filter_id);
-        const int left_order = first_profile_order(left, left_key_range_source);
-        const int right_order = first_profile_order(right, right_key_range_source);
-        if (left_order != right_order) {
-            return left_order < right_order;
-        }
-        const int64_t left_input_rows = first_profile_input_rows(left, left_order);
-        const int64_t right_input_rows = first_profile_input_rows(right, right_order);
-        if (left_input_rows != right_input_rows) {
-            return left_input_rows > right_input_rows;
-        }
+    std::ranges::sort(scan_filter_snapshots, [](const auto& left, const auto& right) {
         return left.desc.filter_id < right.desc.filter_id;
     });
 
@@ -590,9 +492,8 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
     for (const auto& snapshot : scan_filter_snapshots) {
         auto* filter_profile = get_or_create_child(
                 scan_filter_profile, fmt::format("ScanFilter {}", snapshot.desc.filter_id));
-        materialize_filter_counters(
-                filter_profile, snapshot, profile_level,
-                contains_id(key_range_source_filter_ids, snapshot.desc.filter_id));
+        materialize_filter_counters(filter_profile, snapshot, profile_level,
+                                    key_range_source_filter_ids.contains(snapshot.desc.filter_id));
     }
 }
 

--- a/be/src/runtime/scan_filter_profile.cpp
+++ b/be/src/runtime/scan_filter_profile.cpp
@@ -1,0 +1,638 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/scan_filter_profile.h"
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <sstream>
+
+#include "runtime/runtime_profile.h"
+
+namespace doris {
+
+namespace {
+
+constexpr const char* SCAN_FILTER_INFO = "ScanFilterInfo";
+constexpr const char* KEY_RANGE_INFO = "KeyRangeInfo";
+constexpr const char* RUNTIME_FILTER_PARTITION_PRUNING = "RuntimeFilterPartitionPruning";
+
+bool is_index_stage(ScanFilterStage stage) {
+    return stage == ScanFilterStage::INDEX_INVERTED ||
+           stage == ScanFilterStage::INDEX_BLOOM_FILTER ||
+           stage == ScanFilterStage::INDEX_ZONE_MAP || stage == ScanFilterStage::INDEX_DICT ||
+           stage == ScanFilterStage::INDEX_ANN;
+}
+
+bool is_exec_stage(ScanFilterStage stage) {
+    return stage == ScanFilterStage::EXEC_VECTOR || stage == ScanFilterStage::EXEC_SHORT_CIRCUIT ||
+           stage == ScanFilterStage::EXEC_COMMON_EXPR || stage == ScanFilterStage::EXEC_RESIDUAL;
+}
+
+std::string join_ids(const std::vector<int32_t>& ids) {
+    std::stringstream ss;
+    for (size_t i = 0; i < ids.size(); ++i) {
+        if (i != 0) {
+            ss << ",";
+        }
+        ss << ids[i];
+    }
+    return ss.str();
+}
+
+void set_counter(RuntimeProfile* profile, const std::string& name, TUnit::type type,
+                 const std::string& parent, int64_t level, int64_t value) {
+    auto* counter = profile->add_counter(name, type, parent, level);
+    counter->set(value);
+}
+
+void set_root_counter(RuntimeProfile* profile, const std::string& name, TUnit::type type,
+                      int64_t level, int64_t value) {
+    set_counter(profile, name, type, RuntimeProfile::ROOT_COUNTER, level, value);
+}
+
+RuntimeProfile* get_or_create_child(RuntimeProfile* profile, const std::string& name) {
+    auto* child = profile->get_child(name);
+    if (child != nullptr) {
+        return child;
+    }
+    return profile->create_child(name, true, false);
+}
+
+void add_info_string_if_not_empty(RuntimeProfile* profile, const std::string& key,
+                                  const std::string& value) {
+    if (!value.empty()) {
+        profile->add_info_string(key, value);
+    }
+}
+
+int stage_display_order(ScanFilterStage stage) {
+    switch (stage) {
+    case ScanFilterStage::KEY_RANGE:
+        return 1;
+    case ScanFilterStage::INDEX_INVERTED:
+        return 2;
+    case ScanFilterStage::INDEX_ANN:
+        return 3;
+    case ScanFilterStage::INDEX_DICT:
+        return 4;
+    case ScanFilterStage::INDEX_BLOOM_FILTER:
+        return 5;
+    case ScanFilterStage::INDEX_ZONE_MAP:
+        return 6;
+    case ScanFilterStage::EXEC_VECTOR:
+        return 7;
+    case ScanFilterStage::EXEC_SHORT_CIRCUIT:
+        return 8;
+    case ScanFilterStage::EXEC_COMMON_EXPR:
+        return 9;
+    case ScanFilterStage::EXEC_RESIDUAL:
+        return 10;
+    case ScanFilterStage::NUM_STAGES:
+        break;
+    }
+    return 99;
+}
+
+const char* stage_profile_name(ScanFilterStage stage) {
+    return scan_filter_stage_name(stage);
+}
+
+const char* scan_filter_source_name(ScanFilterKind kind) {
+    switch (kind) {
+    case ScanFilterKind::NORMAL:
+        return "Conjunct";
+    case ScanFilterKind::RUNTIME_FILTER:
+        return "RuntimeFilter";
+    case ScanFilterKind::TOPN_FILTER:
+        return "TopNFilter";
+    case ScanFilterKind::KEY_RANGE:
+        return "KeyRange";
+    case ScanFilterKind::UNKNOWN:
+        return "Unknown";
+    }
+    return "Unknown";
+}
+
+bool contains_id(const std::vector<int32_t>& ids, int32_t id) {
+    return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+const ScanRuntimeFilterProfileStats* find_runtime_filter_stats(
+        const std::vector<ScanRuntimeFilterProfileStats>& stats, int32_t runtime_filter_id) {
+    for (const auto& item : stats) {
+        if (item.runtime_filter_id == runtime_filter_id) {
+            return &item;
+        }
+    }
+    return nullptr;
+}
+
+bool has_runtime_filter_partition_pruning_stats(
+        const ScanRuntimeFilterPartitionPruningStats& stats) {
+    return stats.total_partitions > 0 || stats.pruned_partitions > 0 || stats.pruned_tablets > 0;
+}
+
+constexpr std::array<ScanFilterStage, static_cast<size_t>(ScanFilterStage::NUM_STAGES)>
+ordered_stages() {
+    return {ScanFilterStage::KEY_RANGE,          ScanFilterStage::INDEX_INVERTED,
+            ScanFilterStage::INDEX_ANN,          ScanFilterStage::INDEX_DICT,
+            ScanFilterStage::INDEX_BLOOM_FILTER, ScanFilterStage::INDEX_ZONE_MAP,
+            ScanFilterStage::EXEC_VECTOR,        ScanFilterStage::EXEC_SHORT_CIRCUIT,
+            ScanFilterStage::EXEC_COMMON_EXPR,   ScanFilterStage::EXEC_RESIDUAL};
+}
+
+struct SummaryStats {
+    bool participated = false;
+    bool has_filtering_stage = false;
+    bool has_time = false;
+    int first_stage = 99;
+    int last_stage = -1;
+    int64_t input_rows = 0;
+    int64_t output_rows = 0;
+    int64_t filtered_rows = 0;
+    int64_t time_ns = 0;
+};
+
+void update_summary(SummaryStats* summary, ScanFilterStage stage,
+                    const ScanFilterStageStatsSnapshot& stats) {
+    if (!stats.participated) {
+        return;
+    }
+    const auto order = stage_display_order(stage);
+    if (stats.filtered_rows > 0) {
+        if (!summary->has_filtering_stage || order < summary->first_stage) {
+            summary->first_stage = order;
+            summary->input_rows = stats.input_rows;
+        }
+        if (!summary->has_filtering_stage || order > summary->last_stage) {
+            summary->last_stage = order;
+            summary->output_rows = stats.output_rows;
+        }
+        summary->has_filtering_stage = true;
+    } else if (!summary->has_filtering_stage &&
+               (!summary->participated || order > summary->last_stage)) {
+        summary->first_stage = order;
+        summary->last_stage = order;
+        summary->input_rows = stats.input_rows;
+        summary->output_rows = stats.output_rows;
+    }
+    summary->participated = true;
+    summary->filtered_rows += stats.filtered_rows;
+    if (stats.has_time) {
+        summary->has_time = true;
+        summary->time_ns += stats.time_ns;
+    }
+}
+
+struct MaterializedFilterSnapshot {
+    ScanFilterDesc desc;
+    std::array<ScanFilterStageStatsSnapshot, static_cast<size_t>(ScanFilterStage::NUM_STAGES)>
+            stage_snapshots;
+    SummaryStats total;
+    SummaryStats index;
+    SummaryStats exec;
+};
+
+void materialize_filter_stage(RuntimeProfile* filter_profile, ScanFilterStage stage,
+                              const ScanFilterStageStatsSnapshot& stats) {
+    auto* stage_profile = get_or_create_child(filter_profile, stage_profile_name(stage));
+    set_root_counter(stage_profile, "InputRows", TUnit::UNIT, 2, stats.input_rows);
+    set_root_counter(stage_profile, "FilteredRows", TUnit::UNIT, 2, stats.filtered_rows);
+    if (stats.has_time) {
+        set_root_counter(stage_profile, "Time", TUnit::TIME_NS, 2, stats.time_ns);
+    }
+}
+
+std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot,
+                                      bool is_key_range_source) {
+    std::vector<std::string> stages;
+    for (const auto stage : ordered_stages()) {
+        if (snapshot.stage_snapshots[static_cast<size_t>(stage)].participated) {
+            stages.emplace_back(stage_profile_name(stage));
+        }
+    }
+    if (stages.empty()) {
+        return is_key_range_source ? "KeyRangeInfo" : "NotApplied";
+    }
+
+    std::stringstream ss;
+    for (size_t i = 0; i < stages.size(); ++i) {
+        if (i != 0) {
+            ss << " -> ";
+        }
+        ss << stages[i];
+    }
+    return ss.str();
+}
+
+std::string target_string(const ScanFilterDesc& desc) {
+    std::stringstream ss;
+    if (desc.slot_id >= 0) {
+        ss << "slot=" << desc.slot_id;
+    }
+    if (desc.column_id >= 0) {
+        if (ss.tellp() > 0) {
+            ss << ", ";
+        }
+        ss << "column_id=" << desc.column_id;
+    }
+    if (!desc.column_name.empty()) {
+        if (ss.tellp() > 0) {
+            ss << ", ";
+        }
+        ss << "column=" << desc.column_name;
+    }
+    return ss.str();
+}
+
+std::string source_string(const ScanFilterDesc& desc) {
+    if (desc.kind == ScanFilterKind::RUNTIME_FILTER) {
+        return fmt::format("{} rf_id={}", scan_filter_source_name(desc.kind),
+                           desc.runtime_filter_id);
+    }
+    if (desc.kind == ScanFilterKind::TOPN_FILTER) {
+        return fmt::format("{} source_node_id={}", scan_filter_source_name(desc.kind),
+                           desc.topn_filter_source_node_id);
+    }
+    return scan_filter_source_name(desc.kind);
+}
+
+void materialize_filter_counters(RuntimeProfile* filter_profile,
+                                 const MaterializedFilterSnapshot& snapshot, int profile_level,
+                                 bool is_key_range_source,
+                                 const ScanRuntimeFilterProfileStats* runtime_filter_stats) {
+    filter_profile->add_info_string("Source", source_string(snapshot.desc));
+    add_info_string_if_not_empty(filter_profile, "Target", target_string(snapshot.desc));
+    filter_profile->add_info_string("Stages",
+                                    scan_filter_stages_string(snapshot, is_key_range_source));
+    add_info_string_if_not_empty(filter_profile, "Expr", snapshot.desc.compact_info);
+    if (profile_level >= 2 && runtime_filter_stats != nullptr &&
+        !runtime_filter_stats->debug_string.empty()) {
+        filter_profile->add_info_string("RuntimeFilterInfo", runtime_filter_stats->debug_string);
+    }
+    if (profile_level >= 2 && !snapshot.desc.debug_string.empty() &&
+        snapshot.desc.debug_string != snapshot.desc.compact_info) {
+        filter_profile->add_info_string("DebugString", snapshot.desc.debug_string);
+    }
+    if (profile_level >= 2 && !snapshot.desc.source_filter_ids.empty()) {
+        filter_profile->add_info_string("SourceFilterIds",
+                                        join_ids(snapshot.desc.source_filter_ids));
+    }
+
+    if (snapshot.total.participated) {
+        set_root_counter(filter_profile, "InputRows", TUnit::UNIT, 1, snapshot.total.input_rows);
+        set_root_counter(filter_profile, "FilteredRows", TUnit::UNIT, 1,
+                         snapshot.total.filtered_rows);
+        if (snapshot.total.has_time) {
+            set_root_counter(filter_profile, "FilterTime", TUnit::TIME_NS, 1,
+                             snapshot.total.time_ns);
+        }
+    }
+    if (runtime_filter_stats != nullptr) {
+        if (!snapshot.total.participated && runtime_filter_stats->input_rows > 0) {
+            DCHECK_GE(runtime_filter_stats->input_rows, runtime_filter_stats->filtered_rows);
+            set_root_counter(filter_profile, "InputRows", TUnit::UNIT, 1,
+                             runtime_filter_stats->input_rows);
+            set_root_counter(filter_profile, "FilteredRows", TUnit::UNIT, 1,
+                             runtime_filter_stats->filtered_rows);
+        }
+        set_root_counter(filter_profile, "WaitTime", TUnit::TIME_NS, 1,
+                         runtime_filter_stats->wait_time_ns);
+        set_root_counter(filter_profile, "AlwaysTrueFilterRows", TUnit::UNIT, 1,
+                         runtime_filter_stats->always_true_filter_rows);
+    }
+
+    if (profile_level < 2) {
+        return;
+    }
+    for (const auto stage : ordered_stages()) {
+        const auto& stage_stats = snapshot.stage_snapshots[static_cast<size_t>(stage)];
+        if (!stage_stats.participated) {
+            continue;
+        }
+        materialize_filter_stage(filter_profile, stage, stage_stats);
+    }
+}
+
+void materialize_runtime_filter_partition_pruning(
+        RuntimeProfile* scan_filter_profile, const ScanRuntimeFilterPartitionPruningStats& stats) {
+    auto* pruning_profile =
+            get_or_create_child(scan_filter_profile, RUNTIME_FILTER_PARTITION_PRUNING);
+    if (stats.total_partitions > 0) {
+        set_root_counter(pruning_profile, "TotalPartitions", TUnit::UNIT, 1,
+                         stats.total_partitions);
+    }
+    if (stats.pruned_partitions > 0) {
+        set_root_counter(pruning_profile, "PrunedPartitions", TUnit::UNIT, 1,
+                         stats.pruned_partitions);
+    }
+    if (stats.pruned_tablets > 0) {
+        set_root_counter(pruning_profile, "PrunedTablets", TUnit::UNIT, 1, stats.pruned_tablets);
+    }
+}
+
+int first_profile_order(const MaterializedFilterSnapshot& snapshot, bool is_key_range_source) {
+    if (snapshot.total.participated) {
+        return snapshot.total.first_stage;
+    }
+    if (is_key_range_source) {
+        return 1;
+    }
+    return 99;
+}
+
+int64_t first_profile_input_rows(const MaterializedFilterSnapshot& snapshot, int order) {
+    if (snapshot.total.participated && snapshot.total.first_stage == order) {
+        return snapshot.total.input_rows;
+    }
+    return snapshot.total.input_rows;
+}
+
+} // namespace
+
+const char* scan_filter_kind_name(ScanFilterKind kind) {
+    switch (kind) {
+    case ScanFilterKind::NORMAL:
+        return "NORMAL";
+    case ScanFilterKind::RUNTIME_FILTER:
+        return "RUNTIME_FILTER";
+    case ScanFilterKind::TOPN_FILTER:
+        return "TOPN_FILTER";
+    case ScanFilterKind::KEY_RANGE:
+        return "KEY_RANGE";
+    case ScanFilterKind::UNKNOWN:
+        return "UNKNOWN";
+    }
+    return "UNKNOWN";
+}
+
+const char* scan_filter_stage_name(ScanFilterStage stage) {
+    switch (stage) {
+    case ScanFilterStage::KEY_RANGE:
+        return "KeyRange";
+    case ScanFilterStage::INDEX_INVERTED:
+        return "IndexInverted";
+    case ScanFilterStage::INDEX_BLOOM_FILTER:
+        return "IndexBloomFilter";
+    case ScanFilterStage::INDEX_ZONE_MAP:
+        return "IndexZoneMap";
+    case ScanFilterStage::INDEX_DICT:
+        return "IndexDict";
+    case ScanFilterStage::INDEX_ANN:
+        return "IndexAnn";
+    case ScanFilterStage::EXEC_VECTOR:
+        return "ExecuteVector";
+    case ScanFilterStage::EXEC_SHORT_CIRCUIT:
+        return "ExecuteShortCircuit";
+    case ScanFilterStage::EXEC_COMMON_EXPR:
+        return "ExecuteCommonExpr";
+    case ScanFilterStage::EXEC_RESIDUAL:
+        return "ExecuteResidual";
+    case ScanFilterStage::NUM_STAGES:
+        break;
+    }
+    return "Unknown";
+}
+
+void ScanFilterStats::record(ScanFilterStage stage, int64_t input_rows, int64_t output_rows,
+                             std::optional<int64_t> time_ns) {
+    DCHECK_GE(input_rows, output_rows);
+    const auto stage_index = static_cast<size_t>(stage);
+    DCHECK_LT(stage_index, _stage_stats.size());
+    auto& stats = _stage_stats[stage_index];
+    stats.participated.store(true, std::memory_order_relaxed);
+    stats.calls.fetch_add(1, std::memory_order_relaxed);
+    stats.input_rows.fetch_add(input_rows, std::memory_order_relaxed);
+    stats.output_rows.fetch_add(output_rows, std::memory_order_relaxed);
+    stats.filtered_rows.fetch_add(input_rows - output_rows, std::memory_order_relaxed);
+    if (time_ns.has_value()) {
+        stats.has_time.store(true, std::memory_order_relaxed);
+        stats.time_ns.fetch_add(*time_ns, std::memory_order_relaxed);
+    }
+}
+
+ScanFilterStageStatsSnapshot ScanFilterStats::snapshot(ScanFilterStage stage) const {
+    const auto stage_index = static_cast<size_t>(stage);
+    DCHECK_LT(stage_index, _stage_stats.size());
+    const auto& stats = _stage_stats[stage_index];
+    return {.participated = stats.participated.load(std::memory_order_relaxed),
+            .has_time = stats.has_time.load(std::memory_order_relaxed),
+            .calls = stats.calls.load(std::memory_order_relaxed),
+            .input_rows = stats.input_rows.load(std::memory_order_relaxed),
+            .output_rows = stats.output_rows.load(std::memory_order_relaxed),
+            .filtered_rows = stats.filtered_rows.load(std::memory_order_relaxed),
+            .time_ns = stats.time_ns.load(std::memory_order_relaxed)};
+}
+
+ScanFilterHandle ScanFilterProfile::register_filter(ScanFilterDesc desc) {
+    auto stats = std::make_shared<ScanFilterStats>();
+    std::lock_guard lock(_lock);
+    const auto filter_id = static_cast<int32_t>(_descs.size());
+    desc.filter_id = filter_id;
+    _descs.emplace_back(std::move(desc));
+    _stats.emplace_back(stats);
+    return {.filter_id = filter_id, .stats = std::move(stats)};
+}
+
+void ScanFilterProfile::add_source_filter(int32_t filter_id, int32_t source_filter_id) {
+    std::lock_guard lock(_lock);
+    DCHECK_GE(filter_id, 0);
+    DCHECK_LT(filter_id, _descs.size());
+    auto& source_ids = _descs[filter_id].source_filter_ids;
+    if (std::find(source_ids.begin(), source_ids.end(), source_filter_id) == source_ids.end()) {
+        source_ids.push_back(source_filter_id);
+    }
+}
+
+std::vector<ScanFilterProfile::FilterSnapshot> ScanFilterProfile::_snapshots() const {
+    std::lock_guard lock(_lock);
+    std::vector<FilterSnapshot> snapshots;
+    snapshots.reserve(_descs.size());
+    for (size_t i = 0; i < _descs.size(); ++i) {
+        snapshots.push_back({.desc = _descs[i], .stats = _stats[i]});
+    }
+    return snapshots;
+}
+
+std::vector<ScanRuntimeFilterProfileStats> ScanFilterProfile::_runtime_filter_stats_snapshots()
+        const {
+    std::lock_guard lock(_lock);
+    return _runtime_filter_stats;
+}
+
+int64_t ScanFilterProfile::_runtime_filter_acquire_time_snapshot() const {
+    std::lock_guard lock(_lock);
+    return _runtime_filter_acquire_time_ns;
+}
+
+ScanRuntimeFilterPartitionPruningStats
+ScanFilterProfile::_runtime_filter_partition_pruning_stats_snapshot() const {
+    std::lock_guard lock(_lock);
+    return _runtime_filter_partition_pruning_stats;
+}
+
+void ScanFilterProfile::set_runtime_filter_acquire_time(int64_t acquire_time_ns) {
+    std::lock_guard lock(_lock);
+    _runtime_filter_acquire_time_ns = acquire_time_ns;
+}
+
+void ScanFilterProfile::set_runtime_filter_profile_stats(ScanRuntimeFilterProfileStats stats) {
+    std::lock_guard lock(_lock);
+    DCHECK_GE(stats.runtime_filter_id, 0);
+    const auto has_scan_filter_desc = std::ranges::any_of(_descs, [&](const auto& desc) {
+        return desc.kind == ScanFilterKind::RUNTIME_FILTER &&
+               desc.runtime_filter_id == stats.runtime_filter_id;
+    });
+    if (!has_scan_filter_desc) {
+        ScanFilterDesc desc;
+        desc.filter_id = static_cast<int32_t>(_descs.size());
+        desc.kind = ScanFilterKind::RUNTIME_FILTER;
+        desc.runtime_filter_id = stats.runtime_filter_id;
+        _descs.emplace_back(std::move(desc));
+        _stats.emplace_back(std::make_shared<ScanFilterStats>());
+    }
+    for (auto& item : _runtime_filter_stats) {
+        if (item.runtime_filter_id == stats.runtime_filter_id) {
+            item = std::move(stats);
+            return;
+        }
+    }
+    _runtime_filter_stats.emplace_back(std::move(stats));
+}
+
+void ScanFilterProfile::set_runtime_filter_partition_pruning_stats(
+        ScanRuntimeFilterPartitionPruningStats stats) {
+    std::lock_guard lock(_lock);
+    _runtime_filter_partition_pruning_stats = stats;
+}
+
+void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) const {
+    if (profile == nullptr || profile_level <= 0) {
+        return;
+    }
+
+    const auto snapshots = _snapshots();
+    const auto runtime_filter_stats = _runtime_filter_stats_snapshots();
+    const auto runtime_filter_acquire_time_ns = _runtime_filter_acquire_time_snapshot();
+    const auto runtime_filter_partition_pruning_stats =
+            _runtime_filter_partition_pruning_stats_snapshot();
+    std::vector<MaterializedFilterSnapshot> scan_filter_snapshots;
+    std::optional<MaterializedFilterSnapshot> key_range_snapshot;
+    scan_filter_snapshots.reserve(snapshots.size());
+
+    for (const auto& snapshot : snapshots) {
+        MaterializedFilterSnapshot materialized;
+        materialized.desc = snapshot.desc;
+        for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
+            const auto stage = static_cast<ScanFilterStage>(i);
+            materialized.stage_snapshots[i] = snapshot.stats->snapshot(stage);
+            update_summary(&materialized.total, stage, materialized.stage_snapshots[i]);
+            if (is_index_stage(stage)) {
+                update_summary(&materialized.index, stage, materialized.stage_snapshots[i]);
+            } else if (is_exec_stage(stage)) {
+                update_summary(&materialized.exec, stage, materialized.stage_snapshots[i]);
+            }
+        }
+
+        if (materialized.desc.kind == ScanFilterKind::KEY_RANGE) {
+            DCHECK(!key_range_snapshot.has_value());
+            key_range_snapshot = std::move(materialized);
+        } else {
+            scan_filter_snapshots.emplace_back(std::move(materialized));
+        }
+    }
+
+    if (key_range_snapshot.has_value()) {
+        auto* key_range_profile = get_or_create_child(profile, KEY_RANGE_INFO);
+        const auto& snapshot = *key_range_snapshot;
+        if (!snapshot.desc.source_filter_ids.empty()) {
+            key_range_profile->add_info_string("SourceFilterIds",
+                                               join_ids(snapshot.desc.source_filter_ids));
+        }
+        if (profile_level >= 2) {
+            add_info_string_if_not_empty(key_range_profile, "ScanKeys", snapshot.desc.compact_info);
+        }
+
+        set_root_counter(key_range_profile, "RangeNum", TUnit::UNIT, 1, snapshot.desc.range_count);
+        set_root_counter(key_range_profile, "InputRows", TUnit::UNIT, 1, snapshot.total.input_rows);
+        set_root_counter(key_range_profile, "FilteredRows", TUnit::UNIT, 1,
+                         snapshot.total.filtered_rows);
+    }
+
+    const bool has_partition_pruning_stats =
+            has_runtime_filter_partition_pruning_stats(runtime_filter_partition_pruning_stats);
+    if (scan_filter_snapshots.empty() && !has_partition_pruning_stats &&
+        runtime_filter_acquire_time_ns <= 0) {
+        return;
+    }
+
+    std::vector<int32_t> key_range_source_filter_ids;
+    if (key_range_snapshot.has_value()) {
+        key_range_source_filter_ids = key_range_snapshot->desc.source_filter_ids;
+    }
+
+    std::ranges::sort(scan_filter_snapshots, [&](const auto& left, const auto& right) {
+        const bool left_key_range_source =
+                contains_id(key_range_source_filter_ids, left.desc.filter_id);
+        const bool right_key_range_source =
+                contains_id(key_range_source_filter_ids, right.desc.filter_id);
+        const int left_order = first_profile_order(left, left_key_range_source);
+        const int right_order = first_profile_order(right, right_key_range_source);
+        if (left_order != right_order) {
+            return left_order < right_order;
+        }
+        const int64_t left_input_rows = first_profile_input_rows(left, left_order);
+        const int64_t right_input_rows = first_profile_input_rows(right, right_order);
+        if (left_input_rows != right_input_rows) {
+            return left_input_rows > right_input_rows;
+        }
+        return left.desc.filter_id < right.desc.filter_id;
+    });
+
+    auto* scan_filter_profile = get_or_create_child(profile, SCAN_FILTER_INFO);
+    if (runtime_filter_acquire_time_ns > 0) {
+        set_root_counter(scan_filter_profile, "RuntimeFilterAcquireTime", TUnit::TIME_NS, 2,
+                         runtime_filter_acquire_time_ns);
+    }
+    if (has_partition_pruning_stats) {
+        materialize_runtime_filter_partition_pruning(scan_filter_profile,
+                                                     runtime_filter_partition_pruning_stats);
+    }
+
+    if (scan_filter_snapshots.empty()) {
+        return;
+    }
+
+    for (const auto& snapshot : scan_filter_snapshots) {
+        auto* filter_profile = get_or_create_child(
+                scan_filter_profile, fmt::format("ScanFilter {}", snapshot.desc.filter_id));
+        const auto* runtime_filter_stat =
+                snapshot.desc.kind == ScanFilterKind::RUNTIME_FILTER
+                        ? find_runtime_filter_stats(runtime_filter_stats,
+                                                    snapshot.desc.runtime_filter_id)
+                        : nullptr;
+        materialize_filter_counters(
+                filter_profile, snapshot, profile_level,
+                contains_id(key_range_source_filter_ids, snapshot.desc.filter_id),
+                runtime_filter_stat);
+    }
+}
+
+} // namespace doris

--- a/be/src/runtime/scan_filter_profile.cpp
+++ b/be/src/runtime/scan_filter_profile.cpp
@@ -409,9 +409,8 @@ void ScanFilterProfile::set_runtime_filter_partition_pruning_stats(
 }
 
 void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) const {
-    if (profile == nullptr || profile_level <= 0) {
-        return;
-    }
+    DCHECK(profile != nullptr);
+    DCHECK_GT(profile_level, 0);
 
     const auto snapshots = _snapshots();
     const auto key_range_snapshot = _key_range_snapshot();

--- a/be/src/runtime/scan_filter_profile.cpp
+++ b/be/src/runtime/scan_filter_profile.cpp
@@ -25,6 +25,7 @@
 #include <unordered_set>
 
 #include "runtime/runtime_profile.h"
+#include "util/pretty_printer.h"
 
 namespace doris {
 
@@ -33,18 +34,6 @@ namespace {
 constexpr const char* SCAN_FILTER_INFO = "ScanFilterInfo";
 constexpr const char* KEY_RANGE_INFO = "KeyRangeInfo";
 constexpr const char* RUNTIME_FILTER_PARTITION_PRUNING = "RuntimeFilterPartitionPruning";
-constexpr int NOT_APPLIED_PROFILE_ORDER = static_cast<int>(ScanFilterStage::NUM_STAGES);
-
-bool is_index_stage(ScanFilterStage stage) {
-    return stage == ScanFilterStage::INDEX_INVERTED || stage == ScanFilterStage::INDEX_ANN ||
-           stage == ScanFilterStage::INDEX_DICT || stage == ScanFilterStage::INDEX_BLOOM_FILTER ||
-           stage == ScanFilterStage::INDEX_ZONE_MAP;
-}
-
-bool is_exec_stage(ScanFilterStage stage) {
-    return stage == ScanFilterStage::EXEC_VECTOR || stage == ScanFilterStage::EXEC_SHORT_CIRCUIT ||
-           stage == ScanFilterStage::EXEC_COMMON_EXPR || stage == ScanFilterStage::EXEC_RESIDUAL;
-}
 
 void set_counter(RuntimeProfile* profile, const std::string& name, TUnit::type type,
                  const std::string& parent, int64_t level, int64_t value) {
@@ -88,45 +77,15 @@ const char* scan_filter_source_name(ScanFilterKind kind) {
 
 struct SummaryStats {
     bool participated = false;
-    bool has_filtering_stage = false;
-    bool has_time = false;
-    int first_stage = NOT_APPLIED_PROFILE_ORDER;
-    int last_stage = -1;
-    int64_t input_rows = 0;
-    int64_t output_rows = 0;
     int64_t filtered_rows = 0;
-    int64_t time_ns = 0;
 };
 
-void update_summary(SummaryStats* summary, ScanFilterStage stage,
-                    const ScanFilterStageStatsSnapshot& stats) {
+void update_summary(SummaryStats* summary, const ScanFilterStageStatsSnapshot& stats) {
     if (!stats.participated()) {
         return;
     }
-    const auto order = static_cast<int>(stage);
-    if (stats.filtered_rows > 0) {
-        if (!summary->has_filtering_stage || order < summary->first_stage) {
-            summary->first_stage = order;
-            summary->input_rows = stats.input_rows;
-        }
-        if (!summary->has_filtering_stage || order > summary->last_stage) {
-            summary->last_stage = order;
-            summary->output_rows = stats.output_rows;
-        }
-        summary->has_filtering_stage = true;
-    } else if (!summary->has_filtering_stage &&
-               (!summary->participated || order > summary->last_stage)) {
-        summary->first_stage = order;
-        summary->last_stage = order;
-        summary->input_rows = stats.input_rows;
-        summary->output_rows = stats.output_rows;
-    }
     summary->participated = true;
     summary->filtered_rows += stats.filtered_rows;
-    if (stats.has_time) {
-        summary->has_time = true;
-        summary->time_ns += stats.time_ns;
-    }
 }
 
 struct MaterializedFilterSnapshot {
@@ -135,26 +94,21 @@ struct MaterializedFilterSnapshot {
     std::array<ScanFilterStageStatsSnapshot, static_cast<size_t>(ScanFilterStage::NUM_STAGES)>
             stage_snapshots;
     SummaryStats total;
-    SummaryStats index;
-    SummaryStats exec;
 };
 
-void materialize_filter_stage(RuntimeProfile* filter_profile, ScanFilterStage stage,
-                              const ScanFilterStageStatsSnapshot& stats) {
-    auto* stage_profile = get_or_create_child(filter_profile, scan_filter_stage_name(stage));
-    set_root_counter(stage_profile, "InputRows", TUnit::UNIT, 2, stats.input_rows);
-    set_root_counter(stage_profile, "FilteredRows", TUnit::UNIT, 2, stats.filtered_rows);
-    if (stats.has_time) {
-        set_root_counter(stage_profile, "Time", TUnit::TIME_NS, 2, stats.time_ns);
-    }
-}
-
 std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot,
-                                      bool is_key_range_source) {
+                                      bool is_key_range_source, int profile_level) {
     std::vector<std::string> stages;
     for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
         const auto stage = static_cast<ScanFilterStage>(i);
-        if (snapshot.stage_snapshots[static_cast<size_t>(stage)].participated()) {
+        const auto& stage_stats = snapshot.stage_snapshots[static_cast<size_t>(stage)];
+        if (stage_stats.participated()) {
+            if (profile_level >= 2) {
+                stages.emplace_back(
+                        fmt::format("{}({})", scan_filter_stage_name(stage),
+                                    PrettyPrinter::print(stage_stats.filtered_rows, TUnit::UNIT)));
+                continue;
+            }
             stages.emplace_back(scan_filter_stage_name(stage));
         }
     }
@@ -162,17 +116,6 @@ std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot
         return is_key_range_source ? "KeyRangeInfo" : "NotApplied";
     }
     return fmt::format("{}", fmt::join(stages, " -> "));
-}
-
-std::string target_string(const ScanFilterDesc& desc) {
-    std::vector<std::string> parts;
-    if (desc.column_id >= 0) {
-        parts.emplace_back(fmt::format("column_id={}", desc.column_id));
-    }
-    if (!desc.column_name.empty()) {
-        parts.emplace_back(fmt::format("column={}", desc.column_name));
-    }
-    return fmt::format("{}", fmt::join(parts, ", "));
 }
 
 std::string source_string(const ScanFilterDesc& desc) {
@@ -193,29 +136,23 @@ void materialize_filter_counters(RuntimeProfile* filter_profile,
     const auto* runtime_filter_stats =
             snapshot.runtime_filter_stats.has_value() ? &*snapshot.runtime_filter_stats : nullptr;
     filter_profile->add_info_string("Source", source_string(snapshot.desc));
-    add_info_string_if_not_empty(filter_profile, "Target", target_string(snapshot.desc));
-    filter_profile->add_info_string("Stages",
-                                    scan_filter_stages_string(snapshot, is_key_range_source));
-    add_info_string_if_not_empty(filter_profile, "Expr", snapshot.desc.expr_debug_string);
+    filter_profile->add_info_string(
+            "Stages", scan_filter_stages_string(snapshot, is_key_range_source, profile_level));
+    if (profile_level >= 3) {
+        add_info_string_if_not_empty(filter_profile, "Expr", snapshot.desc.expr_debug_string);
+    }
     if (profile_level >= 2 && runtime_filter_stats != nullptr &&
         !runtime_filter_stats->debug_string.empty()) {
         filter_profile->add_info_string("RuntimeFilterInfo", runtime_filter_stats->debug_string);
     }
 
-    if (snapshot.total.participated) {
-        set_root_counter(filter_profile, "InputRows", TUnit::UNIT, 1, snapshot.total.input_rows);
+    if (snapshot.total.filtered_rows > 0) {
         set_root_counter(filter_profile, "FilteredRows", TUnit::UNIT, 1,
                          snapshot.total.filtered_rows);
-        if (snapshot.total.has_time) {
-            set_root_counter(filter_profile, "FilterTime", TUnit::TIME_NS, 1,
-                             snapshot.total.time_ns);
-        }
     }
     if (runtime_filter_stats != nullptr) {
-        if (!snapshot.total.participated && runtime_filter_stats->input_rows > 0) {
+        if (!snapshot.total.participated && runtime_filter_stats->filtered_rows > 0) {
             DCHECK_GE(runtime_filter_stats->input_rows, runtime_filter_stats->filtered_rows);
-            set_root_counter(filter_profile, "InputRows", TUnit::UNIT, 1,
-                             runtime_filter_stats->input_rows);
             set_root_counter(filter_profile, "FilteredRows", TUnit::UNIT, 1,
                              runtime_filter_stats->filtered_rows);
         }
@@ -223,18 +160,6 @@ void materialize_filter_counters(RuntimeProfile* filter_profile,
                          runtime_filter_stats->wait_time_ns);
         set_root_counter(filter_profile, "AlwaysTrueFilterRows", TUnit::UNIT, 1,
                          runtime_filter_stats->always_true_filter_rows);
-    }
-
-    if (profile_level < 2) {
-        return;
-    }
-    for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
-        const auto stage = static_cast<ScanFilterStage>(i);
-        const auto& stage_stats = snapshot.stage_snapshots[static_cast<size_t>(stage)];
-        if (!stage_stats.participated()) {
-            continue;
-        }
-        materialize_filter_stage(filter_profile, stage, stage_stats);
     }
 }
 
@@ -273,6 +198,8 @@ const char* scan_filter_kind_name(ScanFilterKind kind) {
 
 const char* scan_filter_stage_name(ScanFilterStage stage) {
     switch (stage) {
+    case ScanFilterStage::INDEX_ZONE_MAP_SEGMENT:
+        return "IndexZoneMapSegment";
     case ScanFilterStage::KEY_RANGE:
         return "KeyRange";
     case ScanFilterStage::INDEX_INVERTED:
@@ -283,8 +210,8 @@ const char* scan_filter_stage_name(ScanFilterStage stage) {
         return "IndexDict";
     case ScanFilterStage::INDEX_BLOOM_FILTER:
         return "IndexBloomFilter";
-    case ScanFilterStage::INDEX_ZONE_MAP:
-        return "IndexZoneMap";
+    case ScanFilterStage::INDEX_ZONE_MAP_PAGE:
+        return "IndexZoneMapPage";
     case ScanFilterStage::EXEC_VECTOR:
         return "ExecuteVector";
     case ScanFilterStage::EXEC_SHORT_CIRCUIT:
@@ -427,12 +354,7 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
         for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
             const auto stage = static_cast<ScanFilterStage>(i);
             materialized.stage_snapshots[i] = snapshot.stats->snapshot(stage);
-            update_summary(&materialized.total, stage, materialized.stage_snapshots[i]);
-            if (is_index_stage(stage)) {
-                update_summary(&materialized.index, stage, materialized.stage_snapshots[i]);
-            } else if (is_exec_stage(stage)) {
-                update_summary(&materialized.exec, stage, materialized.stage_snapshots[i]);
-            }
+            update_summary(&materialized.total, materialized.stage_snapshots[i]);
         }
         scan_filter_snapshots.emplace_back(std::move(materialized));
     }

--- a/be/src/runtime/scan_filter_profile.cpp
+++ b/be/src/runtime/scan_filter_profile.cpp
@@ -122,8 +122,6 @@ const char* scan_filter_source_name(ScanFilterKind kind) {
         return "RuntimeFilter";
     case ScanFilterKind::TOPN_FILTER:
         return "TopNFilter";
-    case ScanFilterKind::KEY_RANGE:
-        return "KeyRange";
     case ScanFilterKind::UNKNOWN:
         return "Unknown";
     }
@@ -132,16 +130,6 @@ const char* scan_filter_source_name(ScanFilterKind kind) {
 
 bool contains_id(const std::vector<int32_t>& ids, int32_t id) {
     return std::find(ids.begin(), ids.end(), id) != ids.end();
-}
-
-const ScanRuntimeFilterProfileStats* find_runtime_filter_stats(
-        const std::vector<ScanRuntimeFilterProfileStats>& stats, int32_t runtime_filter_id) {
-    for (const auto& item : stats) {
-        if (item.runtime_filter_id == runtime_filter_id) {
-            return &item;
-        }
-    }
-    return nullptr;
 }
 
 bool has_runtime_filter_partition_pruning_stats(
@@ -172,7 +160,7 @@ struct SummaryStats {
 
 void update_summary(SummaryStats* summary, ScanFilterStage stage,
                     const ScanFilterStageStatsSnapshot& stats) {
-    if (!stats.participated) {
+    if (!stats.participated()) {
         return;
     }
     const auto order = stage_display_order(stage);
@@ -203,6 +191,7 @@ void update_summary(SummaryStats* summary, ScanFilterStage stage,
 
 struct MaterializedFilterSnapshot {
     ScanFilterDesc desc;
+    std::optional<ScanRuntimeFilterProfileStats> runtime_filter_stats;
     std::array<ScanFilterStageStatsSnapshot, static_cast<size_t>(ScanFilterStage::NUM_STAGES)>
             stage_snapshots;
     SummaryStats total;
@@ -224,7 +213,7 @@ std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot
                                       bool is_key_range_source) {
     std::vector<std::string> stages;
     for (const auto stage : ordered_stages()) {
-        if (snapshot.stage_snapshots[static_cast<size_t>(stage)].participated) {
+        if (snapshot.stage_snapshots[static_cast<size_t>(stage)].participated()) {
             stages.emplace_back(stage_profile_name(stage));
         }
     }
@@ -244,13 +233,7 @@ std::string scan_filter_stages_string(const MaterializedFilterSnapshot& snapshot
 
 std::string target_string(const ScanFilterDesc& desc) {
     std::stringstream ss;
-    if (desc.slot_id >= 0) {
-        ss << "slot=" << desc.slot_id;
-    }
     if (desc.column_id >= 0) {
-        if (ss.tellp() > 0) {
-            ss << ", ";
-        }
         ss << "column_id=" << desc.column_id;
     }
     if (!desc.column_name.empty()) {
@@ -276,24 +259,17 @@ std::string source_string(const ScanFilterDesc& desc) {
 
 void materialize_filter_counters(RuntimeProfile* filter_profile,
                                  const MaterializedFilterSnapshot& snapshot, int profile_level,
-                                 bool is_key_range_source,
-                                 const ScanRuntimeFilterProfileStats* runtime_filter_stats) {
+                                 bool is_key_range_source) {
+    const auto* runtime_filter_stats =
+            snapshot.runtime_filter_stats.has_value() ? &*snapshot.runtime_filter_stats : nullptr;
     filter_profile->add_info_string("Source", source_string(snapshot.desc));
     add_info_string_if_not_empty(filter_profile, "Target", target_string(snapshot.desc));
     filter_profile->add_info_string("Stages",
                                     scan_filter_stages_string(snapshot, is_key_range_source));
-    add_info_string_if_not_empty(filter_profile, "Expr", snapshot.desc.compact_info);
+    add_info_string_if_not_empty(filter_profile, "Expr", snapshot.desc.expr_debug_string);
     if (profile_level >= 2 && runtime_filter_stats != nullptr &&
         !runtime_filter_stats->debug_string.empty()) {
         filter_profile->add_info_string("RuntimeFilterInfo", runtime_filter_stats->debug_string);
-    }
-    if (profile_level >= 2 && !snapshot.desc.debug_string.empty() &&
-        snapshot.desc.debug_string != snapshot.desc.compact_info) {
-        filter_profile->add_info_string("DebugString", snapshot.desc.debug_string);
-    }
-    if (profile_level >= 2 && !snapshot.desc.source_filter_ids.empty()) {
-        filter_profile->add_info_string("SourceFilterIds",
-                                        join_ids(snapshot.desc.source_filter_ids));
     }
 
     if (snapshot.total.participated) {
@@ -324,7 +300,7 @@ void materialize_filter_counters(RuntimeProfile* filter_profile,
     }
     for (const auto stage : ordered_stages()) {
         const auto& stage_stats = snapshot.stage_snapshots[static_cast<size_t>(stage)];
-        if (!stage_stats.participated) {
+        if (!stage_stats.participated()) {
             continue;
         }
         materialize_filter_stage(filter_profile, stage, stage_stats);
@@ -375,8 +351,6 @@ const char* scan_filter_kind_name(ScanFilterKind kind) {
         return "RUNTIME_FILTER";
     case ScanFilterKind::TOPN_FILTER:
         return "TOPN_FILTER";
-    case ScanFilterKind::KEY_RANGE:
-        return "KEY_RANGE";
     case ScanFilterKind::UNKNOWN:
         return "UNKNOWN";
     }
@@ -417,7 +391,6 @@ void ScanFilterStats::record(ScanFilterStage stage, int64_t input_rows, int64_t 
     const auto stage_index = static_cast<size_t>(stage);
     DCHECK_LT(stage_index, _stage_stats.size());
     auto& stats = _stage_stats[stage_index];
-    stats.participated.store(true, std::memory_order_relaxed);
     stats.calls.fetch_add(1, std::memory_order_relaxed);
     stats.input_rows.fetch_add(input_rows, std::memory_order_relaxed);
     stats.output_rows.fetch_add(output_rows, std::memory_order_relaxed);
@@ -432,8 +405,7 @@ ScanFilterStageStatsSnapshot ScanFilterStats::snapshot(ScanFilterStage stage) co
     const auto stage_index = static_cast<size_t>(stage);
     DCHECK_LT(stage_index, _stage_stats.size());
     const auto& stats = _stage_stats[stage_index];
-    return {.participated = stats.participated.load(std::memory_order_relaxed),
-            .has_time = stats.has_time.load(std::memory_order_relaxed),
+    return {.has_time = stats.has_time.load(std::memory_order_relaxed),
             .calls = stats.calls.load(std::memory_order_relaxed),
             .input_rows = stats.input_rows.load(std::memory_order_relaxed),
             .output_rows = stats.output_rows.load(std::memory_order_relaxed),
@@ -444,37 +416,40 @@ ScanFilterStageStatsSnapshot ScanFilterStats::snapshot(ScanFilterStage stage) co
 ScanFilterHandle ScanFilterProfile::register_filter(ScanFilterDesc desc) {
     auto stats = std::make_shared<ScanFilterStats>();
     std::lock_guard lock(_lock);
-    const auto filter_id = static_cast<int32_t>(_descs.size());
+    const auto filter_id = static_cast<int32_t>(_filters.size());
     desc.filter_id = filter_id;
-    _descs.emplace_back(std::move(desc));
-    _stats.emplace_back(stats);
+    _filters.emplace_back(FilterEntry {
+            .desc = std::move(desc),
+            .stats = stats,
+            .runtime_filter_stats = std::nullopt,
+    });
     return {.filter_id = filter_id, .stats = std::move(stats)};
 }
 
-void ScanFilterProfile::add_source_filter(int32_t filter_id, int32_t source_filter_id) {
+ScanFilterHandle ScanFilterProfile::register_key_range(ScanKeyRangeInfo key_range) {
+    auto stats = std::make_shared<ScanFilterStats>();
     std::lock_guard lock(_lock);
-    DCHECK_GE(filter_id, 0);
-    DCHECK_LT(filter_id, _descs.size());
-    auto& source_ids = _descs[filter_id].source_filter_ids;
-    if (std::find(source_ids.begin(), source_ids.end(), source_filter_id) == source_ids.end()) {
-        source_ids.push_back(source_filter_id);
-    }
+    DCHECK(!_key_range.has_value());
+    key_range.handle = {.stats = stats};
+    _key_range = std::move(key_range);
+    return _key_range->handle;
 }
 
 std::vector<ScanFilterProfile::FilterSnapshot> ScanFilterProfile::_snapshots() const {
     std::lock_guard lock(_lock);
     std::vector<FilterSnapshot> snapshots;
-    snapshots.reserve(_descs.size());
-    for (size_t i = 0; i < _descs.size(); ++i) {
-        snapshots.push_back({.desc = _descs[i], .stats = _stats[i]});
+    snapshots.reserve(_filters.size());
+    for (const auto& filter : _filters) {
+        snapshots.push_back({.desc = filter.desc,
+                             .stats = filter.stats,
+                             .runtime_filter_stats = filter.runtime_filter_stats});
     }
     return snapshots;
 }
 
-std::vector<ScanRuntimeFilterProfileStats> ScanFilterProfile::_runtime_filter_stats_snapshots()
-        const {
+std::optional<ScanKeyRangeInfo> ScanFilterProfile::_key_range_snapshot() const {
     std::lock_guard lock(_lock);
-    return _runtime_filter_stats;
+    return _key_range;
 }
 
 int64_t ScanFilterProfile::_runtime_filter_acquire_time_snapshot() const {
@@ -496,25 +471,21 @@ void ScanFilterProfile::set_runtime_filter_acquire_time(int64_t acquire_time_ns)
 void ScanFilterProfile::set_runtime_filter_profile_stats(ScanRuntimeFilterProfileStats stats) {
     std::lock_guard lock(_lock);
     DCHECK_GE(stats.runtime_filter_id, 0);
-    const auto has_scan_filter_desc = std::ranges::any_of(_descs, [&](const auto& desc) {
-        return desc.kind == ScanFilterKind::RUNTIME_FILTER &&
-               desc.runtime_filter_id == stats.runtime_filter_id;
-    });
-    if (!has_scan_filter_desc) {
-        ScanFilterDesc desc;
-        desc.filter_id = static_cast<int32_t>(_descs.size());
-        desc.kind = ScanFilterKind::RUNTIME_FILTER;
-        desc.runtime_filter_id = stats.runtime_filter_id;
-        _descs.emplace_back(std::move(desc));
-        _stats.emplace_back(std::make_shared<ScanFilterStats>());
-    }
-    for (auto& item : _runtime_filter_stats) {
-        if (item.runtime_filter_id == stats.runtime_filter_id) {
-            item = std::move(stats);
+    for (auto& filter : _filters) {
+        if (filter.desc.kind == ScanFilterKind::RUNTIME_FILTER &&
+            filter.desc.runtime_filter_id == stats.runtime_filter_id) {
+            filter.runtime_filter_stats = std::move(stats);
             return;
         }
     }
-    _runtime_filter_stats.emplace_back(std::move(stats));
+
+    ScanFilterDesc desc;
+    desc.filter_id = static_cast<int32_t>(_filters.size());
+    desc.kind = ScanFilterKind::RUNTIME_FILTER;
+    desc.runtime_filter_id = stats.runtime_filter_id;
+    _filters.emplace_back(FilterEntry {.desc = std::move(desc),
+                                       .stats = std::make_shared<ScanFilterStats>(),
+                                       .runtime_filter_stats = std::move(stats)});
 }
 
 void ScanFilterProfile::set_runtime_filter_partition_pruning_stats(
@@ -529,17 +500,17 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
     }
 
     const auto snapshots = _snapshots();
-    const auto runtime_filter_stats = _runtime_filter_stats_snapshots();
+    const auto key_range_snapshot = _key_range_snapshot();
     const auto runtime_filter_acquire_time_ns = _runtime_filter_acquire_time_snapshot();
     const auto runtime_filter_partition_pruning_stats =
             _runtime_filter_partition_pruning_stats_snapshot();
     std::vector<MaterializedFilterSnapshot> scan_filter_snapshots;
-    std::optional<MaterializedFilterSnapshot> key_range_snapshot;
     scan_filter_snapshots.reserve(snapshots.size());
 
     for (const auto& snapshot : snapshots) {
         MaterializedFilterSnapshot materialized;
         materialized.desc = snapshot.desc;
+        materialized.runtime_filter_stats = snapshot.runtime_filter_stats;
         for (int i = 0; i < static_cast<int>(ScanFilterStage::NUM_STAGES); ++i) {
             const auto stage = static_cast<ScanFilterStage>(i);
             materialized.stage_snapshots[i] = snapshot.stats->snapshot(stage);
@@ -550,30 +521,26 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
                 update_summary(&materialized.exec, stage, materialized.stage_snapshots[i]);
             }
         }
-
-        if (materialized.desc.kind == ScanFilterKind::KEY_RANGE) {
-            DCHECK(!key_range_snapshot.has_value());
-            key_range_snapshot = std::move(materialized);
-        } else {
-            scan_filter_snapshots.emplace_back(std::move(materialized));
-        }
+        scan_filter_snapshots.emplace_back(std::move(materialized));
     }
 
     if (key_range_snapshot.has_value()) {
         auto* key_range_profile = get_or_create_child(profile, KEY_RANGE_INFO);
-        const auto& snapshot = *key_range_snapshot;
-        if (!snapshot.desc.source_filter_ids.empty()) {
+        const auto& key_range = *key_range_snapshot;
+        const auto key_range_stats = key_range.handle.stats->snapshot(ScanFilterStage::KEY_RANGE);
+        if (!key_range.source_filter_ids.empty()) {
             key_range_profile->add_info_string("SourceFilterIds",
-                                               join_ids(snapshot.desc.source_filter_ids));
+                                               join_ids(key_range.source_filter_ids));
         }
         if (profile_level >= 2) {
-            add_info_string_if_not_empty(key_range_profile, "ScanKeys", snapshot.desc.compact_info);
+            add_info_string_if_not_empty(key_range_profile, "ScanKeys", key_range.scan_keys);
         }
 
-        set_root_counter(key_range_profile, "RangeNum", TUnit::UNIT, 1, snapshot.desc.range_count);
-        set_root_counter(key_range_profile, "InputRows", TUnit::UNIT, 1, snapshot.total.input_rows);
+        set_root_counter(key_range_profile, "RangeNum", TUnit::UNIT, 1, key_range.range_count);
+        set_root_counter(key_range_profile, "InputRows", TUnit::UNIT, 1,
+                         key_range_stats.input_rows);
         set_root_counter(key_range_profile, "FilteredRows", TUnit::UNIT, 1,
-                         snapshot.total.filtered_rows);
+                         key_range_stats.filtered_rows);
     }
 
     const bool has_partition_pruning_stats =
@@ -585,7 +552,7 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
 
     std::vector<int32_t> key_range_source_filter_ids;
     if (key_range_snapshot.has_value()) {
-        key_range_source_filter_ids = key_range_snapshot->desc.source_filter_ids;
+        key_range_source_filter_ids = key_range_snapshot->source_filter_ids;
     }
 
     std::ranges::sort(scan_filter_snapshots, [&](const auto& left, const auto& right) {
@@ -623,15 +590,9 @@ void ScanFilterProfile::materialize(RuntimeProfile* profile, int profile_level) 
     for (const auto& snapshot : scan_filter_snapshots) {
         auto* filter_profile = get_or_create_child(
                 scan_filter_profile, fmt::format("ScanFilter {}", snapshot.desc.filter_id));
-        const auto* runtime_filter_stat =
-                snapshot.desc.kind == ScanFilterKind::RUNTIME_FILTER
-                        ? find_runtime_filter_stats(runtime_filter_stats,
-                                                    snapshot.desc.runtime_filter_id)
-                        : nullptr;
         materialize_filter_counters(
                 filter_profile, snapshot, profile_level,
-                contains_id(key_range_source_filter_ids, snapshot.desc.filter_id),
-                runtime_filter_stat);
+                contains_id(key_range_source_filter_ids, snapshot.desc.filter_id));
     }
 }
 

--- a/be/src/runtime/scan_filter_profile.h
+++ b/be/src/runtime/scan_filter_profile.h
@@ -29,24 +29,38 @@ namespace doris {
 
 class RuntimeProfile;
 
+// Describes where a scan filter comes from. Physical mechanisms such as indexes
+// are represented by ScanFilterStage instead of ScanFilterKind.
 enum class ScanFilterKind {
     NORMAL,
     RUNTIME_FILTER,
     TOPN_FILTER,
-    KEY_RANGE,
     UNKNOWN,
 };
 
+// Describes where a filter records rows in the OLAP scan path. The row counts
+// are order-dependent: each stage records the input it sees in the current scan
+// execution order and the rows left after that filter/stage is applied.
 enum class ScanFilterStage {
+    // Storage key range pruning before segment-level predicates.
     KEY_RANGE = 0,
+    // Inverted index bitmap pruning for column predicates or pushed-down exprs.
     INDEX_INVERTED,
+    // Bloom filter index pruning at page granularity.
     INDEX_BLOOM_FILTER,
+    // Zone map pruning at page granularity.
     INDEX_ZONE_MAP,
+    // Dictionary pruning before decoding data pages.
     INDEX_DICT,
+    // ANN range index pruning.
     INDEX_ANN,
+    // Vectorized column predicate evaluation after rows are read.
     EXEC_VECTOR,
+    // Short-circuit column predicate evaluation after lazy materialization.
     EXEC_SHORT_CIRCUIT,
+    // Pushed-down common expr evaluation inside segment iterator.
     EXEC_COMMON_EXPR,
+    // Remaining conjunct evaluation in Scanner after reader output.
     EXEC_RESIDUAL,
     NUM_STAGES,
 };
@@ -56,13 +70,9 @@ struct ScanFilterDesc {
     ScanFilterKind kind = ScanFilterKind::UNKNOWN;
     int32_t runtime_filter_id = -1;
     int32_t topn_filter_source_node_id = -1;
-    int32_t slot_id = -1;
     int32_t column_id = -1;
     std::string column_name;
-    std::string compact_info;
-    std::string debug_string;
-    std::vector<int32_t> source_filter_ids;
-    int64_t range_count = 0;
+    std::string expr_debug_string;
 };
 
 struct ScanRuntimeFilterProfileStats {
@@ -81,13 +91,14 @@ struct ScanRuntimeFilterPartitionPruningStats {
 };
 
 struct ScanFilterStageStatsSnapshot {
-    bool participated = false;
     bool has_time = false;
     int64_t calls = 0;
     int64_t input_rows = 0;
     int64_t output_rows = 0;
     int64_t filtered_rows = 0;
     int64_t time_ns = 0;
+
+    bool participated() const { return calls > 0; }
 };
 
 class ScanFilterStats {
@@ -105,7 +116,6 @@ private:
         std::atomic<int64_t> filtered_rows = 0;
         std::atomic<int64_t> time_ns = 0;
         std::atomic<bool> has_time = false;
-        std::atomic<bool> participated = false;
     };
 
     static constexpr size_t STAGE_NUM = static_cast<size_t>(ScanFilterStage::NUM_STAGES);
@@ -116,13 +126,21 @@ struct ScanFilterHandle {
     int32_t filter_id = -1;
     std::shared_ptr<ScanFilterStats> stats;
 
-    explicit operator bool() const { return filter_id >= 0 && stats != nullptr; }
+    bool has_filter_id() const { return filter_id >= 0 && stats != nullptr; }
+    explicit operator bool() const { return stats != nullptr; }
+};
+
+struct ScanKeyRangeInfo {
+    std::vector<int32_t> source_filter_ids;
+    int64_t range_count = 0;
+    std::string scan_keys;
+    ScanFilterHandle handle;
 };
 
 class ScanFilterProfile {
 public:
     ScanFilterHandle register_filter(ScanFilterDesc desc);
-    void add_source_filter(int32_t filter_id, int32_t source_filter_id);
+    ScanFilterHandle register_key_range(ScanKeyRangeInfo key_range);
     void set_runtime_filter_acquire_time(int64_t acquire_time_ns);
     void set_runtime_filter_profile_stats(ScanRuntimeFilterProfileStats stats);
     void set_runtime_filter_partition_pruning_stats(ScanRuntimeFilterPartitionPruningStats stats);
@@ -132,17 +150,23 @@ private:
     struct FilterSnapshot {
         ScanFilterDesc desc;
         std::shared_ptr<ScanFilterStats> stats;
+        std::optional<ScanRuntimeFilterProfileStats> runtime_filter_stats;
     };
 
     std::vector<FilterSnapshot> _snapshots() const;
-    std::vector<ScanRuntimeFilterProfileStats> _runtime_filter_stats_snapshots() const;
+    std::optional<ScanKeyRangeInfo> _key_range_snapshot() const;
     int64_t _runtime_filter_acquire_time_snapshot() const;
     ScanRuntimeFilterPartitionPruningStats _runtime_filter_partition_pruning_stats_snapshot() const;
 
+    struct FilterEntry {
+        ScanFilterDesc desc;
+        std::shared_ptr<ScanFilterStats> stats;
+        std::optional<ScanRuntimeFilterProfileStats> runtime_filter_stats;
+    };
+
     mutable std::mutex _lock;
-    std::vector<ScanFilterDesc> _descs;
-    std::vector<std::shared_ptr<ScanFilterStats>> _stats;
-    std::vector<ScanRuntimeFilterProfileStats> _runtime_filter_stats;
+    std::vector<FilterEntry> _filters;
+    std::optional<ScanKeyRangeInfo> _key_range;
     int64_t _runtime_filter_acquire_time_ns = 0;
     ScanRuntimeFilterPartitionPruningStats _runtime_filter_partition_pruning_stats;
 };

--- a/be/src/runtime/scan_filter_profile.h
+++ b/be/src/runtime/scan_filter_profile.h
@@ -46,14 +46,14 @@ enum class ScanFilterStage {
     KEY_RANGE = 0,
     // Inverted index bitmap pruning for column predicates or pushed-down exprs.
     INDEX_INVERTED,
+    // ANN range index pruning.
+    INDEX_ANN,
+    // Dictionary pruning before decoding data pages.
+    INDEX_DICT,
     // Bloom filter index pruning at page granularity.
     INDEX_BLOOM_FILTER,
     // Zone map pruning at page granularity.
     INDEX_ZONE_MAP,
-    // Dictionary pruning before decoding data pages.
-    INDEX_DICT,
-    // ANN range index pruning.
-    INDEX_ANN,
     // Vectorized column predicate evaluation after rows are read.
     EXEC_VECTOR,
     // Short-circuit column predicate evaluation after lazy materialization.

--- a/be/src/runtime/scan_filter_profile.h
+++ b/be/src/runtime/scan_filter_profile.h
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace doris {
+
+class RuntimeProfile;
+
+enum class ScanFilterKind {
+    NORMAL,
+    RUNTIME_FILTER,
+    TOPN_FILTER,
+    KEY_RANGE,
+    UNKNOWN,
+};
+
+enum class ScanFilterStage {
+    KEY_RANGE = 0,
+    INDEX_INVERTED,
+    INDEX_BLOOM_FILTER,
+    INDEX_ZONE_MAP,
+    INDEX_DICT,
+    INDEX_ANN,
+    EXEC_VECTOR,
+    EXEC_SHORT_CIRCUIT,
+    EXEC_COMMON_EXPR,
+    EXEC_RESIDUAL,
+    NUM_STAGES,
+};
+
+struct ScanFilterDesc {
+    int32_t filter_id = -1;
+    ScanFilterKind kind = ScanFilterKind::UNKNOWN;
+    int32_t runtime_filter_id = -1;
+    int32_t topn_filter_source_node_id = -1;
+    int32_t slot_id = -1;
+    int32_t column_id = -1;
+    std::string column_name;
+    std::string compact_info;
+    std::string debug_string;
+    std::vector<int32_t> source_filter_ids;
+    int64_t range_count = 0;
+};
+
+struct ScanRuntimeFilterProfileStats {
+    int32_t runtime_filter_id = -1;
+    int64_t input_rows = 0;
+    int64_t filtered_rows = 0;
+    int64_t wait_time_ns = 0;
+    int64_t always_true_filter_rows = 0;
+    std::string debug_string;
+};
+
+struct ScanRuntimeFilterPartitionPruningStats {
+    int64_t total_partitions = 0;
+    int64_t pruned_partitions = 0;
+    int64_t pruned_tablets = 0;
+};
+
+struct ScanFilterStageStatsSnapshot {
+    bool participated = false;
+    bool has_time = false;
+    int64_t calls = 0;
+    int64_t input_rows = 0;
+    int64_t output_rows = 0;
+    int64_t filtered_rows = 0;
+    int64_t time_ns = 0;
+};
+
+class ScanFilterStats {
+public:
+    void record(ScanFilterStage stage, int64_t input_rows, int64_t output_rows,
+                std::optional<int64_t> time_ns = std::nullopt);
+
+    ScanFilterStageStatsSnapshot snapshot(ScanFilterStage stage) const;
+
+private:
+    struct StageStats {
+        std::atomic<int64_t> calls = 0;
+        std::atomic<int64_t> input_rows = 0;
+        std::atomic<int64_t> output_rows = 0;
+        std::atomic<int64_t> filtered_rows = 0;
+        std::atomic<int64_t> time_ns = 0;
+        std::atomic<bool> has_time = false;
+        std::atomic<bool> participated = false;
+    };
+
+    static constexpr size_t STAGE_NUM = static_cast<size_t>(ScanFilterStage::NUM_STAGES);
+    std::array<StageStats, STAGE_NUM> _stage_stats;
+};
+
+struct ScanFilterHandle {
+    int32_t filter_id = -1;
+    std::shared_ptr<ScanFilterStats> stats;
+
+    explicit operator bool() const { return filter_id >= 0 && stats != nullptr; }
+};
+
+class ScanFilterProfile {
+public:
+    ScanFilterHandle register_filter(ScanFilterDesc desc);
+    void add_source_filter(int32_t filter_id, int32_t source_filter_id);
+    void set_runtime_filter_acquire_time(int64_t acquire_time_ns);
+    void set_runtime_filter_profile_stats(ScanRuntimeFilterProfileStats stats);
+    void set_runtime_filter_partition_pruning_stats(ScanRuntimeFilterPartitionPruningStats stats);
+    void materialize(RuntimeProfile* profile, int profile_level) const;
+
+private:
+    struct FilterSnapshot {
+        ScanFilterDesc desc;
+        std::shared_ptr<ScanFilterStats> stats;
+    };
+
+    std::vector<FilterSnapshot> _snapshots() const;
+    std::vector<ScanRuntimeFilterProfileStats> _runtime_filter_stats_snapshots() const;
+    int64_t _runtime_filter_acquire_time_snapshot() const;
+    ScanRuntimeFilterPartitionPruningStats _runtime_filter_partition_pruning_stats_snapshot() const;
+
+    mutable std::mutex _lock;
+    std::vector<ScanFilterDesc> _descs;
+    std::vector<std::shared_ptr<ScanFilterStats>> _stats;
+    std::vector<ScanRuntimeFilterProfileStats> _runtime_filter_stats;
+    int64_t _runtime_filter_acquire_time_ns = 0;
+    ScanRuntimeFilterPartitionPruningStats _runtime_filter_partition_pruning_stats;
+};
+
+const char* scan_filter_kind_name(ScanFilterKind kind);
+const char* scan_filter_stage_name(ScanFilterStage stage);
+
+} // namespace doris

--- a/be/src/runtime/scan_filter_profile.h
+++ b/be/src/runtime/scan_filter_profile.h
@@ -38,12 +38,15 @@ enum class ScanFilterKind {
     UNKNOWN,
 };
 
-// Describes where a filter records rows in the OLAP scan path. The row counts
-// are order-dependent: each stage records the input it sees in the current scan
-// execution order and the rows left after that filter/stage is applied.
+// Describes where a filter records rows in the OLAP scan path. Execution stages
+// record the input they see in the current scan order. Zone map stages record
+// independent per-filter attribution, so different filters can count the same
+// skipped segment or page.
 enum class ScanFilterStage {
-    // Storage key range pruning before segment-level predicates.
-    KEY_RANGE = 0,
+    // Segment-level zone map pruning before segment iterators are initialized.
+    INDEX_ZONE_MAP_SEGMENT = 0,
+    // Storage key range pruning in segment iterators.
+    KEY_RANGE,
     // Inverted index bitmap pruning for column predicates or pushed-down exprs.
     INDEX_INVERTED,
     // ANN range index pruning.
@@ -53,7 +56,7 @@ enum class ScanFilterStage {
     // Bloom filter index pruning at page granularity.
     INDEX_BLOOM_FILTER,
     // Zone map pruning at page granularity.
-    INDEX_ZONE_MAP,
+    INDEX_ZONE_MAP_PAGE,
     // Vectorized column predicate evaluation after rows are read.
     EXEC_VECTOR,
     // Short-circuit column predicate evaluation after lazy materialization.

--- a/be/src/storage/iterators.h
+++ b/be/src/storage/iterators.h
@@ -26,6 +26,7 @@
 #include "exprs/vexpr.h"
 #include "io/io_common.h"
 #include "runtime/runtime_state.h"
+#include "runtime/scan_filter_profile.h"
 #include "storage/index/ann/ann_topn_runtime.h"
 #include "storage/olap_common.h"
 #include "storage/predicate/block_column_predicate.h"
@@ -38,6 +39,7 @@ namespace doris {
 
 class Schema;
 class ColumnPredicate;
+class ScanFilterProfile;
 
 struct IteratorRowRef;
 
@@ -109,6 +111,8 @@ public:
 
     // REQUIRED (null is not allowed)
     OlapReaderStatistics* stats = nullptr;
+    std::shared_ptr<ScanFilterProfile> scan_filter_profile;
+    ScanFilterHandle key_range_scan_filter;
     bool use_page_cache = false;
     uint32_t block_row_max = 4096 - 32; // see https://github.com/apache/doris/pull/11816
     // Effective adaptive batch size byte budget.

--- a/be/src/storage/predicate/block_column_predicate.cpp
+++ b/be/src/storage/predicate/block_column_predicate.cpp
@@ -34,14 +34,14 @@ template <typename EvaluateFunc>
 bool evaluate_and_with_scan_filter(
         const std::vector<std::unique_ptr<BlockColumnPredicate>>& predicates, ScanFilterStage stage,
         int64_t input_rows, EvaluateFunc&& evaluate_func) {
-    bool all_matched = true;
     for (const auto& predicate : predicates) {
-        // Keep scan filter attribution independent from AND short-circuiting.
         const bool matched = evaluate_func(*predicate);
         predicate->record_scan_filter(stage, input_rows, matched ? input_rows : 0);
-        all_matched &= matched;
+        if (!matched) {
+            return false;
+        }
     }
-    return all_matched;
+    return true;
 }
 
 } // namespace

--- a/be/src/storage/predicate/block_column_predicate.cpp
+++ b/be/src/storage/predicate/block_column_predicate.cpp
@@ -28,6 +28,24 @@ namespace segment_v2 {
 class InvertedIndexIterator;
 } // namespace segment_v2
 
+namespace {
+
+template <typename EvaluateFunc>
+bool evaluate_and_with_scan_filter(
+        const std::vector<std::unique_ptr<BlockColumnPredicate>>& predicates, ScanFilterStage stage,
+        int64_t input_rows, EvaluateFunc&& evaluate_func) {
+    for (auto& predicate : predicates) {
+        const bool matched = evaluate_func(*predicate);
+        predicate->record_scan_filter(stage, input_rows, matched ? input_rows : 0);
+        if (!matched) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
 uint16_t SingleColumnBlockPredicate::evaluate(MutableColumns& block, uint16_t* sel,
                                               uint16_t selected_size) const {
     auto column_id = _predicate->column_id();
@@ -181,6 +199,15 @@ bool AndBlockColumnPredicate::evaluate_and(const segment_v2::ZoneMap& zone_map) 
     return true;
 }
 
+bool AndBlockColumnPredicate::evaluate_and_with_scan_filter(const segment_v2::ZoneMap& zone_map,
+                                                            ScanFilterStage stage,
+                                                            int64_t input_rows) const {
+    return doris::evaluate_and_with_scan_filter(_block_column_predicate_vec, stage, input_rows,
+                                                [&zone_map](const BlockColumnPredicate& predicate) {
+                                                    return predicate.evaluate_and(zone_map);
+                                                });
+}
+
 bool AndBlockColumnPredicate::evaluate_and(const segment_v2::BloomFilter* bf) const {
     for (auto& block_column_predicate : _block_column_predicate_vec) {
         if (!block_column_predicate->evaluate_and(bf)) {
@@ -188,6 +215,14 @@ bool AndBlockColumnPredicate::evaluate_and(const segment_v2::BloomFilter* bf) co
         }
     }
     return true;
+}
+
+bool AndBlockColumnPredicate::evaluate_and_with_scan_filter(const segment_v2::BloomFilter* bf,
+                                                            ScanFilterStage stage,
+                                                            int64_t input_rows) const {
+    return doris::evaluate_and_with_scan_filter(
+            _block_column_predicate_vec, stage, input_rows,
+            [bf](const BlockColumnPredicate& predicate) { return predicate.evaluate_and(bf); });
 }
 
 bool AndBlockColumnPredicate::evaluate_and(const StringRef* dict_words,
@@ -198,6 +233,17 @@ bool AndBlockColumnPredicate::evaluate_and(const StringRef* dict_words,
         }
     }
     return true;
+}
+
+bool AndBlockColumnPredicate::evaluate_and_with_scan_filter(const StringRef* dict_words,
+                                                            const size_t dict_num,
+                                                            ScanFilterStage stage,
+                                                            int64_t input_rows) const {
+    return doris::evaluate_and_with_scan_filter(
+            _block_column_predicate_vec, stage, input_rows,
+            [dict_words, dict_num](const BlockColumnPredicate& predicate) {
+                return predicate.evaluate_and(dict_words, dict_num);
+            });
 }
 
 void AndBlockColumnPredicate::evaluate_or(MutableColumns& block, uint16_t* sel,

--- a/be/src/storage/predicate/block_column_predicate.cpp
+++ b/be/src/storage/predicate/block_column_predicate.cpp
@@ -17,7 +17,7 @@
 
 #include "storage/predicate/block_column_predicate.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace roaring {
 class Roaring;
@@ -34,14 +34,14 @@ template <typename EvaluateFunc>
 bool evaluate_and_with_scan_filter(
         const std::vector<std::unique_ptr<BlockColumnPredicate>>& predicates, ScanFilterStage stage,
         int64_t input_rows, EvaluateFunc&& evaluate_func) {
-    for (auto& predicate : predicates) {
+    bool all_matched = true;
+    for (const auto& predicate : predicates) {
+        // Keep scan filter attribution independent from AND short-circuiting.
         const bool matched = evaluate_func(*predicate);
         predicate->record_scan_filter(stage, input_rows, matched ? input_rows : 0);
-        if (!matched) {
-            return false;
-        }
+        all_matched &= matched;
     }
-    return true;
+    return all_matched;
 }
 
 } // namespace
@@ -121,7 +121,7 @@ uint16_t OrBlockColumnPredicate::evaluate(MutableColumns& block, uint16_t* sel,
 
 void OrBlockColumnPredicate::evaluate_or(MutableColumns& block, uint16_t* sel,
                                          uint16_t selected_size, bool* flags) const {
-    for (auto& block_column_predicate : _block_column_predicate_vec) {
+    for (const auto& block_column_predicate : _block_column_predicate_vec) {
         block_column_predicate->evaluate_or(block, sel, selected_size, flags);
     }
 }
@@ -177,7 +177,7 @@ bool AndBlockColumnPredicate::evaluate_and(ParquetPredicate::CachedPageIndexStat
 
 uint16_t AndBlockColumnPredicate::evaluate(MutableColumns& block, uint16_t* sel,
                                            uint16_t selected_size) const {
-    for (auto& block_column_predicate : _block_column_predicate_vec) {
+    for (const auto& block_column_predicate : _block_column_predicate_vec) {
         selected_size = block_column_predicate->evaluate(block, sel, selected_size);
     }
     return selected_size;
@@ -185,13 +185,13 @@ uint16_t AndBlockColumnPredicate::evaluate(MutableColumns& block, uint16_t* sel,
 
 void AndBlockColumnPredicate::evaluate_and(MutableColumns& block, uint16_t* sel,
                                            uint16_t selected_size, bool* flags) const {
-    for (auto& block_column_predicate : _block_column_predicate_vec) {
+    for (const auto& block_column_predicate : _block_column_predicate_vec) {
         block_column_predicate->evaluate_and(block, sel, selected_size, flags);
     }
 }
 
 bool AndBlockColumnPredicate::evaluate_and(const segment_v2::ZoneMap& zone_map) const {
-    for (auto& block_column_predicate : _block_column_predicate_vec) {
+    for (const auto& block_column_predicate : _block_column_predicate_vec) {
         if (!block_column_predicate->evaluate_and(zone_map)) {
             return false;
         }
@@ -209,7 +209,7 @@ bool AndBlockColumnPredicate::evaluate_and_with_scan_filter(const segment_v2::Zo
 }
 
 bool AndBlockColumnPredicate::evaluate_and(const segment_v2::BloomFilter* bf) const {
-    for (auto& block_column_predicate : _block_column_predicate_vec) {
+    for (const auto& block_column_predicate : _block_column_predicate_vec) {
         if (!block_column_predicate->evaluate_and(bf)) {
             return false;
         }
@@ -227,7 +227,7 @@ bool AndBlockColumnPredicate::evaluate_and_with_scan_filter(const segment_v2::Bl
 
 bool AndBlockColumnPredicate::evaluate_and(const StringRef* dict_words,
                                            const size_t dict_num) const {
-    for (auto& predicate : _block_column_predicate_vec) {
+    for (const auto& predicate : _block_column_predicate_vec) {
         if (!predicate->evaluate_and(dict_words, dict_num)) {
             return false;
         }

--- a/be/src/storage/predicate/block_column_predicate.h
+++ b/be/src/storage/predicate/block_column_predicate.h
@@ -60,6 +60,15 @@ public:
     virtual void get_all_column_predicate(
             std::set<std::shared_ptr<const ColumnPredicate>>& predicate_set) const = 0;
 
+    virtual ScanFilterHandle scan_filter_handle() const { return {}; }
+    virtual bool has_scan_filter() const { return static_cast<bool>(scan_filter_handle()); }
+    virtual void record_scan_filter(ScanFilterStage stage, int64_t input_rows,
+                                    int64_t output_rows) const {
+        if (auto handle = scan_filter_handle()) {
+            handle.stats->record(stage, input_rows, output_rows);
+        }
+    }
+
     virtual uint16_t evaluate(MutableColumns& block, uint16_t* sel, uint16_t selected_size) const {
         return selected_size;
     }
@@ -126,6 +135,10 @@ public:
         predicate_set.insert(_predicate);
     }
 
+    ScanFilterHandle scan_filter_handle() const override {
+        return _predicate->scan_filter_handle();
+    }
+
     uint16_t evaluate(MutableColumns& block, uint16_t* sel, uint16_t selected_size) const override;
     void evaluate_and(MutableColumns& block, uint16_t* sel, uint16_t selected_size,
                       bool* flags) const override;
@@ -175,6 +188,22 @@ public:
     }
 
     size_t num_of_column_predicate() const { return _block_column_predicate_vec.size(); }
+
+    bool has_scan_filter() const override {
+        for (const auto& child_block_predicate : _block_column_predicate_vec) {
+            if (child_block_predicate->has_scan_filter()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void record_scan_filter(ScanFilterStage stage, int64_t input_rows,
+                            int64_t output_rows) const override {
+        for (const auto& child_block_predicate : _block_column_predicate_vec) {
+            child_block_predicate->record_scan_filter(stage, input_rows, output_rows);
+        }
+    }
 
     void get_all_column_ids(std::set<ColumnId>& column_id_set) const override {
         for (auto& child_block_predicate : _block_column_predicate_vec) {
@@ -235,9 +264,18 @@ public:
 
     bool evaluate_and(const segment_v2::ZoneMap& zone_map) const override;
 
+    bool evaluate_and_with_scan_filter(const segment_v2::ZoneMap& zone_map, ScanFilterStage stage,
+                                       int64_t input_rows) const;
+
     bool evaluate_and(const segment_v2::BloomFilter* bf) const override;
 
+    bool evaluate_and_with_scan_filter(const segment_v2::BloomFilter* bf, ScanFilterStage stage,
+                                       int64_t input_rows) const;
+
     bool evaluate_and(const StringRef* dict_words, const size_t dict_num) const override;
+
+    bool evaluate_and_with_scan_filter(const StringRef* dict_words, const size_t dict_num,
+                                       ScanFilterStage stage, int64_t input_rows) const;
 
     bool evaluate_and(ParquetPredicate::ColumnStat* statistic) const override {
         for (auto& block_column_predicate : _block_column_predicate_vec) {

--- a/be/src/storage/predicate/column_predicate.h
+++ b/be/src/storage/predicate/column_predicate.h
@@ -27,6 +27,7 @@
 #include "exprs/runtime_filter_expr.h"
 #include "format/parquet/parquet_predicate.h"
 #include "runtime/runtime_profile.h"
+#include "runtime/scan_filter_profile.h"
 #include "storage/index/bloom_filter/bloom_filter.h"
 #include "storage/index/inverted/inverted_index_iterator.h"
 #include "storage/index/zone_map/zone_map_index.h"
@@ -316,6 +317,10 @@ public:
 
     bool opposite() const { return _opposite; }
 
+    void attach_scan_filter(ScanFilterHandle handle) { _scan_filter_handle = std::move(handle); }
+
+    const ScanFilterHandle& scan_filter_handle() const { return _scan_filter_handle; }
+
     void attach_profile_counter(
             int filter_id, std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter,
             std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter,
@@ -422,6 +427,8 @@ protected:
     // without recalculating. At the beginning of the next period,
     // reset_judge_selectivity is used to reset these variables.
     mutable RuntimeFilterSelectivity _rf_selectivity;
+
+    ScanFilterHandle _scan_filter_handle;
 
     std::shared_ptr<RuntimeProfile::Counter> _predicate_filtered_rows_counter =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);

--- a/be/src/storage/rowset/beta_rowset_reader.cpp
+++ b/be/src/storage/rowset/beta_rowset_reader.cpp
@@ -228,6 +228,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.io_ctx.reader_type = _read_context->reader_type;
     _read_options.io_ctx.file_cache_stats = &_stats->file_cache_stats;
     _read_options.runtime_state = _read_context->runtime_state;
+    _read_options.scan_filter_profile = _read_context->scan_filter_profile;
+    _read_options.key_range_scan_filter = _read_context->key_range_scan_filter;
     _read_options.output_columns = _read_context->output_columns;
     _read_options.io_ctx.reader_type = _read_context->reader_type;
     _read_options.io_ctx.is_disposable = _read_context->reader_type != ReaderType::READER_QUERY;

--- a/be/src/storage/rowset/rowset_reader_context.h
+++ b/be/src/storage/rowset/rowset_reader_context.h
@@ -35,6 +35,7 @@ namespace doris {
 class RowCursor;
 class DeleteBitmap;
 class DeleteHandler;
+class ScanFilterProfile;
 class TabletSchema;
 
 struct RowsetReaderContext {
@@ -70,6 +71,8 @@ struct RowsetReaderContext {
     const DeleteHandler* delete_handler = nullptr;
     OlapReaderStatistics* stats = nullptr;
     RuntimeState* runtime_state = nullptr;
+    std::shared_ptr<ScanFilterProfile> scan_filter_profile;
+    ScanFilterHandle key_range_scan_filter;
     VExprContextSPtrs common_expr_ctxs_push_down;
     bool use_page_cache = false;
     int sequence_id_idx = -1;

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -89,6 +89,17 @@ inline bool read_as_string(PrimitiveType type) {
            type == PrimitiveType::TYPE_BITMAP || type == PrimitiveType::TYPE_FIXED_LENGTH_OBJECT;
 }
 
+namespace {
+
+int64_t row_ranges_intersection_count(const RowRanges& row_ranges, ordinal_t from, ordinal_t to) {
+    RowRanges page_row_ranges(RowRanges::create_single(from, to));
+    RowRanges intersected_row_ranges;
+    RowRanges::ranges_intersection(row_ranges, page_row_ranges, &intersected_row_ranges);
+    return cast_set<int64_t>(intersected_row_ranges.count());
+}
+
+} // namespace
+
 Status ColumnReader::create_array(const ColumnReaderOptions& opts, const ColumnMetaPB& meta,
                                   const io::FileReaderSPtr& file_reader,
                                   std::shared_ptr<ColumnReader>* reader) {
@@ -438,9 +449,11 @@ Status ColumnReader::get_row_ranges_by_zone_map(
         const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
         RowRanges* row_ranges, const ColumnIteratorOptions& iter_opts) {
     std::vector<uint32_t> page_indexes;
-    RETURN_IF_ERROR(
-            _get_filtered_pages(col_predicates, delete_predicates, &page_indexes, iter_opts));
-    RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, row_ranges, iter_opts));
+    RETURN_IF_ERROR(_get_filtered_pages(col_predicates, delete_predicates, *row_ranges,
+                                        &page_indexes, iter_opts));
+    RowRanges zone_map_row_ranges;
+    RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, &zone_map_row_ranges, iter_opts));
+    RowRanges::ranges_intersection(*row_ranges, zone_map_row_ranges, row_ranges);
     return Status::OK();
 }
 
@@ -515,18 +528,43 @@ bool ColumnReader::_zone_map_match_condition(const ZoneMap& zone_map,
 Status ColumnReader::_get_filtered_pages(
         const AndBlockColumnPredicate* col_predicates,
         const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
-        std::vector<uint32_t>* page_indexes, const ColumnIteratorOptions& iter_opts) {
+        const RowRanges& input_row_ranges, std::vector<uint32_t>* page_indexes,
+        const ColumnIteratorOptions& iter_opts) {
     RETURN_IF_ERROR(_load_zone_map_index(_use_index_page_cache, _opts.kept_in_memory, iter_opts));
+    const bool collect_scan_filter_stats = col_predicates->has_scan_filter();
+    if (collect_scan_filter_stats) {
+        RETURN_IF_ERROR(
+                _load_ordinal_index(_use_index_page_cache, _opts.kept_in_memory, iter_opts));
+    }
 
     const std::vector<ZoneMapPB>& zone_maps = _zone_map_index->page_zone_maps();
-    size_t page_size = _zone_map_index->num_pages();
-    for (size_t i = 0; i < page_size; ++i) {
+    int page_size = cast_set<int>(_zone_map_index->num_pages());
+    for (int i = 0; i < page_size; ++i) {
+        int64_t page_input_rows = 0;
+        if (collect_scan_filter_stats) {
+            const ordinal_t page_first_id = _ordinal_index->get_first_ordinal(i);
+            const ordinal_t page_last_id = _ordinal_index->get_last_ordinal(i) + 1;
+            page_input_rows =
+                    row_ranges_intersection_count(input_row_ranges, page_first_id, page_last_id);
+            if (page_input_rows == 0) {
+                continue;
+            }
+        }
         if (zone_maps[i].pass_all()) {
+            if (collect_scan_filter_stats) {
+                col_predicates->record_scan_filter(ScanFilterStage::INDEX_ZONE_MAP, page_input_rows,
+                                                   page_input_rows);
+            }
             page_indexes->push_back(cast_set<uint32_t>(i));
         } else {
             segment_v2::ZoneMap zone_map;
             RETURN_IF_ERROR(ZoneMap::from_proto(zone_maps[i], _data_type, zone_map));
-            if (_zone_map_match_condition(zone_map, col_predicates)) {
+            const bool matched =
+                    collect_scan_filter_stats
+                            ? col_predicates->evaluate_and_with_scan_filter(
+                                      zone_map, ScanFilterStage::INDEX_ZONE_MAP, page_input_rows)
+                            : col_predicates->evaluate_and(zone_map);
+            if (matched) {
                 bool should_read = true;
                 if (delete_predicates != nullptr) {
                     for (auto del_pred : *delete_predicates) {
@@ -575,6 +613,7 @@ Status ColumnReader::get_row_ranges_by_bloom_filter(const AndBlockColumnPredicat
     std::unique_ptr<BloomFilterIndexIterator> bf_iter;
     RETURN_IF_ERROR(_bloom_filter_index->new_iterator(&bf_iter, iter_opts.stats));
     size_t range_size = row_ranges->range_size();
+    const bool collect_scan_filter_stats = col_predicates->has_scan_filter();
     // get covered page ids
     std::set<uint32_t> page_ids;
     for (int i = 0; i < range_size; ++i) {
@@ -591,7 +630,19 @@ Status ColumnReader::get_row_ranges_by_bloom_filter(const AndBlockColumnPredicat
     for (auto& pid : page_ids) {
         std::unique_ptr<BloomFilter> bf;
         RETURN_IF_ERROR(bf_iter->read_bloom_filter(pid, &bf));
-        if (col_predicates->evaluate_and(bf.get())) {
+        if (collect_scan_filter_stats) {
+            const ordinal_t page_first_id = _ordinal_index->get_first_ordinal(pid);
+            const ordinal_t page_last_id = _ordinal_index->get_last_ordinal(pid) + 1;
+            const int64_t page_input_rows =
+                    row_ranges_intersection_count(*row_ranges, page_first_id, page_last_id);
+            if (page_input_rows == 0) {
+                continue;
+            }
+            if (col_predicates->evaluate_and_with_scan_filter(
+                        bf.get(), ScanFilterStage::INDEX_BLOOM_FILTER, page_input_rows)) {
+                bf_row_ranges.add(RowRange(page_first_id, page_last_id));
+            }
+        } else if (col_predicates->evaluate_and(bf.get())) {
             bf_row_ranges.add(RowRange(_ordinal_index->get_first_ordinal(pid),
                                        _ordinal_index->get_last_ordinal(pid) + 1));
         }
@@ -2507,7 +2558,13 @@ Status FileColumnIterator::get_row_ranges_by_dict(const AndBlockColumnPredicate*
         CHECK_NOTNULL(_dict_decoder);
     }
 
-    if (!col_predicates->evaluate_and(_dict_word_info.get(), _dict_decoder->count())) {
+    const bool matched =
+            col_predicates->has_scan_filter()
+                    ? col_predicates->evaluate_and_with_scan_filter(
+                              _dict_word_info.get(), _dict_decoder->count(),
+                              ScanFilterStage::INDEX_DICT, cast_set<int64_t>(row_ranges->count()))
+                    : col_predicates->evaluate_and(_dict_word_info.get(), _dict_decoder->count());
+    if (!matched) {
         row_ranges->clear();
     }
     return Status::OK();

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -448,12 +448,12 @@ Status ColumnReader::get_row_ranges_by_zone_map(
         const AndBlockColumnPredicate* col_predicates,
         const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
         RowRanges* row_ranges, const ColumnIteratorOptions& iter_opts) {
+    RETURN_IF_ERROR(_load_ordinal_index(_use_index_page_cache, _opts.kept_in_memory, iter_opts));
     std::vector<uint32_t> page_indexes;
     RETURN_IF_ERROR(_get_filtered_pages(col_predicates, delete_predicates, *row_ranges,
                                         &page_indexes, iter_opts));
-    RowRanges zone_map_row_ranges;
-    RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, &zone_map_row_ranges, iter_opts));
-    RowRanges::ranges_intersection(*row_ranges, zone_map_row_ranges, row_ranges);
+    RowRanges column_zone_map_row_ranges = _row_ranges_by_page_indexes(page_indexes);
+    RowRanges::ranges_intersection(*row_ranges, column_zone_map_row_ranges, row_ranges);
     return Status::OK();
 }
 
@@ -552,10 +552,6 @@ Status ColumnReader::_get_filtered_pages(
         const ColumnIteratorOptions& iter_opts) {
     RETURN_IF_ERROR(_load_zone_map_index(_use_index_page_cache, _opts.kept_in_memory, iter_opts));
     const bool collect_scan_filter_stats = col_predicates->has_scan_filter();
-    if (collect_scan_filter_stats) {
-        RETURN_IF_ERROR(
-                _load_ordinal_index(_use_index_page_cache, _opts.kept_in_memory, iter_opts));
-    }
 
     const std::vector<ZoneMapPB>& zone_maps = _zone_map_index->page_zone_maps();
     int page_size = cast_set<int>(_zone_map_index->num_pages());
@@ -626,18 +622,16 @@ Status ColumnReader::_zone_map_page_should_read(
     return Status::OK();
 }
 
-Status ColumnReader::_calculate_row_ranges(const std::vector<uint32_t>& page_indexes,
-                                           RowRanges* row_ranges,
-                                           const ColumnIteratorOptions& iter_opts) {
-    row_ranges->clear();
-    RETURN_IF_ERROR(_load_ordinal_index(_use_index_page_cache, _opts.kept_in_memory, iter_opts));
+RowRanges ColumnReader::_row_ranges_by_page_indexes(
+        const std::vector<uint32_t>& page_indexes) const {
+    RowRanges row_ranges;
     for (auto i : page_indexes) {
         ordinal_t page_first_id = _ordinal_index->get_first_ordinal(i);
         ordinal_t page_last_id = _ordinal_index->get_last_ordinal(i);
-        RowRanges page_row_ranges(RowRanges::create_single(page_first_id, page_last_id + 1));
-        RowRanges::ranges_union(*row_ranges, page_row_ranges, row_ranges);
+        row_ranges.add(
+                RowRange(cast_set<int64_t>(page_first_id), cast_set<int64_t>(page_last_id + 1)));
     }
-    return Status::OK();
+    return row_ranges;
 }
 
 Status ColumnReader::get_row_ranges_by_bloom_filter(const AndBlockColumnPredicate* col_predicates,

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -490,6 +490,26 @@ Status ColumnReader::match_condition(const AndBlockColumnPredicate* col_predicat
     return Status::OK();
 }
 
+Status ColumnReader::match_condition_with_scan_filter(const AndBlockColumnPredicate* col_predicates,
+                                                      int64_t input_rows, bool* matched) const {
+    *matched = true;
+    if (_zone_map_index == nullptr) {
+        return Status::OK();
+    }
+    ZoneMap zone_map;
+    RETURN_IF_ERROR(ZoneMap::from_proto(*_segment_zone_map, _data_type, zone_map));
+
+    if (zone_map.pass_all) {
+        col_predicates->record_scan_filter(ScanFilterStage::INDEX_ZONE_MAP_SEGMENT, input_rows,
+                                           input_rows);
+        return Status::OK();
+    }
+
+    *matched = col_predicates->evaluate_and_with_scan_filter(
+            zone_map, ScanFilterStage::INDEX_ZONE_MAP_SEGMENT, input_rows);
+    return Status::OK();
+}
+
 Status ColumnReader::prune_predicates_by_zone_map(
         std::vector<std::shared_ptr<ColumnPredicate>>& predicates, const int column_id,
         bool* pruned) const {
@@ -550,42 +570,59 @@ Status ColumnReader::_get_filtered_pages(
                 continue;
             }
         }
-        if (zone_maps[i].pass_all()) {
-            if (collect_scan_filter_stats) {
-                col_predicates->record_scan_filter(ScanFilterStage::INDEX_ZONE_MAP, page_input_rows,
-                                                   page_input_rows);
-            }
+        bool should_read = false;
+        RETURN_IF_ERROR(_zone_map_page_should_read(zone_maps[i], col_predicates, delete_predicates,
+                                                   collect_scan_filter_stats, page_input_rows,
+                                                   &should_read));
+        if (should_read) {
             page_indexes->push_back(cast_set<uint32_t>(i));
-        } else {
-            segment_v2::ZoneMap zone_map;
-            RETURN_IF_ERROR(ZoneMap::from_proto(zone_maps[i], _data_type, zone_map));
-            const bool matched =
-                    collect_scan_filter_stats
-                            ? col_predicates->evaluate_and_with_scan_filter(
-                                      zone_map, ScanFilterStage::INDEX_ZONE_MAP, page_input_rows)
-                            : col_predicates->evaluate_and(zone_map);
-            if (matched) {
-                bool should_read = true;
-                if (delete_predicates != nullptr) {
-                    for (auto del_pred : *delete_predicates) {
-                        // TODO: Both `min_value` and `max_value` should be 0 or neither should be 0.
-                        //  So nullable only need to judge once.
-                        if (del_pred->evaluate_del(zone_map)) {
-                            should_read = false;
-                            break;
-                        }
-                    }
-                }
-                if (should_read) {
-                    page_indexes->push_back(cast_set<uint32_t>(i));
-                }
-            }
         }
     }
     VLOG(1) << "total-pages: " << page_size << " not-filtered-pages: " << page_indexes->size()
             << " filtered-percent:"
             << 1.0 - (static_cast<double>(page_indexes->size()) /
                       (static_cast<double>(page_size) * 1.0));
+    return Status::OK();
+}
+
+Status ColumnReader::_zone_map_page_should_read(
+        const ZoneMapPB& zone_map_pb, const AndBlockColumnPredicate* col_predicates,
+        const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
+        bool collect_scan_filter_stats, int64_t page_input_rows, bool* should_read) const {
+    *should_read = false;
+    if (zone_map_pb.pass_all()) {
+        if (collect_scan_filter_stats) {
+            col_predicates->record_scan_filter(ScanFilterStage::INDEX_ZONE_MAP_PAGE,
+                                               page_input_rows, page_input_rows);
+        }
+        *should_read = true;
+        return Status::OK();
+    }
+
+    segment_v2::ZoneMap zone_map;
+    RETURN_IF_ERROR(ZoneMap::from_proto(zone_map_pb, _data_type, zone_map));
+    const bool matched =
+            collect_scan_filter_stats
+                    ? col_predicates->evaluate_and_with_scan_filter(
+                              zone_map, ScanFilterStage::INDEX_ZONE_MAP_PAGE, page_input_rows)
+                    : col_predicates->evaluate_and(zone_map);
+    if (!matched) {
+        return Status::OK();
+    }
+
+    *should_read = true;
+    if (delete_predicates == nullptr) {
+        return Status::OK();
+    }
+
+    for (const auto& del_pred : *delete_predicates) {
+        // TODO: Both `min_value` and `max_value` should be 0 or neither should be 0.
+        //  So nullable only need to judge once.
+        if (del_pred->evaluate_del(zone_map)) {
+            *should_read = false;
+            return Status::OK();
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -187,6 +187,8 @@ public:
     // Since segment zone map is stored in metadata, this function is fast without I/O.
     // set matched to true if segment zone map is absent or `cond' could be satisfied, false otherwise.
     Status match_condition(const AndBlockColumnPredicate* col_predicates, bool* matched) const;
+    Status match_condition_with_scan_filter(const AndBlockColumnPredicate* col_predicates,
+                                            int64_t input_rows, bool* matched) const;
 
     Status next_batch_of_zone_map(size_t* n, MutableColumnPtr& dst) const;
 
@@ -263,6 +265,10 @@ private:
             const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
             const RowRanges& input_row_ranges, std::vector<uint32_t>* page_indexes,
             const ColumnIteratorOptions& iter_opts);
+    Status _zone_map_page_should_read(
+            const ZoneMapPB& zone_map_pb, const AndBlockColumnPredicate* col_predicates,
+            const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
+            bool collect_scan_filter_stats, int64_t page_input_rows, bool* should_read) const;
 
     Status _calculate_row_ranges(const std::vector<uint32_t>& page_indexes, RowRanges* row_ranges,
                                  const ColumnIteratorOptions& iter_opts);

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -261,7 +261,8 @@ private:
     Status _get_filtered_pages(
             const AndBlockColumnPredicate* col_predicates,
             const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
-            std::vector<uint32_t>* page_indexes, const ColumnIteratorOptions& iter_opts);
+            const RowRanges& input_row_ranges, std::vector<uint32_t>* page_indexes,
+            const ColumnIteratorOptions& iter_opts);
 
     Status _calculate_row_ranges(const std::vector<uint32_t>& page_indexes, RowRanges* row_ranges,
                                  const ColumnIteratorOptions& iter_opts);

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -270,8 +270,7 @@ private:
             const std::vector<std::shared_ptr<const ColumnPredicate>>* delete_predicates,
             bool collect_scan_filter_stats, int64_t page_input_rows, bool* should_read) const;
 
-    Status _calculate_row_ranges(const std::vector<uint32_t>& page_indexes, RowRanges* row_ranges,
-                                 const ColumnIteratorOptions& iter_opts);
+    RowRanges _row_ranges_by_page_indexes(const std::vector<uint32_t>& page_indexes) const;
 
     int64_t _meta_length;
     FieldType _meta_type;

--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -262,15 +262,13 @@ bool Segment::is_tso_placeholder_col(int cid, const Schema& schema,
     return cid == schema.tso_col_idx();
 }
 
-Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_options,
-                             std::unique_ptr<RowwiseIterator>* iter) {
-    if (read_options.runtime_state != nullptr) {
-        _be_exec_version = read_options.runtime_state->be_exec_version();
-    }
-    RETURN_IF_ERROR(_create_column_meta_once(read_options.stats));
-
-    read_options.stats->total_segment_number++;
-    // trying to prune the current segment by segment-level zone map
+Status Segment::_prune_by_segment_zone_map(SchemaSPtr schema,
+                                           const StorageReadOptions& read_options,
+                                           bool* segment_matched) {
+    *segment_matched = true;
+    const bool collect_scan_filter_stats =
+            std::ranges::any_of(read_options.col_id_to_predicates,
+                                [](const auto& entry) { return entry.second->has_scan_filter(); });
     for (const auto& entry : read_options.col_id_to_predicates) {
         int32_t column_id = entry.first;
         // schema change
@@ -296,34 +294,66 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
         // evaluate_and() returns false iff no value in [min, max] can satisfy the predicates,
         // i.e. commit_tso fails them and the whole segment can be pruned. Predicates that don't
         // support zonemap return true (conservative: not pruned, row-level eval handles them).
-        if (read_options.col_id_to_predicates.contains(column_id) &&
-            is_tso_placeholder_col(column_id, *schema, read_options)) {
+        if (is_tso_placeholder_col(column_id, *schema, read_options)) {
             const Int64 commit_tso =
                     read_options.commit_tso.end_tso() == -1 ? 0 : read_options.commit_tso.end_tso();
             ZoneMap zone_map;
             zone_map.min_value = Field::create_field<TYPE_BIGINT>(commit_tso);
             zone_map.max_value = Field::create_field<TYPE_BIGINT>(commit_tso);
             zone_map.has_not_null = true;
-            if (!entry.second->evaluate_and(zone_map)) {
-                // any condition not satisfied, return.
-                *iter = std::make_unique<EmptySegmentIterator>(*schema);
-                read_options.stats->filtered_segment_number++;
+            const bool matched =
+                    collect_scan_filter_stats && entry.second->has_scan_filter()
+                            ? entry.second->evaluate_and_with_scan_filter(
+                                      zone_map, ScanFilterStage::INDEX_ZONE_MAP_SEGMENT,
+                                      cast_set<int64_t>(num_rows()))
+                            : entry.second->evaluate_and(zone_map);
+            if (matched) {
+                continue;
+            }
+            *segment_matched = false;
+            if (!collect_scan_filter_stats) {
                 return Status::OK();
             }
             continue;
         }
-        if (read_options.col_id_to_predicates.contains(column_id) &&
-            can_apply_predicate_safely(column_id, *schema,
-                                       read_options.target_cast_type_for_variants, read_options)) {
-            bool matched = true;
-            RETURN_IF_ERROR(reader->match_condition(entry.second.get(), &matched));
-            if (!matched) {
-                // any condition not satisfied, return.
-                *iter = std::make_unique<EmptySegmentIterator>(*schema);
-                read_options.stats->filtered_segment_number++;
-                return Status::OK();
-            }
+        if (!can_apply_predicate_safely(column_id, *schema,
+                                        read_options.target_cast_type_for_variants, read_options)) {
+            continue;
         }
+
+        bool matched = true;
+        if (collect_scan_filter_stats && entry.second->has_scan_filter()) {
+            RETURN_IF_ERROR(reader->match_condition_with_scan_filter(
+                    entry.second.get(), cast_set<int64_t>(num_rows()), &matched));
+        } else {
+            RETURN_IF_ERROR(reader->match_condition(entry.second.get(), &matched));
+        }
+        if (matched) {
+            continue;
+        }
+        *segment_matched = false;
+        if (!collect_scan_filter_stats) {
+            return Status::OK();
+        }
+    }
+    return Status::OK();
+}
+
+Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_options,
+                             std::unique_ptr<RowwiseIterator>* iter) {
+    if (read_options.runtime_state != nullptr) {
+        _be_exec_version = read_options.runtime_state->be_exec_version();
+    }
+    RETURN_IF_ERROR(_create_column_meta_once(read_options.stats));
+
+    read_options.stats->total_segment_number++;
+    // trying to prune the current segment by segment-level zone map
+    bool segment_matched = true;
+    RETURN_IF_ERROR(_prune_by_segment_zone_map(schema, read_options, &segment_matched));
+    if (!segment_matched) {
+        *iter = std::make_unique<EmptySegmentIterator>(*schema);
+        read_options.stats->filtered_segment_number++;
+        return Status::OK();
     }
 
     {

--- a/be/src/storage/segment/segment.h
+++ b/be/src/storage/segment/segment.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <butil/macros.h>
 #include <gen_cpp/olap_file.pb.h>
 #include <gen_cpp/segment_v2.pb.h>
 #include <glog/logging.h>
@@ -102,6 +101,8 @@ public:
     }
 
     ~Segment() override;
+    Segment(const Segment&) = delete;
+    Segment& operator=(const Segment&) = delete;
 
     int64_t get_metadata_size() const override;
     void update_metadata_size();
@@ -233,7 +234,6 @@ public:
             const io::FileReaderSPtr& file_reader);
 
 private:
-    DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(uint32_t segment_id, RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
             InvertedIndexFileInfo idx_file_info = InvertedIndexFileInfo());
     static Status _open(io::FileSystemSPtr fs, const std::string& path, uint32_t segment_id,
@@ -256,6 +256,8 @@ private:
     Status _open_index_file_reader();
 
     Status _create_column_meta_once(OlapReaderStatistics* stats);
+    Status _prune_by_segment_zone_map(SchemaSPtr schema, const StorageReadOptions& read_options,
+                                      bool* segment_matched);
 
     virtual Status _get_segment_footer(std::shared_ptr<SegmentFooterPB>&,
                                        OlapReaderStatistics* stats);

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -1234,11 +1234,6 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
         pre_size = condition_row_ranges->count();
         RowRanges::ranges_intersection(*condition_row_ranges, zone_map_row_ranges,
                                        condition_row_ranges);
-
-        size_t pre_size2 = condition_row_ranges->count();
-        RowRanges::ranges_intersection(*condition_row_ranges, zone_map_row_ranges,
-                                       condition_row_ranges);
-        _opts.stats->rows_stats_rp_filtered += (pre_size2 - condition_row_ranges->count());
         _opts.stats->rows_stats_filtered += (pre_size - condition_row_ranges->count());
     }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2635,18 +2635,21 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     for (const auto& pred : _pre_eval_block_predicate) {
         if (!pred->always_true()) {
             all_pred_always_true = false;
-        } else {
-            pred->update_filter_info(0, 0, selected_size);
-            if (pred->scan_filter_handle()) {
-                pred->scan_filter_handle().stats->record(ScanFilterStage::EXEC_VECTOR,
-                                                         selected_size, selected_size);
-            }
         }
     }
 
     const uint16_t original_size = selected_size;
     //If all predicates are always_true, then return directly.
     if (all_pred_always_true || !_is_need_vec_eval) {
+        for (const auto& pred : _pre_eval_block_predicate) {
+            if (pred->always_true()) {
+                pred->update_filter_info(0, 0, original_size);
+                if (pred->scan_filter_handle()) {
+                    pred->scan_filter_handle().stats->record(ScanFilterStage::EXEC_VECTOR,
+                                                             original_size, original_size);
+                }
+            }
+        }
         for (uint16_t i = 0; i < original_size; ++i) {
             sel_rowid_idx[i] = i;
         }
@@ -2662,6 +2665,11 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     const bool collect_scan_filter_stats = _opts.scan_filter_profile != nullptr;
     for (auto& pred : _pre_eval_block_predicate) {
         if (pred->always_true()) {
+            pred->update_filter_info(0, 0, current_selected_rows);
+            if (pred->scan_filter_handle()) {
+                pred->scan_filter_handle().stats->record(
+                        ScanFilterStage::EXEC_VECTOR, current_selected_rows, current_selected_rows);
+            }
             continue;
         }
         auto column_id = pred->column_id();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -1335,7 +1335,10 @@ Status SegmentIterator::_apply_index_expr() {
 
     std::unique_ptr<roaring::Roaring> scan_filter_profile_bitmap;
     for (const auto& expr_ctx : _common_expr_ctxs_push_down) {
-        const bool collect_scan_filter_stats = static_cast<bool>(expr_ctx->scan_filter_handle());
+        const bool collect_scan_filter_stats = _opts.scan_filter_profile != nullptr;
+        if (collect_scan_filter_stats) {
+            DCHECK(expr_ctx->scan_filter_handle());
+        }
         if (collect_scan_filter_stats && scan_filter_profile_bitmap == nullptr) {
             scan_filter_profile_bitmap = std::make_unique<roaring::Roaring>(_row_bitmap);
         }
@@ -1352,8 +1355,9 @@ Status SegmentIterator::_apply_index_expr() {
                 return st;
             }
         }
-        if (collect_scan_filter_stats && expr_ctx->get_index_context() != nullptr &&
-            expr_ctx->root() != nullptr) {
+        if (collect_scan_filter_stats) {
+            DCHECK(expr_ctx->get_index_context() != nullptr);
+            DCHECK(expr_ctx->root() != nullptr);
             const auto* result = expr_ctx->get_index_context()->get_index_result_for_expr(
                     expr_ctx->root().get());
             if (result != nullptr && result->get_data_bitmap() != nullptr) {
@@ -1394,7 +1398,8 @@ Status SegmentIterator::_apply_index_expr() {
                 _common_expr_to_slotref_map, _row_bitmap, ann_index_stats,
                 enable_ann_index_result_cache, &ann_range_search_executed));
         if (ann_range_search_executed) {
-            if (expr_ctx->scan_filter_handle()) {
+            if (_opts.scan_filter_profile != nullptr) {
+                DCHECK(expr_ctx->scan_filter_handle());
                 expr_ctx->scan_filter_handle().stats->record(
                         ScanFilterStage::INDEX_ANN, static_cast<int64_t>(origin_rows),
                         static_cast<int64_t>(_row_bitmap.cardinality()));

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -826,7 +826,13 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
     }
     size_t pre_size = _row_bitmap.cardinality();
     _row_bitmap &= RowRanges::ranges_to_roaring(result_ranges);
-    _opts.stats->rows_key_range_filtered += (pre_size - _row_bitmap.cardinality());
+    const size_t post_size = _row_bitmap.cardinality();
+    _opts.stats->rows_key_range_filtered += (pre_size - post_size);
+    if (_opts.key_range_scan_filter) {
+        _opts.key_range_scan_filter.stats->record(ScanFilterStage::KEY_RANGE,
+                                                  static_cast<int64_t>(pre_size),
+                                                  static_cast<int64_t>(post_size));
+    }
 
     return Status::OK();
 }
@@ -1186,10 +1192,8 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
                 continue;
             }
             // get row ranges by bf index of this column,
-            RowRanges column_bf_row_ranges = RowRanges::create_single(num_rows());
             RETURN_IF_ERROR(_column_iterators[cid]->get_row_ranges_by_bloom_filter(
-                    _opts.col_id_to_predicates.at(cid).get(), &column_bf_row_ranges));
-            RowRanges::ranges_intersection(bf_row_ranges, column_bf_row_ranges, &bf_row_ranges);
+                    _opts.col_id_to_predicates.at(cid).get(), &bf_row_ranges));
         }
 
         pre_size = condition_row_ranges->count();
@@ -1219,16 +1223,12 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
                 continue;
             }
             // get row ranges by zone map of this column,
-            RowRanges column_row_ranges = RowRanges::create_single(num_rows());
             RETURN_IF_ERROR(_column_iterators[cid]->get_row_ranges_by_zone_map(
                     _opts.col_id_to_predicates.at(cid).get(),
                     _opts.del_predicates_for_zone_map.count(cid) > 0
                             ? &(_opts.del_predicates_for_zone_map.at(cid))
                             : nullptr,
-                    &column_row_ranges));
-            // intersect different columns's row ranges to get final row ranges by zone map
-            RowRanges::ranges_intersection(zone_map_row_ranges, column_row_ranges,
-                                           &zone_map_row_ranges);
+                    &zone_map_row_ranges));
         }
 
         pre_size = condition_row_ranges->count();
@@ -1333,7 +1333,14 @@ Status SegmentIterator::_apply_index_expr() {
             !_opts.runtime_state->query_options().__isset.enable_ann_index_result_cache ||
             _opts.runtime_state->query_options().enable_ann_index_result_cache;
 
+    std::unique_ptr<roaring::Roaring> scan_filter_profile_bitmap;
     for (const auto& expr_ctx : _common_expr_ctxs_push_down) {
+        const bool collect_scan_filter_stats = static_cast<bool>(expr_ctx->scan_filter_handle());
+        if (collect_scan_filter_stats && scan_filter_profile_bitmap == nullptr) {
+            scan_filter_profile_bitmap = std::make_unique<roaring::Roaring>(_row_bitmap);
+        }
+        const size_t origin_rows =
+                collect_scan_filter_stats ? scan_filter_profile_bitmap->cardinality() : 0;
         if (Status st = expr_ctx->evaluate_inverted_index(num_rows()); !st.ok()) {
             if (_downgrade_without_index(st) || st.code() == ErrorCode::NOT_IMPLEMENTED_ERROR) {
                 continue;
@@ -1343,6 +1350,17 @@ Status SegmentIterator::_apply_index_expr() {
                              << expr_ctx->root()->debug_string()
                              << ", error msg: " << st.to_string();
                 return st;
+            }
+        }
+        if (collect_scan_filter_stats && expr_ctx->get_index_context() != nullptr &&
+            expr_ctx->root() != nullptr) {
+            const auto* result = expr_ctx->get_index_context()->get_index_result_for_expr(
+                    expr_ctx->root().get());
+            if (result != nullptr && result->get_data_bitmap() != nullptr) {
+                *scan_filter_profile_bitmap &= *result->get_data_bitmap();
+                expr_ctx->scan_filter_handle().stats->record(
+                        ScanFilterStage::INDEX_INVERTED, static_cast<int64_t>(origin_rows),
+                        static_cast<int64_t>(scan_filter_profile_bitmap->cardinality()));
             }
         }
     }
@@ -1376,6 +1394,11 @@ Status SegmentIterator::_apply_index_expr() {
                 _common_expr_to_slotref_map, _row_bitmap, ann_index_stats,
                 enable_ann_index_result_cache, &ann_range_search_executed));
         if (ann_range_search_executed) {
+            if (expr_ctx->scan_filter_handle()) {
+                expr_ctx->scan_filter_handle().stats->record(
+                        ScanFilterStage::INDEX_ANN, static_cast<int64_t>(origin_rows),
+                        static_cast<int64_t>(_row_bitmap.cardinality()));
+            }
             _opts.stats->ann_index_range_search_cnt++;
         }
         _opts.stats->rows_ann_index_range_filtered += (origin_rows - _row_bitmap.cardinality());
@@ -1455,6 +1478,7 @@ Status SegmentIterator::_apply_inverted_index_on_column_predicate(
     } else {
         bool need_remaining_after_evaluate = _column_has_fulltext_index(pred->column_id()) &&
                                              PredicateTypeTraits::is_equal_or_list(pred->type());
+        const size_t rows_before = _row_bitmap.cardinality();
         Status res =
                 pred->evaluate(_storage_name_and_type[pred->column_id()],
                                _index_iterators[pred->column_id()].get(), num_rows(), &_row_bitmap);
@@ -1467,6 +1491,12 @@ Status SegmentIterator::_apply_inverted_index_on_column_predicate(
                          << ", column predicate type: " << pred->pred_type_string(pred->type())
                          << ", error msg: " << res;
             return res;
+        }
+        const size_t rows_after = _row_bitmap.cardinality();
+        if (pred->scan_filter_handle()) {
+            pred->scan_filter_handle().stats->record(ScanFilterStage::INDEX_INVERTED,
+                                                     static_cast<int64_t>(rows_before),
+                                                     static_cast<int64_t>(rows_after));
         }
 
         if (_row_bitmap.isEmpty()) {
@@ -2602,6 +2632,10 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
             all_pred_always_true = false;
         } else {
             pred->update_filter_info(0, 0, selected_size);
+            if (pred->scan_filter_handle()) {
+                pred->scan_filter_handle().stats->record(ScanFilterStage::EXEC_VECTOR,
+                                                         selected_size, selected_size);
+            }
         }
     }
 
@@ -2619,6 +2653,8 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     _ret_flags.resize(original_size);
     DCHECK(!_pre_eval_block_predicate.empty());
     bool is_first = true;
+    int64_t current_selected_rows = original_size;
+    const bool collect_scan_filter_stats = _opts.scan_filter_profile != nullptr;
     for (auto& pred : _pre_eval_block_predicate) {
         if (pred->always_true()) {
             continue;
@@ -2630,6 +2666,15 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
             is_first = false;
         } else {
             pred->evaluate_and_vec(*column, original_size, (bool*)_ret_flags.data());
+        }
+        if (collect_scan_filter_stats) {
+            const int64_t output_rows =
+                    std::count(_ret_flags.begin(), _ret_flags.begin() + original_size, 1);
+            if (pred->scan_filter_handle()) {
+                pred->scan_filter_handle().stats->record(ScanFilterStage::EXEC_VECTOR,
+                                                         current_selected_rows, output_rows);
+            }
+            current_selected_rows = output_rows;
         }
     }
 
@@ -2680,7 +2725,12 @@ uint16_t SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_ro
     for (auto predicate : _short_cir_eval_predicate) {
         auto column_id = predicate->column_id();
         auto& short_cir_column = _current_return_columns[column_id];
+        const uint16_t rows_before = selected_size;
         selected_size = predicate->evaluate(*short_cir_column, vec_sel_rowid_idx, selected_size);
+        if (predicate->scan_filter_handle()) {
+            predicate->scan_filter_handle().stats->record(ScanFilterStage::EXEC_SHORT_CIRCUIT,
+                                                          rows_before, selected_size);
+        }
     }
 
     _opts.stats->short_circuit_cond_input_rows += original_size;
@@ -3208,7 +3258,8 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
 
     IColumn::Filter filter;
     RETURN_IF_ERROR(VExprContext::execute_conjuncts_and_filter_block(
-            _common_expr_ctxs_push_down, block, _columns_to_filter, prev_columns, filter));
+            _common_expr_ctxs_push_down, block, _columns_to_filter, prev_columns, filter,
+            ScanFilterStage::EXEC_COMMON_EXPR));
 
     selected_size = _evaluate_common_expr_filter(sel_rowid_idx, selected_size, filter);
     _opts.stats->rows_expr_cond_filtered += original_size - selected_size;

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -133,8 +133,10 @@ public:
     int64_t tablet_id() const { return _tablet_id; }
 
     void update_profile(RuntimeProfile* profile) override {
-        _update_profile(profile, _short_cir_eval_predicate, "ShortCircuitPredicates");
-        _update_profile(profile, _pre_eval_block_predicate, "PreEvaluatePredicates");
+        if (_opts.scan_filter_profile == nullptr) {
+            _update_profile(profile, _short_cir_eval_predicate, "ShortCircuitPredicates");
+            _update_profile(profile, _pre_eval_block_predicate, "PreEvaluatePredicates");
+        }
 
         if (_opts.delete_condition_predicates != nullptr) {
             std::set<std::shared_ptr<const ColumnPredicate>> delete_predicate_set;

--- a/be/src/storage/tablet/tablet_reader.cpp
+++ b/be/src/storage/tablet/tablet_reader.cpp
@@ -232,6 +232,8 @@ Status TabletReader::_init_params(const ReaderParams& read_params) {
     _tablet = read_params.tablet;
     _tablet_schema = read_params.tablet_schema;
     _reader_context.runtime_state = read_params.runtime_state;
+    _reader_context.scan_filter_profile = read_params.scan_filter_profile;
+    _reader_context.key_range_scan_filter = read_params.key_range_scan_filter;
     _reader_context.target_cast_type_for_variants = read_params.target_cast_type_for_variants;
 
     RETURN_IF_ERROR(_init_conditions_param(read_params));
@@ -505,8 +507,10 @@ std::shared_ptr<ColumnPredicate> TabletReader::_parse_to_predicate(
         return nullptr;
     }
     const TabletColumn& column = materialize_column(_tablet_schema->column(index));
-    return create_column_predicate(index, std::make_shared<FunctionFilter>(function_filter),
-                                   column.type(), &column);
+    auto predicate = create_column_predicate(
+            index, std::make_shared<FunctionFilter>(function_filter), column.type(), &column);
+    predicate->attach_scan_filter(function_filter._scan_filter_handle);
+    return predicate;
 }
 
 Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {

--- a/be/src/storage/tablet/tablet_reader.h
+++ b/be/src/storage/tablet/tablet_reader.h
@@ -56,6 +56,7 @@ class ColumnPredicate;
 class DeleteBitmap;
 class HybridSetBase;
 class RuntimeProfile;
+class ScanFilterProfile;
 
 class VCollectIterator;
 class Block;
@@ -160,6 +161,8 @@ public:
         std::set<int32_t> output_columns;
         RuntimeProfile* profile = nullptr;
         RuntimeState* runtime_state = nullptr;
+        std::shared_ptr<ScanFilterProfile> scan_filter_profile;
+        ScanFilterHandle key_range_scan_filter;
 
         // use only in vec exec engine
         std::vector<ColumnId>* origin_return_columns = nullptr;


### PR DESCRIPTION
```sql
SELECT 'sfp_key_range_and_exec' AS case_name, count(*) AS cnt
FROM sfp_fact
WHERE k1 BETWEEN 1000 AND 18000
  AND v BETWEEN 10 AND 20;
  
              KeyRangeInfo:
                 - SourceFilterIds: 0,1
                 - ScanKeys: [1000 : 1354]; [1355 : 1709]; [1710 : 2064]; [2065 : 2419]; [2420 : 2774]; [2775 : 3129]; [3130 : 3484]; [3485 : 3839]; [3840 : 4194]; [4195 : 4549]; [4550 : 4904]; [4905 : 5259]; [5260 : 5614]; [5615 : 5969]; [5970 : 6324]; [6325 : 6679]; [6680 : 7034]; [7035 : 7389]; [7390 : 7744]; [7745 : 8099]; [8100 : 8454]; [8455 : 8809]; [8810 : 9164]; [9165 : 9519]; [9520 : 9874]; [9875 : 10229]; [10230 : 10584]; [10585 : 10939]; [10940 : 11294]; [11295 : 11649]; [11650 : 12004]; [12005 : 12359]; ... 16 more
                 - FilteredRows: 2.999K (2999)
                 - InputRows: 20.0K (20000)
                 - RangeNum: 48
              ScanFilterInfo:
                ScanFilter 0:
                   - Source: Conjunct
                   - Stages: KeyRangeInfo
                ScanFilter 1:
                   - Source: Conjunct
                   - Stages: KeyRangeInfo
                ScanFilter 2:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(1.70K)
                   - FilteredRows: 1.701K (1701)
                ScanFilter 3:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(13.43K)
                   - FilteredRows: 13.43K (13430)
```


```sql
SELECT 'sfp_runtime_filter_join' AS case_name, count(*) AS cnt
FROM sfp_fact f
JOIN sfp_dim d ON f.k2 = d.k2
WHERE d.k2 BETWEEN 5 AND 10
  AND f.v BETWEEN 20 AND 80;

              ScanFilterInfo:
                 - RuntimeFilterAcquireTime: 101.80us
                ScanFilter 0:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(1.56K)
                   - FilteredRows: 1.565K (1565)
                ScanFilter 1:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(16.56K)
                   - FilteredRows: 16.557K (16557)
                ScanFilter 2:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(378)
                   - FilteredRows: 378
                ScanFilter 3:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(363)
                   - FilteredRows: 363
                ScanFilter 4:
                   - Source: RuntimeFilter rf_id=0
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(0)
                   - RuntimeFilterInfo: Consumer: ([id: 0, state: [READY], type: MINMAX_FILTER, column_type: INT], mode: LOCAL, stage: 0, state: APPLIED, reached_timeout: false, timeout_limit: 900000ms)
                   - AlwaysTrueFilterRows: 0
                   - WaitTime: 5.0ms
                ScanFilter 5:
                   - Source: RuntimeFilter rf_id=0
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(0)
                ScanFilter 6:
                   - Source: RuntimeFilter rf_id=1
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteShortCircuit(0)
                   - RuntimeFilterInfo: Consumer: ([id: 1, state: [READY], type: IN_OR_BLOOM_FILTER(IN_FILTER), column_type: INT, size: 6, max_in_num: 40960], mode: LOCAL, stage: 0, state: APPLIED, reached_timeout: false, timeout_limit: 900000ms)
                   - AlwaysTrueFilterRows: 0
                   - WaitTime: 5.0ms
```

```sql
SELECT 'sfp_mix_or_compound' AS case_name, count(*) AS cnt
FROM sfp_index_mix
WHERE k1 BETWEEN 5000 AND 45000
  AND ((category = 'cat_3' AND bf_tag = 'bf_3') OR (category = 'cat_7' AND bf_tag = 'bf_7'))
  AND (search('title:alpha') OR search('content:payment'))
  AND ngram_text LIKE '%needle_3%'

ScanFilterInfo:
                ScanFilter 0:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(142)
                   - FilteredRows: 142
                ScanFilter 1:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexZoneMapPage(0) -> ExecuteVector(142)
                   - FilteredRows: 142
                ScanFilter 2:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexInverted(40.00K) -> IndexDict(0) -> IndexZoneMapPage(0)
                   - FilteredRows: 40.0K (40000)
                ScanFilter 3:
                   - Source: Conjunct
                   - Stages: IndexZoneMapSegment(0) -> IndexDict(0) -> IndexBloomFilter(0) -> IndexZoneMapPage(0) -> ExecuteShortCircuit(858)
                   - FilteredRows: 858
                ScanFilter 4:
                   - Source: Conjunct
                   - Stages: ExecuteCommonExpr(143)
                   - FilteredRows: 143
                ScanFilter 5:
                   - Source: Conjunct
                   - Stages: IndexInverted(8.57K)
                   - FilteredRows: 8.572K (8572)
                ScanFilter 6:
                   - Source: Conjunct
                   - Stages: ExecuteCommonExpr(72)
                   - FilteredRows: 72
```