### PR TITLE
[fix](fe) Reject multi-column NGRAM_BF indexes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/IndexDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/IndexDefinition.java
@@ -344,7 +344,7 @@ public class IndexDefinition {
         if (partitionNames != null) {
             partitionNames.validate();
         }
-        if (isBuildDeferred && indexType == IndexType.INVERTED) {
+        if (isBuildDeferred && (indexType == IndexType.INVERTED || indexType == IndexType.NGRAM_BF)) {
             if (Strings.isNullOrEmpty(name)) {
                 throw new AnalysisException("index name cannot be blank.");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/IndexDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/IndexDefinition.java
@@ -359,7 +359,8 @@ public class IndexDefinition {
             AnnIndexPropertiesChecker.checkProperties(this.properties);
         }
 
-        if (indexType == IndexType.BITMAP || indexType == IndexType.INVERTED) {
+        if (indexType == IndexType.BITMAP || indexType == IndexType.INVERTED
+                || indexType == IndexType.NGRAM_BF) {
             if (cols == null || cols.size() != 1) {
                 throw new AnalysisException(
                         indexType.toString() + " index can only apply to a single column.");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/IndexDefinitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/IndexDefinitionTest.java
@@ -137,6 +137,14 @@ public class IndexDefinitionTest {
     }
 
     @Test
+    void testNgramBFIndexOnlySingleColumn() {
+        IndexDefinition def = new IndexDefinition("ngram_bf_index", false, Lists.newArrayList("col1", "col2"),
+                "NGRAM_BF", null, "comment");
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class, def::validate);
+        Assertions.assertEquals("NGRAM_BF index can only apply to a single column.", exception.getMessage());
+    }
+
+    @Test
     void testInvalidNgramBFIndexColumnType() {
         Map<String, String> properties = new HashMap<>();
         properties.put("gram_size", "3");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/IndexDefinitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/IndexDefinitionTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.info.IndexType;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.plans.commands.info.ColumnDefinition;
 import org.apache.doris.nereids.trees.plans.commands.info.IndexDefinition;
@@ -142,6 +143,12 @@ public class IndexDefinitionTest {
                 "NGRAM_BF", null, "comment");
         AnalysisException exception = Assertions.assertThrows(AnalysisException.class, def::validate);
         Assertions.assertEquals("NGRAM_BF index can only apply to a single column.", exception.getMessage());
+    }
+
+    @Test
+    void testNgramBFBuildIndexValidateWithoutColumns() {
+        IndexDefinition def = new IndexDefinition("ngram_bf_index", null, IndexType.NGRAM_BF);
+        Assertions.assertDoesNotThrow(def::validate);
     }
 
     @Test

--- a/regression-test/suites/index_p0/test_ngram_bloomfilter_index.groovy
+++ b/regression-test/suites/index_p0/test_ngram_bloomfilter_index.groovy
@@ -110,4 +110,41 @@ suite("test_ngram_bloomfilter_index") {
         sql """ALTER TABLE  ${tableName3} ADD INDEX idx_http_url(http_url) USING NGRAM_BF PROPERTIES("gram_size"="256", "bf_size"="65535") COMMENT 'http_url ngram_bf index'"""
         exception "java.sql.SQLException: errCode = 2, detailMessage = 'gram_size' should be an integer between 1 and 255."
     }
+
+    sql "DROP TABLE IF EXISTS test_ngram_bloomfilter_multi_column_index"
+    test {
+        sql """
+        CREATE TABLE test_ngram_bloomfilter_multi_column_index (
+            `key_id` bigint(20) NULL COMMENT '',
+            `http_url` text NULL COMMENT '',
+            `url_path` varchar(2000) NULL COMMENT '',
+            INDEX idx_ngrambf_multi (`http_url`, `url_path`) USING NGRAM_BF
+                PROPERTIES("gram_size" = "2", "bf_size" = "512")
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`key_id`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`key_id`) BUCKETS 1
+        PROPERTIES("replication_num" = "1");
+        """
+        exception "NGRAM_BF index can only apply to a single column."
+    }
+
+    sql """
+        CREATE TABLE test_ngram_bloomfilter_multi_column_index (
+            `key_id` bigint(20) NULL COMMENT '',
+            `http_url` text NULL COMMENT '',
+            `url_path` varchar(2000) NULL COMMENT ''
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`key_id`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`key_id`) BUCKETS 1
+        PROPERTIES("replication_num" = "1");
+        """
+    test {
+        sql """
+        CREATE INDEX idx_ngrambf_multi ON test_ngram_bloomfilter_multi_column_index(`http_url`, `url_path`)
+            USING NGRAM_BF PROPERTIES("gram_size" = "2", "bf_size" = "512")
+        """
+        exception "NGRAM_BF index can only apply to a single column."
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: None

Problem Summary:

Creating an NGRAM_BF index with multiple columns passed FE validation and could reach BE tablet creation, where tablet metadata expects each NGRAM_BF index to bind exactly one column. This rejects invalid multi-column NGRAM_BF definitions during FE analysis for both inline table indexes and CREATE INDEX.

### Release note

Reject invalid multi-column NGRAM_BF index definitions during DDL analysis.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
        - Added coverage in `regression-test/suites/index_p0/test_ngram_bloomfilter_index.groovy` for inline table index and CREATE INDEX paths. Not run locally because no worktree Doris cluster was started.
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.IndexDefinitionTest`
    - [x] Manual test (add detailed scripts or steps below)
        - `./build.sh --fe`
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Invalid multi-column NGRAM_BF index definitions now fail during FE analysis.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
