### PR TITLE
[chore](deps) remove unused commons-lang (2.x) from fe

### DIFF
--- a/fe/be-java-extensions/java-common/pom.xml
+++ b/fe/be-java-extensions/java-common/pom.xml
@@ -100,11 +100,6 @@ under the License.
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
-        </dependency>
         <!-- these dependencies are for iceberg-aws -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -147,11 +147,6 @@ under the License.
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
-        </dependency>
 
         <!-- these dependencies are for iceberg-aws -->
         <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -266,7 +266,6 @@ under the License.
         <commons-filerupload.version>1.6.0</commons-filerupload.version>
         <commons-configuration2.version>2.11.0</commons-configuration2.version>
         <commons-codec.version>1.13</commons-codec.version>
-        <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
         <commons-pool2.version>2.2</commons-pool2.version>
         <commons-pool.version>1.5.1</commons-pool.version>
@@ -854,13 +853,6 @@ under the License.
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons-codec.version}</version>
-            </dependency>
-            <!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
-            <!-- upgrade commons-lang from 2.4 to 2.6 to fix incompatibility of with versioning scheme of Java 9 and later -->
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.version}</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
             <dependency>

--- a/regression-test/java-udf-src/src/main/java/org/apache/doris/udf/StringTest.java
+++ b/regression-test/java-udf-src/src/main/java/org/apache/doris/udf/StringTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.udf;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.ql.exec.UDF;
 
 public class StringTest extends UDF {


### PR DESCRIPTION
commons-lang 2.x is not referenced by any fe source code. It was only declared in java-common and preload-extensions (bundled into the BE java-extensions runtime classpath via the assembly) without being used.

- drop the commons-lang dependencyManagement entry and version property from fe/pom.xml
- drop the unused direct dependency from java-common and preload-extensions
- migrate the only affected usage (regression-test StringTest UDF) from org.apache.commons.lang.StringUtils to org.apache.commons.lang3.StringUtils

### behaviod-changed
**Note: this removes commons-lang 2.x from the BE Java UDF runtime classpath; legacy user UDFs importing org.apache.commons.lang.* must migrate to lang3.**
