### PR TITLE
[improvement](fe) Set default profile level to 2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1431,7 +1431,7 @@ public class SessionVariable implements Serializable, Writable {
                             + "3 表示打开一些可能导致性能回退的 Counter", "The level of query profile, "
                             + "1 means only collect Counter of MergedProfile, 2 means print detailed information,"
                             + " 3 means open some Counters that may cause performance degradation"})
-    public int profileLevel = 1;
+    public int profileLevel = 2;
 
     @VarAttrDef.VarAttr(name = MAX_INSTANCE_NUM)
     public int maxInstanceNum = 64;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The default query profile level is 1, which only collects merged profile counters. This change sets the FE session default profile_level to 2 so detailed query profile information is collected by default.

### Release note

Set the default query profile level to 2.

### Check List (For Author)

- Test: No need to test (only changes the default value of a session variable).
- Behavior changed: Yes. The default profile_level is changed from 1 to 2.
- Does this need documentation: No