### PR TITLE
[fix](be) Fix undefined _Unwind_* symbols in UBSAN and LSAN builds

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -773,11 +773,23 @@ endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(ASAN_LIBS -static-libasan)
-    set(LSAN_LIBS -static-liblsan)
-    set(UBSAN_LIBS -static-libubsan ${MALLOCLIB})
+    set(LSAN_LIBS -static-liblsan -lgcc_eh)
+    set(UBSAN_LIBS -static-libubsan -lgcc_eh ${MALLOCLIB})
     set(TSAN_LIBS -static-libtsan)
 else ()
-    set(UBSAN_LIBS -rtlib=compiler-rt ${MALLOCLIB})
+    # Clang: Linux needs -lgcc_eh, macOS does not
+    if (OS_LINUX)
+        set(ASAN_LIBS -rtlib=compiler-rt -lgcc_eh)
+        set(LSAN_LIBS -rtlib=compiler-rt -lgcc_eh)
+        set(UBSAN_LIBS -rtlib=compiler-rt -lgcc_eh ${MALLOCLIB})
+        set(TSAN_LIBS -rtlib=compiler-rt -lgcc_eh)
+    else ()
+        # macOS and other platforms: no -lgcc_eh
+        set(ASAN_LIBS -rtlib=compiler-rt)
+        set(LSAN_LIBS -rtlib=compiler-rt)
+        set(UBSAN_LIBS -rtlib=compiler-rt ${MALLOCLIB})
+        set(TSAN_LIBS -rtlib=compiler-rt)
+    endif ()
 endif ()
 
 # Add sanitize static link flags

--- a/be/src/util/debug/leak_annotations.h
+++ b/be/src/util/debug/leak_annotations.h
@@ -38,8 +38,6 @@
 #undef ANNOTATE_LEAKING_OBJECT_PTR
 #define ANNOTATE_LEAKING_OBJECT_PTR(p) __lsan_ignore_object(p);
 
-#endif // DORIS_LSAN_ENABLED && __linux__
-
 // API definitions from LLVM lsan_interface.h
 
 extern "C" {
@@ -77,12 +75,22 @@ void __lsan_do_leak_check();
 int __lsan_do_recoverable_leak_check();
 } // extern "C"
 
+#endif // DORIS_LSAN_ENABLED && __linux__
+
 namespace doris::debug {
 
 class ScopedLSANDisabler {
 public:
-    ScopedLSANDisabler() { __lsan_disable(); }
-    ~ScopedLSANDisabler() { __lsan_enable(); }
+    ScopedLSANDisabler() {
+#if defined(DORIS_LSAN_ENABLED) && defined(__linux__)
+        __lsan_disable();
+#endif
+    }
+    ~ScopedLSANDisabler() {
+#if defined(DORIS_LSAN_ENABLED) && defined(__linux__)
+        __lsan_enable();
+#endif
+    }
 };
 
 } // namespace doris::debug

--- a/cloud/CMakeLists.txt
+++ b/cloud/CMakeLists.txt
@@ -357,11 +357,23 @@ endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(ASAN_LIBS -static-libasan)
-    set(LSAN_LIBS -static-liblsan)
-    set(UBSAN_LIBS -static-libubsan ${MALLOCLIB})
+    set(LSAN_LIBS -static-liblsan -lgcc_eh)
+    set(UBSAN_LIBS -static-libubsan -lgcc_eh ${MALLOCLIB})
     set(TSAN_LIBS -static-libtsan)
 else ()
-    set(UBSAN_LIBS -rtlib=compiler-rt ${MALLOCLIB})
+    # Clang: Linux needs -lgcc_eh, macOS does not
+    if (OS_LINUX)
+        set(ASAN_LIBS -rtlib=compiler-rt -lgcc_eh)
+        set(LSAN_LIBS -rtlib=compiler-rt -lgcc_eh)
+        set(UBSAN_LIBS -rtlib=compiler-rt -lgcc_eh ${MALLOCLIB})
+        set(TSAN_LIBS -rtlib=compiler-rt -lgcc_eh)
+    else ()
+        # macOS and other platforms: no -lgcc_eh
+        set(ASAN_LIBS -rtlib=compiler-rt)
+        set(LSAN_LIBS -rtlib=compiler-rt)
+        set(UBSAN_LIBS -rtlib=compiler-rt ${MALLOCLIB})
+        set(TSAN_LIBS -rtlib=compiler-rt)
+    endif ()
 endif ()
 
 # Add sanitize static link flags or tcmalloc


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #64239

Problem Summary: When building BE unit tests in UBSAN mode, the linker reports undefined `_Unwind_*` symbols, causing the build to fail. The same issue also affects LSAN builds, and potentially ASAN and TSAN builds with Clang.

The root cause is that the sanitizer link flags in `CMakeLists.txt` do not include `-lgcc_eh`, which provides the `_Unwind_*` family of symbols. These symbols are required by:

1. `libclang_rt.ubsan_standalone` (references `_Unwind_Backtrace`, `_Unwind_GetIP`)
2. `libprofiler.a` from gperftools (references `_Unwind_Backtrace`, `_Unwind_GetIP`)
3. `libglog.a` (references `_Unwind_GetIP`)
4. `libstdc++.a` (references `_Unwind_Resume`, `_Unwind_RaiseException`, `_Unwind_Resume_or_Rethrow`, `_Unwind_GetTextRelBase`, `_Unwind_GetRegionStart`, `_Unwind_GetDataRelBase`, `_Unwind_SetGR`, `_Unwind_SetIP`, `_Unwind_GetLanguageSpecificData`, `_Unwind_GetIPInfo`, `_Unwind_DeleteException`)

For GCC builds, `-lgcc_eh` is added to `LSAN_LIBS` and `UBSAN_LIBS`. For Clang builds, `-lgcc_eh` is added to all sanitizer libs (`ASAN_LIBS`, `LSAN_LIBS`, `UBSAN_LIBS`, `TSAN_LIBS`) because when using `-rtlib=compiler-rt`, the compiler-rt runtime does not include unwind support by default.

## What is changed and how it works?

In `be/CMakeLists.txt` and `cloud/CMakeLists.txt`:

- GCC path: Add `-lgcc_eh` to `LSAN_LIBS` and `UBSAN_LIBS`
- Clang path: Add `-lgcc_eh` to `ASAN_LIBS`, `LSAN_LIBS`, `UBSAN_LIBS`, and `TSAN_LIBS`

## Check List (For Author)

- Test: Manual test
    - Built BE UT in UBSAN mode successfully after the fix
    be ut log after fix:
    
[ubsan-unwind-symbols_UBSAN_be_ut.log](https://github.com/user-attachments/files/29963503/ubsan-unwind-symbols_UBSAN_be_ut.log)

- Behavior changed: No
- Does this need documentation: No

## Check List (For Reviewer)

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR will not break any existing functionality

## Release note

None