### PR TITLE
[fix](iceberg) Fix wrong processing for `NaN`

### DIFF
--- a/be/src/exec/sink/writer/iceberg/partition_transformers.cpp
+++ b/be/src/exec/sink/writer/iceberg/partition_transformers.cpp
@@ -18,11 +18,27 @@
 #include "exec/sink/writer/iceberg/partition_transformers.h"
 
 #include <any>
+#include <cmath>
 
 #include "core/types.h"
 #include "format/table/iceberg/partition_spec.h"
 
 namespace doris {
+
+namespace {
+
+template <typename T>
+std::string floating_point_partition_value_to_string(T value) {
+    if (std::isnan(value)) {
+        return "NaN";
+    }
+    if (std::isinf(value)) {
+        return value > 0 ? "Infinity" : "-Infinity";
+    }
+    return std::to_string(value);
+}
+
+} // namespace
 
 const std::chrono::sys_days PartitionColumnTransformUtils::EPOCH = std::chrono::sys_days(
         std::chrono::year {1970} / std::chrono::January / std::chrono::day {1});
@@ -225,10 +241,10 @@ std::string PartitionColumnTransform::get_partition_value(const DataTypePtr type
             return std::to_string(std::any_cast<Int64>(value));
         }
         case TYPE_FLOAT: {
-            return std::to_string(std::any_cast<Float32>(value));
+            return floating_point_partition_value_to_string(std::any_cast<Float32>(value));
         }
         case TYPE_DOUBLE: {
-            return std::to_string(std::any_cast<Float64>(value));
+            return floating_point_partition_value_to_string(std::any_cast<Float64>(value));
         }
         case TYPE_VARCHAR:
         case TYPE_CHAR:

--- a/be/test/exec/sink/writer/iceberg/partition_transformers_test.cpp
+++ b/be/test/exec/sink/writer/iceberg/partition_transformers_test.cpp
@@ -118,23 +118,24 @@ TEST_F(PartitionTransformersTest, test_string_truncate_transform) {
 }
 
 TEST_F(PartitionTransformersTest, test_floating_point_special_partition_value) {
-    PartitionColumnTransform transform;
     auto float_type =
             DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_FLOAT, false);
     auto double_type =
             DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_DOUBLE, false);
+    IdentityPartitionColumnTransform float_transform(float_type);
+    IdentityPartitionColumnTransform double_transform(double_type);
 
-    EXPECT_EQ("NaN",
-              transform.get_partition_value(float_type, std::numeric_limits<Float32>::quiet_NaN()));
-    EXPECT_EQ("Infinity",
-              transform.get_partition_value(float_type, std::numeric_limits<Float32>::infinity()));
-    EXPECT_EQ("-Infinity",
-              transform.get_partition_value(float_type, -std::numeric_limits<Float32>::infinity()));
-    EXPECT_EQ("NaN", transform.get_partition_value(double_type,
-                                                   std::numeric_limits<Float64>::quiet_NaN()));
-    EXPECT_EQ("Infinity",
-              transform.get_partition_value(double_type, std::numeric_limits<Float64>::infinity()));
-    EXPECT_EQ("-Infinity", transform.get_partition_value(
+    EXPECT_EQ("NaN", float_transform.get_partition_value(
+                             float_type, std::numeric_limits<Float32>::quiet_NaN()));
+    EXPECT_EQ("Infinity", float_transform.get_partition_value(
+                                  float_type, std::numeric_limits<Float32>::infinity()));
+    EXPECT_EQ("-Infinity", float_transform.get_partition_value(
+                                   float_type, -std::numeric_limits<Float32>::infinity()));
+    EXPECT_EQ("NaN", double_transform.get_partition_value(
+                             double_type, std::numeric_limits<Float64>::quiet_NaN()));
+    EXPECT_EQ("Infinity", double_transform.get_partition_value(
+                                  double_type, std::numeric_limits<Float64>::infinity()));
+    EXPECT_EQ("-Infinity", double_transform.get_partition_value(
                                    double_type, -std::numeric_limits<Float64>::infinity()));
 }
 

--- a/be/test/exec/sink/writer/iceberg/partition_transformers_test.cpp
+++ b/be/test/exec/sink/writer/iceberg/partition_transformers_test.cpp
@@ -19,6 +19,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "core/data_type/data_type_date_or_datetime_v2.h"
 
 namespace doris {
@@ -113,6 +115,27 @@ TEST_F(PartitionTransformersTest, test_string_truncate_transform) {
     for (size_t i = 0; i < result_column->size(); ++i) {
         EXPECT_EQ(expected_data[i], result_column->get_data_at(i));
     }
+}
+
+TEST_F(PartitionTransformersTest, test_floating_point_special_partition_value) {
+    PartitionColumnTransform transform;
+    auto float_type =
+            DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_FLOAT, false);
+    auto double_type =
+            DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_DOUBLE, false);
+
+    EXPECT_EQ("NaN", transform.get_partition_value(
+                             float_type, std::numeric_limits<Float32>::quiet_NaN()));
+    EXPECT_EQ("Infinity", transform.get_partition_value(
+                                  float_type, std::numeric_limits<Float32>::infinity()));
+    EXPECT_EQ("-Infinity", transform.get_partition_value(
+                                   float_type, -std::numeric_limits<Float32>::infinity()));
+    EXPECT_EQ("NaN", transform.get_partition_value(
+                             double_type, std::numeric_limits<Float64>::quiet_NaN()));
+    EXPECT_EQ("Infinity", transform.get_partition_value(
+                                  double_type, std::numeric_limits<Float64>::infinity()));
+    EXPECT_EQ("-Infinity", transform.get_partition_value(
+                                   double_type, -std::numeric_limits<Float64>::infinity()));
 }
 
 TEST_F(PartitionTransformersTest, test_integer_bucket_transform) {

--- a/be/test/exec/sink/writer/iceberg/partition_transformers_test.cpp
+++ b/be/test/exec/sink/writer/iceberg/partition_transformers_test.cpp
@@ -124,16 +124,16 @@ TEST_F(PartitionTransformersTest, test_floating_point_special_partition_value) {
     auto double_type =
             DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_DOUBLE, false);
 
-    EXPECT_EQ("NaN", transform.get_partition_value(
-                             float_type, std::numeric_limits<Float32>::quiet_NaN()));
-    EXPECT_EQ("Infinity", transform.get_partition_value(
-                                  float_type, std::numeric_limits<Float32>::infinity()));
-    EXPECT_EQ("-Infinity", transform.get_partition_value(
-                                   float_type, -std::numeric_limits<Float32>::infinity()));
-    EXPECT_EQ("NaN", transform.get_partition_value(
-                             double_type, std::numeric_limits<Float64>::quiet_NaN()));
-    EXPECT_EQ("Infinity", transform.get_partition_value(
-                                  double_type, std::numeric_limits<Float64>::infinity()));
+    EXPECT_EQ("NaN",
+              transform.get_partition_value(float_type, std::numeric_limits<Float32>::quiet_NaN()));
+    EXPECT_EQ("Infinity",
+              transform.get_partition_value(float_type, std::numeric_limits<Float32>::infinity()));
+    EXPECT_EQ("-Infinity",
+              transform.get_partition_value(float_type, -std::numeric_limits<Float32>::infinity()));
+    EXPECT_EQ("NaN", transform.get_partition_value(double_type,
+                                                   std::numeric_limits<Float64>::quiet_NaN()));
+    EXPECT_EQ("Infinity",
+              transform.get_partition_value(double_type, std::numeric_limits<Float64>::infinity()));
     EXPECT_EQ("-Infinity", transform.get_partition_value(
                                    double_type, -std::numeric_limits<Float64>::infinity()));
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -965,9 +965,9 @@ public class IcebergUtils {
                 case LONG:
                     return Long.parseLong(valueStr);
                 case FLOAT:
-                    return Float.parseFloat(valueStr);
+                    return Float.parseFloat(normalizeFloatingPointPartitionValue(valueStr));
                 case DOUBLE:
-                    return Double.parseDouble(valueStr);
+                    return Double.parseDouble(normalizeFloatingPointPartitionValue(valueStr));
                 case BOOLEAN:
                     return Boolean.parseBoolean(valueStr);
                 case DATE:
@@ -984,6 +984,20 @@ public class IcebergUtils {
             throw new IllegalArgumentException(String.format("Failed to convert partition value '%s' to type %s",
                     valueStr, icebergType), e);
         }
+    }
+
+    private static String normalizeFloatingPointPartitionValue(String valueStr) {
+        if ("nan".equalsIgnoreCase(valueStr)) {
+            return "NaN";
+        }
+        if ("inf".equalsIgnoreCase(valueStr) || "+inf".equalsIgnoreCase(valueStr)
+                || "infinity".equalsIgnoreCase(valueStr) || "+infinity".equalsIgnoreCase(valueStr)) {
+            return "Infinity";
+        }
+        if ("-inf".equalsIgnoreCase(valueStr) || "-infinity".equalsIgnoreCase(valueStr)) {
+            return "-Infinity";
+        }
+        return valueStr;
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
@@ -297,6 +297,26 @@ public class IcebergUtilsTest {
     }
 
     @Test
+    public void testParseFloatingPointPartitionValueSupportsSpecialValues() {
+        Assert.assertTrue(Float.isNaN(
+                (Float) IcebergUtils.parsePartitionValueFromString("NaN", Types.FloatType.get())));
+        Assert.assertTrue(Float.isNaN(
+                (Float) IcebergUtils.parsePartitionValueFromString("nan", Types.FloatType.get())));
+        Assert.assertEquals(Float.POSITIVE_INFINITY,
+                (Float) IcebergUtils.parsePartitionValueFromString("Infinity", Types.FloatType.get()), 0.0F);
+        Assert.assertEquals(Float.NEGATIVE_INFINITY,
+                (Float) IcebergUtils.parsePartitionValueFromString("-inf", Types.FloatType.get()), 0.0F);
+        Assert.assertTrue(Double.isNaN(
+                (Double) IcebergUtils.parsePartitionValueFromString("NaN", Types.DoubleType.get())));
+        Assert.assertTrue(Double.isNaN(
+                (Double) IcebergUtils.parsePartitionValueFromString("nan", Types.DoubleType.get())));
+        Assert.assertEquals(Double.POSITIVE_INFINITY,
+                (Double) IcebergUtils.parsePartitionValueFromString("Infinity", Types.DoubleType.get()), 0.0D);
+        Assert.assertEquals(Double.NEGATIVE_INFINITY,
+                (Double) IcebergUtils.parsePartitionValueFromString("-inf", Types.DoubleType.get()), 0.0D);
+    }
+
+    @Test
     public void testGetMatchingManifest() {
 
         // partition : 100 - 200


### PR DESCRIPTION
### What problem does this PR solve?

This change fixes Iceberg writes when FLOAT or DOUBLE partition values contain NaN or infinity.

  Previously, the BE Iceberg writer serialized floating-point partition values with std::to_string(), which produced lowercase special values such as "nan", "inf", and "-inf". These strings are not accepted by Java's
  Float.parseFloat() / Double.parseDouble() in the FE partition commit path, causing writes with NaN partition values to fail.

  The fix canonicalizes BE floating-point partition serialization to Java/Iceberg-compatible values: "NaN", "Infinity", and "-Infinity". It also makes FE partition value parsing tolerate legacy lowercase forms such as "nan" and
  "-inf".

  Unit tests were added for BE partition value serialization and FE parsing of special floating-point partition values.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

