### PR TITLE
[feature](ann-index) Pre-filter column predicates into ANN TopN searc…

### DIFF
--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -237,8 +237,10 @@ Status ScanLocalState<Derived>::open(RuntimeState* state) {
         RETURN_IF_ERROR(_on_runtime_filter_update());
     }
 
-    // Disable condition cache in topn filter valid. TODO:: Try to support the topn filter in condition cache
-    if (state->query_options().condition_cache_digest && p._topn_filter_source_node_ids.empty()) {
+    // Disable condition cache when TopN filters can shrink the segment row bitmap before caching.
+    // TODO: Try to support TopN filters in condition cache.
+    if (state->query_options().condition_cache_digest && p._topn_filter_source_node_ids.empty() &&
+        _ann_topn_runtime == nullptr) {
         _condition_cache_digest = state->query_options().condition_cache_digest;
         for (auto& conjunct : _conjuncts) {
             _condition_cache_digest = conjunct->get_digest(_condition_cache_digest);

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -239,8 +239,10 @@ Status ScanLocalState<Derived>::open(RuntimeState* state) {
         RETURN_IF_ERROR(_on_runtime_filter_update());
     }
 
-    // Disable condition cache in topn filter valid. TODO:: Try to support the topn filter in condition cache
-    if (state->query_options().condition_cache_digest && p._topn_filter_source_node_ids.empty()) {
+    // Disable condition cache when TopN filters can shrink the segment row bitmap before caching.
+    // TODO: Try to support TopN filters in condition cache.
+    if (state->query_options().condition_cache_digest && p._topn_filter_source_node_ids.empty() &&
+        _ann_topn_runtime == nullptr) {
         _condition_cache_digest = state->query_options().condition_cache_digest;
         for (auto& conjunct : _conjuncts) {
             _condition_cache_digest = conjunct->get_digest(_condition_cache_digest);

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -1075,8 +1075,8 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
 }
 
 bool SegmentIterator::_enable_ann_topn_predicate_prefilter() const {
-    return !_opts.runtime_state ||
-           !_opts.runtime_state->query_options().__isset.enable_ann_topn_predicate_prefilter ||
+    return _opts.runtime_state != nullptr &&
+           _opts.runtime_state->query_options().__isset.enable_ann_topn_predicate_prefilter &&
            _opts.runtime_state->query_options().enable_ann_topn_predicate_prefilter;
 }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -924,7 +924,13 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     bool has_common_expr_push_down = !_common_expr_ctxs_push_down.empty();
     bool has_column_predicate = std::any_of(_is_pred_column.begin(), _is_pred_column.end(),
                                             [](bool is_pred) { return is_pred; });
-    if (!has_ann_index || has_common_expr_push_down || has_column_predicate) {
+    // A column predicate no longer forces a brute-force fallback: it can be pre-evaluated
+    // into the candidate bitmap (see _eager_filter_predicates_into_bitmap). A common-expr
+    // push-down is not yet pre-filtered, so it still falls back.
+    bool prefilter_column_predicate = has_column_predicate && !has_common_expr_push_down &&
+                                      _enable_ann_topn_predicate_prefilter();
+    if (!has_ann_index || has_common_expr_push_down ||
+        (has_column_predicate && !prefilter_column_predicate)) {
         VLOG_DEBUG << fmt::format(
                 "Ann topn can not be evaluated by ann index, has_ann_index: {}, "
                 "has_common_expr_push_down: {}, has_column_predicate: {}",
@@ -969,6 +975,13 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
         _need_read_data_indices[src_cid] = true;
         _opts.stats->ann_fall_back_brute_force_cnt += 1;
         return Status::OK();
+    }
+
+    // Run the pre-filter here: after the metric/direction checks above (so a query that would
+    // fall back anyway does not pay for it) and before pre_size below (so the small-candidate
+    // threshold sees the post-predicate count).
+    if (prefilter_column_predicate) {
+        RETURN_IF_ERROR(_eager_filter_predicates_into_bitmap());
     }
 
     size_t pre_size = _row_bitmap.cardinality();
@@ -1058,6 +1071,79 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     VLOG_DEBUG << fmt::format(
             "Enable ANN index-only scan for src column cid {} (skip reading data pages)", src_cid);
 
+    return Status::OK();
+}
+
+bool SegmentIterator::_enable_ann_topn_predicate_prefilter() const {
+    return !_opts.runtime_state ||
+           !_opts.runtime_state->query_options().__isset.enable_ann_topn_predicate_prefilter ||
+           _opts.runtime_state->query_options().enable_ann_topn_predicate_prefilter;
+}
+
+Status SegmentIterator::_eager_filter_predicates_into_bitmap() {
+    // The residual column predicates (those not resolvable by zonemap/inverted/bitmap index, hence
+    // not yet reflected in _row_bitmap) are evaluated here over the candidate rows, and the
+    // survivors are intersected back into _row_bitmap. The narrowed bitmap is then fed to the ANN
+    // index as an IDSelector (see AnnTopNRuntime::evaluate_vector_ann_search), so a predicated
+    // TopN query keeps using the index instead of degrading to an O(N) brute-force distance scan.
+    //
+    // This runs before the main scan loop sets up _range_iter / _block_rowids /
+    // _current_return_columns (see _lazy_init), so it allocates the predicate columns and drives a
+    // local pass with the same _read_columns_by_index + predicate-evaluation primitives the main
+    // loop uses. All of those members are re-initialized by the main loop afterwards (_range_iter
+    // is recreated over the narrowed _row_bitmap right after _apply_ann_topn_predicate returns).
+    if (!_is_need_vec_eval && !_is_need_short_eval) {
+        // has_column_predicate was true but every predicate was already resolved via index;
+        // there is nothing left to evaluate per row.
+        return Status::OK();
+    }
+
+    _current_return_columns.resize(_schema->columns().size());
+    for (auto cid : _predicate_column_ids) {
+        auto storage_column_type = _storage_name_and_type[cid].second;
+        RETURN_IF_CATCH_EXCEPTION(_current_return_columns[cid] = Schema::get_predicate_column_ptr(
+                                          storage_column_type, _opts.io_ctx.reader_type));
+        _current_return_columns[cid]->set_rowset_segment_id(
+                {_segment->rowset_id(), _segment->id()});
+    }
+
+    if (_block_rowids.size() < _opts.block_row_max) {
+        _block_rowids.resize(_opts.block_row_max);
+    }
+
+    _range_iter.reset(new BitmapRangeIterator(_row_bitmap));
+    roaring::Roaring survivors;
+    while (true) {
+        // The predicate columns are reused across batches, so clear them before each read just
+        // like the main scan loop does in _init_current_block. Without this, _read_columns_by_index
+        // appends onto the previous batch's data and predicate evaluation reads stale rows once the
+        // candidate set spans more than one block_row_max batch.
+        for (auto cid : _predicate_column_ids) {
+            _current_return_columns[cid]->clear();
+        }
+        _selected_size = 0;
+        RETURN_IF_ERROR(_read_columns_by_index(_opts.block_row_max, _selected_size));
+        if (_selected_size == 0) {
+            break;
+        }
+        // Mirror the normal scan loop's post-read fixups (_next_batch_internal): __DORIS_VERSION_COL__
+        // and the row-binlog TSO column are stored as placeholders on disk and only become their
+        // real, predicate-visible values after these substitutions. Skipping them here would let a
+        // predicate on one of those columns narrow _row_bitmap using placeholder data, diverging
+        // from what the normal/brute-force path would evaluate.
+        _replace_version_col_if_needed(_predicate_column_ids, _selected_size);
+        _update_tso_col_if_needed(_predicate_column_ids, _selected_size);
+        _sel_rowid_idx.resize(_selected_size);
+        _convert_dict_code_for_predicate_if_necessary();
+        uint16_t selected =
+                _evaluate_vectorization_predicate(_sel_rowid_idx.data(), _selected_size);
+        selected = _evaluate_short_circuit_predicate(_sel_rowid_idx.data(), selected);
+        for (uint16_t i = 0; i < selected; ++i) {
+            survivors.add(_block_rowids[_sel_rowid_idx[i]]);
+        }
+    }
+
+    _row_bitmap &= survivors;
     return Status::OK();
 }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -934,7 +934,13 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     bool has_common_expr_push_down = !_common_expr_ctxs_push_down.empty();
     bool has_predicate_column = std::ranges::any_of(
             _column_states, [](const auto& state) { return state.has_predicate(); });
-    if (!has_ann_index || has_common_expr_push_down || has_predicate_column) {
+    // A column predicate no longer forces a brute-force fallback: it can be pre-evaluated
+    // into the candidate bitmap (see _eager_filter_predicates_into_bitmap). A common-expr
+    // push-down is not yet pre-filtered, so it still falls back.
+    bool prefilter_column_predicate = has_predicate_column && !has_common_expr_push_down &&
+                                      _enable_ann_topn_predicate_prefilter();
+    if (!has_ann_index || has_common_expr_push_down ||
+        (has_predicate_column && !prefilter_column_predicate)) {
         VLOG_DEBUG << fmt::format(
                 "Ann topn can not be evaluated by ann index, has_ann_index: {}, "
                 "has_common_expr_push_down: {}, has_predicate_column: {}",
@@ -979,6 +985,13 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
         _column_states[src_cid].need_read_data = true;
         _opts.stats->ann_fall_back_brute_force_cnt += 1;
         return Status::OK();
+    }
+
+    // Run the pre-filter here: after the metric/direction checks above (so a query that would
+    // fall back anyway does not pay for it) and before pre_size below (so the small-candidate
+    // threshold sees the post-predicate count).
+    if (prefilter_column_predicate) {
+        RETURN_IF_ERROR(_eager_filter_predicates_into_bitmap());
     }
 
     size_t pre_size = _row_bitmap.cardinality();
@@ -1068,6 +1081,87 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     VLOG_DEBUG << fmt::format(
             "Enable ANN index-only scan for src column cid {} (skip reading data pages)", src_cid);
 
+    return Status::OK();
+}
+
+bool SegmentIterator::_enable_ann_topn_predicate_prefilter() const {
+    return _opts.runtime_state != nullptr &&
+           _opts.runtime_state->query_options().__isset.enable_ann_topn_predicate_prefilter &&
+           _opts.runtime_state->query_options().enable_ann_topn_predicate_prefilter;
+}
+
+Status SegmentIterator::_eager_filter_predicates_into_bitmap() {
+    // The residual column predicates (those not resolvable by zonemap/inverted/bitmap index, hence
+    // not yet reflected in _row_bitmap) are evaluated here over the candidate rows, and the
+    // survivors are intersected back into _row_bitmap. The narrowed bitmap is then fed to the ANN
+    // index as an IDSelector (see AnnTopNRuntime::evaluate_vector_ann_search), so a predicated
+    // TopN query keeps using the index instead of degrading to an O(N) brute-force distance scan.
+    //
+    // This runs before the main scan loop sets up _range_iter / _block_rowids /
+    // _current_columns (see _lazy_init), so it allocates the predicate columns and drives a
+    // local pass with the same _read_columns_by_index + predicate-evaluation primitives the main
+    // loop uses. All of those members are re-initialized by the main loop afterwards (_range_iter
+    // is recreated over the narrowed _row_bitmap right after _apply_ann_topn_predicate returns).
+    if (!_is_need_vec_eval && !_is_need_short_eval) {
+        // has_column_predicate was true but every predicate was already resolved via index;
+        // there is nothing left to evaluate per row.
+        return Status::OK();
+    }
+    if (_row_bitmap.isEmpty()) {
+        return Status::OK();
+    }
+
+    const auto nrows_reserve_limit =
+            std::min(_row_bitmap.cardinality(), uint64_t(_opts.block_row_max));
+    _current_columns.resize(_schema->num_read_columns());
+    for (auto cid : _predicate_ordinals) {
+        auto storage_column_type = _storage_name_and_type[cid].second;
+        RETURN_IF_CATCH_EXCEPTION(_current_columns[cid] = ReadSchema::get_predicate_column_ptr(
+                                          storage_column_type, _opts.io_ctx.reader_type));
+        _current_columns[cid]->set_rowset_segment_id({_segment->rowset_id(), _segment->id()});
+        _current_columns[cid]->reserve(nrows_reserve_limit);
+    }
+
+    if (_block_rowids.size() < _opts.block_row_max) {
+        _block_rowids.resize(_opts.block_row_max);
+    }
+
+    _range_iter.reset(new BitmapRangeIterator(_row_bitmap));
+    roaring::Roaring survivors;
+    while (true) {
+        // The predicate columns are reused across batches, so clear them before each read just
+        // like the main scan loop does in _init_current_block. Without this, _read_columns_by_index
+        // appends onto the previous batch's data and predicate evaluation reads stale rows once the
+        // candidate set spans more than one block_row_max batch.
+        for (auto cid : _predicate_ordinals) {
+            _current_columns[cid]->clear();
+        }
+        _selected_size = 0;
+        RETURN_IF_ERROR(
+                _read_columns_by_index(_predicate_ordinals, _opts.block_row_max, _selected_size));
+        if (_selected_size == 0) {
+            break;
+        }
+        // Mirror the normal scan loop's post-read fixups (_next_batch_internal): __DORIS_VERSION_COL__
+        // and the row-binlog TSO column are stored as placeholders on disk and only become their
+        // real, predicate-visible values after these substitutions. Skipping them here would let a
+        // predicate on one of those columns narrow _row_bitmap using placeholder data, diverging
+        // from what the normal/brute-force path would evaluate.
+        _replace_version_col_if_needed(_predicate_ordinals, _selected_size);
+        _update_tso_col_if_needed(_predicate_ordinals, _selected_size);
+        _sel_rowid_idx.resize(_selected_size);
+        _convert_dict_code_for_predicate_if_necessary();
+        uint16_t selected =
+                _evaluate_vectorization_predicate(_sel_rowid_idx.data(), _selected_size);
+        selected = _evaluate_short_circuit_predicate(_sel_rowid_idx.data(), selected);
+        for (uint16_t i = 0; i < selected; ++i) {
+            survivors.add(_block_rowids[_sel_rowid_idx[i]]);
+        }
+    }
+
+    // Every row in survivors came from _row_bitmap, so replacing the bitmap is equivalent to an
+    // intersection and avoids scanning both roaring containers once more.
+    _row_bitmap = std::move(survivors);
     return Status::OK();
 }
 

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -200,7 +200,7 @@ private:
     // Pre-evaluate the residual column predicates into _row_bitmap so a predicated ANN TopN
     // can keep using the index (IDSelector) instead of falling back to brute force.
     [[nodiscard]] Status _eager_filter_predicates_into_bitmap();
-    // Whether the session enables pre-filtering column predicates for ANN TopN (default true).
+    // Whether the current FE explicitly enables pre-filtering column predicates for ANN TopN.
     bool _enable_ann_topn_predicate_prefilter() const;
     [[nodiscard]] Status _apply_index_expr();
 

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -197,6 +197,11 @@ private:
             std::vector<std::shared_ptr<ColumnPredicate>>& remaining_predicates,
             bool* continue_apply);
     [[nodiscard]] Status _apply_ann_topn_predicate();
+    // Pre-evaluate the residual column predicates into _row_bitmap so a predicated ANN TopN
+    // can keep using the index (IDSelector) instead of falling back to brute force.
+    [[nodiscard]] Status _eager_filter_predicates_into_bitmap();
+    // Whether the session enables pre-filtering column predicates for ANN TopN (default true).
+    bool _enable_ann_topn_predicate_prefilter() const;
     [[nodiscard]] Status _apply_index_expr();
 
     bool _column_has_fulltext_index(int32_t cid);

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -154,6 +154,11 @@ private:
             std::vector<std::shared_ptr<ColumnPredicate>>& remaining_predicates,
             bool* continue_apply);
     [[nodiscard]] Status _apply_ann_topn_predicate();
+    // Pre-evaluate the residual column predicates into _row_bitmap so a predicated ANN TopN
+    // can keep using the index (IDSelector) instead of falling back to brute force.
+    [[nodiscard]] Status _eager_filter_predicates_into_bitmap();
+    // Whether the current FE explicitly enables pre-filtering column predicates for ANN TopN.
+    bool _enable_ann_topn_predicate_prefilter() const;
     [[nodiscard]] Status _apply_index_expr();
     // G02: true iff answering the single pushed-down MATCH predicate by its
     // match COUNT alone is indistinguishable from the row-accurate bitmap for

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -862,6 +862,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_INVERTED_INDEX_SEARCHER_CACHE = "enable_inverted_index_searcher_cache";
     public static final String ENABLE_INVERTED_INDEX_QUERY_CACHE = "enable_inverted_index_query_cache";
     public static final String ENABLE_ANN_INDEX_RESULT_CACHE = "enable_ann_index_result_cache";
+    public static final String ENABLE_ANN_TOPN_PREDICATE_PREFILTER = "enable_ann_topn_predicate_prefilter";
 
     public static final String IN_LIST_VALUE_COUNT_THRESHOLD = "in_list_value_count_threshold";
 
@@ -3493,6 +3494,15 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enableAnnIndexResultCache = true;
 
+    @VarAttrDef.VarAttr(name = ENABLE_ANN_TOPN_PREDICATE_PREFILTER, needForward = true, description = {
+        "开启后，带列谓词的 ANN TopN 查询会先把谓词求值成候选位图喂给 ANN 索引（IDSelector），"
+                + "而不是退化为暴力距离扫描",
+        "When enabled, an ANN TopN query that carries a column predicate pre-filters the predicate "
+                + "into a candidate bitmap fed to the ANN index (IDSelector), instead of falling back "
+                + "to a brute-force distance scan."
+    })
+    public boolean enableAnnTopnPredicatePrefilter = true;
+
     @VarAttrDef.VarAttr(name = IN_LIST_VALUE_COUNT_THRESHOLD, description = {
         "in 条件 value 数量大于这个 threshold 后将不会走 fast_execute",
         "When the number of values in the IN condition exceeds this threshold,"
@@ -5775,6 +5785,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableInvertedIndexSearcherCache(enableInvertedIndexSearcherCache);
         tResult.setEnableInvertedIndexQueryCache(enableInvertedIndexQueryCache);
         tResult.setEnableAnnIndexResultCache(enableAnnIndexResultCache);
+        tResult.setEnableAnnTopnPredicatePrefilter(enableAnnTopnPredicatePrefilter);
         tResult.setHiveOrcUseColumnNames(hiveOrcUseColumnNames);
         tResult.setHiveParquetUseColumnNames(hiveParquetUseColumnNames);
         tResult.setQuerySlotCount(wgQuerySlotCount);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3494,14 +3494,17 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enableAnnIndexResultCache = true;
 
-    @VarAttrDef.VarAttr(name = ENABLE_ANN_TOPN_PREDICATE_PREFILTER, needForward = true,
-            affectQueryResultInExecution = true, description = {
-        "开启后，带列谓词的 ANN TopN 查询会先把谓词求值成候选位图喂给 ANN 索引（IDSelector），"
-                + "而不是退化为暴力距离扫描",
-        "When enabled, an ANN TopN query that carries a column predicate pre-filters the predicate "
-                + "into a candidate bitmap fed to the ANN index (IDSelector), instead of falling back "
-                + "to a brute-force distance scan."
-    })
+    @VarAttrDef.VarAttr(
+            name = ENABLE_ANN_TOPN_PREDICATE_PREFILTER,
+            needForward = true,
+            affectQueryResultInExecution = true,
+            description = {
+                    "开启后，带列谓词的 ANN TopN 查询会先把谓词求值成候选位图喂给 ANN 索引（IDSelector），"
+                            + "而不是退化为暴力距离扫描",
+                    "When enabled, an ANN TopN query that carries a column predicate pre-filters the predicate "
+                            + "into a candidate bitmap fed to the ANN index (IDSelector), instead of falling back "
+                            + "to a brute-force distance scan."
+            })
     public boolean enableAnnTopnPredicatePrefilter = true;
 
     @VarAttrDef.VarAttr(name = IN_LIST_VALUE_COUNT_THRESHOLD, description = {
@@ -3662,29 +3665,31 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enableAddIndexForNewData = false;
 
-    @VarAttrDef.VarAttr(name = HNSW_EF_SEARCH, needForward = true,
+    @VarAttrDef.VarAttr(name = HNSW_EF_SEARCH, needForward = true, affectQueryResultInExecution = true,
             checker = "checkHnswEfSearch",
             description = {"HNSW 索引的 EF 搜索参数，控制搜索的精度和速度",
                     "HNSW index EF search parameter, controls the precision and speed of the search"})
     public int hnswEFSearch = 32;
 
     @VarAttrDef.VarAttr(name = HNSW_CHECK_RELATIVE_DISTANCE, needForward = true,
+            affectQueryResultInExecution = true,
             description = {"是否启用相对距离检查机制，以提升 HNSW 搜索的准确性",
                     "Enable relative distance checking to improve HNSW search accuracy"})
     public boolean hnswCheckRelativeDistance = true;
 
-    @VarAttrDef.VarAttr(name = HNSW_BOUNDED_QUEUE, needForward = true,
+    @VarAttrDef.VarAttr(name = HNSW_BOUNDED_QUEUE, needForward = true, affectQueryResultInExecution = true,
             description = {"是否使用有界优先队列来优化 HNSW 的搜索性能",
                     "Whether to use a bounded priority queue to optimize HNSW search performance"})
     public boolean hnswBoundedQueue = true;
 
-    @VarAttrDef.VarAttr(name = IVF_NPROBE, needForward = true,
+    @VarAttrDef.VarAttr(name = IVF_NPROBE, needForward = true, affectQueryResultInExecution = true,
             checker = "checkIvfNprobe",
             description = {"IVF 索引的 nprobe 参数，控制搜索时访问的聚类数量",
                     "IVF index nprobe parameter, controls the number of clusters to search"})
     public int ivfNprobe = 32;
 
     @VarAttrDef.VarAttr(name = ANN_INDEX_CANDIDATE_ROWS_THRESHOLD, needForward = true,
+            affectQueryResultInExecution = true,
             checker = "checkAnnIndexCandidateRowsThreshold",
             description = {"Skip ANN index when candidate rows before ANN search are less "
                     + "than this threshold. 0 disables the absolute row threshold",
@@ -3693,6 +3698,7 @@ public class SessionVariable implements Serializable, Writable {
     public long annIndexCandidateRowsThreshold = 0;
 
     @VarAttrDef.VarAttr(name = ANN_INDEX_CANDIDATE_ROWS_PERCENT_THRESHOLD, needForward = true,
+            affectQueryResultInExecution = true,
             checker = "checkAnnIndexCandidateRowsPercentThreshold",
             description = {"Skip ANN index when candidate row ratio before ANN search is less "
                     + "than this threshold",

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3494,7 +3494,8 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enableAnnIndexResultCache = true;
 
-    @VarAttrDef.VarAttr(name = ENABLE_ANN_TOPN_PREDICATE_PREFILTER, needForward = true, description = {
+    @VarAttrDef.VarAttr(name = ENABLE_ANN_TOPN_PREDICATE_PREFILTER, needForward = true,
+            affectQueryResultInExecution = true, description = {
         "开启后，带列谓词的 ANN TopN 查询会先把谓词求值成候选位图喂给 ANN 索引（IDSelector），"
                 + "而不是退化为暴力距离扫描",
         "When enabled, an ANN TopN query that carries a column predicate pre-filters the predicate "

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -882,6 +882,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_INVERTED_INDEX_SEARCHER_CACHE = "enable_inverted_index_searcher_cache";
     public static final String ENABLE_INVERTED_INDEX_QUERY_CACHE = "enable_inverted_index_query_cache";
     public static final String ENABLE_ANN_INDEX_RESULT_CACHE = "enable_ann_index_result_cache";
+    public static final String ENABLE_ANN_TOPN_PREDICATE_PREFILTER = "enable_ann_topn_predicate_prefilter";
 
     public static final String IN_LIST_VALUE_COUNT_THRESHOLD = "in_list_value_count_threshold";
 
@@ -3359,6 +3360,13 @@ public class SessionVariable implements Serializable, Writable {
             + "cache the results of ANN index queries.")
     public boolean enableAnnIndexResultCache = true;
 
+    @VarAttrDef.VarAttr(name = ENABLE_ANN_TOPN_PREDICATE_PREFILTER, needForward = true,
+            affectQueryResultInExecution = true,
+            description = "When enabled, an ANN TopN query that carries a column predicate pre-filters the "
+                    + "predicate into a candidate bitmap fed to the ANN index (IDSelector), instead of falling "
+                    + "back to a brute-force distance scan.")
+    public boolean enableAnnTopnPredicatePrefilter = true;
+
     @VarAttrDef.VarAttr(name = IN_LIST_VALUE_COUNT_THRESHOLD, description = "When the number of values in the IN "
             + "condition exceeds this threshold,"
             + " fast_execute will not be used.", affectQueryResultInExecution = true)
@@ -3470,31 +3478,34 @@ public class SessionVariable implements Serializable, Writable {
             + "when disabled rebuild indexes for all data")
     public boolean enableAddIndexForNewData = false;
 
-    @VarAttrDef.VarAttr(name = HNSW_EF_SEARCH, needForward = true,
+    @VarAttrDef.VarAttr(name = HNSW_EF_SEARCH, needForward = true, affectQueryResultInExecution = true,
             checker = "checkHnswEfSearch",
             description = "HNSW index EF search parameter, controls the precision and speed of the search")
     public int hnswEFSearch = 32;
 
     @VarAttrDef.VarAttr(name = HNSW_CHECK_RELATIVE_DISTANCE, needForward = true,
+            affectQueryResultInExecution = true,
             description = "Enable relative distance checking to improve HNSW search accuracy")
     public boolean hnswCheckRelativeDistance = true;
 
-    @VarAttrDef.VarAttr(name = HNSW_BOUNDED_QUEUE, needForward = true,
+    @VarAttrDef.VarAttr(name = HNSW_BOUNDED_QUEUE, needForward = true, affectQueryResultInExecution = true,
             description = "Whether to use a bounded priority queue to optimize HNSW search performance")
     public boolean hnswBoundedQueue = true;
 
-    @VarAttrDef.VarAttr(name = IVF_NPROBE, needForward = true,
+    @VarAttrDef.VarAttr(name = IVF_NPROBE, needForward = true, affectQueryResultInExecution = true,
             checker = "checkIvfNprobe",
             description = "IVF index nprobe parameter, controls the number of clusters to search")
     public int ivfNprobe = 32;
 
     @VarAttrDef.VarAttr(name = ANN_INDEX_CANDIDATE_ROWS_THRESHOLD, needForward = true,
+            affectQueryResultInExecution = true,
             checker = "checkAnnIndexCandidateRowsThreshold",
             description = "Skip ANN index when candidate rows before ANN search are less "
                     + "than this threshold. 0 disables the absolute row threshold")
     public long annIndexCandidateRowsThreshold = 0;
 
     @VarAttrDef.VarAttr(name = ANN_INDEX_CANDIDATE_ROWS_PERCENT_THRESHOLD, needForward = true,
+            affectQueryResultInExecution = true,
             checker = "checkAnnIndexCandidateRowsPercentThreshold",
             description = "Skip ANN index when candidate row ratio before ANN search is less "
                     + "than this threshold")
@@ -5650,6 +5661,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableInvertedIndexSearcherCache(enableInvertedIndexSearcherCache);
         tResult.setEnableInvertedIndexQueryCache(enableInvertedIndexQueryCache);
         tResult.setEnableAnnIndexResultCache(enableAnnIndexResultCache);
+        tResult.setEnableAnnTopnPredicatePrefilter(enableAnnTopnPredicatePrefilter);
         tResult.setHiveOrcUseColumnNames(hiveOrcUseColumnNames);
         tResult.setHiveParquetUseColumnNames(hiveParquetUseColumnNames);
         tResult.setQuerySlotCount(wgQuerySlotCount);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SqlCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SqlCacheTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import java.util.function.Consumer;
 
 public class SqlCacheTest extends TestWithFeService {
     @Test
@@ -63,21 +64,34 @@ public class SqlCacheTest extends TestWithFeService {
     }
 
     @Test
-    public void testCacheKeyIncludesAnnTopnPredicatePrefilter() {
+    public void testCacheKeyIncludesAnnTopnOptions() {
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.enableAnnTopnPredicatePrefilter = false);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.hnswEFSearch = 64);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.hnswCheckRelativeDistance = false);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.hnswBoundedQueue = false);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.ivfNprobe = 64);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.annIndexCandidateRowsThreshold = 1);
+        assertCacheKeyChanges(
+                sessionVariable -> sessionVariable.annIndexCandidateRowsPercentThreshold = 0.2);
+    }
+
+    private void assertCacheKeyChanges(Consumer<SessionVariable> change) {
         UserIdentity admin = new UserIdentity("admin", "127.0.0.1");
 
-        SessionVariable prefilterEnabled = new SessionVariable();
+        SessionVariable defaultSessionVariable = new SessionVariable();
         SqlCacheContext enabledContext = new SqlCacheContext(admin);
         enabledContext.setOriginSql("SELECT * FROM tbl");
-        PUniqueId enabledKey = enabledContext.doComputeCacheKeyMd5(ImmutableSet.of(), prefilterEnabled);
+        PUniqueId defaultKey = enabledContext.doComputeCacheKeyMd5(
+                ImmutableSet.of(), defaultSessionVariable);
 
-        SessionVariable prefilterDisabled = new SessionVariable();
-        prefilterDisabled.enableAnnTopnPredicatePrefilter = false;
+        SessionVariable changedSessionVariable = new SessionVariable();
+        change.accept(changedSessionVariable);
         SqlCacheContext disabledContext = new SqlCacheContext(admin);
         disabledContext.setOriginSql("SELECT * FROM tbl");
-        PUniqueId disabledKey = disabledContext.doComputeCacheKeyMd5(ImmutableSet.of(), prefilterDisabled);
+        PUniqueId changedKey = disabledContext.doComputeCacheKeyMd5(
+                ImmutableSet.of(), changedSessionVariable);
 
-        Assertions.assertNotEquals(enabledKey, disabledKey);
+        Assertions.assertNotEquals(defaultKey, changedKey);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SqlCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SqlCacheTest.java
@@ -63,6 +63,24 @@ public class SqlCacheTest extends TestWithFeService {
     }
 
     @Test
+    public void testCacheKeyIncludesAnnTopnPredicatePrefilter() {
+        UserIdentity admin = new UserIdentity("admin", "127.0.0.1");
+
+        SessionVariable prefilterEnabled = new SessionVariable();
+        SqlCacheContext enabledContext = new SqlCacheContext(admin);
+        enabledContext.setOriginSql("SELECT * FROM tbl");
+        PUniqueId enabledKey = enabledContext.doComputeCacheKeyMd5(ImmutableSet.of(), prefilterEnabled);
+
+        SessionVariable prefilterDisabled = new SessionVariable();
+        prefilterDisabled.enableAnnTopnPredicatePrefilter = false;
+        SqlCacheContext disabledContext = new SqlCacheContext(admin);
+        disabledContext.setOriginSql("SELECT * FROM tbl");
+        PUniqueId disabledKey = disabledContext.doComputeCacheKeyMd5(ImmutableSet.of(), prefilterDisabled);
+
+        Assertions.assertNotEquals(enabledKey, disabledKey);
+    }
+
+    @Test
     public void testSqlCache() throws Exception {
         connectContext.getSessionVariable().setEnableSqlCache(true);
         executeNereidsSql("select 100");

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SqlCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SqlCacheTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import java.util.function.Consumer;
 
 public class SqlCacheTest extends TestWithFeService {
     @Test
@@ -60,6 +61,37 @@ public class SqlCacheTest extends TestWithFeService {
         );
         PUniqueId key3 = cacheContext3.doComputeCacheKeyMd5(ImmutableSet.of(), sessionVariable);
         Assertions.assertNotEquals(key1, key3);
+    }
+
+    @Test
+    public void testCacheKeyIncludesAnnTopnOptions() {
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.enableAnnTopnPredicatePrefilter = false);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.hnswEFSearch = 64);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.hnswCheckRelativeDistance = false);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.hnswBoundedQueue = false);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.ivfNprobe = 64);
+        assertCacheKeyChanges(sessionVariable -> sessionVariable.annIndexCandidateRowsThreshold = 1);
+        assertCacheKeyChanges(
+                sessionVariable -> sessionVariable.annIndexCandidateRowsPercentThreshold = 0.2);
+    }
+
+    private void assertCacheKeyChanges(Consumer<SessionVariable> change) {
+        UserIdentity admin = new UserIdentity("admin", "127.0.0.1");
+
+        SessionVariable defaultSessionVariable = new SessionVariable();
+        SqlCacheContext enabledContext = new SqlCacheContext(admin);
+        enabledContext.setOriginSql("SELECT * FROM tbl");
+        PUniqueId defaultKey = enabledContext.doComputeCacheKeyMd5(
+                ImmutableSet.of(), defaultSessionVariable);
+
+        SessionVariable changedSessionVariable = new SessionVariable();
+        change.accept(changedSessionVariable);
+        SqlCacheContext disabledContext = new SqlCacheContext(admin);
+        disabledContext.setOriginSql("SELECT * FROM tbl");
+        PUniqueId changedKey = disabledContext.doComputeCacheKeyMd5(
+                ImmutableSet.of(), changedSessionVariable);
+
+        Assertions.assertNotEquals(defaultKey, changedKey);
     }
 
     @Test

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -509,7 +509,7 @@ struct TQueryOptions {
   226: optional bool enable_prune_nested_column = false;
   // Pre-filter column predicates into the ANN candidate bitmap (IDSelector) instead of falling
   // back to a brute-force distance scan when an ANN TopN query carries a column predicate.
-  227: optional bool enable_ann_topn_predicate_prefilter = true
+  227: optional bool enable_ann_topn_predicate_prefilter = false
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -507,6 +507,9 @@ struct TQueryOptions {
   225: optional i64 runtime_filter_tree_publish_max_send_bytes = 268435456
 
   226: optional bool enable_prune_nested_column = false;
+  // Pre-filter column predicates into the ANN candidate bitmap (IDSelector) instead of falling
+  // back to a brute-force distance scan when an ANN TopN query carries a column predicate.
+  227: optional bool enable_ann_topn_predicate_prefilter = true
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -518,6 +518,9 @@ struct TQueryOptions {
   230: optional bool supports_external_file_report_ack = false;
   // Fall back to RE2 when Hyperscan cannot compile a regular expression.
   231: optional bool enable_hyperscan_fallback = true;
+  // Pre-filter column predicates into the ANN candidate bitmap (IDSelector) instead of falling
+  // back to a brute-force distance scan when an ANN TopN query carries a column predicate.
+  232: optional bool enable_ann_topn_predicate_prefilter = false
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.

--- a/regression-test/suites/ann_index_p0/ann_topn_predicate_prefilter.groovy
+++ b/regression-test/suites/ann_index_p0/ann_topn_predicate_prefilter.groovy
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression for an ANN TopN query that carries a residual column predicate (one NOT
+// resolvable by zonemap/inverted/bitmap index). Such a predicate must be pre-filtered into a
+// candidate bitmap fed to the ANN index as an IDSelector so the query keeps using the index,
+// instead of degrading to an O(N) brute-force distance scan.
+//
+// Observation mechanism (same as ann_index_only_scan_debug_point): with debug point
+// "segment_iterator._read_columns_by_index" enabled for column_name="embedding", reading the
+// vector column throws "does not need to read data". On the index path the vector column is not
+// read, so the query succeeds; on a brute-force fallback it is read, so the debug point fires.
+//
+// Three cases are covered:
+//   1. a small single-batch segment -- basic index-path + top-K correctness check.
+//   2. a segment large enough to span several scan batches (batch_size) -- this guards the
+//      per-batch column reset in _eager_filter_predicates_into_bitmap. Without that reset,
+//      batches after the first are filtered against stale predicate data, so the prefiltered
+//      candidate set (and the top-K) is wrong. A single-batch segment never exercises it.
+//   3. a segment spanning two condition-cache granules -- ANN TopN must not cache its top-K
+//      truncation as the result of the column predicate.
+suite("ann_topn_predicate_prefilter", "nonConcurrent") {
+    sql "unset variable all;"
+    sql "set enable_common_expr_pushdown=true;"
+    sql "set experimental_enable_virtual_slot_for_cse=true;"
+    sql "set enable_no_need_read_data_opt=true;"
+    sql "set parallel_pipeline_task_num=1;"
+    sql "set enable_sql_cache=false;"
+    sql "set enable_condition_cache=false;"
+
+    // ============================ Case 1: single small batch ============================
+    sql "drop table if exists ann_topn_pred_prefilter"
+    sql """
+        create table ann_topn_pred_prefilter (
+            id int not null,
+            category int not null,
+            embedding array<float> not null,
+            index ann_embedding(`embedding`) using ann properties(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="8"
+            )
+        ) duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties("replication_num"="1");
+    """
+
+    // 7 of 10 rows have category=1 (70% > 30%), so after pre-filtering the candidate set stays
+    // above the small-candidate (0.3) fallback threshold and the ANN index path is exercised.
+    sql """
+        insert into ann_topn_pred_prefilter values
+        (0, 1, [39.906116, 10.495334, 54.08394, 88.67262, 55.243687, 10.162686, 36.335983, 38.684258]),
+        (1, 1, [62.759315, 97.15586, 25.832521, 39.604908, 88.76715, 72.64085, 9.688437, 17.721428]),
+        (2, 1, [15.447449, 59.7771, 65.54516, 12.973712, 99.685135, 72.080734, 85.71118, 99.35976]),
+        (3, 1, [72.26747, 46.42257, 32.368374, 80.50209, 5.777631, 98.803314, 7.0915947, 68.62693]),
+        (4, 1, [22.098177, 74.10027, 63.634556, 4.710955, 12.405106, 79.39356, 63.014366, 68.67834]),
+        (5, 1, [27.53003, 72.1106, 50.891026, 38.459953, 68.30715, 20.610682, 94.806274, 45.181377]),
+        (6, 1, [77.73215, 64.42907, 71.50025, 43.85641, 94.42648, 50.04773, 65.12575, 68.58207]),
+        (7, 2, [2.1537063, 82.667885, 16.171143, 71.126656, 5.335274, 40.286068, 11.943586, 3.69409]),
+        (8, 2, [54.435013, 56.800594, 59.335514, 55.829235, 85.46627, 33.388138, 11.076194, 20.480877]),
+        (9, 2, [76.197945, 60.623528, 84.229805, 31.652937, 71.82595, 48.04684, 71.29212, 30.282396]);
+    """
+
+    def v = "[26.360261917114258,7.05784273147583,32.361351013183594,86.39714050292969,58.79527282714844,27.189321517944336,99.38946533203125,80.19270324707031]"
+
+    // Primary signal: with a category predicate (no index on category, not excluded by zonemap)
+    // the index path must NOT read the vector column. If it fell back to brute force it would read
+    // embedding and the debug point would throw "does not need to read data", failing the query.
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(
+                "segment_iterator._read_columns_by_index", [column_name: "embedding"])
+
+        sql """
+            select id
+            from ann_topn_pred_prefilter
+            where category = 1
+            order by l2_distance_approximate(embedding, ${v})
+            limit 5;
+        """
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("segment_iterator._read_columns_by_index")
+    }
+
+    // Correctness: the index pre-filter path must return the same top-K as the brute-force path
+    // (prefilter off => fall back to an exact distance scan over the same filtered rows).
+    def topnSql = """
+        select id
+        from ann_topn_pred_prefilter
+        where category = 1
+        order by l2_distance_approximate(embedding, ${v})
+        limit 5;
+    """
+
+    sql "set enable_ann_topn_predicate_prefilter=true;"
+    def withPrefilter = sql topnSql
+
+    sql "set enable_ann_topn_predicate_prefilter=false;"
+    def bruteForce = sql topnSql
+
+    assertEquals(bruteForce, withPrefilter,
+            "ANN pre-filter top-K must match brute-force top-K for the same predicated query")
+
+    // ===================== Case 2: multiple scan batches in one segment =====================
+    // Shrink the scan batch so a few hundred rows in a single segment span several batches; this
+    // is the path where a missing per-batch reset would filter later batches with stale data.
+    sql "set batch_size = 64;"
+    // Case 1 left the prefilter disabled (its brute-force leg); re-enable it before the index-path
+    // check below, otherwise the column predicate would force a brute-force fallback.
+    sql "set enable_ann_topn_predicate_prefilter=true;"
+    // Raise ef_search so HNSW searches the full candidate set: the oracle below asserts exact
+    // equality against the brute-force path, which only holds once HNSW is not leaving any of
+    // these few hundred candidates unvisited at the default ef_search.
+    sql "set hnsw_ef_search=4096;"
+
+    sql "drop table if exists ann_topn_pred_prefilter_mb"
+    sql """
+        create table ann_topn_pred_prefilter_mb (
+            id int not null,
+            category int not null,
+            embedding array<float> not null,
+            index ann_embedding(`embedding`) using ann properties(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="8"
+            )
+        ) duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties("replication_num"="1");
+    """
+
+    // Query vector and a deterministic layout: a handful of category=1 rows are planted very
+    // close to the query (increasing distance), all at high ids so they land in batch 2+. One
+    // category=2 row is planted equally close to catch a false-positive leak. Every other row is
+    // far away, so the true top-5 (category=1, nearest) is exactly the 5 planted category=1 ids.
+    def qmb = [10, 10, 10, 10, 10, 10, 10, 10]
+    def plantedCat1 = [100: 1, 140: 2, 180: 3, 220: 4, 260: 6]   // id -> first-coord offset (== L2 distance)
+    def plantedCat2Id = 200
+    def plantedCat2Offset = 5
+    def total = 300
+
+    def fmt = { e -> "[" + e.collect { (it as float) }.join(",") + "]" }
+    def rows = []
+    for (int id = 0; id < total; id++) {
+        def cat
+        def emb
+        if (plantedCat1.containsKey(id)) {
+            cat = 1
+            emb = [10 + plantedCat1[id], 10, 10, 10, 10, 10, 10, 10]
+        } else if (id == plantedCat2Id) {
+            cat = 2
+            emb = [10 + plantedCat2Offset, 10, 10, 10, 10, 10, 10, 10]
+        } else {
+            // ~70% category=1 so survivors stay above the 0.3 fallback threshold; far from qmb.
+            cat = (id % 10 < 7) ? 1 : 2
+            emb = [200 + (id % 7), 201, 202, 203, 204, 205, 206, 207]
+        }
+        rows.add("(${id}, ${cat}, ${fmt(emb)})")
+    }
+    // One INSERT => one rowset => one segment, so the rows really span scan batches in a segment.
+    sql "insert into ann_topn_pred_prefilter_mb values ${rows.join(",")};"
+
+    def vmb = fmt(qmb)
+
+    // Primary signal again: predicated TopN over a multi-batch segment must stay on the index path.
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(
+                "segment_iterator._read_columns_by_index", [column_name: "embedding"])
+
+        sql """
+            select id
+            from ann_topn_pred_prefilter_mb
+            where category = 1
+            order by l2_distance_approximate(embedding, ${vmb})
+            limit 5;
+        """
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("segment_iterator._read_columns_by_index")
+    }
+
+    def topnSqlMb = """
+        select id
+        from ann_topn_pred_prefilter_mb
+        where category = 1
+        order by l2_distance_approximate(embedding, ${vmb})
+        limit 5;
+    """
+
+    sql "set enable_ann_topn_predicate_prefilter=true;"
+    def withPrefilterMb = sql topnSqlMb
+
+    sql "set enable_ann_topn_predicate_prefilter=false;"
+    def bruteForceMb = sql topnSqlMb
+
+    // Same top-K as the exact path, and exactly the planted category=1 ids in distance order.
+    // A stale-batch bug would drop a planted category=1 row or leak the planted category=2 row,
+    // changing this result. The explicit id list also rejects a vacuous (e.g. both-empty) pass.
+    def idsOf = { res -> res.collect { (it[0] as int) } }
+    assertEquals(idsOf(bruteForceMb), idsOf(withPrefilterMb),
+            "multi-batch ANN pre-filter top-K must match brute-force top-K")
+    assertEquals([100, 140, 180, 220, 260], idsOf(withPrefilterMb),
+            "multi-batch ANN pre-filter must return exactly the planted category=1 neighbors")
+
+    // ===================== Case 3: ANN TopN must not poison condition cache =====================
+    // Condition cache tracks predicate survivors at a 2048-row granularity. An ANN TopN scan
+    // narrows its row bitmap to top-K before the scan loop runs, so it must not populate the
+    // predicate cache: a later query with the same predicate would otherwise skip granules that
+    // contain predicate matches but no previous top-K result.
+    sql "set enable_condition_cache=true;"
+    sql "set enable_ann_topn_predicate_prefilter=true;"
+    sql "set enable_ann_index_result_cache=false;"
+    sql "set enable_sql_cache=false;"
+    sql "set parallel_pipeline_task_num=1;"
+    sql "set hnsw_ef_search=4096;"
+
+    sql "drop table if exists ann_topn_pred_prefilter_condition_cache"
+    sql """
+        create table ann_topn_pred_prefilter_condition_cache (
+            id int not null,
+            category int not null,
+            embedding array<float> not null,
+            index ann_embedding(`embedding`) using ann properties(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="8"
+            )
+        ) duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties("replication_num"="1");
+    """
+
+    // Every 2048-row condition-cache granule contains both categories, so zonemap cannot prune
+    // category = 1. The first five category=1 rows are uniquely nearest to the zero query vector
+    // and all belong to the first granule; category=1 stays above the 30% ANN fallback threshold.
+    def conditionCacheRows = []
+    for (int id = 0; id < 4096; id++) {
+        def category = (id % 10 < 7) ? 1 : 2
+        conditionCacheRows.add("(${id}, ${category}, [${id}.0,0,0,0,0,0,0,0])")
+    }
+    sql "insert into ann_topn_pred_prefilter_condition_cache values ${conditionCacheRows.join(',')};"
+    sql "sync"
+
+    def cacheTopnRows = sql """
+        select id
+        from ann_topn_pred_prefilter_condition_cache
+        where category = 1
+        order by l2_distance_approximate(embedding, [0,0,0,0,0,0,0,0])
+        limit 5;
+    """
+    assertEquals([0, 1, 2, 3, 4], cacheTopnRows.collect { it[0] as int })
+
+    // This must be the first non-ANN query with category = 1. Before the fix, the preceding ANN
+    // TopN query caches only the first granule and this count incorrectly returns 1435.
+    def cacheCountRows = sql """
+        select count(*)
+        from ann_topn_pred_prefilter_condition_cache
+        where category = 1;
+    """
+    assertEquals(2869L, cacheCountRows[0][0] as long,
+            "ANN TopN must not poison condition cache for category=1")
+
+    sql "set enable_condition_cache=false;"
+    sql "set enable_ann_topn_predicate_prefilter=true;"
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:


An ANN TopN query that carries a residual column predicate (one not resolvable by
zonemap / inverted / bitmap index) currently gives up the ANN index in
`_apply_ann_topn_predicate` and degrades to an O(N) brute-force distance scan. This
is the largest performance cliff for filtered vector search,).

The FAISS-side IDSelector path is already wired up; the missing piece was that the
column predicate was never evaluated into the candidate bitmap. This PR adds
`_eager_filter_predicates_into_bitmap()`, which reuses the existing
`_read_columns_by_index` + vectorized / short-circuit predicate evaluation over the
candidate set and intersects the survivors back into `_row_bitmap`. The narrowed
bitmap is then fed to the ANN index as an IDSelector instead of triggering the
brute-force fallback.

The optimization is guarded by a new session variable
`enable_ann_topn_predicate_prefilter` (default `true`, forwarded to BE via
`TQueryOptions`). A common-expression push-down (arbitrary expression filter) still
falls back to brute force for now.

## Benchmark: scaling validation (500K vs 30M rows)

Measured on the fix-branch BE, dim=128, HNSW (`l2_distance`, max_degree=32, ef_construction=40). The brute-force path (`enable_ann_topn_predicate_prefilter=false`) is exact and used as recall ground truth; the index path (`=true`) is the path under test — same BE binary, apples-to-apples. The residual predicate is `category < t` over 10 categories (selectivity = t/10), with the filter column independent of vector proximity (worst case for over-fetch).

### 500K rows (1 tablet, 10 query vectors)

```
sel%   k     recall@K  idx_ret  brute_ms  index_ms  speedup
10%    10    1.000     10.0     190       166       1.1x
10%    50    1.000     50.0     164       161       1.0x
10%    100   1.000     100.0    151       155       1.0x
30%    10    1.000     10.0     255       232       1.1x
30%    50    1.000     50.0     270       228       1.2x
30%    100   1.000     100.0    236       234       1.0x
50%    10    0.870     10.0     337       78        4.3x
50%    50    0.854     50.0     319       84        3.8x
50%    100   0.861     100.0    289       81        3.6x
80%    10    0.880     10.0     349       63        5.5x
80%    50    0.856     50.0     397       78        5.1x
80%    100   0.876     100.0    354       76        4.7x
100%   10    1.000     10.0     71        73        1.0x
100%   50    1.000     50.0     67        65        1.0x
100%   100   1.000     100.0    80        68        1.2x
```

### 30M rows (4 tablets, 5 query vectors)

```
sel%   k     recall@K  idx_ret  brute_ms  index_ms  speedup
10%    10    1.000     10.0     2014      1808      1.1x
10%    50    1.000     50.0     2014      1874      1.1x
10%    100   1.000     100.0    2014      1862      1.1x
30%    10    0.900     10.0     4283      850       5.0x
30%    50    0.972     50.0     4283      867       4.9x
30%    100   0.982     100.0    4283      857       5.0x
50%    10    0.900     10.0     8127      167       48.7x
50%    50    0.940     50.0     8127      185       43.9x
50%    100   0.978     100.0    8127      115       70.7x
80%    10    0.900     10.0     7525      201       37.4x
80%    50    0.936     50.0     7525      196       38.4x
80%    100   0.978     100.0    7525      217       34.7x
100%   10    0.900     10.0     157       151       1.0x
100%   50    0.964     50.0     157       149       1.1x
100%   100   1.000     100.0    157       142       1.1x
```

### Takeaways

- **Below 30% selectivity**, the existing 0.3 small-candidate threshold keeps the query on the exact path (recall=1.000, speedup ≈ 1x) — expected, unchanged by this PR.
- **At ≥30% selectivity (where the index path actually runs), the speedup grows sharply with data size**: peak **5.5x at 500K → 70.7x at 30M**. Brute force is O(N) (≈300ms → ≈8000ms, ~25×) while the HNSW index path is ~O(log N) (≈70ms → ≈150ms, ~2×), so the ratio widens as N grows — exactly the regime where the old brute-force fallback hurt most.
- **Returned rows always equal k** in both runs — no row-count shortfall.
- **Recall** stays in 0.85–1.00 on the index path — the inherent approximation of HNSW under IDSelector, not a regression introduced here. At 30M, recall@10 ≈ 0.90 and rises to ≈0.98 at k=100; the small-k gap is the over-fetch direction tracked separately (VEC-11).

> Absolute latencies are not directly comparable across the two runs (500K used 1 tablet, 30M used 4, so the 30M numbers include 4-way tablet parallelism). The **speedup ratio is brute÷index on the *same* table**, so the parallelism cancels and the ratio reflects the O(N) vs O(log N) algorithmic difference.


### Reproducing script:
[bench_recall.sh](https://github.com/user-attachments/files/29194572/bench_recall.sh)
[gen_data.py](https://github.com/user-attachments/files/29194576/gen_data.py)


[verify_ann_predicate_prefilter.sh](https://github.com/user-attachments/files/28833253/verify_ann_predicate_prefilter.sh)

### Reproduction results
[test-results.md](https://github.com/user-attachments/files/29194605/test-results.md)






### Release note

Support pushing column predicates into ANN TopN search as a FAISS IDSelector, avoiding
the brute-force fallback for filtered vector search. Controlled by the session variable
`enable_ann_topn_predicate_prefilter` (default true).



None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

