### PR TITLE
[fix](build) Strip sanitizer and platform-specific flags for OpenBLAS/FAISS

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -470,7 +470,10 @@ set(CXX_FLAGS_ASAN_UT "-O0 -fsanitize=address -DADDRESS_SANITIZER")
 
 # Set the flags to the undefined behavior sanitizer, also known as "ubsan"
 # Turn on sanitizer and debug symbols to get stack traces:
-set(CXX_FLAGS_UBSAN "-O0 -fno-wrapv -mcmodel=medium -fsanitize=undefined -DUNDEFINED_BEHAVIOR_SANITIZER")
+set(CXX_FLAGS_UBSAN "-O0 -fno-wrapv -fsanitize=undefined -DUNDEFINED_BEHAVIOR_SANITIZER")
+if (ARCH_AMD64)
+    set(CXX_FLAGS_UBSAN "${CXX_FLAGS_UBSAN} -mcmodel=medium")
+endif()
 
 # Set the flags to the thread sanitizer, also known as "tsan"
 # Turn on sanitizer and debug symbols to get stack traces:

--- a/be/src/common/phdr_cache.cpp
+++ b/be/src/common/phdr_cache.cpp
@@ -107,7 +107,7 @@ extern "C"
 */
 
 extern "C" {
-#ifdef ADDRESS_SANITIZER
+#if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER)
 void __lsan_ignore_object(const void*);
 #else
 void __lsan_ignore_object(const void*) {} // NOLINT

--- a/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
+++ b/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
@@ -16,6 +16,19 @@
 # under the License.
 
 # Make sure compile check in doris will not break compilation of faiss and openblas
+# Strip sanitizer flags to prevent build-time tools (e.g., openblas getarch) from
+# triggering LeakSanitizer/AddressSanitizer errors during CMake configure phase
+string(REGEX REPLACE "-fsanitize=[a-z,=_./-]+" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "-fsanitize=[a-z,=_./-]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-fno-sanitize=[a-z,=_./-]+" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "-fno-sanitize=[a-z,=_./-]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-fsanitize-ignorelist=[a-z,=_./-]+" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "-fsanitize-ignorelist=[a-z,=_./-]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-D[A-Z_]+SANITIZER" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "-D[A-Z_]+SANITIZER" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+# Strip -mcmodel= which is x86_64-specific and unsupported on aarch64
+string(REGEX REPLACE "-mcmodel=[a-z]+" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "-mcmodel=[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64170

Related PR: #xxx

Problem Summary: On aarch64, building Doris BE with LSAN/ASAN/ASAN_UT/UBSAN sanitizer modes fails. This PR contains two commits to fix the issues.

---

**Commit 1: Strip sanitizer and platform-specific flags for OpenBLAS/FAISS, cause run be ut failure on aarch64**

1. **LSAN/ASAN/ASAN_UT - CMake configuration failure**: The OpenBLAS getarch build-time tool inherits sanitizer flags from the parent CMake context, causing LeakSanitizer to detect memory leaks in OpenBLAS's `detect()` function (strdup without free on aarch64). This makes getarch exit with non-zero code and CMake configuration fails.

   Fix: Strip sanitizer flags (`-fsanitize=*`, `-fno-sanitize=*`, `-fsanitize-ignorelist=*`) and `-D*SANITIZER` defines from `CMAKE_C_FLAGS`/`CMAKE_CXX_FLAGS` in `cmake-protect/CMakeLists.txt` before building OpenBLAS and FAISS.

2. **UBSAN - `-mcmodel=medium` unsupported on aarch64**: `-mcmodel=medium` is x86_64-specific and hardcoded in `CXX_FLAGS_UBSAN`, causing compilation failure in both OpenBLAS getarch and Doris BE targets.

   Fix: Move `-mcmodel=medium` in `CXX_FLAGS_UBSAN` to only apply on `ARCH_AMD64`. Also strip `-mcmodel=` in cmake-protect for OpenBLAS/FAISS.

3. **TSAN - CMake configuration failure**: The OpenBLAS getarch build-time tool inherits `-fsanitize=thread` flag, causing getarch to produce incorrect output with undefined macros.

   Fix: Covered by the same sanitizer flag stripping in cmake-protect. Verified TSAN works on aarch64 after the fix.

4. **LSAN link error**: `__lsan_ignore_object` was only enabled under `ADDRESS_SANITIZER`, but `LEAK_SANITIZER` also provides this symbol. Under LSAN mode, the empty stub was incorrectly used, causing link errors.

   Fix: Enable `__lsan_ignore_object` under both `ADDRESS_SANITIZER` and `LEAK_SANITIZER` in `phdr_cache.cpp`.

Files changed:
- `be/src/storage/index/ann/cmake-protect/CMakeLists.txt` — Strip sanitizer flags and `-mcmodel=`
- `be/CMakeLists.txt` — `-mcmodel=medium` only on `ARCH_AMD64`
- `be/src/common/phdr_cache.cpp` — `__lsan_ignore_object` for `LEAK_SANITIZER`

---

**Commit 2: Fix UBSAN compilation failures on aarch64**

After fixing `-mcmodel=medium` in commit 1, UBSAN build on aarch64 still fails due to `-Wunused-macros` errors (promoted to errors by `-Werror`):

1. **`-Wno-unused-macros` suppression not working for flex/bison generated files**: In `be/src/exprs/CMakeLists.txt`, `-Wno-unused-macros` was incorrectly gated behind the `-Wno-unused-but-set-variable` compiler flag check. If `-Wno-unused-but-set-variable` was not supported by the compiler, `-Wno-unused-macros` would also be skipped, causing flex/bison generated files (`wkt_lex.l.cpp`, `wkt_yacc.y.cpp`) to fail with unused macro errors.

   Fix: Separate the two flag checks into independent `check_cxx_compiler_flag` / `if` blocks.

2. **Unused `#define PMR` macro in `function_string_misc.cpp`**: The `PMR` macro was defined but never used anywhere in the file.

   Fix: Remove the unused `#define PMR` macros.

3. **Unused `ALIGN_CACHE_LINE` and `PURE` macros in `compiler_util.h`**: These macros are defined but never used anywhere in the codebase.

   Fix: Remove the unused macro definitions.

Files changed:
- `be/src/exprs/CMakeLists.txt` — Separate `-Wno-unused-macros` from `-Wno-unused-but-set-variable` conditional
- `be/src/exprs/function/function_string_misc.cpp` — Remove unused `#define PMR`
- `be/src/common/compiler_util.h` — Remove unused `ALIGN_CACHE_LINE` and `PURE`

---

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (Verified LSAN/ASAN/ASAN_UT BE UT can build and run successfully on aarch64; UBSAN pending verification)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason? -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
