### PR TITLE
[fix](parser) make block comments non-nesting to match MySQL (#59691)

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -1299,7 +1299,7 @@ public class NereidsParserTest extends ParserTestBase {
 
         List<String> validComments = Lists.newArrayList(
                 "SELECT 1 as a /* this is comment */, 1",
-                "SELECT 1 as a /* this is comment /* */ */, 1",
+                // non-nesting: `/*` closes at the first `*/` (inside `/* */`), leaving `, 1`
                 "SELECT 1 as a /* this is comment /* */, 1",
                 "SELECT 1 as a /* this is comment -- */, 1",
                 "SELECT 1 as a -- this is comment\n, 1",
@@ -1313,7 +1313,9 @@ public class NereidsParserTest extends ParserTestBase {
 
         List<String> invalidComments = Lists.newArrayList(
                 "SELECT 1 as a /* this is comment */*/, 1",
-                "SELECT 1 as a /* this is comment, 1"
+                "SELECT 1 as a /* this is comment, 1",
+                // non-nesting: first `*/` closes the comment, leaving ` */` as a stray HINT_END token
+                "SELECT 1 as a /* this is comment /* */ */, 1"
         );
 
         for (String sql : invalidComments) {

--- a/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
+++ b/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
@@ -745,8 +745,12 @@ SIMPLE_COMMENT
     : '--' ('\\\n' | ~[\r\n])* '\r'? '\n'? -> channel(HIDDEN)
     ;
 
+// Block comments are NOT nested, matching MySQL/standard SQL semantics: a `/*`
+// is closed by the first following `*/`. Allowing nesting (the recursive
+// `BRACKETED_COMMENT` alternative) made `/* ... /* ... */ ... */` require
+// balanced markers and swallowed trailing SQL, producing wrong results (#59691).
 BRACKETED_COMMENT
-    : COMMENT_START ( BRACKETED_COMMENT | . )*? '*/' -> channel(2)
+    : COMMENT_START .*? '*/' -> channel(2)
     ;
 
 

--- a/fe/fe-sql-parser/src/test/java/org/apache/doris/sqlparser/DorisSqlParserTest.java
+++ b/fe/fe-sql-parser/src/test/java/org/apache/doris/sqlparser/DorisSqlParserTest.java
@@ -72,4 +72,48 @@ class DorisSqlParserTest {
     void rejectsTrailingGarbageInExpression() {
         Assertions.assertThrows(ParseException.class, () -> parser.parseExpression("1 + 2 BAD GARBAGE"));
     }
+
+    @Test
+    void parsesPlainBlockComment() {
+        SingleStatementContext ctx = parser.parseStatement("SELECT 1 /* a plain block comment */ FROM t");
+        Assertions.assertNotNull(ctx);
+        Assertions.assertNotNull(ctx.statement());
+        // comment is on a non-default channel, so it is excluded from getText()
+        Assertions.assertTrue(ctx.getText().startsWith("SELECT1FROMt"), ctx.getText());
+        Assertions.assertFalse(ctx.getText().contains("plain"), ctx.getText());
+    }
+
+    // #59691: block comments must NOT nest. A `/*` is closed by the FIRST following
+    // `*/`, so the inner `/*` is just comment text. This is the exact shape from the
+    // issue: `/* ... /* */ <active sql> -- */`. The first `*/` (inside `/* */`) closes
+    // the comment, so `AND id = 3` stays active and `-- */` is a trailing line comment.
+    // With the previous nesting grammar the outer comment consumed both `*/` markers
+    // and silently swallowed `AND id = 3`, leaving only `WHERE id = 1` (wrong result).
+    @Test
+    void blockCommentDoesNotNest() {
+        SingleStatementContext ctx = parser.parseStatement(
+                "SELECT id FROM t WHERE id = 1 /* AND id = 2 /* */ AND id = 3 -- */");
+        Assertions.assertNotNull(ctx);
+        // The surviving SQL must keep `AND id = 3`; the `AND id = 2` inside the comment
+        // must be dropped.
+        String text = ctx.getText();
+        Assertions.assertTrue(text.contains("ANDid=3"),
+                "trailing `AND id = 3` must survive a non-nesting block comment, got: " + text);
+        Assertions.assertFalse(text.contains("id=2"),
+                "`AND id = 2` is inside the comment and must be dropped, got: " + text);
+    }
+
+    // #59691 second form: `/* ... /*/`. The `/*` closes at the `*/` inside `/*/`,
+    // so `AND id = 3` stays active.
+    @Test
+    void blockCommentSecondFormFromIssue() {
+        SingleStatementContext ctx = parser.parseStatement(
+                "SELECT id FROM t WHERE id = 1 /* AND id = 2 /*/ AND id = 3");
+        Assertions.assertNotNull(ctx);
+        String text = ctx.getText();
+        Assertions.assertTrue(text.contains("ANDid=3"),
+                "trailing `AND id = 3` must survive, got: " + text);
+        Assertions.assertFalse(text.contains("id=2"),
+                "`AND id = 2` is inside the comment and must be dropped, got: " + text);
+    }
 }

--- a/regression-test/suites/nereids_syntax_p0/test_block_comment_no_nesting.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_block_comment_no_nesting.groovy
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression test for https://github.com/apache/doris/issues/59691
+// Block comments /* ... */ must NOT nest (MySQL/standard SQL semantics): a `/*`
+// is closed by the first following `*/`. Previously the grammar treated them as
+// nestable, so the comment swallowed the trailing predicate and returned wrong rows.
+suite("test_block_comment_no_nesting") {
+    sql "drop table if exists test_block_comment_59691"
+    sql """
+        create table test_block_comment_59691 (
+            id INT,
+            name varchar(32)
+        )
+        UNIQUE KEY (id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1");
+    """
+    sql """insert into test_block_comment_59691 values (1, 'Alice'), (2, 'Bob'), (3, 'Camille');"""
+
+    // The first `/*` closes at the first `*/` (inside `/* */`), so `and id = 3`
+    // stays active and `-- */` is a trailing line comment. Expected: only row 3.
+    def r1 = sql """
+        select id from test_block_comment_59691
+          where 1 = 1
+            /* and id = 2
+            /* */
+            and id = 3
+            -- */
+        order by id
+    """
+    assertEquals(1, r1.size())
+    assertEquals(3, r1[0][0])
+
+    // Second form from the issue: `/* ... /*/` also closes at the first `*/`.
+    def r2 = sql """
+        select id from test_block_comment_59691
+          where 1 = 1
+            /* and id = 2 /*/
+            and id = 3
+        order by id
+    """
+    assertEquals(1, r2.size())
+    assertEquals(3, r2[0][0])
+
+    // Plain (non-nested) block comment still works as before.
+    def r3 = sql """
+        select id from test_block_comment_59691
+          where id = 2 /* a plain comment */ or id = 3
+        order by id
+    """
+    assertEquals(2, r3.size())
+
+    sql "drop table if exists test_block_comment_59691"
+}


### PR DESCRIPTION
The BRACKETED_COMMENT lexer rule allowed nested block comments via a recursive alternative:

    BRACKETED_COMMENT : '/*' ( BRACKETED_COMMENT | . )*? '*/'

MySQL / standard SQL block comments do NOT nest: a `/*` is closed by the first following `*/`. With nesting, a query like

    where 1 = 1
      /* and id = 2
      /* */
      and id = 3
      -- */

had its outer comment consume both `*/` markers, swallowing `and id = 3` and silently returning all rows instead of only the matching one.

Drop the recursive alternative so the comment closes at the first `*/`:

    BRACKETED_COMMENT : '/*' .*? '*/'

Add a parser unit test (verified to fail under the old nesting grammar and pass under the fix) and a SQL-level regression test replaying the issue.

### What problem does this PR solve?

Issue Number: #59691 

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

