### PR TITLE
[fix](function) keep struct_element as an alias of element_at

### DIFF
--- a/be/src/exprs/function/array/function_array_element.cpp
+++ b/be/src/exprs/function/array/function_array_element.cpp
@@ -24,6 +24,8 @@ namespace doris {
 void register_function_array_element(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionArrayElement>();
     factory.register_alias(FunctionArrayElement::name, "%element_extract%");
+    // struct_element was merged into element_at in #64027; keep it as an alias
+    factory.register_alias(FunctionArrayElement::name, "struct_element");
 }
 
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -774,7 +774,8 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(Dround.class, "dround"),
             scalar(Dsqrt.class, "dsqrt"),
             scalar(E.class, "e"),
-            scalar(ElementAt.class, "element_at"),
+            // struct_element was merged into element_at in #64027; keep it as an alias
+            scalar(ElementAt.class, "element_at", "struct_element"),
             scalar(Elt.class, "elt"),
             scalar(Embed.class, "embed"),
             scalar(EncodeAsSmallInt.class, "encode_as_smallint"),

--- a/regression-test/data/query_p0/sql_functions/struct_functions/test_struct_functions.out
+++ b/regression-test/data/query_p0/sql_functions/struct_functions/test_struct_functions.out
@@ -39,6 +39,38 @@ a	\N	abc
 \N	\N	\N
 NULL	null	\N
 
+-- !select_struct_element_alias_1 --
+1	2	3	4	5
+1	1000	10000000	100000000000	100000000000
+5	4	3	2	1
+1	\N	3	\N	5
+\N	\N	\N	\N	\N
+\N	\N	\N	\N	\N
+
+-- !select_struct_element_alias_2 --
+1.0	3.33	0.001
+1.0	2.143	0.001
+2.3	23.3	0.333
+2.0	\N	0.001
+\N	\N	\N
+\N	\N	\N
+
+-- !select_struct_element_alias_3 --
+2023-04-01	2023-04-01T12:00	2023-04-01	2023-04-01T12:00:01
+2023-04-01	2023-04-01T12:00	2023-04-01	2023-04-01T12:00:01
+2023-04-01	2023-04-01T12:00	2023-04-01	2023-04-01T12:00:01
+2023-04-01	\N	2023-04-01	\N
+\N	\N	\N	\N
+\N	\N	\N	\N
+
+-- !select_struct_element_alias_4 --
+a	abc	abc
+hi	doris	hello doris
+a	abc	abc
+a	\N	abc
+\N	\N	\N
+NULL	null	\N
+
 -- !select_struct_subscript_1 --
 1	2	3	4	5
 1	1000	10000000	100000000000	100000000000

--- a/regression-test/suites/query_p0/sql_functions/struct_functions/test_struct_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/struct_functions/test_struct_functions.groovy
@@ -48,6 +48,13 @@ suite("test_struct_functions") {
     qt_select_element_at_3 "SELECT element_at(k4,1),element_at(k4,2),element_at(k4,3),element_at(k4,4) FROM ${tableName} ORDER BY k1"
     qt_select_element_at_4 "SELECT element_at(k5,1),element_at(k5,2),element_at(k5,3) FROM ${tableName} ORDER BY k1"
 
+    // #64027: struct_element was merged into element_at. It is kept as an alias of element_at so old
+    // SQL/views still work after upgrade; these must return exactly the same as the element_at cases.
+    qt_select_struct_element_alias_1 "SELECT struct_element(k2,'f1'),struct_element(k2,'f2'),struct_element(k2,'f3'),struct_element(k2,'f4'),struct_element(k2,'f5') FROM ${tableName} ORDER BY k1"
+    qt_select_struct_element_alias_2 "SELECT struct_element(k3,'f1'),struct_element(k3,'f2'),struct_element(k3,'f3') FROM ${tableName} ORDER BY k1"
+    qt_select_struct_element_alias_3 "SELECT struct_element(k4,1),struct_element(k4,2),struct_element(k4,3),struct_element(k4,4) FROM ${tableName} ORDER BY k1"
+    qt_select_struct_element_alias_4 "SELECT struct_element(k5,1),struct_element(k5,2),struct_element(k5,3) FROM ${tableName} ORDER BY k1"
+
     // DORIS-26105: subscript syntax `s['field']` / `s[index]` on STRUCT should work the same as
     // element_at and must not crash the BE (especially for NULL struct rows).
     qt_select_struct_subscript_1 "SELECT k2['f1'],k2['f2'],k2['f3'],k2['f4'],k2['f5'] FROM ${tableName} ORDER BY k1"


### PR DESCRIPTION
#64027 merged struct_element into element_at and removed the struct_element function entirely. Users upgrading from an older version whose SQL / views still reference struct_element then fail with "function not found".

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

