### PR TITLE
[fix](core): fix cumu policy npe when do binlog schedule

### DIFF
--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -1205,6 +1205,17 @@ uint32_t Tablet::calc_compaction_score(CompactionType compaction_type,
 bool Tablet::suitable_for_compaction(
         CompactionType compaction_type,
         std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
+#ifndef BE_TEST
+    if (compaction_type == CompactionType::CUMULATIVE_COMPACTION &&
+        cumulative_compaction_policy != nullptr) {
+        std::lock_guard<std::shared_mutex> wrlock(_meta_lock);
+        if (_cumulative_compaction_policy == nullptr ||
+            _cumulative_compaction_policy->name() != cumulative_compaction_policy->name()) {
+            _cumulative_compaction_policy = cumulative_compaction_policy;
+        }
+    }
+#endif
+
     // Need meta lock, because it will iterator "all_rs_metas" of tablet meta.
     std::shared_lock rdlock(_meta_lock);
     int32_t score = -1;
@@ -1252,12 +1263,6 @@ uint32_t Tablet::_calc_cumulative_compaction_score(
     if (cumulative_compaction_policy == nullptr) [[unlikely]] {
         return 0;
     }
-#ifndef BE_TEST
-    if (_cumulative_compaction_policy == nullptr ||
-        _cumulative_compaction_policy->name() != cumulative_compaction_policy->name()) {
-        _cumulative_compaction_policy = cumulative_compaction_policy;
-    }
-#endif
     DBUG_EXECUTE_IF("Tablet._calc_cumulative_compaction_score.return", {
         LOG_WARNING("Tablet._calc_cumulative_compaction_score.return")
                 .tag("tablet id", tablet_id());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Tablet cumulative policy may not be initialized during binlog scheduling

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

