### PR TITLE
[fix](file-cache) Avoid TTL directory split

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1186,6 +1186,9 @@ DEFINE_mBool(enable_reader_dryrun_when_download_file_cache, "true");
 DEFINE_mInt64(file_cache_background_monitor_interval_ms, "5000");
 DEFINE_mInt64(file_cache_background_ttl_gc_interval_ms, "3000");
 DEFINE_mInt64(file_cache_background_ttl_gc_batch, "1000");
+DEFINE_mBool(enable_file_cache_ttl_repair_checker, "true");
+DEFINE_mInt64(file_cache_ttl_repair_checker_interval_ms, "43200000"); // 12h
+DEFINE_mInt64(file_cache_ttl_repair_checker_max_repairs_per_round, "1000");
 DEFINE_mInt64(file_cache_background_lru_dump_interval_ms, "60000");
 // dump queue only if the queue update specific times through several dump intervals
 DEFINE_mInt64(file_cache_background_lru_dump_update_cnt_threshold, "1000");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1235,6 +1235,9 @@ DECLARE_mBool(enable_reader_dryrun_when_download_file_cache);
 DECLARE_mInt64(file_cache_background_monitor_interval_ms);
 DECLARE_mInt64(file_cache_background_ttl_gc_interval_ms);
 DECLARE_mInt64(file_cache_background_ttl_gc_batch);
+DECLARE_mBool(enable_file_cache_ttl_repair_checker);
+DECLARE_mInt64(file_cache_ttl_repair_checker_interval_ms);
+DECLARE_mInt64(file_cache_ttl_repair_checker_max_repairs_per_round);
 DECLARE_Int32(file_cache_downloader_thread_num_min);
 DECLARE_Int32(file_cache_downloader_thread_num_max);
 // used to persist lru information before be reboot and load the info back

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -349,6 +349,16 @@ BlockFileCache::BlockFileCache(const std::string& cache_base_path,
             _cache_base_path.c_str(), "file_cache_update_lru_blocks_latency_us");
     _ttl_gc_latency_us = std::make_shared<bvar::LatencyRecorder>(_cache_base_path.c_str(),
                                                                  "file_cache_ttl_gc_latency_us");
+    _ttl_repair_checker_latency_us = std::make_shared<bvar::LatencyRecorder>(
+            _cache_base_path.c_str(), "file_cache_ttl_repair_checker_latency_us");
+    _ttl_repair_checker_suspect_hashes = std::make_shared<bvar::Adder<size_t>>(
+            _cache_base_path.c_str(), "file_cache_ttl_repair_checker_suspect_hashes");
+    _ttl_repair_checker_repairs_enqueued = std::make_shared<bvar::Adder<size_t>>(
+            _cache_base_path.c_str(), "file_cache_ttl_repair_checker_repairs_enqueued");
+    _ttl_repair_checker_skipped_unstable_hashes = std::make_shared<bvar::Adder<size_t>>(
+            _cache_base_path.c_str(), "file_cache_ttl_repair_checker_skipped_unstable_hashes");
+    _ttl_repair_checker_skipped_unbound_hashes = std::make_shared<bvar::Adder<size_t>>(
+            _cache_base_path.c_str(), "file_cache_ttl_repair_checker_skipped_unbound_hashes");
     _shadow_queue_levenshtein_distance = std::make_shared<bvar::LatencyRecorder>(
             _cache_base_path.c_str(), "file_cache_shadow_queue_levenshtein_distance");
 
@@ -476,6 +486,8 @@ Status BlockFileCache::initialize_unlocked(std::lock_guard<std::mutex>& cache_lo
             std::thread(&BlockFileCache::run_background_evict_in_advance, this);
     _cache_background_block_lru_update_thread =
             std::thread(&BlockFileCache::run_background_block_lru_update, this);
+    _cache_background_ttl_repair_checker_thread =
+            std::thread(&BlockFileCache::run_background_ttl_repair_checker, this);
 
     // Initialize LRU dump thread and restore queues
     _cache_background_lru_dump_thread = std::thread(&BlockFileCache::run_background_lru_dump, this);
@@ -895,6 +907,112 @@ void BlockFileCache::enqueue_hash_for_cleanup(const UInt128Wrapper& hash) {
     if (!ret) {
         LOG_WARNING("Failed to push recycle hash to queue, hash={}", hash.to_string());
     }
+}
+
+void BlockFileCache::enqueue_key_dir_for_cleanup(const UInt128Wrapper& hash,
+                                                 uint64_t expiration_time) {
+    if (_storage->get_type() != DISK) {
+        return;
+    }
+    bool ret = _recycle_key_dirs.enqueue(std::make_pair(hash, expiration_time));
+    if (!ret) {
+        LOG_WARNING("Failed to push recycle key dir to queue, hash={}, expiration_time={}",
+                    hash.to_string(), expiration_time);
+    }
+}
+
+std::optional<uint64_t> BlockFileCache::get_canonical_storage_expiration_if_stable(
+        const UInt128Wrapper& hash, std::lock_guard<std::mutex>& cache_lock,
+        bool* skipped_unstable) {
+    if (skipped_unstable != nullptr) {
+        *skipped_unstable = false;
+    }
+    auto iter = _files.find(hash);
+    if (iter == _files.end() || iter->second.empty()) {
+        return std::nullopt;
+    }
+
+    std::optional<uint64_t> canonical_expiration;
+    for (const auto& [_, cell] : iter->second) {
+        auto state = cell.file_block->state_unsafe();
+        if (state != FileBlock::State::DOWNLOADED) {
+            if (skipped_unstable != nullptr) {
+                *skipped_unstable = true;
+            }
+            return std::nullopt;
+        }
+        auto storage_expiration = cell.file_block->storage_expiration_time();
+        if (!canonical_expiration.has_value()) {
+            canonical_expiration = storage_expiration;
+        } else if (*canonical_expiration != storage_expiration) {
+            if (skipped_unstable != nullptr) {
+                *skipped_unstable = true;
+            }
+            return std::nullopt;
+        }
+    }
+    return canonical_expiration;
+}
+
+size_t BlockFileCache::repair_duplicate_ttl_dirs_once() {
+    if (_storage->get_type() != DISK || !config::enable_file_cache_ttl_repair_checker) {
+        return 0;
+    }
+    if (_recycle_keys.size_approx() > 0 || _recycle_hashes.size_approx() > 0 ||
+        _recycle_key_dirs.size_approx() > 0) {
+        return 0;
+    }
+
+    std::vector<DuplicateKeyDirs> duplicate_key_dirs;
+    auto st = _storage->list_duplicate_key_dirs(&duplicate_key_dirs, [this]() { return _close; });
+    if (st.is<ErrorCode::CANCELLED>()) {
+        return 0;
+    }
+    if (!st.ok()) {
+        LOG_WARNING("failed to list duplicate file cache ttl dirs").error(st);
+        return 0;
+    }
+
+    *_ttl_repair_checker_suspect_hashes << duplicate_key_dirs.size();
+    size_t repaired_hashes = 0;
+    size_t max_repairs =
+            std::max<int64_t>(config::file_cache_ttl_repair_checker_max_repairs_per_round, 0);
+    for (const auto& duplicate_key_dir : duplicate_key_dirs) {
+        if (_close || repaired_hashes >= max_repairs) {
+            break;
+        }
+
+        bool skipped_unstable = false;
+        std::optional<uint64_t> canonical_expiration;
+        {
+            SCOPED_CACHE_LOCK(_mutex, this);
+            canonical_expiration = get_canonical_storage_expiration_if_stable(
+                    duplicate_key_dir.hash, cache_lock, &skipped_unstable);
+        }
+
+        if (!canonical_expiration.has_value()) {
+            if (skipped_unstable) {
+                *_ttl_repair_checker_skipped_unstable_hashes << 1;
+            } else {
+                *_ttl_repair_checker_skipped_unbound_hashes << 1;
+            }
+            continue;
+        }
+
+        bool enqueued = false;
+        for (auto expiration_time : duplicate_key_dir.expiration_times) {
+            if (expiration_time == *canonical_expiration) {
+                continue;
+            }
+            enqueue_key_dir_for_cleanup(duplicate_key_dir.hash, expiration_time);
+            *_ttl_repair_checker_repairs_enqueued << 1;
+            enqueued = true;
+        }
+        if (enqueued) {
+            ++repaired_hashes;
+        }
+    }
+    return repaired_hashes;
 }
 
 CacheContext BlockFileCache::make_cell_context(
@@ -2237,6 +2355,7 @@ void BlockFileCache::run_background_gc() {
     Thread::set_self_name("run_background_gc");
     FileCacheKey key;
     UInt128Wrapper hash;
+    std::pair<UInt128Wrapper, uint64_t> key_dir;
     while (!_close) {
         int64_t interval_ms = config::file_cache_background_gc_interval_ms;
         size_t batch_limit = config::file_cache_remove_block_qps_limit * interval_ms / 1000;
@@ -2278,8 +2397,49 @@ void BlockFileCache::run_background_gc() {
             }
             batch_count++;
         }
+        while (batch_count < batch_limit && _recycle_key_dirs.try_dequeue(key_dir)) {
+            int64_t duration_ns = 0;
+            Status st;
+            {
+                SCOPED_RAW_TIMER(&duration_ns);
+                st = _storage->remove_key_dir(key_dir.first, key_dir.second);
+            }
+            *_storage_async_remove_latency_us << (duration_ns / 1000);
+
+            if (!st.ok()) {
+                LOG_WARNING("failed to remove file cache dir for hash={}, expiration_time={}",
+                            key_dir.first.to_string(), key_dir.second)
+                        .error(st);
+            }
+            batch_count++;
+        }
         *_recycle_keys_length_recorder << _recycle_keys.size_approx();
         batch_count = 0;
+    }
+}
+
+void BlockFileCache::run_background_ttl_repair_checker() {
+    Thread::set_self_name("run_ttl_repair");
+    while (!_close) {
+        int64_t interval_ms =
+                std::max<int64_t>(config::file_cache_ttl_repair_checker_interval_ms, 1000);
+        {
+            std::unique_lock close_lock(_close_mtx);
+            _close_cv.wait_for(close_lock, std::chrono::milliseconds(interval_ms));
+            if (_close) {
+                break;
+            }
+        }
+        if (!config::enable_file_cache_ttl_repair_checker || _storage->get_type() != DISK) {
+            continue;
+        }
+
+        int64_t duration_ns = 0;
+        {
+            SCOPED_RAW_TIMER(&duration_ns);
+            repair_duplicate_ttl_dirs_once();
+        }
+        *_ttl_repair_checker_latency_us << (duration_ns / 1000);
     }
 }
 

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -559,8 +559,10 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
         }
         FileCacheKey key;
         key.hash = hash;
-        key.meta.type = context.cache_type;
-        key.meta.expiration_time = context.expiration_time;
+        key.offset = range.left;
+        auto cell_context = make_cell_context(hash, context, cache_lock);
+        key.meta.type = cell_context.cache_type;
+        key.meta.expiration_time = cell_context.storage_expiration();
         _storage->load_blocks_directly_unlocked(this, key, cache_lock);
 
         it = _files.find(hash);
@@ -580,87 +582,12 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
         _files.erase(hash);
         return {};
     }
-    // change to ttl if the blocks aren't ttl
-    if (context.cache_type == FileCacheType::TTL && _key_to_time.find(hash) == _key_to_time.end()) {
-        for (auto& [_, cell] : file_blocks) {
-            Status st = cell.file_block->update_expiration_time(context.expiration_time);
-            if (!st.ok()) {
-                LOG_WARNING("Failed to change key meta").error(st);
-            }
-
-            FileCacheType origin_type = cell.file_block->cache_type();
-            if (origin_type == FileCacheType::TTL) continue;
-            st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::TTL);
-            if (st.ok()) {
-                auto& queue = get_queue(origin_type);
-                queue.remove(cell.queue_iterator.value(), cache_lock);
-                _lru_recorder->record_queue_event(origin_type, CacheLRULogType::REMOVE,
-                                                  cell.file_block->get_hash_value(),
-                                                  cell.file_block->offset(), cell.size());
-                auto& ttl_queue = get_queue(FileCacheType::TTL);
-                cell.queue_iterator =
-                        ttl_queue.add(cell.file_block->get_hash_value(), cell.file_block->offset(),
-                                      cell.file_block->range().size(), cache_lock);
-                _lru_recorder->record_queue_event(FileCacheType::TTL, CacheLRULogType::ADD,
-                                                  cell.file_block->get_hash_value(),
-                                                  cell.file_block->offset(), cell.size());
-            } else {
-                LOG_WARNING("Failed to change key meta").error(st);
-            }
-        }
-        _key_to_time[hash] = context.expiration_time;
-        _time_to_key.insert(std::make_pair(context.expiration_time, hash));
-    }
     if (auto iter = _key_to_time.find(hash);
-        // TODO(zhengyu): Why the hell the type is NORMAL while context set expiration_time?
         (context.cache_type == FileCacheType::NORMAL || context.cache_type == FileCacheType::TTL) &&
         iter != _key_to_time.end() && iter->second != context.expiration_time) {
-        // remove from _time_to_key
-        auto _time_to_key_iter = _time_to_key.equal_range(iter->second);
-        while (_time_to_key_iter.first != _time_to_key_iter.second) {
-            if (_time_to_key_iter.first->second == hash) {
-                _time_to_key_iter.first = _time_to_key.erase(_time_to_key_iter.first);
-                break;
-            }
-            _time_to_key_iter.first++;
-        }
-        for (auto& [_, cell] : file_blocks) {
-            Status st = cell.file_block->update_expiration_time(context.expiration_time);
-            if (!st.ok()) {
-                LOG_WARNING("Failed to change key meta").error(st);
-            }
-        }
-        if (context.expiration_time == 0) {
-            for (auto& [_, cell] : file_blocks) {
-                auto cache_type = cell.file_block->cache_type();
-                if (cache_type != FileCacheType::TTL) continue;
-                auto st = cell.file_block->change_cache_type_between_ttl_and_others(
-                        FileCacheType::NORMAL);
-                if (st.ok()) {
-                    if (cell.queue_iterator) {
-                        auto& ttl_queue = get_queue(FileCacheType::TTL);
-                        ttl_queue.remove(cell.queue_iterator.value(), cache_lock);
-                        _lru_recorder->record_queue_event(FileCacheType::TTL,
-                                                          CacheLRULogType::REMOVE,
-                                                          cell.file_block->get_hash_value(),
-                                                          cell.file_block->offset(), cell.size());
-                    }
-                    auto& queue = get_queue(FileCacheType::NORMAL);
-                    cell.queue_iterator =
-                            queue.add(cell.file_block->get_hash_value(), cell.file_block->offset(),
-                                      cell.file_block->range().size(), cache_lock);
-                    _lru_recorder->record_queue_event(FileCacheType::NORMAL, CacheLRULogType::ADD,
-                                                      cell.file_block->get_hash_value(),
-                                                      cell.file_block->offset(), cell.size());
-                } else {
-                    LOG_WARNING("Failed to change key meta").error(st);
-                }
-            }
-            _key_to_time.erase(iter);
-        } else {
-            _time_to_key.insert(std::make_pair(context.expiration_time, hash));
-            iter->second = context.expiration_time;
-        }
+        VLOG_DEBUG << "Skip read-path TTL update. hash=" << hash.to_string()
+                   << " logical_expiration_time=" << iter->second
+                   << " context_expiration_time=" << context.expiration_time;
     }
 
     FileBlocks result;
@@ -789,25 +716,27 @@ FileBlocks BlockFileCache::split_range_into_cells(const UInt128Wrapper& hash,
 
     FileBlocks file_blocks;
     while (current_pos < end_pos_non_included) {
+        auto cell_context = make_cell_context(hash, context, cache_lock);
         current_size = std::min(remaining_size, _max_file_block_size);
         remaining_size -= current_size;
-        state = try_reserve(hash, context, current_pos, current_size, cache_lock)
+        state = try_reserve(hash, cell_context, current_pos, current_size, cache_lock)
                         ? state
                         : FileBlock::State::SKIP_CACHE;
         if (state == FileBlock::State::SKIP_CACHE) [[unlikely]] {
             FileCacheKey key;
             key.hash = hash;
             key.offset = current_pos;
-            key.meta.type = context.cache_type;
-            key.meta.expiration_time = context.expiration_time;
+            key.meta.type = cell_context.cache_type;
+            key.meta.expiration_time = cell_context.storage_expiration();
             auto file_block = std::make_shared<FileBlock>(key, current_size, this,
-                                                          FileBlock::State::SKIP_CACHE);
+                                                          FileBlock::State::SKIP_CACHE,
+                                                          cell_context.expiration_time);
             file_blocks.push_back(std::move(file_block));
         } else {
-            auto* cell = add_cell(hash, context, current_pos, current_size, state, cache_lock);
+            auto* cell = add_cell(hash, cell_context, current_pos, current_size, state, cache_lock);
             if (cell) {
                 file_blocks.push_back(cell->file_block);
-                if (!context.is_cold_data) {
+                if (!cell_context.is_cold_data) {
                     cell->update_atime();
                 }
             }
@@ -958,6 +887,129 @@ FileBlocksHolder BlockFileCache::get_or_set(const UInt128Wrapper& hash, size_t o
     return FileBlocksHolder(std::move(file_blocks));
 }
 
+void BlockFileCache::enqueue_hash_for_cleanup(const UInt128Wrapper& hash) {
+    if (_storage->get_type() != DISK) {
+        return;
+    }
+    bool ret = _recycle_hashes.enqueue(hash);
+    if (!ret) {
+        LOG_WARNING("Failed to push recycle hash to queue, hash={}", hash.to_string());
+    }
+}
+
+CacheContext BlockFileCache::make_cell_context(const UInt128Wrapper& hash,
+                                               const CacheContext& context,
+                                               std::lock_guard<std::mutex>& /* cache_lock */) const {
+    CacheContext result = context;
+    if (result.storage_expiration_time < 0) {
+        result.storage_expiration_time = result.expiration_time;
+    }
+
+    auto file_it = _files.find(hash);
+    if (file_it != _files.end() && !file_it->second.empty()) {
+        const auto& file_block = file_it->second.begin()->second.file_block;
+        result.cache_type = file_block->cache_type();
+        result.expiration_time = file_block->expiration_time();
+        if (context.storage_expiration_time < 0) {
+            result.storage_expiration_time = file_block->storage_expiration_time();
+        }
+    } else if (auto ttl_it = _key_to_time.find(hash); ttl_it != _key_to_time.end()) {
+        result.cache_type = FileCacheType::TTL;
+        result.expiration_time = ttl_it->second;
+    }
+
+    if (result.expiration_time == 0 && result.cache_type == FileCacheType::TTL) {
+        result.cache_type = FileCacheType::NORMAL;
+    } else if (result.expiration_time != 0 && result.cache_type != FileCacheType::TTL) {
+        result.cache_type = FileCacheType::TTL;
+    }
+    return result;
+}
+
+void BlockFileCache::erase_key_expiration_time(const UInt128Wrapper& hash, uint64_t expiration_time,
+                                               std::lock_guard<std::mutex>& /* cache_lock */) {
+    auto time_to_key_iter = _time_to_key.equal_range(expiration_time);
+    while (time_to_key_iter.first != time_to_key_iter.second) {
+        if (time_to_key_iter.first->second == hash) {
+            time_to_key_iter.first = _time_to_key.erase(time_to_key_iter.first);
+            break;
+        }
+        time_to_key_iter.first++;
+    }
+}
+
+Status BlockFileCache::update_cell_logical_meta(FileBlockCell& cell, FileCacheType new_type,
+                                                uint64_t new_expiration_time,
+                                                std::lock_guard<std::mutex>& cache_lock) {
+    auto origin_type = cell.file_block->cache_type();
+    RETURN_IF_ERROR(cell.file_block->update_expiration_time(new_expiration_time));
+    if (origin_type == new_type) {
+        return Status::OK();
+    }
+    if (new_type == FileCacheType::TTL || origin_type == FileCacheType::TTL) {
+        RETURN_IF_ERROR(cell.file_block->change_cache_type_between_ttl_and_others(new_type));
+    } else {
+        RETURN_IF_ERROR(cell.file_block->update_logical_cache_type(new_type));
+    }
+
+    if (cell.queue_iterator) {
+        auto& origin_queue = get_queue(origin_type);
+        origin_queue.remove(cell.queue_iterator.value(), cache_lock);
+        _lru_recorder->record_queue_event(origin_type, CacheLRULogType::REMOVE,
+                                          cell.file_block->get_hash_value(),
+                                          cell.file_block->offset(), cell.size());
+    }
+    auto& new_queue = get_queue(new_type);
+    cell.queue_iterator = new_queue.add(cell.file_block->get_hash_value(),
+                                        cell.file_block->offset(),
+                                        cell.file_block->range().size(), cache_lock);
+    _lru_recorder->record_queue_event(new_type, CacheLRULogType::ADD,
+                                      cell.file_block->get_hash_value(),
+                                      cell.file_block->offset(), cell.size());
+    if (origin_type == FileCacheType::TTL) {
+        _cur_ttl_size -= cell.size();
+    }
+    if (new_type == FileCacheType::TTL) {
+        _cur_ttl_size += cell.size();
+    }
+    return Status::OK();
+}
+
+void BlockFileCache::update_hash_logical_meta(const UInt128Wrapper& hash, FileCacheType new_type,
+                                              uint64_t new_expiration_time,
+                                              std::lock_guard<std::mutex>& cache_lock) {
+    if (auto iter = _files.find(hash); iter != _files.end()) {
+        for (auto& [_, cell] : iter->second) {
+            auto st = update_cell_logical_meta(cell, new_type, new_expiration_time, cache_lock);
+            if (!st.ok()) {
+                LOG_WARNING("Failed to update logical file cache meta. hash={}, expiration_time={}",
+                            hash.to_string(), new_expiration_time)
+                        .error(st);
+            }
+        }
+    }
+
+    if (auto iter = _key_to_time.find(hash); iter != _key_to_time.end()) {
+        erase_key_expiration_time(hash, iter->second, cache_lock);
+        if (new_expiration_time == 0) {
+            _key_to_time.erase(iter);
+        } else {
+            iter->second = new_expiration_time;
+            _time_to_key.insert(std::make_pair(new_expiration_time, hash));
+        }
+    } else if (new_expiration_time != 0) {
+        _key_to_time[hash] = new_expiration_time;
+        _time_to_key.insert(std::make_pair(new_expiration_time, hash));
+    }
+}
+
+void BlockFileCache::update_hash_logical_expiration_time(
+        const UInt128Wrapper& hash, uint64_t new_expiration_time,
+        std::lock_guard<std::mutex>& cache_lock) {
+    auto new_type = new_expiration_time == 0 ? FileCacheType::NORMAL : FileCacheType::TTL;
+    update_hash_logical_meta(hash, new_type, new_expiration_time, cache_lock);
+}
+
 FileBlockCell* BlockFileCache::add_cell(const UInt128Wrapper& hash, const CacheContext& context,
                                         size_t offset, size_t size, FileBlock::State state,
                                         std::lock_guard<std::mutex>& cache_lock) {
@@ -986,23 +1038,16 @@ FileBlockCell* BlockFileCache::add_cell(const UInt128Wrapper& hash, const CacheC
         return &(itr->second);
     }
 
+    CacheContext cell_context = make_cell_context(hash, context, cache_lock);
+
     FileCacheKey key;
     key.hash = hash;
     key.offset = offset;
-    key.meta.type = context.cache_type;
-    key.meta.expiration_time = context.expiration_time;
-    FileBlockCell cell(std::make_shared<FileBlock>(key, size, this, state), cache_lock);
-    Status st;
-    if (context.expiration_time == 0 && context.cache_type == FileCacheType::TTL) {
-        st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::NORMAL);
-    } else if (context.cache_type != FileCacheType::TTL && context.expiration_time != 0) {
-        st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::TTL);
-    }
-    if (!st.ok()) {
-        LOG(WARNING) << "Cannot change cache type. expiration_time=" << context.expiration_time
-                     << " cache_type=" << cache_type_to_string(context.cache_type)
-                     << " error=" << st.msg();
-    }
+    key.meta.type = cell_context.cache_type;
+    key.meta.expiration_time = cell_context.storage_expiration();
+    FileBlockCell cell(std::make_shared<FileBlock>(key, size, this, state,
+                                                   cell_context.expiration_time),
+                       cache_lock);
 
     auto& queue = get_queue(cell.file_block->cache_type());
     cell.queue_iterator = queue.add(hash, offset, size, cache_lock);
@@ -1012,8 +1057,8 @@ FileBlockCell* BlockFileCache::add_cell(const UInt128Wrapper& hash, const CacheC
 
     if (cell.file_block->cache_type() == FileCacheType::TTL) {
         if (_key_to_time.find(hash) == _key_to_time.end()) {
-            _key_to_time[hash] = context.expiration_time;
-            _time_to_key.insert(std::make_pair(context.expiration_time, hash));
+            _key_to_time[hash] = cell.file_block->expiration_time();
+            _time_to_key.insert(std::make_pair(cell.file_block->expiration_time(), hash));
         }
         _cur_ttl_size += cell.size();
     }
@@ -1106,8 +1151,7 @@ void BlockFileCache::remove_file_blocks_and_clean_time_maps(
             auto hash = cell->file_block->get_hash_value();
             remove(file_block, cache_lock, block_lock);
             if (_files.find(hash) == _files.end()) {
-                if (auto iter = _key_to_time.find(hash);
-                    _key_to_time.find(hash) != _key_to_time.end()) {
+                if (auto iter = _key_to_time.find(hash); iter != _key_to_time.end()) {
                     auto _time_to_key_iter = _time_to_key.equal_range(iter->second);
                     while (_time_to_key_iter.first != _time_to_key_iter.second) {
                         if (_time_to_key_iter.first->second == hash) {
@@ -1277,46 +1321,16 @@ void BlockFileCache::try_evict_in_advance(size_t size, std::lock_guard<std::mute
 }
 
 bool BlockFileCache::remove_if_ttl_file_blocks(const UInt128Wrapper& file_key, bool remove_directly,
-                                               std::lock_guard<std::mutex>& cache_lock, bool sync) {
-    auto& ttl_queue = get_queue(FileCacheType::TTL);
+                                               std::lock_guard<std::mutex>& cache_lock, bool sync,
+                                               bool* has_unreleasable) {
+    if (has_unreleasable != nullptr) {
+        *has_unreleasable = false;
+    }
     if (auto iter = _key_to_time.find(file_key);
         _key_to_time.find(file_key) != _key_to_time.end()) {
         if (!remove_directly) {
-            auto it = _files.find(file_key);
-            if (it != _files.end()) {
-                for (auto& [_, cell] : it->second) {
-                    if (cell.file_block->cache_type() != FileCacheType::TTL) {
-                        continue;
-                    }
-                    Status st = cell.file_block->update_expiration_time(0);
-                    if (!st.ok()) {
-                        LOG_WARNING("Failed to update expiration time to 0").error(st);
-                    }
-
-                    if (cell.file_block->cache_type() == FileCacheType::NORMAL) continue;
-                    st = cell.file_block->change_cache_type_between_ttl_and_others(
-                            FileCacheType::NORMAL);
-                    if (st.ok()) {
-                        if (cell.queue_iterator) {
-                            ttl_queue.remove(cell.queue_iterator.value(), cache_lock);
-                            _lru_recorder->record_queue_event(
-                                    FileCacheType::TTL, CacheLRULogType::REMOVE,
-                                    cell.file_block->get_hash_value(), cell.file_block->offset(),
-                                    cell.size());
-                        }
-                        auto& queue = get_queue(FileCacheType::NORMAL);
-                        cell.queue_iterator = queue.add(
-                                cell.file_block->get_hash_value(), cell.file_block->offset(),
-                                cell.file_block->range().size(), cache_lock);
-                        _lru_recorder->record_queue_event(FileCacheType::NORMAL,
-                                                          CacheLRULogType::ADD,
-                                                          cell.file_block->get_hash_value(),
-                                                          cell.file_block->offset(), cell.size());
-                    } else {
-                        LOG_WARNING("Failed to change cache type to normal").error(st);
-                    }
-                }
-            }
+            update_hash_logical_expiration_time(file_key, 0, cache_lock);
+            return true;
         } else {
             std::vector<FileBlockCell*> to_remove;
             auto it = _files.find(file_key);
@@ -1325,6 +1339,9 @@ bool BlockFileCache::remove_if_ttl_file_blocks(const UInt128Wrapper& file_key, b
                     if (cell.releasable()) {
                         to_remove.push_back(&cell);
                     } else {
+                        if (has_unreleasable != nullptr) {
+                            *has_unreleasable = true;
+                        }
                         cell.file_block->set_deleting();
                     }
                 }
@@ -1335,16 +1352,7 @@ bool BlockFileCache::remove_if_ttl_file_blocks(const UInt128Wrapper& file_key, b
                 remove(file_block, cache_lock, block_lock, sync);
             });
         }
-        // remove from _time_to_key
-        // the param hash maybe be passed by _time_to_key, if removed it, cannot use it anymore
-        auto _time_to_key_iter = _time_to_key.equal_range(iter->second);
-        while (_time_to_key_iter.first != _time_to_key_iter.second) {
-            if (_time_to_key_iter.first->second == file_key) {
-                _time_to_key_iter.first = _time_to_key.erase(_time_to_key_iter.first);
-                break;
-            }
-            _time_to_key_iter.first++;
-        }
+        erase_key_expiration_time(file_key, iter->second, cache_lock);
         _key_to_time.erase(iter);
         return true;
     }
@@ -1355,21 +1363,42 @@ bool BlockFileCache::remove_if_ttl_file_blocks(const UInt128Wrapper& file_key, b
 // if in use, cache meta will be deleted after use and the block file is then deleted asynchronously
 void BlockFileCache::remove_if_cached(const UInt128Wrapper& file_key) {
     std::string reason = "remove_if_cached";
-    SCOPED_CACHE_LOCK(_mutex, this);
-    bool is_ttl_file = remove_if_ttl_file_blocks(file_key, true, cache_lock, true);
-    if (!is_ttl_file) {
-        auto iter = _files.find(file_key);
-        std::vector<FileBlockCell*> to_remove;
-        if (iter != _files.end()) {
-            for (auto& [_, cell] : iter->second) {
-                if (cell.releasable()) {
-                    to_remove.push_back(&cell);
-                } else {
-                    cell.file_block->set_deleting();
+    bool has_unreleasable = false;
+    {
+        SCOPED_CACHE_LOCK(_mutex, this);
+        bool is_ttl_file = remove_if_ttl_file_blocks(file_key, true, cache_lock, true,
+                                                     &has_unreleasable);
+        if (!is_ttl_file) {
+            auto iter = _files.find(file_key);
+            std::vector<FileBlockCell*> to_remove;
+            if (iter != _files.end()) {
+                for (auto& [_, cell] : iter->second) {
+                    if (cell.releasable()) {
+                        to_remove.push_back(&cell);
+                    } else {
+                        has_unreleasable = true;
+                        cell.file_block->set_deleting();
+                    }
                 }
             }
+            remove_file_blocks(to_remove, cache_lock, true, reason);
         }
-        remove_file_blocks(to_remove, cache_lock, true, reason);
+        if (has_unreleasable) {
+            _hashes_pending_cleanup.insert(file_key);
+        }
+    }
+    if (!has_unreleasable && _storage->get_type() == DISK) {
+        int64_t duration_ns = 0;
+        Status st;
+        {
+            SCOPED_RAW_TIMER(&duration_ns);
+            st = _storage->remove_all_by_hash(file_key);
+        }
+        *_storage_sync_remove_latency_us << (duration_ns / 1000);
+        if (!st.ok()) {
+            LOG_WARNING("failed to remove all file cache dirs for hash={}", file_key.to_string())
+                    .error(st);
+        }
     }
 }
 
@@ -1378,23 +1407,34 @@ void BlockFileCache::remove_if_cached(const UInt128Wrapper& file_key) {
 // if in use, cache meta will be deleted after use and the block file is then deleted asynchronously
 void BlockFileCache::remove_if_cached_async(const UInt128Wrapper& file_key) {
     std::string reason = "remove_if_cached_async";
-    SCOPED_CACHE_LOCK(_mutex, this);
-    bool is_ttl_file = remove_if_ttl_file_blocks(file_key, true, cache_lock, /*sync*/ false);
-    if (!is_ttl_file) {
-        auto iter = _files.find(file_key);
-        std::vector<FileBlockCell*> to_remove;
-        if (iter != _files.end()) {
-            for (auto& [_, cell] : iter->second) {
-                *_gc_evict_bytes_metrics << cell.size();
-                *_gc_evict_count_metrics << 1;
-                if (cell.releasable()) {
-                    to_remove.push_back(&cell);
-                } else {
-                    cell.file_block->set_deleting();
+    bool has_unreleasable = false;
+    {
+        SCOPED_CACHE_LOCK(_mutex, this);
+        bool is_ttl_file = remove_if_ttl_file_blocks(file_key, true, cache_lock, /*sync*/ false,
+                                                     &has_unreleasable);
+        if (!is_ttl_file) {
+            auto iter = _files.find(file_key);
+            std::vector<FileBlockCell*> to_remove;
+            if (iter != _files.end()) {
+                for (auto& [_, cell] : iter->second) {
+                    *_gc_evict_bytes_metrics << cell.size();
+                    *_gc_evict_count_metrics << 1;
+                    if (cell.releasable()) {
+                        to_remove.push_back(&cell);
+                    } else {
+                        has_unreleasable = true;
+                        cell.file_block->set_deleting();
+                    }
                 }
             }
+            remove_file_blocks(to_remove, cache_lock, false, reason);
         }
-        remove_file_blocks(to_remove, cache_lock, false, reason);
+        if (has_unreleasable) {
+            _hashes_pending_cleanup.insert(file_key);
+        }
+    }
+    if (!has_unreleasable) {
+        enqueue_hash_for_cleanup(file_key);
     }
 }
 
@@ -1608,7 +1648,8 @@ void BlockFileCache::remove(FileBlockSPtr file_block, T& cache_lock, U& block_lo
     auto hash = file_block->get_hash_value();
     auto offset = file_block->offset();
     auto type = file_block->cache_type();
-    auto expiration_time = file_block->expiration_time();
+    auto storage_type = file_block->storage_cache_type();
+    auto expiration_time = file_block->storage_expiration_time();
     auto* cell = get_cell(hash, offset, cache_lock);
     file_block->cell = nullptr;
     DCHECK(cell);
@@ -1632,7 +1673,7 @@ void BlockFileCache::remove(FileBlockSPtr file_block, T& cache_lock, U& block_lo
         FileCacheKey key;
         key.hash = hash;
         key.offset = offset;
-        key.meta.type = type;
+        key.meta.type = storage_type;
         key.meta.expiration_time = expiration_time;
         if (sync) {
             int64_t duration_ns = 0;
@@ -1679,6 +1720,9 @@ void BlockFileCache::remove(FileBlockSPtr file_block, T& cache_lock, U& block_lo
         it->second.erase(file_block->offset());
         if (it->second.empty()) {
             _files.erase(hash);
+            if (_hashes_pending_cleanup.erase(hash) > 0) {
+                enqueue_hash_for_cleanup(hash);
+            }
         }
     }
     *_num_removed_blocks << 1;
@@ -2192,7 +2236,7 @@ void BlockFileCache::run_background_ttl_gc() {
 void BlockFileCache::run_background_gc() {
     Thread::set_self_name("run_background_gc");
     FileCacheKey key;
-    size_t batch_count = 0;
+    UInt128Wrapper hash;
     while (!_close) {
         int64_t interval_ms = config::file_cache_background_gc_interval_ms;
         size_t batch_limit = config::file_cache_remove_block_qps_limit * interval_ms / 1000;
@@ -2204,6 +2248,7 @@ void BlockFileCache::run_background_gc() {
             }
         }
 
+        size_t batch_count = 0;
         while (batch_count < batch_limit && _recycle_keys.try_dequeue(key)) {
             int64_t duration_ns = 0;
             Status st;
@@ -2215,6 +2260,21 @@ void BlockFileCache::run_background_gc() {
 
             if (!st.ok()) {
                 LOG_WARNING("").error(st);
+            }
+            batch_count++;
+        }
+        while (batch_count < batch_limit && _recycle_hashes.try_dequeue(hash)) {
+            int64_t duration_ns = 0;
+            Status st;
+            {
+                SCOPED_RAW_TIMER(&duration_ns);
+                st = _storage->remove_all_by_hash(hash);
+            }
+            *_storage_async_remove_latency_us << (duration_ns / 1000);
+
+            if (!st.ok()) {
+                LOG_WARNING("failed to remove all file cache dirs for hash={}", hash.to_string())
+                        .error(st);
             }
             batch_count++;
         }
@@ -2296,67 +2356,7 @@ void BlockFileCache::run_background_block_lru_update() {
 void BlockFileCache::modify_expiration_time(const UInt128Wrapper& hash,
                                             uint64_t new_expiration_time) {
     SCOPED_CACHE_LOCK(_mutex, this);
-    // 1. If new_expiration_time is equal to zero
-    if (new_expiration_time == 0) {
-        remove_if_ttl_file_blocks(hash, false, cache_lock, false);
-        return;
-    }
-    // 2. If the hash in ttl cache, modify its expiration time.
-    if (auto iter = _key_to_time.find(hash); iter != _key_to_time.end()) {
-        // remove from _time_to_key
-        auto _time_to_key_iter = _time_to_key.equal_range(iter->second);
-        while (_time_to_key_iter.first != _time_to_key_iter.second) {
-            if (_time_to_key_iter.first->second == hash) {
-                _time_to_key_iter.first = _time_to_key.erase(_time_to_key_iter.first);
-                break;
-            }
-            _time_to_key_iter.first++;
-        }
-        _time_to_key.insert(std::make_pair(new_expiration_time, hash));
-        iter->second = new_expiration_time;
-        auto it = _files.find(hash);
-        if (it != _files.end()) {
-            for (auto& [_, cell] : it->second) {
-                Status st = cell.file_block->update_expiration_time(new_expiration_time);
-                if (!st.ok()) {
-                    LOG_WARNING("Failed to modify expiration time").error(st);
-                }
-            }
-        }
-
-        return;
-    }
-    // 3. change to ttl if the blocks aren't ttl
-    if (auto iter = _files.find(hash); iter != _files.end()) {
-        for (auto& [_, cell] : iter->second) {
-            Status st = cell.file_block->update_expiration_time(new_expiration_time);
-            if (!st.ok()) {
-                LOG_WARNING("").error(st);
-            }
-
-            FileCacheType origin_type = cell.file_block->cache_type();
-            if (origin_type == FileCacheType::TTL) continue;
-            st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::TTL);
-            if (st.ok()) {
-                auto& queue = get_queue(origin_type);
-                queue.remove(cell.queue_iterator.value(), cache_lock);
-                _lru_recorder->record_queue_event(origin_type, CacheLRULogType::REMOVE,
-                                                  cell.file_block->get_hash_value(),
-                                                  cell.file_block->offset(), cell.size());
-                auto& ttl_queue = get_queue(FileCacheType::TTL);
-                cell.queue_iterator = ttl_queue.add(hash, cell.file_block->offset(),
-                                                    cell.file_block->range().size(), cache_lock);
-                _lru_recorder->record_queue_event(FileCacheType::TTL, CacheLRULogType::ADD,
-                                                  cell.file_block->get_hash_value(),
-                                                  cell.file_block->offset(), cell.size());
-            }
-            if (!st.ok()) {
-                LOG_WARNING("").error(st);
-            }
-        }
-        _key_to_time[hash] = new_expiration_time;
-        _time_to_key.insert(std::make_pair(new_expiration_time, hash));
-    }
+    update_hash_logical_expiration_time(hash, new_expiration_time, cache_lock);
 }
 
 std::vector<std::tuple<size_t, size_t, FileCacheType, uint64_t>>

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -897,9 +897,9 @@ void BlockFileCache::enqueue_hash_for_cleanup(const UInt128Wrapper& hash) {
     }
 }
 
-CacheContext BlockFileCache::make_cell_context(const UInt128Wrapper& hash,
-                                               const CacheContext& context,
-                                               std::lock_guard<std::mutex>& /* cache_lock */) const {
+CacheContext BlockFileCache::make_cell_context(
+        const UInt128Wrapper& hash, const CacheContext& context,
+        std::lock_guard<std::mutex>& /* cache_lock */) const {
     CacheContext result = context;
     if (result.storage_expiration_time < 0) {
         result.storage_expiration_time = result.expiration_time;
@@ -960,12 +960,12 @@ Status BlockFileCache::update_cell_logical_meta(FileBlockCell& cell, FileCacheTy
                                           cell.file_block->offset(), cell.size());
     }
     auto& new_queue = get_queue(new_type);
-    cell.queue_iterator = new_queue.add(cell.file_block->get_hash_value(),
-                                        cell.file_block->offset(),
-                                        cell.file_block->range().size(), cache_lock);
+    cell.queue_iterator =
+            new_queue.add(cell.file_block->get_hash_value(), cell.file_block->offset(),
+                          cell.file_block->range().size(), cache_lock);
     _lru_recorder->record_queue_event(new_type, CacheLRULogType::ADD,
-                                      cell.file_block->get_hash_value(),
-                                      cell.file_block->offset(), cell.size());
+                                      cell.file_block->get_hash_value(), cell.file_block->offset(),
+                                      cell.size());
     if (origin_type == FileCacheType::TTL) {
         _cur_ttl_size -= cell.size();
     }
@@ -1003,9 +1003,9 @@ void BlockFileCache::update_hash_logical_meta(const UInt128Wrapper& hash, FileCa
     }
 }
 
-void BlockFileCache::update_hash_logical_expiration_time(
-        const UInt128Wrapper& hash, uint64_t new_expiration_time,
-        std::lock_guard<std::mutex>& cache_lock) {
+void BlockFileCache::update_hash_logical_expiration_time(const UInt128Wrapper& hash,
+                                                         uint64_t new_expiration_time,
+                                                         std::lock_guard<std::mutex>& cache_lock) {
     auto new_type = new_expiration_time == 0 ? FileCacheType::NORMAL : FileCacheType::TTL;
     update_hash_logical_meta(hash, new_type, new_expiration_time, cache_lock);
 }
@@ -1045,9 +1045,9 @@ FileBlockCell* BlockFileCache::add_cell(const UInt128Wrapper& hash, const CacheC
     key.offset = offset;
     key.meta.type = cell_context.cache_type;
     key.meta.expiration_time = cell_context.storage_expiration();
-    FileBlockCell cell(std::make_shared<FileBlock>(key, size, this, state,
-                                                   cell_context.expiration_time),
-                       cache_lock);
+    FileBlockCell cell(
+            std::make_shared<FileBlock>(key, size, this, state, cell_context.expiration_time),
+            cache_lock);
 
     auto& queue = get_queue(cell.file_block->cache_type());
     cell.queue_iterator = queue.add(hash, offset, size, cache_lock);
@@ -1366,8 +1366,8 @@ void BlockFileCache::remove_if_cached(const UInt128Wrapper& file_key) {
     bool has_unreleasable = false;
     {
         SCOPED_CACHE_LOCK(_mutex, this);
-        bool is_ttl_file = remove_if_ttl_file_blocks(file_key, true, cache_lock, true,
-                                                     &has_unreleasable);
+        bool is_ttl_file =
+                remove_if_ttl_file_blocks(file_key, true, cache_lock, true, &has_unreleasable);
         if (!is_ttl_file) {
             auto iter = _files.find(file_key);
             std::vector<FileBlockCell*> to_remove;

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1023,23 +1023,39 @@ CacheContext BlockFileCache::make_cell_context(
         result.storage_expiration_time = result.expiration_time;
     }
 
-    auto file_it = _files.find(hash);
-    if (file_it != _files.end() && !file_it->second.empty()) {
-        const auto& file_block = file_it->second.begin()->second.file_block;
-        result.cache_type = file_block->cache_type();
-        result.expiration_time = file_block->expiration_time();
-        if (context.storage_expiration_time < 0) {
-            result.storage_expiration_time = file_block->storage_expiration_time();
-        }
-    } else if (auto ttl_it = _key_to_time.find(hash); ttl_it != _key_to_time.end()) {
-        result.cache_type = FileCacheType::TTL;
-        result.expiration_time = ttl_it->second;
+    if (context.cache_type != FileCacheType::TTL) {
+        return result;
     }
 
-    if (result.expiration_time == 0 && result.cache_type == FileCacheType::TTL) {
-        result.cache_type = FileCacheType::NORMAL;
-    } else if (result.expiration_time != 0 && result.cache_type != FileCacheType::TTL) {
+    auto ttl_it = _key_to_time.find(hash);
+    auto file_it = _files.find(hash);
+    if (file_it != _files.end() && !file_it->second.empty()) {
+        for (const auto& [_, cell] : file_it->second) {
+            const auto& file_block = cell.file_block;
+            if (file_block->cache_type() != FileCacheType::TTL &&
+                file_block->storage_cache_type() != FileCacheType::TTL) {
+                continue;
+            }
+            result.cache_type = file_block->cache_type();
+            result.expiration_time = file_block->expiration_time();
+            if (context.storage_expiration_time < 0) {
+                result.storage_expiration_time = file_block->storage_expiration_time();
+            }
+            break;
+        }
+    }
+
+    if (ttl_it != _key_to_time.end()) {
         result.cache_type = FileCacheType::TTL;
+        result.expiration_time = ttl_it->second;
+        if (context.storage_expiration_time < 0 &&
+            result.storage_expiration_time == context.expiration_time) {
+            result.storage_expiration_time = ttl_it->second;
+        }
+    }
+
+    if (result.cache_type == FileCacheType::TTL && result.expiration_time == 0) {
+        result.cache_type = FileCacheType::NORMAL;
     }
     return result;
 }

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1023,26 +1023,38 @@ CacheContext BlockFileCache::make_cell_context(
         result.storage_expiration_time = result.expiration_time;
     }
 
+    auto ttl_it = _key_to_time.find(hash);
+    const FileBlock* storage_binding = nullptr;
+    const FileBlock* ttl_binding = nullptr;
+    auto file_it = _files.find(hash);
+    if (file_it != _files.end() && !file_it->second.empty()) {
+        for (const auto& [_, cell] : file_it->second) {
+            const auto* file_block = cell.file_block.get();
+            if (storage_binding == nullptr) {
+                storage_binding = file_block;
+            }
+            if (ttl_binding == nullptr &&
+                (file_block->cache_type() == FileCacheType::TTL ||
+                 file_block->storage_cache_type() == FileCacheType::TTL)) {
+                ttl_binding = file_block;
+            }
+        }
+    }
+
+    if (ttl_binding != nullptr) {
+        storage_binding = ttl_binding;
+    }
+    if (context.storage_expiration_time < 0 && storage_binding != nullptr) {
+        result.storage_expiration_time = storage_binding->storage_expiration_time();
+    }
+
     if (context.cache_type != FileCacheType::TTL) {
         return result;
     }
 
-    auto ttl_it = _key_to_time.find(hash);
-    auto file_it = _files.find(hash);
-    if (file_it != _files.end() && !file_it->second.empty()) {
-        for (const auto& [_, cell] : file_it->second) {
-            const auto& file_block = cell.file_block;
-            if (file_block->cache_type() != FileCacheType::TTL &&
-                file_block->storage_cache_type() != FileCacheType::TTL) {
-                continue;
-            }
-            result.cache_type = file_block->cache_type();
-            result.expiration_time = file_block->expiration_time();
-            if (context.storage_expiration_time < 0) {
-                result.storage_expiration_time = file_block->storage_expiration_time();
-            }
-            break;
-        }
+    if (ttl_binding != nullptr) {
+        result.cache_type = ttl_binding->cache_type();
+        result.expiration_time = ttl_binding->expiration_time();
     }
 
     if (ttl_it != _key_to_time.end()) {

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -30,6 +30,7 @@
 #include <optional>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "io/cache/cache_lru_dumper.h"
@@ -42,6 +43,7 @@
 
 namespace doris::io {
 using RecycleFileCacheKeys = moodycamel::ConcurrentQueue<FileCacheKey>;
+using RecycleFileCacheHashes = moodycamel::ConcurrentQueue<UInt128Wrapper>;
 
 class LockScopedTimer {
 public:
@@ -403,6 +405,26 @@ private:
                                     size_t offset, size_t size, FileBlock::State state,
                                     std::lock_guard<std::mutex>& cache_lock);
 
+    CacheContext make_cell_context(const UInt128Wrapper& hash, const CacheContext& context,
+                                   std::lock_guard<std::mutex>& cache_lock) const;
+
+    void enqueue_hash_for_cleanup(const UInt128Wrapper& hash);
+
+    void update_hash_logical_expiration_time(const UInt128Wrapper& hash,
+                                             uint64_t new_expiration_time,
+                                             std::lock_guard<std::mutex>& cache_lock);
+
+    void update_hash_logical_meta(const UInt128Wrapper& hash, FileCacheType new_type,
+                                  uint64_t new_expiration_time,
+                                  std::lock_guard<std::mutex>& cache_lock);
+
+    Status update_cell_logical_meta(FileBlockCell& cell, FileCacheType new_type,
+                                    uint64_t new_expiration_time,
+                                    std::lock_guard<std::mutex>& cache_lock);
+
+    void erase_key_expiration_time(const UInt128Wrapper& hash, uint64_t expiration_time,
+                                   std::lock_guard<std::mutex>& cache_lock);
+
     Status initialize_unlocked(std::lock_guard<std::mutex>& cache_lock);
 
     void update_block_lru(FileBlockSPtr block, std::lock_guard<std::mutex>& cache_lock);
@@ -456,7 +478,8 @@ private:
     bool need_to_move(FileCacheType cell_type, FileCacheType query_type) const;
 
     bool remove_if_ttl_file_blocks(const UInt128Wrapper& file_key, bool remove_directly,
-                                   std::lock_guard<std::mutex>&, bool sync);
+                                   std::lock_guard<std::mutex>&, bool sync,
+                                   bool* has_unreleasable = nullptr);
 
     void run_background_monitor();
     void run_background_ttl_gc();
@@ -550,6 +573,8 @@ private:
 
     // keys for async remove
     RecycleFileCacheKeys _recycle_keys;
+    RecycleFileCacheHashes _recycle_hashes;
+    std::unordered_set<UInt128Wrapper, KeyHash> _hashes_pending_cleanup;
 
     std::unique_ptr<LRUQueueRecorder> _lru_recorder;
     std::unique_ptr<CacheLRUDumper> _lru_dumper;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -44,6 +44,7 @@
 namespace doris::io {
 using RecycleFileCacheKeys = moodycamel::ConcurrentQueue<FileCacheKey>;
 using RecycleFileCacheHashes = moodycamel::ConcurrentQueue<UInt128Wrapper>;
+using RecycleFileCacheKeyDirs = moodycamel::ConcurrentQueue<std::pair<UInt128Wrapper, uint64_t>>;
 
 class LockScopedTimer {
 public:
@@ -201,6 +202,9 @@ public:
         }
         if (_cache_background_block_lru_update_thread.joinable()) {
             _cache_background_block_lru_update_thread.join();
+        }
+        if (_cache_background_ttl_repair_checker_thread.joinable()) {
+            _cache_background_ttl_repair_checker_thread.join();
         }
     }
 
@@ -409,6 +413,11 @@ private:
                                    std::lock_guard<std::mutex>& cache_lock) const;
 
     void enqueue_hash_for_cleanup(const UInt128Wrapper& hash);
+    void enqueue_key_dir_for_cleanup(const UInt128Wrapper& hash, uint64_t expiration_time);
+    size_t repair_duplicate_ttl_dirs_once();
+    std::optional<uint64_t> get_canonical_storage_expiration_if_stable(
+            const UInt128Wrapper& hash, std::lock_guard<std::mutex>& cache_lock,
+            bool* skipped_unstable);
 
     void update_hash_logical_expiration_time(const UInt128Wrapper& hash,
                                              uint64_t new_expiration_time,
@@ -489,6 +498,7 @@ private:
     void restore_lru_queues_from_disk(std::lock_guard<std::mutex>& cache_lock);
     void run_background_evict_in_advance();
     void run_background_block_lru_update();
+    void run_background_ttl_repair_checker();
 
     bool try_reserve_from_other_queue_by_time_interval(FileCacheType cur_type,
                                                        std::vector<FileCacheType> other_cache_types,
@@ -545,6 +555,7 @@ private:
     std::thread _cache_background_lru_dump_thread;
     std::thread _cache_background_lru_log_replay_thread;
     std::thread _cache_background_block_lru_update_thread;
+    std::thread _cache_background_ttl_repair_checker_thread;
     std::atomic_bool _async_open_done {false};
     // disk space or inode is less than the specified value
     bool _disk_resource_limit_mode {false};
@@ -574,6 +585,7 @@ private:
     // keys for async remove
     RecycleFileCacheKeys _recycle_keys;
     RecycleFileCacheHashes _recycle_hashes;
+    RecycleFileCacheKeyDirs _recycle_key_dirs;
     std::unordered_set<UInt128Wrapper, KeyHash> _hashes_pending_cleanup;
 
     std::unique_ptr<LRUQueueRecorder> _lru_recorder;
@@ -638,6 +650,11 @@ private:
     std::shared_ptr<bvar::LatencyRecorder> _update_lru_blocks_latency_us;
     std::shared_ptr<bvar::LatencyRecorder> _need_update_lru_blocks_length_recorder;
     std::shared_ptr<bvar::LatencyRecorder> _ttl_gc_latency_us;
+    std::shared_ptr<bvar::LatencyRecorder> _ttl_repair_checker_latency_us;
+    std::shared_ptr<bvar::Adder<size_t>> _ttl_repair_checker_suspect_hashes;
+    std::shared_ptr<bvar::Adder<size_t>> _ttl_repair_checker_repairs_enqueued;
+    std::shared_ptr<bvar::Adder<size_t>> _ttl_repair_checker_skipped_unstable_hashes;
+    std::shared_ptr<bvar::Adder<size_t>> _ttl_repair_checker_skipped_unbound_hashes;
 
     std::shared_ptr<bvar::LatencyRecorder> _shadow_queue_levenshtein_distance;
     // keep _storage last so it will deconstruct first

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -38,10 +38,16 @@ std::ostream& operator<<(std::ostream& os, const FileBlock::State& value) {
 
 FileBlock::FileBlock(const FileCacheKey& key, size_t size, BlockFileCache* mgr,
                      State download_state)
+        : FileBlock(key, size, mgr, download_state, key.meta.expiration_time) {}
+
+FileBlock::FileBlock(const FileCacheKey& key, size_t size, BlockFileCache* mgr,
+                     State download_state, uint64_t logical_expiration_time)
         : _block_range(key.offset, key.offset + size - 1),
           _download_state(download_state),
           _mgr(mgr),
-          _key(key) {
+          _key(key),
+          _logical_cache_type(key.meta.type),
+          _logical_expiration_time(logical_expiration_time) {
     /// On creation, file block state can be EMPTY, DOWNLOADED, SKIP_CACHE.
     switch (_download_state) {
     case State::DOWNLOADING: {
@@ -180,33 +186,32 @@ Status FileBlock::read(Slice buffer, size_t read_offset) {
 
 Status FileBlock::change_cache_type_between_ttl_and_others(FileCacheType new_type) {
     std::lock_guard block_lock(_mutex);
-    DCHECK(new_type != _key.meta.type);
-    bool expr = (new_type == FileCacheType::TTL || _key.meta.type == FileCacheType::TTL);
+    DCHECK(new_type != _logical_cache_type);
+    bool expr = (new_type == FileCacheType::TTL || _logical_cache_type == FileCacheType::TTL);
     if (!expr) {
         LOG(WARNING) << "none of the cache type is TTL"
                      << ", hash: " << _key.hash.to_string() << ", offset: " << _key.offset
                      << ", new type: " << cache_type_to_string(new_type)
-                     << ", old type: " << cache_type_to_string(_key.meta.type);
+                     << ", old type: " << cache_type_to_string(_logical_cache_type);
     }
     DCHECK(expr);
 
-    // change cache type between TTL to others don't need to rename the filename suffix
-    _key.meta.type = new_type;
+    _logical_cache_type = new_type;
     return Status::OK();
 }
 
 Status FileBlock::change_cache_type_between_normal_and_index(FileCacheType new_type) {
     SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);
     std::lock_guard block_lock(_mutex);
-    bool expr = (new_type != FileCacheType::TTL && _key.meta.type != FileCacheType::TTL);
+    bool expr = (new_type != FileCacheType::TTL && _logical_cache_type != FileCacheType::TTL);
     if (!expr) {
         LOG(WARNING) << "one of the cache type is TTL"
                      << ", hash: " << _key.hash.to_string() << ", offset: " << _key.offset
                      << ", new type: " << cache_type_to_string(new_type)
-                     << ", old type: " << cache_type_to_string(_key.meta.type);
+                     << ", old type: " << cache_type_to_string(_logical_cache_type);
     }
     DCHECK(expr);
-    if (_key.meta.type == FileCacheType::TTL || new_type == _key.meta.type) {
+    if (_logical_cache_type == FileCacheType::TTL || new_type == _logical_cache_type) {
         return Status::OK();
     }
     if (_download_state == State::DOWNLOADED) {
@@ -216,19 +221,30 @@ Status FileBlock::change_cache_type_between_normal_and_index(FileCacheType new_t
     }
     _mgr->change_cache_type(_key.hash, _block_range.left, new_type, cache_lock);
     _key.meta.type = new_type;
+    _logical_cache_type = new_type;
     return Status::OK();
 }
 
 Status FileBlock::update_expiration_time(uint64_t expiration_time) {
     std::lock_guard block_lock(_mutex);
-    if (_download_state == State::DOWNLOADED) {
-        auto st = _mgr->_storage->change_key_meta_expiration(_key, expiration_time);
-        if (!st.ok() && !st.is<ErrorCode::NOT_FOUND>()) {
-            return st;
-        }
-    }
-    _key.meta.expiration_time = expiration_time;
+    _logical_expiration_time = expiration_time;
     return Status::OK();
+}
+
+Status FileBlock::update_logical_cache_type(FileCacheType new_type) {
+    std::lock_guard block_lock(_mutex);
+    _logical_cache_type = new_type;
+    return Status::OK();
+}
+
+void FileBlock::update_storage_expiration_time(uint64_t expiration_time) {
+    std::lock_guard block_lock(_mutex);
+    _key.meta.expiration_time = expiration_time;
+}
+
+void FileBlock::update_storage_cache_type(FileCacheType type) {
+    std::lock_guard block_lock(_mutex);
+    _key.meta.type = type;
 }
 
 FileBlock::State FileBlock::wait() {

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -37,11 +37,13 @@ namespace io {
 
 struct FileBlocksHolder;
 class BlockFileCache;
+class FSFileCacheStorage;
 struct FileBlockCell;
 
 class FileBlock {
     friend struct FileBlocksHolder;
     friend class BlockFileCache;
+    friend class FSFileCacheStorage;
     friend class CachedRemoteFileReader;
     friend struct FileBlockCell;
     friend class FileBlockTestAccessor;
@@ -65,6 +67,8 @@ public:
     };
 
     FileBlock(const FileCacheKey& key, size_t size, BlockFileCache* mgr, State download_state);
+    FileBlock(const FileCacheKey& key, size_t size, BlockFileCache* mgr, State download_state,
+              uint64_t logical_expiration_time);
 
     ~FileBlock() = default;
 
@@ -113,7 +117,9 @@ public:
 
     bool is_downloader() const;
 
-    FileCacheType cache_type() const { return _key.meta.type; }
+    FileCacheType cache_type() const { return _logical_cache_type; }
+
+    FileCacheType storage_cache_type() const { return _key.meta.type; }
 
     static uint64_t get_caller_id();
 
@@ -125,7 +131,11 @@ public:
 
     [[nodiscard]] Status update_expiration_time(uint64_t expiration_time);
 
-    uint64_t expiration_time() const { return _key.meta.expiration_time; }
+    uint64_t expiration_time() const { return _logical_expiration_time; }
+
+    uint64_t storage_expiration_time() const { return _key.meta.expiration_time; }
+
+    FileCacheKey storage_key() const { return _key; }
 
     std::string get_cache_file() const;
 
@@ -152,6 +162,12 @@ private:
 
     void reset_downloader_impl(std::lock_guard<std::mutex>& block_lock);
 
+    void update_storage_expiration_time(uint64_t expiration_time);
+
+    void update_storage_cache_type(FileCacheType type);
+
+    Status update_logical_cache_type(FileCacheType new_type);
+
     Range _block_range;
 
     State _download_state;
@@ -166,6 +182,8 @@ private:
     mutable std::mutex _mutex;
     std::condition_variable _cv;
     FileCacheKey _key;
+    FileCacheType _logical_cache_type {FileCacheType::NORMAL};
+    uint64_t _logical_expiration_time {0};
     size_t _downloaded_size {0};
     bool _is_deleting {false};
 

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -156,15 +156,24 @@ struct CacheContext {
     CacheContext() = default;
     bool operator==(const CacheContext& rhs) const {
         return query_id == rhs.query_id && cache_type == rhs.cache_type &&
-               expiration_time == rhs.expiration_time && is_cold_data == rhs.is_cold_data;
+               expiration_time == rhs.expiration_time &&
+               storage_expiration_time == rhs.storage_expiration_time &&
+               is_cold_data == rhs.is_cold_data;
     }
     TUniqueId query_id;
     FileCacheType cache_type;
     int64_t expiration_time {0};
+    // Used only by cache internals when logical TTL and storage directory diverge.
+    // -1 means using expiration_time as the storage directory expiration.
+    int64_t storage_expiration_time {-1};
     bool is_cold_data {false};
     ReadStatistics* stats;
     bool is_warmup {false};
     int64_t tablet_id {0};
+
+    int64_t storage_expiration() const {
+        return storage_expiration_time >= 0 ? storage_expiration_time : expiration_time;
+    }
 };
 
 template <class Lock>

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <functional>
+#include <vector>
+
 #include "io/cache/file_cache_common.h"
 #include "util/slice.h"
 
@@ -27,6 +30,11 @@ class BlockFileCache;
 using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
 
 enum FileCacheStorageType { DISK = 0, MEMORY = 1 };
+
+struct DuplicateKeyDirs {
+    UInt128Wrapper hash;
+    std::vector<uint64_t> expiration_times;
+};
 
 struct FileWriterMapKeyHash {
     std::size_t operator()(const FileWriterMapKey& w) const {
@@ -57,6 +65,15 @@ public:
     virtual Status remove(const FileCacheKey& key) = 0;
     // remove all directories for the same hash, including unloaded hash_* dirs
     virtual Status remove_all_by_hash(const UInt128Wrapper& hash) { return Status::OK(); }
+    // remove one storage directory for a hash
+    virtual Status remove_key_dir(const UInt128Wrapper&, uint64_t) {
+        return Status::OK();
+    }
+    // find hashes that have more than one storage directory on disk
+    virtual Status list_duplicate_key_dirs(std::vector<DuplicateKeyDirs>*,
+                                           const std::function<bool()>&) {
+        return Status::OK();
+    }
     // change the block meta
     virtual Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) = 0;
     virtual Status change_key_meta_expiration(const FileCacheKey& key,

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -55,6 +55,8 @@ public:
     virtual Status read(const FileCacheKey& key, size_t value_offset, Slice result) = 0;
     // remove the block
     virtual Status remove(const FileCacheKey& key) = 0;
+    // remove all directories for the same hash, including unloaded hash_* dirs
+    virtual Status remove_all_by_hash(const UInt128Wrapper& hash) { return Status::OK(); }
     // change the block meta
     virtual Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) = 0;
     virtual Status change_key_meta_expiration(const FileCacheKey& key,

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -66,9 +66,7 @@ public:
     // remove all directories for the same hash, including unloaded hash_* dirs
     virtual Status remove_all_by_hash(const UInt128Wrapper& hash) { return Status::OK(); }
     // remove one storage directory for a hash
-    virtual Status remove_key_dir(const UInt128Wrapper&, uint64_t) {
-        return Status::OK();
-    }
+    virtual Status remove_key_dir(const UInt128Wrapper&, uint64_t) { return Status::OK(); }
     // find hashes that have more than one storage directory on disk
     virtual Status list_duplicate_key_dirs(std::vector<DuplicateKeyDirs>*,
                                            const std::function<bool()>&) {

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -19,9 +19,11 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <functional>
 #include <iterator>
 #include <mutex>
 #include <system_error>
+#include <unordered_map>
 
 #include "common/logging.h"
 #include "cpp/sync_point.h"
@@ -289,6 +291,99 @@ Status FSFileCacheStorage::remove_all_by_hash(const UInt128Wrapper& hash) {
             return Status::IOError("failed to remove file cache dir {}, error={}", key_dir.path,
                                    ec.message());
         }
+    }
+    return Status::OK();
+}
+
+Status FSFileCacheStorage::remove_key_dir(const UInt128Wrapper& hash, uint64_t expiration_time) {
+    FDCache::instance()->remove_file_readers(hash);
+    auto dir = get_path_in_local_cache(hash, expiration_time);
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    if (ec) {
+        return Status::IOError("failed to remove file cache dir {}, error={}", dir, ec.message());
+    }
+    return Status::OK();
+}
+
+Status FSFileCacheStorage::list_duplicate_key_dirs(
+        std::vector<DuplicateKeyDirs>* duplicate_key_dirs,
+        const std::function<bool()>& should_stop) {
+    DCHECK(duplicate_key_dirs != nullptr);
+    duplicate_key_dirs->clear();
+
+    auto scan_parent = [&](const std::filesystem::path& parent_path) -> Status {
+        std::error_code ec;
+        std::filesystem::directory_iterator dir_it(parent_path, ec);
+        if (ec) {
+            return Status::OK();
+        }
+
+        std::unordered_map<UInt128Wrapper, std::vector<uint64_t>, KeyHash> dirs_by_hash;
+        for (; dir_it != std::filesystem::directory_iterator(); ++dir_it) {
+            if (should_stop && should_stop()) {
+                return Status::Cancelled("file cache ttl repair checker stopped");
+            }
+            if (!dir_it->is_directory(ec) || ec) {
+                ec.clear();
+                continue;
+            }
+            auto filename = dir_it->path().filename().native();
+            auto delim_pos = filename.find('_');
+            if (delim_pos == std::string::npos) {
+                continue;
+            }
+            auto hash_str = filename.substr(0, delim_pos);
+            auto expiration_str = filename.substr(delim_pos + 1);
+            if (hash_str.size() != sizeof(uint128_t) * 2) {
+                continue;
+            }
+            try {
+                size_t parsed_len = 0;
+                auto expiration_time = std::stoull(expiration_str, &parsed_len);
+                if (parsed_len != expiration_str.size()) {
+                    continue;
+                }
+                UInt128Wrapper hash(vectorized::unhex_uint<uint128_t>(hash_str.c_str()));
+                dirs_by_hash[hash].push_back(expiration_time);
+            } catch (...) {
+                LOG(WARNING) << "skip invalid file cache key dir=" << dir_it->path().native();
+            }
+        }
+
+        for (auto& [hash, expirations] : dirs_by_hash) {
+            std::sort(expirations.begin(), expirations.end());
+            expirations.erase(std::unique(expirations.begin(), expirations.end()),
+                              expirations.end());
+            if (expirations.size() > 1) {
+                duplicate_key_dirs->push_back(
+                        DuplicateKeyDirs {.hash = hash, .expiration_times = std::move(expirations)});
+            }
+        }
+        return Status::OK();
+    };
+
+    std::error_code ec;
+    if constexpr (USE_CACHE_VERSION2) {
+        std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
+        if (ec) {
+            return Status::OK();
+        }
+        for (; key_prefix_it != std::filesystem::directory_iterator(); ++key_prefix_it) {
+            if (should_stop && should_stop()) {
+                return Status::Cancelled("file cache ttl repair checker stopped");
+            }
+            if (!key_prefix_it->is_directory(ec) || ec) {
+                ec.clear();
+                continue;
+            }
+            if (key_prefix_it->path().filename().native().size() != KEY_PREFIX_LENGTH) {
+                continue;
+            }
+            RETURN_IF_ERROR(scan_parent(key_prefix_it->path()));
+        }
+    } else {
+        RETURN_IF_ERROR(scan_parent(_cache_base_path));
     }
     return Status::OK();
 }

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -775,8 +775,7 @@ Status FSFileCacheStorage::parse_filename_suffix_to_cache_type(
 bool FSFileCacheStorage::handle_already_loaded_block(
         BlockFileCache* mgr, const UInt128Wrapper& hash, size_t offset, size_t new_size,
         const CacheContext& context, const std::string& key_path, const std::string& offset_path,
-        bool is_tmp,
-        std::lock_guard<std::mutex>& cache_lock) const {
+        bool is_tmp, std::lock_guard<std::mutex>& cache_lock) const {
     auto file_it = mgr->_files.find(hash);
     if (file_it == mgr->_files.end()) {
         return false;
@@ -805,9 +804,8 @@ bool FSFileCacheStorage::handle_already_loaded_block(
     if (accepted_storage_path && old_size != new_size) {
         mgr->reset_range(hash, offset, old_size, new_size, cache_lock);
     }
-    if (accepted_storage_path &&
-        (block->cache_type() != context.cache_type ||
-         block->expiration_time() != context.expiration_time)) {
+    if (accepted_storage_path && (block->cache_type() != context.cache_type ||
+                                  block->expiration_time() != context.expiration_time)) {
         mgr->update_hash_logical_meta(hash, context.cache_type, context.expiration_time,
                                       cache_lock);
     }
@@ -816,8 +814,7 @@ bool FSFileCacheStorage::handle_already_loaded_block(
 
 void FSFileCacheStorage::load_blocks_from_dir_unlocked(
         BlockFileCache* mgr, const UInt128Wrapper& hash, const KeyDir& key_dir,
-        const FileCacheKey* logical_key,
-        std::lock_guard<std::mutex>& cache_lock) const {
+        const FileCacheKey* logical_key, std::lock_guard<std::mutex>& cache_lock) const {
     CacheContext context_original;
     context_original.query_id = TUniqueId();
     context_original.expiration_time =
@@ -836,8 +833,8 @@ void FSFileCacheStorage::load_blocks_from_dir_unlocked(
         bool is_tmp = false;
         FileCacheType cache_type = FileCacheType::NORMAL;
         if (!parse_filename_suffix_to_cache_type(fs, check_it->path().filename().native(),
-                                                 key_dir.expiration_time, size, &offset,
-                                                 &is_tmp, &cache_type)) {
+                                                 key_dir.expiration_time, size, &offset, &is_tmp,
+                                                 &cache_type)) {
             continue;
         }
         context_original.cache_type = logical_key == nullptr ? cache_type : logical_key->meta.type;
@@ -1023,10 +1020,9 @@ void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, cons
         return;
     }
 
-    load_blocks_from_dir_unlocked(mgr, key.hash,
-                                  KeyDir {.expiration_time = key.meta.expiration_time,
-                                          .path = key_path},
-                                  &key, cache_lock);
+    load_blocks_from_dir_unlocked(
+            mgr, key.hash, KeyDir {.expiration_time = key.meta.expiration_time, .path = key_path},
+            &key, cache_lock);
     if (mgr->get_cell(key.hash, key.offset, cache_lock) != nullptr) {
         return;
     }

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -882,7 +882,6 @@ bool FSFileCacheStorage::handle_already_loaded_block(
     }
     auto block = cell_it->second.file_block;
     if (is_tmp) {
-        remove_file_and_empty_dir(offset_path, key_path);
         return true;
     }
     bool accepted_storage_path = true;

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -356,8 +356,8 @@ Status FSFileCacheStorage::list_duplicate_key_dirs(
             expirations.erase(std::unique(expirations.begin(), expirations.end()),
                               expirations.end());
             if (expirations.size() > 1) {
-                duplicate_key_dirs->push_back(
-                        DuplicateKeyDirs {.hash = hash, .expiration_times = std::move(expirations)});
+                duplicate_key_dirs->push_back(DuplicateKeyDirs {
+                        .hash = hash, .expiration_times = std::move(expirations)});
             }
         }
         return Status::OK();

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -17,7 +17,9 @@
 
 #include "io/cache/fs_file_cache_storage.h"
 
+#include <algorithm>
 #include <filesystem>
+#include <iterator>
 #include <mutex>
 #include <system_error>
 
@@ -89,6 +91,22 @@ void FDCache::remove_file_reader(const AccessKeyAndOffset& key) {
     if (auto iter = _file_name_to_reader.find(key); iter != _file_name_to_reader.end()) {
         _file_reader_list.erase(iter->second);
         _file_name_to_reader.erase(key);
+    }
+}
+
+void FDCache::remove_file_readers(const UInt128Wrapper& hash) {
+    if (config::file_cache_max_file_reader_cache_size == 0) [[unlikely]] {
+        return;
+    }
+    DCHECK(ExecEnv::GetInstance());
+    std::lock_guard wlock(_mtx);
+    for (auto iter = _file_name_to_reader.begin(); iter != _file_name_to_reader.end();) {
+        if (iter->first.first == hash) {
+            _file_reader_list.erase(iter->second);
+            iter = _file_name_to_reader.erase(iter);
+        } else {
+            ++iter;
+        }
     }
 }
 
@@ -227,27 +245,50 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
 
 Status FSFileCacheStorage::remove(const FileCacheKey& key) {
     std::string dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-    std::string file = get_path_in_local_cache(dir, key.offset, key.meta.type);
+    auto candidates = get_path_in_local_cache_all_candidates(dir, key.offset);
     FDCache::instance()->remove_file_reader(std::make_pair(key.hash, key.offset));
-    RETURN_IF_ERROR(fs->delete_file(file));
-    // return OK not means the file is deleted, it may be not exist
-    // So for TTL, we make sure the old format will be removed well
-    if (key.meta.type == FileCacheType::TTL) {
+
+    Status last_error = Status::OK();
+    bool removed = false;
+    for (auto& file : candidates) {
         bool exists {false};
-        // try to detect the file with old ttl format
-        file = get_path_in_local_cache_old_ttl_format(dir, key.offset, key.meta.type);
-        RETURN_IF_ERROR(fs->exists(file, &exists));
+        auto st = fs->exists(file, &exists);
+        if (!st.ok()) {
+            last_error = st;
+            continue;
+        }
         if (exists) {
-            VLOG(7) << "try to remove the file with old ttl format"
-                    << " file=" << file;
-            RETURN_IF_ERROR(fs->delete_file(file));
+            st = fs->delete_file(file);
+            if (!st.ok()) {
+                last_error = st;
+            } else {
+                removed = true;
+            }
         }
     }
+    if (!removed && !last_error.ok()) {
+        return last_error;
+    }
+
     std::vector<FileInfo> files;
     bool exists {false};
     RETURN_IF_ERROR(fs->list(dir, true, &files, &exists));
     if (files.empty()) {
         RETURN_IF_ERROR(fs->delete_directory(dir));
+    }
+    return Status::OK();
+}
+
+Status FSFileCacheStorage::remove_all_by_hash(const UInt128Wrapper& hash) {
+    FDCache::instance()->remove_file_readers(hash);
+    auto key_dirs = list_key_dirs(hash);
+    for (const auto& key_dir : key_dirs) {
+        std::error_code ec;
+        std::filesystem::remove_all(key_dir.path, ec);
+        if (ec) {
+            return Status::IOError("failed to remove file cache dir {}, error={}", key_dir.path,
+                                   ec.message());
+        }
     }
     return Status::OK();
 }
@@ -307,7 +348,7 @@ std::string FSFileCacheStorage::get_path_in_local_cache_old_ttl_format(const std
 }
 
 std::vector<std::string> FSFileCacheStorage::get_path_in_local_cache_all_candidates(
-        const std::string& dir, size_t offset) {
+        const std::string& dir, size_t offset) const {
     std::vector<std::string> candidates;
     std::string base = get_path_in_local_cache(dir, offset, FileCacheType::NORMAL);
     candidates.push_back(base);
@@ -333,6 +374,78 @@ std::string FSFileCacheStorage::get_path_in_local_cache(const UInt128Wrapper& va
                 .tag("key", value.to_string())
                 .tag("expiration_time", expiration_time);
         return "";
+    }
+}
+
+std::vector<FSFileCacheStorage::KeyDir> FSFileCacheStorage::list_key_dirs(
+        const UInt128Wrapper& hash) const {
+    std::vector<KeyDir> key_dirs;
+    auto key_str = hash.to_string();
+    std::filesystem::path parent_path;
+    if constexpr (USE_CACHE_VERSION2) {
+        parent_path = Path(_cache_base_path) / key_str.substr(0, KEY_PREFIX_LENGTH);
+    } else {
+        parent_path = _cache_base_path;
+    }
+
+    std::error_code ec;
+    std::filesystem::directory_iterator dir_it(parent_path, ec);
+    if (ec) {
+        return key_dirs;
+    }
+
+    const std::string prefix = key_str + "_";
+    for (; dir_it != std::filesystem::directory_iterator(); ++dir_it) {
+        if (!dir_it->is_directory()) {
+            continue;
+        }
+        auto filename = dir_it->path().filename().native();
+        if (!filename.starts_with(prefix)) {
+            continue;
+        }
+        auto expiration_str = filename.substr(prefix.size());
+        try {
+            key_dirs.push_back(KeyDir {.expiration_time = std::stoull(expiration_str),
+                                       .path = dir_it->path().native()});
+        } catch (...) {
+            LOG(WARNING) << "skip invalid file cache key dir=" << dir_it->path().native();
+        }
+    }
+    std::sort(key_dirs.begin(), key_dirs.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.expiration_time < rhs.expiration_time;
+    });
+    return key_dirs;
+}
+
+bool FSFileCacheStorage::storage_file_exists(const FileCacheKey& key) const {
+    auto dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
+    auto candidates = get_path_in_local_cache_all_candidates(dir, key.offset);
+    for (const auto& candidate : candidates) {
+        bool exists {false};
+        auto st = fs->exists(candidate, &exists);
+        if (st.ok() && exists) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void FSFileCacheStorage::remove_file_and_empty_dir(const std::string& file_path,
+                                                   const std::string& dir_path) const {
+    std::error_code ec;
+    std::filesystem::remove(file_path, ec);
+    if (ec) {
+        LOG(WARNING) << fmt::format("cannot remove {}: {}", file_path, ec.message());
+        return;
+    }
+    std::vector<FileInfo> files;
+    bool exists {false};
+    auto st = fs->list(dir_path, true, &files, &exists);
+    if (st.ok() && files.empty()) {
+        st = fs->delete_directory(dir_path);
+        if (!st.ok()) {
+            LOG_WARNING("failed to remove empty file cache dir {}", dir_path).error(st);
+        }
     }
 }
 
@@ -661,6 +774,8 @@ Status FSFileCacheStorage::parse_filename_suffix_to_cache_type(
 
 bool FSFileCacheStorage::handle_already_loaded_block(
         BlockFileCache* mgr, const UInt128Wrapper& hash, size_t offset, size_t new_size,
+        const CacheContext& context, const std::string& key_path, const std::string& offset_path,
+        bool is_tmp,
         std::lock_guard<std::mutex>& cache_lock) const {
     auto file_it = mgr->_files.find(hash);
     if (file_it == mgr->_files.end()) {
@@ -672,11 +787,71 @@ bool FSFileCacheStorage::handle_already_loaded_block(
         return false;
     }
     auto block = cell_it->second.file_block;
+    if (is_tmp) {
+        remove_file_and_empty_dir(offset_path, key_path);
+        return true;
+    }
+    bool accepted_storage_path = true;
+    if (!storage_file_exists(block->storage_key())) {
+        block->update_storage_expiration_time(context.storage_expiration());
+        block->update_storage_cache_type(context.cache_type);
+    } else if (block->storage_expiration_time() != context.storage_expiration()) {
+        remove_file_and_empty_dir(offset_path, key_path);
+        accepted_storage_path = false;
+    } else if (block->storage_cache_type() != context.cache_type) {
+        block->update_storage_cache_type(context.cache_type);
+    }
     size_t old_size = block->range().size();
-    if (old_size != new_size) {
+    if (accepted_storage_path && old_size != new_size) {
         mgr->reset_range(hash, offset, old_size, new_size, cache_lock);
     }
+    if (accepted_storage_path &&
+        (block->cache_type() != context.cache_type ||
+         block->expiration_time() != context.expiration_time)) {
+        mgr->update_hash_logical_meta(hash, context.cache_type, context.expiration_time,
+                                      cache_lock);
+    }
     return true;
+}
+
+void FSFileCacheStorage::load_blocks_from_dir_unlocked(
+        BlockFileCache* mgr, const UInt128Wrapper& hash, const KeyDir& key_dir,
+        const FileCacheKey* logical_key,
+        std::lock_guard<std::mutex>& cache_lock) const {
+    CacheContext context_original;
+    context_original.query_id = TUniqueId();
+    context_original.expiration_time =
+            logical_key == nullptr ? key_dir.expiration_time : logical_key->meta.expiration_time;
+    context_original.storage_expiration_time = key_dir.expiration_time;
+
+    std::error_code ec;
+    std::filesystem::directory_iterator check_it(key_dir.path, ec);
+    if (ec) [[unlikely]] {
+        LOG(WARNING) << "fail to directory_iterator " << ec.message();
+        return;
+    }
+    for (; check_it != std::filesystem::directory_iterator(); ++check_it) {
+        size_t size = check_it->file_size(ec);
+        size_t offset = 0;
+        bool is_tmp = false;
+        FileCacheType cache_type = FileCacheType::NORMAL;
+        if (!parse_filename_suffix_to_cache_type(fs, check_it->path().filename().native(),
+                                                 key_dir.expiration_time, size, &offset,
+                                                 &is_tmp, &cache_type)) {
+            continue;
+        }
+        context_original.cache_type = logical_key == nullptr ? cache_type : logical_key->meta.type;
+        if (handle_already_loaded_block(mgr, hash, offset, size, context_original, key_dir.path,
+                                        check_it->path().native(), is_tmp, cache_lock)) {
+            continue;
+        }
+        if (is_tmp) {
+            remove_file_and_empty_dir(check_it->path().native(), key_dir.path);
+            continue;
+        }
+        mgr->add_cell(hash, context_original, offset, size, FileBlock::State::DOWNLOADED,
+                      cache_lock);
+    }
 }
 
 void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const {
@@ -688,7 +863,9 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
 
         auto f = [&](const BatchLoadArgs& args) {
             // in async load mode, a cell may be added twice.
-            if (handle_already_loaded_block(_mgr, args.hash, args.offset, args.size, cache_lock)) {
+            if (handle_already_loaded_block(_mgr, args.hash, args.offset, args.size, args.ctx,
+                                            args.key_path, args.offset_path, args.is_tmp,
+                                            cache_lock)) {
                 return;
             }
             // if the file is tmp, it means it is the old file and it should be removed
@@ -727,6 +904,7 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
             context.query_id = TUniqueId();
             long expiration_time = std::stoul(expiration_time_str);
             context.expiration_time = expiration_time;
+            context.storage_expiration_time = expiration_time;
             for (; offset_it != std::filesystem::directory_iterator(); ++offset_it) {
                 size_t size = offset_it->file_size(ec);
                 if (ec) [[unlikely]] {
@@ -803,7 +981,24 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
     if (!batch_load_buffer.empty()) {
         add_cell_batch_func();
     }
+    drop_unbound_loaded_blocks(_mgr);
     TEST_SYNC_POINT_CALLBACK("BlockFileCache::TmpFile2");
+}
+
+void FSFileCacheStorage::drop_unbound_loaded_blocks(BlockFileCache* mgr) const {
+    SCOPED_CACHE_LOCK(mgr->_mutex, mgr);
+    std::vector<FileBlockCell*> to_remove;
+    for (auto& [_, offset_to_cell] : mgr->_files) {
+        for (auto& [__, cell] : offset_to_cell) {
+            if (cell.file_block->state_unsafe() != FileBlock::State::DOWNLOADED) {
+                continue;
+            }
+            if (!storage_file_exists(cell.file_block->storage_key())) {
+                to_remove.push_back(&cell);
+            }
+        }
+    }
+    mgr->remove_file_blocks_and_clean_time_maps(to_remove, cache_lock);
 }
 
 void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, const FileCacheKey& key,
@@ -811,49 +1006,37 @@ void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, cons
     // async load, can't find key, need to check exist.
     auto key_path = get_path_in_local_cache(key.hash, key.meta.expiration_time);
     bool exists = false;
-    auto st = fs->exists(key_path, &exists);
     if (auto st = fs->exists(key_path, &exists); !exists && st.ok()) {
-        // cache miss
+        auto key_dirs = list_key_dirs(key.hash);
+        auto preferred_it = std::find_if(key_dirs.begin(), key_dirs.end(), [&](const auto& dir) {
+            return dir.expiration_time == key.meta.expiration_time;
+        });
+        if (preferred_it != key_dirs.end()) {
+            std::rotate(key_dirs.begin(), preferred_it, std::next(preferred_it));
+        }
+        for (const auto& key_dir : key_dirs) {
+            load_blocks_from_dir_unlocked(mgr, key.hash, key_dir, &key, cache_lock);
+        }
         return;
     } else if (!st.ok()) [[unlikely]] {
         LOG_WARNING("failed to exists file {}", key_path).error(st);
         return;
     }
 
-    CacheContext context_original;
-    context_original.query_id = TUniqueId();
-    context_original.expiration_time = key.meta.expiration_time;
-    std::error_code ec;
-    std::filesystem::directory_iterator check_it(key_path, ec);
-    if (ec) [[unlikely]] {
-        LOG(WARNING) << "fail to directory_iterator " << ec.message();
+    load_blocks_from_dir_unlocked(mgr, key.hash,
+                                  KeyDir {.expiration_time = key.meta.expiration_time,
+                                          .path = key_path},
+                                  &key, cache_lock);
+    if (mgr->get_cell(key.hash, key.offset, cache_lock) != nullptr) {
         return;
     }
-    for (; check_it != std::filesystem::directory_iterator(); ++check_it) {
-        size_t size = check_it->file_size(ec);
-        size_t offset = 0;
-        bool is_tmp = false;
-        FileCacheType cache_type = FileCacheType::NORMAL;
-        if (!parse_filename_suffix_to_cache_type(fs, check_it->path().filename().native(),
-                                                 context_original.expiration_time, size, &offset,
-                                                 &is_tmp, &cache_type)) {
+
+    auto key_dirs = list_key_dirs(key.hash);
+    for (const auto& key_dir : key_dirs) {
+        if (key_dir.expiration_time == key.meta.expiration_time) {
             continue;
         }
-        if (!mgr->_files.contains(key.hash) || !mgr->_files[key.hash].contains(offset)) {
-            // if the file is tmp, it means it is the old file and it should be removed
-            if (is_tmp) {
-                std::error_code ec;
-                std::filesystem::remove(check_it->path(), ec);
-                if (ec) {
-                    LOG(WARNING) << fmt::format("cannot remove {}: {}", check_it->path().native(),
-                                                ec.message());
-                }
-            } else {
-                context_original.cache_type = cache_type;
-                mgr->add_cell(key.hash, context_original, offset, size,
-                              FileBlock::State::DOWNLOADED, cache_lock);
-            }
-        }
+        load_blocks_from_dir_unlocked(mgr, key.hash, key_dir, &key, cache_lock);
     }
 }
 

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -1117,9 +1117,6 @@ void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, cons
     load_blocks_from_dir_unlocked(
             mgr, key.hash, KeyDir {.expiration_time = key.meta.expiration_time, .path = key_path},
             &key, cache_lock);
-    if (mgr->get_cell(key.hash, key.offset, cache_lock) != nullptr) {
-        return;
-    }
 
     auto key_dirs = list_key_dirs(key.hash);
     for (const auto& key_dir : key_dirs) {

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -94,8 +94,7 @@ public:
     bool handle_already_loaded_block(BlockFileCache* mgr, const UInt128Wrapper& hash, size_t offset,
                                      size_t new_size, const CacheContext& context,
                                      const std::string& key_path, const std::string& offset_path,
-                                     bool is_tmp,
-                                     std::lock_guard<std::mutex>& cache_lock) const;
+                                     bool is_tmp, std::lock_guard<std::mutex>& cache_lock) const;
 
 private:
     struct KeyDir {
@@ -126,8 +125,7 @@ private:
     [[nodiscard]] std::vector<KeyDir> list_key_dirs(const UInt128Wrapper& hash) const;
 
     void load_blocks_from_dir_unlocked(BlockFileCache* mgr, const UInt128Wrapper& hash,
-                                       const KeyDir& key_dir,
-                                       const FileCacheKey* logical_key,
+                                       const KeyDir& key_dir, const FileCacheKey* logical_key,
                                        std::lock_guard<std::mutex>& cache_lock) const;
 
     void drop_unbound_loaded_blocks(BlockFileCache* mgr) const;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <shared_mutex>
 #include <thread>
+#include <vector>
 
 #include "io/cache/file_cache_common.h"
 #include "io/cache/file_cache_storage.h"
@@ -40,6 +41,7 @@ public:
     void insert_file_reader(const AccessKeyAndOffset& key, std::shared_ptr<FileReader> file_reader);
 
     void remove_file_reader(const AccessKeyAndOffset& key);
+    void remove_file_readers(const UInt128Wrapper& hash);
 
     // use for test
     bool contains_file_reader(const AccessKeyAndOffset& key);
@@ -67,6 +69,7 @@ public:
     Status finalize(const FileCacheKey& key) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
     Status remove(const FileCacheKey& key) override;
+    Status remove_all_by_hash(const UInt128Wrapper& hash) override;
     Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) override;
     Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
@@ -89,10 +92,17 @@ public:
     FileCacheStorageType get_type() override { return DISK; }
 
     bool handle_already_loaded_block(BlockFileCache* mgr, const UInt128Wrapper& hash, size_t offset,
-                                     size_t new_size,
+                                     size_t new_size, const CacheContext& context,
+                                     const std::string& key_path, const std::string& offset_path,
+                                     bool is_tmp,
                                      std::lock_guard<std::mutex>& cache_lock) const;
 
 private:
+    struct KeyDir {
+        uint64_t expiration_time;
+        std::string path;
+    };
+
     void remove_old_version_directories();
 
     Status collect_directory_entries(const std::filesystem::path& dir_path,
@@ -113,8 +123,21 @@ private:
 
     void load_cache_info_into_memory(BlockFileCache* _mgr) const;
 
+    [[nodiscard]] std::vector<KeyDir> list_key_dirs(const UInt128Wrapper& hash) const;
+
+    void load_blocks_from_dir_unlocked(BlockFileCache* mgr, const UInt128Wrapper& hash,
+                                       const KeyDir& key_dir,
+                                       const FileCacheKey* logical_key,
+                                       std::lock_guard<std::mutex>& cache_lock) const;
+
+    void drop_unbound_loaded_blocks(BlockFileCache* mgr) const;
+
+    bool storage_file_exists(const FileCacheKey& key) const;
+
+    void remove_file_and_empty_dir(const std::string& file_path, const std::string& dir_path) const;
+
     [[nodiscard]] std::vector<std::string> get_path_in_local_cache_all_candidates(
-            const std::string& dir, size_t offset);
+            const std::string& dir, size_t offset) const;
 
     std::string _cache_base_path;
     std::thread _cache_background_load_thread;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -19,6 +19,7 @@
 
 #include <bvar/bvar.h>
 
+#include <functional>
 #include <memory>
 #include <shared_mutex>
 #include <thread>
@@ -70,6 +71,9 @@ public:
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
     Status remove(const FileCacheKey& key) override;
     Status remove_all_by_hash(const UInt128Wrapper& hash) override;
+    Status remove_key_dir(const UInt128Wrapper& hash, uint64_t expiration_time) override;
+    Status list_duplicate_key_dirs(std::vector<DuplicateKeyDirs>* duplicate_key_dirs,
+                                   const std::function<bool()>& should_stop) override;
     Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) override;
     Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -5924,6 +5924,65 @@ TEST_F(BlockFileCacheTest, ttl_gc_before_finalize_keeps_downloading_storage_path
     EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, 0)));
 }
 
+TEST_F(BlockFileCacheTest, ttl_normal_hole_after_expiration_clear_keeps_storage_dir) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 10;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t old_expiration = UnixSeconds() + 180;
+    context.expiration_time = old_expiration;
+    auto key = io::BlockFileCache::hash("ttl_clear_then_normal_hole");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+
+    cache.modify_expiration_time(key, 0);
+    context.cache_type = io::FileCacheType::NORMAL;
+    context.expiration_time = 0;
+    auto holder = cache.get_or_set(key, 0, 20, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 2);
+    assert_range(1, blocks[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
+    assert_range(2, blocks[1], io::FileBlock::Range(10, 19), io::FileBlock::State::EMPTY);
+    EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+    EXPECT_EQ(blocks[0]->expiration_time(), 0);
+    EXPECT_EQ(blocks[0]->storage_expiration_time(), old_expiration);
+    EXPECT_EQ(blocks[1]->cache_type(), io::FileCacheType::NORMAL);
+    EXPECT_EQ(blocks[1]->expiration_time(), 0);
+    EXPECT_EQ(blocks[1]->storage_expiration_time(), old_expiration);
+
+    ASSERT_TRUE(blocks[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(blocks[1]);
+    EXPECT_TRUE(
+            fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::NORMAL)));
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, 0)));
+    EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 1);
+}
+
 TEST_F(BlockFileCacheTest, ttl_lazy_load_misses_exact_dir_and_loads_old_hash_dirs) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
@@ -5987,6 +6046,67 @@ TEST_F(BlockFileCacheTest, ttl_lazy_load_misses_exact_dir_and_loads_old_hash_dir
     EXPECT_TRUE(
             fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
     EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
+}
+
+TEST_F(BlockFileCacheTest, ttl_lazy_load_exact_dir_hit_still_loads_sibling_dirs) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 60;
+    settings.query_queue_elements = 10;
+    settings.ttl_queue_size = 60;
+    settings.ttl_queue_elements = 10;
+    settings.capacity = 120;
+    settings.max_file_block_size = 10;
+    settings.max_query_cache_size = 30;
+    auto key = io::BlockFileCache::hash("ttl_lazy_load_exact_and_sibling");
+
+    auto sp = SyncPoint::get_instance();
+    std::atomic_bool block_scan {true};
+    Defer defer {[sp, &block_scan] {
+        block_scan = false;
+        sp->clear_all_call_backs();
+    }};
+    sp->set_call_back("BlockFileCache::BeforeScan", [&](auto&&) {
+        while (block_scan.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+    sp->enable_processing();
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    int64_t old_expiration = UnixSeconds() + 180;
+    int64_t new_expiration = old_expiration + 60;
+    write_cache_file(cache, key, new_expiration, 0, io::FileCacheType::TTL, std::string(10, 'a'));
+    write_cache_file(cache, key, old_expiration, 20, io::FileCacheType::TTL, std::string(10, 'b'));
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    context.expiration_time = new_expiration;
+    auto holder = cache.get_or_set(key, 0, 30, context);
+    block_scan = false;
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 3);
+    assert_range(1, blocks[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
+    assert_range(2, blocks[1], io::FileBlock::Range(10, 19), io::FileBlock::State::EMPTY);
+    assert_range(3, blocks[2], io::FileBlock::Range(20, 29), io::FileBlock::State::DOWNLOADED);
+    EXPECT_EQ(blocks[0]->expiration_time(), new_expiration);
+    EXPECT_EQ(blocks[0]->storage_expiration_time(), new_expiration);
+    EXPECT_EQ(blocks[2]->expiration_time(), new_expiration);
+    EXPECT_EQ(blocks[2]->storage_expiration_time(), old_expiration);
+
+    std::string buffer(10, '1');
+    ASSERT_TRUE(blocks[2]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+    EXPECT_EQ(buffer, std::string(10, 'b'));
 }
 
 TEST_F(BlockFileCacheTest, remove_if_cached_removes_unloaded_hash_dirs) {

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -163,6 +163,13 @@ void write_cache_file(BlockFileCache& cache, const UInt128Wrapper& key, uint64_t
     ASSERT_TRUE(writer->close().ok());
 }
 
+void drain_recycle_key_dirs(BlockFileCache& cache) {
+    std::pair<UInt128Wrapper, uint64_t> key_dir;
+    while (cache._recycle_key_dirs.try_dequeue(key_dir)) {
+        ASSERT_TRUE(cache._storage->remove_key_dir(key_dir.first, key_dir.second).ok());
+    }
+}
+
 void test_file_cache(io::FileCacheType cache_type) {
     TUniqueId query_id;
     query_id.hi = 1;
@@ -6025,6 +6032,301 @@ TEST_F(BlockFileCacheTest, remove_if_cached_removes_unloaded_hash_dirs) {
     cache.remove_if_cached(key);
     EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 0);
     EXPECT_FALSE(cache._key_to_time.contains(key));
+}
+
+TEST_F(BlockFileCacheTest, ttl_repair_checker_removes_duplicate_stale_dirs) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t canonical_expiration = UnixSeconds() + 180;
+    int64_t stale_expiration = canonical_expiration - 60;
+    context.expiration_time = canonical_expiration;
+    auto key = io::BlockFileCache::hash("ttl_repair_duplicate_dirs");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+    write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL,
+                     std::string(10, 's'));
+    ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+
+    EXPECT_EQ(cache.repair_duplicate_ttl_dirs_once(), 1);
+    drain_recycle_key_dirs(cache);
+
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, canonical_expiration)));
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, stale_expiration)));
+    EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 1);
+}
+
+TEST_F(BlockFileCacheTest, ttl_repair_checker_skips_unbound_duplicate_dirs) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    auto key = io::BlockFileCache::hash("ttl_repair_skip_unbound");
+    int64_t expiration1 = UnixSeconds() + 180;
+    int64_t expiration2 = expiration1 + 60;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    write_cache_file(cache, key, expiration1, 0, io::FileCacheType::TTL, std::string(10, 'a'));
+    write_cache_file(cache, key, expiration2, 10, io::FileCacheType::TTL, std::string(10, 'b'));
+    ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+
+    EXPECT_EQ(cache.repair_duplicate_ttl_dirs_once(), 0);
+    drain_recycle_key_dirs(cache);
+
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, expiration1)));
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, expiration2)));
+    EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+}
+
+TEST_F(BlockFileCacheTest, ttl_repair_checker_respects_disable_config) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t canonical_expiration = UnixSeconds() + 180;
+    int64_t stale_expiration = canonical_expiration - 60;
+    context.expiration_time = canonical_expiration;
+    auto key = io::BlockFileCache::hash("ttl_repair_disabled");
+
+    bool old_enable = config::enable_file_cache_ttl_repair_checker;
+    config::enable_file_cache_ttl_repair_checker = false;
+    Defer defer {[old_enable] { config::enable_file_cache_ttl_repair_checker = old_enable; }};
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+    write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL,
+                     std::string(10, 's'));
+    ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+
+    EXPECT_EQ(cache.repair_duplicate_ttl_dirs_once(), 0);
+    drain_recycle_key_dirs(cache);
+
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, canonical_expiration)));
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, stale_expiration)));
+}
+
+TEST_F(BlockFileCacheTest, ttl_repair_checker_skips_downloading_hash) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t canonical_expiration = UnixSeconds() + 180;
+    int64_t stale_expiration = canonical_expiration - 60;
+    context.expiration_time = canonical_expiration;
+    auto key = io::BlockFileCache::hash("ttl_repair_skip_downloading");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        ASSERT_TRUE(blocks[0]->append(Slice("0000000000", 10)).ok());
+        write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL,
+                         std::string(10, 's'));
+        ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+
+        EXPECT_EQ(cache.repair_duplicate_ttl_dirs_once(), 0);
+        drain_recycle_key_dirs(cache);
+
+        EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, canonical_expiration)));
+        EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, stale_expiration)));
+        ASSERT_TRUE(blocks[0]->finalize().ok());
+    }
+}
+
+TEST_F(BlockFileCacheTest, ttl_repair_checker_skips_when_cleanup_queue_backlogged) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t canonical_expiration = UnixSeconds() + 180;
+    int64_t stale_expiration = canonical_expiration - 60;
+    context.expiration_time = canonical_expiration;
+    auto key = io::BlockFileCache::hash("ttl_repair_backlog");
+
+    int64_t old_gc_interval = config::file_cache_background_gc_interval_ms;
+    config::file_cache_background_gc_interval_ms = 3600000;
+    Defer defer {[old_gc_interval] {
+        config::file_cache_background_gc_interval_ms = old_gc_interval;
+    }};
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+    write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL,
+                     std::string(10, 's'));
+    ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+
+    ASSERT_TRUE(cache._recycle_key_dirs.enqueue(
+            std::make_pair(io::BlockFileCache::hash("ttl_repair_backlog_fake"), uint64_t {1})));
+    EXPECT_EQ(cache.repair_duplicate_ttl_dirs_once(), 0);
+    drain_recycle_key_dirs(cache);
+
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, canonical_expiration)));
+    EXPECT_TRUE(fs::exists(cache_key_dir(cache, key, stale_expiration)));
+}
+
+TEST_F(BlockFileCacheTest, ttl_repair_checker_respects_max_repairs_per_round) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 60;
+    settings.query_queue_elements = 10;
+    settings.ttl_queue_size = 60;
+    settings.ttl_queue_elements = 10;
+    settings.capacity = 120;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t expiration = UnixSeconds() + 180;
+
+    int64_t old_limit = config::file_cache_ttl_repair_checker_max_repairs_per_round;
+    config::file_cache_ttl_repair_checker_max_repairs_per_round = 1;
+    Defer defer {[old_limit] {
+        config::file_cache_ttl_repair_checker_max_repairs_per_round = old_limit;
+    }};
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    std::vector<UInt128Wrapper> keys;
+    for (int i = 0; i < 2; ++i) {
+        auto key = io::BlockFileCache::hash("ttl_repair_limit_" + std::to_string(i));
+        keys.push_back(key);
+        context.expiration_time = expiration + i;
+        {
+            auto holder = cache.get_or_set(key, 0, 10, context);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download(blocks[0]);
+        }
+        write_cache_file(cache, key, expiration - 60 - i, 20, io::FileCacheType::TTL,
+                         std::string(10, 's'));
+        ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+    }
+
+    EXPECT_EQ(cache.repair_duplicate_ttl_dirs_once(), 1);
+    drain_recycle_key_dirs(cache);
+
+    size_t repaired = 0;
+    for (const auto& key : keys) {
+        if (count_cache_key_dirs(cache_base_path, key) == 1) {
+            ++repaired;
+        }
+    }
+    EXPECT_EQ(repaired, 1);
 }
 
 TEST_F(BlockFileCacheTest, file_cache_path_storage_parse) {

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -6241,9 +6241,8 @@ TEST_F(BlockFileCacheTest, ttl_repair_checker_skips_when_cleanup_queue_backlogge
 
     int64_t old_gc_interval = config::file_cache_background_gc_interval_ms;
     config::file_cache_background_gc_interval_ms = 3600000;
-    Defer defer {[old_gc_interval] {
-        config::file_cache_background_gc_interval_ms = old_gc_interval;
-    }};
+    Defer defer {
+            [old_gc_interval] { config::file_cache_background_gc_interval_ms = old_gc_interval; }};
 
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -67,9 +67,11 @@ void download(io::FileBlockSPtr file_block, size_t size) {
     auto key_str = hash.to_string();
     auto subdir = FSFileCacheStorage::USE_CACHE_VERSION2
                           ? fs::path(cache_base_path) / key_str.substr(0, 3) /
-                                    (key_str + "_" + std::to_string(file_block->expiration_time()))
+                                    (key_str + "_" +
+                                     std::to_string(file_block->storage_expiration_time()))
                           : fs::path(cache_base_path) /
-                                    (key_str + "_" + std::to_string(file_block->expiration_time()));
+                                    (key_str + "_" +
+                                     std::to_string(file_block->storage_expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
 }
 
@@ -96,6 +98,68 @@ void complete_into_memory(const io::FileBlocksHolder& holder) {
         ASSERT_TRUE(file_block->get_or_set_downloader() == io::FileBlock::get_caller_id());
         download_into_memory(file_block);
     }
+}
+
+bool wait_async_open(BlockFileCache& cache) {
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_async_open_success()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return cache.get_async_open_success();
+}
+
+std::string cache_key_dir(BlockFileCache& cache, const UInt128Wrapper& key, uint64_t expiration_time) {
+    auto* storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
+    EXPECT_NE(storage, nullptr);
+    if (storage == nullptr) {
+        return "";
+    }
+    return storage->get_path_in_local_cache(key, expiration_time);
+}
+
+std::string cache_file_path(BlockFileCache& cache, const UInt128Wrapper& key,
+                            uint64_t expiration_time, size_t offset, FileCacheType type) {
+    auto* storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
+    EXPECT_NE(storage, nullptr);
+    if (storage == nullptr) {
+        return "";
+    }
+    auto dir = storage->get_path_in_local_cache(key, expiration_time);
+    return storage->get_path_in_local_cache(dir, offset, type);
+}
+
+size_t count_cache_key_dirs(const std::string& base_path, const UInt128Wrapper& key) {
+    auto key_str = key.to_string();
+    auto parent = FSFileCacheStorage::USE_CACHE_VERSION2
+                          ? fs::path(base_path) / key_str.substr(0, 3)
+                          : fs::path(base_path);
+    if (!fs::exists(parent)) {
+        return 0;
+    }
+    size_t count = 0;
+    auto prefix = key_str + "_";
+    for (const auto& entry : fs::directory_iterator(parent)) {
+        if (entry.is_directory() && entry.path().filename().native().starts_with(prefix)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void write_cache_file(BlockFileCache& cache, const UInt128Wrapper& key, uint64_t expiration_time,
+                      size_t offset, FileCacheType type, const std::string& data) {
+    auto dir = cache_key_dir(cache, key, expiration_time);
+    ASSERT_FALSE(dir.empty());
+    auto st = global_local_filesystem()->create_directory(dir, false);
+    ASSERT_TRUE(st.ok() || st.is<ErrorCode::ALREADY_EXIST>());
+    auto path = cache_file_path(cache, key, expiration_time, offset, type);
+    ASSERT_FALSE(path.empty());
+    FileWriterPtr writer;
+    ASSERT_TRUE(global_local_filesystem()->create_file(path, &writer).ok());
+    ASSERT_TRUE(writer->append(Slice(data.data(), data.size())).ok());
+    ASSERT_TRUE(writer->close().ok());
 }
 
 void test_file_cache(io::FileCacheType cache_type) {
@@ -1526,7 +1590,7 @@ TEST_F(BlockFileCacheTest, change_cache_type) {
         ASSERT_TRUE(blocks[0]->finalize().ok());
         auto key_str = key.to_string();
         auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
-                      (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
+                      (key_str + "_" + std::to_string(blocks[0]->storage_expiration_time()));
         ASSERT_TRUE(fs::exists(subdir / "0_idx"));
     }
     if (fs::exists(cache_base_path)) {
@@ -1952,7 +2016,7 @@ TEST_F(BlockFileCacheTest, fix_tmp_file) {
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
     auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
-                  (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
+                  (key_str + "_" + std::to_string(blocks[0]->storage_expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
     size_t size = blocks[0]->range().size();
     std::string data(size, '0');
@@ -2011,7 +2075,7 @@ TEST_F(BlockFileCacheTest, test_async_load) {
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
     auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
-                  (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
+                  (key_str + "_" + std::to_string(blocks[0]->storage_expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
     size_t size = blocks[0]->range().size();
     std::string data(size, '0');
@@ -2076,7 +2140,7 @@ TEST_F(BlockFileCacheTest, test_async_load_with_limit) {
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
     auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
-                  (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
+                  (key_str + "_" + std::to_string(blocks[0]->storage_expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
     size_t size = blocks[0]->range().size();
     std::string data(size, '0');
@@ -2410,18 +2474,32 @@ TEST_F(BlockFileCacheTest, ttl_change_to_normal) {
         auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
         if (auto storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
             storage != nullptr) {
-            std::string dir = storage->get_path_in_local_cache(key2, 0);
+            std::string dir = storage->get_path_in_local_cache(key2, cur_time + 180);
             EXPECT_TRUE(fs::exists(
-                    storage->get_path_in_local_cache(dir, 50, io::FileCacheType::NORMAL)));
+                    storage->get_path_in_local_cache(dir, 50, io::FileCacheType::TTL)));
+            EXPECT_FALSE(fs::exists(storage->get_path_in_local_cache(key2, 0)));
         }
         auto blocks = fromHolder(holder);
         ASSERT_EQ(blocks.size(), 1);
         assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
-        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
-        EXPECT_EQ(blocks[0]->expiration_time(), 0);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(blocks[0]->expiration_time(), cur_time + 180);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), cur_time + 180);
         std::string buffer(10, '1');
         EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
         EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    cache.modify_expiration_time(key2, 0);
+    {
+        context.cache_type = io::FileCacheType::NORMAL;
+        context.expiration_time = 0;
+        auto holder = cache.get_or_set(key2, 50, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(2, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(blocks[0]->expiration_time(), 0);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), cur_time + 180);
     }
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
@@ -2473,11 +2551,22 @@ TEST_F(BlockFileCacheTest, ttl_change_to_normal_memory_storage) {
         auto blocks = fromHolder(holder);
         ASSERT_EQ(blocks.size(), 1);
         assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
-        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
-        EXPECT_EQ(blocks[0]->expiration_time(), 0);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(blocks[0]->expiration_time(), cur_time + 180);
         std::string buffer(10, '1');
         EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
         EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    cache.modify_expiration_time(key2, 0);
+    {
+        context.cache_type = io::FileCacheType::NORMAL;
+        context.expiration_time = 0;
+        auto holder = cache.get_or_set(key2, 50, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(2, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(blocks[0]->expiration_time(), 0);
     }
 }
 
@@ -2541,15 +2630,32 @@ TEST_F(BlockFileCacheTest, ttl_change_expiration_time) {
         auto holder = cache.get_or_set(key2, 50, 10, context); /// Add range [50, 59]
         if (auto storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
             storage != nullptr) {
-            std::string dir = storage->get_path_in_local_cache(key2, change_time);
+            std::string dir = storage->get_path_in_local_cache(key2, cur_time + 180);
             EXPECT_TRUE(
                     fs::exists(storage->get_path_in_local_cache(dir, 50, io::FileCacheType::TTL)));
+            EXPECT_FALSE(fs::exists(storage->get_path_in_local_cache(key2, change_time)));
         }
         auto blocks = fromHolder(holder);
         ASSERT_EQ(blocks.size(), 1);
         assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
         EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(blocks[0]->expiration_time(), cur_time + 180);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), cur_time + 180);
+        std::string buffer(10, '1');
+        EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    cache.modify_expiration_time(key2, change_time);
+    {
+        context.cache_type = io::FileCacheType::TTL;
+        context.expiration_time = change_time;
+        auto holder = cache.get_or_set(key2, 50, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(2, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
         EXPECT_EQ(blocks[0]->expiration_time(), change_time);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), cur_time + 180);
         std::string buffer(10, '1');
         EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
         EXPECT_EQ(buffer, std::string(10, '0'));
@@ -2605,6 +2711,20 @@ TEST_F(BlockFileCacheTest, ttl_change_expiration_time_memory_storage) {
         auto blocks = fromHolder(holder);
         ASSERT_EQ(blocks.size(), 1);
         assert_range(1, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(blocks[0]->expiration_time(), cur_time + 180);
+        std::string buffer(10, '1');
+        EXPECT_TRUE(blocks[0]->read(Slice(buffer.data(), 10), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    cache.modify_expiration_time(key2, change_time);
+    {
+        context.cache_type = io::FileCacheType::TTL;
+        context.expiration_time = change_time;
+        auto holder = cache.get_or_set(key2, 50, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(2, blocks[0], io::FileBlock::Range(50, 59), io::FileBlock::State::DOWNLOADED);
         EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
         EXPECT_EQ(blocks[0]->expiration_time(), change_time);
         std::string buffer(10, '1');
@@ -4529,7 +4649,7 @@ TEST_F(BlockFileCacheTest, test_async_load_with_error_file_1) {
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
     auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
-                  (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
+                  (key_str + "_" + std::to_string(blocks[0]->storage_expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
     size_t size = blocks[0]->range().size();
     std::string data(size, '0');
@@ -4605,7 +4725,7 @@ TEST_F(BlockFileCacheTest, test_async_load_with_error_file_2) {
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
     auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
-                  (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
+                  (key_str + "_" + std::to_string(blocks[0]->storage_expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
     size_t size = blocks[0]->range().size();
     std::string data(size, '0');
@@ -5250,10 +5370,21 @@ TEST_F(BlockFileCacheTest, change_cache_type1) {
         ASSERT_EQ(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(50, 59),
                      io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(segments[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(segments[0]->expiration_time(), cur_time + 120);
+    }
+    sp->clear_call_back("FileBlock::change_cache_type");
+    cache.modify_expiration_time(key1, 0);
+    {
+        auto holder = cache.get_or_set(key1, 50, 10, context);
+        auto segments = fromHolder(holder);
+        ASSERT_EQ(segments.size(), 1);
+        assert_range(2, segments[0], io::FileBlock::Range(50, 59),
+                     io::FileBlock::State::DOWNLOADED);
         EXPECT_EQ(segments[0]->cache_type(), io::FileCacheType::NORMAL);
         EXPECT_EQ(segments[0]->expiration_time(), 0);
     }
-    sp->clear_call_back("FileBlock::change_cache_type");
+    cache.modify_expiration_time(key1, modify_time);
     context.cache_type = io::FileCacheType::TTL;
     context.expiration_time = modify_time;
     {
@@ -5326,10 +5457,21 @@ TEST_F(BlockFileCacheTest, change_cache_type2) {
         ASSERT_EQ(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(50, 59),
                      io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(segments[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(segments[0]->expiration_time(), 0);
+    }
+    sp->clear_call_back("FileBlock::change_cache_type");
+    cache.modify_expiration_time(key1, context.expiration_time);
+    {
+        auto holder = cache.get_or_set(key1, 50, 10, context);
+        auto segments = fromHolder(holder);
+        ASSERT_EQ(segments.size(), 1);
+        assert_range(2, segments[0], io::FileBlock::Range(50, 59),
+                     io::FileBlock::State::DOWNLOADED);
         EXPECT_EQ(segments[0]->cache_type(), io::FileCacheType::TTL);
         EXPECT_EQ(segments[0]->expiration_time(), context.expiration_time);
     }
-    sp->clear_call_back("FileBlock::change_cache_type");
+    cache.modify_expiration_time(key1, 0);
     context.cache_type = io::FileCacheType::NORMAL;
     context.expiration_time = 0;
     {
@@ -5399,7 +5541,8 @@ TEST_F(BlockFileCacheTest, change_cache_type2) {
          if (auto storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
              storage != nullptr) {
              std::string dir =
-                     storage->get_path_in_local_cache(key1, cell.file_block->expiration_time());
+                     storage->get_path_in_local_cache(key1,
+                                                      cell.file_block->storage_expiration_time());
              cur_path = storage->get_path_in_local_cache(dir, cell.file_block->offset(),
                                                          cell.file_block->cache_type());
          }
@@ -5442,7 +5585,8 @@ TEST_F(BlockFileCacheTest, change_cache_type2) {
          if (auto storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
              storage != nullptr) {
              std::string dir =
-                     storage->get_path_in_local_cache(key1, cell.file_block->expiration_time());
+                     storage->get_path_in_local_cache(key1,
+                                                      cell.file_block->storage_expiration_time());
              cur_path = storage->get_path_in_local_cache(dir, cell.file_block->offset(),
                                                          cell.file_block->cache_type());
          }
@@ -5551,6 +5695,276 @@ TEST_F(BlockFileCacheTest, test_load) {
         cache.remove(blocks[0], cache_lock, block_lock);
         ASSERT_FALSE(fs::exists(dir / "20086"));
     }
+}
+
+TEST_F(BlockFileCacheTest, ttl_read_path_mismatch_does_not_update_existing_hash) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t old_expiration = UnixSeconds() + 180;
+    int64_t new_expiration = old_expiration + 60;
+    context.expiration_time = old_expiration;
+    auto key = io::BlockFileCache::hash("ttl_read_path_mismatch");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+
+    context.expiration_time = new_expiration;
+    auto holder = cache.get_or_set(key, 0, 10, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_EQ(blocks[0]->state(), io::FileBlock::State::DOWNLOADED);
+    EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+    EXPECT_EQ(blocks[0]->expiration_time(), old_expiration);
+    EXPECT_EQ(blocks[0]->storage_expiration_time(), old_expiration);
+    ASSERT_TRUE(cache._key_to_time.contains(key));
+    EXPECT_EQ(cache._key_to_time[key], old_expiration);
+    EXPECT_TRUE(fs::exists(cache_file_path(cache, key, old_expiration, 0, io::FileCacheType::TTL)));
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
+}
+
+TEST_F(BlockFileCacheTest, ttl_new_hole_inherits_existing_storage_expiration) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 10;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t old_expiration = UnixSeconds() + 180;
+    int64_t new_expiration = old_expiration + 60;
+    context.expiration_time = old_expiration;
+    auto key = io::BlockFileCache::hash("ttl_new_hole_storage");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+
+    context.expiration_time = new_expiration;
+    auto holder = cache.get_or_set(key, 0, 20, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 2);
+    assert_range(1, blocks[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
+    assert_range(2, blocks[1], io::FileBlock::Range(10, 19), io::FileBlock::State::EMPTY);
+    EXPECT_EQ(blocks[1]->expiration_time(), old_expiration);
+    EXPECT_EQ(blocks[1]->storage_expiration_time(), old_expiration);
+    ASSERT_TRUE(blocks[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(blocks[1]);
+    EXPECT_TRUE(fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
+    EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 1);
+}
+
+TEST_F(BlockFileCacheTest, ttl_modify_expiration_updates_logical_only) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t old_expiration = UnixSeconds() + 180;
+    int64_t new_expiration = old_expiration + 60;
+    context.expiration_time = old_expiration;
+    auto key = io::BlockFileCache::hash("ttl_modify_logical_only");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+
+    cache.modify_expiration_time(key, new_expiration);
+    context.expiration_time = new_expiration;
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::TTL);
+        EXPECT_EQ(blocks[0]->expiration_time(), new_expiration);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), old_expiration);
+        ASSERT_EQ(cache._key_to_time[key], new_expiration);
+        EXPECT_TRUE(
+                fs::exists(cache_file_path(cache, key, old_expiration, 0, io::FileCacheType::TTL)));
+        EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
+
+        std::string buffer(10, '1');
+        ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    cache.remove_if_cached(key);
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, old_expiration)));
+}
+
+TEST_F(BlockFileCacheTest, ttl_lazy_load_misses_exact_dir_and_loads_old_hash_dirs) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 60;
+    settings.query_queue_elements = 10;
+    settings.ttl_queue_size = 60;
+    settings.ttl_queue_elements = 10;
+    settings.capacity = 120;
+    settings.max_file_block_size = 10;
+    settings.max_query_cache_size = 30;
+    auto key = io::BlockFileCache::hash("ttl_lazy_load_old_dir");
+
+    auto sp = SyncPoint::get_instance();
+    std::atomic_bool block_scan {true};
+    Defer defer {[sp, &block_scan] {
+        block_scan = false;
+        sp->clear_all_call_backs();
+    }};
+    sp->set_call_back("BlockFileCache::BeforeScan", [&](auto&&) {
+        while (block_scan.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+    sp->enable_processing();
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    int64_t old_expiration = UnixSeconds() + 180;
+    int64_t new_expiration = old_expiration + 60;
+    write_cache_file(cache, key, old_expiration, 0, io::FileCacheType::TTL, std::string(10, 'a'));
+    write_cache_file(cache, key, old_expiration, 20, io::FileCacheType::TTL, std::string(10, 'b'));
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    context.expiration_time = new_expiration;
+    auto holder = cache.get_or_set(key, 0, 30, context);
+    block_scan = false;
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 3);
+    assert_range(1, blocks[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
+    assert_range(2, blocks[1], io::FileBlock::Range(10, 19), io::FileBlock::State::EMPTY);
+    assert_range(3, blocks[2], io::FileBlock::Range(20, 29), io::FileBlock::State::DOWNLOADED);
+    EXPECT_EQ(blocks[0]->expiration_time(), new_expiration);
+    EXPECT_EQ(blocks[0]->storage_expiration_time(), old_expiration);
+    EXPECT_EQ(blocks[2]->expiration_time(), new_expiration);
+    EXPECT_EQ(blocks[2]->storage_expiration_time(), old_expiration);
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
+
+    ASSERT_TRUE(blocks[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(blocks[1]);
+    EXPECT_EQ(blocks[1]->storage_expiration_time(), old_expiration);
+    EXPECT_TRUE(fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
+}
+
+TEST_F(BlockFileCacheTest, remove_if_cached_removes_unloaded_hash_dirs) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t expiration = UnixSeconds() + 180;
+    int64_t stale_expiration = expiration - 60;
+    context.expiration_time = expiration;
+    auto key = io::BlockFileCache::hash("ttl_remove_all_hash_dirs");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+    write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL, std::string(10, 's'));
+    ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
+
+    cache.remove_if_cached(key);
+    EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 0);
+    EXPECT_FALSE(cache._key_to_time.contains(key));
 }
 
 TEST_F(BlockFileCacheTest, file_cache_path_storage_parse) {

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -110,7 +110,8 @@ bool wait_async_open(BlockFileCache& cache) {
     return cache.get_async_open_success();
 }
 
-std::string cache_key_dir(BlockFileCache& cache, const UInt128Wrapper& key, uint64_t expiration_time) {
+std::string cache_key_dir(BlockFileCache& cache, const UInt128Wrapper& key,
+                          uint64_t expiration_time) {
     auto* storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
     EXPECT_NE(storage, nullptr);
     if (storage == nullptr) {
@@ -2475,8 +2476,8 @@ TEST_F(BlockFileCacheTest, ttl_change_to_normal) {
         if (auto storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
             storage != nullptr) {
             std::string dir = storage->get_path_in_local_cache(key2, cur_time + 180);
-            EXPECT_TRUE(fs::exists(
-                    storage->get_path_in_local_cache(dir, 50, io::FileCacheType::TTL)));
+            EXPECT_TRUE(
+                    fs::exists(storage->get_path_in_local_cache(dir, 50, io::FileCacheType::TTL)));
             EXPECT_FALSE(fs::exists(storage->get_path_in_local_cache(key2, 0)));
         }
         auto blocks = fromHolder(holder);
@@ -5795,7 +5796,8 @@ TEST_F(BlockFileCacheTest, ttl_new_hole_inherits_existing_storage_expiration) {
     EXPECT_EQ(blocks[1]->storage_expiration_time(), old_expiration);
     ASSERT_TRUE(blocks[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
     download(blocks[1]);
-    EXPECT_TRUE(fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
+    EXPECT_TRUE(
+            fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
     EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
     EXPECT_EQ(count_cache_key_dirs(cache_base_path, key), 1);
 }
@@ -5859,6 +5861,62 @@ TEST_F(BlockFileCacheTest, ttl_modify_expiration_updates_logical_only) {
     EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, old_expiration)));
 }
 
+TEST_F(BlockFileCacheTest, ttl_gc_before_finalize_keeps_downloading_storage_path) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.ttl_queue_size = 30;
+    settings.ttl_queue_elements = 5;
+    settings.capacity = 60;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::TTL;
+    context.query_id = query_id;
+    int64_t old_expiration = UnixSeconds() + 3;
+    context.expiration_time = old_expiration;
+    auto key = io::BlockFileCache::hash("ttl_gc_before_finalize");
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    ASSERT_TRUE(wait_async_open(cache));
+    {
+        auto holder = cache.get_or_set(key, 0, 10, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        ASSERT_TRUE(blocks[0]->append(Slice("0000000000", 10)).ok());
+
+        cache.modify_expiration_time(key, 0);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(blocks[0]->expiration_time(), 0);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), old_expiration);
+        EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, 0)));
+
+        ASSERT_TRUE(blocks[0]->finalize().ok());
+        ASSERT_EQ(blocks[0]->state(), io::FileBlock::State::DOWNLOADED);
+        EXPECT_TRUE(
+                fs::exists(cache_file_path(cache, key, old_expiration, 0, io::FileCacheType::TTL)));
+        EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, 0)));
+
+        std::string buffer(10, '1');
+        ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+        EXPECT_EQ(buffer, std::string(10, '0'));
+    }
+    cache.remove_if_cached(key);
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, old_expiration)));
+    EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, 0)));
+}
+
 TEST_F(BlockFileCacheTest, ttl_lazy_load_misses_exact_dir_and_loads_old_hash_dirs) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);
@@ -5919,7 +5977,8 @@ TEST_F(BlockFileCacheTest, ttl_lazy_load_misses_exact_dir_and_loads_old_hash_dir
     ASSERT_TRUE(blocks[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
     download(blocks[1]);
     EXPECT_EQ(blocks[1]->storage_expiration_time(), old_expiration);
-    EXPECT_TRUE(fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
+    EXPECT_TRUE(
+            fs::exists(cache_file_path(cache, key, old_expiration, 10, io::FileCacheType::TTL)));
     EXPECT_FALSE(fs::exists(cache_key_dir(cache, key, new_expiration)));
 }
 
@@ -5959,7 +6018,8 @@ TEST_F(BlockFileCacheTest, remove_if_cached_removes_unloaded_hash_dirs) {
         ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
         download(blocks[0]);
     }
-    write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL, std::string(10, 's'));
+    write_cache_file(cache, key, stale_expiration, 20, io::FileCacheType::TTL,
+                     std::string(10, 's'));
     ASSERT_EQ(count_cache_key_dirs(cache_base_path, key), 2);
 
     cache.remove_if_cached(key);

--- a/be/test/io/cache/block_file_cache_test_lru_dump.cpp
+++ b/be/test/io/cache/block_file_cache_test_lru_dump.cpp
@@ -481,12 +481,22 @@ TEST_F(BlockFileCacheTest, test_lru_duplicate_queue_entry_restore) {
     }
     ASSERT_TRUE(cache2.get_async_open_success());
 
-    // the dup part should be ttl because ttl has higner priority
-    ASSERT_EQ(cache2._ttl_queue.get_elements_num_unsafe(), 5);
+    // LRU dump restore is only a heat hint. The following disk scan must bind the
+    // real storage path and logical type instead of keeping the fake ttl hint.
+    ASSERT_EQ(cache2._ttl_queue.get_elements_num_unsafe(), 0);
     ASSERT_EQ(cache2._index_queue.get_elements_num_unsafe(), 0);
-    ASSERT_EQ(cache2._normal_queue.get_elements_num_unsafe(), 0);
+    ASSERT_EQ(cache2._normal_queue.get_elements_num_unsafe(), 5);
     ASSERT_EQ(cache2._disposable_queue.get_elements_num_unsafe(), 0);
     ASSERT_EQ(cache2._cur_cache_size, 500000);
+    for (offset = 0; offset < 500000; offset += 100000) {
+        auto holder = cache2.get_or_set(key1, offset, 100000, context1);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(3, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                     io::FileBlock::State::DOWNLOADED);
+        EXPECT_EQ(blocks[0]->cache_type(), io::FileCacheType::NORMAL);
+        EXPECT_EQ(blocks[0]->storage_expiration_time(), 0);
+    }
 
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);


### PR DESCRIPTION
## Motivation

In branch-4.0, File Cache still uses the same TTL expiration value for two different purposes:

- logical lifecycle state, such as TTL queue membership and TTL GC decisions;
- physical storage location, because disk directories are named as `hash_expiration`.

That coupling lets multiple paths mutate the same metadata. A normal read with a stale or different TTL context can rename or recreate cache directories for an already cached hash, while tablet meta sync and TTL GC can also update the expiration. When the same hash is represented by multiple `hash_*` directories, the cache may miss blocks that already exist on disk, create another directory for new holes, and fail to remove unloaded sibling directories. Directory-level rename is also fragile when the destination directory already exists and is non-empty.

## Changes

- Split File Cache metadata into logical expiration/type and storage expiration/type.
- Keep read paths read-only for existing TTL metadata; a query context mismatch no longer updates an already managed hash.
- Make new holes inherit the canonical storage expiration from the existing hash, so stale read contexts do not create more `hash_*` directories.
- Change `modify_expiration_time` and TTL GC to update logical metadata and queues only, without requiring a parent directory rename.
- Add same-hash `hash_*` directory discovery for startup loading and lazy-load fallback, so existing blocks in older TTL directories can still be found.
- Add hash-level cleanup to remove all disk directories for a cache hash, including directories that were never loaded into memory.
- Keep compatibility with the old `_ttl` filename suffix.
- Treat LRU restore entries as hints only; disk scan corrects real storage paths or drops unbound restored entries.

## Tests

- `git diff --check`
- `DORIS_TOOLCHAIN=clang DISABLE_BE_JAVA_EXTENSIONS=ON ENABLE_INJECTION_POINT=ON ENABLE_CACHE_LOCK_DEBUG=0 ENABLE_PCH=0 sh run-be-ut.sh --run --filter=BlockFileCacheTest.ttl_modify:BlockFileCacheTest.ttl_modify_memory_storage:BlockFileCacheTest.ttl_change_to_normal:BlockFileCacheTest.ttl_change_to_normal_memory_storage:BlockFileCacheTest.ttl_change_expiration_time:BlockFileCacheTest.ttl_change_expiration_time_memory_storage:BlockFileCacheTest.change_cache_type1:BlockFileCacheTest.change_cache_type2:BlockFileCacheTest.ttl_read_path_mismatch_does_not_update_existing_hash:BlockFileCacheTest.ttl_new_hole_inherits_existing_storage_expiration:BlockFileCacheTest.ttl_modify_expiration_updates_logical_only:BlockFileCacheTest.ttl_lazy_load_misses_exact_dir_and_loads_old_hash_dirs:BlockFileCacheTest.remove_if_cached_removes_unloaded_hash_dirs:BlockFileCacheTest.test_lru_duplicate_queue_entry_restore`

The BE UT filter above passed 14 `BlockFileCacheTest` cases.