### PR TITLE
[fix](test) fix flaky case in variables_persist  test_mtmv

### DIFF
--- a/regression-test/suites/query_p0/variables_persist/test_mtmv.groovy
+++ b/regression-test/suites/query_p0/variables_persist/test_mtmv.groovy
@@ -141,14 +141,14 @@ suite("test_mtmv") {
         sql """
             select t1.f1*t1.f2, t1.f1, t1.f2 from test_decimal_mul_overflow_for_mv t1 where t1.f1>1;
         """
-        contains "where_mv chose"
+        contains "final projections: __multiply_0"
     }
     sql "set enable_decimal256=false;"
     explain {
         sql """
             select t1.f1*t1.f2, t1.f1, t1.f2 from test_decimal_mul_overflow_for_mv t1 where t1.f1>1;
         """
-        contains "where_mv not chose"
+        notContains "final projections: __multiply_0"
     }
     sql "drop materialized view  if exists where_mv;"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
`test_mtmv` checked `where_mv not chose` after setting `enable_decimal256=false`, but this is cost/statistics dependent. The optimizer may still choose `where_mv` as a covering scan and recompute `f1 * f2` from `f1/f2`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

