### PR TITLE
[chore](dep)Upgrade dependencies

### DIFF
--- a/fe/hive-udf/pom.xml
+++ b/fe/hive-udf/pom.xml
@@ -53,6 +53,20 @@ under the License.
             <artifactId>hive-exec</artifactId>
             <version>${hive.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.calcite</groupId>
+                    <artifactId>calcite-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.calcite</groupId>
+                    <artifactId>calcite-druid</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -268,6 +268,7 @@ under the License.
         <commons-codec.version>1.13</commons-codec.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
+        <commons-net.version>3.13.0</commons-net.version>
         <commons-pool2.version>2.2</commons-pool2.version>
         <commons-pool.version>1.5.1</commons-pool.version>
         <commons-text.version>1.10.0</commons-text.version>
@@ -291,9 +292,8 @@ under the License.
         <mqtt.version>1.2.5</mqtt.version>
         <slf4j.version>2.0.17</slf4j.version>
         <metrics-core.version>4.0.2</metrics-core.version>
-        <!--Netty 4.1.94 is not compatible with arrow flight.-->
-        <!--Need to ensure that the version is the same as in arrow/java/pom.xml or compatible with it.-->
-        <netty-all.version>4.1.132.Final</netty-all.version>
+        <!-- Keep Netty compatible with Arrow Flight SQL 19 and other transitive Netty users. -->
+        <netty-all.version>4.2.15.Final</netty-all.version>
         <!--The dependence of transitive dependence cannot be ruled out, only Saving the nation through twisted ways.-->
         <netty-3-test.version>3.10.6.Final</netty-3-test.version>
         <objenesis.version>2.1</objenesis.version>
@@ -403,8 +403,10 @@ under the License.
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <asm.version>9.4</asm.version>
         <airlift.concurrent.version>202</airlift.concurrent.version>
-        <azure.sdk.version>1.3.4</azure.sdk.version>
+        <azure.sdk.version>1.3.7</azure.sdk.version>
         <azure.sdk.batch.version>12.22.0</azure.sdk.batch.version>
+        <msal4j.version>1.25.0</msal4j.version>
+        <azure.keyvault.core.version>1.2.6</azure.keyvault.core.version>
         <semver4j.version>5.3.0</semver4j.version>
         <aliyun-sdk-oss.version>3.15.0</aliyun-sdk-oss.version>
         <!--Fixes the regression described in https://github.com/aws/aws-sdk-java-v2/issues/5805 that forced us to downgrade aws-s3 to version 2.29.x.-->
@@ -867,6 +869,12 @@ under the License.
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+            </dependency>
+            <!-- Pulled in by hive-exec -> hadoop-yarn-registry and hadoop-common. -->
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>${commons-net.version}</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
             <dependency>
@@ -1834,6 +1842,18 @@ under the License.
                 <version>${azure.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Pulled in by azure-identity and msal4j-persistence-extension. -->
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>msal4j</artifactId>
+                <version>${msal4j.version}</version>
+            </dependency>
+            <!-- Pulled in by hadoop-azure -> azure-storage. -->
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-keyvault-core</artifactId>
+                <version>${azure.keyvault.core.version}</version>
             </dependency>
             <!-- tencent COS -->
             <dependency>


### PR DESCRIPTION
## Summary

Upgrade FE dependency versions for dependency scan findings:

- Exclude transitive dependencies from `hive-exec` in `fe/hive-udf`:
  - `org.apache.calcite:calcite-core`
  - `org.apache.calcite:calcite-druid`
  - `log4j:log4j`
- Upgrade Netty managed version from `4.1.132.Final` to `4.2.15.Final`, covering Netty BOM-managed jars such as `netty-codec-memcache`, `netty-codec-mqtt`, and `netty-transport`.
- Upgrade Azure SDK BOM from `1.3.4` to `1.3.7`, updating:
  - `azure-storage-blob` `12.33.1` -> `12.34.0`
  - `azure-core` `1.57.1` -> `1.58.0`
  - `azure-core-http-netty` `1.16.3` -> `1.16.4`
  - `azure-storage-common` `12.32.1` -> `12.33.0`
  - `azure-storage-internal-avro` `12.18.1` -> `12.19.0`
  - `azure-identity` `1.18.2` -> `1.18.3`
- Override Azure transitive dependencies:
  - `msal4j` `1.23.1` -> `1.25.0`
  - `azure-keyvault-core` `1.0.0` -> `1.2.6`
- Manage `commons-net:commons-net` to `3.13.0`, replacing older transitive resolutions such as `3.6` from the Hive/Hadoop path and `3.9.0` from Hadoop common.
