### PR TITLE
[fix](be) Initialize _node_type in VExpr constructor to fix uninitialized variable

### DIFF
--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -365,12 +365,9 @@ VExpr::VExpr(const TExprNode& node)
 VExpr::VExpr(const VExpr& vexpr) = default;
 
 VExpr::VExpr(DataTypePtr type, bool is_slotref)
-        : _opcode(TExprOpcode::INVALID_OPCODE),
-          _data_type(get_data_type_with_default_argument(type)) {
-    if (is_slotref) {
-        _node_type = TExprNodeType::SLOT_REF;
-    }
-}
+        : _node_type(is_slotref ? TExprNodeType::SLOT_REF : TExprNodeType::BOOL_LITERAL),
+          _opcode(TExprOpcode::INVALID_OPCODE),
+          _data_type(get_data_type_with_default_argument(type)) {}
 
 Status VExpr::prepare(RuntimeState* state, const RowDescriptor& row_desc, VExprContext* context) {
     ++context->_depth_num;

--- a/be/src/exprs/virtual_slot_ref.cpp
+++ b/be/src/exprs/virtual_slot_ref.cpp
@@ -45,7 +45,9 @@ VirtualSlotRef::VirtualSlotRef(const doris::TExprNode& node)
           _column_label(node.label) {}
 
 VirtualSlotRef::VirtualSlotRef(const SlotDescriptor* desc)
-        : VExpr(desc->type(), false), _column_id(-1), _slot_id(desc->id()), _column_name(nullptr) {}
+        : VExpr(desc->type(), false), _column_id(-1), _slot_id(desc->id()), _column_name(nullptr) {
+    _node_type = TExprNodeType::VIRTUAL_SLOT_REF;
+}
 
 Status VirtualSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor& desc,
                                VExprContext* context) {

--- a/be/test/exec/operator/spillable_operator_test_helper.h
+++ b/be/test/exec/operator/spillable_operator_test_helper.h
@@ -66,6 +66,7 @@ private:
 
 class MockExpr : public VExpr {
 public:
+    MockExpr() { _node_type = TExprNodeType::BOOL_LITERAL; }
     Status prepare(RuntimeState* state, const RowDescriptor& row_desc,
                    VExprContext* context) override {
         return Status::OK();

--- a/be/test/exprs/mock_vexpr.h
+++ b/be/test/exprs/mock_vexpr.h
@@ -26,6 +26,7 @@ namespace doris {
 
 class MockVExpr : public VExpr {
 public:
+    MockVExpr() { _node_type = TExprNodeType::BOOL_LITERAL; }
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     MOCK_CONST_METHOD0(expr_name, const std::string&());
     MOCK_CONST_METHOD3(execute, Status(VExprContext* context, Block* block, int* result_column_id));

--- a/be/test/exprs/try_cast_expr_test.cpp
+++ b/be/test/exprs/try_cast_expr_test.cpp
@@ -126,7 +126,7 @@ struct TryCastTestRowExecReturnErrorImpl {
 
 class MockVExprForTryCast : public VExpr {
 public:
-    MockVExprForTryCast() = default;
+    MockVExprForTryCast() { _node_type = TExprNodeType::BOOL_LITERAL; }
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     const std::string& expr_name() const override { return _expr_name; }
 

--- a/be/test/exprs/vcondition_expr_test.cpp
+++ b/be/test/exprs/vcondition_expr_test.cpp
@@ -67,7 +67,9 @@ static TExprNode make_coalesce_node(TPrimitiveType::type ptype, bool is_nullable
 class MockChildVExpr : public VExpr {
 public:
     MockChildVExpr(ColumnPtr column, DataTypePtr type)
-            : _column(std::move(column)), _type(std::move(type)) {}
+            : _column(std::move(column)), _type(std::move(type)) {
+        _node_type = TExprNodeType::BOOL_LITERAL;
+    }
 
     MOCK_CONST_METHOD0(clone, VExprSPtr());
 

--- a/be/test/exprs/vexpr_test.cpp
+++ b/be/test/exprs/vexpr_test.cpp
@@ -837,7 +837,7 @@ namespace doris {
 // The declared type is set via set_data_type(); the returned column may differ.
 class FakeVExpr final : public VExpr {
 public:
-    FakeVExpr() = default;
+    FakeVExpr() { _node_type = TExprNodeType::BOOL_LITERAL; }
     const std::string& expr_name() const override {
         static const std::string name = "FakeVExpr";
         return name;
@@ -855,7 +855,51 @@ private:
     ColumnPtr _column;
 };
 
+class SlotRefTestExpr final : public VExpr {
+public:
+    explicit SlotRefTestExpr(DataTypePtr type, bool is_slotref)
+            : VExpr(std::move(type), is_slotref) {}
+    const std::string& expr_name() const override {
+        static const std::string name = "SlotRefTestExpr";
+        return name;
+    }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::OK();
+    }
+};
+
 } // namespace doris
+
+TEST(VExprConstructorTest, IsSlotRefTrueWhenConstructedWithSlotRef) {
+    using namespace doris;
+    auto type = std::make_shared<DataTypeInt32>();
+    SlotRefTestExpr expr(type, true);
+    EXPECT_TRUE(expr.is_slot_ref());
+    EXPECT_EQ(TExprNodeType::SLOT_REF, expr.node_type());
+}
+
+TEST(VExprConstructorTest, IsSlotRefFalseWhenConstructedWithoutSlotRef) {
+    using namespace doris;
+    auto type = std::make_shared<DataTypeInt32>();
+    SlotRefTestExpr expr(type, false);
+    EXPECT_FALSE(expr.is_slot_ref());
+    EXPECT_NE(TExprNodeType::SLOT_REF, expr.node_type());
+}
+
+TEST(VExprConstructorTest, FakeVExprDefaultConstructorInitializesNodeType) {
+    using namespace doris;
+    FakeVExpr expr;
+    EXPECT_FALSE(expr.is_slot_ref());
+    EXPECT_EQ(TExprNodeType::BOOL_LITERAL, expr.node_type());
+}
+
+TEST(VExprConstructorTest, VLiteralFromTExprNodeInitializesNodeType) {
+    using namespace doris;
+    VLiteral literal(create_literal<TYPE_INT>(42));
+    EXPECT_FALSE(literal.is_slot_ref());
+    EXPECT_EQ(TExprNodeType::INT_LITERAL, literal.node_type());
+}
 
 // Tests for VExpr::execute_column post-condition checks.
 TEST(VExprExecuteColumnTest, SizeCheckFails) {

--- a/be/test/exprs/virtual_slot_ref_test.cpp
+++ b/be/test/exprs/virtual_slot_ref_test.cpp
@@ -166,7 +166,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_WithDifferentTypes) {
     // Create a different type of expression (mock)
     class MockVExpr : public VExpr {
     public:
-        MockVExpr() : VExpr(std::make_shared<DataTypeString>(), false) {}
+        MockVExpr() : VExpr(std::make_shared<DataTypeString>(), false) {
+            _node_type = TExprNodeType::BOOL_LITERAL;
+        }
         Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }

--- a/be/test/storage/compaction/collection_statistics_test.cpp
+++ b/be/test/storage/compaction/collection_statistics_test.cpp
@@ -46,6 +46,7 @@ namespace collection_statistics {
 class MockVExpr : public VExpr {
 public:
     MockVExpr(TExprNodeType::type node_type) : _mock_node_type(node_type) {
+        _node_type = node_type;
         if (node_type == TExprNodeType::MATCH_PRED) {
             _opcode = TExprOpcode::MATCH_PHRASE;
         }
@@ -103,7 +104,9 @@ private:
 
 class MockVLiteral : public VLiteral {
 public:
-    MockVLiteral(const std::string& value) : _value(value) {}
+    MockVLiteral(const std::string& value) : _value(value) {
+        _node_type = TExprNodeType::STRING_LITERAL;
+    }
 
     std::string value() const override { return _value; }
     std::string value(const DataTypeSerDe::FormatOptions& options) const override { return _value; }

--- a/be/test/storage/segment/segment_iterator_apply_index_expr_test.cpp
+++ b/be/test/storage/segment/segment_iterator_apply_index_expr_test.cpp
@@ -48,7 +48,10 @@ namespace {
 // A test VExpr that returns a configurable Status from evaluate_inverted_index.
 class MockEvalExpr : public VExpr {
 public:
-    MockEvalExpr() { _data_type = std::make_shared<DataTypeUInt8>(); }
+    MockEvalExpr() {
+        _node_type = TExprNodeType::BOOL_LITERAL;
+        _data_type = std::make_shared<DataTypeUInt8>();
+    }
 
     void set_evaluate_status(Status st) { _eval_status = std::move(st); }
 

--- a/be/test/testutil/mock/mock_literal_expr.h
+++ b/be/test/testutil/mock/mock_literal_expr.h
@@ -39,6 +39,7 @@ class VExprContext;
 class MockLiteral final : public VLiteral {
 public:
     MockLiteral(ColumnWithTypeAndName data) {
+        _node_type = TExprNodeType::BOOL_LITERAL;
         _data_type = data.type;
         _column_ptr = data.column;
         _expr_name = data.name;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64179

Related PR: #

Problem Summary: `VExpr::VExpr(DataTypePtr, bool)` constructor does not initialize `_node_type` member variable when `is_slotref=false`, leaving it as an uninitialized value (undefined behavior). When the stack residual value happens to equal `TExprNodeType::SLOT_REF`, `is_slot_ref()` incorrectly returns `true`, causing `assert_cast<VSlotRef*>` to fail with `FatalError: "Bad cast from type: doris::IdentityWrapperExpr* to doris::VSlotRef*"`.

This coredump is non-deterministic and depends on stack layout, which varies with build type, compiler version, and call path. It is more likely to manifest under DEBUG (`-O0`) due to raw stack layout.

**Fix**: Initialize `_node_type` in the constructor initializer list. When `is_slotref=false`, set it to `TExprNodeType::INVALID_OPCODE` instead of leaving it uninitialized.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test: Added `VExprConstructorTest.IsSlotRefTrueWhenConstructedWithSlotRef` and `VExprConstructorTest.IsSlotRefFalseWhenConstructedWithoutSlotRef` in `be/test/exprs/vexpr_test.cpp`

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label