### PR TITLE
[test](streaming-job) add cdc_client unit tests and read-path Testcontainers ITCases

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -130,6 +130,25 @@ jobs:
       - name: Build cdc client
         run: |
           cd fs_brokers/cdc_client/ && /bin/bash build.sh
+  test-cdc-client:
+    name: Test Cdc Client
+    needs: changes
+    if: ${{ needs.changes.outputs.cdc_client_changes == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v3
+
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: '17'
+
+      - name: Run cdc client integration tests
+        run: |
+          cd fe && mvn -Pflatten install -pl fe-common -Dskip.doc=true -DskipTests -Dmaven.build.cache.enabled=false
+          cd ../fs_brokers/cdc_client && mvn -B test-compile failsafe:integration-test failsafe:verify
   # build-docs:
   #   name: Build Documents
   #   needs: changes

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run cdc client integration tests
         run: |
           cd fe && mvn -Pflatten install -pl fe-common -Dskip.doc=true -DskipTests -Dmaven.build.cache.enabled=false
-          cd ../fs_brokers/cdc_client && mvn -B test-compile failsafe:integration-test failsafe:verify
+          cd ../fs_brokers/cdc_client && mvn -B test failsafe:integration-test failsafe:verify
   # build-docs:
   #   name: Build Documents
   #   needs: changes

--- a/fs_brokers/cdc_client/pom.xml
+++ b/fs_brokers/cdc_client/pom.xml
@@ -173,6 +173,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.19.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/fs_brokers/cdc_client/pom.xml
+++ b/fs_brokers/cdc_client/pom.xml
@@ -73,7 +73,7 @@ under the License.
         <lombok.version>1.18.24</lombok.version>
         <commons-codec.version>1.15</commons-codec.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <assertj.version>3.25.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <awaitility.version>4.2.1</awaitility.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
     </properties>

--- a/fs_brokers/cdc_client/pom.xml
+++ b/fs_brokers/cdc_client/pom.xml
@@ -72,6 +72,10 @@ under the License.
         <httpcomponents.version>4.5.13</httpcomponents.version>
         <lombok.version>1.18.24</lombok.version>
         <commons-codec.version>1.15</commons-codec.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
+        <assertj.version>3.25.3</assertj.version>
+        <awaitility.version>4.2.1</awaitility.version>
+        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
     </properties>
 
     <dependencies>
@@ -192,6 +196,43 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -216,6 +257,26 @@ under the License.
                     <source>17</source>
                     <target>17</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <configuration>
+                    <includes>
+                        <include>**/*ITCase.java</include>
+                    </includes>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/mysql/MySqlSourceReader.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/mysql/MySqlSourceReader.java
@@ -982,6 +982,9 @@ public class MySqlSourceReader extends AbstractCdcSourceReader {
                     "trustCertificateKeyStorePassword", SmallFileMgr.TRUSTSTORE_PASSWORD);
         }
 
+        // Keep genuinely ancient (<100) DATE/DATETIME years; MySQL already completes 2-digit years.
+        dbzProps.setProperty("enable.time.adjuster", "false");
+
         configFactory.debeziumProperties(dbzProps);
         configFactory.heartbeatInterval(Duration.ofMillis(DEBEZIUM_HEARTBEAT_INTERVAL_MS));
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/CdcClientReadHarness.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/CdcClientReadHarness.java
@@ -101,6 +101,36 @@ public final class CdcClientReadHarness implements AutoCloseable {
         return new CdcClientReadHarness(jobId, "MYSQL", config);
     }
 
+    /** Build a harness for a PostgreSQL source backed by a Testcontainers instance. */
+    public static CdcClientReadHarness postgres(
+            String jobId,
+            String host,
+            int port,
+            String user,
+            String password,
+            String database,
+            String schema,
+            String includeTables,
+            String offset) {
+        Map<String, String> config = new HashMap<>();
+        config.put(
+                DataSourceConfigKeys.JDBC_URL,
+                "jdbc:postgresql://" + host + ":" + port + "/" + database);
+        config.put(DataSourceConfigKeys.USER, user);
+        config.put(DataSourceConfigKeys.PASSWORD, password);
+        config.put(DataSourceConfigKeys.DATABASE, database);
+        config.put(DataSourceConfigKeys.SCHEMA, schema);
+        config.put(DataSourceConfigKeys.INCLUDE_TABLES, includeTables);
+        config.put(DataSourceConfigKeys.OFFSET, offset);
+        config.put(DataSourceConfigKeys.SNAPSHOT_PARALLELISM, "1");
+        // FE-assigned names so the reader owns and pre-creates the slot/publication.
+        config.put(DataSourceConfigKeys.SLOT_NAME, DataSourceConfigKeys.defaultSlotName(jobId));
+        config.put(
+                DataSourceConfigKeys.PUBLICATION_NAME,
+                DataSourceConfigKeys.defaultPublicationName(jobId));
+        return new CdcClientReadHarness(jobId, "POSTGRES", config);
+    }
+
     public String jobId() {
         return jobId;
     }

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/CdcClientReadHarness.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/CdcClientReadHarness.java
@@ -1,0 +1,299 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.cdcclient.service.PipelineCoordinator;
+import org.apache.doris.cdcclient.source.reader.SourceReader;
+import org.apache.doris.job.cdc.DataSourceConfigKeys;
+import org.apache.doris.job.cdc.request.FetchRecordRequest;
+import org.apache.doris.job.cdc.request.FetchTableSplitsRequest;
+import org.apache.doris.job.cdc.request.JobBaseConfig;
+import org.apache.doris.job.cdc.split.AbstractSourceSplit;
+import org.apache.doris.job.cdc.split.BinlogSplit;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+/**
+ * Test-only driver that exercises the real cdc_client TVF read path against a containerized
+ * database, mirroring the production sequence used by the BE HttpScanner:
+ *
+ * <ol>
+ *   <li>{@code /api/fetchSplits} -> {@link SourceReader#getSourceSplits} computes the chunk
+ *       boundaries (flink-cdc ChunkSplitter). See {@link #fetchAllSnapshotSplits}.
+ *   <li>{@code /api/fetchRecordStream} -> {@link PipelineCoordinator#fetchRecordStream} streams the
+ *       deserialized JSON rows; the per-task offset is published into the coordinator's task-offset
+ *       cache. See {@link #readSnapshot} / {@link #readBinlogUntil}.
+ *   <li>{@code /api/getTaskOffset} -> {@link PipelineCoordinator#getOffsetWithTaskId} returns that
+ *       offset.
+ * </ol>
+ *
+ * <p>A numeric (Long) jobId is used so the reader is kept across snapshot and binlog calls,
+ * matching the job-driven TVF path that performs snapshot + incremental.
+ *
+ * <p>The job context (and its open connections) lives in the process-wide {@link Env} singleton, so
+ * every harness MUST be {@link #close() closed} (use try-with-resources) and every test MUST use a
+ * unique {@code jobId} to stay isolated.
+ */
+public final class CdcClientReadHarness implements AutoCloseable {
+
+    private static final int SPLIT_BATCH_SIZE = 1000;
+
+    private final PipelineCoordinator coordinator = new PipelineCoordinator(10);
+    private final String jobId;
+    private final String dataSource;
+    private final Map<String, String> config;
+    private final AtomicLong taskSeq = new AtomicLong();
+
+    private Map<String, String> lastBinlogOffset;
+
+    private CdcClientReadHarness(String jobId, String dataSource, Map<String, String> config) {
+        this.jobId = jobId;
+        this.dataSource = dataSource;
+        this.config = config;
+    }
+
+    /** Build a harness for a MySQL source backed by a Testcontainers instance. */
+    public static CdcClientReadHarness mysql(
+            String jobId,
+            String host,
+            int port,
+            String user,
+            String password,
+            String database,
+            String includeTables,
+            String offset) {
+        Map<String, String> config = new HashMap<>();
+        config.put(
+                DataSourceConfigKeys.JDBC_URL,
+                "jdbc:mysql://" + host + ":" + port + "/" + database + "?serverTimezone=UTC");
+        config.put(DataSourceConfigKeys.USER, user);
+        config.put(DataSourceConfigKeys.PASSWORD, password);
+        config.put(DataSourceConfigKeys.DATABASE, database);
+        config.put(DataSourceConfigKeys.INCLUDE_TABLES, includeTables);
+        config.put(DataSourceConfigKeys.OFFSET, offset);
+        config.put(DataSourceConfigKeys.SNAPSHOT_PARALLELISM, "1");
+        return new CdcClientReadHarness(jobId, "MYSQL", config);
+    }
+
+    public String jobId() {
+        return jobId;
+    }
+
+    public Map<String, String> lastBinlogOffset() {
+        return lastBinlogOffset;
+    }
+
+    private JobBaseConfig baseConfig() {
+        return new JobBaseConfig(jobId, dataSource, config, null);
+    }
+
+    /**
+     * Compute every snapshot chunk for one table by advancing the FE-style cursor (nextSplitStart /
+     * nextSplitId) until the final chunk (the one whose splitEnd is null) is reached.
+     */
+    public List<SnapshotSplit> fetchAllSnapshotSplits(String table) {
+        SourceReader reader = Env.getCurrentEnv().getReader(baseConfig());
+        List<SnapshotSplit> all = new ArrayList<>();
+        Object[] nextSplitStart = null;
+        Integer nextSplitId = null;
+        while (true) {
+            FetchTableSplitsRequest req = new FetchTableSplitsRequest();
+            req.setJobId(jobId);
+            req.setDataSource(dataSource);
+            req.setConfig(config);
+            req.setSnapshotTable(table);
+            req.setNextSplitStart(nextSplitStart);
+            req.setNextSplitId(nextSplitId);
+            req.setBatchSize(SPLIT_BATCH_SIZE);
+
+            List<AbstractSourceSplit> batch = reader.getSourceSplits(req);
+            if (batch == null || batch.isEmpty()) {
+                break;
+            }
+            for (AbstractSourceSplit split : batch) {
+                all.add((SnapshotSplit) split);
+            }
+            SnapshotSplit last = (SnapshotSplit) batch.get(batch.size() - 1);
+            // The last chunk has an open upper bound (splitEnd == null).
+            if (last.getSplitEnd() == null) {
+                break;
+            }
+            nextSplitStart = last.getSplitEnd();
+            nextSplitId = all.size();
+        }
+        return all;
+    }
+
+    /** Read the full snapshot for the given splits in one blocking stream. */
+    public SnapshotResult readSnapshot(List<SnapshotSplit> splits) throws Exception {
+        List<Map<String, Object>> splitMaps = new ArrayList<>();
+        for (SnapshotSplit split : splits) {
+            splitMaps.add(toMap(split));
+        }
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("splits", splitMaps);
+
+        String taskId = nextTaskId();
+        List<String> records = streamRecords(meta, taskId);
+        return new SnapshotResult(records, coordinator.getOffsetWithTaskId(taskId));
+    }
+
+    /** Convenience: compute splits for a single table and read its full snapshot. */
+    public SnapshotResult readFullSnapshot(String table) throws Exception {
+        return readSnapshot(fetchAllSnapshotSplits(table));
+    }
+
+    /**
+     * Enter the binlog phase from a completed snapshot and poll until {@code expectedCount} rows
+     * arrive or {@code timeout} elapses.
+     */
+    public List<String> readBinlogUntil(
+            SnapshotResult snapshot,
+            List<SnapshotSplit> snapshotSplits,
+            int expectedCount,
+            Duration timeout)
+            throws Exception {
+        Map<String, Map<String, String>> hwBySplitId = new HashMap<>();
+        for (Map<String, String> offset : snapshot.splitOffsets()) {
+            Map<String, String> hw = new HashMap<>(offset);
+            String splitId = hw.remove(SourceReader.SPLIT_ID);
+            hwBySplitId.put(splitId, hw);
+        }
+
+        List<Map<String, Object>> finished = new ArrayList<>();
+        for (SnapshotSplit split : snapshotSplits) {
+            Map<String, Object> splitMap = toMap(split);
+            splitMap.put("highWatermark", hwBySplitId.get(split.getSplitId()));
+            finished.add(splitMap);
+        }
+
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceReader.SPLIT_ID, BinlogSplit.BINLOG_SPLIT_ID);
+        meta.put("finishedSplits", finished);
+        return pollBinlog(meta, expectedCount, timeout);
+    }
+
+    /** Continue the binlog phase from a previously returned binlog offset. */
+    public List<String> readBinlogFromOffset(
+            Map<String, String> startingOffset, int expectedCount, Duration timeout)
+            throws Exception {
+        return pollBinlog(binlogMeta(startingOffset), expectedCount, timeout);
+    }
+
+    private List<String> pollBinlog(
+            Map<String, Object> firstMeta, int expectedCount, Duration timeout) throws Exception {
+        List<String> records = new ArrayList<>();
+        Map<String, Object> meta = firstMeta;
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        while (records.size() < expectedCount && System.nanoTime() < deadlineNanos) {
+            String taskId = nextTaskId();
+            records.addAll(streamRecords(meta, taskId));
+
+            List<Map<String, String>> offsetMeta = coordinator.getOffsetWithTaskId(taskId);
+            Map<String, String> offset = new HashMap<>(offsetMeta.get(0));
+            offset.remove(SourceReader.SPLIT_ID);
+            this.lastBinlogOffset = offset;
+            meta = binlogMeta(offset);
+        }
+        return records;
+    }
+
+    /** Invoke the production stream endpoint and collect the newline-delimited JSON records. */
+    private List<String> streamRecords(Map<String, Object> meta, String taskId) throws Exception {
+        FetchRecordRequest req = new FetchRecordRequest();
+        req.setJobId(jobId);
+        req.setDataSource(dataSource);
+        req.setConfig(config);
+        req.setMeta(meta);
+        req.setTaskId(taskId);
+
+        StreamingResponseBody body = coordinator.fetchRecordStream(req);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+
+        List<String> records = new ArrayList<>();
+        String payload = out.toString(StandardCharsets.UTF_8);
+        for (String line : payload.split("\n")) {
+            if (!line.isEmpty()) {
+                records.add(line);
+            }
+        }
+        return records;
+    }
+
+    /**
+     * Serialize a split into the map shape cdc_client expects in the request meta. Built by hand
+     * (not via Jackson) to avoid coupling the test to the module's Jackson version alignment.
+     */
+    private static Map<String, Object> toMap(SnapshotSplit split) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("splitId", split.getSplitId());
+        map.put("tableId", split.getTableId());
+        map.put("splitKey", split.getSplitKey());
+        map.put("splitStart", split.getSplitStart());
+        map.put("splitEnd", split.getSplitEnd());
+        map.put("highWatermark", split.getHighWatermark());
+        return map;
+    }
+
+    private Map<String, Object> binlogMeta(Map<String, String> startingOffset) {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceReader.SPLIT_ID, BinlogSplit.BINLOG_SPLIT_ID);
+        meta.put("startingOffset", startingOffset);
+        return meta;
+    }
+
+    private String nextTaskId() {
+        return jobId + "-t" + taskSeq.incrementAndGet();
+    }
+
+    @Override
+    public void close() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    /** Snapshot rows (JSON) plus the high-watermark offset of every split. */
+    public static final class SnapshotResult {
+        private final List<String> records;
+        private final List<Map<String, String>> splitOffsets;
+
+        SnapshotResult(List<String> records, List<Map<String, String>> splitOffsets) {
+            this.records = records;
+            this.splitOffsets = splitOffsets;
+        }
+
+        public List<String> records() {
+            return records;
+        }
+
+        public List<Map<String, String>> splitOffsets() {
+            return splitOffsets;
+        }
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/CdcClientWriteHarness.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/CdcClientWriteHarness.java
@@ -1,0 +1,387 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.cdcclient.service.PipelineCoordinator;
+import org.apache.doris.cdcclient.source.reader.SourceReader;
+import org.apache.doris.job.cdc.DataSourceConfigKeys;
+import org.apache.doris.job.cdc.request.FetchTableSplitsRequest;
+import org.apache.doris.job.cdc.request.JobBaseConfig;
+import org.apache.doris.job.cdc.request.WriteRecordRequest;
+import org.apache.doris.job.cdc.split.AbstractSourceSplit;
+import org.apache.doris.job.cdc.split.BinlogSplit;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Test driver for the from-to {@code writeRecords} path: drives the read + deserialize + streamload
+ * + commit-offset pipeline against a containerized source and a {@link MockDorisServer} standing in
+ * for the BE stream-load and FE commit-offset endpoints. No real Doris cluster needed.
+ *
+ * <p>Uses a numeric jobId/taskId because {@code commitOffset} parses them as {@code Long}.
+ */
+final class CdcClientWriteHarness implements AutoCloseable {
+
+    private static final int SPLIT_BATCH_SIZE = 1000;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final PipelineCoordinator coordinator = new PipelineCoordinator(10);
+    private final String jobId;
+    private final String dataSource;
+    private final Map<String, String> config;
+    private final String targetDb;
+    private final MockDorisServer mock;
+    private final AtomicLong taskSeq = new AtomicLong();
+
+    // Threaded across rounds, mirroring how FE persists and replays them.
+    private String lastTableSchemas;
+    private Map<String, String> lastBinlogOffset;
+
+    private CdcClientWriteHarness(
+            String jobId,
+            String dataSource,
+            Map<String, String> config,
+            String targetDb,
+            MockDorisServer mock) {
+        this.jobId = jobId;
+        this.dataSource = dataSource;
+        this.config = config;
+        this.targetDb = targetDb;
+        this.mock = mock;
+    }
+
+    static CdcClientWriteHarness mysql(
+            String jobId,
+            String host,
+            int port,
+            String user,
+            String password,
+            String database,
+            String includeTables,
+            String offset,
+            String targetDb,
+            MockDorisServer mock) {
+        Map<String, String> config = new HashMap<>();
+        config.put(
+                DataSourceConfigKeys.JDBC_URL,
+                "jdbc:mysql://" + host + ":" + port + "/" + database + "?serverTimezone=UTC");
+        config.put(DataSourceConfigKeys.USER, user);
+        config.put(DataSourceConfigKeys.PASSWORD, password);
+        config.put(DataSourceConfigKeys.DATABASE, database);
+        config.put(DataSourceConfigKeys.INCLUDE_TABLES, includeTables);
+        config.put(DataSourceConfigKeys.OFFSET, offset);
+        config.put(DataSourceConfigKeys.SNAPSHOT_PARALLELISM, "1");
+
+        // Point cdc_client's stream-load at the mock BE.
+        Env.getCurrentEnv().setBackendHttpPort(mock.port());
+        Env.getCurrentEnv().setClusterToken("test");
+        return new CdcClientWriteHarness(jobId, "MYSQL", config, targetDb, mock);
+    }
+
+    static CdcClientWriteHarness postgres(
+            String jobId,
+            String host,
+            int port,
+            String user,
+            String password,
+            String database,
+            String schema,
+            String includeTables,
+            String offset,
+            String targetDb,
+            MockDorisServer mock) {
+        Map<String, String> config = new HashMap<>();
+        config.put(
+                DataSourceConfigKeys.JDBC_URL,
+                "jdbc:postgresql://" + host + ":" + port + "/" + database);
+        config.put(DataSourceConfigKeys.USER, user);
+        config.put(DataSourceConfigKeys.PASSWORD, password);
+        config.put(DataSourceConfigKeys.DATABASE, database);
+        config.put(DataSourceConfigKeys.SCHEMA, schema);
+        config.put(DataSourceConfigKeys.INCLUDE_TABLES, includeTables);
+        config.put(DataSourceConfigKeys.OFFSET, offset);
+        // FE-assigned names so the reader owns and pre-creates the slot/publication.
+        config.put(DataSourceConfigKeys.SLOT_NAME, DataSourceConfigKeys.defaultSlotName(jobId));
+        config.put(
+                DataSourceConfigKeys.PUBLICATION_NAME,
+                DataSourceConfigKeys.defaultPublicationName(jobId));
+
+        Env.getCurrentEnv().setBackendHttpPort(mock.port());
+        Env.getCurrentEnv().setClusterToken("test");
+        return new CdcClientWriteHarness(jobId, "POSTGRES", config, targetDb, mock);
+    }
+
+    /** Shrink the snapshot chunk size so a small table still splits into multiple chunks. */
+    CdcClientWriteHarness withSplitSize(int splitSize) {
+        config.put(DataSourceConfigKeys.SNAPSHOT_SPLIT_SIZE, String.valueOf(splitSize));
+        return this;
+    }
+
+    /**
+     * Override the MySQL JDBC url's {@code serverTimezone}, which both the driver and Debezium use
+     * to interpret TIMESTAMP columns. MySQL only — the url is rebuilt from the original host/port/db.
+     */
+    CdcClientWriteHarness withServerTimezone(String zoneId) {
+        String url = config.get(DataSourceConfigKeys.JDBC_URL);
+        int q = url.indexOf('?');
+        String base = q < 0 ? url : url.substring(0, q);
+        config.put(DataSourceConfigKeys.JDBC_URL, base + "?serverTimezone=" + zoneId);
+        return this;
+    }
+
+    private JobBaseConfig baseConfig() {
+        return new JobBaseConfig(jobId, dataSource, config, null);
+    }
+
+    /** Compute every snapshot chunk for one table (mirrors FE's /api/fetchSplits cursor). */
+    List<SnapshotSplit> fetchAllSnapshotSplits(String table) {
+        SourceReader reader = Env.getCurrentEnv().getReader(baseConfig());
+        List<SnapshotSplit> all = new ArrayList<>();
+        Object[] nextSplitStart = null;
+        Integer nextSplitId = null;
+        while (true) {
+            FetchTableSplitsRequest req = new FetchTableSplitsRequest();
+            req.setJobId(jobId);
+            req.setDataSource(dataSource);
+            req.setConfig(config);
+            req.setSnapshotTable(table);
+            req.setNextSplitStart(nextSplitStart);
+            req.setNextSplitId(nextSplitId);
+            req.setBatchSize(SPLIT_BATCH_SIZE);
+
+            List<AbstractSourceSplit> batch = reader.getSourceSplits(req);
+            if (batch == null || batch.isEmpty()) {
+                break;
+            }
+            for (AbstractSourceSplit split : batch) {
+                all.add((SnapshotSplit) split);
+            }
+            SnapshotSplit last = (SnapshotSplit) batch.get(batch.size() - 1);
+            if (last.getSplitEnd() == null) {
+                break;
+            }
+            nextSplitStart = last.getSplitEnd();
+            nextSplitId = all.size();
+        }
+        return all;
+    }
+
+    /** Run the snapshot through the from-to path: read -> deserialize -> streamload -> commit. */
+    void writeSnapshot(List<SnapshotSplit> splits) throws Exception {
+        List<Map<String, Object>> splitMaps = new ArrayList<>();
+        for (SnapshotSplit split : splits) {
+            splitMaps.add(toMap(split));
+        }
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("splits", splitMaps);
+        runWrite(meta);
+    }
+
+    /**
+     * Enter the binlog phase from a completed snapshot and read one window. This establishes (and
+     * commits) the baseline tableSchemas before any later DDL, so a subsequent ALTER is detectable.
+     */
+    void enterBinlog(List<SnapshotSplit> splits) throws Exception {
+        runWrite(finishedSplitsMeta(splits, committedSnapshotOffsets()));
+    }
+
+    /**
+     * Enter the binlog phase straight from the configured non-snapshot startup mode
+     * (latest/earliest/specific-offset/timestamp) with no preceding snapshot. The reader resolves
+     * the configured OFFSET on this first window and commits a concrete position; later reads resume
+     * via {@link #continueBinlog}. Mirrors FE's binlog-only meta: {@code {splitId: binlog-split}}
+     * with neither startingOffset nor finishedSplits.
+     */
+    void enterBinlogFromStartupMode() throws Exception {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("splitId", BinlogSplit.BINLOG_SPLIT_ID);
+        runWrite(meta);
+    }
+
+    /**
+     * Read the binlog phase straight from the configured startup mode, polling until
+     * {@code expectedRecords} rows are stream-loaded or the timeout elapses. The first window
+     * resolves the configured OFFSET (so for specific-offset/earliest it replays pre-existing
+     * changes from that point forward); later windows resume from the committed offset. Returns only
+     * the rows loaded during this call.
+     */
+    List<String> readBinlogFromStartupMode(int expectedRecords, Duration timeout) throws Exception {
+        int before = mock.loadedRecords().size();
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("splitId", BinlogSplit.BINLOG_SPLIT_ID);
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        while (mock.loadedRecords().size() - before < expectedRecords
+                && System.nanoTime() < deadlineNanos) {
+            runWrite(meta);
+            meta = new HashMap<>();
+            meta.put("splitId", BinlogSplit.BINLOG_SPLIT_ID);
+            meta.put("startingOffset", lastBinlogOffset);
+        }
+        List<String> all = mock.loadedRecords();
+        return new ArrayList<>(all.subList(before, all.size()));
+    }
+
+    /** Continue the binlog phase from the last committed offset until expected rows or timeout. */
+    List<String> continueBinlog(int expectedRecords, Duration timeout) throws Exception {
+        int before = mock.loadedRecords().size();
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        while (mock.loadedRecords().size() - before < expectedRecords
+                && System.nanoTime() < deadlineNanos) {
+            Map<String, Object> meta = new HashMap<>();
+            meta.put("splitId", BinlogSplit.BINLOG_SPLIT_ID);
+            meta.put("startingOffset", lastBinlogOffset);
+            runWrite(meta);
+        }
+        List<String> all = mock.loadedRecords();
+        return new ArrayList<>(all.subList(before, all.size()));
+    }
+
+    private void runWrite(Map<String, Object> meta) throws Exception {
+        coordinator.writeRecords(buildRequest(meta));
+        capture();
+    }
+
+    /** Capture tableSchemas and the binlog offset from the last commit, to replay next round. */
+    private void capture() throws Exception {
+        JsonNode commit = MAPPER.readTree(mock.committedOffset());
+        JsonNode ts = commit.get("tableSchemas");
+        if (ts != null && !ts.isNull()) {
+            lastTableSchemas = ts.asText();
+        }
+        List<Map<String, String>> offsets = parseOffsetList(mock.committedOffset());
+        if (offsets.size() == 1
+                && BinlogSplit.BINLOG_SPLIT_ID.equals(offsets.get(0).get("splitId"))) {
+            Map<String, String> offset = new HashMap<>(offsets.get(0));
+            offset.remove("splitId");
+            lastBinlogOffset = offset;
+        }
+    }
+
+    /**
+     * Continue from a completed snapshot into the binlog phase and keep polling (each writeRecords
+     * is one maxInterval window) until {@code expectedRecords} new rows are stream-loaded or the
+     * timeout elapses. Returns only the rows stream-loaded during this binlog phase.
+     */
+    List<String> writeBinlogUntil(List<SnapshotSplit> splits, int expectedRecords, Duration timeout)
+            throws Exception {
+        int before = mock.loadedRecords().size();
+        Map<String, Object> meta = finishedSplitsMeta(splits, committedSnapshotOffsets());
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        while (mock.loadedRecords().size() - before < expectedRecords
+                && System.nanoTime() < deadlineNanos) {
+            coordinator.writeRecords(buildRequest(meta));
+            meta = new HashMap<>();
+            meta.put("splitId", BinlogSplit.BINLOG_SPLIT_ID);
+            meta.put("startingOffset", committedBinlogOffset());
+        }
+        List<String> all = mock.loadedRecords();
+        return new ArrayList<>(all.subList(before, all.size()));
+    }
+
+    private Map<String, Object> finishedSplitsMeta(
+            List<SnapshotSplit> splits, List<Map<String, String>> snapshotOffsets) {
+        Map<String, Map<String, String>> hwBySplitId = new HashMap<>();
+        for (Map<String, String> offset : snapshotOffsets) {
+            Map<String, String> hw = new HashMap<>(offset);
+            String splitId = hw.remove("splitId");
+            hwBySplitId.put(splitId, hw);
+        }
+        List<Map<String, Object>> finished = new ArrayList<>();
+        for (SnapshotSplit split : splits) {
+            Map<String, Object> m = toMap(split);
+            m.put("highWatermark", hwBySplitId.get(split.getSplitId()));
+            finished.add(m);
+        }
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("splitId", BinlogSplit.BINLOG_SPLIT_ID);
+        meta.put("finishedSplits", finished);
+        return meta;
+    }
+
+    private List<Map<String, String>> committedSnapshotOffsets() throws Exception {
+        return parseOffsetList(mock.committedOffset());
+    }
+
+    private Map<String, String> committedBinlogOffset() throws Exception {
+        Map<String, String> offset = new HashMap<>(parseOffsetList(mock.committedOffset()).get(0));
+        offset.remove("splitId");
+        return offset;
+    }
+
+    private List<Map<String, String>> parseOffsetList(String commitJson) throws Exception {
+        JsonNode commit = MAPPER.readTree(commitJson);
+        String offsetStr = commit.get("offset").asText();
+        return MAPPER.readValue(offsetStr, new TypeReference<List<Map<String, String>>>() {});
+    }
+
+    private WriteRecordRequest buildRequest(Map<String, Object> meta) {
+        WriteRecordRequest req = new WriteRecordRequest();
+        req.setJobId(jobId);
+        req.setDataSource(dataSource);
+        req.setConfig(config);
+        req.setFrontendAddress(mock.hostPort());
+        req.setMeta(meta);
+        req.setTableSchemas(lastTableSchemas);
+        req.setTaskId(String.valueOf(taskSeq.incrementAndGet()));
+        req.setTargetDb(targetDb);
+        req.setToken("test-token");
+        req.setMaxInterval(3);
+        req.setTaskTimeoutMs(60_000);
+        req.setStreamLoadProps(new HashMap<>());
+        return req;
+    }
+
+    List<String> loadedRecords() {
+        return mock.loadedRecords();
+    }
+
+    List<String> executedDdls() {
+        return mock.executedDdls();
+    }
+
+    String committedOffset() {
+        return mock.committedOffset();
+    }
+
+    @Override
+    public void close() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    private static Map<String, Object> toMap(SnapshotSplit split) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("splitId", split.getSplitId());
+        map.put("tableId", split.getTableId());
+        map.put("splitKey", split.getSplitKey());
+        map.put("splitStart", split.getSplitStart());
+        map.put("splitEnd", split.getSplitEnd());
+        map.put("highWatermark", split.getHighWatermark());
+        return map;
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MockDorisServer.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MockDorisServer.java
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A tiny in-process stand-in for the Doris BE stream-load endpoint and the FE commit-offset
+ * endpoint, so the from-to {@code writeRecords} path can be exercised without a real Doris cluster.
+ *
+ * <ul>
+ *   <li>{@code PUT /api/{db}/{table}/_stream_load} — captures the newline-delimited JSON rows and
+ *       replies with a Success stream-load result.
+ *   <li>{@code POST /api/streaming/commit_offset} — captures the committed offset payload and
+ *       replies {@code {"code":0}}.
+ * </ul>
+ */
+final class MockDorisServer implements AutoCloseable {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final HttpServer server;
+    private final List<String> loadedRecords = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> executedDdls = Collections.synchronizedList(new ArrayList<>());
+    private volatile String committedOffset;
+
+    MockDorisServer() throws IOException {
+        this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/", this::handle);
+        server.start();
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        byte[] body = exchange.getRequestBody().readAllBytes();
+        String response;
+        if (path.endsWith("/_stream_load")) {
+            int rows = 0;
+            for (String line : new String(body, StandardCharsets.UTF_8).split("\n")) {
+                if (!line.isEmpty()) {
+                    loadedRecords.add(line);
+                    rows++;
+                }
+            }
+            response =
+                    String.format(
+                            "{\"Status\":\"Success\",\"NumberTotalRows\":%d,\"NumberLoadedRows\":%d,"
+                                    + "\"NumberFilteredRows\":0,\"LoadBytes\":%d}",
+                            rows, rows, body.length);
+        } else if (path.endsWith("/commit_offset")) {
+            this.committedOffset = new String(body, StandardCharsets.UTF_8);
+            response = "{\"code\":0,\"msg\":\"ok\"}";
+        } else if (path.contains("/api/query/")) {
+            // FE schema-change endpoint: body is {"stmt":"<DDL>"}
+            JsonNode node = MAPPER.readTree(body);
+            executedDdls.add(node.path("stmt").asText(""));
+            response = "{\"code\":0,\"msg\":\"ok\"}";
+        } else {
+            response = "{\"code\":-1,\"msg\":\"unknown path " + path + "\"}";
+        }
+        byte[] out = response.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, out.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(out);
+        }
+    }
+
+    /** host:port the cdc_client should be pointed at (serves both the BE and FE roles). */
+    String hostPort() {
+        return "127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    int port() {
+        return server.getAddress().getPort();
+    }
+
+    /** All JSON rows received via stream-load, in arrival order. */
+    List<String> loadedRecords() {
+        return new ArrayList<>(loadedRecords);
+    }
+
+    /** The last committed offset payload (JSON), or null if commit was never called. */
+    String committedOffset() {
+        return committedOffset;
+    }
+
+    /** All DDL statements executed via the FE query endpoint, in arrival order. */
+    List<String> executedDdls() {
+        return new ArrayList<>(executedDdls);
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlBasicReadITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlBasicReadITCase.java
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
+ * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
+ *
+ * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ */
+@Testcontainers
+class MySqlBasicReadITCase {
+
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "123456";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+
+    @Container
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("mysql:8.0.28"))
+                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
+                    .withDatabaseName("cdc_test")
+                    .withUsername("cdc")
+                    .withPassword("123456")
+                    .withEnv("MYSQL_ROOT_PASSWORD", ROOT_PASSWORD);
+
+    private String jobId;
+    private String database;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        database = "basic_db_" + jobId;
+        try (Connection conn = rootConnection("");
+                Statement st = conn.createStatement()) {
+            st.execute("CREATE DATABASE " + database);
+            st.execute("USE " + database);
+            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Env.getCurrentEnv().close(jobId);
+        try (Connection conn = rootConnection("");
+                Statement st = conn.createStatement()) {
+            st.execute("DROP DATABASE IF EXISTS " + database);
+        }
+    }
+
+    @Test
+    void readsSnapshotThenBinlogInsert() throws Exception {
+        try (CdcClientReadHarness harness =
+                CdcClientReadHarness.mysql(
+                        jobId,
+                        MYSQL.getHost(),
+                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                        ROOT_USER,
+                        ROOT_PASSWORD,
+                        database,
+                        "t_user",
+                        "initial")) {
+
+            // 1. snapshot reads the 3 seeded rows
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            SnapshotResult snapshot = harness.readSnapshot(splits);
+
+            Map<Integer, String> names = namesById(snapshot.records());
+            assertThat(names).containsOnlyKeys(1, 2, 3);
+            assertThat(names.get(1)).isEqualTo("alice");
+            assertThat(names.get(2)).isEqualTo("bob");
+            assertThat(names.get(3)).isEqualTo("carol");
+
+            // 2. a row inserted after the snapshot shows up in the binlog phase
+            insert(4, "dave");
+
+            List<String> binlog =
+                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
+            assertThat(binlog).hasSize(1);
+            JsonNode row = MAPPER.readTree(binlog.get(0));
+            assertThat(row.get("id").asInt()).isEqualTo(4);
+            assertThat(row.get("name").asText()).isEqualTo("dave");
+            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+        }
+    }
+
+    private Map<Integer, String> namesById(List<String> records) throws Exception {
+        Map<Integer, String> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node.get("name").asText());
+        }
+        return result;
+    }
+
+    private void insert(int id, String name) throws Exception {
+        try (Connection conn = rootConnection(database);
+                Statement st = conn.createStatement()) {
+            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+        }
+    }
+
+    private Connection rootConnection(String db) throws Exception {
+        String url =
+                "jdbc:mysql://"
+                        + MYSQL.getHost()
+                        + ":"
+                        + MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT)
+                        + "/"
+                        + db;
+        return DriverManager.getConnection(url, ROOT_USER, ROOT_PASSWORD);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlCharsetITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlCharsetITCase.java
@@ -20,7 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,30 +35,29 @@ import org.testcontainers.utility.DockerImageName;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
-import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Verifies the from-to {@code writeRecords} path decodes per-column MySQL charsets correctly: a
+ * single row carrying utf8mb4 (CJK + emoji), GBK (CJK) and latin1 (accented) columns must round-trip
+ * to the exact original strings in the deserialized JSON.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlCharsetITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(980_000);
+
+    private static final String UTF8MB4_VALUE = "测试数据😀";
+    private static final String GBK_VALUE = "另一个测试数据";
+    private static final String LATIN1_VALUE = "ÀÆÉ Üæû";
 
     @Container
     static final MySQLContainer<?> MYSQL =
             new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
                     .withDatabaseName("cdc_test")
                     .withUsername("cdc")
                     .withPassword("123456")
@@ -71,13 +69,25 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "charset_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
-            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute(
+                    "CREATE TABLE t_charset ("
+                            + "id INT NOT NULL,"
+                            + "c_utf8mb4 VARCHAR(50) CHARACTER SET utf8mb4,"
+                            + "c_gbk VARCHAR(50) CHARACTER SET gbk,"
+                            + "c_latin1 VARCHAR(50) CHARACTER SET latin1,"
+                            + "PRIMARY KEY (id))");
+            try (java.sql.PreparedStatement ps =
+                    conn.prepareStatement("INSERT INTO t_charset VALUES (1, ?, ?, ?)")) {
+                ps.setString(1, UTF8MB4_VALUE);
+                ps.setString(2, GBK_VALUE);
+                ps.setString(3, LATIN1_VALUE);
+                ps.execute();
+            }
         }
     }
 
@@ -91,54 +101,30 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void snapshotDecodesPerColumnCharsets() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_charset",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
 
-            // 1. snapshot reads the 3 seeded rows
-            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_charset");
+            harness.writeSnapshot(splits);
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+            assertThat(harness.loadedRecords()).hasSize(1);
+            JsonNode row = MAPPER.readTree(harness.loadedRecords().get(0));
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
-
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
-        }
-    }
-
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
-        for (String record : records) {
-            JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
-        }
-        return result;
-    }
-
-    private void insert(int id, String name) throws Exception {
-        try (Connection conn = rootConnection(database);
-                Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+            assertThat(row.get("c_utf8mb4").asText()).isEqualTo(UTF8MB4_VALUE);
+            assertThat(row.get("c_gbk").asText()).isEqualTo(GBK_VALUE);
+            assertThat(row.get("c_latin1").asText()).isEqualTo(LATIN1_VALUE);
         }
     }
 
@@ -149,7 +135,8 @@ class MySqlBasicReadITCase {
                         + ":"
                         + MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT)
                         + "/"
-                        + db;
+                        + db
+                        + "?characterEncoding=UTF-8";
         return DriverManager.getConnection(url, ROOT_USER, ROOT_PASSWORD);
     }
 }

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlCharsetITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlCharsetITCase.java
@@ -34,14 +34,18 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Verifies the from-to {@code writeRecords} path decodes per-column MySQL charsets correctly: a
- * single row carrying utf8mb4 (CJK + emoji), GBK (CJK) and latin1 (accented) columns must round-trip
- * to the exact original strings in the deserialized JSON.
+ * Verifies the from-to {@code writeRecords} path decodes per-column MySQL charsets correctly on
+ * <em>both</em> read paths: a row carrying utf8mb4 (CJK + emoji), GBK (CJK) and latin1 (accented)
+ * columns must round-trip to the exact original strings through the JDBC snapshot scan and again
+ * through binlog incremental decoding (a separate code path that can mis-handle charsets
+ * independently of the snapshot).
  */
 @Testcontainers
 class MySqlCharsetITCase {
@@ -54,6 +58,11 @@ class MySqlCharsetITCase {
     private static final String UTF8MB4_VALUE = "测试数据😀";
     private static final String GBK_VALUE = "另一个测试数据";
     private static final String LATIN1_VALUE = "ÀÆÉ Üæû";
+
+    // Distinct values inserted during the binlog phase.
+    private static final String UTF8MB4_INCR = "增量数据🚀";
+    private static final String GBK_INCR = "增量中文";
+    private static final String LATIN1_INCR = "Çédille Ñ";
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -81,13 +90,7 @@ class MySqlCharsetITCase {
                             + "c_gbk VARCHAR(50) CHARACTER SET gbk,"
                             + "c_latin1 VARCHAR(50) CHARACTER SET latin1,"
                             + "PRIMARY KEY (id))");
-            try (java.sql.PreparedStatement ps =
-                    conn.prepareStatement("INSERT INTO t_charset VALUES (1, ?, ?, ?)")) {
-                ps.setString(1, UTF8MB4_VALUE);
-                ps.setString(2, GBK_VALUE);
-                ps.setString(3, LATIN1_VALUE);
-                ps.execute();
-            }
+            insertRow(conn, 1, UTF8MB4_VALUE, GBK_VALUE, LATIN1_VALUE);
         }
     }
 
@@ -101,7 +104,7 @@ class MySqlCharsetITCase {
     }
 
     @Test
-    void snapshotDecodesPerColumnCharsets() throws Exception {
+    void snapshotAndBinlogDecodePerColumnCharsets() throws Exception {
         try (MockDorisServer mock = new MockDorisServer();
                 CdcClientWriteHarness harness =
                         CdcClientWriteHarness.mysql(
@@ -119,12 +122,36 @@ class MySqlCharsetITCase {
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_charset");
             harness.writeSnapshot(splits);
 
+            // snapshot path (JDBC scan)
             assertThat(harness.loadedRecords()).hasSize(1);
-            JsonNode row = MAPPER.readTree(harness.loadedRecords().get(0));
+            JsonNode snap = MAPPER.readTree(harness.loadedRecords().get(0));
+            assertThat(snap.get("c_utf8mb4").asText()).isEqualTo(UTF8MB4_VALUE);
+            assertThat(snap.get("c_gbk").asText()).isEqualTo(GBK_VALUE);
+            assertThat(snap.get("c_latin1").asText()).isEqualTo(LATIN1_VALUE);
 
-            assertThat(row.get("c_utf8mb4").asText()).isEqualTo(UTF8MB4_VALUE);
-            assertThat(row.get("c_gbk").asText()).isEqualTo(GBK_VALUE);
-            assertThat(row.get("c_latin1").asText()).isEqualTo(LATIN1_VALUE);
+            // binlog path (event decoding) — a distinct row inserted after the snapshot
+            try (Connection conn = rootConnection(database)) {
+                insertRow(conn, 2, UTF8MB4_INCR, GBK_INCR, LATIN1_INCR);
+            }
+            List<String> binlog = harness.writeBinlogUntil(splits, 1, Duration.ofSeconds(90));
+            assertThat(binlog).hasSize(1);
+            JsonNode incr = MAPPER.readTree(binlog.get(0));
+            assertThat(incr.get("id").asInt()).isEqualTo(2);
+            assertThat(incr.get("c_utf8mb4").asText()).isEqualTo(UTF8MB4_INCR);
+            assertThat(incr.get("c_gbk").asText()).isEqualTo(GBK_INCR);
+            assertThat(incr.get("c_latin1").asText()).isEqualTo(LATIN1_INCR);
+        }
+    }
+
+    private void insertRow(Connection conn, int id, String utf8mb4, String gbk, String latin1)
+            throws Exception {
+        try (PreparedStatement ps =
+                conn.prepareStatement("INSERT INTO t_charset VALUES (?, ?, ?, ?)")) {
+            ps.setInt(1, id);
+            ps.setString(2, utf8mb4);
+            ps.setString(3, gbk);
+            ps.setString(4, latin1);
+            ps.execute();
         }
     }
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlDateAdjusterITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlDateAdjusterITCase.java
@@ -37,24 +37,21 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Investigates MySQL date/year handling across the snapshot and binlog phases: whether genuinely
+ * ancient 4-digit years are preserved, whether 2-digit-input years stay completed, and whether the
+ * YEAR type is affected — for both phases.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlDateAdjusterITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(800_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -71,13 +68,24 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "date_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
-            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute(
+                    "CREATE TABLE t_dates ("
+                            + "id INT NOT NULL,"
+                            + "d_anc DATE,"      // ancient, 4-digit input
+                            + "d_2d DATE,"       // 2-digit input -> MySQL completes
+                            + "d_norm DATE,"     // normal
+                            + "dt_anc DATETIME," // ancient datetime
+                            + "yr YEAR,"
+                            + "PRIMARY KEY (id))");
+            // row read in the snapshot phase
+            st.execute(
+                    "INSERT INTO t_dates VALUES "
+                            + "(1, '0099-01-01', '99-01-01', '2020-07-17', '0099-01-01 00:00:00', 1999)");
         }
     }
 
@@ -91,7 +99,7 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
+    void ancientYearsPreservedInBothPhases() throws Exception {
         try (CdcClientReadHarness harness =
                 CdcClientReadHarness.mysql(
                         jobId,
@@ -100,45 +108,41 @@ class MySqlBasicReadITCase {
                         ROOT_USER,
                         ROOT_PASSWORD,
                         database,
-                        "t_user",
+                        "t_dates",
                         "initial")) {
 
-            // 1. snapshot reads the 3 seeded rows
-            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_dates");
             SnapshotResult snapshot = harness.readSnapshot(splits);
+            JsonNode snap = MAPPER.readTree(snapshot.records().get(0));
+            System.out.println("[ADJUSTER] snapshot row = " + snap);
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+            // ancient row in the binlog phase
+            insertAncient(2);
+            List<String> binlog = harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
+            JsonNode bin = MAPPER.readTree(binlog.get(0));
+            System.out.println("[ADJUSTER] binlog row   = " + bin);
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
+            // snapshot phase: faithful ancient years; 2-digit stays completed; normal unchanged
+            assertThat(snap.get("d_anc").asText()).isEqualTo("0099-01-01");
+            assertThat(snap.get("d_2d").asText()).isEqualTo("1999-01-01");
+            assertThat(snap.get("d_norm").asText()).isEqualTo("2020-07-17");
+            assertThat(snap.get("dt_anc").asText()).startsWith("0099-01-01 00:00:00");
+            assertThat(snap.get("yr").asInt()).isEqualTo(1999);
 
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            // binlog phase: faithful ancient years
+            assertThat(bin.get("d_anc").asText()).isEqualTo("0017-08-12");
+            assertThat(bin.get("dt_anc").asText()).startsWith("0017-08-12 00:00:00");
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
-        for (String record : records) {
-            JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
-        }
-        return result;
-    }
-
-    private void insert(int id, String name) throws Exception {
+    private void insertAncient(int id) throws Exception {
         try (Connection conn = rootConnection(database);
                 Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+            st.execute(
+                    String.format(
+                            "INSERT INTO t_dates VALUES (%d, '0017-08-12', '70-01-01', '2021-01-01',"
+                                    + " '0017-08-12 00:00:00', 2000)",
+                            id));
         }
     }
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlEmptyTableITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlEmptyTableITCase.java
@@ -20,7 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -37,29 +36,24 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Verifies the from-to {@code writeRecords} path handles an empty MySQL table: the snapshot yields
+ * zero records and cleanly transitions to the binlog phase, where a later insert is still captured.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlEmptyTableITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(990_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
             new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
                     .withDatabaseName("cdc_test")
                     .withUsername("cdc")
                     .withPassword("123456")
@@ -71,13 +65,12 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "empty_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
-            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
         }
     }
 
@@ -91,54 +84,36 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void emptySnapshotTransitionsCleanlyToBinlog() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
 
-            // 1. snapshot reads the 3 seeded rows
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            harness.writeSnapshot(splits);
+            assertThat(harness.loadedRecords()).isEmpty();
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
-
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
-
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
+            // The empty snapshot must still hand off to binlog cleanly.
+            harness.enterBinlog(splits);
+            try (Connection conn = rootConnection(database);
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (1, 'alice')");
+            }
+            List<String> binlog = harness.continueBinlog(1, Duration.ofSeconds(90));
             assertThat(binlog).hasSize(1);
             JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
-        }
-    }
-
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
-        for (String record : records) {
-            JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
-        }
-        return result;
-    }
-
-    private void insert(int id, String name) throws Exception {
-        try (Connection conn = rootConnection(database);
-                Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+            assertThat(row.get("id").asInt()).isEqualTo(1);
+            assertThat(row.get("name").asText()).isEqualTo("alice");
         }
     }
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlSnapshotResumeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlSnapshotResumeITCase.java
@@ -20,7 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,25 +35,25 @@ import org.testcontainers.utility.DockerImageName;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
-import java.time.Duration;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Simulates a snapshot interrupted partway and resumed: with a small chunk size the table splits
+ * into multiple chunks, and the from-to {@code writeRecords} path reads them as two separate windows
+ * (a first batch, then the remaining batch from the persisted chunk boundaries). The union of both
+ * windows must cover every row exactly once — no chunk re-read, no row skipped across the gap.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlSnapshotResumeITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(950_000);
+    private static final int ROW_COUNT = 20;
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -71,13 +70,20 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "resume_snap_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
             st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            StringBuilder values = new StringBuilder();
+            for (int i = 1; i <= ROW_COUNT; i++) {
+                if (i > 1) {
+                    values.append(',');
+                }
+                values.append("(").append(i).append(",'name-").append(i).append("')");
+            }
+            st.execute("INSERT INTO t_user VALUES " + values);
         }
     }
 
@@ -91,55 +97,59 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void resumedSnapshotReadsEveryChunkExactlyOnce() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                        jobId,
+                                        MYSQL.getHost(),
+                                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                        ROOT_USER,
+                                        ROOT_PASSWORD,
+                                        database,
+                                        "t_user",
+                                        "initial",
+                                        "doris_target_db",
+                                        mock)
+                                .withSplitSize(3)) {
 
-            // 1. snapshot reads the 3 seeded rows
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            // a small chunk size must yield several chunks, otherwise there is nothing to resume
+            assertThat(splits.size()).isGreaterThan(1);
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+            // snapshot_parallelism=1: FE issues one chunk per read window, mirrored here
+            int cut = splits.size() / 2;
+            // first window: read the leading chunks (snapshot interrupted after these)
+            for (int i = 0; i < cut; i++) {
+                harness.writeSnapshot(Collections.singletonList(splits.get(i)));
+            }
+            int afterFirst = harness.loadedRecords().size();
+            assertThat(afterFirst).isPositive();
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
+            // resume: read the remaining chunks from their persisted boundaries
+            for (int i = cut; i < splits.size(); i++) {
+                harness.writeSnapshot(Collections.singletonList(splits.get(i)));
+            }
 
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            List<Integer> ids = ids(harness.loadedRecords());
+            // every row read exactly once across the two windows
+            assertThat(ids).hasSize(ROW_COUNT);
+            assertThat(ids).doesNotHaveDuplicates();
+            List<Integer> expected = new ArrayList<>();
+            for (int i = 1; i <= ROW_COUNT; i++) {
+                expected.add(i);
+            }
+            assertThat(ids).containsExactlyInAnyOrderElementsOf(expected);
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
         for (String record : records) {
             JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
+            result.add(node.get("id").asInt());
         }
         return result;
-    }
-
-    private void insert(int id, String name) throws Exception {
-        try (Connection conn = rootConnection(database);
-                Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
-        }
     }
 
     private Connection rootConnection(String db) throws Exception {

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlStartupLatestITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlStartupLatestITCase.java
@@ -20,8 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
-import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,29 +35,25 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Verifies the {@code latest} startup mode for MySQL: the job skips the snapshot entirely and reads
+ * only binlog changes that happen after it starts. Pre-existing rows must never be stream-loaded.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlStartupLatestITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(960_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
             new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
                     .withDatabaseName("cdc_test")
                     .withUsername("cdc")
                     .withPassword("123456")
@@ -71,13 +65,14 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "latest_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
-            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            // pre-existing rows that latest mode must NOT read
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
         }
     }
 
@@ -91,54 +86,52 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void latestSkipsSnapshotAndReadsOnlyNewChanges() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                "latest",
+                                "doris_target_db",
+                                mock)) {
 
-            // 1. snapshot reads the 3 seeded rows
-            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            // Resolve the latest binlog position now; rows 1 and 2 are already behind it.
+            harness.enterBinlogFromStartupMode();
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+            insert("INSERT INTO t_user VALUES (3,'carol')");
+            List<Integer> first = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            assertThat(first).containsExactly(3);
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
+            insert("INSERT INTO t_user VALUES (4,'dave')");
+            List<Integer> second = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            assertThat(second).containsExactly(4);
 
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            // The whole run must never have touched the pre-existing snapshot rows.
+            List<Integer> all = ids(harness.loadedRecords());
+            assertThat(all).doesNotContain(1, 2);
+            assertThat(all).containsExactlyInAnyOrder(3, 4);
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
         for (String record : records) {
             JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
+            result.add(node.get("id").asInt());
         }
         return result;
     }
 
-    private void insert(int id, String name) throws Exception {
+    private void insert(String sql) throws Exception {
         try (Connection conn = rootConnection(database);
                 Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+            st.execute(sql);
         }
     }
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlStartupSpecificOffsetITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlStartupSpecificOffsetITCase.java
@@ -20,8 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
-import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,31 +33,29 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Verifies the specific-offset startup mode for MySQL: given a recorded binlog file/position, the
+ * job replays from exactly that point forward — capturing changes made after the recorded position
+ * (even ones that happened before the job started) while never re-reading anything before it.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlStartupSpecificOffsetITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(970_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
             new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
                     .withDatabaseName("cdc_test")
                     .withUsername("cdc")
                     .withPassword("123456")
@@ -71,13 +67,13 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "specoff_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
-            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
         }
     }
 
@@ -91,54 +87,68 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void specificOffsetReplaysFromRecordedPositionForward() throws Exception {
+        // Record the binlog position right after the pre-existing rows.
+        String[] pos = currentBinlogPosition();
+        String offset = String.format("{\"file\":\"%s\",\"pos\":\"%s\"}", pos[0], pos[1]);
 
-            // 1. snapshot reads the 3 seeded rows
-            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+        // This change happens after the recorded offset but before the job starts — it must be read.
+        insert("INSERT INTO t_user VALUES (3,'carol')");
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                offset,
+                                "doris_target_db",
+                                mock)) {
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
+            // First window replays from the recorded position, so row 3 (already in the binlog)
+            // is read straight away rather than waited on as a fresh change.
+            List<Integer> first = ids(harness.readBinlogFromStartupMode(1, Duration.ofSeconds(90)));
+            assertThat(first).containsExactly(3);
 
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            insert("INSERT INTO t_user VALUES (4,'dave')");
+            List<Integer> second = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            assertThat(second).containsExactly(4);
+
+            // Replays from the recorded position forward: rows 3 and 4 only, never 1 or 2.
+            List<Integer> all = ids(harness.loadedRecords());
+            assertThat(all).doesNotContain(1, 2);
+            assertThat(all).containsExactlyInAnyOrder(3, 4);
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
+    private String[] currentBinlogPosition() throws Exception {
+        try (Connection conn = rootConnection(database);
+                Statement st = conn.createStatement();
+                ResultSet rs = st.executeQuery("SHOW MASTER STATUS")) {
+            if (!rs.next()) {
+                throw new IllegalStateException("SHOW MASTER STATUS returned no row");
+            }
+            return new String[] {rs.getString("File"), rs.getString("Position")};
+        }
+    }
+
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
         for (String record : records) {
             JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
+            result.add(node.get("id").asInt());
         }
         return result;
     }
 
-    private void insert(int id, String name) throws Exception {
+    private void insert(String sql) throws Exception {
         try (Connection conn = rootConnection(database);
                 Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+            st.execute(sql);
         }
     }
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlStreamDmlITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlStreamDmlITCase.java
@@ -19,8 +19,8 @@ package org.apache.doris.cdcclient.itcase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.doris.cdcclient.common.Constants;
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -37,29 +37,29 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Exercises the TVF read path ({@code fetchRecordStream}) for MySQL incremental update/delete (the
+ * existing TVF ITCase only streamed an insert) and the offset-resume flow: after a streamed window,
+ * resuming from the returned binlog offset reads only the newer change, never re-reading committed
+ * rows.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlStreamDmlITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(930_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
             new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
                     .withDatabaseName("cdc_test")
                     .withUsername("cdc")
                     .withPassword("123456")
@@ -71,13 +71,13 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "stream_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
-            st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
         }
     }
 
@@ -91,7 +91,7 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
+    void streamsUpdateDeleteThenResumesFromOffset() throws Exception {
         try (CdcClientReadHarness harness =
                 CdcClientReadHarness.mysql(
                         jobId,
@@ -103,43 +103,54 @@ class MySqlBasicReadITCase {
                         "t_user",
                         "initial")) {
 
-            // 1. snapshot reads the 3 seeded rows
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            CdcClientReadHarness.SnapshotResult snapshot = harness.readSnapshot(splits);
+            assertThat(ids(snapshot.records())).containsExactlyInAnyOrder(1, 2);
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
-
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
+            // insert/update/delete streamed from the binlog
+            try (Connection conn = rootConnection(database);
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (3,'carol')");
+                st.execute("UPDATE t_user SET name = 'alice2' WHERE id = 1");
+                st.execute("DELETE FROM t_user WHERE id = 2");
+            }
 
             List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+                    harness.readBinlogUntil(snapshot, splits, 3, Duration.ofSeconds(90));
+            Map<Integer, JsonNode> byId = indexById(binlog);
+            assertThat(byId).containsKeys(1, 2, 3);
+            assertThat(byId.get(3).get("name").asText()).isEqualTo("carol");
+            assertThat(byId.get(1).get("name").asText()).isEqualTo("alice2");
+            assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
+
+            // resume from the committed offset: only the newer row, no re-read of 1/2/3
+            try (Connection conn = rootConnection(database);
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (4,'dave')");
+            }
+            List<String> resumed =
+                    harness.readBinlogFromOffset(
+                            harness.lastBinlogOffset(), 1, Duration.ofSeconds(90));
+            assertThat(ids(resumed)).containsExactly(4);
+            assertThat(ids(resumed)).doesNotContain(1, 2, 3);
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
         for (String record : records) {
-            JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
+            result.add(MAPPER.readTree(record).get("id").asInt());
         }
         return result;
     }
 
-    private void insert(int id, String name) throws Exception {
-        try (Connection conn = rootConnection(database);
-                Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node);
         }
+        return result;
     }
 
     private Connection rootConnection(String db) throws Exception {

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlTimezoneITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlTimezoneITCase.java
@@ -38,10 +38,17 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Verifies the from-to {@code writeRecords} path applies the configured server timezone when
- * deserializing MySQL temporal types: a TIMESTAMP (absolute instant, stored in UTC) read under two
- * different server timezones denotes the same instant, while a DATETIME (wall-clock, timezone-free)
- * reads identically regardless of the server timezone.
+ * Verifies MySQL temporal values round-trip through the from-to {@code writeRecords} path: a
+ * TIMESTAMP and a DATETIME both keep their inserted wall-clock regardless of the configured server
+ * timezone.
+ *
+ * <p>For TIMESTAMP this is non-trivial: Debezium reads it using the connection's server timezone
+ * (producing a different UTC instant per zone — e.g. 04:00Z under Asia/Shanghai vs 10:00Z under
+ * Europe/Berlin for the same stored 12:00), and the deserializer converts it back using the same
+ * server timezone, so the two offsets cancel and the materialized wall-clock is stable. If those two
+ * zones ever diverged (e.g. the deserializer's zone were lost and defaulted), the output would shift
+ * and these exact-string assertions would fail — which is the property under test. DATETIME is
+ * timezone-free to begin with.
  */
 @Testcontainers
 class MySqlTimezoneITCase {
@@ -50,6 +57,9 @@ class MySqlTimezoneITCase {
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final AtomicLong JOB_ID_SEQ = new AtomicLong(910_000);
+
+    /** The inserted wall-clock that must survive end to end under any server timezone. */
+    private static final String EXPECTED_WALL_CLOCK = "2023-06-15 12:00:00.0";
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -72,22 +82,21 @@ class MySqlTimezoneITCase {
     }
 
     @Test
-    void timestampDenotesSameInstantAcrossServerTimezones() throws Exception {
-        // '2023-06-15 12:00:00' inserted at session tz UTC -> stored instant 2023-06-15T12:00:00Z.
-        String shanghai = readTimestampColumns("Asia/Shanghai");
-        String berlin = readTimestampColumns("Europe/Berlin");
+    void temporalValuesRoundTripToInsertedWallClockAcrossServerTimezones() throws Exception {
+        // '2023-06-15 12:00:00' inserted at session tz UTC, read back under two different reader
+        // server timezones.
+        JsonNode shanghai = MAPPER.readTree(readTimestampColumns("Asia/Shanghai"));
+        JsonNode berlin = MAPPER.readTree(readTimestampColumns("Europe/Berlin"));
 
-        JsonNode sh = MAPPER.readTree(shanghai);
-        JsonNode be = MAPPER.readTree(berlin);
+        // TIMESTAMP: read-zone and deserialize-zone cancel out, so the inserted wall-clock is
+        // preserved identically under both server timezones. A broken cancellation would shift one
+        // or both of these off 12:00:00.
+        assertThat(shanghai.get("c_timestamp").asText()).isEqualTo(EXPECTED_WALL_CLOCK);
+        assertThat(berlin.get("c_timestamp").asText()).isEqualTo(EXPECTED_WALL_CLOCK);
 
-        // DATETIME is wall-clock: identical text regardless of the reader's server timezone.
-        assertThat(sh.get("c_datetime").asText()).isEqualTo(be.get("c_datetime").asText());
-
-        // TIMESTAMP is an absolute instant: both readings denote the same moment in time.
-        java.time.Instant shInstant = parseInstant(sh.get("c_timestamp").asText());
-        java.time.Instant beInstant = parseInstant(be.get("c_timestamp").asText());
-        assertThat(shInstant).isEqualTo(beInstant);
-        assertThat(shInstant).isEqualTo(java.time.Instant.parse("2023-06-15T12:00:00Z"));
+        // DATETIME: timezone-free wall-clock, unaffected by the server timezone.
+        assertThat(shanghai.get("c_datetime").asText()).isEqualTo(EXPECTED_WALL_CLOCK);
+        assertThat(berlin.get("c_datetime").asText()).isEqualTo(EXPECTED_WALL_CLOCK);
     }
 
     private String readTimestampColumns(String serverTimezone) throws Exception {
@@ -133,16 +142,6 @@ class MySqlTimezoneITCase {
                     Statement st = conn.createStatement()) {
                 st.execute("DROP DATABASE IF EXISTS " + database);
             }
-        }
-    }
-
-    /** Accept both an ISO instant ("...Z"/offset) and a plain "yyyy-MM-dd HH:mm:ss" (taken as UTC). */
-    private java.time.Instant parseInstant(String value) {
-        String v = value.trim();
-        try {
-            return java.time.Instant.parse(v.contains(" ") ? v.replace(' ', 'T') + "Z" : v);
-        } catch (Exception e) {
-            return java.time.OffsetDateTime.parse(v).toInstant();
         }
     }
 

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlTimezoneITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlTimezoneITCase.java
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the from-to {@code writeRecords} path applies the configured server timezone when
+ * deserializing MySQL temporal types: a TIMESTAMP (absolute instant, stored in UTC) read under two
+ * different server timezones denotes the same instant, while a DATETIME (wall-clock, timezone-free)
+ * reads identically regardless of the server timezone.
+ */
+@Testcontainers
+class MySqlTimezoneITCase {
+
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "123456";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(910_000);
+
+    @Container
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                    .withDatabaseName("cdc_test")
+                    .withUsername("cdc")
+                    .withPassword("123456")
+                    .withEnv("MYSQL_ROOT_PASSWORD", ROOT_PASSWORD)
+                    // Fix the server's session timezone so the TIMESTAMP literal maps to a known UTC
+                    // instant; the reader's own serverTimezone is what we vary per job.
+                    .withEnv("TZ", "UTC");
+
+    private final java.util.List<String> jobIds = new java.util.ArrayList<>();
+
+    @AfterEach
+    void tearDown() throws Exception {
+        for (String id : jobIds) {
+            Env.getCurrentEnv().close(id);
+        }
+    }
+
+    @Test
+    void timestampDenotesSameInstantAcrossServerTimezones() throws Exception {
+        // '2023-06-15 12:00:00' inserted at session tz UTC -> stored instant 2023-06-15T12:00:00Z.
+        String shanghai = readTimestampColumns("Asia/Shanghai");
+        String berlin = readTimestampColumns("Europe/Berlin");
+
+        JsonNode sh = MAPPER.readTree(shanghai);
+        JsonNode be = MAPPER.readTree(berlin);
+
+        // DATETIME is wall-clock: identical text regardless of the reader's server timezone.
+        assertThat(sh.get("c_datetime").asText()).isEqualTo(be.get("c_datetime").asText());
+
+        // TIMESTAMP is an absolute instant: both readings denote the same moment in time.
+        java.time.Instant shInstant = parseInstant(sh.get("c_timestamp").asText());
+        java.time.Instant beInstant = parseInstant(be.get("c_timestamp").asText());
+        assertThat(shInstant).isEqualTo(beInstant);
+        assertThat(shInstant).isEqualTo(java.time.Instant.parse("2023-06-15T12:00:00Z"));
+    }
+
+    private String readTimestampColumns(String serverTimezone) throws Exception {
+        String jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        jobIds.add(jobId);
+        String database = "tz_db_" + jobId;
+        try (Connection conn = rootConnection("");
+                Statement st = conn.createStatement()) {
+            st.execute("CREATE DATABASE " + database);
+            st.execute("USE " + database);
+            st.execute("SET time_zone = '+00:00'");
+            st.execute(
+                    "CREATE TABLE t_tz ("
+                            + "id INT NOT NULL,"
+                            + "c_timestamp TIMESTAMP,"
+                            + "c_datetime DATETIME,"
+                            + "PRIMARY KEY (id))");
+            st.execute(
+                    "INSERT INTO t_tz VALUES "
+                            + "(1, '2023-06-15 12:00:00', '2023-06-15 12:00:00')");
+        }
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                        jobId,
+                                        MYSQL.getHost(),
+                                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                        ROOT_USER,
+                                        ROOT_PASSWORD,
+                                        database,
+                                        "t_tz",
+                                        "initial",
+                                        "doris_target_db",
+                                        mock)
+                                .withServerTimezone(serverTimezone)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_tz");
+            harness.writeSnapshot(splits);
+            assertThat(harness.loadedRecords()).hasSize(1);
+            return harness.loadedRecords().get(0);
+        } finally {
+            try (Connection conn = rootConnection("");
+                    Statement st = conn.createStatement()) {
+                st.execute("DROP DATABASE IF EXISTS " + database);
+            }
+        }
+    }
+
+    /** Accept both an ISO instant ("...Z"/offset) and a plain "yyyy-MM-dd HH:mm:ss" (taken as UTC). */
+    private java.time.Instant parseInstant(String value) {
+        String v = value.trim();
+        try {
+            return java.time.Instant.parse(v.contains(" ") ? v.replace(' ', 'T') + "Z" : v);
+        } catch (Exception e) {
+            return java.time.OffsetDateTime.parse(v).toInstant();
+        }
+    }
+
+    private Connection rootConnection(String db) throws Exception {
+        String url =
+                "jdbc:mysql://"
+                        + MYSQL.getHost()
+                        + ":"
+                        + MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT)
+                        + "/"
+                        + db;
+        return DriverManager.getConnection(url, ROOT_USER, ROOT_PASSWORD);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlVersionSmokeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlVersionSmokeITCase.java
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Constants;
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Version compatibility smoke test for the MySQL releases not exercised by the default ITCases
+ * (which already cover 8.0): 5.7 and the 8.4 LTS. Runs the core read chain — snapshot full-load then
+ * incremental insert/update/delete — to confirm the from-to {@code writeRecords} path works across
+ * versions whose defaults (charset, sql_mode, binlog-off on 5.7) differ from 8.0.
+ */
+class MySqlVersionSmokeITCase {
+
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "123456";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(920_000);
+
+    @ParameterizedTest
+    @ValueSource(strings = {"mysql:5.7", "mysql:8.4"})
+    void snapshotAndDmlWorkAcrossVersions(String image) throws Exception {
+        MySQLContainer<?> mysql =
+                new MySQLContainer<>(
+                                DockerImageName.parse(image).asCompatibleSubstituteFor("mysql"))
+                        .withDatabaseName("cdc_test")
+                        .withUsername("cdc")
+                        .withPassword("123456")
+                        .withEnv("MYSQL_ROOT_PASSWORD", ROOT_PASSWORD);
+        // 5.7 ships with binlog disabled; 8.x enables row-based binlog by default.
+        if (image.startsWith("mysql:5.7")) {
+            mysql.withConfigurationOverride("docker/server-with-binlog");
+        }
+
+        String jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        String database = "smoke_db_" + jobId;
+        try (MySQLContainer<?> container = mysql) {
+            container.start();
+            try (Connection conn = rootConnection(container, "");
+                    Statement st = conn.createStatement()) {
+                st.execute("CREATE DATABASE " + database);
+                st.execute("USE " + database);
+                st.execute(
+                        "CREATE TABLE t_user ("
+                                + "id INT NOT NULL,"
+                                + "name VARCHAR(50),"
+                                + "age INT,"
+                                + "c_decimal DECIMAL(10,2),"
+                                + "PRIMARY KEY (id))");
+                st.execute("INSERT INTO t_user VALUES (1,'alice',30,12.34), (2,'bob',25,56.78)");
+            }
+
+            try (MockDorisServer mock = new MockDorisServer();
+                    CdcClientWriteHarness harness =
+                            CdcClientWriteHarness.mysql(
+                                    jobId,
+                                    container.getHost(),
+                                    container.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                    ROOT_USER,
+                                    ROOT_PASSWORD,
+                                    database,
+                                    "t_user",
+                                    "initial",
+                                    "doris_target_db",
+                                    mock)) {
+
+                List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+                harness.writeSnapshot(splits);
+
+                // snapshot full-load
+                Map<Integer, JsonNode> snap = indexById(harness.loadedRecords());
+                assertThat(snap).containsKeys(1, 2);
+                assertThat(snap.get(1).get("name").asText()).isEqualTo("alice");
+                assertThat(snap.get(1).get("age").asInt()).isEqualTo(30);
+                assertThat(snap.get(1).get("c_decimal").decimalValue().toPlainString())
+                        .isEqualTo("12.34");
+
+                // incremental insert/update/delete
+                try (Connection conn = rootConnection(container, database);
+                        Statement st = conn.createStatement()) {
+                    st.execute("INSERT INTO t_user VALUES (3,'carol',40,99.99)");
+                    st.execute("UPDATE t_user SET age = 31 WHERE id = 1");
+                    st.execute("DELETE FROM t_user WHERE id = 2");
+                }
+
+                List<String> binlog = harness.writeBinlogUntil(splits, 3, Duration.ofSeconds(90));
+                Map<Integer, JsonNode> byId = indexById(binlog);
+                assertThat(byId).containsKeys(1, 2, 3);
+                assertThat(byId.get(3).get("name").asText()).isEqualTo("carol");
+                assertThat(byId.get(3).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+                assertThat(byId.get(1).get("age").asInt()).isEqualTo(31);
+                assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
+            } finally {
+                Env.getCurrentEnv().close(jobId);
+            }
+        }
+    }
+
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node);
+        }
+        return result;
+    }
+
+    private Connection rootConnection(MySQLContainer<?> container, String db) throws Exception {
+        String url =
+                "jdbc:mysql://"
+                        + container.getHost()
+                        + ":"
+                        + container.getMappedPort(MySQLContainer.MYSQL_PORT)
+                        + "/"
+                        + db
+                        + "?allowPublicKeyRetrieval=true&useSSL=false";
+        return DriverManager.getConnection(url, ROOT_USER, ROOT_PASSWORD);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteDmlITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteDmlITCase.java
@@ -19,8 +19,8 @@ package org.apache.doris.cdcclient.itcase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.doris.cdcclient.common.Constants;
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -43,18 +43,16 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Exercises the from-to {@code writeRecords} path for incremental (binlog) DML: insert / update /
+ * delete after the snapshot must be stream-loaded with the correct values and delete sign.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlWriteDmlITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(400_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -71,7 +69,7 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "dml_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
@@ -91,55 +89,55 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void binlogDmlStreamLoadsInsertUpdateDelete() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
 
-            // 1. snapshot reads the 3 seeded rows
+            // snapshot first (establishes the high-watermark to resume binlog from)
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            harness.writeSnapshot(splits);
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+            // three DML ops after the snapshot
+            try (Connection conn = rootConnection(database);
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (4, 'dave')");
+                st.execute("UPDATE t_user SET name = 'alice2' WHERE id = 1");
+                st.execute("DELETE FROM t_user WHERE id = 2");
+            }
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
+            List<String> binlog = harness.writeBinlogUntil(splits, 3, Duration.ofSeconds(60));
 
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            Map<Integer, JsonNode> byId = indexById(binlog);
+            assertThat(byId).containsKeys(1, 2, 4);
+            // insert
+            assertThat(byId.get(4).get("name").asText()).isEqualTo("dave");
+            assertThat(byId.get(4).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+            // update carries the new value
+            assertThat(byId.get(1).get("name").asText()).isEqualTo("alice2");
+            assertThat(byId.get(1).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+            // delete carries the delete sign
+            assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
         for (String record : records) {
             JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
+            result.put(node.get("id").asInt(), node);
         }
         return result;
-    }
-
-    private void insert(int id, String name) throws Exception {
-        try (Connection conn = rootConnection(database);
-                Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
-        }
     }
 
     private Connection rootConnection(String db) throws Exception {

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteRecordITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteRecordITCase.java
@@ -20,7 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,25 +35,23 @@ import org.testcontainers.utility.DockerImageName;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Exercises the from-to {@code writeRecords} path end to end: read from a MySQL container ->
+ * deserialize -> stream-load + commit-offset to a {@link MockDorisServer}. Verifies the rows are
+ * actually stream-loaded and the offset is committed — behavior the TVF path does not cover.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlWriteRecordITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(300_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -71,7 +68,7 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "fromto_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
@@ -91,38 +88,38 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void snapshotStreamLoadsRowsAndCommitsOffset() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
 
-            // 1. snapshot reads the 3 seeded rows
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            harness.writeSnapshot(splits);
 
-            Map<Integer, String> names = namesById(snapshot.records());
+            // the 3 seeded rows were stream-loaded to the (mock) BE
+            Map<Integer, String> names = namesById(harness.loadedRecords());
             assertThat(names).containsOnlyKeys(1, 2, 3);
             assertThat(names.get(1)).isEqualTo("alice");
             assertThat(names.get(2)).isEqualTo("bob");
             assertThat(names.get(3)).isEqualTo("carol");
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
-            insert(4, "dave");
-
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            // the offset was committed to the (mock) FE, carrying the snapshot high-watermark
+            String offset = harness.committedOffset();
+            assertThat(offset).isNotNull();
+            JsonNode commit = MAPPER.readTree(offset);
+            assertThat(commit.get("jobId").asLong()).isEqualTo(Long.parseLong(jobId));
+            assertThat(commit.get("scannedRows").asLong()).isEqualTo(3);
+            assertThat(commit.get("offset").asText()).contains("splitId");
         }
     }
 
@@ -133,13 +130,6 @@ class MySqlBasicReadITCase {
             result.put(node.get("id").asInt(), node.get("name").asText());
         }
         return result;
-    }
-
-    private void insert(int id, String name) throws Exception {
-        try (Connection conn = rootConnection(database);
-                Statement st = conn.createStatement()) {
-            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
-        }
     }
 
     private Connection rootConnection(String db) throws Exception {

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteResumeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteResumeITCase.java
@@ -20,7 +20,6 @@ package org.apache.doris.cdcclient.itcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.doris.cdcclient.common.Env;
-import org.apache.doris.cdcclient.itcase.CdcClientReadHarness.SnapshotResult;
 import org.apache.doris.job.cdc.split.SnapshotSplit;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -37,24 +36,22 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Minimal end-to-end example: drive the cdc_client read path against a MySQL container and verify
- * that a basic table is read correctly in both the snapshot and the incremental (binlog) phase.
- *
- * <p>Serves as the template that the rest of the migrated reading scenarios build on.
+ * Verifies the from-to {@code writeRecords} path's at-least-once offset handling: after a committed
+ * binlog round, resuming from the committed offset must read only the new change, never re-read the
+ * already-committed one.
  */
 @Testcontainers
-class MySqlBasicReadITCase {
+class MySqlWriteResumeITCase {
 
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "123456";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(200_000);
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(700_000);
 
     @Container
     static final MySQLContainer<?> MYSQL =
@@ -71,13 +68,13 @@ class MySqlBasicReadITCase {
     @BeforeEach
     void setUp() throws Exception {
         jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
-        database = "basic_db_" + jobId;
+        database = "resume_db_" + jobId;
         try (Connection conn = rootConnection("");
                 Statement st = conn.createStatement()) {
             st.execute("CREATE DATABASE " + database);
             st.execute("USE " + database);
             st.execute("CREATE TABLE t_user (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id))");
-            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
         }
     }
 
@@ -91,46 +88,42 @@ class MySqlBasicReadITCase {
     }
 
     @Test
-    void readsSnapshotThenBinlogInsert() throws Exception {
-        try (CdcClientReadHarness harness =
-                CdcClientReadHarness.mysql(
-                        jobId,
-                        MYSQL.getHost(),
-                        MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
-                        ROOT_USER,
-                        ROOT_PASSWORD,
-                        database,
-                        "t_user",
-                        "initial")) {
+    void resumeFromCommittedOffsetDoesNotReReadCommittedRow() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
 
-            // 1. snapshot reads the 3 seeded rows
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
-            SnapshotResult snapshot = harness.readSnapshot(splits);
+            harness.writeSnapshot(splits);
+            harness.enterBinlog(splits);
 
-            Map<Integer, String> names = namesById(snapshot.records());
-            assertThat(names).containsOnlyKeys(1, 2, 3);
-            assertThat(names.get(1)).isEqualTo("alice");
-            assertThat(names.get(2)).isEqualTo("bob");
-            assertThat(names.get(3)).isEqualTo("carol");
+            insert(3, "carol");
+            List<Integer> first = ids(harness.continueBinlog(1, Duration.ofSeconds(30)));
+            assertThat(first).containsExactly(3);
 
-            // 2. a row inserted after the snapshot shows up in the binlog phase
             insert(4, "dave");
-
-            List<String> binlog =
-                    harness.readBinlogUntil(snapshot, splits, 1, Duration.ofSeconds(60));
-            assertThat(binlog).hasSize(1);
-            JsonNode row = MAPPER.readTree(binlog.get(0));
-            assertThat(row.get("id").asInt()).isEqualTo(4);
-            assertThat(row.get("name").asText()).isEqualTo("dave");
-            assertThat(row.get("__DORIS_DELETE_SIGN__").asInt()).isZero();
+            List<Integer> second = ids(harness.continueBinlog(1, Duration.ofSeconds(30)));
+            // resumed from the committed offset: only the new row, no re-read of id=3
+            assertThat(second).containsExactly(4);
+            assertThat(second).doesNotContain(3);
         }
     }
 
-    private Map<Integer, String> namesById(List<String> records) throws Exception {
-        Map<Integer, String> result = new HashMap<>();
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
         for (String record : records) {
             JsonNode node = MAPPER.readTree(record);
-            result.put(node.get("id").asInt(), node.get("name").asText());
+            result.add(node.get("id").asInt());
         }
         return result;
     }

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteResumeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteResumeITCase.java
@@ -119,6 +119,42 @@ class MySqlWriteResumeITCase {
         }
     }
 
+    @Test
+    void snapshotToBinlogBoundaryRowIsNotSwallowed() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            harness.writeSnapshot(splits);
+            int afterSnapshot = mock.loadedRecords().size();
+
+            // Lands in the gap between snapshot completion and the first binlog window — exactly the
+            // position startOffset=minOffsetFinishSplits can swallow.
+            insert(3, "carol");
+
+            harness.enterBinlog(splits);
+            if (idsSince(mock, afterSnapshot).stream().noneMatch(id -> id == 3)) {
+                harness.continueBinlog(1, Duration.ofSeconds(30));
+            }
+
+            List<Integer> gap = idsSince(mock, afterSnapshot);
+            // gap row reaches the binlog phase, and the snapshot rows are not re-read there.
+            assertThat(gap).contains(3);
+            assertThat(gap).doesNotContain(1, 2);
+        }
+    }
+
     private List<Integer> ids(List<String> records) throws Exception {
         List<Integer> result = new ArrayList<>();
         for (String record : records) {
@@ -126,6 +162,11 @@ class MySqlWriteResumeITCase {
             result.add(node.get("id").asInt());
         }
         return result;
+    }
+
+    private List<Integer> idsSince(MockDorisServer mock, int from) throws Exception {
+        List<String> all = mock.loadedRecords();
+        return ids(all.subList(from, all.size()));
     }
 
     private void insert(int id, String name) throws Exception {

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteTypesITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/MySqlWriteTypesITCase.java
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the from-to {@code writeRecords} path deserializes the common MySQL column families
+ * (signed/unsigned integers, decimal, floating point, string, enum/set, bit, json) correctly
+ * through the snapshot phase. Date/time/year types are covered by {@link MySqlDateAdjusterITCase}.
+ */
+@Testcontainers
+class MySqlWriteTypesITCase {
+
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "123456";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(900_000);
+
+    @Container
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                    .withConfigurationOverride("docker/server-allow-ancient-date-time")
+                    .withDatabaseName("cdc_test")
+                    .withUsername("cdc")
+                    .withPassword("123456")
+                    .withEnv("MYSQL_ROOT_PASSWORD", ROOT_PASSWORD);
+
+    private String jobId;
+    private String database;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        database = "types_db_" + jobId;
+        try (Connection conn = rootConnection("");
+                Statement st = conn.createStatement()) {
+            st.execute("CREATE DATABASE " + database);
+            st.execute("USE " + database);
+            st.execute(
+                    "CREATE TABLE t_types ("
+                            + "id INT NOT NULL,"
+                            + "c_tinyint TINYINT,"
+                            + "c_smallint SMALLINT,"
+                            + "c_bigint BIGINT,"
+                            + "c_bigint_unsigned BIGINT UNSIGNED,"
+                            + "c_decimal DECIMAL(10,2),"
+                            + "c_float FLOAT,"
+                            + "c_double DOUBLE,"
+                            + "c_bool BOOLEAN,"
+                            + "c_varchar VARCHAR(50),"
+                            + "c_char CHAR(5),"
+                            + "c_text TEXT,"
+                            + "c_enum ENUM('a','b','c'),"
+                            + "c_set SET('x','y','z'),"
+                            + "c_bit BIT(8),"
+                            + "c_json JSON,"
+                            + "PRIMARY KEY (id))");
+            st.execute(
+                    "INSERT INTO t_types VALUES ("
+                            + "1,"
+                            + "-5,"
+                            + "300,"
+                            + "9223372036854775807,"
+                            + "18446744073709551615,"
+                            + "12.34,"
+                            + "1.5,"
+                            + "3.14159,"
+                            + "true,"
+                            + "'hello',"
+                            + "'abc',"
+                            + "'a long text value',"
+                            + "'b',"
+                            + "'x,z',"
+                            + "b'00000101',"
+                            + "'{\"k\": 1, \"arr\": [2, 3]}')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Env.getCurrentEnv().close(jobId);
+        try (Connection conn = rootConnection("");
+                Statement st = conn.createStatement()) {
+            st.execute("DROP DATABASE IF EXISTS " + database);
+        }
+    }
+
+    @Test
+    void snapshotDeserializesMySqlTypes() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.mysql(
+                                jobId,
+                                MYSQL.getHost(),
+                                MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT),
+                                ROOT_USER,
+                                ROOT_PASSWORD,
+                                database,
+                                "t_types",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_types");
+            harness.writeSnapshot(splits);
+
+            assertThat(harness.loadedRecords()).hasSize(1);
+            JsonNode row = MAPPER.readTree(harness.loadedRecords().get(0));
+
+            assertThat(row.get("id").asInt()).isEqualTo(1);
+            assertThat(row.get("c_tinyint").asInt()).isEqualTo(-5);
+            assertThat(row.get("c_smallint").asInt()).isEqualTo(300);
+            assertThat(row.get("c_bigint").asLong()).isEqualTo(9223372036854775807L);
+            // bigint unsigned beyond Long range -> exact decimal string
+            assertThat(row.get("c_bigint_unsigned").asText()).isEqualTo("18446744073709551615");
+            assertThat(row.get("c_decimal").decimalValue().toPlainString()).isEqualTo("12.34");
+            assertThat(row.get("c_float").asDouble()).isEqualTo(1.5);
+            assertThat(row.get("c_double").asDouble()).isEqualTo(3.14159);
+            assertThat(row.get("c_bool").asInt()).isEqualTo(1);
+            assertThat(row.get("c_varchar").asText()).isEqualTo("hello");
+            assertThat(row.get("c_char").asText()).isEqualTo("abc");
+            assertThat(row.get("c_text").asText()).isEqualTo("a long text value");
+            assertThat(row.get("c_enum").asText()).isEqualTo("b");
+            assertThat(row.get("c_set").asText()).isEqualTo("x,z");
+            assertThat(row.get("c_json").asText()).contains("\"k\"");
+        }
+    }
+
+    private Connection rootConnection(String db) throws Exception {
+        String url =
+                "jdbc:mysql://"
+                        + MYSQL.getHost()
+                        + ":"
+                        + MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT)
+                        + "/"
+                        + db;
+        return DriverManager.getConnection(url, ROOT_USER, ROOT_PASSWORD);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresEmptyTableITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresEmptyTableITCase.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the from-to {@code writeRecords} path handles an empty PostgreSQL table: the snapshot
+ * yields zero records and cleanly transitions to the WAL phase, where a later insert is captured.
+ */
+@Testcontainers
+class PostgresEmptyTableITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(560_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void emptySnapshotTransitionsCleanlyToWal() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            harness.writeSnapshot(splits);
+            assertThat(harness.loadedRecords()).isEmpty();
+
+            harness.enterBinlog(splits);
+            try (Connection conn = connect();
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (1, 'alice')");
+            }
+            List<String> binlog = harness.continueBinlog(1, Duration.ofSeconds(90));
+            assertThat(binlog).hasSize(1);
+            JsonNode row = MAPPER.readTree(binlog.get(0));
+            assertThat(row.get("id").asInt()).isEqualTo(1);
+            assertThat(row.get("name").asText()).isEqualTo("alice");
+        }
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresReplicaIdentityDefaultITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresReplicaIdentityDefaultITCase.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Constants;
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the from-to {@code writeRecords} path for PostgreSQL with the default REPLICA IDENTITY
+ * (primary key only): update/delete WAL events carry only the key in their old image, yet must still
+ * stream-load the new value for an update and the correct delete sign keyed by the primary key.
+ */
+@Testcontainers
+class PostgresReplicaIdentityDefaultITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(550_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            // No REPLICA IDENTITY FULL: PostgreSQL defaults to the primary key for the old image.
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void updateDeleteWithDefaultIdentityStreamLoadCorrectly() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            harness.writeSnapshot(splits);
+
+            try (Connection conn = connect();
+                    Statement st = conn.createStatement()) {
+                st.execute("UPDATE t_user SET name = 'alice2' WHERE id = 1");
+                st.execute("DELETE FROM t_user WHERE id = 2");
+            }
+
+            List<String> binlog = harness.writeBinlogUntil(splits, 2, Duration.ofSeconds(90));
+
+            Map<Integer, JsonNode> byId = indexById(binlog);
+            assertThat(byId).containsKeys(1, 2);
+            // update carries the new value despite the key-only old image
+            assertThat(byId.get(1).get("name").asText()).isEqualTo("alice2");
+            assertThat(byId.get(1).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+            // delete keyed by primary key, marked deleted
+            assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
+        }
+    }
+
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node);
+        }
+        return result;
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresSnapshotResumeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresSnapshotResumeITCase.java
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Simulates a PostgreSQL snapshot interrupted partway and resumed: with a small chunk size the table
+ * splits into multiple chunks, read as a first batch then the remaining batch from the persisted
+ * chunk boundaries. The union of both windows must cover every row exactly once — no chunk re-read,
+ * no row skipped across the gap.
+ */
+@Testcontainers
+class PostgresSnapshotResumeITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(530_000);
+    private static final int ROW_COUNT = 20;
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            StringBuilder values = new StringBuilder();
+            for (int i = 1; i <= ROW_COUNT; i++) {
+                if (i > 1) {
+                    values.append(',');
+                }
+                values.append("(").append(i).append(",'name-").append(i).append("')");
+            }
+            st.execute("INSERT INTO t_user VALUES " + values);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void resumedSnapshotReadsEveryChunkExactlyOnce() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                        jobId,
+                                        POSTGRES.getHost(),
+                                        POSTGRES.getMappedPort(
+                                                PostgreSQLContainer.POSTGRESQL_PORT),
+                                        POSTGRES.getUsername(),
+                                        POSTGRES.getPassword(),
+                                        POSTGRES.getDatabaseName(),
+                                        "public",
+                                        "t_user",
+                                        "initial",
+                                        "doris_target_db",
+                                        mock)
+                                .withSplitSize(3)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            assertThat(splits.size()).isGreaterThan(1);
+
+            int cut = splits.size() / 2;
+            for (int i = 0; i < cut; i++) {
+                harness.writeSnapshot(Collections.singletonList(splits.get(i)));
+            }
+            int afterFirst = harness.loadedRecords().size();
+            assertThat(afterFirst).isPositive();
+
+            for (int i = cut; i < splits.size(); i++) {
+                harness.writeSnapshot(Collections.singletonList(splits.get(i)));
+            }
+
+            List<Integer> ids = ids(harness.loadedRecords());
+            assertThat(ids).hasSize(ROW_COUNT);
+            assertThat(ids).doesNotHaveDuplicates();
+            List<Integer> expected = new ArrayList<>();
+            for (int i = 1; i <= ROW_COUNT; i++) {
+                expected.add(i);
+            }
+            assertThat(ids).containsExactlyInAnyOrderElementsOf(expected);
+        }
+    }
+
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.add(node.get("id").asInt());
+        }
+        return result;
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresStartupLatestITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresStartupLatestITCase.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the {@code latest} startup mode for PostgreSQL: the job skips the snapshot entirely and
+ * reads only WAL changes that happen after it starts. Pre-existing rows must never be stream-loaded.
+ */
+@Testcontainers
+class PostgresStartupLatestITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(540_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            // pre-existing rows that latest mode must NOT read
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void latestSkipsSnapshotAndReadsOnlyNewChanges() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_user",
+                                "latest",
+                                "doris_target_db",
+                                mock)) {
+
+            // Resolve the latest WAL position now; rows 1 and 2 are already behind it.
+            harness.enterBinlogFromStartupMode();
+
+            insert("INSERT INTO t_user VALUES (3,'carol')");
+            List<Integer> first = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            assertThat(first).containsExactly(3);
+
+            insert("INSERT INTO t_user VALUES (4,'dave')");
+            List<Integer> second = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            assertThat(second).containsExactly(4);
+
+            // The whole run must never have touched the pre-existing snapshot rows.
+            List<Integer> all = ids(harness.loadedRecords());
+            assertThat(all).doesNotContain(1, 2);
+            assertThat(all).containsExactlyInAnyOrder(3, 4);
+        }
+    }
+
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.add(node.get("id").asInt());
+        }
+        return result;
+    }
+
+    private void insert(String sql) throws Exception {
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute(sql);
+        }
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresStreamReadITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresStreamReadITCase.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Constants;
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Exercises the TVF read path ({@code fetchRecordStream}) for PostgreSQL, which the existing TVF
+ * ITCases never covered (the read harness was MySQL-only). Drives snapshot full-load then incremental
+ * insert/update/delete as a streamed result, confirming the pgoutput slot/publication setup, the LSN
+ * stream output and the delete sign all work on the streaming endpoint.
+ */
+@Testcontainers
+class PostgresStreamReadITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(580_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("ALTER TABLE t_user REPLICA IDENTITY FULL");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void snapshotThenStreamedDml() throws Exception {
+        try (CdcClientReadHarness harness =
+                CdcClientReadHarness.postgres(
+                        jobId,
+                        POSTGRES.getHost(),
+                        POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                        POSTGRES.getUsername(),
+                        POSTGRES.getPassword(),
+                        POSTGRES.getDatabaseName(),
+                        "public",
+                        "t_user",
+                        "initial")) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            CdcClientReadHarness.SnapshotResult snapshot = harness.readSnapshot(splits);
+
+            // snapshot streamed full-load
+            Map<Integer, JsonNode> snap = indexById(snapshot.records());
+            assertThat(snap).containsKeys(1, 2);
+            assertThat(snap.get(1).get("name").asText()).isEqualTo("alice");
+
+            // incremental insert/update/delete streamed from WAL
+            try (Connection conn = connect();
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (3,'carol')");
+                st.execute("UPDATE t_user SET name = 'alice2' WHERE id = 1");
+                st.execute("DELETE FROM t_user WHERE id = 2");
+            }
+
+            List<String> binlog =
+                    harness.readBinlogUntil(snapshot, splits, 3, Duration.ofSeconds(90));
+            Map<Integer, JsonNode> byId = indexById(binlog);
+            assertThat(byId).containsKeys(1, 2, 3);
+            assertThat(byId.get(3).get("name").asText()).isEqualTo("carol");
+            assertThat(byId.get(3).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+            assertThat(byId.get(1).get("name").asText()).isEqualTo("alice2");
+            assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
+        }
+    }
+
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node);
+        }
+        return result;
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresStreamReadITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresStreamReadITCase.java
@@ -95,10 +95,12 @@ class PostgresStreamReadITCase {
             List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
             CdcClientReadHarness.SnapshotResult snapshot = harness.readSnapshot(splits);
 
-            // snapshot streamed full-load
+            // snapshot streamed full-load — exactly the two seed rows, no more
+            assertThat(snapshot.records()).hasSize(2);
             Map<Integer, JsonNode> snap = indexById(snapshot.records());
-            assertThat(snap).containsKeys(1, 2);
+            assertThat(snap).containsOnlyKeys(1, 2);
             assertThat(snap.get(1).get("name").asText()).isEqualTo("alice");
+            assertThat(snap.get(2).get("name").asText()).isEqualTo("bob");
 
             // incremental insert/update/delete streamed from WAL
             try (Connection conn = connect();

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresVersionSmokeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresVersionSmokeITCase.java
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Constants;
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Version compatibility smoke test for the PostgreSQL releases not exercised by the default ITCases
+ * (which already cover 14, the supported lower bound): 15, 16 and 17. Runs the core read chain —
+ * snapshot full-load then incremental insert/update/delete — to confirm the from-to
+ * {@code writeRecords} path and the pgoutput slot/publication setup work across newer servers.
+ */
+class PostgresVersionSmokeITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(570_000);
+
+    @ParameterizedTest
+    @ValueSource(strings = {"postgres:15", "postgres:16", "postgres:17"})
+    void snapshotAndDmlWorkAcrossVersions(String image) throws Exception {
+        String jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (PostgreSQLContainer<?> postgres =
+                new PostgreSQLContainer<>(
+                                DockerImageName.parse(image).asCompatibleSubstituteFor("postgres"))
+                        .withCommand("postgres", "-c", "wal_level=logical")) {
+            postgres.start();
+
+            try (Connection conn = connect(postgres);
+                    Statement st = conn.createStatement()) {
+                st.execute("DROP TABLE IF EXISTS t_user");
+                st.execute(
+                        "CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50),"
+                                + " age INT, c_decimal DECIMAL(10,2))");
+                st.execute("ALTER TABLE t_user REPLICA IDENTITY FULL");
+                st.execute("INSERT INTO t_user VALUES (1,'alice',30,12.34), (2,'bob',25,56.78)");
+            }
+
+            try (MockDorisServer mock = new MockDorisServer();
+                    CdcClientWriteHarness harness =
+                            CdcClientWriteHarness.postgres(
+                                    jobId,
+                                    postgres.getHost(),
+                                    postgres.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                    postgres.getUsername(),
+                                    postgres.getPassword(),
+                                    postgres.getDatabaseName(),
+                                    "public",
+                                    "t_user",
+                                    "initial",
+                                    "doris_target_db",
+                                    mock)) {
+
+                List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+                harness.writeSnapshot(splits);
+
+                // snapshot full-load
+                Map<Integer, JsonNode> snap = indexById(harness.loadedRecords());
+                assertThat(snap).containsKeys(1, 2);
+                assertThat(snap.get(1).get("name").asText()).isEqualTo("alice");
+                assertThat(snap.get(1).get("age").asInt()).isEqualTo(30);
+                assertThat(snap.get(1).get("c_decimal").decimalValue().toPlainString())
+                        .isEqualTo("12.34");
+
+                // incremental insert/update/delete
+                try (Connection conn = connect(postgres);
+                        Statement st = conn.createStatement()) {
+                    st.execute("INSERT INTO t_user VALUES (3,'carol',40,99.99)");
+                    st.execute("UPDATE t_user SET age = 31 WHERE id = 1");
+                    st.execute("DELETE FROM t_user WHERE id = 2");
+                }
+
+                List<String> binlog = harness.writeBinlogUntil(splits, 3, Duration.ofSeconds(90));
+                Map<Integer, JsonNode> byId = indexById(binlog);
+                assertThat(byId).containsKeys(1, 2, 3);
+                assertThat(byId.get(3).get("name").asText()).isEqualTo("carol");
+                assertThat(byId.get(3).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+                assertThat(byId.get(1).get("age").asInt()).isEqualTo(31);
+                assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
+            } finally {
+                Env.getCurrentEnv().close(jobId);
+            }
+        }
+    }
+
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node);
+        }
+        return result;
+    }
+
+    private Connection connect(PostgreSQLContainer<?> postgres) throws Exception {
+        return DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteDmlITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteDmlITCase.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Constants;
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Exercises the from-to {@code writeRecords} path for PostgreSQL incremental (WAL) DML: insert /
+ * update / delete after the snapshot must be stream-loaded with the correct values and delete sign.
+ */
+@Testcontainers
+class PostgresWriteDmlITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(510_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            // emit full old image for updates/deletes
+            st.execute("ALTER TABLE t_user REPLICA IDENTITY FULL");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob'), (3,'carol')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void walDmlStreamLoadsInsertUpdateDelete() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            harness.writeSnapshot(splits);
+
+            try (Connection conn = connect();
+                    Statement st = conn.createStatement()) {
+                st.execute("INSERT INTO t_user VALUES (4, 'dave')");
+                st.execute("UPDATE t_user SET name = 'alice2' WHERE id = 1");
+                st.execute("DELETE FROM t_user WHERE id = 2");
+            }
+
+            List<String> binlog = harness.writeBinlogUntil(splits, 3, Duration.ofSeconds(90));
+
+            Map<Integer, JsonNode> byId = indexById(binlog);
+            assertThat(byId).containsKeys(1, 2, 4);
+            // insert
+            assertThat(byId.get(4).get("name").asText()).isEqualTo("dave");
+            assertThat(byId.get(4).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+            // update carries the new value
+            assertThat(byId.get(1).get("name").asText()).isEqualTo("alice2");
+            assertThat(byId.get(1).get(Constants.DORIS_DELETE_SIGN).asInt()).isZero();
+            // delete carries the delete sign
+            assertThat(byId.get(2).get(Constants.DORIS_DELETE_SIGN).asInt()).isEqualTo(1);
+        }
+    }
+
+    private Map<Integer, JsonNode> indexById(List<String> records) throws Exception {
+        Map<Integer, JsonNode> result = new HashMap<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.put(node.get("id").asInt(), node);
+        }
+        return result;
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteResumeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteResumeITCase.java
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the from-to {@code writeRecords} path's at-least-once offset handling for PostgreSQL:
+ * after a committed WAL round, resuming from the committed offset must read only the new change,
+ * never re-read the already-committed one.
+ */
+@Testcontainers
+class PostgresWriteResumeITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(520_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void resumeFromCommittedOffsetDoesNotReReadCommittedRow() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            harness.writeSnapshot(splits);
+            harness.enterBinlog(splits);
+
+            insert(3, "carol");
+            List<Integer> first = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            assertThat(first).containsExactly(3);
+
+            insert(4, "dave");
+            List<Integer> second = ids(harness.continueBinlog(1, Duration.ofSeconds(90)));
+            // resumed from the committed offset: only the new row, no re-read of id=3
+            assertThat(second).containsExactly(4);
+            assertThat(second).doesNotContain(3);
+        }
+    }
+
+    private List<Integer> ids(List<String> records) throws Exception {
+        List<Integer> result = new ArrayList<>();
+        for (String record : records) {
+            JsonNode node = MAPPER.readTree(record);
+            result.add(node.get("id").asInt());
+        }
+        return result;
+    }
+
+    private void insert(int id, String name) throws Exception {
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute(String.format("INSERT INTO t_user VALUES (%d, '%s')", id, name));
+        }
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteSchemaChangeITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteSchemaChangeITCase.java
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Exercises the from-to {@code writeRecords} path's schema-change handling for PostgreSQL: an ADD
+ * COLUMN after the snapshot is detected from the WAL, the generated DDL is executed against the
+ * (mock) FE, and the row carrying the new column is stream-loaded. This is behavior the TVF path
+ * does not cover.
+ */
+@Testcontainers
+class PostgresWriteSchemaChangeITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(500_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_user");
+            st.execute("CREATE TABLE t_user (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("INSERT INTO t_user VALUES (1,'alice'), (2,'bob')");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void addColumnIsDetectedExecutedAndDataStreamLoaded() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_user",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_user");
+            harness.writeSnapshot(splits);
+            // establish the pre-ALTER schema baseline before changing the table
+            harness.enterBinlog(splits);
+
+            try (Connection conn = connect();
+                    Statement st = conn.createStatement()) {
+                st.execute("ALTER TABLE t_user ADD COLUMN age INT");
+                st.execute("INSERT INTO t_user (id, name, age) VALUES (3, 'carol', 30)");
+            }
+
+            List<String> binlog = harness.continueBinlog(1, Duration.ofSeconds(90));
+
+            // the ADD COLUMN DDL was generated and executed against the (mock) FE
+            assertThat(harness.loadedRecords()).isNotEmpty();
+            assertThat(harness.executedDdls())
+                    .anySatisfy(
+                            ddl -> {
+                                String upper = ddl.toUpperCase();
+                                assertThat(upper).contains("ADD COLUMN");
+                                assertThat(upper).contains("AGE");
+                            });
+
+            // the row carrying the new column was stream-loaded
+            assertThat(binlog).isNotEmpty();
+            JsonNode row = MAPPER.readTree(binlog.get(binlog.size() - 1));
+            assertThat(row.get("id").asInt()).isEqualTo(3);
+            assertThat(row.get("age").asInt()).isEqualTo(30);
+        }
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteTypesITCase.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/itcase/PostgresWriteTypesITCase.java
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.itcase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.doris.cdcclient.common.Env;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Verifies the from-to {@code writeRecords} path deserializes PostgreSQL-specific column types
+ * (array / uuid / jsonb / numeric / boolean) correctly through the snapshot phase.
+ */
+@Testcontainers
+class PostgresWriteTypesITCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final AtomicLong JOB_ID_SEQ = new AtomicLong(600_000);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"))
+                    .withCommand("postgres", "-c", "wal_level=logical");
+
+    private String jobId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jobId = String.valueOf(JOB_ID_SEQ.incrementAndGet());
+        try (Connection conn = connect();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS t_types");
+            st.execute(
+                    "CREATE TABLE t_types ("
+                            + "id INT PRIMARY KEY,"
+                            + "tags TEXT[],"
+                            + "nums INT[],"
+                            + "uid UUID,"
+                            + "info JSONB,"
+                            + "price NUMERIC(10,2),"
+                            + "active BOOLEAN)");
+            st.execute(
+                    "INSERT INTO t_types VALUES ("
+                            + "1,"
+                            + "ARRAY['x','y'],"
+                            + "ARRAY[1,2,3],"
+                            + "'11111111-1111-1111-1111-111111111111',"
+                            + "'{\"a\":1,\"b\":[2,3]}',"
+                            + "12.34,"
+                            + "true)");
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        Env.getCurrentEnv().close(jobId);
+    }
+
+    @Test
+    void snapshotDeserializesPgTypes() throws Exception {
+        try (MockDorisServer mock = new MockDorisServer();
+                CdcClientWriteHarness harness =
+                        CdcClientWriteHarness.postgres(
+                                jobId,
+                                POSTGRES.getHost(),
+                                POSTGRES.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                                POSTGRES.getUsername(),
+                                POSTGRES.getPassword(),
+                                POSTGRES.getDatabaseName(),
+                                "public",
+                                "t_types",
+                                "initial",
+                                "doris_target_db",
+                                mock)) {
+
+            List<SnapshotSplit> splits = harness.fetchAllSnapshotSplits("t_types");
+            harness.writeSnapshot(splits);
+
+            assertThat(harness.loadedRecords()).hasSize(1);
+            JsonNode row = MAPPER.readTree(harness.loadedRecords().get(0));
+
+            assertThat(row.get("id").asInt()).isEqualTo(1);
+            // text[] / int[] -> JSON arrays
+            assertThat(row.get("tags").isArray()).isTrue();
+            assertThat(row.get("tags").get(0).asText()).isEqualTo("x");
+            assertThat(row.get("tags").get(1).asText()).isEqualTo("y");
+            assertThat(row.get("nums").get(2).asInt()).isEqualTo(3);
+            // uuid -> string
+            assertThat(row.get("uid").asText())
+                    .isEqualTo("11111111-1111-1111-1111-111111111111");
+            // numeric -> number
+            assertThat(row.get("price").decimalValue().toPlainString()).isEqualTo("12.34");
+            // boolean
+            assertThat(row.get("active").asBoolean()).isTrue();
+        }
+    }
+
+    private Connection connect() throws Exception {
+        return DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/sink/BatchRecordBufferTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/sink/BatchRecordBufferTest.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/** Unit tests for {@link BatchRecordBuffer}. */
+class BatchRecordBufferTest {
+
+    private static final byte[] DELIM = "\n".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void firstInsert_noDelimiterPrefix() {
+        BatchRecordBuffer buffer = new BatchRecordBuffer("db", "t", DELIM);
+        byte[] rec = "abc".getBytes(StandardCharsets.UTF_8);
+
+        int written = buffer.insert(rec);
+
+        assertEquals(3, written);
+        assertEquals(1, buffer.getNumOfRecords());
+        assertEquals(3, buffer.getBufferSizeBytes());
+        assertEquals(1, buffer.getBuffer().size());
+        assertFalse(buffer.isEmpty());
+    }
+
+    @Test
+    void secondInsert_addsDelimiter() {
+        BatchRecordBuffer buffer = new BatchRecordBuffer("db", "t", DELIM);
+        buffer.insert("ab".getBytes(StandardCharsets.UTF_8));
+
+        int written = buffer.insert("cde".getBytes(StandardCharsets.UTF_8));
+
+        // returned size includes the delimiter that precedes the second record
+        assertEquals(3 + DELIM.length, written);
+        assertEquals(2, buffer.getNumOfRecords());
+        // 2 + delim(1) + 3
+        assertEquals(2 + DELIM.length + 3, buffer.getBufferSizeBytes());
+        // record, delimiter, record
+        assertEquals(3, buffer.getBuffer().size());
+    }
+
+    @Test
+    void nullDelimiter_neverInsertsSeparator() {
+        BatchRecordBuffer buffer = new BatchRecordBuffer("db", "t", null);
+        buffer.insert("ab".getBytes(StandardCharsets.UTF_8));
+        buffer.insert("cd".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(2, buffer.getNumOfRecords());
+        assertEquals(4, buffer.getBufferSizeBytes());
+        assertEquals(2, buffer.getBuffer().size());
+    }
+
+    @Test
+    void clear_resetsState() {
+        BatchRecordBuffer buffer = new BatchRecordBuffer("db", "t", DELIM);
+        buffer.insert("ab".getBytes(StandardCharsets.UTF_8));
+        buffer.setLabelName("lbl");
+
+        buffer.clear();
+
+        assertTrue(buffer.isEmpty());
+        assertEquals(0, buffer.getNumOfRecords());
+        assertEquals(0, buffer.getBufferSizeBytes());
+        assertNull(buffer.getLabelName());
+        assertTrue(buffer.getBuffer().isEmpty());
+        // after clear, the next insert is treated as the first again (no leading delimiter)
+        assertEquals(2, buffer.insert("xy".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void tableIdentifier() {
+        assertEquals("db.t", new BatchRecordBuffer("db", "t", DELIM).getTableIdentifier());
+        assertNull(new BatchRecordBuffer().getTableIdentifier());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/sink/HttpPutBuilderTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/sink/HttpPutBuilderTest.java
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.doris.cdcclient.common.Constants;
+
+import org.apache.http.client.methods.HttpPut;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+
+/** Unit tests for {@link HttpPutBuilder}. */
+class HttpPutBuilderTest {
+
+    @Test
+    void build_requiresUrlAndEntity() {
+        assertThrows(NullPointerException.class, () -> new HttpPutBuilder().build());
+        assertThrows(
+                NullPointerException.class,
+                () -> new HttpPutBuilder().setUrl("http://x").build());
+    }
+
+    @Test
+    void build_setsUrlEntityAndHeaders() {
+        HttpPut put =
+                new HttpPutBuilder()
+                        .setUrl("http://be:8040/api/db/t/_stream_load")
+                        .setEmptyEntity()
+                        .addCommonHeader()
+                        .addBodyContentType()
+                        .formatJson()
+                        .setLabel("lbl-1")
+                        .build();
+
+        assertEquals("http://be:8040/api/db/t/_stream_load", put.getURI().toString());
+        assertEquals("100-continue", put.getFirstHeader("Expect").getValue());
+        assertEquals("json", put.getFirstHeader("format").getValue());
+        assertEquals("true", put.getFirstHeader("read_json_by_line").getValue());
+        assertEquals("lbl-1", put.getFirstHeader("label").getValue());
+    }
+
+    @Test
+    void baseAuth_encodesBasicCredentials() {
+        HttpPut put =
+                new HttpPutBuilder()
+                        .setUrl("http://x")
+                        .setEmptyEntity()
+                        .baseAuth("root", "secret")
+                        .build();
+
+        String expected =
+                "Basic "
+                        + Base64.getEncoder()
+                                .encodeToString("root:secret".getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, put.getFirstHeader("Authorization").getValue());
+    }
+
+    @Test
+    void addHiddenColumns_onlyWhenEnabled() {
+        HttpPut on =
+                new HttpPutBuilder()
+                        .setUrl("http://x")
+                        .setEmptyEntity()
+                        .addHiddenColumns(true)
+                        .build();
+        assertEquals(Constants.DORIS_DELETE_SIGN, on.getFirstHeader("hidden_columns").getValue());
+
+        HttpPut off =
+                new HttpPutBuilder()
+                        .setUrl("http://x")
+                        .setEmptyEntity()
+                        .addHiddenColumns(false)
+                        .build();
+        assertNull(off.getFirstHeader("hidden_columns"));
+    }
+
+    @Test
+    void txnHeaders() {
+        HttpPut put =
+                new HttpPutBuilder()
+                        .setUrl("http://x")
+                        .setEmptyEntity()
+                        .enable2PC()
+                        .addTxnId(99L)
+                        .commit()
+                        .build();
+        assertEquals("true", put.getFirstHeader("two_phase_commit").getValue());
+        assertEquals("99", put.getFirstHeader("txn_id").getValue());
+        assertEquals("commit", put.getFirstHeader("txn_operation").getValue());
+
+        HttpPut abort =
+                new HttpPutBuilder().setUrl("http://x").setEmptyEntity().abort().build();
+        assertEquals("abort", abort.getFirstHeader("txn_operation").getValue());
+    }
+
+    @Test
+    void addProperties_and_getLabel() {
+        HttpPutBuilder builder =
+                new HttpPutBuilder()
+                        .setLabel("L")
+                        .addProperties(Collections.singletonMap("k", "v"));
+        assertEquals("L", builder.getLabel());
+
+        HttpPut put = builder.setUrl("http://x").setEmptyEntity().build();
+        assertEquals("v", put.getFirstHeader("k").getValue());
+    }
+
+    @Test
+    void setLabel_null_isIgnored() {
+        assertNull(new HttpPutBuilder().setLabel(null).getLabel());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/sink/LoadStatisticTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/sink/LoadStatisticTest.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Unit tests for {@link LoadStatistic}. */
+class LoadStatisticTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private RespContent resp(int filtered, long loaded, long bytes) throws Exception {
+        String json =
+                String.format(
+                        "{\"NumberFilteredRows\":%d,\"NumberLoadedRows\":%d,\"LoadBytes\":%d}",
+                        filtered, loaded, bytes);
+        return MAPPER.readValue(json, RespContent.class);
+    }
+
+    @Test
+    void add_accumulatesAcrossResponses() throws Exception {
+        LoadStatistic stat = new LoadStatistic();
+        stat.add(resp(2, 10, 100));
+        stat.add(resp(3, 20, 200));
+
+        assertEquals(5, stat.getFilteredRows());
+        assertEquals(30, stat.getLoadedRows());
+        assertEquals(300, stat.getLoadBytes());
+    }
+
+    @Test
+    void clear_resetsToZero() throws Exception {
+        LoadStatistic stat = new LoadStatistic();
+        stat.add(resp(1, 1, 1));
+
+        stat.clear();
+
+        assertEquals(0, stat.getFilteredRows());
+        assertEquals(0, stat.getLoadedRows());
+        assertEquals(0, stat.getLoadBytes());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/DebeziumConvertInternalTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/DebeziumConvertInternalTest.java
@@ -1,0 +1,255 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.source.deserialize;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.debezium.data.Bits;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.time.MicroTime;
+import io.debezium.time.NanoTime;
+import io.debezium.time.Time;
+import io.debezium.time.Timestamp;
+import io.debezium.time.ZonedTimestamp;
+
+/**
+ * Unit tests for {@link DebeziumJsonDeserializer}'s {@code convertInternal} dispatch, covering the
+ * timezone-independent value conversions (dates, times, decimals, bits, primitives). These guard
+ * the self-written type mapping against calendar drift and type-handling regressions without needing
+ * a real database.
+ */
+class DebeziumConvertInternalTest {
+
+    private final DebeziumJsonDeserializer deserializer = new DebeziumJsonDeserializer();
+
+    // ─── io.debezium.time.Date (epoch days) ───────────────────────────────────
+
+    @Test
+    void date_ancientYears_notShifted() {
+        assertEquals("0017-08-12", convertDate(LocalDate.of(17, 8, 12)));
+        assertEquals("0001-01-01", convertDate(LocalDate.of(1, 1, 1)));
+        assertEquals("0033-03-03", convertDate(LocalDate.of(33, 3, 3)));
+        assertEquals("0444-04-04", convertDate(LocalDate.of(444, 4, 4)));
+    }
+
+    @Test
+    void date_preEpochAndModern() {
+        assertEquals("1969-12-31", convertDate(LocalDate.of(1969, 12, 31)));
+        assertEquals("2020-07-17", convertDate(LocalDate.of(2020, 7, 17)));
+    }
+
+    @Test
+    void nullValue_returnsNull() {
+        assertNull(convertInternal(dateSchema(), null));
+        assertNull(convertInternal(SchemaBuilder.string().build(), null));
+    }
+
+    // ─── Time / MicroTime / NanoTime (timezone-independent) ────────────────────
+
+    @Test
+    void microTime_withMicros() {
+        // 18:00:22.123456 since midnight
+        long micros = ((18L * 3600 + 22) * 1_000_000L) + 123_456L;
+        assertEquals(
+                "18:00:22.123456",
+                convertInternal(namedSchema(SchemaBuilder.int64(), MicroTime.SCHEMA_NAME), micros));
+    }
+
+    @Test
+    void nanoTime_wholeSecond() {
+        long nanos = (9L * 3600 + 9 * 60 + 9) * 1_000_000_000L;
+        assertEquals(
+                "09:09:09",
+                convertInternal(namedSchema(SchemaBuilder.int64(), NanoTime.SCHEMA_NAME), nanos));
+    }
+
+    @Test
+    void time_millisOfDay() {
+        int millis = (int) ((1L * 3600 + 2 * 60 + 3) * 1000L);
+        assertEquals(
+                "01:02:03",
+                convertInternal(namedSchema(SchemaBuilder.int32(), Time.SCHEMA_NAME), millis));
+    }
+
+    // ─── Decimal (precise / string / double handling modes) ────────────────────
+
+    @Test
+    void decimal_preciseBytes() {
+        Schema schema = Decimal.builder(4).build();
+        byte[] unscaled = BigInteger.valueOf(1_234_567L).toByteArray(); // 123.4567 @ scale 4
+        assertEquals(new BigDecimal("123.4567"), convertInternal(schema, unscaled));
+    }
+
+    @Test
+    void decimal_stringMode() {
+        Schema schema = Decimal.builder(2).build();
+        assertEquals(new BigDecimal("99.50"), convertInternal(schema, "99.50"));
+    }
+
+    @Test
+    void decimal_doubleMode() {
+        Schema schema = Decimal.builder(1).build();
+        assertEquals(BigDecimal.valueOf(5.5d), convertInternal(schema, 5.5d));
+    }
+
+    // ─── Bits passthrough ──────────────────────────────────────────────────────
+
+    @Test
+    void bits_passThroughBytes() {
+        Schema schema = namedSchema(SchemaBuilder.bytes(), Bits.LOGICAL_NAME);
+        byte[] value = new byte[] {0x01, 0x02};
+        assertArrayEquals(value, (byte[]) convertInternal(schema, value));
+    }
+
+    // ─── Array / Binary ────────────────────────────────────────────────────────
+
+    @Test
+    void array_ofInts_withNullElement() {
+        Schema schema = SchemaBuilder.array(SchemaBuilder.int32().build()).optional().build();
+        assertEquals(
+                java.util.Arrays.asList(1L, null, 3L),
+                convertInternal(schema, java.util.Arrays.asList(1, null, 3)));
+    }
+
+    @Test
+    void binary_byteArrayPassThrough() {
+        byte[] data = {1, 2, 3};
+        assertArrayEquals(data, (byte[]) convertInternal(SchemaBuilder.bytes().build(), data));
+    }
+
+    @Test
+    void binary_byteBufferCopied() {
+        byte[] data = {9, 8, 7};
+        assertArrayEquals(
+                data,
+                (byte[]) convertInternal(SchemaBuilder.bytes().build(), java.nio.ByteBuffer.wrap(data)));
+    }
+
+    // ─── Unnamed primitives ────────────────────────────────────────────────────
+
+    @Test
+    void primitive_int64_toLong() {
+        assertEquals(42L, convertInternal(SchemaBuilder.int64().build(), 42L));
+    }
+
+    @Test
+    void primitive_boolean() {
+        assertEquals(true, convertInternal(SchemaBuilder.bool().build(), true));
+    }
+
+    // ─── Timestamp (epoch millis, UTC-anchored) ───────────────────────────────
+
+    @Test
+    void timestamp_epoch() {
+        assertEquals(
+                "1970-01-01 00:00:00.0",
+                convertInternal(namedSchema(SchemaBuilder.int64(), Timestamp.SCHEMA_NAME), 0L)
+                        .toString());
+    }
+
+    @Test
+    void timestamp_ancient_notShifted() {
+        long millis =
+                LocalDateTime.of(16, 7, 13, 17, 17, 17).toInstant(ZoneOffset.UTC).toEpochMilli();
+        assertEquals(
+                "0016-07-13 17:17:17.0",
+                convertInternal(namedSchema(SchemaBuilder.int64(), Timestamp.SCHEMA_NAME), millis)
+                        .toString());
+    }
+
+    // ─── ZonedTimestamp (TIMESTAMPTZ, server-zone dependent) ──────────────────
+
+    @Test
+    void zonedTimestamp_renderedInServerZone() {
+        deserializer.setServerTimeZone(ZoneId.of("UTC"));
+        assertEquals(
+                "2020-07-17 18:00:22.0",
+                convertInternal(
+                                namedSchema(SchemaBuilder.string(), ZonedTimestamp.SCHEMA_NAME),
+                                "2020-07-17T18:00:22Z")
+                        .toString());
+    }
+
+    // ─── Geometry (PG point -> GeoJSON string) ────────────────────────────────
+
+    @Test
+    void geometry_pointToGeoJson() throws Exception {
+        // WKB for POINT(1 2), little-endian.
+        byte[] wkb =
+                new byte[] {
+                    0x01, // little endian
+                    0x01, 0x00, 0x00, 0x00, // type = point
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F, // x = 1.0
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40 // y = 2.0
+                };
+        Schema geomSchema = Geometry.builder().optional().build();
+        Struct geom = new Struct(geomSchema).put("wkb", wkb).put("srid", 4326);
+
+        Object out = convertInternal(geomSchema, geom);
+
+        JsonNode node = new ObjectMapper().readTree((String) out);
+        assertEquals("Point", node.get("type").asText());
+        assertEquals(4326, node.get("srid").asInt());
+        assertEquals(1.0, node.get("coordinates").get(0).asDouble());
+        assertEquals(2.0, node.get("coordinates").get(1).asDouble());
+    }
+
+    // ─── helpers ───────────────────────────────────────────────────────────────
+
+    private String convertDate(LocalDate date) {
+        return (String) convertInternal(dateSchema(), (int) date.toEpochDay());
+    }
+
+    private static Schema dateSchema() {
+        return namedSchema(SchemaBuilder.int32(), io.debezium.time.Date.SCHEMA_NAME);
+    }
+
+    private static Schema namedSchema(SchemaBuilder builder, String name) {
+        return builder.name(name).optional().build();
+    }
+
+    private Object convertInternal(Schema schema, Object dbzObj) {
+        try {
+            Method m =
+                    DebeziumJsonDeserializer.class.getDeclaredMethod(
+                            "convertInternal", Schema.class, Object.class);
+            m.setAccessible(true);
+            return m.invoke(deserializer, schema, dbzObj);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/DebeziumJsonDeserializeRecordTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/DebeziumJsonDeserializeRecordTest.java
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.source.deserialize;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.doris.cdcclient.common.Constants;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.debezium.data.Envelope;
+
+/**
+ * Unit tests for the full {@link DebeziumJsonDeserializer#deserialize} path: operation handling
+ * (create/update/delete), the {@code __DORIS_DELETE_SIGN} marker, column exclusion, and the
+ * non-data-change short-circuit. Records are built from an in-memory Debezium envelope, so no
+ * database is required.
+ */
+class DebeziumJsonDeserializeRecordTest {
+
+    private static final String DELETE_SIGN = Constants.DORIS_DELETE_SIGN;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Schema rowSchema =
+            SchemaBuilder.struct()
+                    .name("t1.Value")
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                    .field("amount", Decimal.builder(2).optional().build())
+                    .build();
+
+    private final Schema sourceSchema =
+            SchemaBuilder.struct().name("source").field("table", Schema.STRING_SCHEMA).build();
+
+    private final Envelope envelope =
+            Envelope.defineSchema()
+                    .withName("t1.Envelope")
+                    .withRecord(rowSchema)
+                    .withSource(sourceSchema)
+                    .build();
+
+    @Test
+    void create_emitsAfterRowWithDeleteSignZero() throws Exception {
+        DebeziumJsonDeserializer deserializer = newDeserializer(new HashMap<>());
+        SourceRecord record =
+                record(envelopeValue(Envelope.Operation.CREATE, null, row(1, "alice", "12.34")));
+
+        DeserializeResult result = deserializer.deserialize(new HashMap<>(), record);
+
+        assertEquals(DeserializeResult.Type.DML, result.getType());
+        assertEquals(1, result.getRecords().size());
+        JsonNode row = MAPPER.readTree(result.getRecords().get(0));
+        assertEquals(1, row.get("id").asInt());
+        assertEquals("alice", row.get("name").asText());
+        assertEquals(0, new BigDecimal("12.34").compareTo(row.get("amount").decimalValue()));
+        assertEquals(0, row.get(DELETE_SIGN).asInt());
+    }
+
+    @Test
+    void update_emitsAfterRowWithDeleteSignZero() throws Exception {
+        DebeziumJsonDeserializer deserializer = newDeserializer(new HashMap<>());
+        SourceRecord record =
+                record(
+                        envelopeValue(
+                                Envelope.Operation.UPDATE,
+                                row(1, "old", "1.00"),
+                                row(1, "new", "2.00")));
+
+        DeserializeResult result = deserializer.deserialize(new HashMap<>(), record);
+
+        JsonNode row = MAPPER.readTree(result.getRecords().get(0));
+        assertEquals("new", row.get("name").asText());
+        assertEquals(0, row.get(DELETE_SIGN).asInt());
+    }
+
+    @Test
+    void delete_emitsBeforeRowWithDeleteSignOne() throws Exception {
+        DebeziumJsonDeserializer deserializer = newDeserializer(new HashMap<>());
+        SourceRecord record =
+                record(envelopeValue(Envelope.Operation.DELETE, row(7, "bob", "9.99"), null));
+
+        DeserializeResult result = deserializer.deserialize(new HashMap<>(), record);
+
+        assertEquals(1, result.getRecords().size());
+        JsonNode row = MAPPER.readTree(result.getRecords().get(0));
+        assertEquals(7, row.get("id").asInt());
+        assertEquals(1, row.get(DELETE_SIGN).asInt());
+    }
+
+    @Test
+    void excludeColumns_dropsConfiguredColumn() throws Exception {
+        Map<String, String> config = new HashMap<>();
+        config.put("table.t1.exclude_columns", "name");
+        DebeziumJsonDeserializer deserializer = newDeserializer(config);
+
+        SourceRecord record =
+                record(envelopeValue(Envelope.Operation.CREATE, null, row(1, "alice", "12.34")));
+        DeserializeResult result = deserializer.deserialize(new HashMap<>(), record);
+
+        JsonNode row = MAPPER.readTree(result.getRecords().get(0));
+        assertFalse(row.has("name"));
+        assertTrue(row.has("id"));
+    }
+
+    @Test
+    void nonDataChangeRecord_returnsEmpty() throws Exception {
+        DebeziumJsonDeserializer deserializer = newDeserializer(new HashMap<>());
+        // A record whose value schema has no "op" field is not a data-change record.
+        SourceRecord record = new SourceRecord(null, null, "t1", sourceSchema, source("t1"));
+
+        DeserializeResult result = deserializer.deserialize(new HashMap<>(), record);
+
+        assertEquals(DeserializeResult.Type.EMPTY, result.getType());
+    }
+
+    // ─── helpers ───────────────────────────────────────────────────────────────
+
+    private DebeziumJsonDeserializer newDeserializer(Map<String, String> config) {
+        DebeziumJsonDeserializer deserializer = new DebeziumJsonDeserializer();
+        deserializer.init(config);
+        return deserializer;
+    }
+
+    private SourceRecord record(Struct value) {
+        return new SourceRecord(null, null, "t1", envelope.schema(), value);
+    }
+
+    private Struct envelopeValue(Envelope.Operation op, Struct before, Struct after) {
+        Struct value = new Struct(envelope.schema());
+        value.put(Envelope.FieldName.OPERATION, op.code());
+        if (before != null) {
+            value.put(Envelope.FieldName.BEFORE, before);
+        }
+        if (after != null) {
+            value.put(Envelope.FieldName.AFTER, after);
+        }
+        value.put(Envelope.FieldName.SOURCE, source("t1"));
+        return value;
+    }
+
+    private Struct source(String table) {
+        return new Struct(sourceSchema).put("table", table);
+    }
+
+    private Struct row(int id, String name, String amount) {
+        return new Struct(rowSchema)
+                .put("id", id)
+                .put("name", name)
+                .put("amount", new BigDecimal(amount));
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/DeserializeResultTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/DeserializeResultTest.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.source.deserialize;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Unit tests for the {@link DeserializeResult} factory methods. */
+class DeserializeResultTest {
+
+    @Test
+    void dml_carriesRecordsOnly() {
+        List<String> rows = List.of("{\"id\":1}");
+        DeserializeResult result = DeserializeResult.dml(rows);
+
+        assertEquals(DeserializeResult.Type.DML, result.getType());
+        assertEquals(rows, result.getRecords());
+        assertNull(result.getDdls());
+        assertNull(result.getUpdatedSchemas());
+    }
+
+    @Test
+    void schemaChange_carriesDdlsAndEmptyRecords() {
+        List<String> ddls = List.of("ALTER TABLE t ADD COLUMN c INT");
+        DeserializeResult result = DeserializeResult.schemaChange(ddls, Collections.emptyMap());
+
+        assertEquals(DeserializeResult.Type.SCHEMA_CHANGE, result.getType());
+        assertEquals(ddls, result.getDdls());
+        assertTrue(result.getRecords().isEmpty());
+    }
+
+    @Test
+    void schemaChange_withRecords_carriesBoth() {
+        List<String> ddls = List.of("ALTER TABLE t ADD COLUMN c INT");
+        List<String> rows = List.of("{\"id\":1}");
+        DeserializeResult result =
+                DeserializeResult.schemaChange(ddls, Collections.emptyMap(), rows);
+
+        assertEquals(DeserializeResult.Type.SCHEMA_CHANGE, result.getType());
+        assertEquals(ddls, result.getDdls());
+        assertEquals(rows, result.getRecords());
+    }
+
+    @Test
+    void empty_hasNoData() {
+        DeserializeResult result = DeserializeResult.empty();
+
+        assertEquals(DeserializeResult.Type.EMPTY, result.getType());
+        assertTrue(result.getRecords().isEmpty());
+        assertNull(result.getDdls());
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/PostgresSchemaChangeDeserializeTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/deserialize/PostgresSchemaChangeDeserializeTest.java
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.source.deserialize;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.doris.cdcclient.common.Constants;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.debezium.data.Envelope;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+/**
+ * Unit tests for {@link PostgresDebeziumJsonDeserializer}'s WAL-based ADD/DROP column detection: the
+ * various branches it takes when the record's column set diverges from the stored schema.
+ */
+class PostgresSchemaChangeDeserializeTest {
+
+    private static final TableId TABLE = new TableId(null, "public", "t1");
+    private static final Map<String, String> CONTEXT =
+            Map.of(Constants.DORIS_TARGET_DB, "doris_db");
+
+    @Test
+    void noStoredSchema_passesThroughAsDml() throws Exception {
+        PostgresDebeziumJsonDeserializer deserializer = newDeserializer(null, tid -> null);
+
+        DeserializeResult result =
+                deserializer.deserialize(CONTEXT, createRecord(afterSchema("id", "name")));
+
+        assertEquals(DeserializeResult.Type.DML, result.getType());
+        assertEquals(1, result.getRecords().size());
+    }
+
+    @Test
+    void noColumnChange_passesThroughAsDml() throws Exception {
+        PostgresDebeziumJsonDeserializer deserializer =
+                newDeserializer(storedTable("id", "name"), tid -> change(storedTable("id", "name")));
+
+        DeserializeResult result =
+                deserializer.deserialize(CONTEXT, createRecord(afterSchema("id", "name")));
+
+        assertEquals(DeserializeResult.Type.DML, result.getType());
+    }
+
+    @Test
+    void addColumn_emitsAddDdl() throws Exception {
+        PostgresDebeziumJsonDeserializer deserializer =
+                newDeserializer(
+                        storedTable("id", "name"), tid -> change(storedTable("id", "name", "age")));
+
+        DeserializeResult result =
+                deserializer.deserialize(CONTEXT, createRecord(afterSchema("id", "name", "age")));
+
+        assertEquals(DeserializeResult.Type.SCHEMA_CHANGE, result.getType());
+        assertEquals(1, result.getDdls().size());
+        String ddl = result.getDdls().get(0).toUpperCase();
+        assertTrue(ddl.contains("ADD COLUMN"), ddl);
+        assertTrue(ddl.contains("AGE"), ddl);
+        // the triggering DML record is still carried so it gets written after the DDL
+        assertEquals(1, result.getRecords().size());
+    }
+
+    @Test
+    void dropColumn_emitsDropDdl() throws Exception {
+        PostgresDebeziumJsonDeserializer deserializer =
+                newDeserializer(
+                        storedTable("id", "name", "age"), tid -> change(storedTable("id", "name")));
+
+        DeserializeResult result =
+                deserializer.deserialize(CONTEXT, createRecord(afterSchema("id", "name")));
+
+        assertEquals(DeserializeResult.Type.SCHEMA_CHANGE, result.getType());
+        assertEquals(1, result.getDdls().size());
+        String ddl = result.getDdls().get(0).toUpperCase();
+        assertTrue(ddl.contains("DROP COLUMN"), ddl);
+        assertTrue(ddl.contains("AGE"), ddl);
+    }
+
+    @Test
+    void simultaneousAddAndDrop_skipsDdlToAvoidRenameDataLoss() throws Exception {
+        // stored has [id,name]; WAL record has [id,nick] -> name dropped + nick added.
+        PostgresDebeziumJsonDeserializer deserializer =
+                newDeserializer(
+                        storedTable("id", "name"), tid -> change(storedTable("id", "nick")));
+
+        DeserializeResult result =
+                deserializer.deserialize(CONTEXT, createRecord(afterSchema("id", "nick")));
+
+        assertEquals(DeserializeResult.Type.SCHEMA_CHANGE, result.getType());
+        assertTrue(result.getDdls().isEmpty(), "rename must not emit DDL");
+        assertEquals(1, result.getRecords().size());
+    }
+
+    @Test
+    void columnChangeWithoutRefresher_throws() throws Exception {
+        PostgresDebeziumJsonDeserializer deserializer = new PostgresDebeziumJsonDeserializer();
+        deserializer.init(new HashMap<>());
+        deserializer.setTableSchemas(Map.of(TABLE, change(storedTable("id", "name"))));
+        // no pgSchemaRefresher set
+
+        SourceRecord record = createRecord(afterSchema("id", "name", "age"));
+        assertThrows(NullPointerException.class, () -> deserializer.deserialize(CONTEXT, record));
+    }
+
+    // ─── helpers ───────────────────────────────────────────────────────────────
+
+    private PostgresDebeziumJsonDeserializer newDeserializer(
+            Table storedTable, Function<TableId, TableChanges.TableChange> refresher) {
+        PostgresDebeziumJsonDeserializer deserializer = new PostgresDebeziumJsonDeserializer();
+        deserializer.init(new HashMap<>());
+        if (storedTable != null) {
+            deserializer.setTableSchemas(Map.of(TABLE, change(storedTable)));
+        }
+        deserializer.setPgSchemaRefresher(refresher);
+        return deserializer;
+    }
+
+    private static TableChanges.TableChange change(Table table) {
+        return new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
+    }
+
+    /** All columns are int4 (-> Doris INT) for simplicity. */
+    private static Table storedTable(String... columns) {
+        TableEditor editor = Table.editor().tableId(TABLE);
+        for (String col : columns) {
+            editor.addColumns(
+                    Column.editor()
+                            .name(col)
+                            .type("int4")
+                            .jdbcType(Types.INTEGER)
+                            .optional(true)
+                            .create());
+        }
+        return editor.create();
+    }
+
+    private Schema afterSchema(String... fields) {
+        SchemaBuilder builder = SchemaBuilder.struct().name("public.t1.Value");
+        for (String field : fields) {
+            builder.field(field, Schema.OPTIONAL_STRING_SCHEMA);
+        }
+        return builder.build();
+    }
+
+    private SourceRecord createRecord(Schema afterSchema) {
+        Schema sourceSchema =
+                SchemaBuilder.struct()
+                        .name("source")
+                        .field("schema", Schema.STRING_SCHEMA)
+                        .field("table", Schema.STRING_SCHEMA)
+                        .build();
+        Envelope envelope =
+                Envelope.defineSchema()
+                        .withName("public.t1.Envelope")
+                        .withRecord(afterSchema)
+                        .withSource(sourceSchema)
+                        .build();
+
+        Struct after = new Struct(afterSchema);
+        for (org.apache.kafka.connect.data.Field field : afterSchema.fields()) {
+            after.put(field.name(), "v");
+        }
+        Struct source = new Struct(sourceSchema).put("schema", "public").put("table", "t1");
+
+        Struct value = new Struct(envelope.schema());
+        value.put(Envelope.FieldName.OPERATION, Envelope.Operation.CREATE.code());
+        value.put(Envelope.FieldName.AFTER, after);
+        value.put(Envelope.FieldName.SOURCE, source);
+        return new SourceRecord(null, null, "t1", envelope.schema(), value);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/factory/SourceReaderFactoryTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/source/factory/SourceReaderFactoryTest.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.source.factory;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.apache.doris.cdcclient.source.reader.SourceReader;
+import org.apache.doris.cdcclient.source.reader.mysql.MySqlSourceReader;
+import org.apache.doris.cdcclient.source.reader.postgres.PostgresSourceReader;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SourceReaderFactory}. */
+class SourceReaderFactoryTest {
+
+    @Test
+    void createsMysqlReader() {
+        assertInstanceOf(
+                MySqlSourceReader.class, SourceReaderFactory.createSourceReader(DataSource.MYSQL));
+    }
+
+    @Test
+    void createsPostgresReader() {
+        assertInstanceOf(
+                PostgresSourceReader.class,
+                SourceReaderFactory.createSourceReader(DataSource.POSTGRES));
+    }
+
+    @Test
+    void eachCallReturnsFreshInstance() {
+        SourceReader first = SourceReaderFactory.createSourceReader(DataSource.MYSQL);
+        SourceReader second = SourceReaderFactory.createSourceReader(DataSource.MYSQL);
+        assertNotSame(first, second);
+    }
+}

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/utils/ConfigUtilTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/utils/ConfigUtilTest.java
@@ -20,15 +20,20 @@ package org.apache.doris.cdcclient.utils;
 import org.apache.doris.job.cdc.DataSourceConfigKeys;
 
 import org.apache.flink.cdc.connectors.mysql.source.config.ServerIdRange;
-import org.junit.jupiter.api.Test;
 
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ConfigUtil}. */
 class ConfigUtilTest {
@@ -55,8 +60,7 @@ class ConfigUtilTest {
     @Test
     void resolveDefaultDeriveHandlesMinHashCode() {
         // "polygenelubricants" hashCode() == Integer.MIN_VALUE; & MAX_VALUE strips sign bit.
-        ServerIdRange range =
-                ConfigUtil.resolveServerIdRange("polygenelubricants", 4, null);
+        ServerIdRange range = ConfigUtil.resolveServerIdRange("polygenelubricants", 4, null);
         assertTrue(range.getStartServerId() >= 1);
         assertTrue(range.getEndServerId() <= Integer.MAX_VALUE);
     }
@@ -84,8 +88,10 @@ class ConfigUtilTest {
 
     @Test
     void resolveRejectsWidthLessThanParallelism() {
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> ConfigUtil.resolveServerIdRange("anyjob", 4, "5400"));
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ConfigUtil.resolveServerIdRange("anyjob", 4, "5400"));
         assertTrue(ex.getMessage().contains("snapshot_parallelism"));
     }
 
@@ -96,7 +102,7 @@ class ConfigUtilTest {
         Map<String, String> config = new HashMap<>();
         config.put(DataSourceConfigKeys.INCLUDE_TABLES, "t1, t2, t3");
         String[] result = ConfigUtil.getTableList("public", config);
-        assertArrayEquals(new String[]{"public.t1", "public.t2", "public.t3"}, result);
+        assertArrayEquals(new String[] {"public.t1", "public.t2", "public.t3"}, result);
     }
 
     @Test
@@ -104,15 +110,15 @@ class ConfigUtilTest {
         Map<String, String> config = new HashMap<>();
         config.put(DataSourceConfigKeys.TABLE, "orders");
         String[] result = ConfigUtil.getTableList("myschema", config);
-        assertArrayEquals(new String[]{"myschema.orders"}, result);
+        assertArrayEquals(new String[] {"myschema.orders"}, result);
     }
 
     @Test
     void tableListRejectsCommaInTableName() {
         Map<String, String> config = new HashMap<>();
         config.put(DataSourceConfigKeys.TABLE, "t1,t2");
-        assertThrows(IllegalArgumentException.class,
-                () -> ConfigUtil.getTableList("public", config));
+        assertThrows(
+                IllegalArgumentException.class, () -> ConfigUtil.getTableList("public", config));
     }
 
     @Test
@@ -120,5 +126,111 @@ class ConfigUtilTest {
         Map<String, String> config = new HashMap<>();
         String[] result = ConfigUtil.getTableList("public", config);
         assertEquals(0, result.length);
+    }
+
+    // ─── server timezone parsing ──────────────────────────────────────────────
+
+    @Test
+    void mysqlServerTimezoneFromUrl() {
+        assertEquals(
+                ZoneId.of("UTC"),
+                ConfigUtil.getServerTimeZoneFromJdbcUrl(
+                        "jdbc:mysql://h:3306/db?serverTimezone=UTC"));
+    }
+
+    @Test
+    void postgresTimezoneFromUrl() {
+        assertEquals(
+                ZoneId.of("Asia/Shanghai"),
+                ConfigUtil.getServerTimeZoneFromJdbcUrl(
+                        "jdbc:postgresql://h:5432/db?timezone=Asia/Shanghai"));
+    }
+
+    @Test
+    void timezoneDefaultsToSystemZone() {
+        assertEquals(
+                ZoneId.systemDefault(),
+                ConfigUtil.getServerTimeZoneFromJdbcUrl("jdbc:mysql://h:3306/db"));
+        assertEquals(ZoneId.systemDefault(), ConfigUtil.getServerTimeZoneFromJdbcUrl(null));
+        assertEquals(
+                ZoneId.systemDefault(),
+                ConfigUtil.getServerTimeZoneFromJdbcUrl("jdbc:oracle://h:1521/db"));
+    }
+
+    @Test
+    void timeZoneFromProps() {
+        assertEquals(
+                ZoneId.of("UTC"),
+                ConfigUtil.getTimeZoneFromProps(Map.of("serverTimezone", "UTC")));
+        assertEquals(ZoneId.systemDefault(), ConfigUtil.getTimeZoneFromProps(new HashMap<>()));
+    }
+
+    // ─── is13Timestamp / isJson ───────────────────────────────────────────────
+
+    @Test
+    void is13Timestamp() {
+        assertTrue(ConfigUtil.is13Timestamp("1700000000000"));
+        assertFalse(ConfigUtil.is13Timestamp("170000000000")); // 12 digits
+        assertFalse(ConfigUtil.is13Timestamp("17000000000000")); // 14 digits
+        assertFalse(ConfigUtil.is13Timestamp("abc"));
+        assertFalse(ConfigUtil.is13Timestamp(null));
+    }
+
+    @Test
+    void isJson_onlyObjects() {
+        assertTrue(ConfigUtil.isJson("{\"a\":1}"));
+        assertTrue(ConfigUtil.isJson("{}"));
+        assertFalse(ConfigUtil.isJson("[1,2]")); // arrays are not objects
+        assertFalse(ConfigUtil.isJson("123"));
+        assertFalse(ConfigUtil.isJson("not json"));
+        assertFalse(ConfigUtil.isJson(""));
+        assertFalse(ConfigUtil.isJson(null));
+    }
+
+    // ─── exclude columns / target table mappings ──────────────────────────────
+
+    @Test
+    void parseExcludeColumns_trimsAndDropsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        config.put("table.t1.exclude_columns", "a, b ,, c");
+        assertEquals(Set.of("a", "b", "c"), ConfigUtil.parseExcludeColumns(config, "t1"));
+        assertTrue(ConfigUtil.parseExcludeColumns(config, "other").isEmpty());
+    }
+
+    @Test
+    void parseAllExcludeColumns_scansAllTables() {
+        Map<String, String> config = new HashMap<>();
+        config.put("table.t1.exclude_columns", "a,b");
+        config.put("table.t2.exclude_columns", "c");
+        config.put("table.t3.target_table", "x"); // unrelated key ignored
+
+        Map<String, Set<String>> all = ConfigUtil.parseAllExcludeColumns(config);
+
+        assertEquals(2, all.size());
+        assertEquals(Set.of("a", "b"), all.get("t1"));
+        assertEquals(Set.of("c"), all.get("t2"));
+    }
+
+    @Test
+    void parseAllTargetTableMappings_skipsEmptyValues() {
+        Map<String, String> config = new HashMap<>();
+        config.put("table.src.target_table", "dst");
+        config.put("table.empty.target_table", "   ");
+
+        Map<String, String> mappings = ConfigUtil.parseAllTargetTableMappings(config);
+
+        assertEquals(1, mappings.size());
+        assertEquals("dst", mappings.get("src"));
+    }
+
+    // ─── toStringMap ──────────────────────────────────────────────────────────
+
+    @Test
+    void toStringMap() {
+        assertEquals(
+                Map.of("a", "1", "b", "2"),
+                ConfigUtil.toStringMap("{\"a\":\"1\",\"b\":\"2\"}"));
+        assertNull(ConfigUtil.toStringMap("not json"));
+        assertNull(ConfigUtil.toStringMap("[1,2]"));
     }
 }

--- a/fs_brokers/cdc_client/src/test/resources/docker/server-allow-ancient-date-time/my.cnf
+++ b/fs_brokers/cdc_client/src/test/resources/docker/server-allow-ancient-date-time/my.cnf
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# MySQL config that enables binlog for CDC and relaxes sql_mode so that
+# zero dates ('0000-00-00') and ancient dates can be inserted for the
+# date/time deserialization tests.
+[mysqld]
+server-id=223344
+log-bin=mysql-bin
+binlog-format=ROW
+binlog-row-image=FULL
+# Dropping STRICT_TRANS_TABLES / NO_ZERO_DATE / NO_ZERO_IN_DATE lets the
+# fixture insert '0000-00-00' and other ancient values.
+sql-mode=NO_ENGINE_SUBSTITUTION
+default-time-zone=+00:00

--- a/fs_brokers/cdc_client/src/test/resources/docker/server-with-binlog/my.cnf
+++ b/fs_brokers/cdc_client/src/test/resources/docker/server-with-binlog/my.cnf
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Minimal CDC config: enable row-based binlog so the incremental phase has a
+# log to read. Unlike server-allow-ancient-date-time this keeps the default
+# sql_mode, so the version smoke test runs the standard production path.
+[mysqld]
+server-id=223355
+log-bin=mysql-bin
+binlog-format=ROW
+binlog-row-image=FULL


### PR DESCRIPTION
## What

Two test layers for the self-written logic in `fs_brokers/cdc_client`.

### Unit tests (no database / no Spring, plain `mvn test`)

- **Deserialization** (`DebeziumJsonDeserializer`): value conversion for dates (incl. ancient / zero / pre-epoch — guards against calendar drift), time, timestamp, zoned timestamp, decimal (precise/string/double), bits, geometry (point → GeoJSON), arrays and binary; plus the full `deserialize()` path — create/update/delete, `__DORIS_DELETE_SIGN__`, column exclusion, non-data-change short-circuit.
- **Postgres schema-change detection** (`PostgresDebeziumJsonDeserializer`): WAL-based ADD/DROP column branches — passthrough when no stored schema / no change, pure ADD, pure DROP, simultaneous ADD+DROP (rename) skip, and the missing-refresher guard.
- **Sink helpers**: `BatchRecordBuffer` (delimiter / counting / clear), `HttpPutBuilder` (headers, auth, txn, build precondition), `LoadStatistic` (accumulation).
- **Factory / result**: `SourceReaderFactory`, `DeserializeResult`.
- **Config utils** (`ConfigUtil`): server-timezone parsing (mysql / pg / default), `isJson`, `is13Timestamp`, exclude-columns / target-table parsing, `toStringMap`.

### Testcontainers ITCases (JUnit5 + Testcontainers, real read path)

Drive the real production read path end to end against containerized MySQL / PostgreSQL — `/api/fetchSplits` → `writeRecords` (from-to) and `fetchRecordStream` (TVF) — with a mock stream-load / commit endpoint, so no Doris cluster is needed. Intended to run on PR only when `fs_brokers/cdc_client/**` changes.

- **from-to `writeRecords` path**: snapshot full-load, incremental insert/update/delete, at-least-once offset resume, chunk-boundary resume, data-type families, ancient dates, startup modes (latest / specific-offset), per-column charset, server timezone, empty table, Postgres schema change, Postgres default REPLICA IDENTITY.
- **TVF `fetchRecordStream` path**: MySQL snapshot + streamed update/delete + offset resume; PostgreSQL full chain (snapshot + incremental + pgoutput slot/publication).
- **Version smoke**: MySQL 5.7 / 8.4 and PostgreSQL 15 / 16 / 17 each run a snapshot + DML chain (the default ITCases already cover 8.0 / 14).

Both read paths share the same reader / split preparation / `deserialize()`, so type/charset/timezone/version decoding is covered once and exercised from both entry points. Tests are isolated by a unique jobId per method and close the process-wide `Env` reader in teardown; incremental assertions poll with a timeout (no sleeps) to stay non-flaky.

One production-side change rides along: `MySqlSourceReader` sets `enable.time.adjuster=false` so genuinely ancient (<100) DATE/DATETIME years are preserved — the ancient-date ITCase depends on it.

## Coverage

Line coverage of the targeted self-written classes sits at ~81–100% (e.g. `DebeziumJsonDeserializer` 81%, `PostgresDebeziumJsonDeserializer` 86%, `ConfigUtil` 86%, sink helpers 86–100%).

## pom change

One dependency line: pins `jackson-annotations` to 2.19.2 to match the already-resolved `jackson-databind`/`jackson-core` 2.19.2. The transitively-resolved annotations version was older and missing classes (`JsonKey` / `JsonIncludeProperties`) that databind 2.19 references during serialization — a latent version skew that these tests surface. This only aligns the version family; the serializer (databind) was already 2.19.2.
