### PR TITLE
[fix](be) Use safe file cache clear for sync requests

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -53,6 +53,7 @@
 #include "io/cache/mem_file_cache_storage.h"
 #include "runtime/runtime_profile.h"
 #include "util/concurrency_stats.h"
+#include "util/defer_op.h"
 #include "util/stack_util.h"
 #include "util/stopwatch.hpp"
 #include "util/thread.h"
@@ -592,6 +593,21 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
     }
 
     FileBlocks result;
+    auto use_visible_cell = [&](const FileBlockCell& cell) {
+        if (cell.file_block->is_deleting()) {
+            FileCacheKey key;
+            key.hash = hash;
+            key.offset = cell.file_block->offset();
+            key.meta.type = context.cache_type;
+            key.meta.expiration_time = context.expiration_time;
+            key.meta.tablet_id = context.tablet_id;
+            result.push_back(std::make_shared<FileBlock>(key, cell.file_block->range().size(), this,
+                                                         FileBlock::State::SKIP_CACHE));
+            return;
+        }
+        use_cell(cell, &result, need_to_move(cell.file_block->cache_type(), context.cache_type),
+                 cache_lock);
+    };
     auto block_it = file_blocks.lower_bound(range.left);
     if (block_it == file_blocks.end()) {
         /// N - last cached block for given file hash, block{N}.offset < range.left:
@@ -606,8 +622,7 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
             return {};
         }
 
-        use_cell(cell, &result, need_to_move(cell.file_block->cache_type(), context.cache_type),
-                 cache_lock);
+        use_visible_cell(cell);
     } else { /// block_it <-- segmment{k}
         if (block_it != file_blocks.begin()) {
             const auto& prev_cell = std::prev(block_it)->second;
@@ -620,9 +635,7 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
                 ///       ^
                 ///       range.left
 
-                use_cell(prev_cell, &result,
-                         need_to_move(prev_cell.file_block->cache_type(), context.cache_type),
-                         cache_lock);
+                use_visible_cell(prev_cell);
             }
         }
 
@@ -638,8 +651,7 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
                 break;
             }
 
-            use_cell(cell, &result, need_to_move(cell.file_block->cache_type(), context.cache_type),
-                     cache_lock);
+            use_visible_cell(cell);
             ++block_it;
         }
     }
@@ -656,51 +668,74 @@ void BlockFileCache::add_need_update_lru_block(FileBlockSPtr block) {
 std::string BlockFileCache::clear_file_cache_async() {
     LOG(INFO) << "start clear_file_cache_async, path=" << _cache_base_path;
     _lru_dumper->remove_lru_dump_files();
-    int64_t num_cells_all = 0;
-    int64_t num_cells_to_delete = 0;
-    int64_t num_cells_wait_recycle = 0;
-    int64_t num_files_all = 0;
     TEST_SYNC_POINT_CALLBACK("BlockFileCache::clear_file_cache_async");
+    auto summary = clear_file_cache_common(false);
+
+    std::stringstream ss;
+    ss << "finish clear_file_cache_async, path=" << _cache_base_path
+       << " num_files_all=" << summary.num_files_all << " num_cells_all=" << summary.num_cells_all
+       << " num_cells_to_delete=" << summary.num_cells_to_delete
+       << " num_cells_wait_recycle=" << summary.num_cells_wait_recycle;
+    auto msg = ss.str();
+    LOG(INFO) << msg;
+    _lru_dumper->remove_lru_dump_files();
+    return msg;
+}
+
+std::string BlockFileCache::clear_file_cache_sync() {
+    LOG(INFO) << "start clear_file_cache_sync, path=" << _cache_base_path;
+    pause_ttl_manager();
+    Defer resume_ttl_manager_guard {[this] { resume_ttl_manager(); }};
+
+    _lru_dumper->remove_lru_dump_files();
+    TEST_SYNC_POINT_CALLBACK("BlockFileCache::clear_file_cache_sync");
+    auto summary = clear_file_cache_common(true);
+
+    std::stringstream ss;
+    ss << "finish clear_file_cache_sync, path=" << _cache_base_path
+       << " num_files_all=" << summary.num_files_all << " num_cells_all=" << summary.num_cells_all
+       << " num_cells_to_delete=" << summary.num_cells_to_delete
+       << " num_cells_wait_recycle=" << summary.num_cells_wait_recycle;
+    auto msg = ss.str();
+    LOG(INFO) << msg;
+    _lru_dumper->remove_lru_dump_files();
+    return msg;
+}
+
+BlockFileCache::ClearFileCacheSummary BlockFileCache::clear_file_cache_common(
+        bool sync_remove_releasable) {
+    ClearFileCacheSummary summary;
     {
         SCOPED_CACHE_LOCK(_mutex, this);
 
         std::vector<FileBlockCell*> deleting_cells;
         for (auto& [_, offset_to_cell] : _files) {
-            ++num_files_all;
+            ++summary.num_files_all;
             for (auto& [_1, cell] : offset_to_cell) {
-                ++num_cells_all;
+                ++summary.num_cells_all;
                 deleting_cells.push_back(&cell);
             }
         }
 
-        // we cannot delete the element in the loop above, because it will break the iterator
+        // Removing cells invalidates _files iterators, so the scan first records cell pointers.
         for (auto& cell : deleting_cells) {
             if (!cell->releasable()) {
                 LOG(INFO) << "cell is not releasable, hash="
                           << " offset=" << cell->file_block->offset();
                 cell->file_block->set_deleting();
-                ++num_cells_wait_recycle;
+                ++summary.num_cells_wait_recycle;
                 continue;
             }
             FileBlockSPtr file_block = cell->file_block;
             if (file_block) {
                 std::lock_guard block_lock(file_block->_mutex);
-                remove(file_block, cache_lock, block_lock, false);
-                ++num_cells_to_delete;
+                remove(file_block, cache_lock, block_lock, sync_remove_releasable);
+                ++summary.num_cells_to_delete;
             }
         }
         clear_need_update_lru_blocks();
     }
-
-    std::stringstream ss;
-    ss << "finish clear_file_cache_async, path=" << _cache_base_path
-       << " num_files_all=" << num_files_all << " num_cells_all=" << num_cells_all
-       << " num_cells_to_delete=" << num_cells_to_delete
-       << " num_cells_wait_recycle=" << num_cells_wait_recycle;
-    auto msg = ss.str();
-    LOG(INFO) << msg;
-    _lru_dumper->remove_lru_dump_files();
-    return msg;
+    return summary;
 }
 
 FileBlocks BlockFileCache::split_range_into_cells(const UInt128Wrapper& hash,

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -240,12 +240,10 @@ public:
      */
     void add_need_update_lru_block(FileBlockSPtr block);
 
-    /**
-     * Clear all cached data for this cache instance async
-     *
-     * @returns summary message
-     */
+    /// Clear all cached data for this cache instance using the safe async cleanup path.
     std::string clear_file_cache_async();
+    /// Run a safe clear scan and synchronously remove blocks that are releasable during the scan.
+    std::string clear_file_cache_sync();
     std::string clear_file_cache_directly();
 
     /**
@@ -396,6 +394,13 @@ public:
     Status check_file_cache_consistency(InconsistencyContext& inconsistency_context);
 
 private:
+    struct ClearFileCacheSummary {
+        int64_t num_files_all = 0;
+        int64_t num_cells_all = 0;
+        int64_t num_cells_to_delete = 0;
+        int64_t num_cells_wait_recycle = 0;
+    };
+
     LRUQueue& get_queue(FileCacheType type);
     const LRUQueue& get_queue(FileCacheType type) const;
 
@@ -490,6 +495,7 @@ private:
 
     void remove_file_blocks(std::vector<FileBlockCell*>&, std::lock_guard<std::mutex>&, bool sync,
                             std::string& reason);
+    ClearFileCacheSummary clear_file_cache_common(bool sync_remove_releasable);
 
     void find_evict_candidates(LRUQueue& queue, size_t size, size_t cur_cache_size,
                                size_t& removed_size, std::vector<FileBlockCell*>& to_evict,

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -252,15 +252,13 @@ std::string FileCacheFactory::clear_file_caches(bool sync) {
 #ifndef USE_LIBCPP
     std::for_each(std::execution::par, _caches.begin(), _caches.end(), [&](const auto& cache) {
         size_t index = &cache - &_caches[0];
-        results[index] =
-                sync ? cache->clear_file_cache_directly() : cache->clear_file_cache_async();
+        results[index] = sync ? cache->clear_file_cache_sync() : cache->clear_file_cache_async();
     });
 #else
     // libcpp do not support std::execution::par
     std::for_each(_caches.begin(), _caches.end(), [&](const auto& cache) {
         size_t index = &cache - &_caches[0];
-        results[index] =
-                sync ? cache->clear_file_cache_directly() : cache->clear_file_cache_async();
+        results[index] = sync ? cache->clear_file_cache_sync() : cache->clear_file_cache_async();
     });
 #endif
     std::stringstream ss;

--- a/be/src/io/cache/block_file_cache_factory.h
+++ b/be/src/io/cache/block_file_cache_factory.h
@@ -81,7 +81,7 @@ public:
     /**
      * Clears data of all file cache instances
      *
-     * @param sync wait until all data cleared
+     * @param sync run a safe clear scan and synchronously remove blocks releasable during the scan
      * @return summary message
      */
     std::string clear_file_caches(bool sync);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -58,6 +58,48 @@ io::FileCacheSettings cached_remote_reader_cache_settings() {
     return settings;
 }
 
+io::FileCacheSettings sync_clear_test_settings() {
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.index_queue_size = 30;
+    settings.index_queue_elements = 5;
+    settings.disposable_queue_size = 30;
+    settings.disposable_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 0;
+    return settings;
+}
+
+FileCacheKey make_clear_test_cache_key(const UInt128Wrapper& hash) {
+    FileCacheKey cache_key;
+    cache_key.hash = hash;
+    cache_key.offset = 0;
+    cache_key.meta.type = io::FileCacheType::NORMAL;
+    cache_key.meta.expiration_time = 0;
+    cache_key.meta.tablet_id = 0;
+    return cache_key;
+}
+
+class ScopedLongBackgroundGcInterval {
+public:
+    ScopedLongBackgroundGcInterval()
+            : _origin_background_gc_interval_ms(config::file_cache_background_gc_interval_ms) {
+        config::file_cache_background_gc_interval_ms = 60 * 60 * 1000;
+    }
+
+    ~ScopedLongBackgroundGcInterval() {
+        config::file_cache_background_gc_interval_ms = _origin_background_gc_interval_ms;
+    }
+
+    ScopedLongBackgroundGcInterval(const ScopedLongBackgroundGcInterval&) = delete;
+    ScopedLongBackgroundGcInterval& operator=(const ScopedLongBackgroundGcInterval&) = delete;
+
+private:
+    int64_t _origin_background_gc_interval_ms;
+};
+
 void reset_file_cache_factory_for_test() {
     FileCacheFactory::instance()->_caches.clear();
     FileCacheFactory::instance()->_path_to_cache.clear();
@@ -3003,6 +3045,253 @@ TEST_F(BlockFileCacheTest, late_holder_remove_skips_replaced_cache_cell) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
     }
+}
+
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_removes_releasable_blocks_before_return) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    ScopedLongBackgroundGcInterval background_gc_interval;
+
+    io::BlockFileCache cache(cache_base_path, sync_clear_test_settings());
+    ASSERT_TRUE(cache.initialize());
+    wait_until_cache_ready(cache);
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+
+    auto held_key = io::BlockFileCache::hash("sync-clear-held-block");
+    auto free_key = io::BlockFileCache::hash("sync-clear-free-block");
+
+    auto held_holder =
+            std::make_unique<FileBlocksHolder>(cache.get_or_set(held_key, 0, 5, context));
+    auto held_blocks = fromHolder(*held_holder);
+    ASSERT_EQ(held_blocks.size(), 1);
+    ASSERT_EQ(held_blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+    download(held_blocks[0]);
+
+    {
+        auto free_holder = cache.get_or_set(free_key, 0, 5, context);
+        auto free_blocks = fromHolder(free_holder);
+        ASSERT_EQ(free_blocks.size(), 1);
+        ASSERT_EQ(free_blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        download(free_blocks[0]);
+    }
+
+    auto held_file = cache._storage->get_local_file(make_clear_test_cache_key(held_key));
+    auto free_file = cache._storage->get_local_file(make_clear_test_cache_key(free_key));
+    ASSERT_TRUE(fs::exists(held_file));
+    ASSERT_TRUE(fs::exists(free_file));
+    ASSERT_EQ(cache._cur_cache_size, 10);
+
+    auto result = cache.clear_file_cache_sync();
+    EXPECT_NE(result.find("finish clear_file_cache_sync"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_to_delete=1"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_wait_recycle=1"), std::string::npos);
+    EXPECT_TRUE(fs::exists(held_file));
+    EXPECT_FALSE(fs::exists(free_file));
+
+    EXPECT_EQ(cache._cur_cache_size, 5);
+    {
+        auto* cache_ptr = &cache;
+        SCOPED_CACHE_LOCK(cache_ptr->_mutex, cache_ptr);
+        auto* held_cell = cache.get_cell(held_key, 0, cache_lock);
+        ASSERT_NE(held_cell, nullptr);
+        EXPECT_TRUE(held_cell->file_block->is_deleting());
+        EXPECT_EQ(cache.get_cell(free_key, 0, cache_lock), nullptr);
+    }
+
+    held_blocks.clear();
+    held_holder.reset();
+
+    EXPECT_EQ(cache._cur_cache_size, 0);
+    EXPECT_TRUE(cache._files.empty());
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_makes_held_blocks_invisible_to_new_lookup) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    ScopedLongBackgroundGcInterval background_gc_interval;
+
+    io::BlockFileCache cache(cache_base_path, sync_clear_test_settings());
+    ASSERT_TRUE(cache.initialize());
+    wait_until_cache_ready(cache);
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+
+    auto key = io::BlockFileCache::hash("sync-clear-held-block-invisible");
+    auto holder = std::make_unique<FileBlocksHolder>(cache.get_or_set(key, 0, 5, context));
+    auto blocks = fromHolder(*holder);
+    ASSERT_EQ(blocks.size(), 1);
+    auto* old_block = blocks[0].get();
+    ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+    download(blocks[0]);
+
+    auto file = cache._storage->get_local_file(make_clear_test_cache_key(key));
+    ASSERT_TRUE(fs::exists(file));
+
+    auto result = cache.clear_file_cache_sync();
+    EXPECT_NE(result.find("finish clear_file_cache_sync"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_to_delete=0"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_wait_recycle=1"), std::string::npos);
+
+    {
+        auto new_holder = cache.get_or_set(key, 0, 5, context);
+        auto new_blocks = fromHolder(new_holder);
+        ASSERT_EQ(new_blocks.size(), 1);
+        EXPECT_NE(new_blocks[0].get(), old_block);
+        EXPECT_EQ(new_blocks[0]->range().left, 0);
+        EXPECT_EQ(new_blocks[0]->range().right, 4);
+        EXPECT_EQ(new_blocks[0]->state(), io::FileBlock::State::SKIP_CACHE);
+    }
+
+    EXPECT_EQ(cache._cur_cache_size, 5);
+    {
+        auto* cache_ptr = &cache;
+        SCOPED_CACHE_LOCK(cache_ptr->_mutex, cache_ptr);
+        auto* cell = cache.get_cell(key, 0, cache_lock);
+        ASSERT_NE(cell, nullptr);
+        EXPECT_EQ(cell->file_block.get(), old_block);
+        EXPECT_TRUE(cell->file_block->is_deleting());
+    }
+
+    blocks.clear();
+    holder.reset();
+
+    EXPECT_EQ(cache._cur_cache_size, 0);
+    EXPECT_TRUE(cache._files.empty());
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, file_cache_factory_sync_clear_uses_safe_sync_wrapper) {
+    reset_file_cache_factory_for_test();
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    ScopedLongBackgroundGcInterval background_gc_interval;
+    Defer cleanup {[&] {
+        if (fs::exists(cache_base_path)) {
+            fs::remove_all(cache_base_path);
+        }
+        reset_file_cache_factory_for_test();
+    }};
+
+    ASSERT_TRUE(FileCacheFactory::instance()
+                        ->create_file_cache(cache_base_path, sync_clear_test_settings())
+                        .ok());
+    auto* cache = FileCacheFactory::instance()->get_by_path(cache_base_path);
+    ASSERT_NE(cache, nullptr);
+    wait_until_cache_ready(*cache);
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+
+    auto key = io::BlockFileCache::hash("factory-sync-clear-held-block");
+    auto holder = std::make_unique<FileBlocksHolder>(cache->get_or_set(key, 0, 5, context));
+    auto blocks = fromHolder(*holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+    download(blocks[0]);
+    auto free_key = io::BlockFileCache::hash("factory-sync-clear-free-block");
+    {
+        auto free_holder = cache->get_or_set(free_key, 0, 5, context);
+        auto free_blocks = fromHolder(free_holder);
+        ASSERT_EQ(free_blocks.size(), 1);
+        ASSERT_EQ(free_blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        download(free_blocks[0]);
+    }
+
+    auto free_file = cache->_storage->get_local_file(make_clear_test_cache_key(free_key));
+    ASSERT_TRUE(fs::exists(free_file));
+    ASSERT_EQ(cache->_cur_cache_size, 10);
+
+    auto result = FileCacheFactory::instance()->clear_file_caches(true);
+    EXPECT_NE(result.find("finish clear_file_cache_sync"), std::string::npos);
+    EXPECT_EQ(result.find("finish clear_file_cache_directly"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_to_delete=1"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_wait_recycle=1"), std::string::npos);
+    EXPECT_FALSE(fs::exists(free_file));
+
+    EXPECT_EQ(cache->_cur_cache_size, 5);
+    {
+        SCOPED_CACHE_LOCK(cache->_mutex, cache);
+        auto* cell = cache->get_cell(key, 0, cache_lock);
+        ASSERT_NE(cell, nullptr);
+        EXPECT_TRUE(cell->file_block->is_deleting());
+    }
+
+    blocks.clear();
+    holder.reset();
+    EXPECT_EQ(cache->_cur_cache_size, 0);
+    EXPECT_TRUE(cache->_files.empty());
+}
+
+TEST_F(BlockFileCacheTest, file_cache_factory_async_clear_enqueues_recycle_without_sync_remove) {
+    reset_file_cache_factory_for_test();
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    ScopedLongBackgroundGcInterval background_gc_interval;
+    Defer cleanup {[&] {
+        if (fs::exists(cache_base_path)) {
+            fs::remove_all(cache_base_path);
+        }
+        reset_file_cache_factory_for_test();
+    }};
+
+    ASSERT_TRUE(FileCacheFactory::instance()
+                        ->create_file_cache(cache_base_path, sync_clear_test_settings())
+                        .ok());
+    auto* cache = FileCacheFactory::instance()->get_by_path(cache_base_path);
+    ASSERT_NE(cache, nullptr);
+    wait_until_cache_ready(*cache);
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+
+    auto key = io::BlockFileCache::hash("factory-async-clear-free-block");
+    {
+        auto holder = cache->get_or_set(key, 0, 5, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+    ASSERT_EQ(cache->_cur_cache_size, 5);
+    auto free_file = cache->_storage->get_local_file(make_clear_test_cache_key(key));
+    ASSERT_TRUE(fs::exists(free_file));
+
+    auto result = FileCacheFactory::instance()->clear_file_caches(false);
+    EXPECT_NE(result.find("finish clear_file_cache_async"), std::string::npos);
+    EXPECT_EQ(result.find("finish clear_file_cache_sync"), std::string::npos);
+    EXPECT_EQ(result.find("finish clear_file_cache_directly"), std::string::npos);
+    EXPECT_NE(result.find("num_cells_to_delete=1"), std::string::npos);
+
+    EXPECT_EQ(cache->_cur_cache_size, 0);
+    EXPECT_TRUE(cache->_files.empty());
+    EXPECT_EQ(cache->_recycle_keys.size_approx(), 1);
+    EXPECT_TRUE(fs::exists(free_file));
 }
 
 TEST_F(BlockFileCacheTest, test_factory_1) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: FileCacheFactory::clear_file_caches(true) used to call BlockFileCache::clear_file_cache_directly(), which clears storage and cache indexes without respecting FileBlock holder lifetime. This changes the sync branch to use a safe clear scan that keeps the existing holder lifecycle checks. Blocks that are releasable during the scan are removed through synchronous storage remove before the call returns, while held blocks are marked deleting and remain protected until their holders release them. The async and sync clear entry points share the same scan helper; the only behavioral split is whether releasable downloaded blocks are enqueued for async recycle or synchronously removed from storage. Blocks already marked deleting are hidden from later get_or_set() lookups by returning non-cached SKIP_CACHE placeholders, so new readers cannot reacquire a held block after sync clear returns.

### Release note

File cache clear with sync=true no longer uses direct directory-level deletion. It now synchronously removes blocks that are releasable during the scan, but it does not wait for held blocks, recycle queue drain, or meta fence completion. Held blocks marked deleting are not returned as cache hits to new readers.

### Check List (For Author)

- Test: Unit Test
    - git diff --check
    - PATH=/mnt/disk1/zhangzhengyu/build-dep/ldb_toolchain.back/bin:$PATH build-support/check-format.sh
    - JAVA_HOME=/mnt/disk1/zhangzhengyu/build-dep/jdk-17.0.2/ DORIS_TOOLCHAIN=clang DISABLE_BE_JAVA_EXTENSIONS=ON ENABLE_INJECTION_POINT=ON ENABLE_CACHE_LOCK_DEBUG=0 ENABLE_PCH=0 sh run-be-ut.sh --run --filter="BlockFileCacheTest.clear_file_cache_sync_removes_releasable_blocks_before_return:BlockFileCacheTest.clear_file_cache_sync_makes_held_blocks_invisible_to_new_lookup:BlockFileCacheTest.file_cache_factory_sync_clear_uses_safe_sync_wrapper:BlockFileCacheTest.file_cache_factory_async_clear_enqueues_recycle_without_sync_remove:BlockFileCacheTest.recyle_cache_async:BlockFileCacheTest.recyle_cache_async_ttl:BlockFileCacheTest.late_holder_remove_skips_missing_cache_cell:BlockFileCacheTest.late_holder_remove_skips_replaced_cache_cell:BlockFileCacheTest.test_factory_1"
    - Result: 9 tests passed.
- Behavior changed: Yes. sync=true clear no longer uses direct directory-level deletion; it synchronously removes scan-time releasable blocks, hides held deleting blocks from new cache lookups, and leaves held blocks to the deleting/recycle lifecycle.
- Does this need documentation: No