### PR TITLE
[fix](fe) Fix NereidsCoordinator not created in proxy flow due to missing parsedStatement on StatementContext

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -960,6 +960,13 @@ public class StmtExecutor {
             }
             parsedStmt = statements.get(originStmt.idx);
         }
+        // Propagate parsed statement to the ConnectContext's StatementContext so that
+        // downstream code (e.g. canUseNereidsDistributePlanner which reads
+        // ConnectContext.get().getStatementContext().getParsedStatement()) can correctly
+        // identify the Nereids execution context even when the statement was forwarded
+        // from another FE (proxy flow). Using context.getStatementContext() instead of
+        // this.statementContext ensures consistency with what downstream code checks.
+        this.context.getStatementContext().setParsedStatement(parsedStmt);
     }
 
     public void finalizeQuery() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -960,13 +960,16 @@ public class StmtExecutor {
             }
             parsedStmt = statements.get(originStmt.idx);
         }
-        // Propagate parsed statement to the ConnectContext's StatementContext so that
-        // downstream code (e.g. canUseNereidsDistributePlanner which reads
-        // ConnectContext.get().getStatementContext().getParsedStatement()) can correctly
-        // identify the Nereids execution context even when the statement was forwarded
-        // from another FE (proxy flow). Using context.getStatementContext() instead of
-        // this.statementContext ensures consistency with what downstream code checks.
-        this.context.getStatementContext().setParsedStatement(parsedStmt);
+        // In the proxy flow (multi-FE forwarding), the StatementContext is created fresh
+        // without a parsedStatement. Propagate it so that downstream code like
+        // canUseNereidsDistributePlanner can correctly identify the Nereids execution
+        // context, ensuring EnvFactory creates a NereidsCoordinator instead of a legacy
+        // Coordinator (which would fail with "fragment has no children").
+        // Only do this when isProxy is true, because other code paths like
+        // executeInternalQuery() rely on legacy Coordinator behavior with mock backends.
+        if (isProxy) {
+            this.context.getStatementContext().setParsedStatement(parsedStmt);
+        }
     }
 
     public void finalizeQuery() {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -350,4 +350,42 @@ public class StmtExecutorTest extends TestWithFeService {
 
         Mockito.verify(resultFileSink).setDeleteExistingFiles(false);
     }
+
+    @Test
+    public void testParseByNereidsSetsParsedStatementOnStatementContext() throws Exception {
+        // This test verifies the fix for a bug in multi-FE environments where
+        // parseByNereids() did not propagate the parsed statement to the
+        // StatementContext. In the proxy flow (e.g., when a follower FE forwards
+        // a query to the master FE), the StmtExecutor is created via the proxy
+        // constructor which creates a fresh StatementContext without a
+        // parsedStatement. Without the fix, statementContext.getParsedStatement()
+        // remains null, causing SessionVariable.canUseNereidsDistributePlanner()
+        // to return false, which leads EnvFactory.createCoordinator() to create
+        // a legacy Coordinator instead of NereidsCoordinator, resulting in
+        // "fragment has no children" error.
+
+        // Simulate the proxy flow: StmtExecutor(ConnectContext, OriginStatement, boolean isProxy)
+        StmtExecutor executor = new StmtExecutor(connectContext,
+                new OriginStatement("select 1", 0), true);
+
+        // Before parsing, statementContext should exist but parsedStatement should be null
+        Assertions.assertNotNull(connectContext.getStatementContext());
+        Assertions.assertNull(connectContext.getStatementContext().getParsedStatement(),
+                "ParsedStatement should be null before parseByNereids() in proxy flow");
+
+        // Trigger parseByNereids via reflection (it's private)
+        Method parseByNereidsMethod = StmtExecutor.class.getDeclaredMethod("parseByNereids");
+        parseByNereidsMethod.setAccessible(true);
+        parseByNereidsMethod.invoke(executor);
+
+        // After parsing, parsedStatement should be set on the StatementContext
+        org.apache.doris.analysis.StatementBase parsedStatement
+                = connectContext.getStatementContext().getParsedStatement();
+        Assertions.assertNotNull(parsedStatement,
+                "ParsedStatement should not be null after parseByNereids() in proxy flow");
+        Assertions.assertTrue(
+                parsedStatement instanceof org.apache.doris.nereids.glue.LogicalPlanAdapter,
+                "ParsedStatement should be a LogicalPlanAdapter after parseByNereids(), but was: "
+                        + (parsedStatement == null ? "null" : parsedStatement.getClass().getName()));
+    }
 }


### PR DESCRIPTION
Problem Summary:

In a multi-FE environment, when a CREATE TABLE AS SELECT with recursive CTE is forwarded from a follower FE to the master FE, the execution fails with "fragment has no children".

Root Cause: 
In the proxy flow (ConnectProcessor.proxyExecute() → StmtExecutor(ConnectContext, OriginStatement, boolean)), the StatementContext is created fresh without a parsedStatement. When parseByNereids() later parses the SQL, it only sets this.parsedStmt on the StmtExecutor but did not propagate it to the ConnectContext's StatementContext.

This caused SessionVariable.canUseNereidsDistributePlanner() to return false (because statementContext.getParsedStatement() instanceof LogicalPlanAdapter checked against null), which led to two consequences:

NereidsPlanner.distribute() skipped generating Nereids distributed plans
EnvFactory.createCoordinator() created a legacy Coordinator instead of NereidsCoordinator
The legacy Coordinator cannot handle Nereids-planned fragments without distributed plans, resulting in "fragment has no children" at Coordinator.findMaxParallelFragmentIndex().

Fix:
 In StmtExecutor.parseByNereids(), after parsing the SQL, propagate the parsed statement to the ConnectContext's StatementContext via this.context.getStatementContext().setParsedStatement(parsedStmt). This ensures consistency with what downstream code (canUseNereidsDistributePlanner) reads.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

