### PR TITLE
bound sparse register index in HyperLogLog deserialize

### DIFF
--- a/be/src/core/value/hll.cpp
+++ b/be/src/core/value/hll.cpp
@@ -293,6 +293,9 @@ bool HyperLogLog::deserialize(const Slice& slice) {
             // 1 byte: register value
             uint16_t register_idx = decode_fixed16_le(ptr);
             ptr += 2;
+            if (register_idx >= HLL_REGISTERS_COUNT) {
+                return false;
+            }
             _registers[register_idx] = *ptr++;
         }
         break;

--- a/be/test/core/value/hll_test.cpp
+++ b/be/test/core/value/hll_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest-test-part.h>
 
 #include "gtest/gtest_pred_impl.h"
+#include "util/coding.h"
 #include "util/hash_util.hpp"
 #include "util/slice.h"
 
@@ -204,6 +205,27 @@ TEST_F(TestHll, InvalidPtr) {
         HyperLogLog hll(Slice(buf, 1));
         EXPECT_EQ(0, hll.estimate_cardinality());
     }
+}
+
+// A crafted sparse encoding can carry a register index past HLL_REGISTERS_COUNT.
+// is_valid only checks the slice length, so deserialize is the layer that has to
+// reject the index, otherwise it writes out of bounds of the register array.
+TEST_F(TestHll, SparseRegisterIndexOutOfRange) {
+    uint8_t buf[8];
+    uint8_t* ptr = buf;
+    *ptr++ = HLL_DATA_SPARSE;
+    encode_fixed32_le(ptr, 1); // a single register entry
+    ptr += 4;
+    encode_fixed16_le(ptr, HLL_REGISTERS_COUNT); // one past the last valid index
+    ptr += 2;
+    *ptr++ = 0x41; // register value
+
+    Slice str((char*)buf, ptr - buf);
+    // the length is well-formed, only the index is out of range
+    EXPECT_TRUE(HyperLogLog::is_valid(str));
+
+    HyperLogLog hll(str);
+    EXPECT_EQ(0, hll.estimate_cardinality());
 }
 
 } // namespace doris


### PR DESCRIPTION
Reading an HLL_DATA_SPARSE blob in HyperLogLog::deserialize, the loop pulls a uint16 register index and an 8-bit value per entry and writes straight into _registers, a 16384-byte array sized to HLL_REGISTERS_COUNT. The only guard ahead of it is is_valid(), which validates the slice length (5 + 3*num_registers) but never inspects the index value, so any index from 16384 up to 65535 passes through. I traced this back from the column deserialisation paths that feed serialised HLL bytes in again, and a crafted sparse entry lands the write up to roughly 49KB beyond the allocation, with both the offset and the byte under the caller's control.

The index has to be bounded where the write happens. is_valid() is deliberately O(1) and several callers reach deserialize without going through it, so moving the check there would miss them; rejecting an out-of-range index inside deserialize closes the write on every path. A guard-page run confirmed the unpatched code faults on the very first index of 16384 while is_valid() still reports the blob as well formed. Left alone this is a heap out-of-bounds write reachable from attacker-influenced HLL data, which sits at the corruption end of the scale rather than a benign crash.