### PR TITLE
[fix](test) Make test_analyze_long_string Case 5 stable against sample rows randomness

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -2642,6 +2642,33 @@ class Suite implements GroovyInterceptable {
         return false;
     }
 
+    // Wait until the table row count reported by BE reaches the expected value.
+    // This is necessary before running sample analyze, because if row count is 0
+    // at task creation time, OlapAnalysisTask.doExecute() returns early without
+    // collecting any statistics, causing the analyze task to finish with an empty
+    // message instead of the expected skip reason.
+    void waitRowCountReady(String db, String table, long expectedRowCount) {
+        Awaitility.await().atMost(120, TimeUnit.SECONDS)
+                .pollInterval(3, TimeUnit.SECONDS).until {
+            def data = sql_return_maparray """SHOW DATA FROM ${db}.${table};"""
+            logger.info("SHOW DATA FROM ${db}.${table}: ${data}")
+            if (data.size() > 0) {
+                // Row 0 is the base index row which always has RowCount.
+                // The last row is "Total" whose RowCount may be empty.
+                def rc = data[0].RowCount
+                // RowCount may be empty string if BE hasn't reported yet.
+                if (rc == null || rc == '') {
+                    return false
+                }
+                def rowCount = (rc as long)
+                if (rowCount >= expectedRowCount) {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+
     // Given tables to decide whether the table partition row count statistic is ready or not
     boolean is_partition_statistics_ready(db, tables)  {
         boolean isReady = true;

--- a/regression-test/suites/statistics/test_analyze_long_string.groovy
+++ b/regression-test/suites/statistics/test_analyze_long_string.groovy
@@ -162,6 +162,8 @@ suite("test_analyze_long_string", "nonConcurrent") {
     sql """insert into test_analyze_long_string_sample values(4, 'dd', 'short3')"""
     sql """insert into test_analyze_long_string_sample values(5, 'ee', 'short4')"""
 
+    waitRowCountReady("test_analyze_long_string", "test_analyze_long_string_sample", 5)
+
     setFeConfigTemporary([statistics_max_string_column_length: 1024]) {
         sql """analyze table test_analyze_long_string_sample with sample percent 100"""
         def jobId = findJobId("internal", "test_analyze_long_string", "test_analyze_long_string_sample")
@@ -232,10 +234,12 @@ suite("test_analyze_long_string", "nonConcurrent") {
         PROPERTIES ("replication_allocation" = "tag.location.default: 1");
     """
     sql """insert into test_analyze_long_string_duj1 values(1, 'aa', repeat('z', 2048))"""
-    sql """insert into test_analyze_long_string_duj1 values(2, 'bb', 'short1')"""
-    sql """insert into test_analyze_long_string_duj1 values(3, 'cc', 'short2')"""
-    sql """insert into test_analyze_long_string_duj1 values(4, 'dd', 'short3')"""
-    sql """insert into test_analyze_long_string_duj1 values(5, 'ee', 'short4')"""
+    sql """insert into test_analyze_long_string_duj1 values(2, 'bb', repeat('z', 2048))"""
+    sql """insert into test_analyze_long_string_duj1 values(3, 'cc', repeat('z', 2048))"""
+    sql """insert into test_analyze_long_string_duj1 values(4, 'dd', repeat('z', 2048))"""
+    sql """insert into test_analyze_long_string_duj1 values(5, 'ee', repeat('z', 2048))"""
+
+    waitRowCountReady("test_analyze_long_string", "test_analyze_long_string_duj1", 5)
 
     setFeConfigTemporary([statistics_max_string_column_length: 1024]) {
         GetDebugPoint().enableDebugPointForAllFEs('OlapAnalysisTask.useDUJ1Template')


### PR DESCRIPTION
## Problem

`test_analyze_long_string` Case 5 (and potentially Case 3) can flake because
after inserting data, the BE may not have reported the row count to FE yet.

When `OlapAnalysisTask.doExecute()` runs with `info.rowCount == 0` and
`tableSample != null`, it returns early without executing any SQL — the
column finishes with `FINISHED` state but an empty message, so the expected
skip reason from the `assert_true` long-string guard is never produced:

```
expected skip reason visible for col big_str, got msg=
==> expected: <true> but was: <false>
```

The audit log confirms that no sampling SQL was issued for `big_str` in
the failing run — the task was short-circuited entirely.

## Fix

1. **Suite.groovy**: Add `waitRowCountReady(db, table, expectedRowCount)`
   that polls `SHOW DATA FROM db.table` via `sql_return_maparray` until
   the BE-reported row count reaches the expected value.

2. **test_analyze_long_string.groovy**: Call `waitRowCountReady` after
   inserts for both sample analyze cases:
   - Case 3 (sample percent 100)
   - Case 5 (sample rows 3, DUJ1 template)

3. Case 5 data uses `repeat('z', 2048)` for all rows — a secondary defense
   against sample randomness missing the long row even when row count is
   properly reported.