### PR TITLE
fix(regression): Make test_analyze_mv row_count assertion stable after truncate

### DIFF
--- a/regression-test/suites/statistics/test_analyze_mv.groovy
+++ b/regression-test/suites/statistics/test_analyze_mv.groovy
@@ -611,7 +611,8 @@ suite("test_analyze_mv") {
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mv3", result_row[0][1])
     assertEquals("0", result_row[0][3])
-    assertEquals("-1", result_row[0][4])
+    assertTrue(result_row[0][4] == "-1" || result_row[0][4] == "0",
+        "Expected row_count to be -1 or 0 after truncate, but got: ${result_row[0][4]}")
 
     // ** Embedded test for skip auto analyze when table is empty
     sql """analyze table mvTestDup properties ("use.auto.analyzer" = "true")"""


### PR DESCRIPTION
## Problem

`statistics/test_analyze_mv.groovy` line 614 asserts `assertEquals("-1", result_row[0][4])` immediately after `truncate table`, expecting `report_row_count_for_nereids` to be -1 (unreported). This is a race condition: BE asynchronously reports new tablet stats (0 rows for empty table) to FE, and if the report arrives before the assertion, the value is 0 instead of -1.

On cloud, this is amplified by `CloudTabletStatMgr` unconditionally setting `rowCountReported=true`, making the -1 state exceptionally short-lived or unobservable.

## Root Cause

After `truncate table`, the FE stat manager (`CloudTabletStatMgr` / `TabletStatMgr`) updates `MaterializedIndex.rowCount` and sets `rowCountReported=true`. The test assertion races with this update:
- If BE hasn't reported yet → `getRowCountForIndex(id, true)` returns -1 ✓
- If BE has reported → returns 0 ✗ (test fails)

## Fix

Change the assertion to accept both -1 and 0, since both are valid states for an empty table after truncate:
- -1: tablet row count not yet reported
- 0: tablet row count reported as 0 (empty table)

Add assertion message with actual value for debuggability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
