### PR TITLE
[fix](be) Rename CPU time profile counter

### DIFF
--- a/be/src/exec/exchange/vdata_stream_recvr.cpp
+++ b/be/src/exec/exchange/vdata_stream_recvr.cpp
@@ -417,7 +417,7 @@ VDataStreamRecvr::VDataStreamRecvr(VDataStreamMgr* stream_mgr,
     _blocks_produced_counter = ADD_COUNTER(_profile, "BlocksProduced", TUnit::UNIT);
     _max_wait_worker_time = ADD_COUNTER(_profile, "MaxWaitForWorkerTime", TUnit::UNIT);
     _max_wait_to_process_time = ADD_COUNTER(_profile, "MaxWaitToProcessTime", TUnit::UNIT);
-    _max_find_recvr_time = ADD_COUNTER(_profile, "MaxFindRecvrTime(NS)", TUnit::UNIT);
+    _max_find_recvr_time = ADD_COUNTER(_profile, "MaxFindRecvrCpuTime(NS)", TUnit::UNIT);
 }
 
 VDataStreamRecvr::~VDataStreamRecvr() {

--- a/be/test/exec/pipeline/vdata_stream_recvr_test.cpp
+++ b/be/test/exec/pipeline/vdata_stream_recvr_test.cpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -89,6 +90,23 @@ TEST_F(DataStreamRecvrTest, TestCreateSenderQueue) {
             EXPECT_EQ(queue->_num_remaining_senders, 1);
         }
     }
+}
+
+TEST_F(DataStreamRecvrTest, CpuTimeCounterNamesAreMarked) {
+    create_recvr(1, false);
+
+    EXPECT_NE(_mock_profile->get_counter("MaxFindRecvrCpuTime(NS)"), nullptr);
+    EXPECT_EQ(_mock_profile->get_counter("MaxFindRecvrTime(NS)"), nullptr);
+    EXPECT_EQ(_mock_profile->get_counter("MaxFindRecvrTime(NS) (Cpu Time)"), nullptr);
+
+    std::stringstream ss;
+    _mock_profile->pretty_print(&ss);
+    const auto profile_text = ss.str();
+    EXPECT_NE(profile_text.find("- MaxFindRecvrCpuTime(NS):"), std::string::npos);
+    EXPECT_EQ(profile_text.find("- MaxFindRecvrTime(NS):"), std::string::npos);
+    EXPECT_EQ(profile_text.find("- MaxFindRecvrTime(NS) (Cpu Time):"), std::string::npos);
+
+    recvr->close();
 }
 
 TEST_F(DataStreamRecvrTest, TestSender) {

--- a/be/test/runtime/runtime_profile_test.cpp
+++ b/be/test/runtime/runtime_profile_test.cpp
@@ -24,12 +24,32 @@
 
 #include "common/exception.h"
 #include "common/object_pool.h"
+#include "runtime/runtime_profile_counter_names.h"
 
 using namespace std;
 
 namespace doris {
 
 class RuntimeProfileTest : public testing::Test {};
+
+TEST(RuntimeProfileTest, CpuTimeCounterNamesAreMarked) {
+    RuntimeProfile profile("ProfileWithCpuTime");
+    ADD_TIMER(&profile, profile::TASK_CPU_TIME)->set(int64_t {1000});
+    ADD_TIMER(&profile, profile::SCANNER_CPU_TIME)->set(int64_t {2000});
+
+    EXPECT_NE(profile.get_counter("TaskCpuTime"), nullptr);
+    EXPECT_NE(profile.get_counter("ScannerCpuTime"), nullptr);
+    EXPECT_EQ(profile.get_counter("TaskCpuTime (Cpu Time)"), nullptr);
+    EXPECT_EQ(profile.get_counter("ScannerCpuTime (Cpu Time)"), nullptr);
+
+    std::stringstream ss;
+    profile.pretty_print(&ss);
+    const auto profile_text = ss.str();
+    EXPECT_NE(profile_text.find("- TaskCpuTime:"), std::string::npos);
+    EXPECT_NE(profile_text.find("- ScannerCpuTime:"), std::string::npos);
+    EXPECT_EQ(profile_text.find("- TaskCpuTime (Cpu Time):"), std::string::npos);
+    EXPECT_EQ(profile_text.find("- ScannerCpuTime (Cpu Time):"), std::string::npos);
+}
 
 TEST(RuntimeProfileTest, Basic) {
     RuntimeProfile profile_a("ProfileA");

--- a/regression-test/suites/query_profile/scanner_profile.groovy
+++ b/regression-test/suites/query_profile/scanner_profile.groovy
@@ -77,6 +77,7 @@ suite('scanner_profile') {
     List profileData = profileAction.getProfileList()
     def profileWithLimit1 = getProfileByToken(token)
     logger.info("${token} Profile Data: ${profileWithLimit1}")
+    assertTrue(profileWithLimit1.toString().contains("- TaskCpuTime:"))
     assertTrue(profileWithLimit1.toString().contains("- MaxScanConcurrency: 1"))
 
     token = UUID.randomUUID().toString()
@@ -86,10 +87,14 @@ suite('scanner_profile') {
 
     String profileWithFilter = getProfileByToken(token)
     logger.info("${token} Profile Data: ${profileWithFilter}")
+    assertTrue(profileWithFilter.toString().contains("- TaskCpuTime:"))
+    assertTrue(profileWithFilter.toString().contains("- ScannerCpuTime:"))
+    assertFalse(profileWithFilter.toString().contains("- TaskCpuTime (Cpu Time):"))
+    assertFalse(profileWithFilter.toString().contains("- ScannerCpuTime (Cpu Time):"))
     // Verify actualRows is backfilled onto the scan node. The exact value is
     // unstable because 9 INT keys hash-distribute into 10 buckets and a few
     // tablets may be pruned at runtime, so only assert it is in [1, 9].
-    def matcher = (profileWithFilter.toString() =~ /PhysicalOlapScan\[scanner_profile\][^\n]*actualRows=(\d+)/)
+    def matcher = (profileWithFilter.toString() =~ /PhysicalOlapScan[^\n]*scanner_profile[^\n]*actualRows=(\d+)/)
     assertTrue(matcher.find(), "actualRows not found on PhysicalOlapScan[scanner_profile] in profile")
     int actualRows = matcher.group(1) as int
     assertTrue(actualRows >= 1 && actualRows <= 9,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Runtime profiles had a CPU-time counter named MaxFindRecvrTime(NS), while the naming convention for CPU-time counters is to include CpuTime directly in the counter name. This makes it hard to distinguish CPU-time counters from wall-time counters by name. Rename the exchange receiver counter to MaxFindRecvrCpuTime(NS), keep existing TaskCpuTime and ScannerCpuTime names without an extra suffix, and cover the expected profile names in BE unit tests and the existing scanner profile regression test.
