### PR TITLE
[fix](lazy topn) Fix slot-not-found after PullUpProjectExprUnderTopN with chained expressions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/CustomRewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/CustomRewriteJob.java
@@ -59,7 +59,7 @@ public class CustomRewriteJob implements RewriteJob {
         // COUNTER_TRACER.log(CounterEvent.of(Memo.get=-StateId(), CounterType.JOB_EXECUTION, group, logicalExpression,
         //         root));
         Plan rewrittenRoot = customRewriter.get().rewriteRoot(root, context);
-        if (rewrittenRoot == null) {
+        if (rewrittenRoot == null || rewrittenRoot == root) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
@@ -242,19 +242,19 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
         if (node instanceof LogicalProject) {
             LogicalProject<? extends Plan> project = (LogicalProject<? extends Plan>) node;
             for (NamedExpression ne : project.getProjects()) {
-                if (canPullUp(ne) && !blockedExprIds.contains(ne.getExprId())) {
-                    info.addPulledUpExpr(project, ne);
-                } else if (ne instanceof Alias && ne.child(0) instanceof Slot) {
-                    // Chain: this intermediate project renames a slot that may
-                    // come from a pulled-up expression deeper in the tree.
-                    // Always register Slot(alias.toSlot()) → child Slot so that
-                    // getPullUpReplaceExpression can resolve the chain later.
-                    context.pullUpExprReplaceMap.putIfAbsent(ne.toSlot(), ne.child(0));
-                    // Only propagate blocking when the alias itself is blocked
-                    // (e.g. TopN order key, Join condition). Forwarding renames
-                    // of unblocked slots must not block the underlying expression.
-                    if (blockedExprIds.contains(ne.getExprId())) {
-                        blockedExprIds.add(((Slot) ne.child(0)).getExprId());
+                if (blockedExprIds.contains(ne.getExprId())) {
+                    for (Slot slot : ne.getInputSlots()) {
+                        blockedExprIds.add(slot.getExprId());
+                    }
+                } else {
+                    if (canPullUp(ne)) {
+                        info.addPulledUpExpr(project, ne);
+                    } else if (ne instanceof Alias && ne.child(0) instanceof Slot) {
+                        // Chain: this intermediate project renames a slot that may
+                        // come from a pulled-up expression deeper in the tree.
+                        // Always register Slot(alias.toSlot()) → child Slot so that
+                        // getPullUpReplaceExpression can resolve the chain later.
+                        context.pullUpExprReplaceMap.putIfAbsent(ne.toSlot(), ne.child(0));
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
@@ -112,6 +112,31 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
         final Map<LogicalProject<? extends Plan>, List<NamedExpression>> projectToPulledUpExprs
                 = new LinkedHashMap<>();
         final Map<ExprId, List<Slot>> baseSlotsByExpr = new HashMap<>();
+        /**
+         * Pulled-up expressions removed from this TopN by deduplicatePullUps because
+         * an outer TopN already owns the same Project expression. The inner TopN
+         * should not restore the expression itself, but it may still need to pass
+         * the expression's input slots through so the outer TopN can restore it.
+         *
+         * <p>Example before deduplication:
+         * <pre>
+         * TopN outer
+         *   Project(x)
+         *     TopN inner
+         *       Project(x = a + 1, id)
+         *         Scan(a, id)
+         * </pre>
+         *
+         * <p>Both TopNs collect {@code x = a + 1} from the same Project. Dedup keeps
+         * it in the outer TopN's {@code allPulledUpExprs}, and records it in the
+         * inner TopN as:
+         * <pre>
+         * passThroughExprByDeduplicatedExpr[x.exprId] = (x = a + 1)
+         * </pre>
+         *
+         * <p>The inner TopN can then pass {@code a} through instead of producing
+         * {@code x}, and the outer TopN restores {@code x = a + 1} above itself.
+         */
         final Map<ExprId, NamedExpression> passThroughExprByDeduplicatedExpr = new HashMap<>();
 
         PullUpInfo(LogicalTopN topN) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
@@ -701,10 +701,19 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
                 upperOutput.add(pulledUpExpr);
                 upperOutputExprIds.add(pulledUpExpr.getExprId());
             } else {
+                Slot currentSlot = currentOutputByExprId.get(origSlot.getExprId());
+                if (currentSlot != null) {
+                    if (!passThroughOutputExprIds.contains(currentSlot.getExprId())) {
+                        upperOutput.add(currentSlot);
+                        upperOutputExprIds.add(currentSlot.getExprId());
+                    }
+                    continue;
+                }
                 // origSlot may map to a pulled-up expression via chain:
                 //   v1#4 → SlotRef#10 → ElementAt(sa#1, 'fa')
                 // Create a synthetic Alias to compute the expression
-                // in the upper project (above TopN).
+                // in the upper project (above TopN), but only when the
+                // rewritten TopN no longer produces origSlot directly.
                 Expression chainedExpr = getPullUpReplaceExpression(origSlot, context);
                 if (chainedExpr != null && !(chainedExpr instanceof Slot)
                         && !upperOutputExprIds.contains(origSlot.getExprId())) {
@@ -714,28 +723,20 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
                     upperOutputExprIds.add(synthetic.getExprId());
                     continue;
                 }
-                Slot currentSlot = currentOutputByExprId.get(origSlot.getExprId());
-                if (currentSlot != null) {
-                    if (!passThroughOutputExprIds.contains(currentSlot.getExprId())) {
-                        upperOutput.add(currentSlot);
-                        upperOutputExprIds.add(currentSlot.getExprId());
-                    }
+                NamedExpression passThroughExpr = info.passThroughExprByDeduplicatedExpr.get(origSlot.getExprId());
+                if (passThroughExpr != null) {
+                    List<Slot> passThroughSlots = resolveInputSlots(passThroughExpr, context, currentOutputExprIds);
+                    addPassThroughSlots(upperOutput, upperOutputExprIds, passThroughOutputExprIds,
+                            currentOutputByExprId, passThroughSlots);
                 } else {
-                    NamedExpression passThroughExpr = info.passThroughExprByDeduplicatedExpr.get(origSlot.getExprId());
-                    if (passThroughExpr != null) {
-                        List<Slot> passThroughSlots = resolveInputSlots(passThroughExpr, context, currentOutputExprIds);
-                        addPassThroughSlots(upperOutput, upperOutputExprIds, passThroughOutputExprIds,
-                                currentOutputByExprId, passThroughSlots);
-                    } else {
-                        // When NestedColumnPruning has run before this rule, the
-                        // originalTopNOutput may contain intermediate expression
-                        // slots (element_at results) that were simplified away by
-                        // simplifyProject. These slots are no longer produced by
-                        // the rewritten TopN's child and would cause CheckAfterRewrite
-                        // failures if passed through. Skip them — the corresponding
-                        // computation is already covered by the pulled-up Aliases
-                        // or by the base slots added during simplification.
-                    }
+                    // When NestedColumnPruning has run before this rule, the
+                    // originalTopNOutput may contain intermediate expression
+                    // slots (element_at results) that were simplified away by
+                    // simplifyProject. These slots are no longer produced by
+                    // the rewritten TopN's child and would cause CheckAfterRewrite
+                    // failures if passed through. Skip them — the corresponding
+                    // computation is already covered by the pulled-up Aliases
+                    // or by the base slots added during simplification.
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
@@ -586,38 +586,42 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
         for (NamedExpression ne : project.getProjects()) {
             if (!pulledUpExprIds.contains(ne.getExprId())
                     && !isUnavailablePullUpSlot(ne, context, childOutputExprIds)) {
-                NamedExpression resolved = resolveNamedExpression(ne, context, childOutputExprIds);
+                NamedExpression resolved = resolveAliasChildIfNeeded(ne, context, childOutputExprIds);
 
-                // This rule pulls up non-trivial expressions from below TopN
-                // to above TopN, so that only base columns flow through the
-                // TopN operator (enabling lazy materialization).
+                // This rule pulls non-trivial expressions above TopN so the
+                // TopN only carries the slots needed to restore them later.
                 //
-                // When adjacent Projects below a TopN form a chain — an
-                // upper Project renames a slot produced by a lower Project's
-                // pulled-up expression — the Collector pass records each
-                // link in pullUpExprReplaceMap so that getPullUpReplaceExpression
-                // can follow the chain to its end.
-                //
-                // Example plan tree that produces the chain v1#4 → SlotRef#10
-                // → ElementAt(sa#1, 'fa'):
+                // A common shape after nested-column or variant rewrites is a
+                // chain of adjacent Projects:
                 //
                 //   TopN (output: id#0, v1#4)
-                //     Project (id#0, slotref#10 as v1#4)          ← Alias(Slot):
-                //     │                                                 map[v1#4] = slotref#10
-                //     Project (id#0, element_at(sa#1,'fa') as slotref#10)  ← pull-up expr:
-                //       Scan (id#0, sa#1)                                   map[slotref#10] = element_at(...)
+                //     Project1(id#0, slotref#10 AS v1#4)
+                //       Project2(id#0, element_at(sa#1, 'fa') AS slotref#10)
+                //         Scan(id#0, sa#1)
                 //
-                // getPullUpReplaceExpression(Slot(v1#4)):
-                //   v1#4 → SlotRef#10 (is Slot → recurse)
-                //        → ElementAt(sa#1, 'fa') (not Slot → return)
+                // Project1 is only a rename, while Project2 contains the
+                // expression that can be restored above TopN.
+                // During collection, we record both links:
                 //
-                // Here, if the resolved expression differs from the original
-                // (meaning chain resolution kicked in) and the final
-                // replacement is a non-Slot expression, then the upper
-                // project (added above TopN by addUpperProject) will already
-                // compute it. We therefore skip the full expression in this
-                // lower project to avoid duplicate computation, and only
-                // retain its base input slots so they can pass through TopN.
+                //   v1#4      -> slotref#10
+                //   slotref#10 -> element_at(sa#1, 'fa')
+                // after pullup, the expected plan is
+                //
+                //  ProjectUpper(id#0, element_at(sa#1, 'fa') AS v1#4)
+                //      TopN (output: id#0, sa#1)
+                //          Project1'(id#0, sa#1)
+                //              Project2'(id#0, sa#1)
+                //                  Scan(id#0, sa#1)
+                //
+                // If Project1 is being simplified after the expression in
+                // Project2 was pulled up, Project1 should no longer compute
+                // v1#4 itself. The upper Project added by addUpperProject will
+                // compute element_at(sa#1, 'fa') AS v1#4 above TopN instead.
+                // Project1 must therefore output the input slot sa#1, not
+                // element_at(sa#1, 'fa') AS v1#4. Otherwise TopN would output
+                // v1#4 but not sa#1, and the upper Project would fail the plan
+                // validity check because its input slot sa#1 is not produced by
+                // its child.
                 boolean pulledAbove = false;
                 if (resolved != ne) {
                     Expression replaceExpr = getPullUpReplaceExpression(
@@ -646,7 +650,7 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
         }
 
         for (NamedExpression pulledUpExpr : pulledUpExprs) {
-            for (Slot baseSlot : resolveInputSlots(pulledUpExpr, context, childOutputExprIds)) {
+            for (Slot baseSlot : resolveInputSlots(pulledUpExpr.child(0), context, childOutputExprIds)) {
                 if (!existingExprIds.contains(baseSlot.getExprId())) {
                     simplified.add(baseSlot);
                     existingExprIds.add(baseSlot.getExprId());
@@ -689,7 +693,15 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
     private static Expression getPullUpReplaceExpression(Slot slot, CollectorContext context) {
         Expression result = context.pullUpExprReplaceMap.get(slot);
 
-        // Resolve one-level chain: Slot(v1#4) → Slot(element_at#10) → ElementAt(sa#1,'fa')
+        // Follow Slot-to-Slot rename chains recorded from adjacent Projects:
+        //   v1#4      -> slotref#10
+        //   slotref#10 -> element_at(sa#1, 'fa')
+        //
+        // getPullUpReplaceExpression(v1#4) returns element_at(sa#1, 'fa').
+        // It only recurses while the whole replacement is a Slot. It does not
+        // rewrite slots inside a non-Slot replacement. For example, even if
+        // another mapping has sa#1 -> raw#0, this function returns
+        // element_at(sa#1, 'fa'), not element_at(raw#0, 'fa').
         if (result instanceof Slot) {
             Expression chained = getPullUpReplaceExpression((Slot) result, context);
             if (chained != null) {
@@ -705,7 +717,8 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
         Map<ExprId, NamedExpression> pulledUpBySlotExprId = new HashMap<>();
         Set<ExprId> currentOutputExprIds = topN.getOutputExprIdSet();
         for (NamedExpression e : info.allPulledUpExprs) {
-            pulledUpBySlotExprId.put(e.toSlot().getExprId(), resolvePulledUpExpr(e, context, currentOutputExprIds));
+            pulledUpBySlotExprId.put(e.toSlot().getExprId(),
+                    resolveAliasChildIfNeeded(e, context, currentOutputExprIds));
         }
 
         // Use the current (possibly rewritten) TopN's output so that slots
@@ -734,11 +747,28 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
                     }
                     continue;
                 }
-                // origSlot may map to a pulled-up expression via chain:
-                //   v1#4 → SlotRef#10 → ElementAt(sa#1, 'fa')
-                // Create a synthetic Alias to compute the expression
-                // in the upper project (above TopN), but only when the
-                // rewritten TopN no longer produces origSlot directly.
+                // The original TopN output may be a rename whose child was
+                // removed when a lower Project was simplified. For example:
+                //
+                //   Before rewrite:
+                //     TopN (output: id#0, v1#4)
+                //       Project(id#0, slotref#10 AS v1#4)
+                //         Project(id#0, element_at(sa#1, 'fa') AS slotref#10)
+                //           Scan(id#0, sa#1)
+                //
+                //   After simplifying Projects below TopN:
+                //     TopN (output: id#0, sa#1)
+                //       Project(id#0, sa#1)
+                //         Scan(id#0, sa#1)
+                //
+                // The rewritten TopN no longer produces v1#4, but the final
+                // query still expects v1#4. In that case, use the recorded
+                // chain v1#4 -> slotref#10 -> element_at(sa#1, 'fa') and add
+                // a synthetic Alias above TopN to restore v1#4. If the
+                // rewritten TopN still produces origSlot directly, the earlier
+                // currentSlot branch must pass it through instead of expanding
+                // the chain; otherwise a still-available forwarding slot such
+                // as d2 can be incorrectly expanded to dt['b'] above TopN.
                 Expression chainedExpr = getPullUpReplaceExpression(origSlot, context);
                 if (chainedExpr != null && !(chainedExpr instanceof Slot)
                         && !upperOutputExprIds.contains(origSlot.getExprId())) {
@@ -750,7 +780,8 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
                 }
                 NamedExpression passThroughExpr = info.passThroughExprByDeduplicatedExpr.get(origSlot.getExprId());
                 if (passThroughExpr != null) {
-                    List<Slot> passThroughSlots = resolveInputSlots(passThroughExpr, context, currentOutputExprIds);
+                    List<Slot> passThroughSlots = resolveInputSlots(
+                            passThroughExpr.child(0), context, currentOutputExprIds);
                     addPassThroughSlots(upperOutput, upperOutputExprIds, passThroughOutputExprIds,
                             currentOutputByExprId, passThroughSlots);
                 } else {
@@ -780,7 +811,7 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
         return new LogicalProject<>(ImmutableList.copyOf(upperOutput), topN);
     }
 
-    private static NamedExpression resolveNamedExpression(NamedExpression expr, CollectorContext context,
+    private static NamedExpression resolveAliasChildIfNeeded(NamedExpression expr, CollectorContext context,
             Set<ExprId> availableExprIds) {
         if (!(expr instanceof Alias)) {
             return expr;
@@ -790,19 +821,6 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
             return expr;
         }
         return new Alias(expr.getExprId(), resolvedChild, expr.getName());
-    }
-
-    private static NamedExpression resolvePulledUpExpr(NamedExpression expr, CollectorContext context,
-            Set<ExprId> availableExprIds) {
-        if (!(expr instanceof Alias)) {
-            return expr;
-        }
-        return new Alias(expr.getExprId(), resolveExpression(expr.child(0), context, availableExprIds), expr.getName());
-    }
-
-    private static List<Slot> resolveInputSlots(NamedExpression expr, CollectorContext context,
-            Set<ExprId> availableExprIds) {
-        return ImmutableList.copyOf(resolveExpression(expr.child(0), context, availableExprIds).getInputSlots());
     }
 
     private static List<Slot> resolveInputSlots(Expression expr, CollectorContext context,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopN.java
@@ -244,6 +244,18 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
             for (NamedExpression ne : project.getProjects()) {
                 if (canPullUp(ne) && !blockedExprIds.contains(ne.getExprId())) {
                     info.addPulledUpExpr(project, ne);
+                } else if (ne instanceof Alias && ne.child(0) instanceof Slot) {
+                    // Chain: this intermediate project renames a slot that may
+                    // come from a pulled-up expression deeper in the tree.
+                    // Always register Slot(alias.toSlot()) → child Slot so that
+                    // getPullUpReplaceExpression can resolve the chain later.
+                    context.pullUpExprReplaceMap.putIfAbsent(ne.toSlot(), ne.child(0));
+                    // Only propagate blocking when the alias itself is blocked
+                    // (e.g. TopN order key, Join condition). Forwarding renames
+                    // of unblocked slots must not block the underlying expression.
+                    if (blockedExprIds.contains(ne.getExprId())) {
+                        blockedExprIds.add(((Slot) ne.child(0)).getExprId());
+                    }
                 }
             }
             // Continue into the project's child. Chained projects are all visited.
@@ -519,8 +531,24 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
             CollectorContext context) {
         Set<ExprId> childOutputExprIds = ((Plan) project.child(0)).getOutputExprIdSet();
         List<Expression> passThroughExprs = collectUnavailablePullUpExprs(project, context, childOutputExprIds);
+        // When projects below the TopN were simplified, an above-TopN project may
+        // still hold Aliases whose children are intermediate SlotReferences (e.g.
+        // element_at results) that were removed from the child output. Even when
+        // pulledUpExprs and passThroughExprs are empty, we must still process such
+        // Aliases — replace them with SlotReferences pointing to the child output
+        // where the computation was restored by addUpperProject.
+        boolean hasAliasWithUnavailableChild = false;
         if (pulledUpExprs.isEmpty() && passThroughExprs.isEmpty()) {
-            return project;
+            for (NamedExpression ne : project.getProjects()) {
+                if (ne instanceof Alias && ne.child(0) instanceof Slot
+                        && !childOutputExprIds.contains(((Slot) ne.child(0)).getExprId())) {
+                    hasAliasWithUnavailableChild = true;
+                    break;
+                }
+            }
+            if (!hasAliasWithUnavailableChild) {
+                return project;
+            }
         }
 
         Set<ExprId> pulledUpExprIds = new HashSet<>();
@@ -534,21 +562,69 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
             if (!pulledUpExprIds.contains(ne.getExprId())
                     && !isUnavailablePullUpSlot(ne, context, childOutputExprIds)) {
                 NamedExpression resolved = resolveNamedExpression(ne, context, childOutputExprIds);
-                simplified.add(resolved);
-                existingExprIds.add(resolved.getExprId());
+
+                // This rule pulls up non-trivial expressions from below TopN
+                // to above TopN, so that only base columns flow through the
+                // TopN operator (enabling lazy materialization).
+                //
+                // When adjacent Projects below a TopN form a chain — an
+                // upper Project renames a slot produced by a lower Project's
+                // pulled-up expression — the Collector pass records each
+                // link in pullUpExprReplaceMap so that getPullUpReplaceExpression
+                // can follow the chain to its end.
+                //
+                // Example plan tree that produces the chain v1#4 → SlotRef#10
+                // → ElementAt(sa#1, 'fa'):
+                //
+                //   TopN (output: id#0, v1#4)
+                //     Project (id#0, slotref#10 as v1#4)          ← Alias(Slot):
+                //     │                                                 map[v1#4] = slotref#10
+                //     Project (id#0, element_at(sa#1,'fa') as slotref#10)  ← pull-up expr:
+                //       Scan (id#0, sa#1)                                   map[slotref#10] = element_at(...)
+                //
+                // getPullUpReplaceExpression(Slot(v1#4)):
+                //   v1#4 → SlotRef#10 (is Slot → recurse)
+                //        → ElementAt(sa#1, 'fa') (not Slot → return)
+                //
+                // Here, if the resolved expression differs from the original
+                // (meaning chain resolution kicked in) and the final
+                // replacement is a non-Slot expression, then the upper
+                // project (added above TopN by addUpperProject) will already
+                // compute it. We therefore skip the full expression in this
+                // lower project to avoid duplicate computation, and only
+                // retain its base input slots so they can pass through TopN.
+                boolean pulledAbove = false;
+                if (resolved != ne) {
+                    Expression replaceExpr = getPullUpReplaceExpression(
+                            resolved.toSlot(), context);
+                    if (replaceExpr != null && !(replaceExpr instanceof Slot)) {
+                        pulledAbove = true;
+                        // Expression pulled above → only base slots stay
+                        // in the lower project (for lazy mat through TopN).
+                        for (Slot slot : resolved.getInputSlots()) {
+                            ExprId slotEid = slot.getExprId();
+                            if (!existingExprIds.contains(slotEid)
+                                    && childOutputExprIds.contains(slotEid)) {
+                                simplified.add(slot);
+                                existingExprIds.add(slotEid);
+                            }
+                        }
+                    }
+                }
+                if (!pulledAbove) {
+                    if (!existingExprIds.contains(resolved.getExprId())) {
+                        simplified.add(resolved);
+                        existingExprIds.add(resolved.getExprId());
+                    }
+                }
             }
         }
 
         for (NamedExpression pulledUpExpr : pulledUpExprs) {
-            for (PullUpInfo info : context.topNToPullUpInfo.values()) {
-                if (info.baseSlotsByExpr.get(pulledUpExpr.getExprId()) != null) {
-                    for (Slot baseSlot : resolveInputSlots(pulledUpExpr, context, childOutputExprIds)) {
-                        if (!existingExprIds.contains(baseSlot.getExprId())) {
-                            simplified.add(baseSlot);
-                            existingExprIds.add(baseSlot.getExprId());
-                        }
-                    }
-                    break; // found, no need to check other PullUpInfos
+            for (Slot baseSlot : resolveInputSlots(pulledUpExpr, context, childOutputExprIds)) {
+                if (!existingExprIds.contains(baseSlot.getExprId())) {
+                    simplified.add(baseSlot);
+                    existingExprIds.add(baseSlot.getExprId());
                 }
             }
         }
@@ -586,12 +662,16 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
     }
 
     private static Expression getPullUpReplaceExpression(Slot slot, CollectorContext context) {
-        for (Map.Entry<Slot, Expression> entry : context.pullUpExprReplaceMap.entrySet()) {
-            if (entry.getKey().getExprId().equals(slot.getExprId())) {
-                return entry.getValue();
+        Expression result = context.pullUpExprReplaceMap.get(slot);
+
+        // Resolve one-level chain: Slot(v1#4) → Slot(element_at#10) → ElementAt(sa#1,'fa')
+        if (result instanceof Slot) {
+            Expression chained = getPullUpReplaceExpression((Slot) result, context);
+            if (chained != null) {
+                return chained;
             }
         }
-        return null;
+        return result;
     }
 
     /** Create a new Project above the TopN that restores pulled-up expressions. */
@@ -621,6 +701,19 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
                 upperOutput.add(pulledUpExpr);
                 upperOutputExprIds.add(pulledUpExpr.getExprId());
             } else {
+                // origSlot may map to a pulled-up expression via chain:
+                //   v1#4 → SlotRef#10 → ElementAt(sa#1, 'fa')
+                // Create a synthetic Alias to compute the expression
+                // in the upper project (above TopN).
+                Expression chainedExpr = getPullUpReplaceExpression(origSlot, context);
+                if (chainedExpr != null && !(chainedExpr instanceof Slot)
+                        && !upperOutputExprIds.contains(origSlot.getExprId())) {
+                    NamedExpression synthetic = new Alias(
+                            origSlot.getExprId(), chainedExpr, origSlot.getName());
+                    upperOutput.add(synthetic);
+                    upperOutputExprIds.add(synthetic.getExprId());
+                    continue;
+                }
                 Slot currentSlot = currentOutputByExprId.get(origSlot.getExprId());
                 if (currentSlot != null) {
                     if (!passThroughOutputExprIds.contains(currentSlot.getExprId())) {
@@ -634,14 +727,27 @@ public class PullUpProjectExprUnderTopN implements CustomRewriter {
                         addPassThroughSlots(upperOutput, upperOutputExprIds, passThroughOutputExprIds,
                                 currentOutputByExprId, passThroughSlots);
                     } else {
-                        // Slot was lost during simplifyProject — pass through directly.
-                        // TopN is a pass-through node; the computation for this slot
-                        // exists below the TopN even if the intermediate project lost it.
-                        if (upperOutputExprIds.add(origSlot.getExprId())) {
-                            upperOutput.add(origSlot);
-                        }
+                        // When NestedColumnPruning has run before this rule, the
+                        // originalTopNOutput may contain intermediate expression
+                        // slots (element_at results) that were simplified away by
+                        // simplifyProject. These slots are no longer produced by
+                        // the rewritten TopN's child and would cause CheckAfterRewrite
+                        // failures if passed through. Skip them — the corresponding
+                        // computation is already covered by the pulled-up Aliases
+                        // or by the base slots added during simplification.
                     }
                 }
+            }
+        }
+
+        // Add current TopN output slots that are not already in upperOutput
+        // and were part of the original TopN output (i.e. not base structs
+        // injected by simplifyProject solely for lazy mat).
+        for (Slot slot : currentOutput) {
+            if (!upperOutputExprIds.contains(slot.getExprId())
+                    && info.originalTopNOutput.contains(slot)) {
+                upperOutput.add(slot);
+                upperOutputExprIds.add(slot.getExprId());
             }
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopNTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopNTest.java
@@ -1166,22 +1166,22 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
     }
 
     /**
-     * Simulates e.sql: JOIN with chained element_at-like expressions pulled up
-     * through TopN. The lower projects compute non-trivial expressions (v1 from a,
-     * v3 from b), an intermediate project forwards them as Slots, and the TopN
-     * has both a pass-through and a blocked (ORDER BY) expression.
+     * Simulates e.sql: JOIN with chained element_at-like expressions below TopN.
+     * The lower projects compute non-trivial expressions (v1 from a, v3 from b),
+     * an intermediate project forwards them as Slots, and the TopN has both a
+     * pass-through expression and a blocked ORDER BY expression.
      *
      * Before pullup:
      *   TopN(order by id_a, v2)
-     *     Project(v1#slot, v2, v3#slot, ...)   ← wraps intermediate Slots
+     *     Project(v1#slot, (v1+1) as v2, v3#slot, ...)   ← wraps intermediate Slots
      *       Join
      *         Project(id_a, v1, v3')            ← computes v1=a+1, v3=b+1
      *           Scan(ta: id_a, a, b)
      *
      * After pullup:
-     *   Project(v1=..., v3=..., ...)            ← upper (pulled above TopN)
+     *   Project(v1#slot, v2#slot, v3=..., ...)  ← upper: only v3 is pulled up
      *     TopN
-     *       Project(a, v2, b, id_a)             ← base slots only (no duplicates)
+     *       Project(v1#slot, v2, b, id_a)       ← v1 kept for blocked v2
      *         Join (simplified children)
      */
     @Test
@@ -1216,7 +1216,7 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
         LogicalProject<LogicalPlan> midProject = new LogicalProject<>(
                 ImmutableList.of(v1.toSlot(), v2, v3.toSlot(), idA, idB), join);
 
-        // TopN with v2 in ORDER BY (blocks v2 pull-up, but v1/v3 should still be pulled)
+        // TopN with v2 in ORDER BY. v2 is blocked, and its dependency v1 is blocked too.
         LogicalTopN<LogicalProject<LogicalPlan>> topN = new LogicalTopN<>(
                 ImmutableList.of(
                         new OrderKey(idA, false, false),
@@ -1233,30 +1233,41 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
                 "Root should be LogicalProject (upper project above TopN)");
         LogicalProject<?> upperProject = (LogicalProject<?>) rewritten;
 
-        // Upper project must contain pulled-up Aliases: v1 and v3
+        // Upper project must contain v1 as pass-through and v3 as a pulled-up Alias.
         Assertions.assertTrue(upperProject.getProjects().stream()
-                .anyMatch(e -> "v1".equals(e.getName())),
-                "v1 should be pulled above TopN");
+                .anyMatch(e -> e.getExprId().equals(v1.getExprId())),
+                "v1 should pass through TopN because v2 depends on it");
         Assertions.assertTrue(upperProject.getProjects().stream()
                 .anyMatch(e -> "v3".equals(e.getName())),
                 "v3 should be pulled above TopN");
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .filter(e -> "v3".equals(e.getName()))
+                .anyMatch(e -> e.getInputSlots().stream()
+                        .anyMatch(s -> s.getExprId().equals(c.getExprId()))),
+                "Pulled-up v3 should reference its base slot");
 
         // TopN is child of upper project
         Assertions.assertTrue(upperProject.child(0) instanceof LogicalTopN);
         LogicalTopN<?> rewrittenTopN = (LogicalTopN<?>) upperProject.child(0);
 
-        // Below TopN: the lower project must contain base slot a (for v1)
-        // and must NOT contain duplicate v1 or v3 Aliases
+        // Below TopN: v1 must stay because v2 (an order key) depends on it.
+        // v3 should be removed and replaced by its base slot c for lazy materialization.
         LogicalProject<?> lowerProject = (LogicalProject<?>) rewrittenTopN.child(0);
         Assertions.assertTrue(lowerProject.getProjects().stream()
-                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
-                "Lower project must contain base slot a (for lazy mat)");
-        Assertions.assertFalse(lowerProject.getProjects().stream()
-                .anyMatch(e -> "v1".equals(e.getName())),
-                "Lower project must NOT contain duplicate v1");
+                .anyMatch(e -> e.getExprId().equals(v1.getExprId())),
+                "Lower project must contain v1 because order key v2 depends on it");
+        Assertions.assertTrue(lowerProject.getProjects().stream()
+                .anyMatch(e -> "v2".equals(e.getName())),
+                "Lower project must contain v2 for TopN order key");
+        Assertions.assertTrue(lowerProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(c.getExprId())),
+                "Lower project must contain base slot c for pulled-up v3");
         Assertions.assertFalse(lowerProject.getProjects().stream()
                 .anyMatch(e -> "v3".equals(e.getName())),
-                "Lower project must NOT contain duplicate v3");
+                "Lower project must NOT contain v3 because it is pulled above TopN");
+        Assertions.assertFalse(lowerProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Lower project should not expose base slot a when v1 is blocked");
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopNTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopNTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Abs;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.AssertTrue;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Score;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
@@ -1163,4 +1164,515 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
                                 .anyMatch(e -> "x".equals(e.getName())))
                 );
     }
+
+    /**
+     * Simulates e.sql: JOIN with chained element_at-like expressions pulled up
+     * through TopN. The lower projects compute non-trivial expressions (v1 from a,
+     * v3 from b), an intermediate project forwards them as Slots, and the TopN
+     * has both a pass-through and a blocked (ORDER BY) expression.
+     *
+     * Before pullup:
+     *   TopN(order by id_a, v2)
+     *     Project(v1#slot, v2, v3#slot, ...)   ← wraps intermediate Slots
+     *       Join
+     *         Project(id_a, v1, v3')            ← computes v1=a+1, v3=b+1
+     *           Scan(ta: id_a, a, b)
+     *
+     * After pullup:
+     *   Project(v1=..., v3=..., ...)            ← upper (pulled above TopN)
+     *     TopN
+     *       Project(a, v2, b, id_a)             ← base slots only (no duplicates)
+     *         Join (simplified children)
+     */
+    @Test
+    void testPullUpChainedExpressionsThroughJoinAndTopN() {
+        LogicalOlapScan scanTa = PlanConstructor.newLogicalOlapScan(0, "ta", 0);
+        LogicalOlapScan scanTb = PlanConstructor.newLogicalOlapScan(1, "tb", 0);
+        Slot idA = scanTa.getOutput().get(0);
+        Slot a = scanTa.getOutput().get(1);     // simulates sa (base struct)
+        Slot idB = scanTb.getOutput().get(0);
+        Slot c = scanTb.getOutput().get(1);     // simulates sb (base struct)
+
+        // v1 = a + 1 (simulates element_at(sa, 'fa'))
+        Alias v1 = new Alias(new Add(a, new IntegerLiteral((byte) 1)), "v1");
+        // v3 = c + 1 (simulates element_at(sb, 'fc'))
+        Alias v3 = new Alias(new Add(c, new IntegerLiteral((byte) 1)), "v3");
+        // v2 = v1 + 1 (COALESCE-like, depends on v1, in ORDER BY)
+        Alias v2 = new Alias(new Add(v1.toSlot(), new IntegerLiteral((byte) 1)), "v2");
+
+        // Lower project on ta side: computes v1
+        LogicalProject<LogicalOlapScan> taProj
+                = new LogicalProject<>(ImmutableList.of(idA, v1), scanTa);
+        // Lower project on tb side: computes v3
+        LogicalProject<LogicalOlapScan> tbProj
+                = new LogicalProject<>(ImmutableList.of(idB, v3), scanTb);
+
+        // Join
+        LogicalJoin<LogicalPlan, LogicalPlan> join = new LogicalJoin<>(
+                JoinType.INNER_JOIN, ImmutableList.of(new EqualTo(idA, idB)),
+                taProj, tbProj, null);
+
+        // Intermediate project: forwards v1, v3 as Slots, adds v2 (ORDER BY dep)
+        LogicalProject<LogicalPlan> midProject = new LogicalProject<>(
+                ImmutableList.of(v1.toSlot(), v2, v3.toSlot(), idA, idB), join);
+
+        // TopN with v2 in ORDER BY (blocks v2 pull-up, but v1/v3 should still be pulled)
+        LogicalTopN<LogicalProject<LogicalPlan>> topN = new LogicalTopN<>(
+                ImmutableList.of(
+                        new OrderKey(idA, false, false),
+                        new OrderKey(v2.toSlot(), false, false)),
+                10, 0, midProject);
+
+        LogicalPlan rewritten = (LogicalPlan) PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyCustom(new PullUpProjectExprUnderTopN())
+                .getPlan();
+
+        // Root should be a Project (upper) → TopN → ...
+        Assertions.assertTrue(rewritten instanceof LogicalProject,
+                "Root should be LogicalProject (upper project above TopN)");
+        LogicalProject<?> upperProject = (LogicalProject<?>) rewritten;
+
+        // Upper project must contain pulled-up Aliases: v1 and v3
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .anyMatch(e -> "v1".equals(e.getName())),
+                "v1 should be pulled above TopN");
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .anyMatch(e -> "v3".equals(e.getName())),
+                "v3 should be pulled above TopN");
+
+        // TopN is child of upper project
+        Assertions.assertTrue(upperProject.child(0) instanceof LogicalTopN);
+        LogicalTopN<?> rewrittenTopN = (LogicalTopN<?>) upperProject.child(0);
+
+        // Below TopN: the lower project must contain base slot a (for v1)
+        // and must NOT contain duplicate v1 or v3 Aliases
+        LogicalProject<?> lowerProject = (LogicalProject<?>) rewrittenTopN.child(0);
+        Assertions.assertTrue(lowerProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Lower project must contain base slot a (for lazy mat)");
+        Assertions.assertFalse(lowerProject.getProjects().stream()
+                .anyMatch(e -> "v1".equals(e.getName())),
+                "Lower project must NOT contain duplicate v1");
+        Assertions.assertFalse(lowerProject.getProjects().stream()
+                .anyMatch(e -> "v3".equals(e.getName())),
+                "Lower project must NOT contain duplicate v3");
+    }
+
+    /**
+     * Verifies that addUpperProject does not leak base slots (injected by
+     * simplifyProject for lazy materialization) into the upper project's visible
+     * output. The upper project must expose only what the original TopN output had.
+     *
+     * Before pullup:
+     *   TopN(order by idA, limit 10, output: [v1, v2, idA, idB])
+     *     Project(v1 = a + 1, v2 = b + 1, idA, idB)
+     *       Scan(a, b, idA, idB)
+     *
+     * After pullup:
+     *   Project(v1 = a + 1, v2 = b + 1, idA, idB)   ← upper: must NOT leak a, b
+     *     TopN(order by idA)                          ← carries a, b internally
+     *       Project(a, b, idA, idB)                   ← base slots for lazy mat
+     *         Scan(a, b, idA, idB)
+     */
+    @Test
+    void testUpperProjectDoesNotLeakBaseSlots() {
+        LogicalOlapScan scan = new LogicalOlapScan(
+                PlanConstructor.getNextRelationId(), PlanConstructor.student, ImmutableList.of("db"));
+        Slot idA = scan.getOutput().get(0);
+        Slot a = scan.getOutput().get(1);
+        Slot idB = scan.getOutput().get(2);
+        Slot b = scan.getOutput().get(3);
+        Alias v1 = new Alias(new Add(a, new IntegerLiteral((byte) 1)), "v1");
+        Alias v2 = new Alias(new Add(b, new IntegerLiteral((byte) 1)), "v2");
+
+        LogicalPlan plan = new LogicalPlanBuilder(scan)
+                .projectExprs(ImmutableList.of(v1, v2, idA, idB))
+                .topN(10, 0, ImmutableList.of(2))
+                .build();
+
+        LogicalPlan rewritten = (LogicalPlan) PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .applyCustom(new PullUpProjectExprUnderTopN())
+                .getPlan();
+
+        LogicalProject<?> upperProject = (LogicalProject<?>) rewritten;
+        // Must expose exactly the original TopN output: [v1, v2, idA, idB]
+        Assertions.assertEquals(4, upperProject.getProjects().size(),
+                "Upper project output must match original TopN output size");
+        Assertions.assertEquals(v1.getExprId(), upperProject.getProjects().get(0).getExprId());
+        Assertions.assertEquals(v2.getExprId(), upperProject.getProjects().get(1).getExprId());
+        Assertions.assertEquals(idA.getExprId(), upperProject.getProjects().get(2).getExprId());
+        Assertions.assertEquals(idB.getExprId(), upperProject.getProjects().get(3).getExprId());
+        // Base slots must NOT leak into upper project output
+        Assertions.assertFalse(upperProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Base slot a must not leak into upper project output");
+        Assertions.assertFalse(upperProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Base slot b must not leak into upper project output");
+
+        // Base slots must still pass through TopN for lazy materialization
+        LogicalTopN<?> topN = (LogicalTopN<?>) upperProject.child(0);
+        Assertions.assertTrue(topN.getOutput().stream()
+                .anyMatch(s -> s.getExprId().equals(a.getExprId())),
+                "Base slot a must pass through TopN internally");
+        Assertions.assertTrue(topN.getOutput().stream()
+                .anyMatch(s -> s.getExprId().equals(b.getExprId())),
+                "Base slot b must pass through TopN internally");
+    }
+
+    /**
+     * Tests pass-through slot handling when an upper project forwards a bare
+     * Slot whose underlying expression was pulled up from a lower project.
+     *
+     * Before pullup:
+     *   TopN(order by id, limit 10)
+     *     Project1(id, x)              ← x is bare Slot (pass-through from child)
+     *       Project2(id, a+b as x)     ← computes x = a+b
+     *         Scan(id, a, b)
+     *
+     * After pullup:
+     *   Project(x = a + b, id)         ← upper (pulled above TopN)
+     *     TopN(order by id)
+     *       Project(id, a, b)          ← base slots only, x replaced by a, b
+     *         Project(id, a, b)        ← simplified lower project
+     *           Scan(id, a, b)
+     *
+     * The key mechanism: x in Project1 is a bare Slot that becomes unavailable
+     * after Project2 is simplified (x is removed). It is detected as an
+     * "unavailable pull-up slot" via isUnavailablePullUpSlot, and its
+     * replacement expression (a+b) is added to passThroughExprs. The base
+     * slots a, b from passThroughExprs are then retained in the simplified
+     * Project1 so they can flow through TopN for lazy materialization.
+     */
+    @Test
+    void testPassThroughSlotWithPulledUpExpressionFromLowerProject() {
+        LogicalOlapScan scan = new LogicalOlapScan(
+                PlanConstructor.getNextRelationId(), PlanConstructor.student, ImmutableList.of("db"));
+        Slot id = scan.getOutput().get(0);
+        Slot a = scan.getOutput().get(1);   // gender column, used as "a"
+        Slot b = scan.getOutput().get(2);   // name column, used as "b"
+
+        // Lower project: computes x = a + b
+        Alias x = new Alias(new Add(a, b), "x");
+        LogicalProject<LogicalOlapScan> lowerProject
+                = new LogicalProject<>(ImmutableList.of(id, x), scan);
+
+        // Upper project: passes through x as a bare Slot, plus id
+        LogicalProject<LogicalProject<LogicalOlapScan>> upperProject
+                = new LogicalProject<>(ImmutableList.of(x.toSlot(), id), lowerProject);
+
+        // TopN(order by id)
+        LogicalTopN<LogicalProject<LogicalProject<LogicalOlapScan>>> topN = new LogicalTopN<>(
+                ImmutableList.of(new OrderKey(id, false, false)),
+                10, 0, upperProject);
+
+        LogicalPlan rewritten = (LogicalPlan) PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyCustom(new PullUpProjectExprUnderTopN())
+                .getPlan();
+
+        // Root should be a Project (upper) → TopN → ...
+        Assertions.assertTrue(rewritten instanceof LogicalProject,
+                "Root should be LogicalProject (upper project above TopN)");
+        LogicalProject<?> rewrittenUpper = (LogicalProject<?>) rewritten;
+
+        // Upper project must contain Alias(x, a+b) — the pulled-up expression
+        Assertions.assertTrue(rewrittenUpper.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "x should be pulled above TopN in upper project");
+
+        // Upper project must retain id
+        Assertions.assertTrue(rewrittenUpper.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(id.getExprId())),
+                "id should be in upper project output");
+
+        // Base slots a, b must NOT leak into upper project output
+        Assertions.assertFalse(rewrittenUpper.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Base slot a must not leak into upper project output");
+        Assertions.assertFalse(rewrittenUpper.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Base slot b must not leak into upper project output");
+
+        // TopN is child of upper project
+        Assertions.assertTrue(rewrittenUpper.child(0) instanceof LogicalTopN);
+        LogicalTopN<?> rewrittenTopN = (LogicalTopN<?>) rewrittenUpper.child(0);
+
+        // Below TopN: must contain base slots a and b (from passThroughExprs)
+        LogicalProject<?> midProject = (LogicalProject<?>) rewrittenTopN.child(0);
+        Assertions.assertTrue(midProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Project below TopN must contain base slot a (for lazy mat)");
+        Assertions.assertTrue(midProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Project below TopN must contain base slot b (for lazy mat)");
+
+        // Must NOT contain Alias x in the lower projects (expression pulled up)
+        Assertions.assertFalse(midProject.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Project below TopN must NOT contain x (pulled above)");
+
+        // The lowest project (original lowerProject after simplification)
+        // should also only contain id, a, b
+        LogicalProject<?> lowestProject = (LogicalProject<?>) midProject.child(0);
+        Assertions.assertFalse(lowestProject.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Lowest project must NOT contain x (pulled above)");
+        Assertions.assertTrue(lowestProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Lowest project must contain base slot a");
+        Assertions.assertTrue(lowestProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Lowest project must contain base slot b");
+    }
+
+    /**
+     * Tests chain resolution when an upper project computes an expression
+     * (abs(x)) that references a slot (x) defined as a pulled-up expression
+     * (a+b) in a lower project. Verifies that both expressions are resolved
+     * through the chain and the intermediate slot disappears.
+     *
+     * Before pullup:
+     *   TopN(order by id, limit 10)
+     *     Project1(id, abs(x) as y)       ← y = abs(x), x from child
+     *       Project2(id, a+b as x)        ← x = a+b
+     *         Scan(id, a, b)
+     *
+     * After pullup:
+     *   Project(y = abs(a + b), id)       ← upper: chain resolved to a+b
+     *     TopN(order by id)
+     *       Project(id, a, b)             ← only base slots
+     *         Project(id, a, b)           ← simplified lower project
+     *           Scan(id, a, b)
+     *
+     * Key mechanism: y = abs(x) is pulled up (canPullUp=true, child is not Slot).
+     * x = a+b is also pulled up. In the replacer, resolveExpression replaces
+     * SlotRef(x) with (a+b) via pullUpExprReplaceMap, so y becomes abs(a+b).
+     * The intermediate slot x disappears entirely — it is neither in the upper
+     * project output (originalTopNOutput only has y, id) nor in the lower
+     * projects (pulled up).
+     */
+    @Test
+    void testExpressionChainResolvedThroughIntermediateSlot() {
+        LogicalOlapScan scan = new LogicalOlapScan(
+                PlanConstructor.getNextRelationId(), PlanConstructor.student, ImmutableList.of("db"));
+        Slot id = scan.getOutput().get(0);
+        Slot a = scan.getOutput().get(1);   // gender column, used as "a"
+        Slot b = scan.getOutput().get(2);   // name column, used as "b"
+
+        // Lower project: computes x = a + b
+        Alias x = new Alias(new Add(a, b), "x");
+        LogicalProject<LogicalOlapScan> lowerProject
+                = new LogicalProject<>(ImmutableList.of(id, x), scan);
+
+        // Upper project: computes y = abs(x)
+        Alias y = new Alias(new Abs(x.toSlot()), "y");
+        LogicalProject<LogicalProject<LogicalOlapScan>> upperProject
+                = new LogicalProject<>(ImmutableList.of(y, id), lowerProject);
+
+        // TopN(order by id)
+        LogicalTopN<LogicalProject<LogicalProject<LogicalOlapScan>>> topN = new LogicalTopN<>(
+                ImmutableList.of(new OrderKey(id, false, false)),
+                10, 0, upperProject);
+
+        LogicalPlan rewritten = (LogicalPlan) PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyCustom(new PullUpProjectExprUnderTopN())
+                .getPlan();
+
+        // Root should be a Project (upper)
+        Assertions.assertTrue(rewritten instanceof LogicalProject,
+                "Root should be LogicalProject (upper project above TopN)");
+        LogicalProject<?> project3 = (LogicalProject<?>) rewritten;
+
+        // === Verify project3 (upper) output ===
+        // Must contain y (the pulled-up expression, now resolved to abs(a+b))
+        Assertions.assertTrue(project3.getProjects().stream()
+                .anyMatch(e -> "y".equals(e.getName())),
+                "Upper project must contain y");
+
+        // Must contain id
+        Assertions.assertTrue(project3.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(id.getExprId())),
+                "Upper project must contain id");
+
+        // Must NOT contain x (intermediate slot, fully resolved away)
+        Assertions.assertFalse(project3.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Upper project must NOT contain x (intermediate slot resolved away)");
+
+        // Base slots a, b must NOT leak into upper project output
+        Assertions.assertFalse(project3.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Base slot a must not leak into upper project output");
+        Assertions.assertFalse(project3.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Base slot b must not leak into upper project output");
+
+        // === Verify TopN ===
+        Assertions.assertTrue(project3.child(0) instanceof LogicalTopN);
+        LogicalTopN<?> rewrittenTopN = (LogicalTopN<?>) project3.child(0);
+
+        // === Verify project4 (below TopN) output ===
+        LogicalProject<?> project4 = (LogicalProject<?>) rewrittenTopN.child(0);
+        // Must contain base slots a, b (for lazy mat)
+        Assertions.assertTrue(project4.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Project below TopN must contain base slot a");
+        Assertions.assertTrue(project4.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Project below TopN must contain base slot b");
+        // Must contain id
+        Assertions.assertTrue(project4.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(id.getExprId())),
+                "Project below TopN must contain id");
+        // Must NOT contain x or y (both pulled up)
+        Assertions.assertFalse(project4.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Project below TopN must NOT contain x (pulled above)");
+        Assertions.assertFalse(project4.getProjects().stream()
+                .anyMatch(e -> "y".equals(e.getName())),
+                "Project below TopN must NOT contain y (pulled above)");
+
+        // === Verify project5 (lowest) output ===
+        LogicalProject<?> project5 = (LogicalProject<?>) project4.child(0);
+        Assertions.assertFalse(project5.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Lowest project must NOT contain x");
+        Assertions.assertTrue(project5.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Lowest project must contain base slot a");
+        Assertions.assertTrue(project5.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Lowest project must contain base slot b");
+    }
+
+    /**
+     * Tests that when a TopN order key (z = abs(x)) depends on an intermediate
+     * slot (x), the underlying expression (x = a+b) can still be pulled up
+     * together with a non-blocked expression (y = abs(x)) that shares the same
+     * dependency. Verifies chain resolution handles shared dependencies and
+     * the blocked order key stays below TopN.
+     *
+     * Before pullup:
+     *   TopN(order by z, limit 10)       blocked={z}
+     *     Project0(abs(x) as z, id, y)
+     *       Project1(abs(x) as y, id)
+     *         Project2(a+b as x, id)
+     *           Scan(id, a, b)
+     *
+     * After pullup (current code behavior, where Project handler does NOT
+     * propagate input-slot blocking for non-Slot Alias children):
+     *   Project(z, id, y = abs(a+b))     ← upper: y resolved through chain x→a+b
+     *     TopN(order by z)
+     *       Project(z = abs(a+b), id, a, b)
+     *         Project(id, a, b)
+     *           Project(id, a, b)
+     *             Scan(id, a, b)
+     *
+     * Key observations:
+     * 1. y = abs(x) IS pulled up (y was not blocked, and x was not blocked
+     *    either — Project handler doesn't propagate input-slot blocking).
+     * 2. x = a+b is also pulled up → chain resolution expands abs(x) to abs(a+b).
+     * 3. z = abs(a+b) stays below TopN (blocked as order key) — abs(a+b) is
+     *    computed below AND above (duplicate), which is suboptimal but correct.
+     * 4. If input-slot blocking were propagated for blocked Aliases, x would be
+     *    blocked → x = a+b kept below → y = abs(x) pulled up with x passing
+     *    through TopN (no duplicate abs computation).
+     */
+    @Test
+    void testBlockedOrderKeySharesDependencyWithPulledUpExpression() {
+        LogicalOlapScan scan = new LogicalOlapScan(
+                PlanConstructor.getNextRelationId(), PlanConstructor.student, ImmutableList.of("db"));
+        Slot id = scan.getOutput().get(0);
+        Slot a = scan.getOutput().get(1);
+        Slot b = scan.getOutput().get(2);
+
+        // Project2: x = a + b
+        Alias x = new Alias(new Add(a, b), "x");
+        LogicalProject<LogicalOlapScan> project2
+                = new LogicalProject<>(ImmutableList.of(id, x), scan);
+
+        // Project1: y = abs(x)
+        Alias y = new Alias(new Abs(x.toSlot()), "y");
+        LogicalProject<LogicalProject<LogicalOlapScan>> project1
+                = new LogicalProject<>(ImmutableList.of(y, id), project2);
+
+        // Project0: z = abs(x), plus pass-through id, y
+        Alias z = new Alias(new Abs(x.toSlot()), "z");
+        LogicalProject<LogicalProject<LogicalProject<LogicalOlapScan>>> project0
+                = new LogicalProject<>(ImmutableList.of(z, id, y.toSlot()), project1);
+
+        // TopN(order by z)
+        LogicalTopN<LogicalProject<LogicalProject<LogicalProject<LogicalOlapScan>>>> topN
+                = new LogicalTopN<>(
+                        ImmutableList.of(new OrderKey(z.toSlot(), false, false)),
+                        10, 0, project0);
+
+        LogicalPlan rewritten = (LogicalPlan) PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyCustom(new PullUpProjectExprUnderTopN())
+                .getPlan();
+
+        // Root should be a Project (upper)
+        Assertions.assertTrue(rewritten instanceof LogicalProject,
+                "Root should be LogicalProject (upper project above TopN)");
+        LogicalProject<?> upperProject = (LogicalProject<?>) rewritten;
+
+        // === Verify upper project output ===
+        // Must contain y (pulled up, chain-resolved to abs(a+b))
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .anyMatch(e -> "y".equals(e.getName())),
+                "Upper project must contain y (pulled up)");
+        // Must contain z (order key, passed through from TopN output)
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .anyMatch(e -> "z".equals(e.getName())),
+                "Upper project must contain z (order key, pass-through)");
+        // Must contain id
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(id.getExprId())),
+                "Upper project must contain id");
+        // Must NOT contain x (intermediate, resolved away)
+        Assertions.assertFalse(upperProject.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Upper project must NOT contain x (resolved away)");
+        // Base slots must NOT leak
+        Assertions.assertFalse(upperProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Base slot a must not leak into upper project");
+        Assertions.assertFalse(upperProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Base slot b must not leak into upper project");
+
+        // === Verify TopN still has z as order key ===
+        Assertions.assertTrue(upperProject.child(0) instanceof LogicalTopN);
+        LogicalTopN<?> rewrittenTopN = (LogicalTopN<?>) upperProject.child(0);
+        Assertions.assertEquals(1, rewrittenTopN.getOrderKeys().size());
+        Assertions.assertEquals(z.getExprId(),
+                ((NamedExpression) rewrittenTopN.getOrderKeys().get(0).getExpr()).getExprId(),
+                "TopN order key should still be z");
+
+        // === Verify project below TopN ===
+        // Must contain z (order key, computed as abs(a+b) after chain resolution)
+        // and base slots a, b for lazy mat
+        LogicalProject<?> lowerProject = (LogicalProject<?>) rewrittenTopN.child(0);
+        Assertions.assertTrue(lowerProject.getProjects().stream()
+                .anyMatch(e -> "z".equals(e.getName())),
+                "Lower project must contain z (order key expression)");
+        Assertions.assertTrue(lowerProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Lower project must contain base slot a");
+        Assertions.assertTrue(lowerProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Lower project must contain base slot b");
+        // Must NOT contain x or y (both pulled up / resolved away)
+        Assertions.assertFalse(lowerProject.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Lower project must NOT contain x");
+        Assertions.assertFalse(lowerProject.getProjects().stream()
+                .anyMatch(e -> "y".equals(e.getName())),
+                "Lower project must NOT contain y (pulled above)");
+    }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopNTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PullUpProjectExprUnderTopNTest.java
@@ -1550,10 +1550,9 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
 
     /**
      * Tests that when a TopN order key (z = abs(x)) depends on an intermediate
-     * slot (x), the underlying expression (x = a+b) can still be pulled up
-     * together with a non-blocked expression (y = abs(x)) that shares the same
-     * dependency. Verifies chain resolution handles shared dependencies and
-     * the blocked order key stays below TopN.
+     * slot (x), the blocked order key also blocks the dependency x from being
+     * pulled up. The non-blocked expression (y = abs(x)) can still be pulled up
+     * and should reuse x passed through TopN.
      *
      * Before pullup:
      *   TopN(order by z, limit 10)       blocked={z}
@@ -1562,24 +1561,19 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
      *         Project2(a+b as x, id)
      *           Scan(id, a, b)
      *
-     * After pullup (current code behavior, where Project handler does NOT
-     * propagate input-slot blocking for non-Slot Alias children):
-     *   Project(z, id, y = abs(a+b))     ← upper: y resolved through chain x→a+b
+     * After pullup:
+     *   Project(z, id, y = abs(x))       ← upper: y reuses x passed through TopN
      *     TopN(order by z)
-     *       Project(z = abs(a+b), id, a, b)
-     *         Project(id, a, b)
-     *           Project(id, a, b)
+     *       Project(z = abs(x), id, x)
+     *         Project(id, x)
+     *           Project(id, x = a+b)
      *             Scan(id, a, b)
      *
      * Key observations:
-     * 1. y = abs(x) IS pulled up (y was not blocked, and x was not blocked
-     *    either — Project handler doesn't propagate input-slot blocking).
-     * 2. x = a+b is also pulled up → chain resolution expands abs(x) to abs(a+b).
-     * 3. z = abs(a+b) stays below TopN (blocked as order key) — abs(a+b) is
-     *    computed below AND above (duplicate), which is suboptimal but correct.
-     * 4. If input-slot blocking were propagated for blocked Aliases, x would be
-     *    blocked → x = a+b kept below → y = abs(x) pulled up with x passing
-     *    through TopN (no duplicate abs computation).
+     * 1. z = abs(x) stays below TopN because z is the order key.
+     * 2. Blocking z propagates to its input x, so x = a+b also stays below TopN.
+     * 3. y = abs(x) is pulled up because y itself is not blocked.
+     * 4. The pulled-up y must reference x, not expand x to a+b.
      */
     @Test
     void testBlockedOrderKeySharesDependencyWithPulledUpExpression() {
@@ -1621,10 +1615,15 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
         LogicalProject<?> upperProject = (LogicalProject<?>) rewritten;
 
         // === Verify upper project output ===
-        // Must contain y (pulled up, chain-resolved to abs(a+b))
+        // Must contain y (pulled up, still depending on x passed through TopN)
         Assertions.assertTrue(upperProject.getProjects().stream()
                 .anyMatch(e -> "y".equals(e.getName())),
                 "Upper project must contain y (pulled up)");
+        Assertions.assertTrue(upperProject.getProjects().stream()
+                .filter(e -> "y".equals(e.getName()))
+                .anyMatch(e -> e.getInputSlots().stream()
+                        .anyMatch(s -> s.getExprId().equals(x.getExprId()))),
+                "Pulled-up y should still reference x");
         // Must contain z (order key, passed through from TopN output)
         Assertions.assertTrue(upperProject.getProjects().stream()
                 .anyMatch(e -> "z".equals(e.getName())),
@@ -1633,10 +1632,10 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
         Assertions.assertTrue(upperProject.getProjects().stream()
                 .anyMatch(e -> e.getExprId().equals(id.getExprId())),
                 "Upper project must contain id");
-        // Must NOT contain x (intermediate, resolved away)
+        // Must NOT expose x as final output.
         Assertions.assertFalse(upperProject.getProjects().stream()
                 .anyMatch(e -> "x".equals(e.getName())),
-                "Upper project must NOT contain x (resolved away)");
+                "Upper project must NOT expose x");
         // Base slots must NOT leak
         Assertions.assertFalse(upperProject.getProjects().stream()
                 .anyMatch(e -> e.getExprId().equals(a.getExprId())),
@@ -1654,25 +1653,33 @@ class PullUpProjectExprUnderTopNTest implements MemoPatternMatchSupported {
                 "TopN order key should still be z");
 
         // === Verify project below TopN ===
-        // Must contain z (order key, computed as abs(a+b) after chain resolution)
-        // and base slots a, b for lazy mat
+        // Must contain z (order key), id and x. x is kept below TopN because z depends on it.
         LogicalProject<?> lowerProject = (LogicalProject<?>) rewrittenTopN.child(0);
         Assertions.assertTrue(lowerProject.getProjects().stream()
                 .anyMatch(e -> "z".equals(e.getName())),
                 "Lower project must contain z (order key expression)");
         Assertions.assertTrue(lowerProject.getProjects().stream()
-                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
-                "Lower project must contain base slot a");
-        Assertions.assertTrue(lowerProject.getProjects().stream()
-                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
-                "Lower project must contain base slot b");
-        // Must NOT contain x or y (both pulled up / resolved away)
-        Assertions.assertFalse(lowerProject.getProjects().stream()
-                .anyMatch(e -> "x".equals(e.getName())),
-                "Lower project must NOT contain x");
+                .anyMatch(e -> e.getExprId().equals(x.getExprId())),
+                "Lower project must contain x because order key z depends on it");
         Assertions.assertFalse(lowerProject.getProjects().stream()
                 .anyMatch(e -> "y".equals(e.getName())),
                 "Lower project must NOT contain y (pulled above)");
+
+        LogicalProject<?> middleProject = (LogicalProject<?>) lowerProject.child(0);
+        Assertions.assertTrue(middleProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(x.getExprId())),
+                "Middle project must pass through x");
+
+        LogicalProject<?> lowestProject = (LogicalProject<?>) middleProject.child(0);
+        Assertions.assertTrue(lowestProject.getProjects().stream()
+                .anyMatch(e -> "x".equals(e.getName())),
+                "Lowest project must still compute x");
+        Assertions.assertFalse(lowestProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(a.getExprId())),
+                "Lowest project should not expose base slot a when x is blocked");
+        Assertions.assertFalse(lowestProject.getProjects().stream()
+                .anyMatch(e -> e.getExprId().equals(b.getExprId())),
+                "Lowest project should not expose base slot b when x is blocked");
     }
 
 }


### PR DESCRIPTION
### What problem does this PR solve?
When projects below TopN are simplified by NestedColumnPruning, the
    above-TopN project may hold Aliases whose children reference intermediate
    slots (e.g. element_at results) that were removed from the child output.
    This caused CheckAfterRewrite failures because those slots could not be
    found in the rewritten plan output.
    
    Changes:
    1. Register intermediate alias-to-slot mappings so chain resolution
       (v1#4 → SlotRef#10 → ElementAt(sa#1,fa)) works correctly
    2. When an expression is pulled above TopN via chain resolution, only
       keep base slots in the lower project to avoid duplicate computation
    3. Skip pass-through for intermediate expression slots that were
       simplified away — their computation is covered by pulled-up aliases
    4. Re-add current TopN output slots (e.g. base structs for lazy mat)
       that are not already in upperOutput
    
    Added testPullUpChainedExpressionsThroughJoinAndTopN to cover this scenario.
Issue Number: close #xxx

Related PR: #63736

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

