### PR TITLE
[fix](regression) Address colocate stability review comments

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -997,7 +997,7 @@ class Suite implements GroovyInterceptable {
     }
 
     void waitForColocateGroupStable(String dbName, String groupName, int timeoutSeconds = 60) {
-        String fullGroupName = "${dbName}.${groupName}"
+        String fullGroupName = groupName.startsWith("__global__") ? groupName : "${dbName}.${groupName}"
         logger.info("wait colocate group ${fullGroupName} stable")
         awaitUntil(timeoutSeconds) {
             def groups = sql_return_maparray("SHOW PROC '/colocation_group'")

--- a/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
+++ b/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
@@ -52,6 +52,7 @@ suite("test_colocate_join_of_column_order") {
     sql """insert into test_colocate_join_of_column_order_t2 values('k1','k2',11);"""
 
     sql """set enable_nereids_planner=true; """
+    waitForColocateGroupStable("group_column_order")
     explain {
         sql("select * from test_colocate_join_of_column_order_t1 a join test_colocate_join_of_column_order_t2 b on a.k1=b.k1 and a.k2=b.k2;")
         notContains "COLOCATE"
@@ -68,7 +69,6 @@ suite("test_colocate_join_of_column_order") {
         sql("select * from test_colocate_join_of_column_order_t1 a join test_colocate_join_of_column_order_t2 b on a.k1=b.k2 and a.v=b.v;")
         notContains "COLOCATE"
     }
-    waitForColocateGroupStable("group_column_order")
     explain {
         sql("select * from test_colocate_join_of_column_order_t1 a join test_colocate_join_of_column_order_t2 b on a.k1=b.k2 and a.k2=b.k1;")
         contains "COLOCATE"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64361

Problem Summary:

This follow-up addresses review comments left on #64361 after it had already been merged.

The shared colocate stability helper always prefixed the group name with the database name. Global colocate groups start with `__global__` and are reported by `SHOW PROC '/colocation_group'` without a database prefix, so waiting for a global group would time out.

Additionally, the column-order suite waited for group stability only before its positive `COLOCATE` assertions. Its negative assertions could therefore pass because an unstable group disables colocate join, rather than because the tested join columns are incompatible.

This PR preserves bare global group names and moves the stability wait before the first column-order EXPLAIN.

### Release note

None

### Check List (For Author)

- Test: Regression test
    - `./run-regression-test.sh --clean --run -d correctness_p0 -s test_colocate_join_of_column_order`
- Behavior changed: No
- Does this need documentation: No
