### PR TITLE
[feature](runtime-filter) Support bloom pruning for list partitions

### DIFF
--- a/be/src/exec/runtime_filter/runtime_filter_partition_pruner.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_partition_pruner.cpp
@@ -46,13 +46,13 @@ namespace doris {
 
 namespace {
 
-template <typename CvrType>
-bool bloom_may_match_fixed_values(const CvrType& cvr, BloomFilterFuncBase* bloom_filter) {
+template <PrimitiveType PT>
+bool bloom_may_match_fixed_values(const ColumnValueRange<PT>& cvr,
+                                  BloomFilterFuncBase* bloom_filter) {
     if (cvr.get_fixed_value_size() == 0) {
         return false;
     }
 
-    static constexpr PrimitiveType PT = CvrType::type_value;
     using CppType = typename PrimitiveTypeTraits<PT>::CppType;
     using ColumnType = typename PrimitiveTypeTraits<PT>::ColumnType;
 

--- a/be/src/exec/runtime_filter/runtime_filter_partition_pruner.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_partition_pruner.cpp
@@ -46,17 +46,13 @@ namespace doris {
 
 namespace {
 
-template <typename T>
-struct ColumnValueRangePrimitiveType;
-
-template <PrimitiveType PT>
-struct ColumnValueRangePrimitiveType<ColumnValueRange<PT>> {
-    static constexpr PrimitiveType value = PT;
-};
-
 template <typename CvrType>
 bool bloom_may_match_fixed_values(const CvrType& cvr, BloomFilterFuncBase* bloom_filter) {
-    static constexpr PrimitiveType PT = ColumnValueRangePrimitiveType<CvrType>::value;
+    if (cvr.get_fixed_value_size() == 0) {
+        return false;
+    }
+
+    static constexpr PrimitiveType PT = CvrType::type_value;
     using CppType = typename PrimitiveTypeTraits<PT>::CppType;
     using ColumnType = typename PrimitiveTypeTraits<PT>::ColumnType;
 
@@ -66,14 +62,11 @@ bool bloom_may_match_fixed_values(const CvrType& cvr, BloomFilterFuncBase* bloom
     } else {
         values_column = ColumnType::create();
     }
-    auto* typed_column = assert_cast<ColumnType*>(values_column.get());
+    auto* typed_column = static_cast<ColumnType*>(values_column.get());
     for (const auto& value : cvr.get_fixed_value_set()) {
         typed_column->insert_value(value);
     }
     const size_t row_count = values_column->size();
-    if (row_count == 0) {
-        return false;
-    }
 
     std::vector<uint8_t> results(row_count, 0);
     ColumnPtr values_column_ptr = std::move(values_column);
@@ -675,24 +668,11 @@ void RuntimeFilterPartitionPruner::_try_prune_by_single_rf(
     // FilterBase::contain_null() already folds in `_null_aware`, so we only
     // get a true result when the build side is actually null-aware AND
     // produced a NULL value.
-    bool rf_contains_null = false;
-    if (auto hybrid_set = impl->get_set_func()) {
-        rf_contains_null = hybrid_set->contain_null();
-    } else if (impl->node_type() == TExprNodeType::BLOOM_PRED) {
-        auto bloom = impl->get_bloom_filter_func();
-        rf_contains_null = bloom && bloom->contain_null();
-    } else if (impl->node_type() == TExprNodeType::NULL_AWARE_BINARY_PRED) {
-        // Min/Max RF built on a null-safe equal join. The literal child holds
-        // the min or max bound; the NULL semantic is conveyed by the node
-        // type itself (see create_vbin_predicate in runtime_filter/utils.cpp).
-        rf_contains_null = true;
-    }
-
     if (impl->node_type() == TExprNodeType::BLOOM_PRED) {
         auto bloom = impl->get_bloom_filter_func();
-        if (!bloom) {
-            return;
-        }
+        DORIS_CHECK(bloom != nullptr);
+        bool rf_contains_null = bloom->contain_null();
+
         for (const auto& pb : boundaries) {
             if (_pruned_partition_ids.contains(pb.partition_id) ||
                 newly_pruned.contains(pb.partition_id)) {
@@ -726,6 +706,16 @@ void RuntimeFilterPartitionPruner::_try_prune_by_single_rf(
             }
         }
         return;
+    }
+
+    bool rf_contains_null = false;
+    if (auto hybrid_set = impl->get_set_func()) {
+        rf_contains_null = hybrid_set->contain_null();
+    } else if (impl->node_type() == TExprNodeType::NULL_AWARE_BINARY_PRED) {
+        // Min/Max RF built on a null-safe equal join. The literal child holds
+        // the min or max bound; the NULL semantic is conveyed by the node
+        // type itself (see create_vbin_predicate in runtime_filter/utils.cpp).
+        rf_contains_null = true;
     }
 
     std::optional<ColumnValueRangeType> rf_cvr;

--- a/be/src/exec/runtime_filter/runtime_filter_partition_pruner.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_partition_pruner.cpp
@@ -23,10 +23,14 @@
 #include <optional>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "core/block/block.h"
 #include "core/column/column.h"
+#include "core/column/column_decimal.h"
 #include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_nullable.h"
 #include "core/field.h"
 #include "exprs/bloom_filter_func.h"
@@ -39,6 +43,46 @@
 #include "runtime/descriptors.h"
 
 namespace doris {
+
+namespace {
+
+template <typename T>
+struct ColumnValueRangePrimitiveType;
+
+template <PrimitiveType PT>
+struct ColumnValueRangePrimitiveType<ColumnValueRange<PT>> {
+    static constexpr PrimitiveType value = PT;
+};
+
+template <typename CvrType>
+bool bloom_may_match_fixed_values(const CvrType& cvr, BloomFilterFuncBase* bloom_filter) {
+    static constexpr PrimitiveType PT = ColumnValueRangePrimitiveType<CvrType>::value;
+    using CppType = typename PrimitiveTypeTraits<PT>::CppType;
+    using ColumnType = typename PrimitiveTypeTraits<PT>::ColumnType;
+
+    MutableColumnPtr values_column;
+    if constexpr (IsDecimalNumber<CppType>) {
+        values_column = ColumnType::create(0, cvr.scale());
+    } else {
+        values_column = ColumnType::create();
+    }
+    auto* typed_column = assert_cast<ColumnType*>(values_column.get());
+    for (const auto& value : cvr.get_fixed_value_set()) {
+        typed_column->insert_value(value);
+    }
+    const size_t row_count = values_column->size();
+    if (row_count == 0) {
+        return false;
+    }
+
+    std::vector<uint8_t> results(row_count, 0);
+    ColumnPtr values_column_ptr = std::move(values_column);
+    bloom_filter->find_fixed_len(values_column_ptr, results.data());
+    return std::any_of(results.begin(), results.end(),
+                       [](uint8_t matched) { return matched != 0; });
+}
+
+} // namespace
 
 // NOLINTBEGIN(readability-function-cognitive-complexity,readability-function-size)
 // Complexity is inflated by macro expansion for each PrimitiveType case.
@@ -79,6 +123,7 @@ Status ParsedPartitionBoundaries::parse(
         bool is_list = tb.__isset.list_values && !tb.list_values.empty();                         \
         bool is_range = tb.__isset.range_start || tb.__isset.range_end;                           \
         DORIS_CHECK(is_list || is_range);                                                         \
+        boundary.is_list_boundary = is_list;                                                      \
         ColumnValueRange<TYPE_##NAME> cvr(slot->col_name(), is_nullable, precision, scale);       \
         /* Returns nullopt if `node` is a NULL literal; the caller then sets contain_null  */     \
         /* on the CVR instead of trying to extract a typed value (which would dereference  */     \
@@ -381,8 +426,9 @@ Status ParsedPartitionBoundaries::get_or_compute_projected_boundaries(
             DCHECK(cvr != nullptr);                                                              \
             DCHECK(!boundary.only_null);                                                         \
             DCHECK(!boundary.contains_null);                                                     \
-            boundary_is_list[i] = cvr->is_fixed_value_range();                                   \
+            boundary_is_list[i] = boundary.is_list_boundary;                                     \
             if (boundary_is_list[i]) {                                                           \
+                DORIS_CHECK(cvr->is_fixed_value_range());                                        \
                 list_result_begin[i] = list_row_count;                                           \
                 for (const auto& value : cvr->get_fixed_value_set()) {                           \
                     list_inner->insert_value(value);                                             \
@@ -516,6 +562,7 @@ Status ParsedPartitionBoundaries::get_or_compute_projected_boundaries(
                 projected_boundary.partition_id = orig_boundary.partition_id;                   \
                 projected_boundary.slot_id = leaf_slot_id;                                      \
                 projected_boundary.is_nullable = out_nullable;                                  \
+                projected_boundary.is_list_boundary = true;                                     \
                 projected_boundary.contains_null = list_has_null;                               \
                 projected_boundary.only_null = list_has_null && !list_has_value;                \
                 projected_boundary.boundary_cvr = std::move(cvr);                               \
@@ -552,6 +599,7 @@ Status ParsedPartitionBoundaries::get_or_compute_projected_boundaries(
             projected_boundary.partition_id = orig_boundary.partition_id;                       \
             projected_boundary.slot_id = leaf_slot_id;                                          \
             projected_boundary.is_nullable = out_nullable;                                      \
+            projected_boundary.is_list_boundary = false;                                        \
             projected_boundary.only_null = orig_boundary.only_null;                             \
             projected_boundary.contains_null = orig_boundary.contains_null;                     \
             projected_boundary.boundary_cvr = std::move(cvr);                                   \
@@ -638,6 +686,46 @@ void RuntimeFilterPartitionPruner::_try_prune_by_single_rf(
         // the min or max bound; the NULL semantic is conveyed by the node
         // type itself (see create_vbin_predicate in runtime_filter/utils.cpp).
         rf_contains_null = true;
+    }
+
+    if (impl->node_type() == TExprNodeType::BLOOM_PRED) {
+        auto bloom = impl->get_bloom_filter_func();
+        if (!bloom) {
+            return;
+        }
+        for (const auto& pb : boundaries) {
+            if (_pruned_partition_ids.contains(pb.partition_id) ||
+                newly_pruned.contains(pb.partition_id)) {
+                continue;
+            }
+
+            if (pb.only_null) {
+                if (!rf_contains_null) {
+                    newly_pruned.insert(pb.partition_id);
+                }
+                continue;
+            }
+            if (pb.contains_null && rf_contains_null) {
+                continue;
+            }
+            if (!pb.is_list_boundary) {
+                continue;
+            }
+
+            bool may_match = true;
+            std::visit(
+                    [&](const auto& boundary_cvr) {
+                        if (!boundary_cvr.is_fixed_value_range()) {
+                            return;
+                        }
+                        may_match = bloom_may_match_fixed_values(boundary_cvr, bloom.get());
+                    },
+                    pb.boundary_cvr);
+            if (!may_match) {
+                newly_pruned.insert(pb.partition_id);
+            }
+        }
+        return;
     }
 
     std::optional<ColumnValueRangeType> rf_cvr;

--- a/be/src/exec/runtime_filter/runtime_filter_partition_pruner.h
+++ b/be/src/exec/runtime_filter/runtime_filter_partition_pruner.h
@@ -43,6 +43,10 @@ struct ParsedBoundary {
     int64_t partition_id = 0;
     SlotId slot_id = 0;
     bool is_nullable = false;
+    // True only when the original/projection boundary is a finite LIST value set.
+    // Bloom RF pruning relies on complete value enumeration and must not use RANGE
+    // boundaries, even when a RANGE projection degenerates to a single point.
+    bool is_list_boundary = false;
     ColumnValueRangeType boundary_cvr;
     // True if the partition's value set is exactly {NULL} (e.g. LIST
     // partition whose only key is NULL). The CVR alone cannot encode

--- a/be/src/storage/olap_scan_common.h
+++ b/be/src/storage/olap_scan_common.h
@@ -60,6 +60,8 @@ namespace doris {
 template <PrimitiveType primitive_type>
 class ColumnValueRange {
 public:
+    static constexpr PrimitiveType type_value = primitive_type;
+
     using CppType = typename PrimitiveTypeTraits<primitive_type>::CppType;
     using SetType = std::set<CppType, doris::Less<CppType>>;
     using IteratorType = typename SetType::iterator;

--- a/be/src/storage/olap_scan_common.h
+++ b/be/src/storage/olap_scan_common.h
@@ -60,8 +60,6 @@ namespace doris {
 template <PrimitiveType primitive_type>
 class ColumnValueRange {
 public:
-    static constexpr PrimitiveType type_value = primitive_type;
-
     using CppType = typename PrimitiveTypeTraits<primitive_type>::CppType;
     using SetType = std::set<CppType, doris::Less<CppType>>;
     using IteratorType = typename SetType::iterator;

--- a/be/test/exec/runtime_filter/runtime_filter_partition_pruner_test.cpp
+++ b/be/test/exec/runtime_filter/runtime_filter_partition_pruner_test.cpp
@@ -28,9 +28,11 @@
 #include "core/data_type/data_type_factory.hpp"
 #include "core/string_ref.h"
 #include "core/types.h"
+#include "exec/runtime_filter/runtime_filter_definitions.h"
 #include "exec/runtime_filter/utils.h"
 #include "exprs/create_predicate_function.h"
 #include "exprs/runtime_filter_expr.h"
+#include "exprs/vbloom_predicate.h"
 #include "exprs/vdirect_in_predicate.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
@@ -165,6 +167,42 @@ protected:
     }
 
     template <PrimitiveType PT>
+    VExprSPtr bloom_predicate(const std::vector<CppType<PT>>& values, bool contain_null = false) {
+        std::shared_ptr<BloomFilterFuncBase> filter(create_bloom_filter(PT, contain_null));
+        RuntimeFilterParams params;
+        params.filter_type = RuntimeFilterType::BLOOM_FILTER;
+        params.column_return_type = PT;
+        params.null_aware = contain_null;
+        params.bloom_filter_size = 1024;
+        filter->init_params(&params);
+        EXPECT_TRUE(filter->init_with_fixed_length(1024).ok());
+
+        using ColumnType = typename PrimitiveTypeTraits<PT>::ColumnType;
+        MutableColumnPtr values_column = ColumnType::create();
+        auto* typed_column = assert_cast<ColumnType*>(values_column.get());
+        for (const auto& value : values) {
+            typed_column->insert_value(value);
+        }
+        ColumnPtr values_column_ptr = std::move(values_column);
+        filter->insert_fixed_len(values_column_ptr, 0);
+
+        if (contain_null) {
+            std::shared_ptr<HybridSetBase> null_set(create_set(PT, contain_null));
+            null_set->insert(static_cast<const void*>(nullptr));
+            filter->insert_set(null_set);
+        }
+
+        TExprNode node;
+        node.__set_type(create_type_desc(PrimitiveType::TYPE_BOOLEAN));
+        node.__set_node_type(TExprNodeType::BLOOM_PRED);
+        node.__set_opcode(TExprOpcode::RT_FILTER);
+        node.__set_is_nullable(false);
+        auto bloom_pred = VBloomPredicate::create_shared(node);
+        bloom_pred->set_filter(filter);
+        return bloom_pred;
+    }
+
+    template <PrimitiveType PT>
     VExprSPtr minmax_predicate_le(const CppType<PT>& value, const DataTypePtr& type) {
         VExprSPtr pred;
         TExprNode node;
@@ -226,6 +264,7 @@ protected:
         ASSERT_FALSE(parsed->empty());
         ASSERT_EQ(parsed->total_partitions(), 2);
         const auto& parsed_boundaries = parsed->slot_to_boundaries().at(SLOT_ID);
+        EXPECT_TRUE(parsed_boundaries[0].is_list_boundary);
 
         RuntimeFilterPartitionPruner in_pruner;
         phmap::flat_hash_set<int64_t> in_pruned;
@@ -247,6 +286,7 @@ protected:
         auto parsed_range = parse_boundaries(PT, range_boundaries, false, precision, scale);
         EXPECT_FALSE(parsed_range->empty());
         EXPECT_EQ(parsed_range->total_partitions(), 1);
+        EXPECT_FALSE(parsed_range->slot_to_boundaries().at(SLOT_ID)[0].is_list_boundary);
     }
 
     DateV2Value<DateV2ValueType> date_v2(uint16_t year, uint8_t month, uint8_t day) {
@@ -346,6 +386,8 @@ TEST_F(RuntimeFilterPartitionPrunerTest, ProjectedBoundariesSupportListValues) {
                         .ok());
     ASSERT_EQ(projected->size(), 2);
 
+    EXPECT_TRUE(projected->at(0).is_list_boundary);
+    EXPECT_TRUE(projected->at(1).is_list_boundary);
     const auto& first = std::get<ColumnValueRange<TYPE_INT>>(projected->at(0).boundary_cvr);
     EXPECT_TRUE(first.is_fixed_value_range());
     EXPECT_TRUE(first.get_fixed_value_set().contains(one));
@@ -359,6 +401,71 @@ TEST_F(RuntimeFilterPartitionPrunerTest, ProjectedBoundariesSupportListValues) {
     pruner._try_prune_by_single_rf(*projected, in_predicate<TYPE_INT>(two), pruned);
     EXPECT_FALSE(pruned.contains(1));
     EXPECT_TRUE(pruned.contains(2));
+}
+
+TEST_F(RuntimeFilterPartitionPrunerTest, BloomPrunesListPartitionFixedValues) {
+    int32_t one = 1;
+    int32_t two = 2;
+    int32_t three = 3;
+    int32_t four = 4;
+    int32_t five = 5;
+    std::vector<TPartitionBoundary> boundaries {
+            list_boundary<TYPE_INT>(1, {literal_node<TYPE_INT>(one)}),
+            list_boundary<TYPE_INT>(2,
+                                    {literal_node<TYPE_INT>(two), literal_node<TYPE_INT>(three)}),
+            list_boundary<TYPE_INT>(3,
+                                    {literal_node<TYPE_INT>(four), literal_node<TYPE_INT>(five)})};
+    auto parsed = parse_boundaries(TYPE_INT, boundaries);
+    const auto& parsed_boundaries = parsed->slot_to_boundaries().at(SLOT_ID);
+
+    RuntimeFilterPartitionPruner pruner;
+    phmap::flat_hash_set<int64_t> pruned;
+    pruner._try_prune_by_single_rf(parsed_boundaries, bloom_predicate<TYPE_INT>({two}), pruned);
+    EXPECT_TRUE(pruned.contains(1));
+    EXPECT_FALSE(pruned.contains(2));
+    EXPECT_TRUE(pruned.contains(3));
+}
+
+TEST_F(RuntimeFilterPartitionPrunerTest, BloomPreservesListNullSemantics) {
+    int32_t one = 1;
+    int32_t two = 2;
+    std::vector<TPartitionBoundary> boundaries {
+            list_boundary<TYPE_INT>(1, {null_node(TYPE_INT)}),
+            list_boundary<TYPE_INT>(2, {null_node(TYPE_INT), literal_node<TYPE_INT>(one)}),
+            list_boundary<TYPE_INT>(3, {literal_node<TYPE_INT>(two)})};
+    auto parsed = parse_boundaries(TYPE_INT, boundaries, true);
+    const auto& parsed_boundaries = parsed->slot_to_boundaries().at(SLOT_ID);
+
+    RuntimeFilterPartitionPruner non_null_pruner;
+    phmap::flat_hash_set<int64_t> non_null_pruned;
+    non_null_pruner._try_prune_by_single_rf(parsed_boundaries, bloom_predicate<TYPE_INT>({one}),
+                                            non_null_pruned);
+    EXPECT_TRUE(non_null_pruned.contains(1));
+    EXPECT_FALSE(non_null_pruned.contains(2));
+    EXPECT_TRUE(non_null_pruned.contains(3));
+
+    RuntimeFilterPartitionPruner null_aware_pruner;
+    phmap::flat_hash_set<int64_t> null_aware_pruned;
+    null_aware_pruner._try_prune_by_single_rf(
+            parsed_boundaries, bloom_predicate<TYPE_INT>({one}, true), null_aware_pruned);
+    EXPECT_FALSE(null_aware_pruned.contains(1));
+    EXPECT_FALSE(null_aware_pruned.contains(2));
+    EXPECT_TRUE(null_aware_pruned.contains(3));
+}
+
+TEST_F(RuntimeFilterPartitionPrunerTest, BloomDoesNotPruneRangePartition) {
+    int32_t one = 1;
+    int32_t two = 2;
+    int32_t miss = 100;
+    std::vector<TPartitionBoundary> boundaries {range_boundary<TYPE_INT>(1, one, two)};
+    auto parsed = parse_boundaries(TYPE_INT, boundaries);
+    const auto& parsed_boundaries = parsed->slot_to_boundaries().at(SLOT_ID);
+    ASSERT_FALSE(parsed_boundaries[0].is_list_boundary);
+
+    RuntimeFilterPartitionPruner pruner;
+    phmap::flat_hash_set<int64_t> pruned;
+    pruner._try_prune_by_single_rf(parsed_boundaries, bloom_predicate<TYPE_INT>({miss}), pruned);
+    EXPECT_TRUE(pruned.empty());
 }
 
 TEST_F(RuntimeFilterPartitionPrunerTest, InvalidPartitionBoundaryRejected) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -36,6 +36,7 @@ import org.apache.doris.nereids.trees.expressions.functions.Monotonic;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanNode;
+import org.apache.doris.thrift.TRuntimeFilterType;
 import org.apache.doris.thrift.TTargetExprMonotonicity;
 
 import com.google.common.collect.Range;
@@ -55,7 +56,8 @@ final class RuntimeFilterPartitionPruneClassifier {
     private RuntimeFilterPartitionPruneClassifier() {
     }
 
-    static Classification classify(Expr targetExpr, Expression nereidsTargetExpr, PlanNode scanNode) {
+    static Classification classify(TRuntimeFilterType filterType, Expr targetExpr,
+            Expression nereidsTargetExpr, PlanNode scanNode) {
         if (!(scanNode instanceof OlapScanNode)) {
             return Classification.unsupported("target scan is not an OlapScanNode");
         }
@@ -70,6 +72,9 @@ final class RuntimeFilterPartitionPruneClassifier {
         PartitionType partType = partitionInfo.getType();
         if (partType != PartitionType.RANGE && partType != PartitionType.LIST) {
             return Classification.unsupported("partition type is not RANGE or LIST");
+        }
+        if (filterType == TRuntimeFilterType.BLOOM && partType == PartitionType.RANGE) {
+            return Classification.unsupported("BLOOM runtime filter does not support RANGE partition pruning");
         }
         if (hasUnsupportedAutomaticPartitionExpression(partitionInfo)) {
             return Classification.unsupported("automatic partition expression boundary is not modeled");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -251,7 +251,7 @@ public class RuntimeFilterTranslator {
                     }
                     RuntimeFilterPartitionPruneClassifier.Classification classification =
                             RuntimeFilterPartitionPruneClassifier.classify(
-                                    targetExpr, nereidsTargetExprList.get(i), scanNode);
+                                    head.getType(), targetExpr, nereidsTargetExprList.get(i), scanNode);
                     if (classification.canPrunePartitions()) {
                         origFilter.markTargetCanPrunePartitions(scanNode.getId());
                     }
@@ -361,7 +361,7 @@ public class RuntimeFilterTranslator {
                     }
                     RuntimeFilterPartitionPruneClassifier.Classification classification =
                             RuntimeFilterPartitionPruneClassifier.classify(
-                                    targetExpr, filter.getTargetExpressions().get(i), scanNode);
+                                    filter.getType(), targetExpr, filter.getTargetExpressions().get(i), scanNode);
                     if (classification.canPrunePartitions()) {
                         origFilter.markTargetCanPrunePartitions(scanNode.getId());
                     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -17,14 +17,34 @@
 
 package org.apache.doris.nereids.glue.translator;
 
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.SlotId;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.ListPartitionItem;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.PartitionItem;
+import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.RangePartitionItem;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.Monotonic;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateTrunc;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.thrift.TRuntimeFilterType;
+import org.apache.doris.thrift.TTargetExprMonotonicity;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
 
 class RuntimeFilterPartitionPruneClassifierTest {
     @Test
@@ -46,5 +66,63 @@ class RuntimeFilterPartitionPruneClassifierTest {
 
         Assertions.assertTrue(RuntimeFilterPartitionPruneClassifier.hasInputSlotOnlyInMonotonicChild(
                 dateTrunc, monotonic.getMonotonicFunctionChildIndex()));
+    }
+
+    @Test
+    void testBloomRangePartitionUnsupported() {
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.BLOOM, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("BLOOM"));
+        Assertions.assertTrue(classification.getPartitionMonotonicity().isEmpty());
+    }
+
+    @Test
+    void testBloomListPartitionSupported() {
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.BLOOM, PartitionType.LIST, ListPartitionItem.DUMMY_ITEM);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    @Test
+    void testInOrBloomRangePartitionStillSupported() {
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.IN_OR_BLOOM, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem) {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(1), new TupleId(1));
+        slotDescriptor.setColumn(partitionColumn);
+        slotDescriptor.setType(partitionColumn.getType());
+        SlotRef targetSlot = new SlotRef(slotDescriptor);
+        SlotReference nereidsTarget = new SlotReference("part_col", IntegerType.INSTANCE);
+
+        OlapTable table = Mockito.mock(OlapTable.class);
+        PartitionInfo partitionInfo = Mockito.mock(PartitionInfo.class);
+        OlapScanNode scanNode = Mockito.mock(OlapScanNode.class);
+        Mockito.when(scanNode.getOlapTable()).thenReturn(table);
+        Mockito.when(scanNode.getSelectedPartitionIds()).thenReturn(ImmutableList.of(1L, 2L));
+        Mockito.when(table.getPartitionInfo()).thenReturn(partitionInfo);
+        Mockito.when(partitionInfo.getType()).thenReturn(partitionType);
+        Mockito.when(partitionInfo.getPartitionColumns()).thenReturn(ImmutableList.of(partitionColumn));
+        Mockito.when(partitionInfo.getItem(1L)).thenReturn(partitionItem);
+        Mockito.when(partitionInfo.getItem(2L)).thenReturn(partitionItem);
+
+        return RuntimeFilterPartitionPruneClassifier.classify(filterType, targetSlot, nereidsTarget, scanNode);
+    }
+
+    private void assertSupportedIncreasingPartitions(
+            RuntimeFilterPartitionPruneClassifier.Classification classification) {
+        Assertions.assertTrue(classification.canPrunePartitions());
+        Map<Long, TTargetExprMonotonicity> monotonicity = classification.getPartitionMonotonicity();
+        Assertions.assertEquals(2, monotonicity.size());
+        Assertions.assertEquals(TTargetExprMonotonicity.MONOTONIC_INCREASING, monotonicity.get(1L));
+        Assertions.assertEquals(TTargetExprMonotonicity.MONOTONIC_INCREASING, monotonicity.get(2L));
     }
 }

--- a/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
+++ b/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
@@ -30,6 +30,12 @@
 5	3	e
 6	3	f
 
+-- !list_int_bloom --
+1	1	a
+2	1	b
+5	3	e
+6	3	f
+
 -- !no_pruning --
 13	250	m
 18	350	r
@@ -123,3 +129,12 @@ Beijing	3
 2	1	4	b
 3	1	5	c
 4	1	9	d
+
+-- !list_expr_bloom --
+1	1	a
+2	1	b
+5	3	e
+6	3	f
+
+-- !list_str_bloom --
+3	c

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -434,6 +434,12 @@ suite("rf_partition_pruning", "nonConcurrent") {
 
     // Test 6b: List partition (INT) - Bloom filter prune.
     // Regions {1, 3} keep two LIST partitions and prune the other three.
+    order_qt_list_int_bloom """
+        SELECT /*+ SET_VAR(runtime_filter_type='BLOOM_FILTER') */
+            f.id, f.region_id, f.value
+        FROM rf_prune_list_int f
+        JOIN rf_prune_dim_region d ON f.region_id = d.dim_region
+    """
     assertPruningProfile(
         "* FROM rf_prune_list_int f JOIN rf_prune_dim_region d ON f.region_id = d.dim_region",
         "BLOOM_FILTER", 5, 3)
@@ -1452,6 +1458,16 @@ suite("rf_partition_pruning", "nonConcurrent") {
         "count(*) FROM rf_prune_list_int f JOIN rf_prune_dim_region_twice d "
                 + "ON f.region_id + f.region_id = d.dim_region",
         "IN_OR_BLOOM_FILTER", 5, 3)
+    order_qt_list_expr_bloom """
+        SELECT /*+ SET_VAR(runtime_filter_type='BLOOM_FILTER') */
+            f.id, f.region_id, f.value
+        FROM rf_prune_list_int f
+        JOIN rf_prune_dim_region_twice d ON f.region_id + f.region_id = d.dim_region
+    """
+    assertPruningProfile(
+        "count(*) FROM rf_prune_list_int f JOIN rf_prune_dim_region_twice d "
+                + "ON f.region_id + f.region_id = d.dim_region",
+        "BLOOM_FILTER", 5, 3)
 
     // ============================================================
     // Test 51: String partition column (LIST partition on VARCHAR).
@@ -1496,6 +1512,12 @@ suite("rf_partition_pruning", "nonConcurrent") {
     assertPruningProfile(
         "* FROM rf_prune_list_str f JOIN rf_prune_dim_str d ON f.part_col = d.dim_key",
         "IN_OR_BLOOM_FILTER", 4, 3)
+    order_qt_list_str_bloom """
+        SELECT /*+ SET_VAR(runtime_filter_type='BLOOM_FILTER') */
+            f.id, f.part_col
+        FROM rf_prune_list_str f
+        JOIN rf_prune_dim_str d ON f.part_col = d.dim_key
+    """
     assertPruningProfile(
         "* FROM rf_prune_list_str f JOIN rf_prune_dim_str d ON f.part_col = d.dim_key",
         "BLOOM_FILTER", 4, 3)

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -438,11 +438,11 @@ suite("rf_partition_pruning", "nonConcurrent") {
         "* FROM rf_prune_list_int f JOIN rf_prune_dim_region d ON f.region_id = d.dim_region",
         "BLOOM_FILTER", 5, 3)
 
-    // Test 6c: Range partition (INT) - Bloom filter must not prune.
+    // Test 6c: Range partition (INT) - Bloom filter must not register RF partition pruning.
     // A Bloom filter can disprove individual values, not an arbitrary [a, b) range.
-    assertPruningProfile(
+    assertNoPartitionPruningProfile(
         "* FROM rf_prune_range_int f JOIN rf_prune_dim_int d ON f.part_col = d.dim_key",
-        "BLOOM_FILTER", 4, 0)
+        "BLOOM_FILTER")
 
     // Test 7: No pruning - dim matches all partitions
     sql "drop table if exists rf_prune_dim_all"

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -432,6 +432,18 @@ suite("rf_partition_pruning", "nonConcurrent") {
         "* FROM rf_prune_list_int f JOIN rf_prune_dim_region d ON f.region_id = d.dim_region",
         "IN_OR_BLOOM_FILTER", 5, 3)
 
+    // Test 6b: List partition (INT) - Bloom filter prune.
+    // Regions {1, 3} keep two LIST partitions and prune the other three.
+    assertPruningProfile(
+        "* FROM rf_prune_list_int f JOIN rf_prune_dim_region d ON f.region_id = d.dim_region",
+        "BLOOM_FILTER", 5, 3)
+
+    // Test 6c: Range partition (INT) - Bloom filter must not prune.
+    // A Bloom filter can disprove individual values, not an arbitrary [a, b) range.
+    assertPruningProfile(
+        "* FROM rf_prune_range_int f JOIN rf_prune_dim_int d ON f.part_col = d.dim_key",
+        "BLOOM_FILTER", 4, 0)
+
     // Test 7: No pruning - dim matches all partitions
     sql "drop table if exists rf_prune_dim_all"
     sql """
@@ -1060,6 +1072,9 @@ suite("rf_partition_pruning", "nonConcurrent") {
     assertPruningProfile(
         "* FROM rf_prune_list_mixed f JOIN rf_prune_dim_five d ON f.part_col = d.dim_key",
         "IN_OR_BLOOM_FILTER", 3, 2)
+    assertPruningProfile(
+        "* FROM rf_prune_list_mixed f JOIN rf_prune_dim_five d ON f.part_col = d.dim_key",
+        "BLOOM_FILTER", 3, 2)
 
     // Test 31: Mixed partition {NULL,5} + RF {7} (no value match, RF non-null-aware)
     //   p_a still pruned (NULL row can't match non-null RF; concrete 5 != 7)
@@ -1086,6 +1101,9 @@ suite("rf_partition_pruning", "nonConcurrent") {
     assertPruningProfile(
         "* FROM rf_prune_list_mixed f JOIN rf_prune_dim_seven d ON f.part_col = d.dim_key",
         "IN_OR_BLOOM_FILTER", 3, 3)
+    assertPruningProfile(
+        "* FROM rf_prune_list_mixed f JOIN rf_prune_dim_seven d ON f.part_col = d.dim_key",
+        "BLOOM_FILTER", 3, 3)
 
     // Test 32: Null-safe equal join (<=>) on mixed partition. RF is null_aware AND
     //   contains NULL (build side has NULL key), so p_a (which contains NULL) MUST
@@ -1107,6 +1125,9 @@ suite("rf_partition_pruning", "nonConcurrent") {
         FROM rf_prune_list_mixed f
         JOIN rf_prune_dim_null d ON f.part_col <=> d.dim_key
     """
+    assertPruningProfile(
+        "* FROM rf_prune_list_mixed f JOIN rf_prune_dim_null d ON f.part_col <=> d.dim_key",
+        "BLOOM_FILTER", 3, 2)
 
     // Test 32b: Nullable RANGE partition columns can store NULL rows in the
     // MINVALUE-side first partition. A null-aware RF containing only NULL must
@@ -1475,6 +1496,9 @@ suite("rf_partition_pruning", "nonConcurrent") {
     assertPruningProfile(
         "* FROM rf_prune_list_str f JOIN rf_prune_dim_str d ON f.part_col = d.dim_key",
         "IN_OR_BLOOM_FILTER", 4, 3)
+    assertPruningProfile(
+        "* FROM rf_prune_list_str f JOIN rf_prune_dim_str d ON f.part_col = d.dim_key",
+        "BLOOM_FILTER", 4, 3)
 
     // ============================================================
     // Test 52: Grouped RF with multiple targets.


### PR DESCRIPTION
## Proposed changes

Support runtime-filter Bloom pruning for internal table LIST partitions:

## Scope

The RANGE-partition script provided by the reviewer was used as a shape
reference, but the measured case is intentionally LIST partitioned. Pure Bloom
runtime-filter pruning for RANGE partitions remains disabled by design in this
PR; using `IN_OR_BLOOM_FILTER` on a tiny build side can measure the pre-existing
IN-set RANGE pruning path instead of the new Bloom LIST path.

## Data Set

Fact table:

- Table: `rf_perf_fact_list`
- Rows: `50,000,000`
- Partitioning: LIST on `part_col`
- Partitions: `4096`, one integer value per partition: `p0 VALUES IN (0)` through `p4095 VALUES IN (4095)`
- Buckets: `4`
- Tablets: `16,384`
- `part_col = number % 4096`

Dimension table:

- Table: `rf_perf_dim_list`
- Rows: `5`
- Keys: `1, 7, 42, 100, 999`

Sanity checks:

- `COUNT(*)` on fact table: `50,000,000`
- `COUNT(DISTINCT part_col)` on fact table: `4096`
- Join result count: `61,039`

Setup timings:

- Create 4096-partition fact table: `3.493s`
- Insert 50M fact rows: `173.112s`
- Analyze fact and dim tables with sync: `7.713s`

## Query

Measured query:

```sql
SELECT /*+ SET_VAR(runtime_filter_type='BLOOM_FILTER') */
       '<unique token>' AS token,
       COUNT(*) AS matched_rows
FROM rf_perf_fact_list f
JOIN rf_perf_dim_list d ON f.part_col = d.dim_key;
```

Session settings:

```sql
SET enable_profile = true;
SET profile_level = 2;
SET runtime_filter_wait_infinitely = true;
SET disable_join_reorder = true;
SET parallel_pipeline_task_num = 1;
SET enable_runtime_filter_prune = false;
SET enable_runtime_filter_partition_prune = <false or true>;
```

`enable_runtime_filter_prune` was disabled to prevent the legacy RF pruner from
removing the runtime filter before BE partition-pruning counters can be
populated.

Each mode was run once as warmup and then three measured times.

## Results

| Mode | Measured run | Profile total | Client wall time | Matched rows | Total RF partitions | RF-pruned partitions | Total tablets | RF-pruned tablets | ScanRows |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| OFF | 1 | 1sec717ms | 1.749s | 61,039 | 0 | 0 | 16,384 | 0 | 50,000,000 |
| OFF | 2 | 1sec879ms | 1.908s | 61,039 | 0 | 0 | 16,384 | 0 | 50,000,000 |
| OFF | 3 | 1sec842ms | 1.869s | 61,039 | 0 | 0 | 16,384 | 0 | 50,000,000 |
| ON | 1 | 364ms | 0.394s | 61,039 | 4,096 | 4,091 | 16,384 | 16,364 | 61,039 |
| ON | 2 | 360ms | 0.391s | 61,039 | 4,096 | 4,091 | 16,384 | 16,364 | 61,039 |
| ON | 3 | 382ms | 0.409s | 61,039 | 4,096 | 4,091 | 16,384 | 16,364 | 61,039 |

Aggregates:

- Average profile total, OFF: `1812.7ms`
- Average profile total, ON: `368.7ms`
- Profile-total speedup: `4.92x`
- Average client wall time, OFF: `1.842s`
- Average client wall time, ON: `0.398s`
- Client-wall speedup: `4.63x`
- Fact scan rows reduction: `50,000,000 -> 61,039`, a `99.878%` reduction
- Partition pruning rate: `4,091 / 4,096 = 99.878%`
- Tablet pruning rate: `16,364 / 16,384 = 99.878%`

## Profile Evidence

Representative ON profile counters:

```text
PartitionsPrunedByRuntimeFilter: 4.091K (4091)
RowsRead: 61.039K (61039)
ScanRows: 61.039K (61039)
TabletNum: 16.384K (16384)
TabletsPrunedByRuntimeFilter: 16.364K (16364)
TotalPartitionsForRFPruning: 4.096K (4096)
```

Representative OFF profile counters:

```text
ScanRows: 50.000M (50000000)
TabletNum: 16.384K (16384)
TabletsPrunedByRuntimeFilter: 0
TotalPartitionsForRFPruning: 0
PartitionsPrunedByRuntimeFilter: 0
```

## Conclusion

On the deployed PR 64318 cluster, enabling runtime-filter partition pruning for
a pure Bloom RF on a 4096-partition LIST table prunes 4091 partitions and 16364
tablets before scan. The measured query keeps the same result count (`61,039`)
while reducing fact-side `ScanRows` from `50,000,000` to `61,039`.

For this workload, the end-to-end query profile improves from `1812.7ms` to
`368.7ms` on average, about `4.92x` faster.

