### PR TITLE
[fix](be) Return NaN for avg_weighted when sum of weights is zero

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
+++ b/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <type_traits>
 
@@ -76,7 +77,12 @@ struct AggregateFunctionAvgWeightedData {
         weight_sum = 0.0;
     }
 
-    double get() const { return data_sum / weight_sum; }
+    double get() const {
+        if (weight_sum == 0.0) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        return data_sum / weight_sum;
+    }
 
     double data_sum = 0.0;
     double weight_sum = 0.0;

--- a/regression-test/data/query_p0/aggregate/support_type/avg_weighted/avg_weighted.out
+++ b/regression-test/data/query_p0/aggregate/support_type/avg_weighted/avg_weighted.out
@@ -2,3 +2,6 @@
 -- !sql_double --
 2.718281828
 
+-- !sql_zero_weight --
+NaN
+

--- a/regression-test/suites/query_p0/aggregate/support_type/avg_weighted/avg_weighted.groovy
+++ b/regression-test/suites/query_p0/aggregate/support_type/avg_weighted/avg_weighted.groovy
@@ -43,4 +43,18 @@ suite("avg_weighted") {
     """
     
     qt_sql_double """select avg_weighted(col_double, weight_double) from d_table;"""
+
+    // weight sum is zero, should return NaN instead of +/-Infinity
+    sql """
+        drop table if exists test_avg_weighted_zero;
+    """
+    sql """
+        create table test_avg_weighted_zero (f1 int, f2 int)
+        distributed BY hash(f1) buckets 1
+        properties("replication_num" = "1");
+    """
+    sql """
+        insert into test_avg_weighted_zero values (1, 1), (2, -1);
+    """
+    qt_sql_zero_weight """select avg_weighted(f1, f2) from test_avg_weighted_zero;"""
 }


### PR DESCRIPTION
Issue Number: close #xxx

Problem Summary: When the sum of weights passed to avg_weighted is zero but the weighted data sum is non-zero, the function computed data_sum / weight_sum and returned +/-Infinity (e.g. avg_weighted(f1, f2) over rows (1, 1), (2, -1) returned -Infinity). The expected mathematical result of a division by zero weight is undefined, so it should return NaN.

This fixes AggregateFunctionAvgWeightedData::get() to return quiet_NaN() when weight_sum is exactly zero, instead of producing Infinity.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

