### PR TITLE
[fix](nereids) strip NULL access path when OFFSET path exists for the same field in NestedColumnPruning

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
@@ -275,7 +275,7 @@ public class NestedColumnPruning implements CustomRewriter {
             Slot slot = kv.getKey();
             DataTypeAccessTree accessTree = kv.getValue();
             DataType prunedDataType = accessTree.pruneDataType().orElse(slot.getDataType());
-
+            stripNullSuffixPaths(slot, allAccessPaths);
             if (slot.getDataType().isStringLikeType()) {
                 if (accessTree.hasStringOffsetOnlyAccess()) {
                     if (skipDataSkippingOnlyAccessPath) {
@@ -284,7 +284,6 @@ public class NestedColumnPruning implements CustomRewriter {
                     // Offset-only access (e.g. length(str_col)): type stays varchar,
                     // but we must still send the access path to BE so it skips the char data.
                     stripExactCoveredDataSkippingSuffixPaths(slot, allAccessPaths, allAccessPaths);
-                    stripNullSuffixPaths(slot, allAccessPaths);
                     List<ColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
                     result.put(slot.getExprId().asInt(),
                             new AccessPathInfo(slot.getDataType(), allPaths, new ArrayList<>()));
@@ -359,9 +358,6 @@ public class NestedColumnPruning implements CustomRewriter {
             // of gating this logic on the root slot type.
             stripCoveredOffsetSuffixPaths(slot, allAccessPaths, allAccessPaths);
 
-            // Strip NULL-suffix paths when a non-NULL path also exists for the same slot.
-            // E.g. `SELECT col FROM t WHERE col IS NULL` — full data is needed, NULL path is redundant.
-            stripNullSuffixPaths(slot, allAccessPaths);
             List<ColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
             if (shouldSkipAccessInfo(slot, prunedDataType, allPaths, predicateAccessPaths)) {
                 continue;

--- a/regression-test/data/nereids_rules_p0/column_pruning/string_length_column_pruning.out
+++ b/regression-test/data/nereids_rules_p0/column_pruning/string_length_column_pruning.out
@@ -65,3 +65,18 @@ true
 4
 5
 
+-- !cardinality_arr_col --
+3	false
+
+-- !cardinality_map_col --
+2	false
+
+-- !length_struct_f3 --
+5	false
+
+-- !cardinality_struct_arr --
+2	false
+
+-- !cardinality_struct_m --
+2	false
+

--- a/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
@@ -662,4 +662,81 @@ suite("string_length_column_pruning") {
         contains "OFFSET"
     }
     order_qt_length_varchar "select length(v) from slcp_varchar_tbl"
+
+    // ─── OFFSET covers NULL across all complex data types ──────────────────────
+    //
+    // When both OFFSET and NULL access paths exist for the same field/subfield,
+    // the NULL path is redundant because the OFFSET data already provides
+    // nullness information for variable-length columns. stripNullSuffixPaths()
+    // removes [col.NULL] when [col.OFFSET] exists for the same prefix.
+    //
+    // This applies uniformly to all complex data types: array, map, struct
+    // subfields of string, array, and map.
+
+    // Array root: cardinality(arr_col) -> [arr_col.OFFSET]
+    //             arr_col IS NULL      -> [arr_col.NULL]
+    // OFFSET covers NULL → [arr_col.NULL] must not appear.
+    explain {
+        sql "select cardinality(arr_col), arr_col is null from slcp_str_tbl"
+        contains "nested columns"
+        contains "arr_col.OFFSET"
+        notContains "arr_col.NULL"
+    }
+    sql "select cardinality(arr_col), arr_col is null from slcp_str_tbl"
+
+    // Map root: cardinality(map_col) -> [map_col.OFFSET]
+    //           map_col IS NULL      -> [map_col.NULL]
+    // OFFSET covers NULL → [map_col.NULL] must not appear.
+    explain {
+        sql "select cardinality(map_col), map_col is null from slcp_str_tbl"
+        contains "nested columns"
+        contains "map_col.OFFSET"
+        notContains "map_col.NULL"
+    }
+    sql "select cardinality(map_col), map_col is null from slcp_str_tbl"
+
+    // Struct string subfield: length(element_at(struct_col, 'f3')) -> [struct_col.f3.OFFSET]
+    //                         element_at(struct_col, 'f3') IS NULL  -> [struct_col.f3.NULL]
+    // OFFSET covers NULL → [struct_col.f3.NULL] must not appear.
+    explain {
+        sql """select length(element_at(struct_col, 'f3')),
+                     element_at(struct_col, 'f3') is null
+              from slcp_str_tbl"""
+        contains "nested columns"
+        contains "OFFSET"
+        notContains "struct_col.f3.NULL"
+    }
+    sql """select length(element_at(struct_col, 'f3')),
+                 element_at(struct_col, 'f3') is null
+          from slcp_str_tbl"""
+
+    // Struct array subfield: cardinality(element_at(s, 'arr')) -> [s.arr.OFFSET]
+    //                        element_at(s, 'arr') IS NULL      -> [s.arr.NULL]
+    // OFFSET covers NULL → [s.arr.NULL] must not appear.
+    explain {
+        sql """select cardinality(element_at(s, 'arr')),
+                     element_at(s, 'arr') is null
+              from slcp_struct_root_tbl"""
+        contains "nested columns"
+        contains "OFFSET"
+        notContains "s.arr.NULL"
+    }
+    sql """select cardinality(element_at(s, 'arr')),
+                 element_at(s, 'arr') is null
+          from slcp_struct_root_tbl"""
+
+    // Struct map subfield: cardinality(element_at(s, 'm')) -> [s.m.OFFSET]
+    //                      element_at(s, 'm') IS NULL      -> [s.m.NULL]
+    // OFFSET covers NULL → [s.m.NULL] must not appear.
+    explain {
+        sql """select cardinality(element_at(s, 'm')),
+                     element_at(s, 'm') is null
+              from slcp_struct_root_tbl"""
+        contains "nested columns"
+        contains "OFFSET"
+        notContains "s.m.NULL"
+    }
+    sql """select cardinality(element_at(s, 'm')),
+                 element_at(s, 'm') is null
+          from slcp_struct_root_tbl"""
 }

--- a/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
@@ -682,7 +682,7 @@ suite("string_length_column_pruning") {
         contains "arr_col.OFFSET"
         notContains "arr_col.NULL"
     }
-    sql "select cardinality(arr_col), arr_col is null from slcp_str_tbl"
+    order_qt_cardinality_arr_col "select cardinality(arr_col), arr_col is null from slcp_str_tbl"
 
     // Map root: cardinality(map_col) -> [map_col.OFFSET]
     //           map_col IS NULL      -> [map_col.NULL]
@@ -693,7 +693,7 @@ suite("string_length_column_pruning") {
         contains "map_col.OFFSET"
         notContains "map_col.NULL"
     }
-    sql "select cardinality(map_col), map_col is null from slcp_str_tbl"
+    order_qt_cardinality_map_col "select cardinality(map_col), map_col is null from slcp_str_tbl"
 
     // Struct string subfield: length(element_at(struct_col, 'f3')) -> [struct_col.f3.OFFSET]
     //                         element_at(struct_col, 'f3') IS NULL  -> [struct_col.f3.NULL]
@@ -706,7 +706,8 @@ suite("string_length_column_pruning") {
         contains "OFFSET"
         notContains "struct_col.f3.NULL"
     }
-    sql """select length(element_at(struct_col, 'f3')),
+    order_qt_length_struct_f3 """
+          select length(element_at(struct_col, 'f3')),
                  element_at(struct_col, 'f3') is null
           from slcp_str_tbl"""
 
@@ -721,7 +722,7 @@ suite("string_length_column_pruning") {
         contains "OFFSET"
         notContains "s.arr.NULL"
     }
-    sql """select cardinality(element_at(s, 'arr')),
+    order_qt_cardinality_struct_arr """select cardinality(element_at(s, 'arr')),
                  element_at(s, 'arr') is null
           from slcp_struct_root_tbl"""
 
@@ -736,7 +737,7 @@ suite("string_length_column_pruning") {
         contains "OFFSET"
         notContains "s.m.NULL"
     }
-    sql """select cardinality(element_at(s, 'm')),
+    order_qt_cardinality_struct_m """select cardinality(element_at(s, 'm')),
                  element_at(s, 'm') is null
           from slcp_struct_root_tbl"""
 }


### PR DESCRIPTION

stripNullSuffixPaths() already contains the logic to remove [col.NULL] when [col.OFFSET] covers the same prefix (lines 834-839), but it was only called in the string-like and general branches, not in the array/map early-continue branch. This caused queries like `SELECT cardinality(arr), arr IS NULL` to emit redundant [arr.NULL] alongside [arr.OFFSET] in the access paths.

Fix: move stripNullSuffixPaths() call to line 278 (before all type-specific early-continue branches) so it applies uniformly to all complex data types.

Add regression tests covering array root, map root, struct string subfield, struct array subfield, and struct map subfield.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

