### PR TITLE
[fix](test) skip force_olap_table_replication_num check in cloud mode for show replica dist

### DIFF
--- a/regression-test/suites/query_p0/show/test_nereids_show_replica_dist.groovy
+++ b/regression-test/suites/query_p0/show/test_nereids_show_replica_dist.groovy
@@ -61,9 +61,15 @@ suite("test_nereids_show_replica_dist") {
     }
     
     def replication_num = 1
-    def forceReplicaNum = getFeConfig('force_olap_table_replication_num').toInteger()
-    if (forceReplicaNum > 0) {
-        replication_num = forceReplicaNum
+    // In cloud mode the data is stored once on shared storage, so each tablet always
+    // has a single replica regardless of force_olap_table_replication_num. The cloud
+    // CloudPropertyAnalyzer unconditionally rewrites replication_num back to 1, so the
+    // forced replication num must not be applied to the expected value here.
+    if (!isCloudMode()) {
+        def forceReplicaNum = getFeConfig('force_olap_table_replication_num').toInteger()
+        if (forceReplicaNum > 0) {
+            replication_num = forceReplicaNum
+        }
     }
 
     assertEquals(replication_num, queryReplicaCount("p3"))   


### PR DESCRIPTION
### What problem does this PR solve?

Related Jira: DORIS-26262

The regression case `query_p0/show/test_nereids_show_replica_dist` (run as `nereids_p0.show.test_nereids_show_replica_dist` in the pipeline) failed in the cloud-26.0.4 S3 P0 release regression with:

```
org.opentest4j.AssertionFailedError: expected: <3> but was: <1>
```

**Root cause** — the case is not cloud-aware:

The case reads FE config `force_olap_table_replication_num` and, when it is `> 0` (the pipeline sets it to `3`), it expects every partition's replica count to be `3`. This assumption only holds in non-cloud mode.

In `PropertyAnalyzer.rewriteOlapProperties()` two steps run in order:
1. `rewriteReplicaAllocationProperties()` rewrites `replication_num` to `3` because `force_olap_table_replication_num=3`;
2. `rewriteForceProperties()` in cloud mode goes through `CloudPropertyAnalyzer`, whose `forceProperties` unconditionally `replace`s `replication_num` with `ReplicaAllocation.DEFAULT_ALLOCATION`, which is `new ReplicaAllocation((short)1)` in cloud.

So step 2 overwrites the `3` from step 1 back to `1`. This is by design: cloud uses shared storage (S3), data is stored once and each tablet always has exactly one replica, so `force_olap_table_replication_num` must not take effect.

Pipeline log confirms it — `SHOW REPLICA DISTRIBUTION ... PARTITION p3` returns 4 BEs with only one holding a replica (sum = 1), while the expected value was forced to 3.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
