### PR TITLE
[fix](auth) tolerate trailing zero bytes in OIDC client auth packet

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/MysqlAuthPacketCredentialExtractor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/MysqlAuthPacketCredentialExtractor.java
@@ -75,10 +75,25 @@ public class MysqlAuthPacketCredentialExtractor {
         } catch (RuntimeException e) {
             return authResponse;
         }
-        if (oidcToken == null || oidcToken.length == 0 || payload.remaining() != 0 || !looksLikeJwt(oidcToken)) {
+        if (oidcToken == null || oidcToken.length == 0 || !isTrailingAllZero(payload) || !looksLikeJwt(oidcToken)) {
             return authResponse;
         }
         return oidcToken;
+    }
+
+    /**
+     * Some JDBC clients (e.g. mysql-connector-j 9.x) pre-allocate a buffer that may be
+     * larger than the actual string when sending strings, so the bytes on the wire can
+     * end with one or more zero bytes after the length-encoded payload. Treat such
+     * trailing zero bytes as harmless padding rather than rejecting the packet.
+     */
+    private static boolean isTrailingAllZero(ByteBuffer payload) {
+        while (payload.hasRemaining()) {
+            if (payload.get() != 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean looksLikeJwt(byte[] bytes) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/MysqlAuthPacketCredentialExtractorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/MysqlAuthPacketCredentialExtractorTest.java
@@ -81,6 +81,34 @@ class MysqlAuthPacketCredentialExtractorTest {
         Assertions.assertEquals(token, ((ClearPassword) request.getPassword()).getPassword());
     }
 
+    /**
+     * Some JDBC clients (e.g. mysql-connector-j 9.x) pre-allocate a buffer that is larger
+     * than the actual string when sending strings, so the auth response can end with one
+     * or more zero bytes after the length-encoded payload. The extractor must accept such
+     * packets instead of falling back to treating the whole buffer as the token.
+     */
+    @Test
+    void testExtractAuthenticateRequestForOidcClientPayloadWithTrailingZeroBytes() {
+        MysqlAuthPacketCredentialExtractor extractor = new MysqlAuthPacketCredentialExtractor();
+        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+        MysqlAuthPacket authPacket = Mockito.mock(MysqlAuthPacket.class);
+        String token = "eyJhbGciOiJSUzI1NiJ9.payload.signature";
+        byte[] payload = oidcClientPayload(token);
+        byte[] paddedPayload = new byte[payload.length + 8];
+        System.arraycopy(payload, 0, paddedPayload, 0, payload.length);
+        Mockito.when(channel.getRemoteIp()).thenReturn(REMOTE_IP);
+        Mockito.when(authPacket.getPluginName()).thenReturn(OIDC_CLIENT_PLUGIN);
+        Mockito.when(authPacket.getAuthResponse()).thenReturn(paddedPayload);
+
+        AuthenticateRequest request = extractor.extractAuthenticateRequest(USER_NAME, channel, authPacket)
+                .orElseThrow(() -> new AssertionError("request is required"));
+
+        Assertions.assertEquals(CredentialType.OAUTH_TOKEN, request.getCredentialType());
+        Assertions.assertArrayEquals(token.getBytes(StandardCharsets.UTF_8), request.getCredential());
+        Assertions.assertInstanceOf(ClearPassword.class, request.getPassword());
+        Assertions.assertEquals(token, ((ClearPassword) request.getPassword()).getPassword());
+    }
+
     private static byte[] oidcClientPayload(String token) {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         serializer.writeInt1(1);


### PR DESCRIPTION
Some JDBC clients (notably mysql-connector-j 9.x) pre-allocate an in-memory buffer that is larger than the actual string when sending strings, so the auth response on the wire may contain extra zero bytes after the length-encoded OIDC token. The previous strict check 'payload.remaining() != 0'treated such packets as malformed and made the extractor fall back to using the whole buffer (including the leading length byte) as the token, which caused OIDC authentication to be rejected incorrectly.
Relax the check to accept the packet as long as the trailing bytes are all zero, which matches the padding behavior of those JDBC clients while still rejecting truly malformed payloads. 

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

