### PR TITLE
bounds-check dictionary indices in parquet dict decoders

### DIFF
--- a/be/src/format/parquet/byte_array_dict_decoder.cpp
+++ b/be/src/format/parquet/byte_array_dict_decoder.cpp
@@ -139,6 +139,7 @@ Status ByteArrayDictDecoder::_decode_values(MutableColumnPtr& doris_column, Data
     }
     _indexes.resize(non_null_size);
     _index_batch_decoder->GetBatch(_indexes.data(), cast_set<uint32_t>(non_null_size));
+    RETURN_IF_ERROR(_check_dict_indexes(_dict_items.size()));
 
     if (doris_column->is_column_dictionary() || is_dict_filter) {
         return _decode_dict_values<has_filter>(doris_column, select_vector, is_dict_filter);

--- a/be/src/format/parquet/decoder.h
+++ b/be/src/format/parquet/decoder.h
@@ -152,6 +152,20 @@ protected:
         return Status::OK();
     }
 
+    // The index bit width is read from the data page and is fully attacker controlled,
+    // so a decoded index may point past the dictionary. Reject it before it is used to
+    // look up _dict_items.
+    Status _check_dict_indexes(size_t dict_size) {
+        for (uint32_t index : _indexes) {
+            if (UNLIKELY(index >= dict_size)) {
+                return Status::Corruption(
+                        "Parquet dictionary index {} out of bounds, dictionary size {}", index,
+                        dict_size);
+            }
+        }
+        return Status::OK();
+    }
+
     // For dictionary encoding
     DorisUniqueBufferPtr<uint8_t> _dict;
     std::unique_ptr<RleBatchDecoder<uint32_t>> _index_batch_decoder;

--- a/be/src/format/parquet/decoder.h
+++ b/be/src/format/parquet/decoder.h
@@ -20,6 +20,7 @@
 #include <gen_cpp/parquet_types.h>
 #include <glog/logging.h>
 
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -100,7 +101,19 @@ public:
     Status set_data(Slice* data) override {
         _data = data;
         _offset = 0;
+        // The first byte of the data page carries the RLE index bit width and is fully
+        // attacker controlled. _index_batch_decoder is a RleBatchDecoder<uint32_t>, so a
+        // width above 32 makes RleBatchDecoder read more bytes than fit in a uint32_t (the
+        // size guard inside it is only a DCHECK, so release builds overflow). Reject empty
+        // pages and out of range widths before constructing the decoder.
+        if (data->size < 1) {
+            return Status::Corruption("Parquet dictionary index page is empty");
+        }
         uint8_t bit_width = *data->data;
+        if (bit_width > sizeof(uint32_t) * CHAR_BIT) {
+            return Status::Corruption("Parquet dictionary index bit width {} out of range",
+                                      bit_width);
+        }
         _index_batch_decoder = std::make_unique<RleBatchDecoder<uint32_t>>(
                 reinterpret_cast<uint8_t*>(data->data) + 1, static_cast<int>(data->size) - 1,
                 bit_width);

--- a/be/src/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/format/parquet/fix_length_dict_decoder.hpp
@@ -96,6 +96,7 @@ public:
         }
         _indexes.resize(non_null_size);
         _index_batch_decoder->GetBatch(_indexes.data(), cast_set<uint32_t>(non_null_size));
+        RETURN_IF_ERROR(_check_dict_indexes(_dict_items.size()));
 
         if (doris_column->is_column_dictionary() || is_dict_filter) {
             return _decode_dict_values<has_filter>(doris_column, select_vector, is_dict_filter);

--- a/be/test/format/parquet/byte_array_dict_decoder_test.cpp
+++ b/be/test/format/parquet/byte_array_dict_decoder_test.cpp
@@ -528,4 +528,40 @@ TEST_F(ByteArrayDictDecoderTest, test_set_dict_rejects_truncated_payload_after_p
     ASSERT_FALSE(decoder.set_dict(dict_data, 4, 1).ok());
 }
 
+// A data page whose leading bit-width byte is wider than a uint32_t index must be
+// rejected before the RLE decoder is built, otherwise the batch reader memcpys more
+// bytes than fit in the repeated value.
+TEST_F(ByteArrayDictDecoderTest, test_set_data_rejects_oversized_bit_width) {
+    std::vector<uint8_t> rle_data = {33, 0x00, 0x00};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_FALSE(_decoder.set_data(&data_slice).ok());
+}
+
+// An empty page has no bit-width byte to read.
+TEST_F(ByteArrayDictDecoderTest, test_set_data_rejects_empty_page) {
+    Slice data_slice(static_cast<char*>(nullptr), 0);
+    ASSERT_FALSE(_decoder.set_data(&data_slice).ok());
+}
+
+// A decoded index past the end of the dictionary must be rejected rather than used to
+// look up _dict_items. bit width 3, one repeated run of value 5 against a 3 entry dict.
+TEST_F(ByteArrayDictDecoderTest, test_decode_rejects_out_of_range_index) {
+    MutableColumnPtr column = ColumnString::create();
+    DataTypePtr data_type = std::make_shared<DataTypeString>();
+
+    std::vector<uint8_t> rle_data = {3, 0x08, 0x05};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_TRUE(_decoder.set_data(&data_slice).ok());
+
+    size_t num_values = 4;
+    std::vector<uint16_t> run_length_null_map(1, num_values); // All non-null
+    std::vector<uint8_t> filter_data(num_values, 1);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+    ColumnSelectVector select_vector;
+    ASSERT_TRUE(select_vector.init(run_length_null_map, num_values, nullptr, &filter_map, 0).ok());
+
+    ASSERT_FALSE(_decoder.decode_values(column, data_type, select_vector, false).ok());
+}
+
 } // namespace doris

--- a/be/test/format/parquet/fix_length_dict_decoder_test.cpp
+++ b/be/test/format/parquet/fix_length_dict_decoder_test.cpp
@@ -626,4 +626,40 @@ TEST_F(FixLengthDictDecoderTest, test_skip_value) {
     }
 }
 
+// A data page whose leading bit-width byte is wider than a uint32_t index must be
+// rejected before the RLE decoder is built, otherwise the batch reader memcpys more
+// bytes than fit in the repeated value.
+TEST_F(FixLengthDictDecoderTest, test_set_data_rejects_oversized_bit_width) {
+    std::vector<uint8_t> rle_data = {33, 0x00, 0x00};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_FALSE(_decoder.set_data(&data_slice).ok());
+}
+
+// An empty page has no bit-width byte to read.
+TEST_F(FixLengthDictDecoderTest, test_set_data_rejects_empty_page) {
+    Slice data_slice(static_cast<char*>(nullptr), 0);
+    ASSERT_FALSE(_decoder.set_data(&data_slice).ok());
+}
+
+// A decoded index past the end of the dictionary must be rejected rather than used to
+// look up _dict_items. bit width 3, one repeated run of value 5 against a 3 entry dict.
+TEST_F(FixLengthDictDecoderTest, test_decode_rejects_out_of_range_index) {
+    MutableColumnPtr column = ColumnUInt8::create();
+    DataTypePtr data_type = std::make_shared<DataTypeUInt8>();
+
+    std::vector<uint8_t> rle_data = {3, 0x08, 0x05};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_TRUE(_decoder.set_data(&data_slice).ok());
+
+    size_t num_values = 4;
+    std::vector<uint16_t> run_length_null_map(1, num_values); // All non-null
+    std::vector<uint8_t> filter_data(num_values, 1);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+    ColumnSelectVector select_vector;
+    ASSERT_TRUE(select_vector.init(run_length_null_map, num_values, nullptr, &filter_map, 0).ok());
+
+    ASSERT_FALSE(_decoder.decode_values(column, data_type, select_vector, false).ok());
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

While reading parquet files through the external file path I traced how dictionary encoded columns are decoded. The index bit width is taken from the first byte of the data page in `BaseDictDecoder::set_data`, fed straight into the RLE batch decoder, and the resulting values are used as `_dict_items[_indexes[...]]` in both `ByteArrayDictDecoder` and `FixLengthDictDecoder`. Nothing compares those indices against the dictionary size, so a file whose data page advertises a wider bit width than the dictionary needs (or simply emits an index past the end) walks off the end of `_dict_items`. Under ASAN this shows up as a heap-buffer-overflow read inside the decode loop; without it the reader silently dereferences whatever memory follows the vector.

The root cause is the missing range check between the untrusted index stream and the dictionary it addresses. Both decoders share the same `_indexes`/`_dict_items` shape, so the guard sits in the common base and is called from each decoder right after the batch is decoded, before any lookup happens. Left unfixed this is an out of bounds read reachable by anyone able to point Doris at a crafted parquet file (table valued function, external table, file load), so closing it at the decoder layer is safer than trusting the encoder to stay within the dictionary.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason: the change only adds a defensive bounds check that rejects corrupt input. Triggering it needs a hand crafted parquet file carrying out of range dictionary indices; the path was validated here by annotating the decode flow rather than committing such a fixture.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.
