### PR TITLE
[fix](load) Report variant key errors in stream load error url

### DIFF
--- a/be/src/format/json/new_json_reader.cpp
+++ b/be/src/format/json/new_json_reader.cpp
@@ -1030,8 +1030,9 @@ Status NewJsonReader::_simdjson_set_column_value(simdjson::ondemand::object* val
         auto* column_ptr = block.get_by_position(column_index).column->assert_mutable().get();
         RETURN_IF_ERROR(_simdjson_write_data_to_column<false>(
                 val, slot_descs[column_index]->type(), column_ptr,
-                slot_descs[column_index]->col_name(), _serdes[column_index], valid));
+                slot_descs[column_index]->col_name(), _serdes[column_index], value, true, valid));
         if (!(*valid)) {
+            json_reader_detail::truncate_block_to_rows(block, cur_row_count);
             return Status::OK();
         }
         _seen_columns[column_index] = true;
@@ -1114,7 +1115,10 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
                                                      const DataTypePtr& type_desc,
                                                      IColumn* column_ptr,
                                                      const std::string& column_name,
-                                                     DataTypeSerDeSPtr serde, bool* valid) {
+                                                     DataTypeSerDeSPtr serde,
+                                                     simdjson::ondemand::object* src_obj,
+                                                     bool allow_variant_load_error,
+                                                     bool* valid) {
     ColumnNullable* nullable_column = nullptr;
     IColumn* data_column_ptr = column_ptr;
     DataTypeSerDeSPtr data_serde = serde;
@@ -1145,6 +1149,26 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
 
     auto primitive_type = type_desc->get_primitive_type();
     if (_is_load || !is_complex_type(primitive_type)) {
+        auto deserialize_one_cell = [&](Slice& slice) {
+            const auto old_size = data_column_ptr->size();
+            Status st = data_serde->deserialize_one_cell_from_json(*data_column_ptr, slice,
+                                                                   _serde_options);
+            if (st.ok()) {
+                return Status::OK();
+            }
+            if (allow_variant_load_error && _is_load && primitive_type == TYPE_VARIANT &&
+                st.is<INVALID_ARGUMENT>()) {
+                if (data_column_ptr->size() > old_size) {
+                    data_column_ptr->pop_back(data_column_ptr->size() - old_size);
+                }
+                return _append_error_msg(
+                        src_obj,
+                        fmt::format("Failed to parse variant column `{}`: {}", column_name,
+                                    st.to_string()),
+                        "", valid);
+            }
+            return st;
+        };
         if (value.type() == simdjson::ondemand::json_type::string) {
             std::string_view value_string;
             if constexpr (use_string_cache) {
@@ -1161,8 +1185,10 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
             }
 
             Slice slice {value_string.data(), value_string.size()};
-            RETURN_IF_ERROR(data_serde->deserialize_one_cell_from_json(*data_column_ptr, slice,
-                                                                       _serde_options));
+            RETURN_IF_ERROR(deserialize_one_cell(slice));
+            if (!(*valid)) {
+                return Status::OK();
+            }
 
         } else if (value.type() == simdjson::ondemand::json_type::boolean) {
             const char* str_value = nullptr;
@@ -1173,15 +1199,19 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
                 str_value = (char*)"0";
             }
             Slice slice {str_value, 1};
-            RETURN_IF_ERROR(data_serde->deserialize_one_cell_from_json(*data_column_ptr, slice,
-                                                                       _serde_options));
+            RETURN_IF_ERROR(deserialize_one_cell(slice));
+            if (!(*valid)) {
+                return Status::OK();
+            }
         } else {
             // Maybe we can `switch (value->GetType()) case: kNumberType`.
             // Note that `if (value->IsInt())`, but column is FloatColumn.
             std::string_view json_str = simdjson::to_json_string(value);
             Slice slice {json_str.data(), json_str.size()};
-            RETURN_IF_ERROR(data_serde->deserialize_one_cell_from_json(*data_column_ptr, slice,
-                                                                       _serde_options));
+            RETURN_IF_ERROR(deserialize_one_cell(slice));
+            if (!(*valid)) {
+                return Status::OK();
+            }
         }
     } else if (primitive_type == TYPE_STRUCT) {
         if (value.type() != simdjson::ondemand::json_type::object) [[unlikely]] {
@@ -1222,7 +1252,10 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
             const auto& sub_col_type = type_struct->get_element(sub_column_idx);
             RETURN_IF_ERROR(_simdjson_write_data_to_column<use_string_cache>(
                     sub.value(), sub_col_type, sub_column_ptr.get(), column_name + "." + sub_key,
-                    sub_serdes[sub_column_idx], valid));
+                    sub_serdes[sub_column_idx], src_obj, false, valid));
+            if (!(*valid)) {
+                return Status::OK();
+            }
         }
 
         //fill missing subcolumn
@@ -1284,7 +1317,10 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
                     assert_cast<const DataTypeMap*>(remove_nullable(type_desc).get())
                             ->get_value_type(),
                     map_column_ptr->get_values_ptr()->assert_mutable()->get_ptr().get(),
-                    column_name + ".value", sub_serdes[1], valid));
+                    column_name + ".value", sub_serdes[1], src_obj, false, valid));
+            if (!(*valid)) {
+                return Status::OK();
+            }
             field_count++;
         }
 
@@ -1309,7 +1345,10 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
                     assert_cast<const DataTypeArray*>(remove_nullable(type_desc).get())
                             ->get_nested_type(),
                     array_column_ptr->get_data().get_ptr().get(), column_name + ".element",
-                    sub_serdes[0], valid));
+                    sub_serdes[0], src_obj, false, valid));
+            if (!(*valid)) {
+                return Status::OK();
+            }
             field_count++;
         }
         auto& offsets = array_column_ptr->get_offsets();
@@ -1500,6 +1539,7 @@ Status NewJsonReader::_simdjson_write_columns_by_jsonpath(
         Block& block, bool* valid) {
     // write by jsonpath
     bool has_valid_value = false;
+    size_t cur_row_count = block.rows();
 
     Defer clear_defer([this]() { _cached_string_values.clear(); });
 
@@ -1536,8 +1576,9 @@ Status NewJsonReader::_simdjson_write_columns_by_jsonpath(
         } else {
             RETURN_IF_ERROR(_simdjson_write_data_to_column<true>(json_value, slot_desc->type(),
                                                                  column_ptr, slot_desc->col_name(),
-                                                                 _serdes[i], valid));
+                                                                 _serdes[i], value, true, valid));
             if (!(*valid)) {
+                json_reader_detail::truncate_block_to_rows(block, cur_row_count);
                 return Status::OK();
             }
             has_valid_value = true;

--- a/be/src/format/json/new_json_reader.h
+++ b/be/src/format/json/new_json_reader.h
@@ -171,7 +171,8 @@ private:
     Status _simdjson_write_data_to_column(simdjson::ondemand::value& value,
                                           const DataTypePtr& type_desc, IColumn* column_ptr,
                                           const std::string& column_name, DataTypeSerDeSPtr serde,
-                                          bool* valid);
+                                          simdjson::ondemand::object* src_obj,
+                                          bool allow_variant_load_error, bool* valid);
 
     Status _simdjson_write_columns_by_jsonpath(simdjson::ondemand::object* value,
                                                const std::vector<SlotDescriptor*>& slot_descs,

--- a/be/src/util/json/json_parser.cpp
+++ b/be/src/util/json/json_parser.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -35,6 +36,29 @@
 #include "util/json/simd_json_parser.h"
 
 namespace doris {
+
+namespace {
+
+constexpr size_t JSON_KEY_ERROR_PREVIEW_BYTES = 128;
+
+std::string json_key_length_error(std::string_view key, size_t max_key_length,
+                                  std::string_view parent_path = {}) {
+    std::string_view key_preview =
+            key.substr(0, std::min(key.size(), JSON_KEY_ERROR_PREVIEW_BYTES));
+    std::string truncated_suffix;
+    if (key_preview.size() != key.size()) {
+        truncated_suffix = "...";
+    }
+    std::string path_msg;
+    if (!parent_path.empty()) {
+        path_msg = fmt::format(" parent path: '{}'.", parent_path);
+    }
+    return fmt::format(
+            "Key length exceeds maximum allowed size of {} bytes. key length: {}, key: '{}{}'.{}",
+            max_key_length, key.size(), key_preview, truncated_suffix, path_msg);
+}
+
+} // namespace
 
 template <typename ParserImpl>
 std::optional<ParseResult> JSONDataParser<ParserImpl>::parse(const char* begin, size_t length,
@@ -106,13 +130,12 @@ template <typename ParserImpl>
 void JSONDataParser<ParserImpl>::traverseObject(const JSONObject& object, ParseContext& ctx) {
     ctx.paths.reserve(ctx.paths.size() + object.size());
     ctx.values.reserve(ctx.values.size() + object.size());
-    auto check_key_length = [](const auto& key) {
+    auto check_key_length = [&](const auto& key) {
         const size_t max_key_length = cast_set<size_t>(config::variant_max_json_key_length);
         if (key.size() > max_key_length) {
             throw doris::Exception(
                     doris::ErrorCode::INVALID_ARGUMENT,
-                    fmt::format("Key length exceeds maximum allowed size of {} bytes.",
-                                max_key_length));
+                    json_key_length_error(key, max_key_length, ctx.builder.build().get_path()));
         }
     };
     auto traverse_object_member = [&](const auto& key, const auto& value) {
@@ -162,8 +185,7 @@ void JSONDataParser<ParserImpl>::traverseObjectAsJsonb(const JSONObject& object,
         if (key.size() > max_key_length) {
             throw doris::Exception(
                     doris::ErrorCode::INVALID_ARGUMENT,
-                    fmt::format("Key length exceeds maximum allowed size of {} bytes.",
-                                max_key_length));
+                    json_key_length_error(key, max_key_length));
         }
         writer.writeKey(key.data(), cast_set<uint8_t>(key.size()));
         traverseAsJsonb(value, writer);

--- a/regression-test/suites/variant_p0/test_variant_stream_load_key_error_url.groovy
+++ b/regression-test/suites/variant_p0/test_variant_stream_load_key_error_url.groovy
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_variant_stream_load_key_error_url", "variant_type,p0") {
+    sql "DROP TABLE IF EXISTS test_variant_stream_load_key_error_url"
+    sql """
+        CREATE TABLE test_variant_stream_load_key_error_url (
+            k INT,
+            v VARIANT
+        )
+        DUPLICATE KEY(k)
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES("replication_num" = "1");
+    """
+
+    String longKey = "a" * 256
+    File dataFile = new File("/tmp/test_variant_stream_load_key_error_url.json")
+    dataFile.withWriter { writer ->
+        writer.writeLine('{"k":1,"v":{"short_key":1}}')
+        writer.writeLine("""{"k":2,"v":{"${longKey}":2}}""")
+    }
+
+    streamLoad {
+        table "test_variant_stream_load_key_error_url"
+        set 'read_json_by_line', 'true'
+        set 'format', 'json'
+        set 'max_filter_ratio', '0.9'
+        file dataFile.absolutePath
+        time 10000
+
+        check { result, exception, startTime, endTime ->
+            if (exception != null) {
+                throw exception
+            }
+            def json = parseJson(result)
+            assertEquals("success", json.Status.toLowerCase())
+            assertEquals(2, json.NumberTotalRows)
+            assertEquals(1, json.NumberLoadedRows)
+            assertEquals(1, json.NumberFilteredRows)
+            assertTrue(json.ErrorURL != null && json.ErrorURL != "N/A")
+
+            def (code, out, err) = curl("GET", json.ErrorURL)
+            assertEquals(0, code)
+            assertTrue(out.contains("Failed to parse variant column `v`"))
+            assertTrue(out.contains("Key length exceeds maximum allowed size of 255 bytes"))
+            assertTrue(out.contains("key length: 256"))
+            assertTrue(out.contains('"k":2'))
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Stream load failed the whole load when a VARIANT JSON object key exceeded variant_max_json_key_length. The failure happened inside VARIANT deserialization and returned before the JSON reader wrote a row-level error log, so the load result had no ErrorURL and users could not locate the source row. This change converts direct VARIANT column INVALID_ARGUMENT failures in the JSON load reader into row-level load errors, writes the source row to the error log, and enriches the key length error with key length, key preview, and parent path when available.

### Release note

Stream load now reports direct VARIANT JSON key length parse failures through the load error URL.

### Check List (For Author)

- Test: Added regression test test_variant_stream_load_key_error_url. Ran git diff --check. Attempted ./run-be-ut.sh --run --filter=JsonParserTest.KeyLengthLimitByConfig, but it stopped before running tests because thirdparty/installed/lib/libcrc32c.a is missing in this workspace.
- Behavior changed: Yes. Direct VARIANT column key length parse failures during JSON stream load are reported as row-level load errors with ErrorURL instead of only aborting without an error log.
- Does this need documentation: No