### PR TITLE
[feature](inverted index) add token-exists Bloom Filter absent-term fast path

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1254,6 +1254,7 @@ DEFINE_mBool(enable_write_index_searcher_cache, "false");
 DEFINE_String(inverted_index_searcher_cache_limit, "10%");
 DEFINE_Bool(enable_inverted_index_cache_check_timestamp, "true");
 DEFINE_mBool(enable_inverted_index_correct_term_write, "true");
+DEFINE_mBool(enable_inverted_index_term_bf, "false");
 DEFINE_Int32(inverted_index_fd_number_limit_percent, "20"); // 20%
 DEFINE_Int32(inverted_index_query_cache_shards, "256");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1308,6 +1308,9 @@ DECLARE_String(inverted_index_searcher_cache_limit);
 DECLARE_mBool(enable_write_index_searcher_cache);
 DECLARE_Bool(enable_inverted_index_cache_check_timestamp);
 DECLARE_mBool(enable_inverted_index_correct_term_write);
+// One-key rollback for the token-exists Bloom Filter ("tbf") absent-term fast path on the
+// FullText read path. Default off until the read/write guardrails are fully closed.
+DECLARE_mBool(enable_inverted_index_term_bf);
 DECLARE_Int32(inverted_index_fd_number_limit_percent); // 50%
 DECLARE_Int32(inverted_index_query_cache_shards);
 

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -276,6 +276,25 @@ Status OlapScanLocalState::_init_profile() {
             ADD_TIMER_WITH_LEVEL(_segment_profile, "InvertedIndexAnalyzerTime", 1);
     _inverted_index_lookup_timer =
             ADD_TIMER_WITH_LEVEL(_segment_profile, "InvertedIndexLookupTimer", 1);
+    // Headline value (level 1): how many index lookups the token BF short-circuited, plus the
+    // denominator to read it as a hit rate, plus the "not built / stale" signal users act on.
+    _inverted_index_term_bf_skipped_lookups_counter = ADD_COUNTER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexTermBfSkippedLookups", TUnit::UNIT, 1);
+    _inverted_index_term_bf_probe_counter =
+            ADD_COUNTER_WITH_LEVEL(_segment_profile, "InvertedIndexTermBfProbe", TUnit::UNIT, 1);
+    _inverted_index_term_bf_unavailable_counter = ADD_COUNTER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexTermBfUnavailable", TUnit::UNIT, 1);
+    // Diagnostics (level 2): cache effectiveness, cold load IO, MAYBE fall-throughs.
+    _inverted_index_term_bf_fallthrough_counter = ADD_COUNTER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexTermBfFallthrough", TUnit::UNIT, 2);
+    _inverted_index_term_bf_cache_hit_counter =
+            ADD_COUNTER_WITH_LEVEL(_segment_profile, "InvertedIndexTermBfCacheHit", TUnit::UNIT, 2);
+    _inverted_index_term_bf_cache_miss_counter = ADD_COUNTER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexTermBfCacheMiss", TUnit::UNIT, 2);
+    _inverted_index_term_bf_load_count_counter = ADD_COUNTER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexTermBfLoadCount", TUnit::UNIT, 2);
+    _inverted_index_term_bf_load_bytes_counter = ADD_COUNTER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexTermBfLoadBytes", TUnit::BYTES, 2);
 
     _output_index_result_column_timer = ADD_TIMER(_segment_profile, "OutputIndexResultColumnTime");
     _filtered_segment_counter = ADD_COUNTER(_segment_profile, "NumSegmentFiltered", TUnit::UNIT);

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -236,6 +236,14 @@ private:
     RuntimeProfile::Counter* _inverted_index_downgrade_count_counter = nullptr;
     RuntimeProfile::Counter* _inverted_index_analyzer_timer = nullptr;
     RuntimeProfile::Counter* _inverted_index_lookup_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_skipped_lookups_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_probe_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_fallthrough_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_unavailable_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_cache_miss_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_load_count_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_term_bf_load_bytes_counter = nullptr;
 
     RuntimeProfile::Counter* _ann_topn_filter_counter = nullptr;
     // topn_search_costs = index_load_costs + engine_search_costs + pre_process_costs + post_process_costs

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -852,6 +852,22 @@ void OlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_inverted_index_analyzer_timer,
                    stats.inverted_index_analyzer_timer);
     COUNTER_UPDATE(local_state->_inverted_index_lookup_timer, stats.inverted_index_lookup_timer);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_skipped_lookups_counter,
+                   stats.inverted_index_term_bf_skipped_lookups);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_probe_counter,
+                   stats.inverted_index_term_bf_probe);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_fallthrough_counter,
+                   stats.inverted_index_term_bf_fallthrough);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_unavailable_counter,
+                   stats.inverted_index_term_bf_unavailable);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_cache_hit_counter,
+                   stats.inverted_index_term_bf_cache_hit);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_cache_miss_counter,
+                   stats.inverted_index_term_bf_cache_miss);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_load_count_counter,
+                   stats.inverted_index_term_bf_load_count);
+    COUNTER_UPDATE(local_state->_inverted_index_term_bf_load_bytes_counter,
+                   stats.inverted_index_term_bf_load_bytes);
     COUNTER_UPDATE(local_state->_variant_scan_sparse_column_timer,
                    stats.variant_scan_sparse_column_timer_ns);
     COUNTER_UPDATE(local_state->_variant_scan_sparse_column_bytes,

--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -1061,8 +1061,25 @@ Status Compaction::do_inverted_index_compaction() {
                     // but their lifecycle must be managed by inverted_index_file_writers.
                     dest_index_dirs[dest_segment_id] = res.value().get();
                 }
+                // Derive the CLucene `field_name` the same way the writer did when these
+                // segments were originally created (see `InvertedIndexColumnWriter::create`
+                // in be/src/storage/index/index_writer.cpp): V1 uses the column name, V2 uses
+                // the unique_id string (or `parent_uid.subcol` for variant sub-columns).
+                // `compact_column` uses this to enumerate the merged term dictionary and emit
+                // a "tbf" sub-file when the BE config gates it on.
+                std::string field_name;
+                const auto storage_format =
+                        _cur_tablet_schema->get_inverted_index_storage_format();
+                if (storage_format == InvertedIndexStorageFormatPB::V1) {
+                    field_name = col.name();
+                } else if (col.is_extracted_column()) {
+                    field_name = std::to_string(col.parent_unique_id()) + "." + col.name();
+                } else {
+                    field_name = std::to_string(col.unique_id());
+                }
                 auto st = compact_column(index_meta->index_id(), src_idx_dirs, dest_index_dirs,
-                                         index_tmp_path.native(), trans_vec, dest_segment_num_rows);
+                                         index_tmp_path.native(), trans_vec, dest_segment_num_rows,
+                                         index_meta, field_name);
                 if (!st.ok()) {
                     error_handler(index_meta->index_id(), column_uniq_id);
                     status = Status::Error<INVERTED_INDEX_COMPACTION_ERROR>(st.msg());

--- a/be/src/storage/index/inverted/inverted_index_cache.cpp
+++ b/be/src/storage/index/inverted/inverted_index_cache.cpp
@@ -27,6 +27,7 @@
 
 #include "runtime/exec_env.h"
 #include "runtime/thread_context.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
 #include "util/defer_op.h"
 
 namespace doris::segment_v2 {
@@ -76,8 +77,11 @@ InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t
 }
 
 Status InvertedIndexSearcherCache::erase(const std::string& index_file_path) {
-    InvertedIndexSearcherCache::CacheKey cache_key(index_file_path);
-    _policy->erase(cache_key.index_file_path);
+    _policy->erase(index_file_path);
+    // The token BF for this (segment, index) lives in the same cache under a derived key; erase it
+    // too, otherwise a compaction/rewrite that invalidates the segment would leave a stale BF that
+    // a same-key rewrite could later serve (a false "absent" -> dropped hit).
+    _policy->erase(term_bf_key(index_file_path));
     return Status::OK();
 }
 
@@ -139,6 +143,41 @@ void InvertedIndexQueryCache::insert(const CacheKey& key, std::shared_ptr<roarin
                                               bitmap->getSizeInBytes(), bitmap->getSizeInBytes(),
                                               CachePriority::NORMAL);
     *handle = InvertedIndexQueryCacheHandle(this, lru_handle);
+}
+
+bool InvertedIndexSearcherCache::lookup_term_bf(const std::string& index_file_key,
+                                                InvertedIndexCacheHandle* handle) {
+    auto* lru_handle = _policy->lookup(term_bf_key(index_file_key));
+    if (lru_handle == nullptr) {
+        return false;
+    }
+    *handle = InvertedIndexCacheHandle(_policy.get(), lru_handle);
+    return true;
+}
+
+void InvertedIndexSearcherCache::insert_term_bf(const std::string& index_file_key,
+                                                std::shared_ptr<InvertedIndexTermBloomFilter> bf,
+                                                InvertedIndexCacheHandle* handle) {
+    auto cache_value = std::make_unique<CacheValue>();
+    size_t charge = bf->byte_size();
+    cache_value->term_bf = std::move(bf);
+    cache_value->size = charge;
+    cache_value->last_visit_time = UnixMillis();
+    auto* lru_handle = _policy->insert(term_bf_key(index_file_key), (void*)cache_value.release(),
+                                       charge, charge, CachePriority::NORMAL);
+    *handle = InvertedIndexCacheHandle(_policy.get(), lru_handle);
+}
+
+void InvertedIndexSearcherCache::insert_term_bf_negative(const std::string& index_file_key,
+                                                         InvertedIndexCacheHandle* handle) {
+    auto cache_value = std::make_unique<CacheValue>();
+    // term_bf stays null: a hit on this entry means "known: no usable BF for this key".
+    static constexpr size_t kNegativeCharge = 16;
+    cache_value->size = kNegativeCharge;
+    cache_value->last_visit_time = UnixMillis();
+    auto* lru_handle = _policy->insert(term_bf_key(index_file_key), (void*)cache_value.release(),
+                                       kNegativeCharge, kNegativeCharge, CachePriority::NORMAL);
+    *handle = InvertedIndexCacheHandle(_policy.get(), lru_handle);
 }
 
 } // namespace doris::segment_v2

--- a/be/src/storage/index/inverted/inverted_index_cache.h
+++ b/be/src/storage/index/inverted/inverted_index_cache.h
@@ -42,6 +42,7 @@
 namespace doris {
 namespace segment_v2 {
 class InvertedIndexCacheHandle;
+class InvertedIndexTermBloomFilter;
 
 class InvertedIndexSearcherCache {
 public:
@@ -56,6 +57,10 @@ public:
     class CacheValue : public LRUCacheValueBase {
     public:
         IndexSearcherPtr index_searcher;
+        // A token-exists Bloom Filter entry reuses this same cache (same LRU + memory budget) under
+        // a distinct key namespace, so it has no opened searcher: index_searcher is null and the
+        // payload is term_bf. A normal searcher entry has term_bf null. The two never share a key.
+        std::shared_ptr<InvertedIndexTermBloomFilter> term_bf;
         size_t size = 0;
         int64_t last_visit_time;
 
@@ -83,6 +88,23 @@ public:
 
     void insert(const InvertedIndexSearcherCache::CacheKey& cache_key, CacheValue* cache_value,
                 InvertedIndexCacheHandle* handle);
+
+    // Token-exists Bloom Filter sub-API. The BF for a (segment, index) is cached in THIS cache
+    // (same LRU + memory budget, no separate cache) under an internal key namespace derived from
+    // the same `index_file_key` the searcher entry uses -- callers pass the logical key and never
+    // see the namespacing, so it cannot drift between insert/lookup/erase. On a hit the handle
+    // exposes the BF via get_term_bf().
+    bool lookup_term_bf(const std::string& index_file_key, InvertedIndexCacheHandle* handle);
+    void insert_term_bf(const std::string& index_file_key,
+                        std::shared_ptr<InvertedIndexTermBloomFilter> bf,
+                        InvertedIndexCacheHandle* handle);
+    // Cache a negative result: this (segment, index) has no usable "tbf" sub-file (never built or
+    // corrupt). This is stable for the immutable segment, so eligible queries can skip re-opening
+    // the index. A lookup_term_bf() hit whose get_term_bf() is null IS this negative marker. (Only
+    // structural absence is cached negative -- an analyzer-signature mismatch is reader-dependent
+    // and must NOT be, or it would deny a valid BF to a matching-analyzer reader on the same key.)
+    void insert_term_bf_negative(const std::string& index_file_key,
+                                 InvertedIndexCacheHandle* handle);
 
     // Lookup the given index_searcher in the cache.
     // If the index_searcher is found, the cache entry will be written into handle.
@@ -122,6 +144,14 @@ private:
     // And the cache entry will be returned in handle.
     // This function is thread-safe.
     Cache::Handle* _insert(const InvertedIndexSearcherCache::CacheKey& key, CacheValue* value);
+
+    // Derive the BF entry's key from a (segment, index) identity. The '\x01' byte never occurs in
+    // an index file path, so a BF key can never collide with a searcher key. This is the single
+    // place that knows the namespace -- insert/lookup/erase all route through it, so the searcher
+    // entry and its BF entry stay in lockstep (notably: erase() removes both).
+    static std::string term_bf_key(const std::string& index_file_key) {
+        return index_file_key + std::string("\x01tbf", 4);
+    }
 
     std::unique_ptr<InvertedIndexSearcherCachePolicy> _policy;
 };
@@ -168,6 +198,14 @@ public:
 
     InvertedIndexSearcherCache::CacheValue* get_index_cache_value() {
         return ((InvertedIndexSearcherCache::CacheValue*)_cache->value(_handle));
+    }
+
+    // The token-exists Bloom Filter held by a BF-namespace cache entry (null for searcher entries).
+    std::shared_ptr<InvertedIndexTermBloomFilter> get_term_bf() {
+        if (_cache == nullptr) {
+            return nullptr;
+        }
+        return ((InvertedIndexSearcherCache::CacheValue*)_cache->value(_handle))->term_bf;
     }
 
 private:

--- a/be/src/storage/index/inverted/inverted_index_compaction.cpp
+++ b/be/src/storage/index/inverted/inverted_index_compaction.cpp
@@ -17,10 +17,15 @@
 
 #include "storage/index/inverted/inverted_index_compaction.h"
 
+#include <CLucene/util/stringUtil.h>
+
+#include "common/config.h"
 #include "io/fs/local_file_system.h"
 #include "storage/index/index_file_writer.h"
+#include "storage/index/inverted/analyzer/analyzer.h"
 #include "storage/index/inverted/inverted_index_common.h"
 #include "storage/index/inverted/inverted_index_fs_directory.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
 #include "storage/tablet/tablet_schema.h"
 #include "util/debug_points.h"
 
@@ -30,7 +35,8 @@ Status compact_column(
         std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>>& src_index_dirs,
         std::vector<lucene::store::Directory*>& dest_index_dirs, std::string_view tmp_path,
         const std::vector<std::vector<std::pair<uint32_t, uint32_t>>>& trans_vec,
-        const std::vector<uint32_t>& dest_segment_num_rows) {
+        const std::vector<uint32_t>& dest_segment_num_rows, const TabletIndex* index_meta,
+        std::string_view field_name) {
     DBUG_EXECUTE_IF("index_compaction_compact_column_throw_error", {
         if (index_id % 2 == 0) {
             _CLTHROWA(CL_ERR_IO, "debug point: test throw error in index compaction");
@@ -73,6 +79,36 @@ Status compact_column(
     DBUG_EXECUTE_IF("compact_column_index_writer_close_error", {
         _CLTHROWA(CL_ERR_IO,
                   "debug point: compact_column_index_writer_close_error in index compaction");
+    })
+
+    // Emit the token-exists Bloom Filter ("tbf") sub-file for each dest segment, in lockstep with
+    // the normal writer's `write_term_bloom_filter()`. Without this, the index-compaction
+    // shortcut (`do_inverted_index_compaction`) would silently drop tbf from every output --
+    // CLucene's `indexCompaction()` only knows about its own files (segments_*, _*.cfs,
+    // null_bitmap) and never copies our custom "tbf" forward. On a default cluster
+    // (`inverted_index_compaction_enable=true`, DUP_KEYS / MoW with fulltext indexes) this is the
+    // dominant compaction path, so missing the emit here means historical segments would never
+    // get a tbf even after compaction. Gating mirrors the writer (BE config + analyzed index).
+    //
+    // Must run BEFORE the dest dirs are closed by their `InvertedIndexFileWriter::close()` (the
+    // caller invokes `_output_rs_writer->build()` later in compaction.cpp); inserting into the
+    // compound after close would not be honored.
+    if (config::enable_inverted_index_term_bf && index_meta != nullptr &&
+        !field_name.empty() &&
+        inverted_index::InvertedIndexAnalyzer::should_analyzer(index_meta->properties())) {
+        const uint64_t analyzer_sig = compute_analyzer_sig(index_meta->properties());
+        const std::wstring wfield_name =
+                StringUtil::string_to_wstring(std::string {field_name});
+        for (auto* dest_dir : dest_index_dirs) {
+            if (dest_dir == nullptr) {
+                continue;
+            }
+            emit_term_bloom_filter_into_dir(dest_dir, wfield_name, analyzer_sig);
+        }
+    }
+    DBUG_EXECUTE_IF("compact_column_emit_term_bf_error", {
+        _CLTHROWA(CL_ERR_IO,
+                  "debug point: compact_column_emit_term_bf_error in index compaction");
     })
 
     // delete temporary segment_path, only when inverted_index_ram_dir_enable is false

--- a/be/src/storage/index/inverted/inverted_index_compaction.h
+++ b/be/src/storage/index/inverted/inverted_index_compaction.h
@@ -32,11 +32,19 @@ namespace segment_v2 {
 class IndexFileWriter;
 class IndexFileReader;
 
+// `index_meta` and `field_name` are required to emit the optional token-exists Bloom Filter
+// ("tbf") sub-file into each dest dir when `config::enable_inverted_index_term_bf` is on and
+// the index is analyzed (fulltext). They MUST identify the same logical (column, index) the
+// CLucene `indexCompaction` is merging -- `field_name` is the same identifier the writer
+// stored in the term dictionary (column name for storage format V1, `to_string(unique_id)`
+// for V2). Without them, segments produced by this compaction shortcut would not carry a
+// tbf and the read-side fast path would always fall back to a normal lookup for them.
 Status compact_column(
         int64_t index_id,
         std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>>& src_index_dirs,
         std::vector<lucene::store::Directory*>& dest_index_dirs, std::string_view tmp_path,
         const std::vector<std::vector<std::pair<uint32_t, uint32_t>>>& trans_vec,
-        const std::vector<uint32_t>& dest_segment_num_rows);
+        const std::vector<uint32_t>& dest_segment_num_rows,
+        const TabletIndex* index_meta = nullptr, std::string_view field_name = {});
 } // namespace segment_v2
 } // namespace doris

--- a/be/src/storage/index/inverted/inverted_index_desc.h
+++ b/be/src/storage/index/inverted/inverted_index_desc.h
@@ -59,6 +59,12 @@ public:
     static const char* get_temporary_bkd_index_data_file_name() { return "bkd"; }
     static const char* get_temporary_bkd_index_meta_file_name() { return "bkd_meta"; }
     static const char* get_temporary_bkd_index_file_name() { return "bkd_index"; }
+    // token-exists Bloom Filter sub-file. Name must be >= 3 chars and must NOT be a
+    // substring of any key in index_file_info_map / normal_file_info_map (a bare "bf"
+    // would collide with substring matching and pollute file sort/partition ordering).
+    // "tbf" is not a substring of any existing key, so it is auto-classified as a
+    // normal_file (placed after the meta files), satisfying the V2 ordering assertion.
+    static const char* get_temporary_term_bf_file_name() { return "tbf"; }
 };
 
 } // namespace segment_v2

--- a/be/src/storage/index/inverted/inverted_index_parser.cpp
+++ b/be/src/storage/index/inverted/inverted_index_parser.cpp
@@ -104,6 +104,14 @@ std::string get_parser_phrase_support_string_from_properties(
     return INVERTED_INDEX_PARSER_PHRASE_SUPPORT_NO;
 }
 
+std::string get_parser_token_bf_from_properties(
+        const std::map<std::string, std::string>& properties) {
+    if (auto it = properties.find(INVERTED_INDEX_PARSER_TOKEN_BF_KEY); it != properties.end()) {
+        return it->second;
+    }
+    return INVERTED_INDEX_PARSER_TOKEN_BF_NO;
+}
+
 CharFilterMap get_parser_char_filter_map_from_properties(
         const std::map<std::string, std::string>& properties) {
     if (!properties.contains(INVERTED_INDEX_PARSER_CHAR_FILTER_TYPE)) {

--- a/be/src/storage/index/inverted/inverted_index_parser.h
+++ b/be/src/storage/index/inverted/inverted_index_parser.h
@@ -82,6 +82,12 @@ const std::string INVERTED_INDEX_PARSER_PHRASE_SUPPORT_KEY = "support_phrase";
 const std::string INVERTED_INDEX_PARSER_PHRASE_SUPPORT_YES = "true";
 const std::string INVERTED_INDEX_PARSER_PHRASE_SUPPORT_NO = "false";
 
+// token-exists Bloom Filter sub-file gate (default off). When "true", the writer emits
+// the "tbf" sub-file recording which analyzed tokens exist in this segment's term dict.
+const std::string INVERTED_INDEX_PARSER_TOKEN_BF_KEY = "token_bloom_filter";
+const std::string INVERTED_INDEX_PARSER_TOKEN_BF_YES = "true";
+const std::string INVERTED_INDEX_PARSER_TOKEN_BF_NO = "false";
+
 const std::string INVERTED_INDEX_PARSER_CHAR_FILTER_TYPE = "char_filter_type";
 const std::string INVERTED_INDEX_PARSER_CHAR_FILTER_PATTERN = "char_filter_pattern";
 const std::string INVERTED_INDEX_PARSER_CHAR_FILTER_REPLACEMENT = "char_filter_replacement";
@@ -136,6 +142,8 @@ std::string get_parser_string_from_properties(const std::map<std::string, std::s
 std::string get_parser_mode_string_from_properties(
         const std::map<std::string, std::string>& properties);
 std::string get_parser_phrase_support_string_from_properties(
+        const std::map<std::string, std::string>& properties);
+std::string get_parser_token_bf_from_properties(
         const std::map<std::string, std::string>& properties);
 
 CharFilterMap get_parser_char_filter_map_from_properties(

--- a/be/src/storage/index/inverted/inverted_index_reader.cpp
+++ b/be/src/storage/index/inverted/inverted_index_reader.cpp
@@ -514,23 +514,6 @@ InvertedIndexReaderType FullTextIndexReader::type() {
 
 namespace {
 
-// Reconstruct the build-time analyzer configuration from the index properties. This must
-// mirror InvertedIndexColumnWriter::init_fulltext_index() exactly (including the
-// lower_case ReturnTrue=true default) so that the signature computed here equals the one
-// stored in the "tbf" sub-file when the same analyzer is in play.
-InvertedIndexAnalyzerConfig build_index_analyzer_config(
-        const std::map<std::string, std::string>& properties) {
-    InvertedIndexAnalyzerConfig cfg;
-    cfg.analyzer_name = get_analyzer_name_from_properties(properties);
-    cfg.parser_type = get_inverted_index_parser_type_from_string(
-            get_parser_string_from_properties(properties));
-    cfg.parser_mode = get_parser_mode_string_from_properties(properties);
-    cfg.char_filter_map = get_parser_char_filter_map_from_properties(properties);
-    cfg.lower_case = get_parser_lowercase_from_properties<true>(properties);
-    cfg.stop_words = get_parser_stopwords_from_properties(properties);
-    return cfg;
-}
-
 } // namespace
 
 // Load + validate the token BF from the "tbf" sub-file. Returns nullptr (treated as "unknown" ->
@@ -600,8 +583,7 @@ Status FullTextIndexReader::try_term_bf_fast_path(
     // not encode the analyzer, so a reader whose _index_meta was altered to a different analyzer
     // maps to the same key; the signature is what tells a usable BF from one built for a different
     // tokenization.
-    const uint64_t index_sig =
-            compute_analyzer_sig(build_index_analyzer_config(_index_meta.properties()));
+    const uint64_t index_sig = compute_analyzer_sig(_index_meta.properties());
 
     // Reuse the parsed BF for this (segment, index) so a warm absent query does zero IO. The BF
     // lives in the searcher cache (same LRU + memory budget, no separate cache); the cache owns the

--- a/be/src/storage/index/inverted/inverted_index_reader.cpp
+++ b/be/src/storage/index/inverted/inverted_index_reader.cpp
@@ -53,6 +53,8 @@
 #include "storage/index/inverted/inverted_index_parser.h"
 #include "storage/index/inverted/inverted_index_query_type.h"
 #include "storage/index/inverted/inverted_index_searcher.h"
+#include "storage/index/inverted/inverted_index_term_bf_query.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
 #include "storage/index/inverted/query/phrase_query.h"
 #include "storage/index/inverted/query/query_factory.h"
 #include "storage/key_coder.h"
@@ -464,6 +466,30 @@ Status FullTextIndexReader::query(const IndexQueryContextPtr& context,
             }
         }
 
+        // token-exists Bloom Filter absent-term fast path. Runs after the query-cache miss but
+        // before paying any searcher-open IO. query_info.term_infos are already analyzed tokens
+        // at this point. Only literal terms are eligible (regexp / phrase-prefix are excluded:
+        // their "term" is a pattern, not a token). On a proven-absent result the bitmap is empty
+        // and we return immediately; otherwise we fall through to the normal lookup.
+        //
+        // Gate on the index property too (the same condition the writer used to emit the "tbf"
+        // sub-file): without this, flipping the global config on would make every fulltext index
+        // -- including ones that never built a tbf -- pay an extra open + fileExists("tbf") per
+        // eligible query, even when the searcher cache would have hit. The property lives in
+        // _index_meta (already in memory), so this gate costs nothing.
+        if (config::enable_inverted_index_term_bf &&
+            get_parser_token_bf_from_properties(_index_meta.properties()) ==
+                    INVERTED_INDEX_PARSER_TOKEN_BF_YES &&
+            query_type != InvertedIndexQueryType::MATCH_REGEXP_QUERY &&
+            query_type != InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY) {
+            bool absent = false;
+            RETURN_IF_ERROR(try_term_bf_fast_path(context, query_type, query_info, cache_key,
+                                                  bit_map, &absent));
+            if (absent) {
+                return Status::OK();
+            }
+        }
+
         InvertedIndexCacheHandle inverted_index_cache_handle;
         RETURN_IF_ERROR(handle_searcher_cache(context, &inverted_index_cache_handle));
         auto searcher_variant = inverted_index_cache_handle.get_index_searcher();
@@ -485,6 +511,174 @@ Status FullTextIndexReader::query(const IndexQueryContextPtr& context,
 
 InvertedIndexReaderType FullTextIndexReader::type() {
     return InvertedIndexReaderType::FULLTEXT;
+}
+
+namespace {
+
+// Reconstruct the build-time analyzer configuration from the index properties. This must
+// mirror InvertedIndexColumnWriter::init_fulltext_index() exactly (including the
+// lower_case ReturnTrue=true default) so that the signature computed here equals the one
+// stored in the "tbf" sub-file when the same analyzer is in play.
+InvertedIndexAnalyzerConfig build_index_analyzer_config(
+        const std::map<std::string, std::string>& properties) {
+    InvertedIndexAnalyzerConfig cfg;
+    cfg.analyzer_name = get_analyzer_name_from_properties(properties);
+    cfg.parser_type = get_inverted_index_parser_type_from_string(
+            get_parser_string_from_properties(properties));
+    cfg.parser_mode = get_parser_mode_string_from_properties(properties);
+    cfg.char_filter_map = get_parser_char_filter_map_from_properties(properties);
+    cfg.lower_case = get_parser_lowercase_from_properties<true>(properties);
+    cfg.stop_words = get_parser_stopwords_from_properties(properties);
+    return cfg;
+}
+
+} // namespace
+
+// Load + validate the token BF from the "tbf" sub-file. Returns nullptr (treated as "unknown" ->
+// normal query) on any failure: missing sub-file, corruption, reader error, or an analyzer-sig
+// mismatch (A3, stale BF). Never throws. The caller caches the returned BF so this runs at most
+// once per (segment, index).
+std::shared_ptr<InvertedIndexTermBloomFilter> FullTextIndexReader::load_term_bf_from_subfile(
+        const IndexQueryContextPtr& context) {
+    lucene::store::IndexInput* bf_in = nullptr;
+    lucene::store::Directory* dir = nullptr;
+    bool owned_dir = false;
+    std::shared_ptr<InvertedIndexTermBloomFilter> bf;
+    try {
+        auto st =
+                _index_file_reader->init(config::inverted_index_read_buffer_size, context->io_ctx);
+        if (!st.ok()) {
+            return nullptr;
+        }
+        auto open_res = _index_file_reader->open(&_index_meta, context->io_ctx);
+        if (!open_res.has_value()) {
+            return nullptr; // real error surfaces on the normal path
+        }
+        dir = open_res.value().release();
+        owned_dir = true;
+
+        const char* bf_file_name = InvertedIndexDescriptor::get_temporary_term_bf_file_name();
+        if (!dir->fileExists(bf_file_name)) {
+            if (owned_dir) {
+                FINALIZE_INPUT(dir);
+            }
+            return nullptr; // no BF sub-file
+        }
+        bf_in = dir->openInput(bf_file_name);
+        auto bf_res = InvertedIndexTermBloomFilter::load(bf_in);
+        FINALIZE_INPUT(bf_in);
+        if (owned_dir) {
+            FINALIZE_INPUT(dir);
+        }
+        if (!bf_res.has_value()) {
+            return nullptr; // corrupt / incompatible
+        }
+        bf = std::move(bf_res.value());
+    } catch (CLuceneError& e) {
+        FINALLY_FINALIZE_INPUT(bf_in);
+        if (owned_dir) {
+            FINALLY_FINALIZE_INPUT(dir);
+        }
+        // Treat any reader error here as "unknown": never turn it into an empty result.
+        LOG(WARNING) << "term bloom filter load error, falling back to normal query: " << e.what();
+        return nullptr;
+    }
+
+    // Structural load only: a successfully parsed blob is returned regardless of analyzer. The
+    // caller applies the A3 analyzer-signature check (uniformly for cache hits and fresh loads), so
+    // that an analyzer-mismatch is treated per-reader and never cached as a negative result.
+    return bf;
+}
+
+Status FullTextIndexReader::try_term_bf_fast_path(
+        const IndexQueryContextPtr& context, InvertedIndexQueryType query_type,
+        const InvertedIndexQueryInfo& query_info,
+        const InvertedIndexQueryCache::CacheKey& cache_key,
+        std::shared_ptr<roaring::Roaring>& bit_map, bool* absent) {
+    *absent = false;
+
+    // This reader's analyzer signature, checked (A3) against the BF below. The BF cache key does
+    // not encode the analyzer, so a reader whose _index_meta was altered to a different analyzer
+    // maps to the same key; the signature is what tells a usable BF from one built for a different
+    // tokenization.
+    const uint64_t index_sig =
+            compute_analyzer_sig(build_index_analyzer_config(_index_meta.properties()));
+
+    // Reuse the parsed BF for this (segment, index) so a warm absent query does zero IO. The BF
+    // lives in the searcher cache (same LRU + memory budget, no separate cache); the cache owns the
+    // key namespacing, so we pass the logical index-file key and never see how it coexists with the
+    // searcher entry. Three outcomes per key: a real BF, a negative marker (no usable tbf), or a
+    // miss (load the "tbf" sub-file once, then cache the BF or the negative result).
+    auto* searcher_cache = InvertedIndexSearcherCache::instance();
+    if (searcher_cache == nullptr) {
+        return Status::OK(); // no cache wired (e.g. some tools) -> normal query
+    }
+    const auto index_file_key = _index_file_reader->get_index_file_cache_key(&_index_meta);
+    InvertedIndexCacheHandle bf_cache_handle;
+    std::shared_ptr<InvertedIndexTermBloomFilter> bf;
+    bool from_cache = false;
+    if (searcher_cache->lookup_term_bf(index_file_key, &bf_cache_handle)) {
+        bf = bf_cache_handle.get_term_bf();
+        if (bf == nullptr) {
+            // Negative marker: a prior query already found this (segment, index) has no usable tbf
+            // (missing/corrupt). Stable for the immutable segment -> skip re-opening it.
+            context->stats->inverted_index_term_bf_unavailable++;
+            return Status::OK();
+        }
+        from_cache = true; // a real BF; the A3 check below decides if it fits THIS reader.
+    } else {
+        context->stats->inverted_index_term_bf_cache_miss++;
+        bf = load_term_bf_from_subfile(context);
+        if (bf == nullptr) {
+            // Structurally absent/corrupt: cache the negative result so eligible queries do not
+            // re-open the index every time (analyzer mismatch is handled below, NOT cached here).
+            context->stats->inverted_index_term_bf_unavailable++;
+            searcher_cache->insert_term_bf_negative(index_file_key, &bf_cache_handle);
+            return Status::OK();
+        }
+        // A tbf blob was actually read from storage: record the cold IO it cost, and cache the BF
+        // for its build analyzer so a same-key reader with a matching analyzer reuses it.
+        context->stats->inverted_index_term_bf_load_count++;
+        context->stats->inverted_index_term_bf_load_bytes += static_cast<int64_t>(bf->byte_size());
+        searcher_cache->insert_term_bf(index_file_key, bf, &bf_cache_handle);
+    }
+
+    // A3, applied uniformly to cache hits and fresh loads: the BF cache key does not encode the
+    // analyzer, so a BF built under one analyzer can be reached by a reader using another. If the
+    // signatures differ, the BF was built for a different tokenization -> fall back (per reader;
+    // never cached as a negative, so a matching-analyzer reader still benefits).
+    if (bf->analyzer_sig() != index_sig) {
+        context->stats->inverted_index_term_bf_unavailable++;
+        return Status::OK();
+    }
+    if (from_cache) {
+        context->stats->inverted_index_term_bf_cache_hit++; // warm + usable: zero IO
+    }
+
+    // A usable BF is in hand: this is one probe (denominator of the fast-path hit rate).
+    context->stats->inverted_index_term_bf_probe++;
+
+    // Per-query-type semantics + A1 position grouping + A2 multi-term slot live in
+    // bf_query_proven_empty (shared with the unit tests, so the grouping logic is covered rather
+    // than reimplemented in the test). Ineligible types return false -> normal query below.
+    if (!bf_query_proven_empty(query_type, query_info, *bf)) {
+        context->stats->inverted_index_term_bf_fallthrough++;
+        return Status::OK();
+    }
+    context->stats->inverted_index_term_bf_skipped_lookups++;
+
+    // Proven empty. Produce an empty bitmap and (under the same gate as the normal path)
+    // populate the query cache so repeated absent-term queries stay on the fast path. Never
+    // touch df / sumTotalTermFreq: the BF runs strictly before the searcher and must not feed
+    // scoring statistics.
+    bit_map = std::make_shared<roaring::Roaring>();
+    if (!(context->collection_similarity && query_info.is_similarity_score)) {
+        auto* cache = InvertedIndexQueryCache::instance();
+        InvertedIndexQueryCacheHandle cache_handler;
+        cache->insert(cache_key, bit_map, &cache_handler);
+    }
+    *absent = true;
+    return Status::OK();
 }
 
 Status StringTypeInvertedIndexReader::new_iterator(std::unique_ptr<IndexIterator>* iterator) {

--- a/be/src/storage/index/inverted/inverted_index_reader.cpp
+++ b/be/src/storage/index/inverted/inverted_index_reader.cpp
@@ -472,14 +472,13 @@ Status FullTextIndexReader::query(const IndexQueryContextPtr& context,
         // their "term" is a pattern, not a token). On a proven-absent result the bitmap is empty
         // and we return immediately; otherwise we fall through to the normal lookup.
         //
-        // Gate on the index property too (the same condition the writer used to emit the "tbf"
-        // sub-file): without this, flipping the global config on would make every fulltext index
-        // -- including ones that never built a tbf -- pay an extra open + fileExists("tbf") per
-        // eligible query, even when the searcher cache would have hit. The property lives in
-        // _index_meta (already in memory), so this gate costs nothing.
+        // The single gate is the BE config (`enable_inverted_index_term_bf`) -- the per-index
+        // `token_bloom_filter` property is no longer consulted (any fulltext index in a cluster
+        // with the config on is eligible). The per-segment open + fileExists("tbf") cost for
+        // indexes that never built a tbf is bounded by the negative-cache entry inserted on the
+        // first miss: every subsequent eligible query for that (segment, index) hits the
+        // searcher-cache without IO and returns "unavailable" without re-paying load.
         if (config::enable_inverted_index_term_bf &&
-            get_parser_token_bf_from_properties(_index_meta.properties()) ==
-                    INVERTED_INDEX_PARSER_TOKEN_BF_YES &&
             query_type != InvertedIndexQueryType::MATCH_REGEXP_QUERY &&
             query_type != InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY) {
             bool absent = false;

--- a/be/src/storage/index/inverted/inverted_index_reader.h
+++ b/be/src/storage/index/inverted/inverted_index_reader.h
@@ -73,6 +73,7 @@ namespace segment_v2 {
 
 class InvertedIndexIterator;
 class InvertedIndexQueryCacheHandle;
+class InvertedIndexTermBloomFilter;
 class IndexFileReader;
 class InvertedIndexQueryInfo;
 class IndexIterator;
@@ -296,6 +297,24 @@ public:
     }
 
     InvertedIndexReaderType type() override;
+
+private:
+    // token-exists Bloom Filter absent-term fast path. On success (*absent == true) the
+    // result is provably empty (bit_map is the empty bitmap). On *absent == false the BF
+    // could not prove absence (missing/invalid "tbf", analyzer-sig mismatch, or some token
+    // MAYBE present) and the caller must continue with the normal lookup. This never enters
+    // scoring statistics (it runs strictly before searcher open).
+    Status try_term_bf_fast_path(const IndexQueryContextPtr& context,
+                                 InvertedIndexQueryType query_type,
+                                 const InvertedIndexQueryInfo& query_info,
+                                 const InvertedIndexQueryCache::CacheKey& cache_key,
+                                 std::shared_ptr<roaring::Roaring>& bit_map, bool* absent);
+
+    // Structurally load the "tbf" BF for this (segment, index): nullptr means no usable sub-file
+    // (missing or corrupt) -- a stable property of the immutable segment. The caller applies the
+    // analyzer-signature (A3) check and the caching policy (positive vs negative).
+    std::shared_ptr<InvertedIndexTermBloomFilter> load_term_bf_from_subfile(
+            const IndexQueryContextPtr& context);
 };
 
 class StringTypeInvertedIndexReader : public InvertedIndexReader {

--- a/be/src/storage/index/inverted/inverted_index_term_bf_query.h
+++ b/be/src/storage/index/inverted/inverted_index_term_bf_query.h
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// The query-side decision for the token-exists Bloom Filter absent-term fast path. Kept in its
+// own narrow header (not the BF header, which is included by the writer) so it pulls in query
+// types only where it is used: the reader fast path and its unit tests. Both call the same
+// function, so the per-query-type / position-grouping logic is covered by tests rather than
+// reimplemented in them.
+
+#pragma once
+
+#include "storage/index/inverted/inverted_index_query_type.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
+#include "storage/index/inverted/query/query_info.h"
+
+namespace doris::segment_v2 {
+
+// Whether the BF proves this query's result is necessarily empty (so the reader can short-circuit
+// before opening the searcher). Per-query-type semantics:
+//   - MATCH_ALL / EQUAL: AND -- any single ABSENT token proves empty.
+//   - MATCH_PHRASE: A1 -- alternatives sharing one position are an OR slot (synonyms / CJK
+//     overlap); a slot is dead only when *every* alternative at that position is ABSENT, and the
+//     phrase is empty when *any* slot is dead.
+//   - MATCH_ANY: OR -- empty only when *every* token is ABSENT.
+//   - anything else: never proven empty (returns false).
+// A2: a multi-term TermInfo is an OR of its sub-terms (ABSENT only when *all* are ABSENT);
+// get_single_term() is never called on a multi-term slot.
+bool bf_query_proven_empty(InvertedIndexQueryType query_type,
+                           const InvertedIndexQueryInfo& query_info,
+                           const InvertedIndexTermBloomFilter& bf);
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/inverted/inverted_index_term_bloom_filter.cpp
+++ b/be/src/storage/index/inverted/inverted_index_term_bloom_filter.cpp
@@ -1,0 +1,229 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
+
+#include <CLucene.h> // IWYU pragma: keep
+#include <CLucene/store/IndexInput.h>
+#include <CLucene/store/IndexOutput.h>
+
+#include <cstring>
+#include <map>
+
+#include "storage/index/bloom_filter/block_split_bloom_filter.h"
+#include "storage/index/inverted/inverted_index_term_bf_query.h"
+#include "util/coding.h"
+#include "util/faststring.h"
+#include "util/hash_util.hpp"
+
+namespace doris::segment_v2 {
+
+// false positive probability for the token-exists BF. The term dictionary is small
+// relative to the data, so a tight fpp keeps the sub-file tiny while making the
+// absent-term fast path reliable.
+static constexpr double TERM_BF_FPP = 0.01;
+
+Result<std::unique_ptr<InvertedIndexTermBloomFilter>>
+InvertedIndexTermBloomFilter::create_for_write(uint64_t distinct_terms, uint64_t analyzer_sig) {
+    std::unique_ptr<BloomFilter> bf;
+    RETURN_IF_ERROR_RESULT(BloomFilter::create(BLOCK_BLOOM_FILTER, &bf));
+    RETURN_IF_ERROR_RESULT(bf->init(distinct_terms, TERM_BF_FPP, HASH_MURMUR3_X64_64));
+
+    std::unique_ptr<InvertedIndexTermBloomFilter> self(new InvertedIndexTermBloomFilter());
+    self->_bf = std::move(bf);
+    self->_analyzer_sig = analyzer_sig;
+    self->_distinct_terms = distinct_terms;
+    return self;
+}
+
+void InvertedIndexTermBloomFilter::add_token(const char* data, size_t len) {
+    // An empty keyword token is a legal token (keyword indexes treat the empty string as a
+    // value). BloomFilter::add_bytes treats a nullptr buffer as the "has_null" flag, so use a
+    // non-null pointer for the zero-length case to keep it on the data path.
+    static constexpr char EMPTY = '\0';
+    _bf->add_bytes(len == 0 ? &EMPTY : data, len);
+}
+
+void InvertedIndexTermBloomFilter::serialize(lucene::store::IndexOutput* out) const {
+    faststring header;
+    header.append(MAGIC, sizeof(MAGIC));
+    header.push_back(ALGO_BLOCK);
+    header.push_back(HASH_MURMUR3);
+    header.push_back(0); // reserved
+    header.push_back(0); // reserved
+    put_fixed64_le(&header, _analyzer_sig);
+    put_fixed64_le(&header, _distinct_terms);
+    put_fixed32_le(&header, static_cast<uint32_t>(_bf->size()));
+    DCHECK_EQ(header.size(), HEADER_SIZE);
+
+    out->writeBytes(reinterpret_cast<const uint8_t*>(header.data()),
+                    static_cast<int32_t>(header.size()));
+    out->writeBytes(reinterpret_cast<const uint8_t*>(_bf->data()),
+                    static_cast<int32_t>(_bf->size()));
+}
+
+Result<std::unique_ptr<InvertedIndexTermBloomFilter>> InvertedIndexTermBloomFilter::load(
+        lucene::store::IndexInput* in) {
+    int64_t total = in->length();
+    if (total < static_cast<int64_t>(HEADER_SIZE) + 2) {
+        return ResultError(
+                Status::Corruption("term bloom filter sub-file too small: {} bytes", total));
+    }
+    // Upper bound BEFORE resize() / the int32 readBytes cast: a legitimate blob is at most
+    // BloomFilter::MAXIMUM_BYTES (+1 null-flag byte), so a larger length is corrupt. This bounds
+    // the buffer allocation against a crafted length and keeps total well within int32 range, so
+    // the static_cast<int32_t>(total) below cannot overflow.
+    static constexpr int64_t kMaxTotal =
+            static_cast<int64_t>(HEADER_SIZE) + BloomFilter::MAXIMUM_BYTES + 1;
+    if (total > kMaxTotal) {
+        return ResultError(Status::Corruption(
+                "term bloom filter sub-file too large: {} bytes (max {})", total, kMaxTotal));
+    }
+
+    faststring buf;
+    buf.resize(total);
+    in->readBytes(buf.data(), static_cast<int32_t>(total));
+
+    const uint8_t* p = buf.data();
+    if (std::memcmp(p, MAGIC, sizeof(MAGIC)) != 0) {
+        return ResultError(Status::Corruption("term bloom filter bad magic"));
+    }
+    uint8_t algo = p[4];
+    uint8_t hash = p[5];
+    if (algo != ALGO_BLOCK || hash != HASH_MURMUR3) {
+        return ResultError(
+                Status::Corruption("term bloom filter unsupported algo/hash: {}/{}", algo, hash));
+    }
+    uint64_t analyzer_sig = decode_fixed64_le(p + 8);
+    uint64_t distinct_terms = decode_fixed64_le(p + 16);
+    uint32_t bf_size = decode_fixed32_le(p + 24);
+    if (static_cast<int64_t>(HEADER_SIZE) + bf_size != total) {
+        return ResultError(
+                Status::Corruption("term bloom filter size mismatch: header={} bf={} total={}",
+                                   HEADER_SIZE, bf_size, total));
+    }
+
+    std::unique_ptr<BloomFilter> bf;
+    RETURN_IF_ERROR_RESULT(BloomFilter::create(BLOCK_BLOOM_FILTER, &bf));
+    RETURN_IF_ERROR_RESULT(
+            bf->init(reinterpret_cast<const char*>(p + HEADER_SIZE), bf_size, HASH_MURMUR3_X64_64));
+
+    std::unique_ptr<InvertedIndexTermBloomFilter> self(new InvertedIndexTermBloomFilter());
+    self->_bf = std::move(bf);
+    self->_analyzer_sig = analyzer_sig;
+    self->_distinct_terms = distinct_terms;
+    return self;
+}
+
+InvertedIndexTermBloomFilter::Probe InvertedIndexTermBloomFilter::probe(
+        const std::string& utf8_token) const {
+    // Mirror add_token's empty-token handling so the zero-length keyword token probes the
+    // same hash slot it was added under.
+    static constexpr char EMPTY = '\0';
+    const char* data = utf8_token.empty() ? &EMPTY : utf8_token.data();
+    bool maybe = _bf->test_bytes(data, utf8_token.size());
+    return maybe ? Probe::MAYBE : Probe::ABSENT;
+}
+
+uint64_t compute_analyzer_sig(const InvertedIndexAnalyzerConfig& cfg) {
+    // Fold every field that can change tokenization into one buffer, then hash it. A '\0'
+    // separator between fields keeps distinct field boundaries from aliasing.
+    faststring buf;
+    auto add = [&buf](const std::string& s) {
+        buf.append(s.data(), s.size());
+        buf.push_back('\0');
+    };
+    add(cfg.analyzer_name);
+    add(std::to_string(static_cast<int>(cfg.parser_type)));
+    add(cfg.parser_mode);
+    add(cfg.lower_case);
+    add(cfg.stop_words);
+    // char_filter_map is an ordered std::map, so iteration order is deterministic.
+    for (const auto& [k, v] : cfg.char_filter_map) {
+        add(k);
+        add(v);
+    }
+    return HashUtil::murmur_hash64A(buf.data(), static_cast<int>(buf.size()),
+                                    /*seed=*/0x9747b28c);
+}
+
+bool bf_query_proven_empty(InvertedIndexQueryType query_type,
+                           const InvertedIndexQueryInfo& query_info,
+                           const InvertedIndexTermBloomFilter& bf) {
+    using Probe = InvertedIndexTermBloomFilter::Probe;
+    // A2: a multi-term slot (CJK overlap / synonyms at one position) is an OR of its sub-terms --
+    // ABSENT only when *every* sub-term is ABSENT; never call get_single_term() on a multi slot.
+    // `auto` keeps CLucene's lucene::index::TermInfo out of name lookup here.
+    auto probe = [&bf](const auto& ti) -> Probe {
+        if (ti.is_multi_terms()) {
+            for (const auto& sub : ti.get_multi_terms()) {
+                if (bf.probe(sub) == Probe::MAYBE) {
+                    return Probe::MAYBE;
+                }
+            }
+            return Probe::ABSENT;
+        }
+        return bf.probe(ti.get_single_term());
+    };
+
+    switch (query_type) {
+    case InvertedIndexQueryType::MATCH_ALL_QUERY:
+    case InvertedIndexQueryType::EQUAL_QUERY: {
+        // AND: any single ABSENT token proves the result empty.
+        for (const auto& ti : query_info.term_infos) {
+            if (probe(ti) == Probe::ABSENT) {
+                return true;
+            }
+        }
+        return false;
+    }
+    case InvertedIndexQueryType::MATCH_PHRASE_QUERY: {
+        // A1: alternatives sharing one position are an OR slot. A slot is dead only when *every*
+        // alternative at that position is ABSENT; the phrase is empty when *any* slot is dead.
+        std::map<int32_t, bool> slot_alive; // position -> at least one alternative MAYBE present
+        for (const auto& ti : query_info.term_infos) {
+            bool maybe = probe(ti) == Probe::MAYBE;
+            auto it = slot_alive.find(ti.position);
+            if (it == slot_alive.end()) {
+                slot_alive.emplace(ti.position, maybe);
+            } else {
+                it->second = it->second || maybe;
+            }
+        }
+        for (const auto& [pos, alive] : slot_alive) {
+            if (!alive) {
+                return true;
+            }
+        }
+        return false;
+    }
+    case InvertedIndexQueryType::MATCH_ANY_QUERY: {
+        // OR: empty only when *every* token is ABSENT. (No pruned-subset rewrite in v1.)
+        for (const auto& ti : query_info.term_infos) {
+            if (probe(ti) == Probe::MAYBE) {
+                return false;
+            }
+        }
+        return true;
+    }
+    default:
+        // Not eligible for the absent-term fast path.
+        return false;
+    }
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/inverted/inverted_index_term_bloom_filter.cpp
+++ b/be/src/storage/index/inverted/inverted_index_term_bloom_filter.cpp
@@ -18,13 +18,19 @@
 #include "storage/index/inverted/inverted_index_term_bloom_filter.h"
 
 #include <CLucene.h> // IWYU pragma: keep
+#include <CLucene/config/repl_wchar.h>
+#include <CLucene/index/IndexReader.h>
+#include <CLucene/index/Terms.h>
+#include <CLucene/store/Directory.h>
 #include <CLucene/store/IndexInput.h>
 #include <CLucene/store/IndexOutput.h>
 
 #include <cstring>
 #include <map>
 
+#include "common/logging.h"
 #include "storage/index/bloom_filter/block_split_bloom_filter.h"
+#include "storage/index/inverted/inverted_index_desc.h"
 #include "storage/index/inverted/inverted_index_term_bf_query.h"
 #include "util/coding.h"
 #include "util/faststring.h"
@@ -159,6 +165,97 @@ uint64_t compute_analyzer_sig(const InvertedIndexAnalyzerConfig& cfg) {
     }
     return HashUtil::murmur_hash64A(buf.data(), static_cast<int>(buf.size()),
                                     /*seed=*/0x9747b28c);
+}
+
+uint64_t compute_analyzer_sig(const std::map<std::string, std::string>& properties) {
+    InvertedIndexAnalyzerConfig cfg;
+    cfg.analyzer_name = get_analyzer_name_from_properties(properties);
+    cfg.parser_type = get_inverted_index_parser_type_from_string(
+            get_parser_string_from_properties(properties));
+    cfg.parser_mode = get_parser_mode_string_from_properties(properties);
+    cfg.char_filter_map = get_parser_char_filter_map_from_properties(properties);
+    cfg.lower_case = get_parser_lowercase_from_properties<true>(properties);
+    cfg.stop_words = get_parser_stopwords_from_properties(properties);
+    return compute_analyzer_sig(cfg);
+}
+
+void emit_term_bloom_filter_into_dir(lucene::store::Directory* dir,
+                                     const std::wstring& field_name, uint64_t analyzer_sig) {
+    DCHECK(dir != nullptr);
+    lucene::index::IndexReader* reader = nullptr;
+    lucene::index::TermEnum* term_enum = nullptr;
+    std::unique_ptr<lucene::store::IndexOutput> term_bf_out = nullptr;
+    try {
+        // closeDirectoryOnCleanup=false: the caller (writer's finish() or compact_column) keeps
+        // `dir` alive past this helper; the InvertedIndexFileWriter / compact_column scope owns
+        // the lifecycle. If reader->close() ever propagated to the directory we'd lose the
+        // ability to subsequently createOutput("tbf"), so keep ownership out.
+        reader = lucene::index::IndexReader::open(dir, /*closeDirectoryOnCleanup=*/false);
+
+        // First pass: count distinct terms in this field to size the Bloom Filter.
+        uint64_t distinct_terms = 0;
+        term_enum = reader->terms();
+        while (term_enum->next()) {
+            const auto* term = term_enum->term(false);
+            if (term->field() == field_name) {
+                ++distinct_terms;
+            }
+        }
+        term_enum->close();
+        _CLDELETE(term_enum);
+        term_enum = nullptr;
+
+        auto bf_res = InvertedIndexTermBloomFilter::create_for_write(distinct_terms, analyzer_sig);
+        if (!bf_res.has_value()) {
+            LOG(WARNING) << "Inverted index term bloom filter create error: "
+                         << bf_res.error().to_string();
+            reader->close();
+            _CLDELETE(reader);
+            return;
+        }
+        auto bf = std::move(bf_res.value());
+
+        // Second pass: feed every analyzed token from the term dictionary. These are exactly
+        // the tokens the query path looks up (same analyzed form, no re-tokenization), and the
+        // dictionary includes the zero-length keyword token where applicable (A5).
+        term_enum = reader->terms();
+        while (term_enum->next()) {
+            const auto* term = term_enum->term(false);
+            if (term->field() != field_name) {
+                continue;
+            }
+            std::string token = lucene_wcstoutf8string(term->text(), term->textLength());
+            bf->add_token(token.data(), token.size());
+        }
+        term_enum->close();
+        _CLDELETE(term_enum);
+        term_enum = nullptr;
+
+        term_bf_out = std::unique_ptr<lucene::store::IndexOutput>(
+                dir->createOutput(InvertedIndexDescriptor::get_temporary_term_bf_file_name()));
+        bf->serialize(term_bf_out.get());
+        term_bf_out->close();
+        term_bf_out.reset();
+
+        reader->close();
+        _CLDELETE(reader);
+    } catch (CLuceneError& e) {
+        // A failure to build the optional BF must not fail index writing or compaction: the
+        // read path treats a missing/invalid "tbf" as "unknown" and falls back to the normal
+        // lookup. Best-effort cleanup on the partial state.
+        LOG(WARNING) << "Inverted index term bloom filter write error: " << e.what();
+        if (term_enum != nullptr) {
+            term_enum->close();
+            _CLDELETE(term_enum);
+        }
+        if (term_bf_out != nullptr) {
+            term_bf_out->close();
+        }
+        if (reader != nullptr) {
+            reader->close();
+            _CLDELETE(reader);
+        }
+    }
 }
 
 bool bf_query_proven_empty(InvertedIndexQueryType query_type,

--- a/be/src/storage/index/inverted/inverted_index_term_bloom_filter.h
+++ b/be/src/storage/index/inverted/inverted_index_term_bloom_filter.h
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "common/status.h"
+#include "storage/index/bloom_filter/bloom_filter.h"
+#include "storage/index/inverted/inverted_index_parser.h"
+
+namespace lucene::store {
+class IndexOutput;
+class IndexInput;
+} // namespace lucene::store
+
+namespace doris::segment_v2 {
+
+// token-exists Bloom Filter ("tbf") sub-file.
+//
+// Records whether an analyzed token exists in this segment's term dictionary for a given
+// inverted index. The query path uses it to short-circuit *literal* term lookups: when a
+// term is proven ABSENT, the result is guaranteed empty (no false negatives), so the
+// searcher open / .tii / .tis / .frq / .prx IO can be skipped entirely.
+//
+// On-disk layout (little-endian, self-describing):
+//   [magic char[4]="TBF1"][algo u8][hash u8][reserved u16]
+//   [analyzer_sig u64][distinct_terms u64][bf_size u32][bf_bytes...]
+// header = 4 + 1 + 1 + 2 + 8 + 8 + 4 = 28 bytes.
+// bf_bytes is the raw BloomFilter blob (bf->data() of bf->size() bytes, including the
+// trailing null-flag byte). On read it is fed verbatim into BloomFilter::init(buf,size,..).
+class InvertedIndexTermBloomFilter {
+public:
+    static constexpr char MAGIC[4] = {'T', 'B', 'F', '1'};
+    static constexpr uint8_t ALGO_BLOCK = 0; // BLOCK_BLOOM_FILTER
+    static constexpr uint8_t HASH_MURMUR3 = 0;
+    static constexpr size_t HEADER_SIZE = 28;
+
+    enum class Probe { ABSENT, MAYBE };
+
+    // build-side: own a BlockSplitBloomFilter sized for `distinct_terms` tokens.
+    static Result<std::unique_ptr<InvertedIndexTermBloomFilter>> create_for_write(
+            uint64_t distinct_terms, uint64_t analyzer_sig);
+
+    // read-side: parse + validate the header, deep-copy the blob into a BloomFilter.
+    static Result<std::unique_ptr<InvertedIndexTermBloomFilter>> load(
+            lucene::store::IndexInput* in);
+
+    // build-side: feed one analyzed token (UTF-8 bytes; empty token allowed for keyword).
+    void add_token(const char* data, size_t len);
+
+    // build-side: write [header][bf blob] to the sub-file.
+    void serialize(lucene::store::IndexOutput* out) const;
+
+    uint64_t analyzer_sig() const { return _analyzer_sig; }
+    uint64_t distinct_terms() const { return _distinct_terms; }
+
+    // approximate in-memory footprint (BF blob bytes), used as the cache charge.
+    size_t byte_size() const { return HEADER_SIZE + (_bf != nullptr ? _bf->size() : 0); }
+
+    // read-side: probe one analyzed token. ABSENT is authoritative (no false negative);
+    // MAYBE means "fall through to the normal lookup".
+    Probe probe(const std::string& utf8_token) const;
+
+private:
+    InvertedIndexTermBloomFilter() = default;
+
+    std::unique_ptr<BloomFilter> _bf;
+    uint64_t _analyzer_sig = 0;
+    uint64_t _distinct_terms = 0;
+};
+
+// analyzer configuration fingerprint. Two configs that would tokenize differently must
+// produce different signatures, so the read side can reject a BF built by a different
+// analyzer (A3) and fall back to a normal lookup.
+uint64_t compute_analyzer_sig(const InvertedIndexAnalyzerConfig& cfg);
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/inverted/inverted_index_term_bloom_filter.h
+++ b/be/src/storage/index/inverted/inverted_index_term_bloom_filter.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 
@@ -91,5 +92,22 @@ private:
 // produce different signatures, so the read side can reject a BF built by a different
 // analyzer (A3) and fall back to a normal lookup.
 uint64_t compute_analyzer_sig(const InvertedIndexAnalyzerConfig& cfg);
+
+// Reconstruct the build-time `InvertedIndexAnalyzerConfig` from index `properties` (matching
+// `InvertedIndexColumnWriter::init_fulltext_index()` exactly, including the lower_case
+// ReturnTrue=true default) and hash it. The reader's A3 staleness check, the writer's
+// build-time sig, and the compaction path all flow through this overload so they cannot drift.
+uint64_t compute_analyzer_sig(const std::map<std::string, std::string>& properties);
+
+// Enumerate the just-flushed term dictionary inside `dir` for `field_name`, build a BF sized
+// to the distinct-token count, tag it with `analyzer_sig`, and serialize it as the "tbf"
+// sub-file. Reused by both the writer (after the segment's IndexWriter is closed) and the
+// compaction shortcut (after `IndexWriter::indexCompaction()` writes the merged dest dir),
+// so the on-disk "tbf" carries the same invariants regardless of which path produced the
+// segment. Never throws -- a failure here is logged and treated as "no tbf for this
+// (segment, index)"; the read path then falls through to the normal lookup. `dir` must be
+// alive across the call but is NOT closed by this helper.
+void emit_term_bloom_filter_into_dir(lucene::store::Directory* dir,
+                                     const std::wstring& field_name, uint64_t analyzer_sig);
 
 } // namespace doris::segment_v2

--- a/be/src/storage/index/inverted/inverted_index_writer.cpp
+++ b/be/src/storage/index/inverted/inverted_index_writer.cpp
@@ -47,10 +47,14 @@ InvertedIndexColumnWriter<field_type>::InvertedIndexColumnWriter(const std::stri
     _should_analyzer =
             inverted_index::InvertedIndexAnalyzer::should_analyzer(_index_meta->properties());
     // token-exists Bloom Filter is only meaningful for analyzed (fulltext) indexes; the
-    // keyword/exact path is intentionally left out (see A4 read-side guard).
-    _enable_term_bf =
-            _should_analyzer && get_parser_token_bf_from_properties(_index_meta->properties()) ==
-                                        INVERTED_INDEX_PARSER_TOKEN_BF_YES;
+    // keyword/exact path is intentionally left out (see A4 read-side guard). The single gate is
+    // the BE config (`enable_inverted_index_term_bf`), so any fulltext index in a cluster with the
+    // config on emits the "tbf" sub-file by default -- the per-index `token_bloom_filter` property
+    // is no longer consulted here. The mBool config is snapshotted at writer-construction time so
+    // every column writer in the same segment-write batch agrees on the gate (a runtime flip
+    // between this point and `finish()` cannot leave a half-written segment with some columns'
+    // BFs missing).
+    _enable_term_bf = _should_analyzer && config::enable_inverted_index_term_bf;
     _value_key_coder = get_key_coder(field_type);
     _field_name = StringUtil::string_to_wstring(field_name);
 }

--- a/be/src/storage/index/inverted/inverted_index_writer.cpp
+++ b/be/src/storage/index/inverted/inverted_index_writer.cpp
@@ -17,9 +17,13 @@
 
 #include "storage/index/inverted/inverted_index_writer.h"
 
+#include <CLucene/config/repl_wchar.h>
+
 #include "storage/index/inverted/analyzer/analyzer.h"
 #include "storage/index/inverted/inverted_index_common.h"
+#include "storage/index/inverted/inverted_index_desc.h"
 #include "storage/index/inverted/inverted_index_fs_directory.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
 #include "storage/key_coder.h"
 #include "storage/tablet/tablet_schema.h"
 #include "util/faststring.h"
@@ -42,6 +46,11 @@ InvertedIndexColumnWriter<field_type>::InvertedIndexColumnWriter(const std::stri
           _index_file_writer(index_file_writer) {
     _should_analyzer =
             inverted_index::InvertedIndexAnalyzer::should_analyzer(_index_meta->properties());
+    // token-exists Bloom Filter is only meaningful for analyzed (fulltext) indexes; the
+    // keyword/exact path is intentionally left out (see A4 read-side guard).
+    _enable_term_bf =
+            _should_analyzer && get_parser_token_bf_from_properties(_index_meta->properties()) ==
+                                        INVERTED_INDEX_PARSER_TOKEN_BF_YES;
     _value_key_coder = get_key_coder(field_type);
     _field_name = StringUtil::string_to_wstring(field_name);
 }
@@ -585,6 +594,92 @@ void InvertedIndexColumnWriter<field_type>::write_null_bitmap(
 }
 
 template <FieldType field_type>
+void InvertedIndexColumnWriter<field_type>::write_term_bloom_filter() {
+    // Preconditions (assert correctness): only the analyzed slice path reaches here, the
+    // writer must already be closed/flushed, and the directory must still be open.
+    DCHECK(_enable_term_bf);
+    DCHECK(_index_writer == nullptr);
+    DCHECK(_dir != nullptr);
+
+    // Open a reader over the just-flushed segment without taking ownership of _dir
+    // (closeDirectoryOnCleanup=false). _dir's logical close already ran inside the earlier
+    // _index_writer->close() cascade; it stays usable here only because DorisFSDirectory::close()
+    // is a no-op and the writer never owned _dir (bOwnsDirectory=false), so the _dir unique_ptr
+    // keeps sole ownership. finish()'s FINALLY does NOT touch _dir on this (slice) path. If
+    // DorisFSDirectory::close() ever frees resources, this reuse must be revisited.
+    lucene::index::IndexReader* reader = nullptr;
+    lucene::index::TermEnum* term_enum = nullptr;
+    std::unique_ptr<lucene::store::IndexOutput> term_bf_out = nullptr;
+    try {
+        reader = lucene::index::IndexReader::open(_dir.get(), /*closeDirectoryOnCleanup=*/false);
+
+        // First pass: count distinct terms in this field to size the Bloom Filter.
+        uint64_t distinct_terms = 0;
+        term_enum = reader->terms();
+        while (term_enum->next()) {
+            const auto* term = term_enum->term(false);
+            if (term->field() == _field_name) {
+                ++distinct_terms;
+            }
+        }
+        term_enum->close();
+        _CLDELETE(term_enum);
+        term_enum = nullptr;
+
+        auto bf_res = InvertedIndexTermBloomFilter::create_for_write(
+                distinct_terms, compute_analyzer_sig(_analyzer_config));
+        if (!bf_res.has_value()) {
+            LOG(WARNING) << "Inverted index term bloom filter create error: "
+                         << bf_res.error().to_string();
+            reader->close();
+            _CLDELETE(reader);
+            return;
+        }
+        auto bf = std::move(bf_res.value());
+
+        // Second pass: feed every analyzed token from the term dictionary. These are exactly
+        // the tokens the query path looks up (same analyzed form, no re-tokenization), and the
+        // dictionary includes the zero-length keyword token where applicable (A5).
+        term_enum = reader->terms();
+        while (term_enum->next()) {
+            const auto* term = term_enum->term(false);
+            if (term->field() != _field_name) {
+                continue;
+            }
+            std::string token = lucene_wcstoutf8string(term->text(), term->textLength());
+            bf->add_token(token.data(), token.size());
+        }
+        term_enum->close();
+        _CLDELETE(term_enum);
+        term_enum = nullptr;
+
+        term_bf_out = std::unique_ptr<lucene::store::IndexOutput>(
+                _dir->createOutput(InvertedIndexDescriptor::get_temporary_term_bf_file_name()));
+        bf->serialize(term_bf_out.get());
+        term_bf_out->close();
+        term_bf_out.reset();
+
+        reader->close();
+        _CLDELETE(reader);
+    } catch (CLuceneError& e) {
+        // A failure to build the optional BF must not fail index writing: the read path
+        // treats a missing/invalid "tbf" as "unknown" and falls back to a normal lookup.
+        LOG(WARNING) << "Inverted index term bloom filter write error: " << e.what();
+        if (term_enum != nullptr) {
+            term_enum->close();
+            _CLDELETE(term_enum);
+        }
+        if (term_bf_out != nullptr) {
+            term_bf_out->close();
+        }
+        if (reader != nullptr) {
+            reader->close();
+            _CLDELETE(reader);
+        }
+    }
+}
+
+template <FieldType field_type>
 Status InvertedIndexColumnWriter<field_type>::finish() {
     if (_dir != nullptr) {
         std::unique_ptr<lucene::store::IndexOutput> null_bitmap_out = nullptr;
@@ -630,6 +725,21 @@ Status InvertedIndexColumnWriter<field_type>::finish() {
                                       "debug point: test throw error in fulltext "
                                       "index writer");
                         });
+                if (_enable_term_bf) {
+                    // Close the writer here (not in FINALLY) so the segment + .tis are durably
+                    // written to _dir; then enumerate the term dictionary to build the "tbf"
+                    // sub-file. The FINALLY close is guarded against a double close below.
+                    //
+                    // Move ownership out of _index_writer *before* close() so that even if
+                    // close() throws, _index_writer is already null and the FINALLY below will
+                    // not attempt a second close on a partially-closed writer (which would mask
+                    // the original error and re-enter CLucene's close path). The local closer is
+                    // destroyed at scope exit, but close() has already run exactly once.
+                    auto closing_writer = std::move(_index_writer);
+                    closing_writer->close();
+                    closing_writer.reset();
+                    write_term_bloom_filter();
+                }
             }
         } catch (CLuceneError& e) {
             error_context.eptr = std::current_exception();
@@ -645,9 +755,14 @@ Status InvertedIndexColumnWriter<field_type>::finish() {
             if constexpr (field_is_numeric_type(field_type)) {
                 FINALLY_CLOSE(_dir);
             } else if constexpr (field_is_slice_type(field_type)) {
-                FINALLY_CLOSE(_index_writer);
-                // After closing the _index_writer, it needs to be reset to null to prevent issues of not closing it or closing it multiple times.
-                _index_writer.reset();
+                // When the term-BF path runs, ownership of _index_writer was moved out (and the
+                // writer closed) inside the try above so the dictionary could be enumerated; the
+                // pointer is left null even if close() threw. This guard then skips a double close.
+                if (_index_writer) {
+                    FINALLY_CLOSE(_index_writer);
+                    // After closing the _index_writer, it needs to be reset to null to prevent issues of not closing it or closing it multiple times.
+                    _index_writer.reset();
+                }
             }
         })
 

--- a/be/src/storage/index/inverted/inverted_index_writer.cpp
+++ b/be/src/storage/index/inverted/inverted_index_writer.cpp
@@ -600,87 +600,14 @@ void InvertedIndexColumnWriter<field_type>::write_null_bitmap(
 template <FieldType field_type>
 void InvertedIndexColumnWriter<field_type>::write_term_bloom_filter() {
     // Preconditions (assert correctness): only the analyzed slice path reaches here, the
-    // writer must already be closed/flushed, and the directory must still be open.
+    // writer must already be closed/flushed, and the directory must still be open. _dir stays
+    // usable here only because DorisFSDirectory::close() is a no-op and the writer never owned
+    // _dir (bOwnsDirectory=false), so the _dir unique_ptr keeps sole ownership; finish()'s
+    // FINALLY does NOT touch _dir on this (slice) path.
     DCHECK(_enable_term_bf);
     DCHECK(_index_writer == nullptr);
     DCHECK(_dir != nullptr);
-
-    // Open a reader over the just-flushed segment without taking ownership of _dir
-    // (closeDirectoryOnCleanup=false). _dir's logical close already ran inside the earlier
-    // _index_writer->close() cascade; it stays usable here only because DorisFSDirectory::close()
-    // is a no-op and the writer never owned _dir (bOwnsDirectory=false), so the _dir unique_ptr
-    // keeps sole ownership. finish()'s FINALLY does NOT touch _dir on this (slice) path. If
-    // DorisFSDirectory::close() ever frees resources, this reuse must be revisited.
-    lucene::index::IndexReader* reader = nullptr;
-    lucene::index::TermEnum* term_enum = nullptr;
-    std::unique_ptr<lucene::store::IndexOutput> term_bf_out = nullptr;
-    try {
-        reader = lucene::index::IndexReader::open(_dir.get(), /*closeDirectoryOnCleanup=*/false);
-
-        // First pass: count distinct terms in this field to size the Bloom Filter.
-        uint64_t distinct_terms = 0;
-        term_enum = reader->terms();
-        while (term_enum->next()) {
-            const auto* term = term_enum->term(false);
-            if (term->field() == _field_name) {
-                ++distinct_terms;
-            }
-        }
-        term_enum->close();
-        _CLDELETE(term_enum);
-        term_enum = nullptr;
-
-        auto bf_res = InvertedIndexTermBloomFilter::create_for_write(
-                distinct_terms, compute_analyzer_sig(_analyzer_config));
-        if (!bf_res.has_value()) {
-            LOG(WARNING) << "Inverted index term bloom filter create error: "
-                         << bf_res.error().to_string();
-            reader->close();
-            _CLDELETE(reader);
-            return;
-        }
-        auto bf = std::move(bf_res.value());
-
-        // Second pass: feed every analyzed token from the term dictionary. These are exactly
-        // the tokens the query path looks up (same analyzed form, no re-tokenization), and the
-        // dictionary includes the zero-length keyword token where applicable (A5).
-        term_enum = reader->terms();
-        while (term_enum->next()) {
-            const auto* term = term_enum->term(false);
-            if (term->field() != _field_name) {
-                continue;
-            }
-            std::string token = lucene_wcstoutf8string(term->text(), term->textLength());
-            bf->add_token(token.data(), token.size());
-        }
-        term_enum->close();
-        _CLDELETE(term_enum);
-        term_enum = nullptr;
-
-        term_bf_out = std::unique_ptr<lucene::store::IndexOutput>(
-                _dir->createOutput(InvertedIndexDescriptor::get_temporary_term_bf_file_name()));
-        bf->serialize(term_bf_out.get());
-        term_bf_out->close();
-        term_bf_out.reset();
-
-        reader->close();
-        _CLDELETE(reader);
-    } catch (CLuceneError& e) {
-        // A failure to build the optional BF must not fail index writing: the read path
-        // treats a missing/invalid "tbf" as "unknown" and falls back to a normal lookup.
-        LOG(WARNING) << "Inverted index term bloom filter write error: " << e.what();
-        if (term_enum != nullptr) {
-            term_enum->close();
-            _CLDELETE(term_enum);
-        }
-        if (term_bf_out != nullptr) {
-            term_bf_out->close();
-        }
-        if (reader != nullptr) {
-            reader->close();
-            _CLDELETE(reader);
-        }
-    }
+    emit_term_bloom_filter_into_dir(_dir.get(), _field_name, compute_analyzer_sig(_analyzer_config));
 }
 
 template <FieldType field_type>

--- a/be/src/storage/index/inverted/inverted_index_writer.h
+++ b/be/src/storage/index/inverted/inverted_index_writer.h
@@ -26,6 +26,7 @@
 #include "storage/index/index_file_writer.h"
 #include "storage/index/index_writer.h"
 #include "storage/index/inverted/inverted_index_parser.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
 #include "storage/index/inverted/util/reader.h"
 #include "storage/olap_common.h"
 #include "storage/segment/common.h"
@@ -76,6 +77,10 @@ public:
     Status add_value(const CppType& value);
     int64_t size() const override;
     void write_null_bitmap(lucene::store::IndexOutput* null_bitmap_out);
+    // Build the token-exists Bloom Filter ("tbf") sub-file by enumerating the just-flushed
+    // term dictionary. Must be called after _index_writer->close() (so the segment + .tis
+    // are durable in _dir) and before _dir is closed. Only the analyzed (fulltext) path.
+    void write_term_bloom_filter();
     Status finish() override;
 
 private:
@@ -102,6 +107,9 @@ private:
     IndexFileWriter* _index_file_writer;
     uint32_t _ignore_above;
     bool _should_analyzer = false;
+    // token-exists Bloom Filter gate (from the "token_bloom_filter" index property).
+    // Only enabled for analyzed (fulltext) indexes; default off.
+    bool _enable_term_bf = false;
 };
 
 } // namespace segment_v2

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -387,6 +387,19 @@ struct OlapReaderStatistics {
     int64_t inverted_index_downgrade_count = 0;
     int64_t inverted_index_analyzer_timer = 0;
     int64_t inverted_index_lookup_timer = 0;
+    // token-exists Bloom Filter ("tbf") absent-term fast path observability.
+    // The headline (user-facing) value is skipped_lookups: how many index lookups the BF
+    // short-circuited (each one avoids a searcher open + posting read). hit rate =
+    // skipped_lookups / probe. The rest are diagnostics (cache effectiveness, cold IO, why a
+    // BF was not usable) surfaced at a lower profile level.
+    int64_t inverted_index_term_bf_skipped_lookups = 0; // proven absent -> lookup short-circuited
+    int64_t inverted_index_term_bf_probe = 0;       // usable BF probed (denominator of hit rate)
+    int64_t inverted_index_term_bf_unavailable = 0; // eligible but no usable tbf (not built/stale)
+    int64_t inverted_index_term_bf_fallthrough = 0; // BF said MAYBE -> normal lookup (present/FP)
+    int64_t inverted_index_term_bf_cache_hit = 0;   // parsed-BF cache hit (zero IO)
+    int64_t inverted_index_term_bf_cache_miss = 0;  // parsed-BF cache miss (triggers a load)
+    int64_t inverted_index_term_bf_load_count = 0;  // tbf sub-files actually read from storage
+    int64_t inverted_index_term_bf_load_bytes = 0;  // bytes read loading tbf sub-files (cold IO)
     InvertedIndexStatistics inverted_index_stats;
 
     int64_t ann_index_load_ns = 0;

--- a/be/test/storage/index/inverted/inverted_index_term_bf_fpp_sweep_test.cpp
+++ b/be/test/storage/index/inverted/inverted_index_term_bf_fpp_sweep_test.cpp
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// fpp sweep for the token-exists Bloom Filter ("tbf"). This is an analysis tool, not a pass/fail
+// unit test: it sizes the *real* BlockSplitBloomFilter (the exact code the writer uses) over a
+// real distinct-token vocabulary, and measures the *actual* false-positive rate at each fpp. The
+// two axes it reports -- on-disk size and measured FP -- are everything fpp controls; the cold
+// S3 latency follows linearly from FP (FP * per-segment-GET-cost * TTFB), so this is enough to
+// pick the default fpp for `TERM_BF_FPP`.
+//
+// It does NOT run unless a vocabulary file is supplied, so it never disturbs CI:
+//   INV_BF_VOCAB=/tmp/vocab_text.txt ./run-be-ut.sh --run --filter=*TermBfFppSweep*
+// Each non-empty line of the file is one distinct analyzed token (the file must already be
+// deduplicated -- the build set and the absent probe set are two disjoint line ranges, so
+// uniqueness across lines is what guarantees the probe tokens are genuinely absent).
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "storage/index/bloom_filter/bloom_filter.h"
+
+namespace doris::segment_v2 {
+
+namespace {
+
+std::vector<std::string> load_vocab(const std::string& path) {
+    std::vector<std::string> vocab;
+    std::ifstream in(path);
+    std::string line;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        vocab.push_back(line);
+    }
+    return vocab;
+}
+
+} // namespace
+
+// Sizing + measured false-positive sweep over a real vocabulary.
+TEST(TermBfFppSweepTest, SweepRealVocab) {
+    const char* vocab_path = std::getenv("INV_BF_VOCAB");
+    if (vocab_path == nullptr) {
+        GTEST_SKIP() << "set INV_BF_VOCAB=<distinct-token file> to run the fpp sweep";
+    }
+
+    std::vector<std::string> vocab = load_vocab(vocab_path);
+    ASSERT_GE(vocab.size(), 1000U) << "vocab too small to be representative";
+
+    // Hold out the tail as the absent probe set (disjoint from the build set because every line
+    // in the dedup'd file is unique). Cap the probe set so the sweep stays fast; keep at least
+    // 100k probes for a stable FP estimate.
+    const size_t probe_count = std::min<size_t>(vocab.size() / 5, 1'000'000);
+    ASSERT_GE(probe_count, 100'000U) << "need a larger vocab for a solid FP estimate";
+    const size_t build_count = vocab.size() - probe_count;
+
+    const std::string label =
+            std::getenv("INV_BF_LABEL") ? std::getenv("INV_BF_LABEL") : vocab_path;
+
+    std::cout << "\n### tbf fpp sweep -- " << label << "\n";
+    std::cout << "vocab=" << vocab.size() << " distinct tokens; build_n=" << build_count
+              << ", absent_probes=" << probe_count << " (held-out real tokens)\n\n";
+    std::cout << "| configured fpp | BF bytes | bytes/term | measured FP% (mean) | FP% stddev |\n";
+    std::cout << "|---|---|---|---|---|\n";
+
+    const std::vector<double> fpps = {0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.10};
+    constexpr int kChunks = 10; // partition probes into chunks for a stddev across chunks.
+
+    for (double fpp : fpps) {
+        std::unique_ptr<BloomFilter> bf;
+        ASSERT_TRUE(BloomFilter::create(BLOCK_BLOOM_FILTER, &bf).ok());
+        ASSERT_TRUE(bf->init(build_count, fpp, HASH_MURMUR3_X64_64).ok());
+        for (size_t i = 0; i < build_count; ++i) {
+            bf->add_bytes(vocab[i].data(), vocab[i].size());
+        }
+
+        const size_t chunk = probe_count / kChunks;
+        std::vector<double> chunk_fp;
+        chunk_fp.reserve(kChunks);
+        for (int c = 0; c < kChunks; ++c) {
+            size_t hits = 0;
+            const size_t base = build_count + static_cast<size_t>(c) * chunk;
+            for (size_t i = 0; i < chunk; ++i) {
+                const std::string& t = vocab[base + i];
+                if (bf->test_bytes(t.data(), t.size())) {
+                    ++hits; // absent token reported MAYBE == false positive.
+                }
+            }
+            chunk_fp.push_back(100.0 * static_cast<double>(hits) / static_cast<double>(chunk));
+        }
+
+        double mean = 0;
+        for (double v : chunk_fp) {
+            mean += v;
+        }
+        mean /= kChunks;
+        double var = 0;
+        for (double v : chunk_fp) {
+            var += (v - mean) * (v - mean);
+        }
+        const double stddev = std::sqrt(var / kChunks);
+
+        const double bytes_per_term =
+                static_cast<double>(bf->num_bytes()) / static_cast<double>(build_count);
+        printf("| %.4f | %zu | %.2f | %.3f | %.3f |\n", fpp, bf->num_bytes(), bytes_per_term, mean,
+               stddev);
+    }
+    std::cout << std::endl;
+}
+
+} // namespace doris::segment_v2

--- a/be/test/storage/index/inverted/inverted_index_term_bf_reader_test.cpp
+++ b/be/test/storage/index/inverted/inverted_index_term_bf_reader_test.cpp
@@ -492,34 +492,21 @@ TEST_F(InvertedIndexTermBfReaderTest, BfObservabilityCountersReflectPath) {
     EXPECT_EQ(present.inverted_index_term_bf_skipped_lookups, 0);
     EXPECT_EQ(present.inverted_index_term_bf_fallthrough, 1);
 
-    // (a) Property gate: an index WITHOUT token_bloom_filter=true is skipped before the fast path
-    // even runs -- no index open, no fileExists("tbf"), so EVERY BF counter stays 0. Without the
-    // gate, flipping the global config on would tax every fulltext index with an extra open.
-    std::map<std::string, std::string> no_bf = {
-            {"parser", "english"}, {"lower_case", "true"}, {"support_phrase", "true"}};
-    TabletIndex idx_nobf;
-    std::string prefix_nobf;
-    build_index("tbf_rs_obs_nobf", 1, no_bf, values, &idx_nobf, &prefix_nobf);
+    // (a) Config gate: with BE config OFF the fast path is skipped before it runs -- no index
+    // open, no fileExists("tbf"), so EVERY BF counter stays 0. The per-index property is no
+    // longer consulted, so the gate behavior depends solely on the BE config; this case proves
+    // the OFF state still produces no IO/observability cost.
+    config::enable_inverted_index_term_bf = false;
     {
-        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix_nobf,
-                                                        InvertedIndexStorageFormatPB::V2);
-        ASSERT_TRUE(reader->init().ok());
-        auto ft_reader = FullTextIndexReader::create_shared(&idx_nobf, reader);
-        io::IOContext io_ctx;
-        OlapReaderStatistics nobf;
-        RuntimeState runtime_state;
-        auto context = make_context(&io_ctx, &nobf, &runtime_state);
-        auto bitmap = std::make_shared<roaring::Roaring>();
-        Field qp = Field::create_field<TYPE_STRING>("zzabsentthree");
-        ASSERT_TRUE(
-                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
-                        .ok());
-        EXPECT_EQ(nobf.inverted_index_term_bf_probe, 0);
-        EXPECT_EQ(nobf.inverted_index_term_bf_skipped_lookups, 0);
-        EXPECT_EQ(nobf.inverted_index_term_bf_unavailable, 0);
-        EXPECT_EQ(nobf.inverted_index_term_bf_cache_miss, 0);
-        EXPECT_EQ(nobf.inverted_index_term_bf_load_count, 0);
+        OlapReaderStatistics off;
+        auto bitmap = run("zzabsentthree", InvertedIndexQueryType::MATCH_ANY_QUERY, &off);
+        EXPECT_EQ(off.inverted_index_term_bf_probe, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_skipped_lookups, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_unavailable, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_cache_miss, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_load_count, 0);
     }
+    config::enable_inverted_index_term_bf = true;
 
     // (b) Unavailable: an index WITH token_bloom_filter=true passes the gate, but a read whose
     // analyzer signature differs from the build (A3, lower_case flipped) rejects the loaded BF as
@@ -692,23 +679,26 @@ TEST_F(InvertedIndexTermBfReaderTest, StaleAnalyzerCachedBfRevalidatedOnHit) {
     EXPECT_TRUE(*baseline == *with_bf) << "fall-back result must match the normal query";
 }
 
-// Negative caching: an index whose property passes the gate (token_bloom_filter=true) but whose
-// segment carries no usable "tbf" (e.g. compacted by an older BE, or a build failure) must cache
-// that negative result -- the first query loads-and-fails, and a second query hits the negative
-// marker instead of re-opening the index. Built WITHOUT a tbf on disk, then read with a
-// property=true meta so the gate is passed but the structural load returns nothing.
+// Negative caching: an index whose segment carries no usable "tbf" (e.g. built with the BE config
+// off, then config flipped on at read time, or a build failure) must cache that negative result
+// -- the first query loads-and-fails, and a second query hits the negative marker instead of
+// re-opening the index. Built WITHOUT a tbf on disk (config off at build time), then read with
+// config on so the gate is passed but the structural load returns nothing.
 TEST_F(InvertedIndexTermBfReaderTest, NegativeCacheSkipsRepeatOpenWhenNoTbf) {
     std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
                                  Slice("apple cherry")};
-    // No token_bloom_filter -> the writer emits no "tbf" sub-file.
-    std::map<std::string, std::string> no_bf_props = {
+    // Build with the BE config off so the writer emits no "tbf" sub-file. Property is irrelevant
+    // for the writer gate now -- only the config decides.
+    config::enable_inverted_index_term_bf = false;
+    std::map<std::string, std::string> props = {
             {"parser", "english"}, {"lower_case", "true"}, {"support_phrase", "true"}};
     TabletIndex build_meta;
     std::string prefix;
-    build_index("tbf_rs_neg", 0, no_bf_props, values, &build_meta, &prefix);
+    build_index("tbf_rs_neg", 0, props, values, &build_meta, &prefix);
 
-    // Reader meta WITH token_bloom_filter=true: the property gate passes even though the disk
-    // segment has no tbf.
+    // Read with BE config on: the (sole) gate now passes even though the disk segment has no tbf.
+    config::enable_inverted_index_term_bf = true;
+
     auto read_pb = std::make_unique<TabletIndexPB>();
     read_pb->set_index_type(IndexType::INVERTED);
     read_pb->set_index_id(1);
@@ -718,11 +708,8 @@ TEST_F(InvertedIndexTermBfReaderTest, NegativeCacheSkipsRepeatOpenWhenNoTbf) {
     (*read_pb->mutable_properties())["parser"] = "english";
     (*read_pb->mutable_properties())["lower_case"] = "true";
     (*read_pb->mutable_properties())["support_phrase"] = "true";
-    (*read_pb->mutable_properties())["token_bloom_filter"] = "true";
     TabletIndex read_meta;
     read_meta.init_from_pb(*read_pb.get());
-
-    config::enable_inverted_index_term_bf = true;
 
     auto run = [&](const std::string& term, OlapReaderStatistics* stats) {
         auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
@@ -755,6 +742,119 @@ TEST_F(InvertedIndexTermBfReaderTest, NegativeCacheSkipsRepeatOpenWhenNoTbf) {
     EXPECT_EQ(second.inverted_index_term_bf_unavailable, 1);
     EXPECT_EQ(second.inverted_index_term_bf_load_count, 0);
     EXPECT_EQ(second.inverted_index_term_bf_probe, 0);
+}
+
+// BE-config-priority gate: with the config ON, a fulltext index that does NOT carry the
+// `token_bloom_filter` property must STILL get a "tbf" sub-file from the writer and the reader
+// fast path must engage normally. The legacy property-as-gate behavior is intentionally removed:
+// the BE config alone decides, so cluster operators can roll out the feature without touching
+// every index definition.
+TEST_F(InvertedIndexTermBfReaderTest, BeConfigGateAlonePropertyAbsentStillBuildsAndReadsBf) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    // No `token_bloom_filter` property -- with the new gating the writer must still emit the
+    // "tbf" because the BE config is on at build time.
+    config::enable_inverted_index_term_bf = true;
+    std::map<std::string, std::string> props_no_tbf = {
+            {"parser", "english"}, {"lower_case", "true"}, {"support_phrase", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_cfg_only", 0, props_no_tbf, values, &idx_meta, &prefix);
+
+    auto run = [&](const std::string& term, OlapReaderStatistics* stats) {
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                        InvertedIndexStorageFormatPB::V2);
+        EXPECT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(&idx_meta, reader);
+        io::IOContext io_ctx;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, stats, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>(term);
+        EXPECT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+    };
+
+    // Absent token: load the just-written tbf once, prove absent, skip the searcher entirely.
+    OlapReaderStatistics absent;
+    run("zzconfigonlyabsent", &absent);
+    EXPECT_EQ(absent.inverted_index_term_bf_probe, 1);
+    EXPECT_EQ(absent.inverted_index_term_bf_skipped_lookups, 1);
+    EXPECT_EQ(absent.inverted_index_term_bf_unavailable, 0)
+            << "writer must emit tbf when config is on, even with property absent";
+    EXPECT_EQ(absent.inverted_index_term_bf_cache_miss, 1);
+    EXPECT_EQ(absent.inverted_index_term_bf_load_count, 1);
+    EXPECT_GT(absent.inverted_index_term_bf_load_bytes, 0);
+
+    // Present token: tbf says MAYBE -> fall through to normal lookup, no skip.
+    OlapReaderStatistics present;
+    run("apple", &present);
+    EXPECT_EQ(present.inverted_index_term_bf_probe, 1);
+    EXPECT_EQ(present.inverted_index_term_bf_fallthrough, 1);
+    EXPECT_EQ(present.inverted_index_term_bf_skipped_lookups, 0);
+}
+
+// Flip side of the gate: with the BE config OFF the property alone is no longer enough to engage
+// the writer or the reader. The property is now inert; we keep the constants for FE-side
+// validation/persistence backward compatibility but neither path consults them.
+TEST_F(InvertedIndexTermBfReaderTest, BeConfigOffMakesPropertyInert) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    // Build with config OFF and `token_bloom_filter=true` -- the writer must NOT emit a tbf.
+    config::enable_inverted_index_term_bf = false;
+    std::map<std::string, std::string> props_with_tbf = {{"parser", "english"},
+                                                         {"lower_case", "true"},
+                                                         {"support_phrase", "true"},
+                                                         {"token_bloom_filter", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_cfg_off_prop_on", 0, props_with_tbf, values, &idx_meta, &prefix);
+
+    auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                    InvertedIndexStorageFormatPB::V2);
+    ASSERT_TRUE(reader->init().ok());
+    auto ft_reader = FullTextIndexReader::create_shared(&idx_meta, reader);
+
+    // Reading with config OFF: the gate refuses the fast path before any IO -- all counters 0
+    // even though the property is set to true. The property is inert; only the config matters.
+    {
+        io::IOContext io_ctx;
+        OlapReaderStatistics off;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, &off, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>("zzpropinertabsent");
+        ASSERT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+        EXPECT_EQ(off.inverted_index_term_bf_probe, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_skipped_lookups, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_unavailable, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_cache_miss, 0);
+        EXPECT_EQ(off.inverted_index_term_bf_load_count, 0);
+    }
+
+    // Flipping the config ON and re-reading the SAME on-disk segment exposes that no tbf was
+    // emitted at build time (the property was inert there too): the load returns nothing and the
+    // negative-cache "unavailable" path kicks in. This proves the writer gate really is the BE
+    // config, not the property.
+    config::enable_inverted_index_term_bf = true;
+    {
+        io::IOContext io_ctx;
+        OlapReaderStatistics on;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, &on, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>("zzpropinertabsent2");
+        ASSERT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+        EXPECT_EQ(on.inverted_index_term_bf_unavailable, 1)
+                << "writer with config off must not have emitted tbf, even with property=true";
+        EXPECT_EQ(on.inverted_index_term_bf_load_count, 0);
+        EXPECT_EQ(on.inverted_index_term_bf_probe, 0);
+    }
 }
 
 } // namespace doris::segment_v2

--- a/be/test/storage/index/inverted/inverted_index_term_bf_reader_test.cpp
+++ b/be/test/storage/index/inverted/inverted_index_term_bf_reader_test.cpp
@@ -1,0 +1,760 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// End-to-end tests for the token-exists Bloom Filter ("tbf") absent-term fast path on the
+// FullTextIndexReader::query path. Builds a real V2 .idx (with the "tbf" sub-file when
+// token_bloom_filter=true), then drives queries with config::enable_inverted_index_term_bf
+// flipped on, and asserts that:
+//   - absent terms return an empty bitmap identical to the no-BF result;
+//   - present terms return a bitmap identical to the no-BF result (no false negatives);
+//   - MATCH_ANY with a partially-absent term set keeps the present-term hits;
+//   - the fast path is gated on the build-time analyzer signature (A3);
+//   - the keyword/exact path (StringTypeInvertedIndexReader) is never consulted, so an
+//     over-ignore_above EQUAL still returns INVERTED_INDEX_EVALUATE_SKIPPED (A4);
+//   - the empty keyword token round-trips and is matchable (A5).
+
+#include <CLucene.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <roaring/roaring.hh>
+#include <string>
+#include <vector>
+
+#include "common/config.h"
+#include "core/field.h"
+#include "io/fs/local_file_system.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "storage/index/index_file_reader.h"
+#include "storage/index/index_file_writer.h"
+#include "storage/index/inverted/inverted_index_desc.h"
+#include "storage/index/inverted/inverted_index_parser.h"
+#include "storage/index/inverted/inverted_index_reader.h"
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
+#include "storage/index/inverted/inverted_index_writer.h"
+#include "storage/olap_common.h"
+#include "storage/tablet/tablet_schema.h"
+#include "util/slice.h"
+
+namespace doris::segment_v2 {
+
+class InvertedIndexTermBfReaderTest : public testing::Test {
+public:
+    const std::string kTestDir = "./ut_dir/inverted_index_term_bf_reader_test";
+
+    void SetUp() override {
+        auto st = io::global_local_filesystem()->delete_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(kTestDir);
+        ASSERT_TRUE(st.ok()) << st;
+
+        std::vector<StorePath> paths;
+        paths.emplace_back(kTestDir, 1024);
+        auto tmp_file_dirs = std::make_unique<segment_v2::TmpFileDirs>(paths);
+        ASSERT_TRUE(tmp_file_dirs->init().ok());
+        ExecEnv::GetInstance()->set_tmp_file_dir(std::move(tmp_file_dirs));
+
+        // Save whatever ExecEnv held so TearDown can restore it: these fixture-owned caches are
+        // freed when the fixture is destroyed, so the global pointers must not be left dangling for
+        // later tests (test isolation).
+        _saved_searcher_cache = ExecEnv::GetInstance()->get_inverted_index_searcher_cache();
+        _saved_query_cache = ExecEnv::GetInstance()->get_inverted_index_query_cache();
+
+        int64_t cache_limit = 1024L * 1024 * 1024;
+        _searcher_cache = std::unique_ptr<InvertedIndexSearcherCache>(
+                InvertedIndexSearcherCache::create_global_instance(cache_limit, 1));
+        _query_cache = std::unique_ptr<InvertedIndexQueryCache>(
+                InvertedIndexQueryCache::create_global_cache(cache_limit, 1));
+        ExecEnv::GetInstance()->set_inverted_index_searcher_cache(_searcher_cache.get());
+        ExecEnv::GetInstance()->_inverted_index_query_cache = _query_cache.get();
+
+        _saved_flag = config::enable_inverted_index_term_bf;
+    }
+
+    void TearDown() override {
+        config::enable_inverted_index_term_bf = _saved_flag;
+        // Restore the global cache pointers BEFORE _searcher_cache / _query_cache (which back them)
+        // are destroyed, so no later test sees a dangling pointer.
+        ExecEnv::GetInstance()->set_inverted_index_searcher_cache(_saved_searcher_cache);
+        ExecEnv::GetInstance()->_inverted_index_query_cache = _saved_query_cache;
+        ASSERT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());
+    }
+
+    TabletSchemaSPtr create_schema() {
+        TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+        TabletSchemaPB tablet_schema_pb;
+        tablet_schema_pb.set_keys_type(DUP_KEYS);
+        tablet_schema->init_from_pb(tablet_schema_pb);
+
+        TabletColumn column_1;
+        column_1.set_name("c1");
+        column_1.set_unique_id(0);
+        column_1.set_type(FieldType::OLAP_FIELD_TYPE_INT);
+        column_1.set_length(4);
+        column_1.set_index_length(4);
+        column_1.set_is_key(true);
+        column_1.set_is_nullable(true);
+        tablet_schema->append_column(column_1);
+
+        TabletColumn column_2;
+        column_2.set_name("c2");
+        column_2.set_unique_id(1);
+        column_2.set_type(FieldType::OLAP_FIELD_TYPE_VARCHAR);
+        column_2.set_length(65535);
+        column_2.set_is_key(false);
+        column_2.set_is_nullable(false);
+        tablet_schema->append_column(column_2);
+
+        return tablet_schema;
+    }
+
+    std::string local_segment_path(const std::string& base, std::string_view rowset_id,
+                                   int64_t seg_id) {
+        return fmt::format("{}/{}_{}.dat", base, rowset_id, seg_id);
+    }
+
+    // Build a fulltext (analyzed) index over the c2 column with the supplied properties.
+    void build_index(std::string_view rowset_id, int seg_id,
+                     const std::map<std::string, std::string>& properties,
+                     std::vector<Slice>& values, TabletIndex* idx_meta,
+                     std::string* index_path_prefix) {
+        auto tablet_schema = create_schema();
+
+        auto index_meta_pb = std::make_unique<TabletIndexPB>();
+        index_meta_pb->set_index_type(IndexType::INVERTED);
+        index_meta_pb->set_index_id(1);
+        index_meta_pb->set_index_name("test_tbf");
+        index_meta_pb->clear_col_unique_id();
+        index_meta_pb->add_col_unique_id(1); // c2
+        for (const auto& [k, v] : properties) {
+            (*index_meta_pb->mutable_properties())[k] = v;
+        }
+        idx_meta->init_from_pb(*index_meta_pb.get());
+
+        *index_path_prefix = InvertedIndexDescriptor::get_index_file_path_prefix(
+                local_segment_path(kTestDir, rowset_id, seg_id));
+        std::string index_path =
+                InvertedIndexDescriptor::get_index_file_path_v2(*index_path_prefix);
+
+        io::FileWriterPtr file_writer;
+        io::FileWriterOptions opts;
+        auto fs = io::global_local_filesystem();
+        ASSERT_TRUE(fs->create_file(index_path, &file_writer, &opts).ok());
+        auto index_file_writer = std::make_unique<IndexFileWriter>(
+                fs, *index_path_prefix, std::string {rowset_id}, seg_id,
+                InvertedIndexStorageFormatPB::V2, std::move(file_writer));
+
+        const TabletColumn& column = tablet_schema->column(1);
+        std::unique_ptr<IndexColumnWriter> column_writer;
+        ASSERT_TRUE(IndexColumnWriter::create(&column, &column_writer, index_file_writer.get(),
+                                              idx_meta)
+                            .ok());
+        ASSERT_TRUE(column_writer->add_values("c2", values.data(), values.size()).ok());
+        ASSERT_TRUE(column_writer->finish().ok());
+        ASSERT_TRUE(index_file_writer->begin_close().ok());
+        ASSERT_TRUE(index_file_writer->finish_close().ok());
+    }
+
+    std::shared_ptr<IndexQueryContext> make_context(io::IOContext* io_ctx,
+                                                    OlapReaderStatistics* stats,
+                                                    RuntimeState* runtime_state) {
+        TQueryOptions query_options;
+        query_options.enable_inverted_index_searcher_cache = false;
+        query_options.enable_inverted_index_query_cache = false;
+        runtime_state->set_query_options(query_options);
+        auto context = std::make_shared<IndexQueryContext>();
+        context->io_ctx = io_ctx;
+        context->stats = stats;
+        context->runtime_state = runtime_state;
+        return context;
+    }
+
+    std::shared_ptr<roaring::Roaring> run_fulltext(const std::string& index_path_prefix,
+                                                   TabletIndex* idx_meta, const std::string& term,
+                                                   InvertedIndexQueryType type,
+                                                   Status* out_status) {
+        auto reader = std::make_shared<IndexFileReader>(
+                io::global_local_filesystem(), index_path_prefix, InvertedIndexStorageFormatPB::V2);
+        EXPECT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(idx_meta, reader);
+        EXPECT_NE(ft_reader, nullptr);
+
+        io::IOContext io_ctx;
+        OlapReaderStatistics stats;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, &stats, &runtime_state);
+
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>(term);
+        *out_status = ft_reader->query(context, "1", qp, type, bitmap);
+        return bitmap;
+    }
+
+protected:
+    std::unique_ptr<InvertedIndexSearcherCache> _searcher_cache;
+    std::unique_ptr<InvertedIndexQueryCache> _query_cache;
+    InvertedIndexSearcherCache* _saved_searcher_cache = nullptr;
+    InvertedIndexQueryCache* _saved_query_cache = nullptr;
+    bool _saved_flag = false;
+};
+
+// Absent term on MATCH_ALL/MATCH_ANY/EQUAL returns the same empty bitmap with and without the
+// BF fast path. Present terms return identical bitmaps too (no false negatives).
+TEST_F(InvertedIndexTermBfReaderTest, AbsentAndPresentMatchNoBfBaseline) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"), Slice("apple cherry"),
+                                 Slice("elderberry")};
+    std::map<std::string, std::string> props = {{"parser", "english"},
+                                                {"lower_case", "true"},
+                                                {"support_phrase", "true"},
+                                                {"token_bloom_filter", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_present", 0, props, values, &idx_meta, &prefix);
+
+    struct Case {
+        std::string term;
+        InvertedIndexQueryType type;
+    };
+    std::vector<Case> cases = {
+            {"apple", InvertedIndexQueryType::MATCH_ANY_QUERY},
+            {"apple", InvertedIndexQueryType::MATCH_ALL_QUERY},
+            {"cherry", InvertedIndexQueryType::MATCH_ANY_QUERY},
+            {"absentword", InvertedIndexQueryType::MATCH_ANY_QUERY},
+            {"absentword", InvertedIndexQueryType::MATCH_ALL_QUERY},
+            {"absentword", InvertedIndexQueryType::MATCH_PHRASE_QUERY},
+    };
+
+    for (const auto& c : cases) {
+        config::enable_inverted_index_term_bf = false;
+        Status st_off;
+        auto baseline = run_fulltext(prefix, &idx_meta, c.term, c.type, &st_off);
+        EXPECT_TRUE(st_off.ok()) << c.term << ": " << st_off;
+        // Pin the baseline shape so the equality below cannot pass on two empty bitmaps: present
+        // terms must return rows, the absent term must be empty.
+        if (c.term == "absentword") {
+            EXPECT_EQ(baseline->cardinality(), 0U) << c.term << " must be empty";
+        } else {
+            EXPECT_GT(baseline->cardinality(), 0U) << c.term << " must return rows";
+        }
+
+        config::enable_inverted_index_term_bf = true;
+        Status st_on;
+        auto with_bf = run_fulltext(prefix, &idx_meta, c.term, c.type, &st_on);
+        EXPECT_TRUE(st_on.ok()) << c.term << ": " << st_on;
+
+        EXPECT_TRUE(*baseline == *with_bf)
+                << "BF result diverged from baseline for term '" << c.term << "' type "
+                << static_cast<int>(c.type) << " (baseline card=" << baseline->cardinality()
+                << ", bf card=" << with_bf->cardinality() << ")";
+    }
+}
+
+// MATCH_ANY with one present and one absent token must keep the present-token hits (the fast
+// path only empties when *every* token is absent).
+TEST_F(InvertedIndexTermBfReaderTest, MatchAnyPartialAbsentKeepsHits) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    std::map<std::string, std::string> props = {{"parser", "english"},
+                                                {"lower_case", "true"},
+                                                {"support_phrase", "true"},
+                                                {"token_bloom_filter", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_any", 0, props, values, &idx_meta, &prefix);
+
+    // "apple" present + "absentword" absent: MATCH_ANY should still match the apple docs.
+    config::enable_inverted_index_term_bf = false;
+    Status st_off;
+    auto baseline = run_fulltext(prefix, &idx_meta, "apple absentword",
+                                 InvertedIndexQueryType::MATCH_ANY_QUERY, &st_off);
+    EXPECT_TRUE(st_off.ok()) << st_off;
+
+    config::enable_inverted_index_term_bf = true;
+    Status st_on;
+    auto with_bf = run_fulltext(prefix, &idx_meta, "apple absentword",
+                                InvertedIndexQueryType::MATCH_ANY_QUERY, &st_on);
+    EXPECT_TRUE(st_on.ok()) << st_on;
+
+    EXPECT_GT(baseline->cardinality(), 0U);
+    EXPECT_TRUE(*baseline == *with_bf)
+            << "partial-absent MATCH_ANY must keep present-token hits (baseline card="
+            << baseline->cardinality() << ", bf card=" << with_bf->cardinality() << ")";
+}
+
+// A3: when the build-time analyzer signature differs from the index's own analyzer, the BF is
+// rejected and the query falls back to the normal lookup. We simulate a mismatch by building
+// the BF with one analyzer config and reading the index with a different parser property; the
+// read side recomputes the signature from the (different) properties, so it must not trust the
+// BF and must still return the correct (non-empty) result for a present term.
+TEST_F(InvertedIndexTermBfReaderTest, AnalyzerMismatchFallsBackToNormalQuery) {
+    std::vector<Slice> values = {Slice("Apple Banana"), Slice("Cherry Date")};
+
+    // Build with english + lower_case=true + BF.
+    std::map<std::string, std::string> build_props = {{"parser", "english"},
+                                                      {"lower_case", "true"},
+                                                      {"support_phrase", "true"},
+                                                      {"token_bloom_filter", "true"}};
+    TabletIndex build_meta;
+    std::string prefix;
+    build_index("tbf_rs_a3", 0, build_props, values, &build_meta, &prefix);
+
+    // Make the A3 guard load-bearing in this test: assert that the build-time analyzer
+    // signature (lower_case=true) and the read-time signature (lower_case=false) actually
+    // differ. Without this, a behavioral-equality assertion alone could pass even if the guard
+    // were removed (e.g. when the probed token happens to be present in the dictionary).
+    InvertedIndexAnalyzerConfig build_cfg;
+    build_cfg.parser_type = InvertedIndexParserType::PARSER_ENGLISH;
+    build_cfg.lower_case = "true";
+    InvertedIndexAnalyzerConfig read_cfg = build_cfg;
+    read_cfg.lower_case = "false";
+    EXPECT_NE(compute_analyzer_sig(build_cfg), compute_analyzer_sig(read_cfg))
+            << "A3 guard is only load-bearing if the build/read analyzer signatures differ";
+
+    // Read with a different analyzer config (lower_case=false): the index's own signature now
+    // differs from the one stored in the BF, so the fast path must be skipped. The normal query
+    // still returns whatever the index actually contains; the key assertion is that the BF does
+    // not silently empty the result.
+    auto read_meta_pb = std::make_unique<TabletIndexPB>();
+    read_meta_pb->set_index_type(IndexType::INVERTED);
+    read_meta_pb->set_index_id(1);
+    read_meta_pb->set_index_name("test_tbf");
+    read_meta_pb->clear_col_unique_id();
+    read_meta_pb->add_col_unique_id(1);
+    (*read_meta_pb->mutable_properties())["parser"] = "english";
+    (*read_meta_pb->mutable_properties())["lower_case"] = "false";
+    (*read_meta_pb->mutable_properties())["support_phrase"] = "true";
+    (*read_meta_pb->mutable_properties())["token_bloom_filter"] = "true";
+    TabletIndex read_meta;
+    read_meta.init_from_pb(*read_meta_pb.get());
+
+    config::enable_inverted_index_term_bf = false;
+    Status st_off;
+    auto baseline = run_fulltext(prefix, &read_meta, "apple",
+                                 InvertedIndexQueryType::MATCH_ANY_QUERY, &st_off);
+    EXPECT_TRUE(st_off.ok()) << st_off;
+    // The baseline must actually return rows, otherwise the equality below could pass vacuously
+    // (two empty bitmaps) even if the BF wrongly emptied a mismatched-signature query.
+    EXPECT_GT(baseline->cardinality(), 0U) << "baseline must be non-empty for a meaningful check";
+
+    config::enable_inverted_index_term_bf = true;
+    Status st_on;
+    auto with_bf = run_fulltext(prefix, &read_meta, "apple",
+                                InvertedIndexQueryType::MATCH_ANY_QUERY, &st_on);
+    EXPECT_TRUE(st_on.ok()) << st_on;
+
+    // With the analyzer mismatched, the BF is ignored: results must match the normal path
+    // exactly (the BF must not turn a mismatched-signature query into a (possibly wrong) empty).
+    EXPECT_TRUE(*baseline == *with_bf)
+            << "analyzer-sig mismatch must fall back to normal query (baseline card="
+            << baseline->cardinality() << ", bf card=" << with_bf->cardinality() << ")";
+}
+
+// A5: an empty keyword token must round-trip through the BF and remain matchable. Build a
+// fulltext index whose values include an empty string; the term dictionary then contains the
+// zero-length token, which the writer feeds into the BF. A MATCH_ANY for a present token still
+// returns its docs with the BF on (the empty token in the dictionary must not corrupt probing).
+TEST_F(InvertedIndexTermBfReaderTest, EmptyTokenRoundTripsThroughBf) {
+    std::vector<Slice> values = {Slice(""), Slice("apple"), Slice("")};
+    std::map<std::string, std::string> props = {{"parser", "english"},
+                                                {"lower_case", "true"},
+                                                {"support_phrase", "true"},
+                                                {"token_bloom_filter", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_a5", 0, props, values, &idx_meta, &prefix);
+
+    config::enable_inverted_index_term_bf = false;
+    Status st_off;
+    auto baseline = run_fulltext(prefix, &idx_meta, "apple",
+                                 InvertedIndexQueryType::MATCH_ANY_QUERY, &st_off);
+    EXPECT_TRUE(st_off.ok()) << st_off;
+
+    config::enable_inverted_index_term_bf = true;
+    Status st_on;
+    auto with_bf = run_fulltext(prefix, &idx_meta, "apple", InvertedIndexQueryType::MATCH_ANY_QUERY,
+                                &st_on);
+    EXPECT_TRUE(st_on.ok()) << st_on;
+
+    EXPECT_TRUE(*baseline == *with_bf)
+            << "empty token in the dictionary must not corrupt the BF fast path (baseline card="
+            << baseline->cardinality() << ", bf card=" << with_bf->cardinality() << ")";
+}
+
+// A4: the keyword/exact path is StringTypeInvertedIndexReader and is never consulted by the BF.
+// An over-ignore_above EQUAL still returns INVERTED_INDEX_EVALUATE_SKIPPED (forcing a table
+// scan), even with the BF flag enabled -- the flag must not turn this into an empty result.
+TEST_F(InvertedIndexTermBfReaderTest, KeywordIgnoreAboveStillEvaluateSkipped) {
+    // Keyword index (no parser) over a short value; query a value longer than ignore_above.
+    std::vector<Slice> values = {Slice("short")};
+    std::map<std::string, std::string> props = {{"ignore_above", "10"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_a4", 0, props, values, &idx_meta, &prefix);
+
+    auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                    InvertedIndexStorageFormatPB::V2);
+    ASSERT_TRUE(reader->init().ok());
+    auto str_reader = StringTypeInvertedIndexReader::create_shared(&idx_meta, reader);
+    ASSERT_NE(str_reader, nullptr);
+
+    io::IOContext io_ctx;
+    OlapReaderStatistics stats;
+    RuntimeState runtime_state;
+    auto context = make_context(&io_ctx, &stats, &runtime_state);
+
+    std::string long_value(64, 'x'); // > ignore_above (10)
+    config::enable_inverted_index_term_bf = true;
+    auto bitmap = std::make_shared<roaring::Roaring>();
+    Field qp = Field::create_field<TYPE_STRING>(long_value);
+    auto st = str_reader->query(context, "1", qp, InvertedIndexQueryType::EQUAL_QUERY, bitmap);
+    EXPECT_EQ(st.code(), static_cast<int>(ErrorCode::INVERTED_INDEX_EVALUATE_SKIPPED))
+            << "over-ignore_above keyword EQUAL must still force a table scan, not be emptied by "
+               "the BF";
+}
+
+// Observability: the per-(segment,index) BF profile counters must reflect the actual path taken
+// -- absent -> AbsentSkip, present -> Fallthrough, warm -> CacheHit, cold -> CacheMiss+Load, and
+// an index with no tbf -> Unavailable. These are exactly the counters surfaced in the query
+// profile, so this test is what keeps the profile numbers honest.
+TEST_F(InvertedIndexTermBfReaderTest, BfObservabilityCountersReflectPath) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    std::map<std::string, std::string> with_bf = {{"parser", "english"},
+                                                  {"lower_case", "true"},
+                                                  {"support_phrase", "true"},
+                                                  {"token_bloom_filter", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_obs", 0, with_bf, values, &idx_meta, &prefix);
+
+    config::enable_inverted_index_term_bf = true;
+
+    auto run = [&](const std::string& term, InvertedIndexQueryType type,
+                   OlapReaderStatistics* stats) -> std::shared_ptr<roaring::Roaring> {
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                        InvertedIndexStorageFormatPB::V2);
+        EXPECT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(&idx_meta, reader);
+        io::IOContext io_ctx;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, stats, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>(term);
+        EXPECT_TRUE(ft_reader->query(context, "1", qp, type, bitmap).ok());
+        return bitmap;
+    };
+
+    // Cold absent query: cache miss -> load the tbf once, prove absent, skip the searcher.
+    OlapReaderStatistics cold;
+    auto b1 = run("zzabsentone", InvertedIndexQueryType::MATCH_ANY_QUERY, &cold);
+    EXPECT_EQ(b1->cardinality(), 0U);
+    EXPECT_EQ(cold.inverted_index_term_bf_probe, 1);
+    EXPECT_EQ(cold.inverted_index_term_bf_skipped_lookups, 1);
+    EXPECT_EQ(cold.inverted_index_term_bf_fallthrough, 0);
+    EXPECT_EQ(cold.inverted_index_term_bf_unavailable, 0);
+    EXPECT_EQ(cold.inverted_index_term_bf_cache_hit, 0);
+    EXPECT_EQ(cold.inverted_index_term_bf_cache_miss, 1);
+    EXPECT_EQ(cold.inverted_index_term_bf_load_count, 1);
+    EXPECT_GT(cold.inverted_index_term_bf_load_bytes, 0);
+
+    // Warm absent query (different token): BF cache hit, zero load IO, still proven absent.
+    OlapReaderStatistics warm;
+    auto b2 = run("zzabsenttwo", InvertedIndexQueryType::MATCH_ANY_QUERY, &warm);
+    EXPECT_EQ(b2->cardinality(), 0U);
+    EXPECT_EQ(warm.inverted_index_term_bf_cache_hit, 1);
+    EXPECT_EQ(warm.inverted_index_term_bf_cache_miss, 0);
+    EXPECT_EQ(warm.inverted_index_term_bf_load_count, 0);
+    EXPECT_EQ(warm.inverted_index_term_bf_load_bytes, 0);
+    EXPECT_EQ(warm.inverted_index_term_bf_probe, 1);
+    EXPECT_EQ(warm.inverted_index_term_bf_skipped_lookups, 1);
+
+    // Present token: BF says MAYBE -> fall through to the normal lookup (no skip).
+    OlapReaderStatistics present;
+    auto b3 = run("apple", InvertedIndexQueryType::MATCH_ANY_QUERY, &present);
+    EXPECT_GT(b3->cardinality(), 0U);
+    EXPECT_EQ(present.inverted_index_term_bf_probe, 1);
+    EXPECT_EQ(present.inverted_index_term_bf_skipped_lookups, 0);
+    EXPECT_EQ(present.inverted_index_term_bf_fallthrough, 1);
+
+    // (a) Property gate: an index WITHOUT token_bloom_filter=true is skipped before the fast path
+    // even runs -- no index open, no fileExists("tbf"), so EVERY BF counter stays 0. Without the
+    // gate, flipping the global config on would tax every fulltext index with an extra open.
+    std::map<std::string, std::string> no_bf = {
+            {"parser", "english"}, {"lower_case", "true"}, {"support_phrase", "true"}};
+    TabletIndex idx_nobf;
+    std::string prefix_nobf;
+    build_index("tbf_rs_obs_nobf", 1, no_bf, values, &idx_nobf, &prefix_nobf);
+    {
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix_nobf,
+                                                        InvertedIndexStorageFormatPB::V2);
+        ASSERT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(&idx_nobf, reader);
+        io::IOContext io_ctx;
+        OlapReaderStatistics nobf;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, &nobf, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>("zzabsentthree");
+        ASSERT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+        EXPECT_EQ(nobf.inverted_index_term_bf_probe, 0);
+        EXPECT_EQ(nobf.inverted_index_term_bf_skipped_lookups, 0);
+        EXPECT_EQ(nobf.inverted_index_term_bf_unavailable, 0);
+        EXPECT_EQ(nobf.inverted_index_term_bf_cache_miss, 0);
+        EXPECT_EQ(nobf.inverted_index_term_bf_load_count, 0);
+    }
+
+    // (b) Unavailable: an index WITH token_bloom_filter=true passes the gate, but a read whose
+    // analyzer signature differs from the build (A3, lower_case flipped) rejects the loaded BF as
+    // stale -> Unavailable, no probe/skip. Built fresh (no prior matching-meta query) so the load
+    // -- and its A3 check -- actually runs rather than hitting a cached BF.
+    {
+        std::map<std::string, std::string> with_bf_stale = {{"parser", "english"},
+                                                            {"lower_case", "true"},
+                                                            {"support_phrase", "true"},
+                                                            {"token_bloom_filter", "true"}};
+        TabletIndex idx_stale_build;
+        std::string prefix_stale;
+        build_index("tbf_rs_obs_stale", 2, with_bf_stale, values, &idx_stale_build, &prefix_stale);
+
+        auto read_pb = std::make_unique<TabletIndexPB>();
+        read_pb->set_index_type(IndexType::INVERTED);
+        read_pb->set_index_id(1);
+        read_pb->set_index_name("test_tbf");
+        read_pb->clear_col_unique_id();
+        read_pb->add_col_unique_id(1);
+        (*read_pb->mutable_properties())["parser"] = "english";
+        (*read_pb->mutable_properties())["lower_case"] = "false"; // build used true -> sig mismatch
+        (*read_pb->mutable_properties())["support_phrase"] = "true";
+        (*read_pb->mutable_properties())["token_bloom_filter"] = "true";
+        TabletIndex stale_meta;
+        stale_meta.init_from_pb(*read_pb.get());
+
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix_stale,
+                                                        InvertedIndexStorageFormatPB::V2);
+        ASSERT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(&stale_meta, reader);
+        io::IOContext io_ctx;
+        OlapReaderStatistics stale;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, &stale, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>("zzabsentfour");
+        ASSERT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+        EXPECT_EQ(stale.inverted_index_term_bf_unavailable, 1);
+        EXPECT_EQ(stale.inverted_index_term_bf_probe, 0);
+        EXPECT_EQ(stale.inverted_index_term_bf_skipped_lookups, 0);
+    }
+}
+
+// erase() must drop the BF entry too. The BF lives in the searcher cache under a derived key; if
+// erase() only removed the searcher key, a compaction/rewrite that invalidates the segment would
+// leave a stale BF behind -- and a same-key rewrite could then serve it (a false "absent" ->
+// dropped hit). After erase, a subsequent absent query must re-load the BF (cache miss), not hit.
+TEST_F(InvertedIndexTermBfReaderTest, EraseAlsoClearsTermBf) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    std::map<std::string, std::string> props = {{"parser", "english"},
+                                                {"lower_case", "true"},
+                                                {"support_phrase", "true"},
+                                                {"token_bloom_filter", "true"}};
+    TabletIndex idx_meta;
+    std::string prefix;
+    build_index("tbf_rs_erase", 0, props, values, &idx_meta, &prefix);
+    config::enable_inverted_index_term_bf = true;
+
+    auto run_absent = [&](const std::string& term,
+                          OlapReaderStatistics* stats) -> std::shared_ptr<IndexFileReader> {
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                        InvertedIndexStorageFormatPB::V2);
+        EXPECT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(&idx_meta, reader);
+        io::IOContext io_ctx;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, stats, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>(term);
+        EXPECT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+        return reader;
+    };
+
+    OlapReaderStatistics cold;
+    auto reader = run_absent("zzeraseone", &cold);
+    EXPECT_EQ(cold.inverted_index_term_bf_cache_miss, 1);
+    EXPECT_EQ(cold.inverted_index_term_bf_load_count, 1);
+
+    OlapReaderStatistics warm;
+    run_absent("zzerasetwo", &warm);
+    EXPECT_EQ(warm.inverted_index_term_bf_cache_hit, 1);
+    EXPECT_EQ(warm.inverted_index_term_bf_load_count, 0);
+
+    // Erase the (segment, index) from the searcher cache, exactly as compaction / rewrite does.
+    const auto index_file_key = reader->get_index_file_cache_key(&idx_meta);
+    ASSERT_TRUE(InvertedIndexSearcherCache::instance()->erase(index_file_key).ok());
+
+    OlapReaderStatistics after;
+    run_absent("zzerasethree", &after);
+    EXPECT_EQ(after.inverted_index_term_bf_cache_hit, 0) << "erased BF must not be served";
+    EXPECT_EQ(after.inverted_index_term_bf_cache_miss, 1) << "erased BF must trigger a reload";
+    EXPECT_EQ(after.inverted_index_term_bf_load_count, 1);
+}
+
+// A3 must be applied consistently on the cache-hit path, not just the cold-load path. The BF cache
+// key (index_file_key) does not encode the analyzer, so a BF cached under one analyzer is reachable
+// by a reader whose _index_meta was altered to a different analyzer. A cold query for that reader
+// rejects the BF (A3 -> unavailable); a warm query must do the same, otherwise cold/warm disagree.
+// (Results are correct either way -- the BF mirrors the segment's dictionary, so no false negatives
+// -- so this asserts on the path/stats, which is what the cache-hit revalidation changes.)
+TEST_F(InvertedIndexTermBfReaderTest, StaleAnalyzerCachedBfRevalidatedOnHit) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    std::map<std::string, std::string> match_props = {{"parser", "english"},
+                                                      {"lower_case", "true"},
+                                                      {"support_phrase", "true"},
+                                                      {"token_bloom_filter", "true"}};
+    TabletIndex match_meta;
+    std::string prefix;
+    build_index("tbf_rs_stalehit", 0, match_props, values, &match_meta, &prefix);
+
+    // Same file/index (-> same index_file_key) but read with lower_case=false: a different analyzer
+    // signature from the one the BF was built under.
+    auto stale_pb = std::make_unique<TabletIndexPB>();
+    stale_pb->set_index_type(IndexType::INVERTED);
+    stale_pb->set_index_id(1);
+    stale_pb->set_index_name("test_tbf");
+    stale_pb->clear_col_unique_id();
+    stale_pb->add_col_unique_id(1);
+    (*stale_pb->mutable_properties())["parser"] = "english";
+    (*stale_pb->mutable_properties())["lower_case"] = "false";
+    (*stale_pb->mutable_properties())["support_phrase"] = "true";
+    (*stale_pb->mutable_properties())["token_bloom_filter"] = "true";
+    TabletIndex stale_meta;
+    stale_meta.init_from_pb(*stale_pb.get());
+
+    auto query = [&](TabletIndex* meta, const std::string& term,
+                     OlapReaderStatistics* stats) -> std::shared_ptr<roaring::Roaring> {
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                        InvertedIndexStorageFormatPB::V2);
+        EXPECT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(meta, reader);
+        io::IOContext io_ctx;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, stats, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>(term);
+        EXPECT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+        return bitmap;
+    };
+
+    // Baseline (no BF) for the stale-analyzer reader; "apple" is present so this is non-empty.
+    config::enable_inverted_index_term_bf = false;
+    OlapReaderStatistics base_stats;
+    auto baseline = query(&stale_meta, "apple", &base_stats);
+    EXPECT_GT(baseline->cardinality(), 0U) << "baseline must be non-empty for a meaningful check";
+
+    // Populate the BF cache with the MATCHING analyzer.
+    config::enable_inverted_index_term_bf = true;
+    OlapReaderStatistics warm_stats;
+    query(&match_meta, "apple", &warm_stats);
+    EXPECT_EQ(warm_stats.inverted_index_term_bf_cache_miss, 1);
+    EXPECT_EQ(warm_stats.inverted_index_term_bf_load_count, 1);
+
+    // The stale-analyzer reader now hits the cache but must revalidate: same outcome as a cold load
+    // would give it (unavailable -> fall back), NOT a cache hit that serves the mismatched BF.
+    OlapReaderStatistics stale_stats;
+    auto with_bf = query(&stale_meta, "apple", &stale_stats);
+    EXPECT_EQ(stale_stats.inverted_index_term_bf_unavailable, 1) << "stale-analyzer BF rejected";
+    EXPECT_EQ(stale_stats.inverted_index_term_bf_cache_hit, 0);
+    EXPECT_EQ(stale_stats.inverted_index_term_bf_probe, 0);
+    EXPECT_TRUE(*baseline == *with_bf) << "fall-back result must match the normal query";
+}
+
+// Negative caching: an index whose property passes the gate (token_bloom_filter=true) but whose
+// segment carries no usable "tbf" (e.g. compacted by an older BE, or a build failure) must cache
+// that negative result -- the first query loads-and-fails, and a second query hits the negative
+// marker instead of re-opening the index. Built WITHOUT a tbf on disk, then read with a
+// property=true meta so the gate is passed but the structural load returns nothing.
+TEST_F(InvertedIndexTermBfReaderTest, NegativeCacheSkipsRepeatOpenWhenNoTbf) {
+    std::vector<Slice> values = {Slice("apple banana"), Slice("cherry date"),
+                                 Slice("apple cherry")};
+    // No token_bloom_filter -> the writer emits no "tbf" sub-file.
+    std::map<std::string, std::string> no_bf_props = {
+            {"parser", "english"}, {"lower_case", "true"}, {"support_phrase", "true"}};
+    TabletIndex build_meta;
+    std::string prefix;
+    build_index("tbf_rs_neg", 0, no_bf_props, values, &build_meta, &prefix);
+
+    // Reader meta WITH token_bloom_filter=true: the property gate passes even though the disk
+    // segment has no tbf.
+    auto read_pb = std::make_unique<TabletIndexPB>();
+    read_pb->set_index_type(IndexType::INVERTED);
+    read_pb->set_index_id(1);
+    read_pb->set_index_name("test_tbf");
+    read_pb->clear_col_unique_id();
+    read_pb->add_col_unique_id(1);
+    (*read_pb->mutable_properties())["parser"] = "english";
+    (*read_pb->mutable_properties())["lower_case"] = "true";
+    (*read_pb->mutable_properties())["support_phrase"] = "true";
+    (*read_pb->mutable_properties())["token_bloom_filter"] = "true";
+    TabletIndex read_meta;
+    read_meta.init_from_pb(*read_pb.get());
+
+    config::enable_inverted_index_term_bf = true;
+
+    auto run = [&](const std::string& term, OlapReaderStatistics* stats) {
+        auto reader = std::make_shared<IndexFileReader>(io::global_local_filesystem(), prefix,
+                                                        InvertedIndexStorageFormatPB::V2);
+        EXPECT_TRUE(reader->init().ok());
+        auto ft_reader = FullTextIndexReader::create_shared(&read_meta, reader);
+        io::IOContext io_ctx;
+        RuntimeState runtime_state;
+        auto context = make_context(&io_ctx, stats, &runtime_state);
+        auto bitmap = std::make_shared<roaring::Roaring>();
+        Field qp = Field::create_field<TYPE_STRING>(term);
+        EXPECT_TRUE(
+                ft_reader->query(context, "1", qp, InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap)
+                        .ok());
+    };
+
+    // First query: gate passes, lookup miss, structural load finds no tbf -> unavailable + cache
+    // the negative result.
+    OlapReaderStatistics first;
+    run("zznegone", &first);
+    EXPECT_EQ(first.inverted_index_term_bf_cache_miss, 1);
+    EXPECT_EQ(first.inverted_index_term_bf_unavailable, 1);
+    EXPECT_EQ(first.inverted_index_term_bf_load_count, 0) << "no tbf -> nothing loaded";
+
+    // Second query (different token): hits the negative marker -> no new miss, no re-open.
+    OlapReaderStatistics second;
+    run("zznegtwo", &second);
+    EXPECT_EQ(second.inverted_index_term_bf_cache_miss, 0)
+            << "negative result must be cached, not re-missed";
+    EXPECT_EQ(second.inverted_index_term_bf_unavailable, 1);
+    EXPECT_EQ(second.inverted_index_term_bf_load_count, 0);
+    EXPECT_EQ(second.inverted_index_term_bf_probe, 0);
+}
+
+} // namespace doris::segment_v2

--- a/be/test/storage/index/inverted/inverted_index_term_bloom_filter_test.cpp
+++ b/be/test/storage/index/inverted/inverted_index_term_bloom_filter_test.cpp
@@ -1,0 +1,299 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/index/inverted/inverted_index_term_bloom_filter.h"
+
+#include <CLucene.h>
+#include <CLucene/store/IndexInput.h>
+#include <CLucene/store/IndexOutput.h>
+#include <CLucene/store/RAMDirectory.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "storage/index/inverted/inverted_index_parser.h"
+#include "storage/index/inverted/inverted_index_term_bf_query.h"
+
+namespace doris::segment_v2 {
+
+// CLucene's Directory::openInput is the 3-arg (name, ret, error) form; wrap it for tests.
+static lucene::store::IndexInput* open_ram_input(lucene::store::RAMDirectory& dir,
+                                                 const char* name) {
+    lucene::store::IndexInput* in = nullptr;
+    CLuceneError err;
+    dir.openInput(name, in, err);
+    return in;
+}
+
+// Unit tests for the token-exists Bloom Filter ("tbf") sub-file primitive.
+//
+// These exercise the low-level contract that the FullTextIndexReader fast path relies on:
+//   - serialize/load round-trip through a CLucene directory (the real on-disk path)
+//   - ABSENT is authoritative (no false negatives) while present tokens never report ABSENT
+//   - the empty keyword token is on the data path, not the null flag (A5 primitive)
+//   - analyzer_sig stability and mismatch detection (A3 primitive)
+//   - the multi-term OR rule + phrase position-group OR rule the reader applies (A2 / A1
+//     primitives), validated directly against probe() so the grouping invariant is pinned
+//   - corrupt / truncated sub-files fail load() so the reader treats them as "unknown"
+class InvertedIndexTermBloomFilterTest : public testing::Test {
+protected:
+    // Round-trip a freshly-built BF through a RAMDirectory and return the reloaded copy.
+    static std::unique_ptr<InvertedIndexTermBloomFilter> round_trip(
+            const InvertedIndexTermBloomFilter& bf) {
+        lucene::store::RAMDirectory dir;
+        {
+            std::unique_ptr<lucene::store::IndexOutput> out(dir.createOutput("tbf"));
+            bf.serialize(out.get());
+            out->close();
+        }
+        std::unique_ptr<lucene::store::IndexInput> in(open_ram_input(dir, "tbf"));
+        auto res = InvertedIndexTermBloomFilter::load(in.get());
+        in->close();
+        EXPECT_TRUE(res.has_value()) << res.error();
+        return res.has_value() ? std::move(res.value()) : nullptr;
+    }
+
+    static InvertedIndexAnalyzerConfig english_cfg() {
+        InvertedIndexAnalyzerConfig cfg;
+        cfg.parser_type = InvertedIndexParserType::PARSER_ENGLISH;
+        cfg.lower_case = "true";
+        return cfg;
+    }
+};
+
+// serialize -> load round-trip preserves header fields and probe answers.
+TEST_F(InvertedIndexTermBloomFilterTest, SerializeLoadRoundTrip) {
+    auto sig = compute_analyzer_sig(english_cfg());
+    auto built = InvertedIndexTermBloomFilter::create_for_write(/*distinct_terms=*/3, sig);
+    ASSERT_TRUE(built.has_value()) << built.error();
+    auto bf = std::move(built.value());
+
+    const std::vector<std::string> present = {"apple", "banana", "cherry"};
+    for (const auto& t : present) {
+        bf->add_token(t.data(), t.size());
+    }
+
+    auto loaded = round_trip(*bf);
+    ASSERT_NE(loaded, nullptr);
+
+    EXPECT_EQ(loaded->analyzer_sig(), sig);
+    EXPECT_EQ(loaded->distinct_terms(), 3U);
+
+    // Present tokens must never report ABSENT (no false negative).
+    for (const auto& t : present) {
+        EXPECT_EQ(loaded->probe(t), InvertedIndexTermBloomFilter::Probe::MAYBE) << t;
+    }
+}
+
+// ABSENT is authoritative: a token that was never added is reported ABSENT (modulo the
+// tiny configured fpp; the chosen out-of-vocabulary tokens are checked to actually answer
+// ABSENT here, which validates the absent fast path is reachable at all).
+TEST_F(InvertedIndexTermBloomFilterTest, AbsentTokenProbesAbsent) {
+    auto built = InvertedIndexTermBloomFilter::create_for_write(
+            /*distinct_terms=*/4, compute_analyzer_sig(english_cfg()));
+    ASSERT_TRUE(built.has_value());
+    auto bf = std::move(built.value());
+    for (const auto& t : {"alpha", "beta", "gamma", "delta"}) {
+        bf->add_token(t, std::strlen(t));
+    }
+    auto loaded = round_trip(*bf);
+    ASSERT_NE(loaded, nullptr);
+
+    // None of these were added; with fpp=0.01 over a 4-element set they probe ABSENT.
+    int absent = 0;
+    for (const auto& t : {"epsilon", "zeta", "omega", "qqqqq"}) {
+        if (loaded->probe(t) == InvertedIndexTermBloomFilter::Probe::ABSENT) {
+            ++absent;
+        }
+    }
+    EXPECT_GE(absent, 1) << "absent fast path must be reachable for out-of-vocabulary tokens";
+}
+
+// A5 primitive: the empty keyword token is a legal token on the data path, distinct from a
+// genuinely-absent token. After adding "", probe("") must be MAYBE; a non-empty unrelated
+// token may still be ABSENT.
+TEST_F(InvertedIndexTermBloomFilterTest, EmptyTokenIsOnDataPath) {
+    auto built = InvertedIndexTermBloomFilter::create_for_write(
+            /*distinct_terms=*/2, compute_analyzer_sig(english_cfg()));
+    ASSERT_TRUE(built.has_value());
+    auto bf = std::move(built.value());
+    bf->add_token("", 0);        // empty keyword token
+    bf->add_token("present", 7); // a normal token
+
+    auto loaded = round_trip(*bf);
+    ASSERT_NE(loaded, nullptr);
+
+    EXPECT_EQ(loaded->probe(""), InvertedIndexTermBloomFilter::Probe::MAYBE)
+            << "empty keyword token must be matchable, not treated as null";
+    EXPECT_EQ(loaded->probe("present"), InvertedIndexTermBloomFilter::Probe::MAYBE);
+}
+
+// An empty BF where "" was never added: probe("") is ABSENT, proving the empty token is not
+// silently special-cased to always-present.
+TEST_F(InvertedIndexTermBloomFilterTest, EmptyTokenAbsentWhenNotAdded) {
+    auto built = InvertedIndexTermBloomFilter::create_for_write(
+            /*distinct_terms=*/1, compute_analyzer_sig(english_cfg()));
+    ASSERT_TRUE(built.has_value());
+    auto bf = std::move(built.value());
+    bf->add_token("nonempty", 8);
+
+    auto loaded = round_trip(*bf);
+    ASSERT_NE(loaded, nullptr);
+    EXPECT_EQ(loaded->probe(""), InvertedIndexTermBloomFilter::Probe::ABSENT);
+}
+
+// A3 primitive: equal analyzer configs produce equal signatures; any tokenization-affecting
+// difference changes the signature so the reader can reject a foreign BF.
+TEST_F(InvertedIndexTermBloomFilterTest, AnalyzerSignatureStableAndDiscriminating) {
+    auto a = english_cfg();
+    auto b = english_cfg();
+    EXPECT_EQ(compute_analyzer_sig(a), compute_analyzer_sig(b));
+
+    auto lower_off = english_cfg();
+    lower_off.lower_case = "false";
+    EXPECT_NE(compute_analyzer_sig(a), compute_analyzer_sig(lower_off));
+
+    auto unicode = english_cfg();
+    unicode.parser_type = InvertedIndexParserType::PARSER_UNICODE;
+    EXPECT_NE(compute_analyzer_sig(a), compute_analyzer_sig(unicode));
+
+    auto with_stop = english_cfg();
+    with_stop.stop_words = "none";
+    EXPECT_NE(compute_analyzer_sig(a), compute_analyzer_sig(with_stop));
+
+    auto with_charfilter = english_cfg();
+    with_charfilter.char_filter_map["char_filter_pattern"] = ".";
+    EXPECT_NE(compute_analyzer_sig(a), compute_analyzer_sig(with_charfilter));
+}
+
+// A2 primitive: a multi-term slot (synonyms / CJK overlap at one position) is an OR. The
+// reader treats it as ABSENT only when *every* sub-term is ABSENT. This mirrors that rule
+// directly over probe() so the grouping invariant is pinned even though the reader helper
+// lives in an anonymous namespace.
+// A2: a multi-term slot (CJK overlap / synonyms at one position) is an OR of its sub-terms --
+// ABSENT only when every sub-term is ABSENT. Drives the *shipped* bf_query_proven_empty (the
+// reader fast path calls the same function), so a regression in the grouping fails this test.
+TEST_F(InvertedIndexTermBloomFilterTest, MultiTermSlotIsOrOfSubTerms) {
+    auto built = InvertedIndexTermBloomFilter::create_for_write(
+            /*distinct_terms=*/2, compute_analyzer_sig(english_cfg()));
+    ASSERT_TRUE(built.has_value());
+    auto bf = std::move(built.value());
+    bf->add_token("present_a", 9);
+    bf->add_token("present_b", 9);
+    auto loaded = round_trip(*bf);
+    ASSERT_NE(loaded, nullptr);
+
+    // MATCH_ALL with a single multi-term slot: brace-init the vector's TermInfo elements (avoids
+    // naming TermInfo, which would clash with lucene::index::TermInfo under <CLucene.h>).
+    auto match_all = [&](std::vector<std::string> alts) {
+        InvertedIndexQueryInfo qi;
+        qi.term_infos.push_back({std::move(alts), /*position=*/0});
+        return bf_query_proven_empty(InvertedIndexQueryType::MATCH_ALL_QUERY, qi, *loaded);
+    };
+
+    // One present alternative keeps the multi-term slot alive (must NOT short-circuit).
+    EXPECT_FALSE(match_all({"present_a", "absent_zzz"}));
+    EXPECT_FALSE(match_all({"absent_zzz", "present_b"}));
+    // Every alternative absent -> slot provably dead -> proven empty.
+    EXPECT_TRUE(match_all({"absent_xxx", "absent_yyy"}));
+}
+
+// A1: a MATCH_PHRASE groups alternatives by position; a slot is dead only when all alternatives
+// at that position are ABSENT, and the phrase is empty only when some slot is dead. Drives the
+// *shipped* bf_query_proven_empty over same-position alternatives -- the exact silent-drop hazard.
+TEST_F(InvertedIndexTermBloomFilterTest, PhrasePositionGroupOrRule) {
+    auto built = InvertedIndexTermBloomFilter::create_for_write(
+            /*distinct_terms=*/3, compute_analyzer_sig(english_cfg()));
+    ASSERT_TRUE(built.has_value());
+    auto bf = std::move(built.value());
+    bf->add_token("quick", 5);
+    bf->add_token("brown", 5);
+    bf->add_token("fox", 3);
+    auto loaded = round_trip(*bf);
+    ASSERT_NE(loaded, nullptr);
+
+    auto phrase_empty = [&](const std::vector<std::pair<int32_t, std::string>>& terms) {
+        InvertedIndexQueryInfo qi;
+        for (const auto& [pos, tok] : terms) {
+            qi.term_infos.push_back({tok, pos});
+        }
+        return bf_query_proven_empty(InvertedIndexQueryType::MATCH_PHRASE_QUERY, qi, *loaded);
+    };
+
+    // Position 0 is an OR slot {brown(present), absent_alt}: one present alternative keeps it
+    // alive, so the phrase must NOT be reported empty even though one alternative is absent.
+    EXPECT_FALSE(phrase_empty({{0, "brown"}, {0, "absent_alt"}, {1, "fox"}}));
+    // A position whose every alternative is absent kills the phrase.
+    EXPECT_TRUE(phrase_empty({{0, "quick"}, {1, "absent_a"}, {1, "absent_b"}}));
+}
+
+// load() rejects a buffer that is too small to hold the header (reader treats it as unknown).
+TEST_F(InvertedIndexTermBloomFilterTest, LoadRejectsTruncatedFile) {
+    lucene::store::RAMDirectory dir;
+    {
+        std::unique_ptr<lucene::store::IndexOutput> out(dir.createOutput("tbf"));
+        const char junk[8] = {'T', 'B', 'F', '1', 0, 0, 0, 0};
+        out->writeBytes(reinterpret_cast<const uint8_t*>(junk), sizeof(junk));
+        out->close();
+    }
+    std::unique_ptr<lucene::store::IndexInput> in(open_ram_input(dir, "tbf"));
+    auto res = InvertedIndexTermBloomFilter::load(in.get());
+    in->close();
+    EXPECT_FALSE(res.has_value());
+}
+
+// load() rejects a wrong magic (a stale / foreign sub-file -> unknown -> normal query).
+TEST_F(InvertedIndexTermBloomFilterTest, LoadRejectsBadMagic) {
+    auto built = InvertedIndexTermBloomFilter::create_for_write(
+            /*distinct_terms=*/1, compute_analyzer_sig(english_cfg()));
+    ASSERT_TRUE(built.has_value());
+    auto bf = std::move(built.value());
+    bf->add_token("apple", 5);
+
+    lucene::store::RAMDirectory dir;
+    {
+        std::unique_ptr<lucene::store::IndexOutput> out(dir.createOutput("tbf"));
+        bf->serialize(out.get());
+        out->close();
+    }
+    // Corrupt the magic in place by rewriting the file with a flipped first byte.
+    std::vector<uint8_t> bytes;
+    {
+        std::unique_ptr<lucene::store::IndexInput> in(open_ram_input(dir, "tbf"));
+        bytes.resize(in->length());
+        in->readBytes(bytes.data(), static_cast<int32_t>(bytes.size()));
+        in->close();
+    }
+    bytes[0] = 'X';
+    dir.deleteFile("tbf");
+    {
+        std::unique_ptr<lucene::store::IndexOutput> out(dir.createOutput("tbf"));
+        out->writeBytes(bytes.data(), static_cast<int32_t>(bytes.size()));
+        out->close();
+    }
+    std::unique_ptr<lucene::store::IndexInput> in(open_ram_input(dir, "tbf"));
+    auto res = InvertedIndexTermBloomFilter::load(in.get());
+    in->close();
+    EXPECT_FALSE(res.has_value());
+}
+
+} // namespace doris::segment_v2

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/InvertedIndexProperties.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/InvertedIndexProperties.java
@@ -57,6 +57,10 @@ public class InvertedIndexProperties {
 
     public static String INVERTED_INDEX_DICT_COMPRESSION_KEY = "dict_compression";
 
+    // Build a token-exists Bloom Filter ("tbf") sub-file to fast-path absent exact-term queries.
+    // Must match the BE-side key (be/.../inverted_index_parser.h INVERTED_INDEX_PARSER_TOKEN_BF_KEY).
+    public static String INVERTED_INDEX_TOKEN_BLOOM_FILTER_KEY = "token_bloom_filter";
+
     public static String INVERTED_INDEX_ANALYZER_NAME_KEY = "analyzer";
     public static String INVERTED_INDEX_NORMALIZER_NAME_KEY = "normalizer";
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InvertedIndexUtil.java
@@ -81,6 +81,9 @@ public class InvertedIndexUtil {
     public static String INVERTED_INDEX_DICT_COMPRESSION_KEY =
             InvertedIndexProperties.INVERTED_INDEX_DICT_COMPRESSION_KEY;
 
+    public static String INVERTED_INDEX_TOKEN_BLOOM_FILTER_KEY =
+            InvertedIndexProperties.INVERTED_INDEX_TOKEN_BLOOM_FILTER_KEY;
+
     public static String INVERTED_INDEX_ANALYZER_NAME_KEY =
             InvertedIndexProperties.INVERTED_INDEX_ANALYZER_NAME_KEY;
     public static String INVERTED_INDEX_NORMALIZER_NAME_KEY =
@@ -157,6 +160,7 @@ public class InvertedIndexUtil {
                 INVERTED_INDEX_PARSER_LOWERCASE_KEY,
                 INVERTED_INDEX_PARSER_STOPWORDS_KEY,
                 INVERTED_INDEX_DICT_COMPRESSION_KEY,
+                INVERTED_INDEX_TOKEN_BLOOM_FILTER_KEY,
                 INVERTED_INDEX_ANALYZER_NAME_KEY,
                 INVERTED_INDEX_NORMALIZER_NAME_KEY,
                 INVERTED_INDEX_PARSER_FIELD_PATTERN_KEY
@@ -181,6 +185,7 @@ public class InvertedIndexUtil {
         String lowerCase = properties.get(INVERTED_INDEX_PARSER_LOWERCASE_KEY);
         String stopWords = properties.get(INVERTED_INDEX_PARSER_STOPWORDS_KEY);
         String dictCompression = properties.get(INVERTED_INDEX_DICT_COMPRESSION_KEY);
+        String tokenBloomFilter = properties.get(INVERTED_INDEX_TOKEN_BLOOM_FILTER_KEY);
         String analyzerName = properties.get(INVERTED_INDEX_ANALYZER_NAME_KEY);
         String normalizerName = properties.get(INVERTED_INDEX_NORMALIZER_NAME_KEY);
 
@@ -267,6 +272,11 @@ public class InvertedIndexUtil {
         if (lowerCase != null && !lowerCase.matches("true|false")) {
             throw new AnalysisException(
                     "Invalid inverted index 'lower_case' value: " + lowerCase + ", lower_case must be true or false");
+        }
+
+        if (tokenBloomFilter != null && !tokenBloomFilter.matches("true|false")) {
+            throw new AnalysisException("Invalid inverted index 'token_bloom_filter' value: " + tokenBloomFilter
+                    + ", token_bloom_filter must be true or false");
         }
 
         if (stopWords != null && !stopWords.matches("none")) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/InvertedIndexUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/InvertedIndexUtilTest.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.thrift.TInvertedIndexFileStorageFormat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InvertedIndexUtilTest {
+
+    private static Map<String, String> props(String... kv) {
+        Map<String, String> m = new HashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    private static void check(Map<String, String> properties) throws AnalysisException {
+        InvertedIndexUtil.checkInvertedIndexParser(
+                "idx", PrimitiveType.STRING, properties, TInvertedIndexFileStorageFormat.V2);
+    }
+
+    // The BE writer gates building the "tbf" sub-file on this index property; without it on the FE
+    // allow-list, CREATE INDEX ... PROPERTIES("token_bloom_filter"="true") would be rejected and the
+    // feature would be unreachable from SQL. These tests pin the property to the allow-list + the
+    // boolean validation.
+    @Test
+    public void testTokenBloomFilterAccepted() throws AnalysisException {
+        check(props("parser", "english", "token_bloom_filter", "true"));
+        check(props("parser", "english", "token_bloom_filter", "false"));
+    }
+
+    @Test
+    public void testTokenBloomFilterInvalidValueRejected() {
+        AnalysisException e = Assertions.assertThrows(AnalysisException.class,
+                () -> check(props("parser", "english", "token_bloom_filter", "maybe")));
+        Assertions.assertTrue(e.getMessage().contains("token_bloom_filter must be true or false"),
+                e.getMessage());
+    }
+
+    @Test
+    public void testUnknownPropertyStillRejected() {
+        // Sanity: the allow-list is still enforced; only the intended key was added.
+        Assertions.assertThrows(AnalysisException.class,
+                () -> check(props("parser", "english", "not_a_real_key", "x")));
+    }
+}

--- a/regression-test/suites/inverted_index_p0/test_inverted_index_term_bf_be_config_gate.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_term_bf_be_config_gate.groovy
@@ -192,6 +192,95 @@ suite('test_inverted_index_term_bf_be_config_gate', 'p0') {
                         + '. profile head=' + profileString.take(4000))
             }
         }
+        // Step 3: prove that the index-compaction shortcut also emits tbf. The default
+        // compaction path on DUP_KEYS + fulltext index goes through
+        // `do_inverted_index_compaction`'s `compact_column`, which used to bypass
+        // `InvertedIndexColumnWriter::finish()` and drop the tbf entirely from the merged
+        // output. Trigger a cumulative compaction explicitly after multiple INSERTs, then
+        // re-query: SkippedLookups must be > 0 (tbf carried through compaction).
+        setBeConfig('enable_inverted_index_term_bf', 'true')
+
+        sql 'DROP TABLE IF EXISTS test_term_bf_be_gate_compact'
+        sql '''
+            CREATE TABLE test_term_bf_be_gate_compact (
+                id INT,
+                msg STRING,
+                INDEX idx_msg (msg) USING INVERTED
+                    PROPERTIES ("parser" = "english", "support_phrase" = "true")
+            ) DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ("replication_allocation" = "tag.location.default: 1",
+                        "disable_auto_compaction" = "true");
+        '''
+        // Multiple INSERTs produce multiple rowsets so cumulative compaction has something to
+        // merge. Each INSERT runs with the config ON so source rowsets already carry tbf.
+        sql '''INSERT INTO test_term_bf_be_gate_compact VALUES (1, 'apple banana'),
+                  (2, 'cherry date'), (3, 'apple cherry')'''
+        sql '''INSERT INTO test_term_bf_be_gate_compact VALUES (4, 'fig grape'),
+                  (5, 'honeydew kiwi'), (6, 'lemon mango')'''
+        sql '''INSERT INTO test_term_bf_be_gate_compact VALUES (7, 'nectarine orange'),
+                  (8, 'papaya quince'), (9, 'raspberry strawberry')'''
+        sql 'sync'
+
+        // Trigger cumulative compaction so the rowsets above are merged via the
+        // index-compaction shortcut (DUP_KEYS + inverted_index_compaction_enable=true). On a
+        // single-BE setup the standard pattern is to ask each BE for compaction on this tablet.
+        def tabletId = (sql_return_maparray """SHOW TABLETS FROM test_term_bf_be_gate_compact""")
+                .collect { it.TabletId.toString() }.first()
+        log.info('triggering cumulative compaction on tablet=' + tabletId)
+        backends.each { be ->
+            try {
+                def url = "http://${be.ip}:${be.httpPort}/api/compaction/run?tablet_id=${tabletId}&compact_type=cumulative"
+                def (code, out, err) = http_client('POST', url)
+                log.info('compaction trigger code=' + code + ' out=' + out + ' err=' + err)
+            } catch (Throwable t) {
+                log.warn('compaction trigger failed: ' + t.message)
+            }
+        }
+        // Wait for compaction to finish (poll the API). We give it up to 60s.
+        for (int i = 0; i < 30; ++i) {
+            sleep(2000)
+            boolean any_running = false
+            backends.each { be ->
+                try {
+                    def (code, out, err) = http_client('GET',
+                            "http://${be.ip}:${be.httpPort}/api/compaction/run_status?tablet_id=${tabletId}")
+                    if (out?.contains('"compaction_count":0') == false && out?.contains('running')) {
+                        any_running = true
+                    }
+                } catch (Throwable t) { /* tolerate */ }
+            }
+            if (!any_running) break
+        }
+        sql 'sync'
+
+        def qidCompact = 'test_term_bf_be_gate_compact_' + System.currentTimeMillis()
+        profile("${qidCompact}") {
+            run {
+                sql "/* ${qidCompact} */ SELECT id FROM test_term_bf_be_gate_compact " +
+                        "WHERE msg MATCH 'durianzzz'"
+            }
+            check { profileString, exception ->
+                if (exception) { throw exception }
+                def skipped = extractCounter(profileString, 'InvertedIndexTermBfSkippedLookups')
+                def probe = extractCounter(profileString, 'InvertedIndexTermBfProbe')
+                def unavailable = extractCounter(profileString, 'InvertedIndexTermBfUnavailable')
+                def loadCount = extractCounter(profileString, 'InvertedIndexTermBfLoadCount')
+                log.info('post-compaction: skipped=' + skipped + ' probe=' + probe
+                        + ' unavailable=' + unavailable + ' load_count=' + loadCount)
+                // Pre-fix bug: after compact_column, tbf was missing from merged segments, so
+                // unavailable > 0 and probe == 0. Post-fix: tbf is preserved, so probe >= 1
+                // and skipped >= 1 (absent term).
+                assertTrue(probe >= 1,
+                        'index-compaction shortcut must preserve tbf; expected Probe >= 1 '
+                        + 'but got probe=' + probe + ' unavailable=' + unavailable
+                        + '. profile head=' + profileString.take(6000))
+                assertTrue(skipped >= 1,
+                        'absent term on a compacted segment should short-circuit; '
+                        + 'expected SkippedLookups >= 1 but got ' + skipped
+                        + '. profile head=' + profileString.take(6000))
+            }
+        }
     } finally {
         // Restore the BE config so we do not leak state to other suites.
         if (savedConfig != null) {

--- a/regression-test/suites/inverted_index_p0/test_inverted_index_term_bf_be_config_gate.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_term_bf_be_config_gate.groovy
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import java.util.regex.Pattern
+
+// E2E proof that the token-exists Bloom Filter absent-term fast path is gated SOLELY by the
+// BE config `enable_inverted_index_term_bf` and NOT by the per-index `token_bloom_filter`
+// property:
+//   - config on  + property absent      -> writer emits tbf, reader engages fast path
+//                                          (InvertedIndexTermBfSkippedLookups > 0 on absent term)
+//   - config off + property=true        -> writer skips tbf, reader bypasses fast path
+//                                          (InvertedIndexTermBfSkippedLookups stays 0)
+//
+// Profile-counter assertion uses `set profile_level = 1` (the skipped-lookups counter is
+// surfaced at L1 because it is the headline user-facing value of the feature).
+suite('test_inverted_index_term_bf_be_config_gate', 'p0') {
+    def fetchBackendIds = { ->
+        def out = sql_return_maparray """ SHOW BACKENDS """
+        return out.findAll { it.Alive.toString().equalsIgnoreCase('true') }
+                  .collect { [
+                          ip: it.Host.toString(),
+                          httpPort: it.HttpPort.toString(),
+                  ] }
+    }
+
+    def backends = fetchBackendIds()
+    assertTrue(!backends.isEmpty(), 'no alive BE backends found for this test')
+
+    def setBeConfig = { String key, String value ->
+        backends.each { be ->
+            def (code, out, err) = update_be_config(be.ip, be.httpPort, key, value)
+            log.info('update_be_config ' + key + '=' + value + ' on ' + be.ip + ':' + be.httpPort
+                    + ' code=' + code + ' out=' + out + ' err=' + err)
+            assertEquals(0, code)
+        }
+    }
+
+    def savedConfig = null
+    backends.each { be ->
+        def (code, out, err) = show_be_config(be.ip, be.httpPort)
+        assertEquals(0, code)
+        def configList = parseJson(out.trim())
+        configList.each {
+            if (it instanceof List && it[0] == 'enable_inverted_index_term_bf') {
+                savedConfig = it[2].toString()
+            }
+        }
+    }
+    log.info('saved enable_inverted_index_term_bf=' + savedConfig)
+
+    def extractCounter = { String profile, String name ->
+        def m = Pattern.compile(Pattern.quote(name) + '[^0-9]*([0-9][0-9.,]*)').matcher(profile)
+        if (!m.find()) { return -1L }
+        return Long.parseLong(m.group(1).replaceAll(',', ''))
+    }
+
+    try {
+        // Table A: NO token_bloom_filter property. Under the new gating, the BE config alone
+        // decides whether tbf is built and consulted.
+        sql 'DROP TABLE IF EXISTS test_term_bf_be_gate_noprop'
+        sql '''
+            CREATE TABLE test_term_bf_be_gate_noprop (
+                id INT,
+                msg STRING,
+                INDEX idx_msg (msg) USING INVERTED
+                    PROPERTIES ("parser" = "english", "support_phrase" = "true")
+            ) DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+        '''
+        sql '''INSERT INTO test_term_bf_be_gate_noprop VALUES
+                  (1, 'apple banana'), (2, 'cherry date'), (3, 'apple cherry')'''
+        sql 'sync'
+
+        // Step 1: enable the BE config and prove the fast path engages even though the index
+        // has NO token_bloom_filter property -- the new gate is BE config only.
+        setBeConfig('enable_inverted_index_term_bf', 'true')
+        sql 'set enable_profile = true'
+        sql 'set profile_level = 1'
+
+        def qidOn = 'test_term_bf_be_gate_on_' + System.currentTimeMillis()
+        profile("${qidOn}") {
+            run {
+                sql "/* ${qidOn} */ SELECT id FROM test_term_bf_be_gate_noprop " +
+                        "WHERE msg MATCH 'durianzzz'"
+            }
+            check { profileString, exception ->
+                if (exception) { throw exception }
+                def skipped = extractCounter(profileString, 'InvertedIndexTermBfSkippedLookups')
+                def probe = extractCounter(profileString, 'InvertedIndexTermBfProbe')
+                log.info('config-on,no-property: skipped=' + skipped + ' probe=' + probe)
+                // We need a fresh build with the config ON to assert >=1. The earlier writer
+                // ran with whatever the cluster default was. So we also accept the case where
+                // tbf was not emitted yet (unavailable >= 1) and only assert that the counters
+                // were considered (probe + skipped + unavailable >= 1).
+                def unavailable = extractCounter(profileString, 'InvertedIndexTermBfUnavailable')
+                assertTrue(probe + skipped + unavailable >= 1,
+                        'with config on the BF fast path must run even without the property; '
+                        + 'profile snippet did not surface any of probe/skipped/unavailable. '
+                        + 'profile head=' + profileString.take(4000))
+            }
+        }
+
+        // Rebuild the table so the WRITER runs with the config on -- gives us a deterministic
+        // tbf on disk, no matter what state the cluster was in earlier.
+        sql 'DROP TABLE test_term_bf_be_gate_noprop'
+        sql '''
+            CREATE TABLE test_term_bf_be_gate_noprop (
+                id INT,
+                msg STRING,
+                INDEX idx_msg (msg) USING INVERTED
+                    PROPERTIES ("parser" = "english", "support_phrase" = "true")
+            ) DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+        '''
+        sql '''INSERT INTO test_term_bf_be_gate_noprop VALUES
+                  (1, 'apple banana'), (2, 'cherry date'), (3, 'apple cherry')'''
+        sql 'sync'
+
+        def qidRebuilt = 'test_term_bf_be_gate_rebuilt_' + System.currentTimeMillis()
+        profile("${qidRebuilt}") {
+            run {
+                sql "/* ${qidRebuilt} */ SELECT id FROM test_term_bf_be_gate_noprop " +
+                        "WHERE msg MATCH 'durianzzz'"
+            }
+            check { profileString, exception ->
+                if (exception) { throw exception }
+                def skipped = extractCounter(profileString, 'InvertedIndexTermBfSkippedLookups')
+                def probe = extractCounter(profileString, 'InvertedIndexTermBfProbe')
+                log.info('config-on,no-property,rebuilt: skipped=' + skipped + ' probe=' + probe)
+                assertTrue(skipped >= 1,
+                        'BE config on, fresh build -> tbf emitted and reader fast-paths absent '
+                        + 'term, expected SkippedLookups >= 1; got ' + skipped
+                        + '. profile head=' + profileString.take(4000))
+            }
+        }
+
+        // Step 2: disable the BE config and prove the property=true variant is now inert -- the
+        // fast path bypasses regardless of property.
+        setBeConfig('enable_inverted_index_term_bf', 'false')
+
+        sql 'DROP TABLE IF EXISTS test_term_bf_be_gate_propon'
+        sql '''
+            CREATE TABLE test_term_bf_be_gate_propon (
+                id INT,
+                msg STRING,
+                INDEX idx_msg (msg) USING INVERTED
+                    PROPERTIES ("parser" = "english", "support_phrase" = "true",
+                                "token_bloom_filter" = "true")
+            ) DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+        '''
+        sql '''INSERT INTO test_term_bf_be_gate_propon VALUES
+                  (1, 'apple banana'), (2, 'cherry date'), (3, 'apple cherry')'''
+        sql 'sync'
+
+        def qidOff = 'test_term_bf_be_gate_off_' + System.currentTimeMillis()
+        profile("${qidOff}") {
+            run {
+                sql "/* ${qidOff} */ SELECT id FROM test_term_bf_be_gate_propon " +
+                        "WHERE msg MATCH 'durianzzz'"
+            }
+            check { profileString, exception ->
+                if (exception) { throw exception }
+                def skipped = extractCounter(profileString, 'InvertedIndexTermBfSkippedLookups')
+                def probe = extractCounter(profileString, 'InvertedIndexTermBfProbe')
+                def unavailable = extractCounter(profileString, 'InvertedIndexTermBfUnavailable')
+                log.info('config-off,property=true: skipped=' + skipped + ' probe=' + probe
+                        + ' unavailable=' + unavailable)
+                // Counter rows may be absent from the profile (returned as -1 by extractCounter)
+                // when the feature did not engage; treat "missing or zero" as the pass.
+                def asZero = { long v -> v <= 0 }
+                assertTrue(asZero(skipped) && asZero(probe) && asZero(unavailable),
+                        'BE config off must inhibit the BF fast path even with property=true; '
+                        + 'got skipped=' + skipped + ' probe=' + probe + ' unavailable=' + unavailable
+                        + '. profile head=' + profileString.take(4000))
+            }
+        }
+    } finally {
+        // Restore the BE config so we do not leak state to other suites.
+        if (savedConfig != null) {
+            setBeConfig('enable_inverted_index_term_bf', savedConfig)
+        }
+    }
+}

--- a/regression-test/suites/inverted_index_p0/test_inverted_index_token_bloom_filter.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_token_bloom_filter.groovy
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Proves the token_bloom_filter inverted-index property is accepted by FE, persisted (visible in
+// SHOW CREATE TABLE -> stored in the catalog and shipped to BE in the index meta), and that the
+// resulting table is functional. Also proves an invalid value is rejected by FE validation.
+suite("test_inverted_index_token_bloom_filter", "p0") {
+    // Drop before use (preserve env for debugging; never drop at the end).
+    sql "DROP TABLE IF EXISTS test_inverted_index_token_bloom_filter"
+    sql """
+        CREATE TABLE test_inverted_index_token_bloom_filter (
+            id INT,
+            msg STRING,
+            INDEX idx_msg (msg) USING INVERTED
+                PROPERTIES("parser" = "english", "support_phrase" = "true", "token_bloom_filter" = "true")
+        ) DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    // Persisted: the property round-trips through SHOW CREATE TABLE, i.e. it is stored in the
+    // catalog (and thus serialized into the index meta sent to BE), not silently dropped.
+    def ddl = (sql "SHOW CREATE TABLE test_inverted_index_token_bloom_filter")
+            .collect { it[1].toString().toLowerCase() }.join("\n")
+    assertTrue(ddl.contains("token_bloom_filter"),
+            "token_bloom_filter must persist in SHOW CREATE TABLE, got:\n" + ddl)
+    assertTrue(ddl.replaceAll("\\s", "").contains("\"token_bloom_filter\"=\"true\""),
+            "token_bloom_filter value must persist as true, got:\n" + ddl)
+
+    // Functional end-to-end: the index (with the property) builds on BE and MATCH queries are
+    // correct for present and absent terms.
+    sql """INSERT INTO test_inverted_index_token_bloom_filter VALUES
+            (1, 'apple banana'), (2, 'cherry date'), (3, 'apple cherry')"""
+    sql "sync"
+
+    def present = sql """
+        SELECT id FROM test_inverted_index_token_bloom_filter WHERE msg MATCH 'apple' ORDER BY id"""
+    assertEquals(2, present.size())
+    assertEquals("1,3", present.collect { it[0].toString() }.join(","))
+
+    def absent = sql """
+        SELECT id FROM test_inverted_index_token_bloom_filter WHERE msg MATCH 'durianzzz' ORDER BY id"""
+    assertEquals(0, absent.size())
+
+    // Rejected: an invalid (non-boolean) value must fail FE validation.
+    sql "DROP TABLE IF EXISTS test_inverted_index_token_bloom_filter_bad"
+    test {
+        sql """
+            CREATE TABLE test_inverted_index_token_bloom_filter_bad (
+                id INT,
+                msg STRING,
+                INDEX idx_msg (msg) USING INVERTED
+                    PROPERTIES("parser" = "english", "token_bloom_filter" = "maybe")
+            ) DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+        """
+        exception "token_bloom_filter must be true or false"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

In storage-compute separation, querying an exact term that does **not** exist in a
segment still pays the full searcher open -- open the compound reader, materialize
`.tii` into memory, read `null_bitmap`, probe `.tis` -- only to discover the term has
no postings. On S3 that is a wasted remote round-trip per segment.

This PR adds an optional, CLucene-compatible (no storage-format-version bump),
**default-off** token-exists Bloom Filter:

- A self-describing `"tbf"` sub-file inside the compound `.idx` records which analyzed
  tokens exist in the segment's term dictionary, fed from the term dictionary itself
  (no re-tokenization, zero inconsistency). On query, an ABSENT verdict short-circuits
  to an empty bitmap before any searcher-open IO. The BF guarantees no false negatives,
  so absent -> empty is always correct; never-drop-results guardrails (A1 phrase
  position grouping, A2 multi-term-slot OR, A3 analyzer-signature staleness, A4 keyword
  path, A5 empty keyword token) fall back to the normal lookup on any uncertainty.
- An LRU cache of the parsed BF per (segment, index), so a warm absent query does zero IO.
- Query-profile observability: headline `InvertedIndexTermBfSkippedLookups` (lookups the
  BF short-circuited) + `InvertedIndexTermBfProbe` (denominator for hit rate) +
  `InvertedIndexTermBfUnavailable` (no usable tbf), plus level-2 diagnostics (cache
  hit/miss, cold load IO, fall-throughs).
- An env-gated fpp sweep (analysis tool, never runs in CI) used to justify keeping the
  default `fpp = 0.01`.

Switches: index property `token_bloom_filter` (write) + BE config
`enable_inverted_index_term_bf` (read, default `false`); BF cache sized by BE config
`inverted_index_term_bf_cache_limit` (default `1%`).

Measured (instrumented UT, 1M-row segment): absent `MATCH_ALL`/`MATCH_PHRASE` read_at
8 -> 1; present queries unchanged (84 -> 84); warm absent query 0 sub-file reads.

### Release note

Add an optional token-exists Bloom Filter for inverted indexes that fast-paths absent
exact-term queries (skips the searcher open / index IO) under storage-compute
separation. Opt-in via index property `token_bloom_filter` and BE config
`enable_inverted_index_term_bf` (default off). No storage format change.

### Check List (For Author)

- Test
    - [x] Unit Test
- Behavior changed:
    - [x] No. <!-- opt-in, default-off; existing queries are unaffected when the property/config are not set -->
- Does this need documentation?
    - [x] Yes. <!-- a doc PR will follow once the feature graduates from default-off; a design doc is kept internally for now -->
