### PR TITLE
[fix](be) Preserve variant structure in row copy

### DIFF
--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -458,6 +458,10 @@ void ColumnVariant::Subcolumn::insert_range_from(const Subcolumn& src, size_t st
     if (pos < src.data.size() && processed_rows < end) {
         size_t part_end = end - processed_rows;
         insert_from_part(src.data[pos], src.data_types[pos], 0, part_end);
+        processed_rows = end;
+    }
+    if (processed_rows < end) {
+        data.back()->insert_many_defaults(end - processed_rows);
     }
 }
 
@@ -839,7 +843,7 @@ void ColumnVariant::for_each_subcolumn(ColumnCallback callback) {
 }
 
 void ColumnVariant::insert_from(const IColumn& src, size_t n) {
-    const auto* src_v = assert_cast<const ColumnVariant*>(&src);
+    const auto* src_v = check_and_get_column<ColumnVariant>(src);
     ENABLE_CHECK_CONSISTENCY(src_v);
     ENABLE_CHECK_CONSISTENCY(this);
     // Preserve the original root-only copy path for ordinary variant columns.
@@ -855,7 +859,7 @@ void ColumnVariant::insert_from(const IColumn& src, size_t n) {
         serialized_doc_value_column->insert_from(*src_v->get_doc_value_column(), n);
         num_rows++;
     } else {
-        try_insert((*src_v)[n]);
+        insert_range_from(*src_v, n, 1);
     }
     ENABLE_CHECK_CONSISTENCY(this);
 }

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -1066,6 +1066,61 @@ TEST_F(ColumnVariantTest, test_insert_indices_from) {
     }
 }
 
+TEST_F(ColumnVariantTest, insert_range_from_materializes_pending_default_suffix) {
+    auto nested = ColumnInt64::create();
+    nested->insert_value(7);
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(0);
+
+    auto root_type = make_nullable(std::make_shared<DataTypeInt64>());
+    auto root_column = ColumnNullable::create(std::move(nested), std::move(null_map));
+    ColumnVariant::Subcolumn root(std::move(root_column), root_type, true, true);
+    root.increment_default_counter();
+
+    ColumnVariant::Subcolumns subcolumns;
+    subcolumns.create_root(std::move(root));
+    auto src = ColumnVariant::create(0, false, std::move(subcolumns));
+    EXPECT_EQ(src->size(), 2);
+
+    auto dst = ColumnVariant::create(0, false);
+    dst->insert_range_from(*src, 0, 2);
+    dst->finalize();
+
+    const auto& copied_root =
+            assert_cast<const ColumnNullable&>(*static_cast<const ColumnVariant&>(*dst).get_root());
+    EXPECT_EQ(copied_root.size(), 2);
+    EXPECT_EQ(copied_root.get_null_map_data()[0], 0);
+    EXPECT_EQ(copied_root.get_null_map_data()[1], 1);
+}
+
+TEST_F(ColumnVariantTest, insert_from_preserves_sparse_limit_for_object_rows) {
+    auto src = ColumnVariant::create(0, false);
+    auto row = VariantUtil::construct_variant_map({
+            {"v.a", VariantUtil::get_field("int")},
+            {"v.b", VariantUtil::get_field("string")},
+            {"v.c", VariantUtil::get_field("array_str")},
+    });
+    src->try_insert(row);
+
+    auto dst = ColumnVariant::create(1, false);
+    dst->insert_from(*src, 0);
+
+    EXPECT_EQ(dst->size(), 1);
+    EXPECT_EQ(dst->get_subcolumns().size(), 2);
+    const auto& [sparse_paths, sparse_values] = dst->get_sparse_data_paths_and_values();
+    EXPECT_EQ(sparse_paths->size(), 2);
+    EXPECT_EQ(sparse_values->size(), 2);
+
+    Field copied;
+    dst->get(0, copied);
+    ASSERT_EQ(copied.get_type(), PrimitiveType::TYPE_VARIANT);
+    const auto& copied_object = copied.get<TYPE_VARIANT>();
+    EXPECT_EQ(copied_object.size(), 3);
+    EXPECT_NE(copied_object.find(PathInData("v.a")), copied_object.end());
+    EXPECT_NE(copied_object.find(PathInData("v.b")), copied_object.end());
+    EXPECT_NE(copied_object.find(PathInData("v.c")), copied_object.end());
+}
+
 TEST_F(ColumnVariantTest, is_variable_length) {
     EXPECT_TRUE(column_variant->is_variable_length());
 }

--- a/regression-test/suites/variant_p0/test_variant_sparse_sort_insert_from.groovy
+++ b/regression-test/suites/variant_p0/test_variant_sparse_sort_insert_from.groovy
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_variant_sparse_sort_insert_from", "p0") {
+    sql "set experimental_enable_nereids_planner=true"
+    sql "set enable_fallback_to_original_planner=false"
+    sql "set batch_size=4064"
+    sql "set broker_load_batch_size=16352"
+    sql "set enable_broadcast_join_force_passthrough=true"
+    sql "set enable_distinct_streaming_aggregation=true"
+    sql "set enable_distinct_streaming_agg_force_passthrough=false"
+    sql "set enable_streaming_agg_hash_join_force_passthrough=false"
+    sql "set experimental_parallel_scan_max_scanners_count=8"
+    sql "set experimental_parallel_scan_min_rows_per_scanner=256"
+    sql "set experimental_use_serial_exchange=true"
+    sql "set enable_fold_constant_by_be=true"
+    sql "set enable_force_spill=true"
+    sql "set enable_reserve_memory=false"
+    sql "set enable_runtime_filter_prune=false"
+    sql "set enable_share_hash_table_for_broadcast_join=false"
+    sql "set parallel_prepare_threshold=18"
+    sql "set rewrite_or_to_in_predicate_threshold=100000"
+    sql "set runtime_filter_type='BLOOM_FILTER,MIN_MAX'"
+    sql "set short_circuit_evaluation=true"
+    sql "set spill_min_revocable_mem=1048576"
+    sql "set topn_opt_limit_threshold=1000"
+    sql "set default_variant_enable_doc_mode=false"
+    sql "set default_variant_doc_hash_shard_count=0"
+    sql "set default_variant_max_subcolumns_count=1"
+    sql "set default_variant_sparse_hash_shard_count=2"
+    sql "set use_v3_storage_format=false"
+    sql "set parallel_pipeline_task_num=2"
+    sql "set enable_spill=true"
+
+    sql "DROP TABLE IF EXISTS test_variant_sparse_sort_insert_from"
+    sql """
+        CREATE TABLE test_variant_sparse_sort_insert_from (
+            k bigint,
+            v variant
+        )
+        DUPLICATE KEY(`k`)
+        DISTRIBUTED BY HASH(k) BUCKETS 6
+        properties("replication_num" = "1", "disable_auto_compaction" = "false");
+    """
+
+    sql """
+        INSERT INTO test_variant_sparse_sort_insert_from
+        SELECT * FROM (
+            SELECT 0, '{"a": 11245, "b": [123, {"xx": 1}], "c": {"c": 456, "d": null, "e": 7.111}}' AS json_str
+            UNION ALL SELECT 1, '{"a": 1123}' AS json_str
+            UNION ALL SELECT 2, '{"a": 1234, "xxxx": "kaana"}' AS json_str FROM numbers("number" = "4096")
+        ) t ORDER BY 1 LIMIT 4096;
+    """
+    sql "sync"
+
+    sql """
+        SELECT v FROM test_variant_sparse_sort_insert_from
+        WHERE json_extract_string(v, "\$") != "{}"
+        ORDER BY cast(v AS string) LIMIT 10;
+    """
+
+    sql "TRUNCATE TABLE test_variant_sparse_sort_insert_from"
+    sql """
+        INSERT INTO test_variant_sparse_sort_insert_from
+        SELECT * FROM (
+            SELECT 0, '{"a": 1123, "b": [123, {"xx": 1}], "c": {"c": 456, "d": null, "e": 7.111}, "zzz": null, "oooo": {"akakaka": null, "xxxx": {"xxx": 123}}}' AS json_str
+            UNION ALL SELECT 1, '{"a": 1234, "xxxx": "kaana", "ddd": {"aaa": 123, "mxmxm": [456, "789"]}}' AS json_str FROM numbers("number" = "4096")
+        ) t ORDER BY 1 LIMIT 4096;
+    """
+    sql "sync"
+
+    sql """
+        SELECT v FROM test_variant_sparse_sort_insert_from
+        WHERE json_extract_string(v, "\$") != "{}"
+        ORDER BY cast(v AS string) LIMIT 10;
+    """
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: ColumnVariant::insert_from rebuilt non-root-only rows through Field and try_insert, which re-inferred variant paths and could change sparse/dense layout while sorted run merge copied rows. Subcolumn range copy also dropped pending default suffix rows. Together these could surface type mismatches for mixed-shape variant rows under sparse subcolumn limits.

### Release note

None

### Check List (For Author)

- Test:
    - Regression test
        - Red on upstream/master: `./run-regression-test.sh --run -d variant_p0 -s test_variant_sparse_sort_insert_from -c 'jdbc:mysql://127.0.0.1:22030/?useLocalSessionState=true&allowLoadLocalInfile=true&zeroDateTimeBehavior=round' -ha '127.0.0.1:21030' -parallel 1 -suiteParallel 1` failed with `Field::get type mismatch: requested STRING, actual BIGINT`
        - Green after fix: `./run-regression-test.sh --run -d variant_p0 -s test_variant_sparse_sort_insert_from -c 'jdbc:mysql://127.0.0.1:22030/?useLocalSessionState=true&allowLoadLocalInfile=true&zeroDateTimeBehavior=round' -ha '127.0.0.1:21030' -parallel 1 -suiteParallel 1`
    - Unit Test
        - Red on upstream/master: `./run-be-ut.sh --run --filter='ColumnVariantTest.insert_range_from_materializes_pending_default_suffix:ColumnVariantTest.insert_from_preserves_sparse_limit_for_object_rows'` failed both added tests
        - Green after fix: `./run-be-ut.sh --run --filter='ColumnVariantTest.insert_range_from_materializes_pending_default_suffix:ColumnVariantTest.insert_from_preserves_sparse_limit_for_object_rows'`
- Behavior changed: No
- Does this need documentation: No
