### PR TITLE
[fix](be) Add explicit template instantiation for BlockFileCache::get_cell

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -2666,4 +2666,7 @@ Status BlockFileCache::check_file_cache_consistency(InconsistencyContext& incons
     return Status::OK();
 }
 
+template FileBlockCell* BlockFileCache::get_cell(const UInt128Wrapper& hash, size_t offset,
+                                                 std::lock_guard<std::mutex>& cache_lock);
+
 } // namespace doris::io


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64227

Related PR: #xxx

Problem Summary: When building BE UT with TSAN, the linker reports undefined symbol for `BlockFileCache::get_cell<std::lock_guard<std::mutex>>`. The template function `get_cell` is defined in `block_file_cache.cpp` but lacks explicit template instantiation. Non-TSAN builds may inline the template, masking the issue, but TSAN disables inlining, exposing the missing symbol.

normal log after fix:
[tsan_get_cell_link_error_TSAN.log](https://github.com/user-attachments/files/28731231/tsan_get_cell_link_error_TSAN.log)

The same pattern already exists for the `remove` template function (`block_file_cache.cpp:2515`) and `LRUQueue` templates (`file_cache_common.cpp:149-150`). `get_cell` is simply missing the same explicit instantiation.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason? -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label