### PR TITLE
[fix](mtmv) guard OlapTable.getInvertedIndex against null TableIndexes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -3801,6 +3801,9 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
     }
 
     public Index getInvertedIndex(Column column, List<String> subPath, String analyzer) {
+        if (indexes == null) {
+            return null;
+        }
         List<Index> invertedIndexes = new ArrayList<>();
         for (Index index : indexes.getIndexes()) {
             if (index.getIndexType() == IndexDef.IndexType.INVERTED) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -261,6 +261,35 @@ public class OlapTableTest {
         Assert.assertTrue(schemaAllIndexes.contains(col2));
     }
 
+    // DORIS-22946: getInvertedIndex must return null instead of NPE when
+    // the table has no TableIndexes set (the default state for an MTMV
+    // created via OlapTableFactory, which never calls withIndexes()).
+    @Test
+    public void testGetInvertedIndexWhenIndexesNull() {
+        OlapTable table = new OlapTable();
+        Assert.assertNull(table.getTableIndexes());
+
+        Column titleColumn = new Column("title", PrimitiveType.VARCHAR);
+        Assert.assertNull(table.getInvertedIndex(titleColumn, null));
+        Assert.assertNull(table.getInvertedIndex(titleColumn, Lists.newArrayList()));
+        Assert.assertNull(table.getInvertedIndex(titleColumn, Lists.newArrayList("sub")));
+    }
+
+    @Test
+    public void testGetInvertedIndexWhenIndexesPresent() {
+        OlapTable table = new OlapTable();
+        Column titleColumn = new Column("title", PrimitiveType.VARCHAR);
+        Column contentColumn = new Column("content", PrimitiveType.VARCHAR);
+
+        Index titleIdx = new Index(1L, "idx_title", Lists.newArrayList("title"),
+                IndexDef.IndexType.INVERTED, Maps.newHashMap(), "");
+        table.setIndexes(Lists.newArrayList(titleIdx));
+
+        Assert.assertNotNull(table.getInvertedIndex(titleColumn, null));
+        Assert.assertEquals("idx_title", table.getInvertedIndex(titleColumn, null).getIndexName());
+        Assert.assertNull(table.getInvertedIndex(contentColumn, null));
+    }
+
     @Test
     public void testTopNPushDownWithTag() throws Exception {
         FeConstants.runningUnitTest = true;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #N/A

### What problem does this PR solve?

Related Jira: DORIS-22946

`OlapTableFactory.withExtraParams` only attaches a `TableIndexes` to plain OLAP tables; the MTMV branch (`CreateMTMVInfo` path) never calls `withIndexes()`, so a freshly created MTMV has `OlapTable.indexes == null`.

When the optimizer transparently rewrites a `MATCH` predicate to an MTMV, `ExpressionTranslator.visitMatch()` calls `OlapTable.getInvertedIndex(column, subPath)` on that MTMV. The method dereferences `indexes.getIndexes()` without a null check, so the query fails with:

```
Cannot invoke "org.apache.doris.catalog.TableIndexes.getIndexes()" because "this.indexes" is null
```

This matches the exception observed when a `MATCH` query against a base table is transparently rewritten to an MTMV whose `TableIndexes` has not been initialized.

Sibling accessors (`getIndexes()`, `getIndexIds()`, `hasIndexOfType()`, `getIndexesMap()`) already guard against `indexes == null`. Master / 4.1 already null-guard `getInvertedIndex` (via #63637). This change brings the same guard to branch-4.0 so the NPE no longer surfaces during MV rewrite. Returning \`null\` is consistent with "no inverted index found on this column", which is the correct semantics here.

### Release note

Fix a NullPointerException raised by MATCH predicates that are rewritten to an asynchronous materialized view whose \`TableIndexes\` has not been initialized.

### Check List (For Author)

- Test
    - [x] Unit Test

- Behavior changed:
    - [ ] No.

- Does this need documentation?
    - [ ] No.

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label