### PR TITLE
[fix](clone) When a tablet has some cooldown data, clone will fail

### DIFF
--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -710,7 +710,12 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                         auto ret = ref_tablet->capture_consistent_rowsets_unlocked(
                                 {max_cooldowned_version + 1, version}, CaptureRowsetOps {});
                         if (ret) {
-                            consistent_rowsets = std::move(ret->rowsets);
+                            // Append local rowsets after remote rowsets, do NOT overwrite
+                            auto& local_rowsets = ret->rowsets;
+                            consistent_rowsets.insert(
+                                    consistent_rowsets.end(),
+                                    std::make_move_iterator(local_rowsets.begin()),
+                                    std::make_move_iterator(local_rowsets.end()));
                         } else {
                             res = std::move(ret.error());
                         }


### PR DESCRIPTION
### What problem does this PR solve?
Bug behavior:

When some tablet contains cooldown rowsets and hot rowsets, clone will fail:

meet error status: [INTERNAL_ERROR]unexpected version. tablet version: -1, expected version: 4721

   0#  doris::EngineCloneTask::_set_tablet_info()

   1#  doris::EngineCloneTask::_do_clone()

   2#  doris::EngineCloneTask::execute()

   3#  doris::clone_callback(doris::StorageEngine&, doris::ClusterInfo const*, doris::TAgentTaskRequest const&)

   4#  doris::PriorTaskWorkerPool::normal_loop()

   5#  doris::Thread::supervise_thread(void*)



reproduce:



CREATE RESOURCE s3_resource

PROPERTIES

(

   "type" = "s3",

   "s3.endpoint" = "http://cos.ap-beijing.myqcloud.com/",

   "s3.region" = "ap-beijing",

   "s3.access_key" = "xx",

   "s3.secret_key" = "xx",

    "s3.root.path" = "/luciantest/cooldown_test/",

   "s3.bucket" = "xxxxx-bj-yyyyy",

   "use_path_style" = "false"

);

                             







CREATE STORAGE POLICY cool_policy

PROPERTIES(

    "storage_resource" = "s3_resource",

    "cooldown_ttl" = "600"  

);





CREATE TABLE t1 (

id int

)

DISTRIBUTED BY HASH(`id`) BUCKETS 3

PROPERTIES (

    "storage_policy" = "cool_policy",

    "replication_num" = "1"

);

insert into test.t1 values(1779336512);

-- wait 10 minutes

alter table t1 set ("min_load_replica_num" = "1");


insert into test.t1 values(1779336512);  

alter table t1 set ("replication_allocation" = "tag.location.default: 3");  -- trigger balance and clone


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

