### PR TITLE
[Bug] Fix invalid validation for sampled column statistics with ndv=0 and non-null min/max

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -647,8 +647,7 @@ public abstract class BaseAnalysisTask {
         try (AutoCloseConnectContext a  = StatisticsUtil.buildConnectContext(false)) {
             a.connectContext.getState().setPlanWithUnKnownColumnStats(true);
             stmtExecutor = new StmtExecutor(a.connectContext, sql);
-            boolean isSample = info.analysisMethod == AnalysisInfo.AnalysisMethod.SAMPLE || tableSample != null;
-            ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0), isSample);
+            ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0));
             if (!colStatsData.isValid()) {
                 if (MetricRepo.isInit) {
                     MetricRepo.COUNTER_STATISTICS_INVALID_STATS.increase(1L);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -647,7 +647,8 @@ public abstract class BaseAnalysisTask {
         try (AutoCloseConnectContext a  = StatisticsUtil.buildConnectContext(false)) {
             a.connectContext.getState().setPlanWithUnKnownColumnStats(true);
             stmtExecutor = new StmtExecutor(a.connectContext, sql);
-            ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0));
+            boolean isSample = info.analysisMethod == AnalysisInfo.AnalysisMethod.SAMPLE || tableSample != null;
+            ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0), isSample);
             if (!colStatsData.isValid()) {
                 if (MetricRepo.isInit) {
                     MetricRepo.COUNTER_STATISTICS_INVALID_STATS.increase(1L);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
@@ -95,15 +95,23 @@ public class ColStatsData {
     }
 
     public ColStatsData(ResultRow row) {
+        this(row, false);
+    }
+
+    public ColStatsData(ResultRow row, boolean isSample) {
         this.statsId = new StatsId(row);
         this.count = (long) Double.parseDouble(row.getWithDefault(7, "0"));
-        this.ndv = (long) Double.parseDouble(row.getWithDefault(8, "0"));
+        long tmpNdv = (long) Double.parseDouble(row.getWithDefault(8, "0"));
         this.nullCount = (long) Double.parseDouble(row.getWithDefault(9, "0"));
         this.minLit = row.get(10);
         this.maxLit = row.get(11);
         this.dataSizeInBytes = (long) Double.parseDouble(row.getWithDefault(12, "0"));
         this.updateTime = row.get(13);
         this.hotValues = row.get(14);
+        if (isSample && tmpNdv == 0 && (!isNull(minLit) || !isNull(maxLit))) {
+            tmpNdv = 1;
+        }
+        this.ndv = tmpNdv;
     }
 
     public ColStatsData(String id, long catalogId, long dbId, long tblId, long idxId, String colId, String partId,

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColStatsData.java
@@ -95,23 +95,15 @@ public class ColStatsData {
     }
 
     public ColStatsData(ResultRow row) {
-        this(row, false);
-    }
-
-    public ColStatsData(ResultRow row, boolean isSample) {
         this.statsId = new StatsId(row);
         this.count = (long) Double.parseDouble(row.getWithDefault(7, "0"));
-        long tmpNdv = (long) Double.parseDouble(row.getWithDefault(8, "0"));
+        this.ndv = (long) Double.parseDouble(row.getWithDefault(8, "0"));
         this.nullCount = (long) Double.parseDouble(row.getWithDefault(9, "0"));
         this.minLit = row.get(10);
         this.maxLit = row.get(11);
         this.dataSizeInBytes = (long) Double.parseDouble(row.getWithDefault(12, "0"));
         this.updateTime = row.get(13);
         this.hotValues = row.get(14);
-        if (isSample && tmpNdv == 0 && (!isNull(minLit) || !isNull(maxLit))) {
-            tmpNdv = 1;
-        }
-        this.ndv = tmpNdv;
     }
 
     public ColStatsData(String id, long catalogId, long dbId, long tblId, long idxId, String colId, String partId,
@@ -146,6 +138,9 @@ public class ColStatsData {
     }
 
     public ColumnStatistic toColumnStatistic() {
+        if (ColumnStatistic.isSuspiciousStats(ndv, isNull(minLit), isNull(maxLit), nullCount, count)) {
+            return ColumnStatistic.UNKNOWN;
+        }
         try {
             ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(count);
             columnStatisticBuilder.setNdv(ndv);
@@ -205,12 +200,6 @@ public class ColStatsData {
     public boolean isValid() {
         if (ndv > 10 * count) {
             String message = String.format("ColStatsData ndv too large. %s", toSQL(true));
-            LOG.warn(message);
-            return false;
-        }
-        if (ndv == 0 && (!isNull(minLit) || !isNull(maxLit)) && nullCount != count) {
-            String message = String.format("ColStatsData ndv 0 but min/max is not null and nullCount != count. %s",
-                    toSQL(true));
             LOG.warn(message);
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -125,6 +125,15 @@ public class ColumnStatistic {
         this.hotValues = hotValues;
     }
 
+    public static boolean isSuspiciousStats(
+            double ndv,
+            boolean minIsNull,
+            boolean maxIsNull,
+            double nullCount,
+            double count) {
+        return ndv == 0 && (!minIsNull || !maxIsNull) && nullCount != count;
+    }
+
     public static ColumnStatistic fromResultRowList(List<ResultRow> resultRows) {
         ColumnStatistic columnStatistic = ColumnStatistic.UNKNOWN;
         for (ResultRow resultRow : resultRows) {
@@ -143,11 +152,18 @@ public class ColumnStatistic {
      */
     public static ColumnStatistic fromResultRow(ResultRow row) {
         double count = Double.parseDouble(row.get(7));
-        ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(count);
         double ndv = Double.parseDouble(row.getWithDefault(8, "0"));
+        double nullCount = Double.parseDouble(row.getWithDefault(9, "0"));
+        String min = row.get(10);
+        String max = row.get(11);
+        boolean minIsNull = min == null || min.equalsIgnoreCase("NULL");
+        boolean maxIsNull = max == null || max.equalsIgnoreCase("NULL");
+        if (isSuspiciousStats(ndv, minIsNull, maxIsNull, nullCount, count)) {
+            return ColumnStatistic.UNKNOWN;
+        }
+        ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(count);
         columnStatisticBuilder.setNdv(ndv);
-        String nullCount = row.getWithDefault(9, "0");
-        columnStatisticBuilder.setNumNulls(Double.parseDouble(nullCount));
+        columnStatisticBuilder.setNumNulls(nullCount);
         columnStatisticBuilder.setDataSize(Double
                 .parseDouble(row.getWithDefault(12, "0")));
         columnStatisticBuilder.setAvgSizeByte(columnStatisticBuilder.getCount() == 0

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -131,7 +131,7 @@ public class ColumnStatistic {
             boolean maxIsNull,
             double nullCount,
             double count) {
-        return ndv == 0 && (!minIsNull || !maxIsNull) && nullCount != count;
+        return ndv == 0 && (!minIsNull || !maxIsNull);
     }
 
     public static ColumnStatistic fromResultRowList(List<ResultRow> resultRows) {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
@@ -216,13 +216,13 @@ public class ColStatsDataTest {
         values.set(8, "0");
         row = new ResultRow(values);
         data = new ColStatsData(row);
-        Assertions.assertFalse(data.isValid());
+        Assertions.assertTrue(data.isValid());
 
         // Set min to null, min/max is not null
         values.set(10, null);
         row = new ResultRow(values);
         data = new ColStatsData(row);
-        Assertions.assertFalse(data.isValid());
+        Assertions.assertTrue(data.isValid());
 
         // Set max to null, min/max are all null
         values.set(11, null);
@@ -234,7 +234,7 @@ public class ColStatsDataTest {
         values.set(10, "min");
         row = new ResultRow(values);
         data = new ColStatsData(row);
-        Assertions.assertFalse(data.isValid());
+        Assertions.assertTrue(data.isValid());
 
         // Set min and max to null, nullNum = 0
         values.set(9, "0");
@@ -262,7 +262,7 @@ public class ColStatsDataTest {
     }
 
     @Test
-    public void testIsValidSample() {
+    public void testSuspiciousStatsPattern() {
         List<String> values = Lists.newArrayList();
         values.add("id");
         values.add("10000");
@@ -280,17 +280,15 @@ public class ColStatsDataTest {
         values.add("500");
         values.add(null);
 
-        // Case 1: isSample = false (FULL analyze). ndv = 0, min/max not null, nullCount != count.
-        // It should remain 0 and isValid() should be false.
         ResultRow row = new ResultRow(values);
-        ColStatsData dataFull = new ColStatsData(row, false);
-        Assertions.assertEquals(0, dataFull.ndv);
-        Assertions.assertFalse(dataFull.isValid());
+        ColStatsData data = new ColStatsData(row);
+        Assertions.assertEquals(0, data.ndv);
+        Assertions.assertTrue(data.isValid());
 
-        // Case 2: isSample = true (SAMPLE analyze). ndv = 0, min/max not null, nullCount != count.
-        // It should clamp ndv to 1, and isValid() should be true.
-        ColStatsData dataSample = new ColStatsData(row, true);
-        Assertions.assertEquals(1, dataSample.ndv);
-        Assertions.assertTrue(dataSample.isValid());
+        ColumnStatistic columnStatisticFromData = data.toColumnStatistic();
+        Assertions.assertEquals(ColumnStatistic.UNKNOWN, columnStatisticFromData);
+
+        ColumnStatistic columnStatisticFromRow = ColumnStatistic.fromResultRow(row);
+        Assertions.assertEquals(ColumnStatistic.UNKNOWN, columnStatisticFromRow);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
@@ -260,4 +260,37 @@ public class ColStatsDataTest {
         data = new ColStatsData();
         Assertions.assertTrue(data.isValid());
     }
+
+    @Test
+    public void testIsValidSample() {
+        List<String> values = Lists.newArrayList();
+        values.add("id");
+        values.add("10000");
+        values.add("20000");
+        values.add("30000");
+        values.add("0");
+        values.add("col");
+        values.add(null);
+        values.add("200"); // count
+        values.add("0"); // ndv
+        values.add("199"); // nullCount
+        values.add("min");
+        values.add("max");
+        values.add("400");
+        values.add("500");
+        values.add(null);
+
+        // Case 1: isSample = false (FULL analyze). ndv = 0, min/max not null, nullCount != count.
+        // It should remain 0 and isValid() should be false.
+        ResultRow row = new ResultRow(values);
+        ColStatsData dataFull = new ColStatsData(row, false);
+        Assertions.assertEquals(0, dataFull.ndv);
+        Assertions.assertFalse(dataFull.isValid());
+
+        // Case 2: isSample = true (SAMPLE analyze). ndv = 0, min/max not null, nullCount != count.
+        // It should clamp ndv to 1, and isValid() should be true.
+        ColStatsData dataSample = new ColStatsData(row, true);
+        Assertions.assertEquals(1, dataSample.ndv);
+        Assertions.assertTrue(dataSample.isValid());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/ColStatsDataTest.java
@@ -290,5 +290,18 @@ public class ColStatsDataTest {
 
         ColumnStatistic columnStatisticFromRow = ColumnStatistic.fromResultRow(row);
         Assertions.assertEquals(ColumnStatistic.UNKNOWN, columnStatisticFromRow);
+
+        // Case where nullCount == count (200 == 200)
+        values.set(9, "200");
+        row = new ResultRow(values);
+        data = new ColStatsData(row);
+        Assertions.assertEquals(0, data.ndv);
+        Assertions.assertTrue(data.isValid());
+
+        columnStatisticFromData = data.toColumnStatistic();
+        Assertions.assertEquals(ColumnStatistic.UNKNOWN, columnStatisticFromData);
+
+        columnStatisticFromRow = ColumnStatistic.fromResultRow(row);
+        Assertions.assertEquals(ColumnStatistic.UNKNOWN, columnStatisticFromRow);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64122

Problem Summary:

`ColStatsData.isValid()` applies a validation rule that assumes all statistics originate from the same source. However, during SAMPLE ANALYZE this assumption does not always hold:

* `min/max` values may come from a full-table scan.
* `ndv` may be estimated from sampled data.
* `nullCount` may be a scaled estimate and therefore differ from `count`.

As a result, sampled column statistics can be incorrectly rejected when:

```java
ndv == 0
&& (!isNull(minLit) || !isNull(maxLit))
&& nullCount != count
```

This PR introduces sample-aware handling by adding an `isSample` flag to `ColStatsData`. For sampled statistics, when `ndv == 0` but non-null `min/max` values exist, `ndv` is normalized to `1` before validation. This prevents valid sampled statistics from being rejected while preserving the existing validation behavior for full analyze jobs.

### Release note

None

### Check List (For Author)

* Test

  * [x] Unit Test

* Behavior changed:

  * [x] No.

* Does this need documentation?

  * [x] No.

### Test Details

Added unit tests in `ColStatsDataTest` covering:

1. Full analyze statistics:

   * `ndv = 0`
   * non-null `min/max`
   * `nullCount != count`

   Expected result: validation fails.

2. Sample analyze statistics:

   * `ndv = 0`
   * non-null `min/max`
   * `nullCount != count`

   Expected result:

   * `ndv` is normalized to `1`
   * validation succeeds.
