### PR TITLE
feat(riscv): add vectorscan 5.4.12 support for RISC-V

### DIFF
--- a/thirdparty/patches/vectorscan-5.4.12.patch
+++ b/thirdparty/patches/vectorscan-5.4.12.patch
@@ -1,0 +1,126 @@
+diff -Nur vectorscan-vectorscan-5.4.12/CMakeLists.txt vectorscan-vectorscan-5.4.12-riscv/CMakeLists.txt
+--- vectorscan-vectorscan-5.4.12/CMakeLists.txt	2024-10-01 00:00:00.000000000 +0800
++++ vectorscan-vectorscan-5.4.12-riscv/CMakeLists.txt	2026-06-07 00:00:00.000000000 +0800
+@@ -130,6 +130,10 @@
+ include (${CMAKE_MODULE_PATH}/osdetection.cmake)
+ 
+ if(ARCH_X86_64 AND BUILD_SSE2_SIMDE AND NOT FAT_RUNTIME)
++    set(SIMDE_BACKEND True)
++endif()
++
++if(ARCH_RISCV64)
+     set(SIMDE_BACKEND True)
+ endif()
+ 
+@@ -139,6 +143,8 @@
+     include (${CMAKE_MODULE_PATH}/cflags-arm.cmake)
+ elseif (ARCH_PPC64EL)
+     include (${CMAKE_MODULE_PATH}/cflags-ppc64le.cmake)
++elseif (ARCH_RISCV64)
++    include (${CMAKE_MODULE_PATH}/cflags-riscv.cmake)
+ else ()
+     message(FATAL_ERROR "Unsupported platform")
+ endif ()
+diff -Nur vectorscan-vectorscan-5.4.12/cmake/archdetect.cmake vectorscan-vectorscan-5.4.12-riscv/cmake/archdetect.cmake
+--- vectorscan-vectorscan-5.4.12/cmake/archdetect.cmake	2024-10-01 00:00:00.000000000 +0800
++++ vectorscan-vectorscan-5.4.12-riscv/cmake/archdetect.cmake	2026-06-07 00:00:00.000000000 +0800
+@@ -80,6 +80,18 @@
+         elseif(ARCH_PPC64EL)
+             set(GNUCC_ARCH power8)
+             set(TUNE_FLAG power8)
++	elseif(ARCH_RISCV64)
++            set(GNUCC_ARCH rv64gc)
++            include (${CMAKE_MODULE_PATH}/cflags-riscv.cmake)
++            if(HAVE_RVV OR HAVE_RVV_1_0)
++                message(STATUS "Enabling RISC-V Vector extension (RVV)")
++                set(GNUCC_ARCH "${GNUCC_ARCH}v")
++
++                if(HAVE_RVV_1_0)
++                    message(STATUS "RVV 1.0 support confirmed")
++                endif()
++            endif()
++            set(TUNE_FLAG sifive-u54)
+         else()
+             set(GNUCC_ARCH x86-64-v2)
+             set(TUNE_FLAG generic)
+@@ -115,6 +127,18 @@
+     elseif(ARCH_PPC64EL)
+        set(GNUCC_ARCH power8)
+        set(TUNE_FLAG power8)
++    elseif(ARCH_RISCV64)
++       set(GNUCC_ARCH rv64gc)
++       include (${CMAKE_MODULE_PATH}/cflags-riscv.cmake)
++       if(HAVE_RVV OR HAVE_RVV_1_0)
++           message(STATUS "Enabling RISC-V Vector extension (RVV)")
++           set(GNUCC_ARCH "${GNUCC_ARCH}v")
++
++           if(HAVE_RVV_1_0)
++               message(STATUS "RVV 1.0 support confirmed")
++           endif()
++       endif()
++       set(TUNE_FLAG sifive-u54)
+     else()
+        set(GNUCC_ARCH native)
+        set(TUNE_FLAG native)
+diff -Nur vectorscan-vectorscan-5.4.12/cmake/cflags-riscv.cmake vectorscan-vectorscan-5.4.12-riscv/cmake/cflags-riscv.cmake
+--- vectorscan-vectorscan-5.4.12/cmake/cflags-riscv.cmake	1970-01-01 08:00:00.000000000 +0800
++++ vectorscan-vectorscan-5.4.12-riscv/cmake/cflags-riscv.cmake	2026-06-07 00:00:00.000000000 +0800
+@@ -0,0 +1,44 @@
++CHECK_INCLUDE_FILE_CXX("riscv_vector.h" HAVE_RISCV_VECTOR_H)
++
++if(HAVE_RISCV_VECTOR_H)
++    set(RVV_INTRIN_INC_H "riscv_vector.h")
++    message(STATUS "Found riscv_vector.h")
++else()
++    message(WARNING "riscv_vector.h not found - RISC-V Vector extension may be unavailable")
++    set(HAVE_RVV FALSE)
++    set(HAVE_RVV_1_0 FALSE)
++endif()
++
++if(HAVE_RISCV_VECTOR_H)
++    CHECK_C_SOURCE_COMPILES("
++    #include <${RVV_INTRIN_INC_H}>
++
++    int main() {
++        size_t vl = vsetvl_e32m1(4);
++        vfloat32m1_t a = vfmv_v_f_f32m1(1.0f, vl);
++        vfloat32m1_t b = vfadd_vv_f32m1(a, a, vl);
++        (void)b;
++        return 0;
++    }" HAVE_RVV)
++
++    if(HAVE_RVV)
++        message(STATUS "RISC-V Vector (RVV) extension support detected")
++    else()
++        message(WARNING "RISC-V Vector (RVV) extension not supported by compiler")
++    endif()
++
++    CHECK_C_SOURCE_COMPILES("
++    #include <${RVV_INTRIN_INC_H}>
++
++    #if __riscv_v != 10000
++    #error \"RVV version mismatch\"
++    #endif
++
++    int main() { return 0; }" HAVE_RVV_1_0)
++
++    if(NOT HAVE_RVV_1_0)
++        message(WARNING "RVV version is not 1.0 (or version check failed)")
++    else()
++        message(STATUS "RVV version 1.0 confirmed")
++    endif()
++endif()
+diff -Nur vectorscan-vectorscan-5.4.12/cmake/platform.cmake vectorscan-vectorscan-5.4.12-riscv/cmake/platform.cmake
+--- vectorscan-vectorscan-5.4.12/cmake/platform.cmake	2024-10-01 00:00:00.000000000 +0800
++++ vectorscan-vectorscan-5.4.12-riscv/cmake/platform.cmake	2026-06-07 00:00:00.000000000 +0800
+@@ -5,7 +5,9 @@
+ CHECK_C_SOURCE_COMPILES("#if !defined(__ARM_ARCH_ISA_A64)\n#error not 64bit\n#endif\nint main(void) { return 0; }" ARCH_AARCH64)
+ CHECK_C_SOURCE_COMPILES("#if !defined(__ARM_ARCH_ISA_ARM)\n#error not 32bit\n#endif\nint main(void) { return 0; }" ARCH_ARM32)
+ CHECK_C_SOURCE_COMPILES("#if !defined(__PPC64__) && !(defined(__LITTLE_ENDIAN__) && defined(__VSX__))\n#error not ppc64el\n#endif\nint main(void) { return 0; }" ARCH_PPC64EL)
+-if (ARCH_X86_64 OR ARCH_AARCH64 OR ARCH_PPC64EL)
++CHECK_C_SOURCE_COMPILES("#if !(defined(__riscv) && __riscv_xlen == 64)\n#error Not RISC-V 64-bit\n#endif\nint main(void) { return 0; }" ARCH_RISCV64)
++CHECK_C_SOURCE_COMPILES("#if !(defined(__riscv) && __riscv_xlen == 32)\n#error Not RISC-V 32-bit\n#endif\nint main(void) { return 0; }" ARCH_RISCV32)
++if (ARCH_X86_64 OR ARCH_AARCH64 OR ARCH_PPC64EL OR ARCH_RISCV64)
+   set(ARCH_64_BIT TRUE)
+ else()
+   set(ARCH_32_BIT TRUE)

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -174,6 +174,13 @@ if [[ "${MACHINE_TYPE}" == "aarch64" || "${MACHINE_TYPE}" == 'arm64' ]]; then
     HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.11
     HYPERSCAN_MD5SUM="e67b70403cba6c1654a9fef4fd15a2f2"
 fi
+if [[ "${MACHINE_TYPE}" == 'riscv64' ]]; then
+    echo "use vectorscan instead of hyperscan on riscv64"
+    HYPERSCAN_DOWNLOAD="https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.12.tar.gz"
+    HYPERSCAN_NAME=vectorscan-5.4.12.tar.gz
+    HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.12
+    HYPERSCAN_MD5SUM=""
+fi
 
 # ragel (dependency for hyperscan)
 RAGEL_DOWNLOAD="http://www.colm.net/files/ragel/ragel-6.10.tar.gz"


### PR DESCRIPTION
## What problem was fixed

Apache Doris uses Hyperscan for LIKE pattern matching, but Hyperscan does not support RISC-V architecture. Without this patch, thirdparty compilation fails on RISC-V because Hyperscan cannot be built for riscv64.

## How it was fixed

We use vectorscan (the open-source fork of Hyperscan) with its SIMDE backend, which translates x86 SSE/AVX intrinsics to GCC vector extensions. The compiler then generates RVV (RISC-V Vector) instructions.

1. In `thirdparty/vars.sh`, added riscv64 detection to download vectorscan 5.4.12 instead of Hyperscan.
2. In `thirdparty/patches/vectorscan-5.4.12.patch`, added RISC-V build system support:
   - Added RISC-V architecture detection in `cmake/archdetect.cmake`
   - Created `cmake/cflags-riscv.cmake` for RISC-V compiler flags with RVV
   - Updated `cmake/platform.cmake` to recognize RISC-V platform

## Which behaviors were modified

- **Before**: thirdparty build fails on RISC-V (Hyperscan has no RISC-V support)
- **After**: vectorscan 5.4.12 is downloaded and compiled with SIMDE backend on RISC-V, providing the same hs_scan/hs_compile API as Hyperscan

## Test

- Hardware: SOPHGO SG2044 (rv64gcv)
- vectorscan unit tests: 2984/2984 pass