### PR TITLE
[refactor](be) Normalize parquet complex schema projection

### DIFF
--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -185,7 +185,7 @@ int32_t schema_field_id_or(const format::ColumnDefinition* schema_column, int32_
 std::string schema_field_name_or(const format::ColumnDefinition* schema_column,
                                  std::string fallback) {
     return schema_column == nullptr || schema_column->name.empty() ? std::move(fallback)
-                                                                  : schema_column->name;
+                                                                   : schema_column->name;
 }
 
 struct AccessPathNode {
@@ -269,12 +269,12 @@ Status build_all_nested_children_from_schema(format::ColumnDefinition* column,
     case TYPE_ARRAY: {
         const auto& array_type = assert_cast<const DataTypeArray&>(*nested_type);
         const auto* element_schema = &schema_column->children[0];
-        auto* child = find_or_add_child(
-                column, schema_field_id_or(element_schema, 0),
-                schema_field_name_or(element_schema, "element"), array_type.get_nested_type());
+        auto* child = find_or_add_child(column, schema_field_id_or(element_schema, 0),
+                                        schema_field_name_or(element_schema, "element"),
+                                        array_type.get_nested_type());
         inherit_schema_metadata(child, element_schema);
-        return build_nested_children_from_access_node(child, child->type, project_all,
-                                                      path + ".*", element_schema);
+        return build_nested_children_from_access_node(child, child->type, project_all, path + ".*",
+                                                      element_schema);
     }
     case TYPE_MAP: {
         const auto& map_type = assert_cast<const DataTypeMap&>(*nested_type);
@@ -285,20 +285,18 @@ Status build_all_nested_children_from_schema(format::ColumnDefinition* column,
         Strings entry_child_names {"key", "value"};
         auto entry_type = std::make_shared<DataTypeStruct>(entry_child_types, entry_child_names);
         auto* entry_child = find_or_add_child(column, 0, "entries", entry_type);
-        auto* key_child = find_or_add_child(
-                entry_child, schema_field_id_or(key_schema, 0),
-                schema_field_name_or(key_schema, "key"), map_type.get_key_type());
+        auto* key_child =
+                find_or_add_child(entry_child, schema_field_id_or(key_schema, 0),
+                                  schema_field_name_or(key_schema, "key"), map_type.get_key_type());
         inherit_schema_metadata(key_child, key_schema);
-        RETURN_IF_ERROR(build_nested_children_from_access_node(key_child, key_child->type,
-                                                               project_all, path + ".KEYS",
-                                                               key_schema));
-        auto* value_child = find_or_add_child(
-                entry_child, schema_field_id_or(value_schema, 1),
-                schema_field_name_or(value_schema, "value"), map_type.get_value_type());
+        RETURN_IF_ERROR(build_nested_children_from_access_node(
+                key_child, key_child->type, project_all, path + ".KEYS", key_schema));
+        auto* value_child = find_or_add_child(entry_child, schema_field_id_or(value_schema, 1),
+                                              schema_field_name_or(value_schema, "value"),
+                                              map_type.get_value_type());
         inherit_schema_metadata(value_child, value_schema);
-        RETURN_IF_ERROR(build_nested_children_from_access_node(value_child, value_child->type,
-                                                               project_all, path + ".VALUES",
-                                                               value_schema));
+        RETURN_IF_ERROR(build_nested_children_from_access_node(
+                value_child, value_child->type, project_all, path + ".VALUES", value_schema));
         return Status::OK();
     }
     default:
@@ -428,10 +426,9 @@ Status build_map_children_from_access_node(format::ColumnDefinition* column,
                                                                path + ".KEYS", key_schema));
     }
     if (need_value) {
-        auto* value_child =
-                find_or_add_child(entry_child, schema_field_id_or(value_schema, 1),
-                                  schema_field_name_or(value_schema, "value"),
-                                  map_type.get_value_type());
+        auto* value_child = find_or_add_child(entry_child, schema_field_id_or(value_schema, 1),
+                                              schema_field_name_or(value_schema, "value"),
+                                              map_type.get_value_type());
         inherit_schema_metadata(value_child, value_schema);
         RETURN_IF_ERROR(build_nested_children_from_access_node(
                 value_child, value_child->type, value_node, path + ".VALUES", value_schema));
@@ -463,10 +460,9 @@ Status build_nested_children_from_access_node(format::ColumnDefinition* column,
         const auto* element_schema = schema_column != nullptr && !schema_column->children.empty()
                                              ? &schema_column->children[0]
                                              : nullptr;
-        auto* child =
-                find_or_add_child(column, schema_field_id_or(element_schema, 0),
-                                  schema_field_name_or(element_schema, "element"),
-                                  array_type.get_nested_type());
+        auto* child = find_or_add_child(column, schema_field_id_or(element_schema, 0),
+                                        schema_field_name_or(element_schema, "element"),
+                                        array_type.get_nested_type());
         inherit_schema_metadata(child, element_schema);
         return build_nested_children_from_access_node(child, child->type, node.children.at("*"),
                                                       path + ".*", element_schema);

--- a/be/src/format_v2/column_data.h
+++ b/be/src/format_v2/column_data.h
@@ -253,8 +253,7 @@ struct ColumnDefinition {
     //
     // Table/global columns carry projected table children. File-local schemas returned by
     // FileReader::get_schema() also expose semantic children, not physical reader wrappers. For
-    // example, MAP children are key/value, while a file format such as Parquet may keep its
-    // key_value/entry wrapper in its private reader schema and translate projections internally.
+    // example, MAP children are key/value and ARRAY children contain only the element field.
     std::vector<ColumnDefinition> children {};
     // Expression used to materialize missing/default/generated values when the column is not read
     // directly from the file.

--- a/be/src/format_v2/column_data.h
+++ b/be/src/format_v2/column_data.h
@@ -249,8 +249,12 @@ struct ColumnDefinition {
     // use this to resolve partition path keys after column rename.
     std::vector<std::string> name_mapping {};
     DataTypePtr type;
-    // Projected nested table children. Children use table/global identifiers; they are resolved to
-    // file-local child ids by TableColumnMapper before reaching FileReader.
+    // Semantic nested children for this schema node.
+    //
+    // Table/global columns carry projected table children. File-local schemas returned by
+    // FileReader::get_schema() also expose semantic children, not physical reader wrappers. For
+    // example, MAP children are key/value, while a file format such as Parquet may keep its
+    // key_value/entry wrapper in its private reader schema and translate projections internally.
     std::vector<ColumnDefinition> children {};
     // Expression used to materialize missing/default/generated values when the column is not read
     // directly from the file.

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -840,7 +840,13 @@ static Status rebuild_projected_file_children_and_type(
     return Status::OK();
 }
 
-// Build the complex column projection according to the ColumnMapping which is re-ordered by the file-schema's order.
+// Build the complex column projection according to the ColumnMapping which is re-ordered by the
+// file-schema's order.
+//
+// For MAP, a partial projection represents value-subtree pruning only. The key child is not a
+// projected output shape; file readers still read full keys to construct ColumnMap offsets and keep
+// key semantics unchanged. If a caller tries to project only/prune the key child, the common schema
+// projection helper rejects it.
 static Status build_complex_projection(const ColumnMapping& mapping, LocalColumnIndex* projection) {
     if (projection == nullptr) {
         return Status::InvalidArgument("projection is null");

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1545,8 +1545,8 @@ Status TableColumnMapper::_create_direct_mapping(const ColumnDefinition& table_c
     if (!table_column.children.empty()) {
         DORIS_CHECK(is_complex_type(mapping->file_type->get_primitive_type()));
         for (const auto& table_child : table_column.children) {
-            const auto* file_child = matcher_for_mode(_options.mode)
-                                             .find(table_child, file_field.children);
+            const auto* file_child =
+                    matcher_for_mode(_options.mode).find(table_child, file_field.children);
             if (file_child == nullptr) {
                 ColumnMapping child_mapping;
                 child_mapping.table_column_name = table_child.name;

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -541,25 +541,6 @@ static void collect_top_level_slot_columns(const VExprSPtr& expr,
     }
 }
 
-static std::vector<ColumnDefinition> projected_file_children_from_child_mappings(
-        const std::vector<ColumnDefinition>& original_file_children,
-        const std::vector<ColumnMapping>& child_mappings) {
-    std::vector<ColumnDefinition> result;
-    result.reserve(child_mappings.size());
-    for (const auto* child_mapping : present_child_mappings_in_file_order(child_mappings)) {
-        const auto file_child_it = std::ranges::find_if(
-                original_file_children, [&](const ColumnDefinition& file_child) {
-                    return file_child.file_local_id() == *child_mapping->file_local_id;
-                });
-        DORIS_CHECK(file_child_it != original_file_children.end());
-        ColumnDefinition projected_child = *file_child_it;
-        projected_child.type = child_mapping->file_type;
-        projected_child.children = child_mapping->projected_file_children;
-        result.push_back(std::move(projected_child));
-    }
-    return result;
-}
-
 static VExprSPtr rewrite_literal_to_file_type(const VExprSPtr& literal_expr,
                                               const FileSlotRewriteInfo& rewrite_info,
                                               RewriteContext* rewrite_context) {
@@ -828,24 +809,35 @@ static bool needs_nested_file_projection(const ColumnMapping& mapping) {
     });
 }
 
-// Build the projected file type according to the pruned complex projection. For example, if we
-// have a struct column `s` with children `id` and `name`, and the projection only keeps `s.name`,
-// then we need to build the projected file type of `s` to only contain `name` so that the file
-// reader can read it correctly.
-static Status build_projected_child_type(const DataTypePtr& file_type,
-                                         const std::vector<ColumnMapping>& child_mappings,
-                                         DataTypePtr* projected_type) {
+static Status build_complex_projection(const ColumnMapping& mapping, LocalColumnIndex* projection);
+
+// Build the projected file children/type according to the pruned complex projection. For example,
+// if we have a struct column `s` with children `id` and `name`, and the projection only keeps
+// `s.name`, then the file reader should expose `STRUCT<name ...>`.
+static Status rebuild_projected_file_children_and_type(
+        const DataTypePtr& file_type, const std::vector<ColumnDefinition>& original_file_children,
+        const std::vector<ColumnMapping>& child_mappings,
+        std::vector<ColumnDefinition>* projected_file_children, DataTypePtr* projected_type) {
     DORIS_CHECK(file_type != nullptr);
+    DORIS_CHECK(projected_file_children != nullptr);
     DORIS_CHECK(projected_type != nullptr);
-    DataTypes child_types;
-    Strings child_names;
-    child_types.reserve(child_mappings.size());
-    child_names.reserve(child_mappings.size());
+    ColumnDefinition field;
+    field.type = file_type;
+    field.children = original_file_children;
+    LocalColumnIndex projection = LocalColumnIndex::partial_local(-1);
+    projection.children.reserve(child_mappings.size());
     for (const auto* child_mapping : present_child_mappings_in_file_order(child_mappings)) {
-        child_types.push_back(child_mapping->file_type);
-        child_names.push_back(child_mapping->file_column_name);
+        DORIS_CHECK(child_mapping->file_local_id.has_value());
+        LocalColumnIndex child_projection;
+        RETURN_IF_ERROR(build_complex_projection(*child_mapping, &child_projection));
+        projection.children.push_back(std::move(child_projection));
     }
-    return rebuild_projected_type(file_type, child_types, child_names, projected_type);
+
+    ColumnDefinition projected_field;
+    RETURN_IF_ERROR(project_column_definition(field, projection, &projected_field));
+    *projected_file_children = std::move(projected_field.children);
+    *projected_type = std::move(projected_field.type);
+    return Status::OK();
 }
 
 // Build the complex column projection according to the ColumnMapping which is re-ordered by the file-schema's order.
@@ -1547,8 +1539,8 @@ Status TableColumnMapper::_create_direct_mapping(const ColumnDefinition& table_c
     if (!table_column.children.empty()) {
         DORIS_CHECK(is_complex_type(mapping->file_type->get_primitive_type()));
         for (const auto& table_child : table_column.children) {
-            const auto* file_child =
-                    find_file_child_for_complex_wrapper(table_child, file_field, _options.mode);
+            const auto* file_child = matcher_for_mode(_options.mode)
+                                             .find(table_child, file_field.children);
             if (file_child == nullptr) {
                 ColumnMapping child_mapping;
                 child_mapping.table_column_name = table_child.name;
@@ -1567,10 +1559,9 @@ Status TableColumnMapper::_create_direct_mapping(const ColumnDefinition& table_c
         }
         if (needs_projected_file_type_rebuild(*mapping)) {
             // If complex projection prunes some children, we have to rebuild the projected file type to make sure the reader expression can find the correct child types by name.
-            RETURN_IF_ERROR(build_projected_child_type(mapping->file_type, mapping->child_mappings,
-                                                       &mapping->file_type));
-            mapping->projected_file_children = projected_file_children_from_child_mappings(
-                    mapping->original_file_children, mapping->child_mappings);
+            RETURN_IF_ERROR(rebuild_projected_file_children_and_type(
+                    mapping->file_type, mapping->original_file_children, mapping->child_mappings,
+                    &mapping->projected_file_children, &mapping->file_type));
             DCHECK(mapping->table_type != nullptr);
             mapping->is_trivial = mapping->table_type->equals(*mapping->file_type);
             // TODO: ? READER_EXPRESSION

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1107,34 +1107,6 @@ static std::map<GlobalIndex, FileSlotRewriteInfo> build_file_slot_rewrite_map(
     return global_to_file_slot;
 }
 
-static const ColumnDefinition* find_file_child_by_table_column(
-        const ColumnDefinition& table_column, const std::vector<ColumnDefinition>& file_children,
-        TableColumnMappingMode mode) {
-    return matcher_for_mode(mode).find(table_column, file_children);
-}
-
-static const ColumnDefinition* find_file_child_for_complex_wrapper(
-        const ColumnDefinition& table_child, const ColumnDefinition& file_field,
-        TableColumnMappingMode mode) {
-    if (file_field.children.empty()) {
-        return nullptr;
-    }
-    const auto* file_child =
-            find_file_child_by_table_column(table_child, file_field.children, mode);
-    if (file_child != nullptr) {
-        return file_child;
-    }
-    if (remove_nullable(file_field.type)->get_primitive_type() == TYPE_ARRAY &&
-        file_field.children.size() == 1) {
-        return &file_field.children[0];
-    }
-    if (remove_nullable(file_field.type)->get_primitive_type() == TYPE_MAP &&
-        file_field.children.size() == 1 && column_has_name(table_child, "entries")) {
-        return &file_field.children[0];
-    }
-    return nullptr;
-}
-
 Status TableColumnMapper::_create_by_index_mapping(const ColumnDefinition& table_column,
                                                    const std::vector<ColumnDefinition>& file_schema,
                                                    ColumnMapping* mapping) {

--- a/be/src/format_v2/column_mapper.h
+++ b/be/src/format_v2/column_mapper.h
@@ -130,8 +130,8 @@ struct ColumnMapping {
     // and to localize nested filters that reference children not present in the output projection.
     DataTypePtr original_file_type;
     std::vector<ColumnDefinition> original_file_children;
-    // File children after applying the scan projection. The order follows the physical file schema,
-    // not table child order. TableReader uses this to map table-output children back to the
+    // File children after applying the scan projection. The order follows the file-local semantic
+    // schema, not table child order. TableReader uses this to map table-output children back to the
     // file-local block layout when projection, predicate-only children, and schema evolution mix.
     std::vector<ColumnDefinition> projected_file_children;
     // Split/file-local constant entry when this mapping is produced from partition/default/virtual

--- a/be/src/format_v2/file_reader.h
+++ b/be/src/format_v2/file_reader.h
@@ -212,12 +212,14 @@ public:
     // Initialize file reader and parse file metadata.
     virtual Status init(RuntimeState* state);
 
-    // Get file-local schema from file metadata. The file schema is determined by file format and
-    // file content, and does not contain table/global schema semantics. A file reader may expose
-    // raw file identifiers, such as Parquet field_id, through ColumnDefinition::identifier, but it
-    // must not interpret table-format semantics such as Iceberg name mapping, default/generated
-    // columns, or partition columns. This method can only be called after init() successfully, but
-    // does not require open() to be called.
+    // Get semantic file-local schema from file metadata. The file schema is determined by file
+    // format and file content, and does not contain table/global schema semantics. A file reader may
+    // expose raw file identifiers, such as Parquet field_id, through ColumnDefinition::identifier,
+    // but it must not interpret table-format semantics such as Iceberg name mapping,
+    // default/generated columns, or partition columns. File-format physical wrappers should stay in
+    // private reader schema; for example, a Parquet MAP is exposed as key/value children rather than
+    // key_value/entry. This method can only be called after init() successfully, but does not
+    // require open() to be called.
     virtual Status get_schema(std::vector<ColumnDefinition>* file_schema) const = 0;
 
     // Open the file reader with file-local scan request. The file reader should initialize its internal state according to the request, but does not need to interpret table/global schema semantics. For example, all schema change, filter localization, default/generated/partition columns should be handled in table reader layer. This method can only be called after init() successfully.

--- a/be/src/format_v2/file_reader.h
+++ b/be/src/format_v2/file_reader.h
@@ -216,10 +216,10 @@ public:
     // format and file content, and does not contain table/global schema semantics. A file reader may
     // expose raw file identifiers, such as Parquet field_id, through ColumnDefinition::identifier,
     // but it must not interpret table-format semantics such as Iceberg name mapping,
-    // default/generated columns, or partition columns. File-format physical wrappers should stay in
-    // private reader schema; for example, a Parquet MAP is exposed as key/value children rather than
-    // key_value/entry. This method can only be called after init() successfully, but does not
-    // require open() to be called.
+    // default/generated columns, or partition columns. File-format physical wrappers should be
+    // normalized away before exposing this schema; for example, Parquet MAP is exposed as key/value
+    // children rather than key_value/entry. This method can only be called after init()
+    // successfully, but does not require open() to be called.
     virtual Status get_schema(std::vector<ColumnDefinition>* file_schema) const = 0;
 
     // Open the file reader with file-local scan request. The file reader should initialize its internal state according to the request, but does not need to interpret table/global schema semantics. For example, all schema change, filter localization, default/generated/partition columns should be handled in table reader layer. This method can only be called after init() successfully.

--- a/be/src/format_v2/parquet/parquet_column_schema.cpp
+++ b/be/src/format_v2/parquet/parquet_column_schema.cpp
@@ -160,8 +160,9 @@ void propagate_child_levels(ParquetColumnSchema* column_schema) {
 // Important cases:
 // - repeated primitive: the primitive itself is the element (legacy two-level LIST).
 // - repeated group with multiple children: the group itself is a STRUCT element.
-// - repeated group named "array" or "<list_name>_tuple": the group itself is a STRUCT element per
-//   Parquet backward compatibility rules, even when it has one child.
+// - repeated group named "array" or "<list_name>_tuple" and without a logical annotation: the
+//   group itself is a STRUCT element per Parquet backward compatibility rules, even when it has
+//   one child.
 // - repeated group with a logical annotation, or whose only child is repeated: the group itself is
 //   the element. This preserves nested LIST/MAP and repeated fields inside struct elements.
 // - otherwise, strip the one-child repeated wrapper as standard three-level LIST encoding.
@@ -193,9 +194,11 @@ Status resolve_list_element_node(const ::parquet::schema::GroupNode& list_group,
         return Status::NotSupported("Unsupported parquet LIST element layout for column {}",
                                     list_group.name());
     }
+    const bool repeated_group_has_logical_annotation = has_logical_annotation(repeated_group);
     if (repeated_group.field_count() > 1 ||
-        has_structural_list_name(list_group.name(), repeated_group.name()) ||
-        has_logical_annotation(repeated_group)) {
+        (!repeated_group_has_logical_annotation &&
+         has_structural_list_name(list_group.name(), repeated_group.name())) ||
+        repeated_group_has_logical_annotation) {
         result->element_node = &repeated_node;
         result->element_context = result->repeated_context;
         result->element_is_repeated_node = true;

--- a/be/src/format_v2/parquet/parquet_column_schema.cpp
+++ b/be/src/format_v2/parquet/parquet_column_schema.cpp
@@ -43,6 +43,46 @@ struct SchemaBuildContext {
     int16_t repeated_ancestor_definition_level = 0;
 };
 
+enum class SchemaBuildMode {
+    // Normal recursive schema build. A repeated LIST/MAP annotated group is rejected in this mode
+    // because Parquet LIST/MAP outer groups are not allowed to be repeated at a top-level or struct
+    // field boundary.
+    NORMAL,
+    // Build the current repeated node as the already-selected element of an enclosing LIST. This
+    // is the compatibility path for Arrow/parquet-format legacy two-level LIST encodings where the
+    // repeated node itself is the array element instead of a wrapper that should be stripped.
+    REPEATED_NODE_AS_LIST_ELEMENT,
+};
+
+// Result of applying Parquet LIST backward compatibility rules to the single repeated child of a
+// LIST-annotated group. The repeated child can either be a physical wrapper whose only child is the
+// element, or the element node itself.
+struct ListElementResolution {
+    // Parquet node that should be exposed as Doris ARRAY element.
+    const ::parquet::schema::Node* element_node = nullptr;
+    // Level state after consuming the LIST repeated child. The parent ARRAY schema keeps this state
+    // to materialize offsets, empty arrays and null arrays.
+    SchemaBuildContext repeated_context;
+    // Level state used to build element_node. This equals repeated_context when the repeated child
+    // itself is the element, and includes the wrapper's only child when standard 3-level LIST
+    // encoding is stripped.
+    SchemaBuildContext element_context;
+    // True when element_node is the repeated child itself. The builder then uses
+    // REPEATED_NODE_AS_LIST_ELEMENT so the repeated level is not interpreted as a second unrelated
+    // array at the same boundary.
+    bool element_is_repeated_node = false;
+};
+
+// Resolved repeated entry group of a MAP-annotated group. The entry wrapper is a physical Parquet
+// encoding detail; Doris folds it into the parent MAP schema and exposes only direct [key, value]
+// children.
+struct MapEntryResolution {
+    const ::parquet::schema::GroupNode* entry_group = nullptr;
+    // Level state after consuming the repeated entry group. The parent MAP schema keeps this state
+    // to materialize offsets, empty maps and null maps.
+    SchemaBuildContext entry_context;
+};
+
 bool is_list_node(const ::parquet::schema::Node& node) {
     const auto& logical_type = node.logical_type();
     return node.converted_type() == ::parquet::ConvertedType::LIST ||
@@ -54,6 +94,17 @@ bool is_map_node(const ::parquet::schema::Node& node) {
     return node.converted_type() == ::parquet::ConvertedType::MAP ||
            node.converted_type() == ::parquet::ConvertedType::MAP_KEY_VALUE ||
            (logical_type != nullptr && logical_type->is_valid() && logical_type->is_map());
+}
+
+bool has_logical_annotation(const ::parquet::schema::Node& node) {
+    const auto& logical_type = node.logical_type();
+    return (node.converted_type() != ::parquet::ConvertedType::NONE &&
+            node.converted_type() != ::parquet::ConvertedType::UNDEFINED) ||
+           (logical_type != nullptr && logical_type->is_valid() && !logical_type->is_none());
+}
+
+bool has_structural_list_name(const std::string& list_name, const std::string& repeated_name) {
+    return repeated_name == "array" || repeated_name == list_name + "_tuple";
 }
 
 DataTypePtr nullable_if_needed(DataTypePtr type, const ::parquet::schema::Node& node) {
@@ -103,10 +154,154 @@ void propagate_child_levels(ParquetColumnSchema* column_schema) {
     }
 }
 
-// Recursively builds ParquetColumnSchema for the given schema node and its children in Parquet file's metadata.
-Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
-                         const ::parquet::schema::Node& node, const SchemaBuildContext& context,
-                         std::unique_ptr<ParquetColumnSchema>* result) {
+// Mirrors Arrow's ResolveList() compatibility rules, but only decides which Parquet node is the
+// logical LIST element. The caller still builds Doris' semantic LIST->[element] schema tree.
+//
+// Important cases:
+// - repeated primitive: the primitive itself is the element (legacy two-level LIST).
+// - repeated group with multiple children: the group itself is a STRUCT element.
+// - repeated group named "array" or "<list_name>_tuple": the group itself is a STRUCT element per
+//   Parquet backward compatibility rules, even when it has one child.
+// - repeated group with a logical annotation, or whose only child is repeated: the group itself is
+//   the element. This preserves nested LIST/MAP and repeated fields inside struct elements.
+// - otherwise, strip the one-child repeated wrapper as standard three-level LIST encoding.
+Status resolve_list_element_node(const ::parquet::schema::GroupNode& list_group,
+                                 const SchemaBuildContext& list_context,
+                                 ListElementResolution* result) {
+    if (result == nullptr) {
+        return Status::InvalidArgument("result is null");
+    }
+    if (list_group.field_count() != 1) {
+        return Status::NotSupported("Unsupported parquet LIST encoding for column {}",
+                                    list_group.name());
+    }
+    const auto& repeated_node = *list_group.field(0);
+    if (!repeated_node.is_repeated()) {
+        return Status::NotSupported("Unsupported parquet LIST encoding for column {}",
+                                    list_group.name());
+    }
+    result->repeated_context = child_context(list_context, repeated_node, 0);
+    if (repeated_node.is_primitive()) {
+        result->element_node = &repeated_node;
+        result->element_context = result->repeated_context;
+        result->element_is_repeated_node = true;
+        return Status::OK();
+    }
+
+    const auto& repeated_group = static_cast<const ::parquet::schema::GroupNode&>(repeated_node);
+    if (repeated_group.field_count() == 0) {
+        return Status::NotSupported("Unsupported parquet LIST element layout for column {}",
+                                    list_group.name());
+    }
+    if (repeated_group.field_count() > 1 ||
+        has_structural_list_name(list_group.name(), repeated_group.name()) ||
+        has_logical_annotation(repeated_group)) {
+        result->element_node = &repeated_node;
+        result->element_context = result->repeated_context;
+        result->element_is_repeated_node = true;
+        return Status::OK();
+    }
+
+    const auto& only_child = *repeated_group.field(0);
+    if (only_child.is_repeated()) {
+        result->element_node = &repeated_node;
+        result->element_context = result->repeated_context;
+        result->element_is_repeated_node = true;
+        return Status::OK();
+    }
+
+    result->element_node = &only_child;
+    result->element_context = child_context(result->repeated_context, only_child, 0);
+    result->element_is_repeated_node = false;
+    return Status::OK();
+}
+
+// Resolves the repeated entry group of a MAP/MAP_KEY_VALUE node. Unlike LIST, MAP has no supported
+// two-level form in this reader: Doris requires a repeated group with exactly required key and
+// value children, then folds that physical entry group out of ParquetColumnSchema.
+Status resolve_map_entry_group(const ::parquet::schema::GroupNode& map_group,
+                               const SchemaBuildContext& map_context, MapEntryResolution* result) {
+    if (result == nullptr) {
+        return Status::InvalidArgument("result is null");
+    }
+    if (map_group.field_count() != 1) {
+        return Status::NotSupported("Unsupported parquet MAP encoding for column {}",
+                                    map_group.name());
+    }
+    const auto& entry_node = *map_group.field(0);
+    if (!entry_node.is_repeated()) {
+        return Status::NotSupported("Unsupported parquet MAP encoding for column {}",
+                                    map_group.name());
+    }
+    if (entry_node.is_primitive()) {
+        return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
+                                    map_group.name());
+    }
+    const auto& entry_group = static_cast<const ::parquet::schema::GroupNode&>(entry_node);
+    if (entry_group.field_count() != 2) {
+        return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
+                                    map_group.name());
+    }
+    if (entry_group.field(0)->repetition() != ::parquet::Repetition::REQUIRED) {
+        return Status::NotSupported("Unsupported nullable parquet MAP key for column {}",
+                                    map_group.name());
+    }
+    result->entry_group = &entry_group;
+    result->entry_context = child_context(map_context, entry_node, 0);
+    return Status::OK();
+}
+
+Status build_node_schema_with_mode(const ::parquet::SchemaDescriptor& schema,
+                                   const ::parquet::schema::Node& node,
+                                   const SchemaBuildContext& context,
+                                   std::unique_ptr<ParquetColumnSchema>* result,
+                                   SchemaBuildMode mode);
+
+// Builds a semantic ARRAY schema for a simple repeated field. Arrow handles this in
+// NodeToSchemaField()/GroupToSchemaField(); Doris only enables it while materializing the element
+// of a LIST-annotated parent, so existing top-level repeated primitive rejection is unchanged.
+//
+// Example:
+//   optional group a (LIST) {
+//     repeated group element {
+//       repeated int32 items;
+//     }
+//   }
+// The outer LIST element is the repeated "element" group, and its repeated "items" child should be
+// represented as a field of type ARRAY<INT> inside the struct element.
+Status build_repeated_field_as_list_schema(const ::parquet::SchemaDescriptor& schema,
+                                           const ::parquet::schema::Node& repeated_node,
+                                           const SchemaBuildContext& repeated_context,
+                                           std::unique_ptr<ParquetColumnSchema>* result) {
+    if (result == nullptr) {
+        return Status::InvalidArgument("result is null");
+    }
+    auto list_schema = std::make_unique<ParquetColumnSchema>();
+    inherit_common_schema_state(repeated_node, repeated_context, list_schema.get());
+    list_schema->kind = ParquetColumnSchemaKind::LIST;
+    list_schema->definition_level = repeated_context.definition_level;
+    list_schema->repetition_level = repeated_context.repetition_level;
+    list_schema->repeated_repetition_level = repeated_context.repeated_repetition_level;
+
+    std::unique_ptr<ParquetColumnSchema> element_child;
+    RETURN_IF_ERROR(build_node_schema_with_mode(schema, repeated_node, repeated_context,
+                                                &element_child,
+                                                SchemaBuildMode::REPEATED_NODE_AS_LIST_ELEMENT));
+    list_schema->type = std::make_shared<DataTypeArray>(element_child->type);
+    list_schema->children.push_back(std::move(element_child));
+    propagate_child_levels(list_schema.get());
+    *result = std::move(list_schema);
+    return Status::OK();
+}
+
+// Recursively builds ParquetColumnSchema for the given schema node and its children in Parquet
+// file's metadata. The mode only affects repeated nodes that have already been selected as LIST
+// elements by resolve_list_element_node(); normal file schema recursion remains strict.
+Status build_node_schema_with_mode(const ::parquet::SchemaDescriptor& schema,
+                                   const ::parquet::schema::Node& node,
+                                   const SchemaBuildContext& context,
+                                   std::unique_ptr<ParquetColumnSchema>* result,
+                                   SchemaBuildMode mode) {
     if (result == nullptr) {
         return Status::InvalidArgument("result is null");
     }
@@ -141,30 +336,22 @@ Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
 
     const auto& group = static_cast<const ::parquet::schema::GroupNode&>(node);
     if (is_list_node(node)) {
+        if (mode == SchemaBuildMode::NORMAL && node.is_repeated()) {
+            return Status::NotSupported("Unsupported repeated parquet LIST column {}", node.name());
+        }
         column_schema->kind = ParquetColumnSchemaKind::LIST;
-        if (group.field_count() != 1) {
-            return Status::NotSupported("Unsupported parquet LIST encoding for column {}",
-                                        node.name());
-        }
-        const auto& repeated_node = *group.field(0);
-        if (!repeated_node.is_repeated() || repeated_node.is_primitive()) {
-            return Status::NotSupported("Unsupported parquet LIST encoding for column {}",
-                                        node.name());
-        }
-        const auto& repeated_group =
-                static_cast<const ::parquet::schema::GroupNode&>(repeated_node);
-        if (repeated_group.field_count() != 1) {
-            return Status::NotSupported("Unsupported parquet LIST element layout for column {}",
-                                        node.name());
-        }
-        auto repeated_context = child_context(context, repeated_node, 0);
-        column_schema->definition_level = repeated_context.definition_level;
-        column_schema->repetition_level = repeated_context.repetition_level;
-        column_schema->repeated_repetition_level = repeated_context.repeated_repetition_level;
+        ListElementResolution list_element;
+        RETURN_IF_ERROR(resolve_list_element_node(group, context, &list_element));
+        column_schema->definition_level = list_element.repeated_context.definition_level;
+        column_schema->repetition_level = list_element.repeated_context.repetition_level;
+        column_schema->repeated_repetition_level =
+                list_element.repeated_context.repeated_repetition_level;
         std::unique_ptr<ParquetColumnSchema> child;
-        RETURN_IF_ERROR(build_node_schema(
-                schema, *repeated_group.field(0),
-                child_context(repeated_context, *repeated_group.field(0), 0), &child));
+        RETURN_IF_ERROR(build_node_schema_with_mode(
+                schema, *list_element.element_node, list_element.element_context, &child,
+                list_element.element_is_repeated_node
+                        ? SchemaBuildMode::REPEATED_NODE_AS_LIST_ELEMENT
+                        : SchemaBuildMode::NORMAL));
         column_schema->type =
                 nullable_if_needed(std::make_shared<DataTypeArray>(child->type), node);
         column_schema->children.push_back(std::move(child));
@@ -174,44 +361,27 @@ Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
     }
 
     if (is_map_node(node)) {
+        if (mode == SchemaBuildMode::NORMAL && node.is_repeated()) {
+            return Status::NotSupported("Unsupported repeated parquet MAP column {}", node.name());
+        }
         column_schema->kind = ParquetColumnSchemaKind::MAP;
-        if (group.field_count() != 1) {
-            return Status::NotSupported("Unsupported parquet MAP encoding for column {}",
-                                        node.name());
-        }
-        const auto& key_value_node = *group.field(0);
-        if (!key_value_node.is_repeated()) {
-            return Status::NotSupported("Unsupported parquet MAP encoding for column {}",
-                                        node.name());
-        }
-        auto key_value_context = child_context(context, key_value_node, 0);
-        column_schema->definition_level = key_value_context.definition_level;
-        column_schema->repetition_level = key_value_context.repetition_level;
-        column_schema->repeated_repetition_level = key_value_context.repeated_repetition_level;
-        if (key_value_node.is_primitive()) {
-            return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
-                                        node.name());
-        }
-        const auto& key_value_group =
-                static_cast<const ::parquet::schema::GroupNode&>(key_value_node);
-        if (key_value_group.field_count() != 2) {
-            return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
-                                        node.name());
-        }
-        for (int child_idx = 0; child_idx < key_value_group.field_count(); ++child_idx) {
+        MapEntryResolution map_entry;
+        RETURN_IF_ERROR(resolve_map_entry_group(group, context, &map_entry));
+        column_schema->definition_level = map_entry.entry_context.definition_level;
+        column_schema->repetition_level = map_entry.entry_context.repetition_level;
+        column_schema->repeated_repetition_level =
+                map_entry.entry_context.repeated_repetition_level;
+        for (int child_idx = 0; child_idx < map_entry.entry_group->field_count(); ++child_idx) {
             std::unique_ptr<ParquetColumnSchema> child;
-            RETURN_IF_ERROR(build_node_schema(
-                    schema, *key_value_group.field(child_idx),
-                    child_context(key_value_context, *key_value_group.field(child_idx), child_idx),
-                    &child));
+            RETURN_IF_ERROR(build_node_schema_with_mode(
+                    schema, *map_entry.entry_group->field(child_idx),
+                    child_context(map_entry.entry_context, *map_entry.entry_group->field(child_idx),
+                                  child_idx),
+                    &child, SchemaBuildMode::NORMAL));
             column_schema->children.push_back(std::move(child));
         }
         if (column_schema->children.size() != 2) {
             return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
-                                        node.name());
-        }
-        if (key_value_group.field(0)->repetition() != ::parquet::Repetition::REQUIRED) {
-            return Status::NotSupported("Unsupported nullable parquet MAP key for column {}",
                                         node.name());
         }
         auto key_type = make_nullable(column_schema->children[0]->type);
@@ -229,10 +399,17 @@ Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
     child_types.reserve(group.field_count());
     child_names.reserve(group.field_count());
     for (int child_idx = 0; child_idx < group.field_count(); ++child_idx) {
+        const auto& child_node = *group.field(child_idx);
         std::unique_ptr<ParquetColumnSchema> child;
-        RETURN_IF_ERROR(build_node_schema(
-                schema, *group.field(child_idx),
-                child_context(context, *group.field(child_idx), child_idx), &child));
+        const auto child_ctx = child_context(context, child_node, child_idx);
+        if (mode == SchemaBuildMode::REPEATED_NODE_AS_LIST_ELEMENT && child_node.is_repeated() &&
+            !is_list_node(child_node) && !is_map_node(child_node)) {
+            RETURN_IF_ERROR(
+                    build_repeated_field_as_list_schema(schema, child_node, child_ctx, &child));
+        } else {
+            RETURN_IF_ERROR(build_node_schema_with_mode(schema, child_node, child_ctx, &child,
+                                                        SchemaBuildMode::NORMAL));
+        }
         child_types.push_back(make_nullable(child->type));
         child_names.push_back(child->name);
         column_schema->children.push_back(std::move(child));
@@ -242,6 +419,12 @@ Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
     propagate_child_levels(column_schema.get());
     *result = std::move(column_schema);
     return Status::OK();
+}
+
+Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
+                         const ::parquet::schema::Node& node, const SchemaBuildContext& context,
+                         std::unique_ptr<ParquetColumnSchema>* result) {
+    return build_node_schema_with_mode(schema, node, context, result, SchemaBuildMode::NORMAL);
 }
 
 } // namespace

--- a/be/src/format_v2/parquet/parquet_column_schema.cpp
+++ b/be/src/format_v2/parquet/parquet_column_schema.cpp
@@ -198,26 +198,15 @@ Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
             return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
                                         node.name());
         }
-        auto key_value = std::make_unique<ParquetColumnSchema>();
-        inherit_common_schema_state(key_value_node, key_value_context, key_value.get());
-        key_value->kind = ParquetColumnSchemaKind::STRUCT;
-        DataTypes child_types;
-        Strings child_names;
-        child_types.reserve(key_value_group.field_count());
-        child_names.reserve(key_value_group.field_count());
         for (int child_idx = 0; child_idx < key_value_group.field_count(); ++child_idx) {
             std::unique_ptr<ParquetColumnSchema> child;
             RETURN_IF_ERROR(build_node_schema(
                     schema, *key_value_group.field(child_idx),
                     child_context(key_value_context, *key_value_group.field(child_idx), child_idx),
                     &child));
-            child_types.push_back(make_nullable(child->type));
-            child_names.push_back(child->name);
-            key_value->children.push_back(std::move(child));
+            column_schema->children.push_back(std::move(child));
         }
-        key_value->type = std::make_shared<DataTypeStruct>(child_types, child_names);
-        propagate_child_levels(key_value.get());
-        if (key_value->children.size() != 2) {
+        if (column_schema->children.size() != 2) {
             return Status::NotSupported("Unsupported parquet MAP key_value layout for column {}",
                                         node.name());
         }
@@ -225,11 +214,10 @@ Status build_node_schema(const ::parquet::SchemaDescriptor& schema,
             return Status::NotSupported("Unsupported nullable parquet MAP key for column {}",
                                         node.name());
         }
-        auto key_type = make_nullable(key_value->children[0]->type);
-        auto value_type = make_nullable(key_value->children[1]->type);
+        auto key_type = make_nullable(column_schema->children[0]->type);
+        auto value_type = make_nullable(column_schema->children[1]->type);
         column_schema->type =
                 nullable_if_needed(std::make_shared<DataTypeMap>(key_type, value_type), node);
-        column_schema->children.push_back(std::move(key_value));
         propagate_child_levels(column_schema.get());
         *result = std::move(column_schema);
         return Status::OK();

--- a/be/src/format_v2/parquet/parquet_column_schema.h
+++ b/be/src/format_v2/parquet/parquet_column_schema.h
@@ -39,8 +39,13 @@ enum class ParquetColumnSchemaKind {
     MAP,
 };
 
-// 新 Parquet reader 的 file-local schema tree。
-// 它描述 Parquet 逻辑字段到 leaf column ordinal 的关系，不包含 table/global schema 语义。
+// New Parquet reader file-local schema tree.
+//
+// The tree describes Parquet logical fields and leaf column ordinals, but its DataType is already
+// converted to Doris external-table semantics: Doris does not expose required nested fields from
+// external files, so STRUCT children, LIST elements, and MAP key/value children are widened to
+// nullable. Parquet required/optional details are still preserved in the level fields and
+// ColumnDescriptor metadata below for reader materialization.
 // LIST repeated-group wrappers and MAP key_value/entry wrappers are folded into their parent
 // schema nodes; LIST children are [element] and MAP children are [key, value]. The folded parent
 // nodes keep the repeated definition/repetition levels needed to assemble nested values.

--- a/be/src/format_v2/parquet/parquet_column_schema.h
+++ b/be/src/format_v2/parquet/parquet_column_schema.h
@@ -41,6 +41,9 @@ enum class ParquetColumnSchemaKind {
 
 // 新 Parquet reader 的 file-local schema tree。
 // 它描述 Parquet 逻辑字段到 leaf column ordinal 的关系，不包含 table/global schema 语义。
+// LIST repeated-group wrappers and MAP key_value/entry wrappers are folded into their parent
+// schema nodes; LIST children are [element] and MAP children are [key, value]. The folded parent
+// nodes keep the repeated definition/repetition levels needed to assemble nested values.
 struct ParquetColumnSchema {
     // Reader-local id inside the parent schema node.
     //

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -79,6 +80,154 @@ static Status find_projected_minmax_leaf(const ParquetColumnSchema& column_schem
                                    child_projection.local_id(), column_schema.name);
 }
 
+// Convert the semantic projection accepted by FileReader::open() back to the physical Parquet
+// schema tree consumed by Parquet internals.
+//
+// ParquetReader::get_schema() exposes a semantic file-local ColumnDefinition tree:
+//
+//   MAP children = [key, value]
+//
+// The private ParquetColumnSchema tree still mirrors the physical Parquet layout:
+//
+//   MAP children = [key_value/entry]
+//   key_value/entry children = [key, value]
+//
+// Row group pruning, page pruning and ParquetColumnReaderFactory all walk ParquetColumnSchema and
+// match LocalColumnIndex children against that physical tree. Therefore a table-layer request such
+// as `m.value.b` must be translated from semantic form:
+//
+//   m -> value -> b
+//
+// to physical Parquet form:
+//
+//   m -> key_value/entry -> key, value -> b
+//
+// The key child is always included for MAP because Doris MAP materialization requires both key and
+// value columns even when the projection only prunes inside the value type.
+static Status translate_projection_to_physical(const ParquetColumnSchema& column_schema,
+                                               const format::LocalColumnIndex& semantic_projection,
+                                               format::LocalColumnIndex* physical_projection) {
+    DORIS_CHECK(physical_projection != nullptr);
+    *physical_projection = semantic_projection;
+    if (semantic_projection.project_all_children || semantic_projection.children.empty()) {
+        physical_projection->project_all_children = true;
+        physical_projection->children.clear();
+        return Status::OK();
+    }
+
+    physical_projection->project_all_children = false;
+    physical_projection->children.clear();
+    switch (column_schema.kind) {
+    case ParquetColumnSchemaKind::STRUCT:
+    case ParquetColumnSchemaKind::LIST: {
+        physical_projection->children.reserve(semantic_projection.children.size());
+        for (const auto& semantic_child_projection : semantic_projection.children) {
+            const auto child_schema_it =
+                    std::ranges::find_if(column_schema.children, [&](const auto& child_schema) {
+                        return child_schema->local_id == semantic_child_projection.local_id();
+                    });
+            if (child_schema_it == column_schema.children.end()) {
+                return Status::InvalidArgument(
+                        "Invalid parquet projection child id {} for column {}",
+                        semantic_child_projection.local_id(), column_schema.name);
+            }
+            format::LocalColumnIndex physical_child_projection;
+            RETURN_IF_ERROR(translate_projection_to_physical(
+                    **child_schema_it, semantic_child_projection, &physical_child_projection));
+            physical_projection->children.push_back(std::move(physical_child_projection));
+        }
+        return Status::OK();
+    }
+    case ParquetColumnSchemaKind::MAP: {
+        if (column_schema.children.size() != 1 || column_schema.children[0]->children.size() != 2) {
+            return Status::NotSupported("Unsupported parquet MAP layout for column {}",
+                                        column_schema.name);
+        }
+        const auto& entry_schema = *column_schema.children[0];
+        const auto& key_schema = *entry_schema.children[0];
+        const auto& value_schema = *entry_schema.children[1];
+        const auto* value_projection =
+                format::find_child_projection(&semantic_projection, value_schema.local_id);
+        if (value_projection == nullptr) {
+            return Status::NotSupported("Parquet MAP projection for column {} contains no value",
+                                        column_schema.name);
+        }
+
+        format::LocalColumnIndex entry_projection =
+                format::LocalColumnIndex::partial_local(entry_schema.local_id);
+        entry_projection.children.push_back(format::LocalColumnIndex::local(key_schema.local_id));
+        format::LocalColumnIndex physical_value_projection;
+        RETURN_IF_ERROR(translate_projection_to_physical(value_schema, *value_projection,
+                                                         &physical_value_projection));
+        entry_projection.children.push_back(std::move(physical_value_projection));
+        physical_projection->children.push_back(std::move(entry_projection));
+        return Status::OK();
+    }
+    case ParquetColumnSchemaKind::PRIMITIVE:
+        return Status::InvalidArgument("Cannot project children from primitive parquet column {}",
+                                       column_schema.name);
+    }
+    return Status::InvalidArgument("Unknown parquet schema kind for column {}", column_schema.name);
+}
+
+// Translate every column projection in a scan request from the semantic FileReader API shape to the
+// physical Parquet reader shape. local_positions and expressions stay unchanged because they are
+// keyed by top-level file-local column ids; only nested projection paths need physical wrappers.
+static Status translate_request_to_physical(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& semantic_request,
+        std::shared_ptr<format::FileScanRequest>* physical_request) {
+    DORIS_CHECK(physical_request != nullptr);
+    auto translated = std::make_shared<format::FileScanRequest>(semantic_request);
+    auto translate_root_projection = [&](format::LocalColumnIndex* projection) -> Status {
+        DORIS_CHECK(projection != nullptr);
+        const auto local_id = projection->local_id();
+        if (local_id == format::ROW_POSITION_COLUMN_ID ||
+            local_id == format::GLOBAL_ROWID_COLUMN_ID) {
+            return Status::OK();
+        }
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
+            return Status::InvalidArgument("Invalid parquet projection top-level local id {}",
+                                           local_id);
+        }
+        format::LocalColumnIndex physical_projection;
+        RETURN_IF_ERROR(translate_projection_to_physical(*file_schema[local_id], *projection,
+                                                         &physical_projection));
+        *projection = std::move(physical_projection);
+        return Status::OK();
+    };
+    for (auto& projection : translated->predicate_columns) {
+        RETURN_IF_ERROR(translate_root_projection(&projection));
+    }
+    for (auto& projection : translated->non_predicate_columns) {
+        RETURN_IF_ERROR(translate_root_projection(&projection));
+    }
+    *physical_request = std::move(translated);
+    return Status::OK();
+}
+
+// Aggregate pushdown resolves a single primitive Parquet leaf from the projection. It shares the
+// same physical ParquetColumnSchema traversal as normal scans, so nested aggregate projections need
+// the same semantic-to-physical translation before min/max leaf lookup.
+static Status translate_aggregate_request_to_physical(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileAggregateRequest& semantic_request,
+        format::FileAggregateRequest* physical_request) {
+    DORIS_CHECK(physical_request != nullptr);
+    *physical_request = semantic_request;
+    for (auto& column : physical_request->columns) {
+        const auto local_id = column.projection.local_id();
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
+            return Status::InvalidArgument("Invalid parquet aggregate column id {}", local_id);
+        }
+        format::LocalColumnIndex physical_projection;
+        RETURN_IF_ERROR(translate_projection_to_physical(*file_schema[local_id], column.projection,
+                                                         &physical_projection));
+        column.projection = std::move(physical_projection);
+    }
+    return Status::OK();
+}
+
 void ParquetReader::_fill_column_definition(const ParquetColumnSchema& column_schema,
                                             format::ColumnDefinition* field) const {
     if (column_schema.parquet_field_id >= 0) {
@@ -90,6 +239,23 @@ void ParquetReader::_fill_column_definition(const ParquetColumnSchema& column_sc
     field->name = column_schema.name;
     field->type = column_schema.type;
     field->children.clear();
+    if (column_schema.kind == ParquetColumnSchemaKind::MAP) {
+        // Expose semantic Doris MAP children through FileReader::get_schema(). The Parquet
+        // key_value/entry wrapper remains private in ParquetColumnSchema and is restored only when
+        // translating FileScanRequest projections for the physical reader path.
+        if (column_schema.children.empty()) {
+            return;
+        }
+        const auto& entry_schema = *column_schema.children[0];
+        DORIS_CHECK(entry_schema.children.size() == 2);
+        field->children.reserve(entry_schema.children.size());
+        for (const auto& child : entry_schema.children) {
+            format::ColumnDefinition child_field;
+            _fill_column_definition(*child, &child_field);
+            field->children.push_back(std::move(child_field));
+        }
+        return;
+    }
     field->children.reserve(column_schema.children.size());
     for (const auto& child : column_schema.children) {
         format::ColumnDefinition child_field;
@@ -161,6 +327,15 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
     auto request_snapshot = request;
     DORIS_CHECK(request_snapshot != nullptr);
     RETURN_IF_ERROR(format::FileReader::open(std::move(request)));
+    // The table layer builds FileScanRequest from FileReader::get_schema(), so nested paths use the
+    // semantic ColumnDefinition shape. Parquet scan planning and column readers consume the private
+    // ParquetColumnSchema physical shape, so keep the public request contract semantic and adapt it
+    // at this boundary.
+    std::shared_ptr<format::FileScanRequest> physical_request;
+    RETURN_IF_ERROR(translate_request_to_physical(_state->file_schema, *request_snapshot,
+                                                  &physical_request));
+    request_snapshot = std::move(physical_request);
+    _request = request_snapshot;
 
     const int num_fields = static_cast<int>(_state->file_schema.size());
     for (const auto& column_filter : request_snapshot->column_predicate_filters) {
@@ -311,10 +486,15 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
         return Status::OK();
     }
 
-    result->columns.resize(request.columns.size());
-    for (size_t request_column_idx = 0; request_column_idx < request.columns.size();
+    format::FileAggregateRequest physical_request;
+    RETURN_IF_ERROR(translate_aggregate_request_to_physical(_state->file_schema, request,
+                                                            &physical_request));
+
+    result->columns.resize(physical_request.columns.size());
+    for (size_t request_column_idx = 0; request_column_idx < physical_request.columns.size();
          ++request_column_idx) {
-        const auto file_column_id = request.columns[request_column_idx].projection.local_id();
+        const auto file_column_id =
+                physical_request.columns[request_column_idx].projection.local_id();
         if (file_column_id < 0 ||
             file_column_id >= static_cast<int32_t>(_state->file_schema.size())) {
             return Status::InvalidArgument("Invalid parquet aggregate column id {}",
@@ -324,7 +504,8 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
         DORIS_CHECK(column_schema != nullptr);
         const ParquetColumnSchema* leaf_schema = nullptr;
         RETURN_IF_ERROR(find_projected_minmax_leaf(
-                *column_schema, request.columns[request_column_idx].projection, &leaf_schema));
+                *column_schema, physical_request.columns[request_column_idx].projection,
+                &leaf_schema));
         DORIS_CHECK(leaf_schema != nullptr);
 
         auto& aggregate_column = result->columns[request_column_idx];

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -80,154 +80,6 @@ static Status find_projected_minmax_leaf(const ParquetColumnSchema& column_schem
                                    child_projection.local_id(), column_schema.name);
 }
 
-// Convert the semantic projection accepted by FileReader::open() back to the physical Parquet
-// schema tree consumed by Parquet internals.
-//
-// ParquetReader::get_schema() exposes a semantic file-local ColumnDefinition tree:
-//
-//   MAP children = [key, value]
-//
-// The private ParquetColumnSchema tree still mirrors the physical Parquet layout:
-//
-//   MAP children = [key_value/entry]
-//   key_value/entry children = [key, value]
-//
-// Row group pruning, page pruning and ParquetColumnReaderFactory all walk ParquetColumnSchema and
-// match LocalColumnIndex children against that physical tree. Therefore a table-layer request such
-// as `m.value.b` must be translated from semantic form:
-//
-//   m -> value -> b
-//
-// to physical Parquet form:
-//
-//   m -> key_value/entry -> key, value -> b
-//
-// The key child is always included for MAP because Doris MAP materialization requires both key and
-// value columns even when the projection only prunes inside the value type.
-static Status translate_projection_to_physical(const ParquetColumnSchema& column_schema,
-                                               const format::LocalColumnIndex& semantic_projection,
-                                               format::LocalColumnIndex* physical_projection) {
-    DORIS_CHECK(physical_projection != nullptr);
-    *physical_projection = semantic_projection;
-    if (semantic_projection.project_all_children || semantic_projection.children.empty()) {
-        physical_projection->project_all_children = true;
-        physical_projection->children.clear();
-        return Status::OK();
-    }
-
-    physical_projection->project_all_children = false;
-    physical_projection->children.clear();
-    switch (column_schema.kind) {
-    case ParquetColumnSchemaKind::STRUCT:
-    case ParquetColumnSchemaKind::LIST: {
-        physical_projection->children.reserve(semantic_projection.children.size());
-        for (const auto& semantic_child_projection : semantic_projection.children) {
-            const auto child_schema_it =
-                    std::ranges::find_if(column_schema.children, [&](const auto& child_schema) {
-                        return child_schema->local_id == semantic_child_projection.local_id();
-                    });
-            if (child_schema_it == column_schema.children.end()) {
-                return Status::InvalidArgument(
-                        "Invalid parquet projection child id {} for column {}",
-                        semantic_child_projection.local_id(), column_schema.name);
-            }
-            format::LocalColumnIndex physical_child_projection;
-            RETURN_IF_ERROR(translate_projection_to_physical(
-                    **child_schema_it, semantic_child_projection, &physical_child_projection));
-            physical_projection->children.push_back(std::move(physical_child_projection));
-        }
-        return Status::OK();
-    }
-    case ParquetColumnSchemaKind::MAP: {
-        if (column_schema.children.size() != 1 || column_schema.children[0]->children.size() != 2) {
-            return Status::NotSupported("Unsupported parquet MAP layout for column {}",
-                                        column_schema.name);
-        }
-        const auto& entry_schema = *column_schema.children[0];
-        const auto& key_schema = *entry_schema.children[0];
-        const auto& value_schema = *entry_schema.children[1];
-        const auto* value_projection =
-                format::find_child_projection(&semantic_projection, value_schema.local_id);
-        if (value_projection == nullptr) {
-            return Status::NotSupported("Parquet MAP projection for column {} contains no value",
-                                        column_schema.name);
-        }
-
-        format::LocalColumnIndex entry_projection =
-                format::LocalColumnIndex::partial_local(entry_schema.local_id);
-        entry_projection.children.push_back(format::LocalColumnIndex::local(key_schema.local_id));
-        format::LocalColumnIndex physical_value_projection;
-        RETURN_IF_ERROR(translate_projection_to_physical(value_schema, *value_projection,
-                                                         &physical_value_projection));
-        entry_projection.children.push_back(std::move(physical_value_projection));
-        physical_projection->children.push_back(std::move(entry_projection));
-        return Status::OK();
-    }
-    case ParquetColumnSchemaKind::PRIMITIVE:
-        return Status::InvalidArgument("Cannot project children from primitive parquet column {}",
-                                       column_schema.name);
-    }
-    return Status::InvalidArgument("Unknown parquet schema kind for column {}", column_schema.name);
-}
-
-// Translate every column projection in a scan request from the semantic FileReader API shape to the
-// physical Parquet reader shape. local_positions and expressions stay unchanged because they are
-// keyed by top-level file-local column ids; only nested projection paths need physical wrappers.
-static Status translate_request_to_physical(
-        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        const format::FileScanRequest& semantic_request,
-        std::shared_ptr<format::FileScanRequest>* physical_request) {
-    DORIS_CHECK(physical_request != nullptr);
-    auto translated = std::make_shared<format::FileScanRequest>(semantic_request);
-    auto translate_root_projection = [&](format::LocalColumnIndex* projection) -> Status {
-        DORIS_CHECK(projection != nullptr);
-        const auto local_id = projection->local_id();
-        if (local_id == format::ROW_POSITION_COLUMN_ID ||
-            local_id == format::GLOBAL_ROWID_COLUMN_ID) {
-            return Status::OK();
-        }
-        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
-            return Status::InvalidArgument("Invalid parquet projection top-level local id {}",
-                                           local_id);
-        }
-        format::LocalColumnIndex physical_projection;
-        RETURN_IF_ERROR(translate_projection_to_physical(*file_schema[local_id], *projection,
-                                                         &physical_projection));
-        *projection = std::move(physical_projection);
-        return Status::OK();
-    };
-    for (auto& projection : translated->predicate_columns) {
-        RETURN_IF_ERROR(translate_root_projection(&projection));
-    }
-    for (auto& projection : translated->non_predicate_columns) {
-        RETURN_IF_ERROR(translate_root_projection(&projection));
-    }
-    *physical_request = std::move(translated);
-    return Status::OK();
-}
-
-// Aggregate pushdown resolves a single primitive Parquet leaf from the projection. It shares the
-// same physical ParquetColumnSchema traversal as normal scans, so nested aggregate projections need
-// the same semantic-to-physical translation before min/max leaf lookup.
-static Status translate_aggregate_request_to_physical(
-        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        const format::FileAggregateRequest& semantic_request,
-        format::FileAggregateRequest* physical_request) {
-    DORIS_CHECK(physical_request != nullptr);
-    *physical_request = semantic_request;
-    for (auto& column : physical_request->columns) {
-        const auto local_id = column.projection.local_id();
-        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
-            return Status::InvalidArgument("Invalid parquet aggregate column id {}", local_id);
-        }
-        format::LocalColumnIndex physical_projection;
-        RETURN_IF_ERROR(translate_projection_to_physical(*file_schema[local_id], column.projection,
-                                                         &physical_projection));
-        column.projection = std::move(physical_projection);
-    }
-    return Status::OK();
-}
-
 void ParquetReader::_fill_column_definition(const ParquetColumnSchema& column_schema,
                                             format::ColumnDefinition* field) const {
     if (column_schema.parquet_field_id >= 0) {
@@ -239,23 +91,6 @@ void ParquetReader::_fill_column_definition(const ParquetColumnSchema& column_sc
     field->name = column_schema.name;
     field->type = column_schema.type;
     field->children.clear();
-    if (column_schema.kind == ParquetColumnSchemaKind::MAP) {
-        // Expose semantic Doris MAP children through FileReader::get_schema(). The Parquet
-        // key_value/entry wrapper remains private in ParquetColumnSchema and is restored only when
-        // translating FileScanRequest projections for the physical reader path.
-        if (column_schema.children.empty()) {
-            return;
-        }
-        const auto& entry_schema = *column_schema.children[0];
-        DORIS_CHECK(entry_schema.children.size() == 2);
-        field->children.reserve(entry_schema.children.size());
-        for (const auto& child : entry_schema.children) {
-            format::ColumnDefinition child_field;
-            _fill_column_definition(*child, &child_field);
-            field->children.push_back(std::move(child_field));
-        }
-        return;
-    }
     field->children.reserve(column_schema.children.size());
     for (const auto& child : column_schema.children) {
         format::ColumnDefinition child_field;
@@ -327,15 +162,6 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
     auto request_snapshot = request;
     DORIS_CHECK(request_snapshot != nullptr);
     RETURN_IF_ERROR(format::FileReader::open(std::move(request)));
-    // The table layer builds FileScanRequest from FileReader::get_schema(), so nested paths use the
-    // semantic ColumnDefinition shape. Parquet scan planning and column readers consume the private
-    // ParquetColumnSchema physical shape, so keep the public request contract semantic and adapt it
-    // at this boundary.
-    std::shared_ptr<format::FileScanRequest> physical_request;
-    RETURN_IF_ERROR(translate_request_to_physical(_state->file_schema, *request_snapshot,
-                                                  &physical_request));
-    request_snapshot = std::move(physical_request);
-    _request = request_snapshot;
 
     const int num_fields = static_cast<int>(_state->file_schema.size());
     for (const auto& column_filter : request_snapshot->column_predicate_filters) {
@@ -486,15 +312,10 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
         return Status::OK();
     }
 
-    format::FileAggregateRequest physical_request;
-    RETURN_IF_ERROR(translate_aggregate_request_to_physical(_state->file_schema, request,
-                                                            &physical_request));
-
-    result->columns.resize(physical_request.columns.size());
-    for (size_t request_column_idx = 0; request_column_idx < physical_request.columns.size();
+    result->columns.resize(request.columns.size());
+    for (size_t request_column_idx = 0; request_column_idx < request.columns.size();
          ++request_column_idx) {
-        const auto file_column_id =
-                physical_request.columns[request_column_idx].projection.local_id();
+        const auto file_column_id = request.columns[request_column_idx].projection.local_id();
         if (file_column_id < 0 ||
             file_column_id >= static_cast<int32_t>(_state->file_schema.size())) {
             return Status::InvalidArgument("Invalid parquet aggregate column id {}",
@@ -504,8 +325,7 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
         DORIS_CHECK(column_schema != nullptr);
         const ParquetColumnSchema* leaf_schema = nullptr;
         RETURN_IF_ERROR(find_projected_minmax_leaf(
-                *column_schema, physical_request.columns[request_column_idx].projection,
-                &leaf_schema));
+                *column_schema, request.columns[request_column_idx].projection, &leaf_schema));
         DORIS_CHECK(leaf_schema != nullptr);
 
         auto& aggregate_column = result->columns[request_column_idx];

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -592,8 +592,7 @@ const ParquetColumnSchema* ParquetStatisticsUtils::ResolvePredicateLeafSchema(
 
 ParquetColumnStatistics ParquetStatisticsUtils::TransformColumnStatistics(
         const ParquetColumnSchema& column_schema,
-        const std::shared_ptr<::parquet::Statistics>& statistics,
-        const cctz::time_zone* timezone) {
+        const std::shared_ptr<::parquet::Statistics>& statistics, const cctz::time_zone* timezone) {
     ParquetColumnStatistics result;
     if (statistics == nullptr) {
         return result;
@@ -663,8 +662,7 @@ bool ParquetStatisticsUtils::CheckStatistics(const format::FileColumnPredicateFi
 ParquetRowGroupPruneReason ParquetStatisticsUtils::RowGroupPruneReason(
         const ::parquet::RowGroupMetaData& row_group, ::parquet::ParquetFileReader* file_reader,
         int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
-        const format::FileColumnPredicateFilter& column_filter,
-        const cctz::time_zone* timezone) {
+        const format::FileColumnPredicateFilter& column_filter, const cctz::time_zone* timezone) {
     if (column_filter.predicates.empty()) {
         return ParquetRowGroupPruneReason::NONE;
     }
@@ -677,9 +675,9 @@ ParquetRowGroupPruneReason ParquetStatisticsUtils::RowGroupPruneReason(
     if (column_chunk == nullptr) {
         return ParquetRowGroupPruneReason::NONE;
     }
-    if (CheckStatistics(column_filter,
-                        TransformColumnStatistics(*column_schema, column_chunk->statistics(),
-                                                  timezone))) {
+    if (CheckStatistics(
+                column_filter,
+                TransformColumnStatistics(*column_schema, column_chunk->statistics(), timezone))) {
         return ParquetRowGroupPruneReason::STATISTICS;
     }
     if (!supports_dictionary_pruning(*column_schema, *column_chunk, column_filter) ||
@@ -702,8 +700,7 @@ ParquetRowGroupPruneReason ParquetStatisticsUtils::RowGroupPruneReason(
 bool ParquetStatisticsUtils::RowGroupExcludes(
         const ::parquet::RowGroupMetaData& row_group, ::parquet::ParquetFileReader* file_reader,
         int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
-        const format::FileColumnPredicateFilter& column_filter,
-        const cctz::time_zone* timezone) {
+        const format::FileColumnPredicateFilter& column_filter, const cctz::time_zone* timezone) {
     return RowGroupPruneReason(row_group, file_reader, row_group_idx, schema, column_filter,
                                timezone) != ParquetRowGroupPruneReason::NONE;
 }
@@ -827,8 +824,7 @@ namespace {
 template <typename ParquetDType>
 bool set_page_decoded_min_max(const std::shared_ptr<::parquet::ColumnIndex>& column_index,
                               const ParquetColumnSchema& column_schema, size_t page_idx,
-                              DecodedValueKind value_kind,
-                              ParquetColumnStatistics* page_statistics,
+                              DecodedValueKind value_kind, ParquetColumnStatistics* page_statistics,
                               const cctz::time_zone* timezone) {
     const auto typed_index =
             std::static_pointer_cast<::parquet::TypedColumnIndex<ParquetDType>>(column_index);
@@ -905,14 +901,13 @@ bool set_page_string_min_max(const std::shared_ptr<::parquet::ColumnIndex>& colu
 
 bool set_page_min_max(const std::shared_ptr<::parquet::ColumnIndex>& column_index,
                       const ParquetColumnSchema& column_schema, size_t page_idx,
-                      ParquetColumnStatistics* page_statistics,
-                      const cctz::time_zone* timezone) {
+                      ParquetColumnStatistics* page_statistics, const cctz::time_zone* timezone) {
     DORIS_CHECK(column_schema.type != nullptr);
     switch (column_schema.descriptor->physical_type()) {
     case ::parquet::Type::BOOLEAN:
-        return set_page_decoded_min_max<::parquet::BooleanType>(
-                column_index, column_schema, page_idx, DecodedValueKind::BOOL, page_statistics,
-                timezone);
+        return set_page_decoded_min_max<::parquet::BooleanType>(column_index, column_schema,
+                                                                page_idx, DecodedValueKind::BOOL,
+                                                                page_statistics, timezone);
     case ::parquet::Type::INT32:
         return set_page_decoded_min_max<::parquet::Int32Type>(
                 column_index, column_schema, page_idx,
@@ -922,13 +917,13 @@ bool set_page_min_max(const std::shared_ptr<::parquet::ColumnIndex>& column_inde
                 column_index, column_schema, page_idx,
                 decoded_value_kind(column_schema.type_descriptor), page_statistics, timezone);
     case ::parquet::Type::FLOAT:
-        return set_page_decoded_min_max<::parquet::FloatType>(
-                column_index, column_schema, page_idx, DecodedValueKind::FLOAT, page_statistics,
-                timezone);
+        return set_page_decoded_min_max<::parquet::FloatType>(column_index, column_schema, page_idx,
+                                                              DecodedValueKind::FLOAT,
+                                                              page_statistics, timezone);
     case ::parquet::Type::DOUBLE:
-        return set_page_decoded_min_max<::parquet::DoubleType>(
-                column_index, column_schema, page_idx, DecodedValueKind::DOUBLE, page_statistics,
-                timezone);
+        return set_page_decoded_min_max<::parquet::DoubleType>(column_index, column_schema,
+                                                               page_idx, DecodedValueKind::DOUBLE,
+                                                               page_statistics, timezone);
     case ::parquet::Type::BYTE_ARRAY:
     case ::parquet::Type::FIXED_LEN_BYTE_ARRAY:
         return set_page_string_min_max(column_index, column_schema, page_idx, page_statistics,

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -397,14 +397,7 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
         return Status::NotSupported("Unsupported parquet MAP layout for column {}",
                                     column_schema.name);
     }
-    std::unique_ptr<ParquetColumnReader> key_reader;
     const auto& key_schema = *column_schema.children[0];
-    const auto* key_projection = format::find_child_projection(projection, key_schema.local_id);
-    // MAP materialization always needs keys. A partial MAP projection may prune inside the value
-    // type, but it must not drop the key stream because offsets and entry existence are derived
-    // from the key levels.
-    RETURN_IF_ERROR(create_column_reader(key_schema, key_projection, true, &key_reader));
-    std::unique_ptr<ParquetColumnReader> value_reader;
     const auto& value_schema = *column_schema.children[1];
     const auto* value_projection =
             format::find_child_projection(projection, value_schema.local_id);
@@ -414,18 +407,26 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
                                         column_schema.name);
         }
         for (const auto& child_projection : projection->children) {
-            if (child_projection.local_id() != key_schema.local_id &&
-                child_projection.local_id() != value_schema.local_id) {
+            if (child_projection.local_id() == key_schema.local_id) {
+                return Status::NotSupported(
+                        "Parquet MAP projection for column {} does not support key child",
+                        column_schema.name);
+            }
+            if (child_projection.local_id() != value_schema.local_id) {
                 return Status::InvalidArgument(
                         "Parquet MAP projection for column {} contains invalid child",
                         column_schema.name);
             }
         }
     }
+    std::unique_ptr<ParquetColumnReader> key_reader;
+    // MAP materialization always needs the full key stream. It owns entry existence, offsets and
+    // key equality semantics, so MAP projection is defined only as value-subtree pruning.
+    RETURN_IF_ERROR(create_column_reader(key_schema, nullptr, true, &key_reader));
+    std::unique_ptr<ParquetColumnReader> value_reader;
     RETURN_IF_ERROR(create_column_reader(value_schema, value_projection, true, &value_reader));
     DataTypePtr type = column_schema.type;
-    if (format::is_partial_projection(key_projection) ||
-        format::is_partial_projection(value_projection)) {
+    if (format::is_partial_projection(value_projection)) {
         type = std::make_shared<DataTypeMap>(make_nullable(key_reader->type()),
                                              make_nullable(value_reader->type()));
         if (column_schema.type != nullptr && column_schema.type->is_nullable()) {

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -393,26 +393,35 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
     if (reader == nullptr) {
         return Status::InvalidArgument("reader is null");
     }
-    if (column_schema.children.size() != 1 || column_schema.children[0]->children.size() != 2) {
+    if (column_schema.children.size() != 2) {
         return Status::NotSupported("Unsupported parquet MAP layout for column {}",
                                     column_schema.name);
     }
-    const auto& key_value_schema = *column_schema.children[0];
-    const auto* key_value_projection =
-            format::find_child_projection(projection, key_value_schema.local_id);
-    if (format::is_partial_projection(projection) && key_value_projection == nullptr) {
-        return Status::NotSupported("Parquet MAP projection for column {} contains no entry",
-                                    column_schema.name);
-    }
     std::unique_ptr<ParquetColumnReader> key_reader;
-    const auto& key_schema = *key_value_schema.children[0];
-    const auto* key_projection =
-            format::find_child_projection(key_value_projection, key_schema.local_id);
+    const auto& key_schema = *column_schema.children[0];
+    const auto* key_projection = format::find_child_projection(projection, key_schema.local_id);
+    // MAP materialization always needs keys. A partial MAP projection may prune inside the value
+    // type, but it must not drop the key stream because offsets and entry existence are derived
+    // from the key levels.
     RETURN_IF_ERROR(create_column_reader(key_schema, key_projection, true, &key_reader));
     std::unique_ptr<ParquetColumnReader> value_reader;
-    const auto& value_schema = *key_value_schema.children[1];
+    const auto& value_schema = *column_schema.children[1];
     const auto* value_projection =
-            format::find_child_projection(key_value_projection, value_schema.local_id);
+            format::find_child_projection(projection, value_schema.local_id);
+    if (format::is_partial_projection(projection)) {
+        if (value_projection == nullptr) {
+            return Status::NotSupported("Parquet MAP projection for column {} contains no value",
+                                        column_schema.name);
+        }
+        for (const auto& child_projection : projection->children) {
+            if (child_projection.local_id() != key_schema.local_id &&
+                child_projection.local_id() != value_schema.local_id) {
+                return Status::InvalidArgument(
+                        "Parquet MAP projection for column {} contains invalid child",
+                        column_schema.name);
+            }
+        }
+    }
     RETURN_IF_ERROR(create_column_reader(value_schema, value_projection, true, &value_reader));
     DataTypePtr type = column_schema.type;
     if (format::is_partial_projection(key_projection) ||

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -344,11 +344,7 @@ Status ParquetColumnReaderFactory::create_struct_column_reader(
             continue;
         }
         std::unique_ptr<ParquetColumnReader> child_reader;
-        if (child_schema->kind == ParquetColumnSchemaKind::PRIMITIVE) {
-            RETURN_IF_ERROR(create_nested_scalar_column_reader(*child_schema, &child_reader));
-        } else {
-            RETURN_IF_ERROR(create(*child_schema, child_projection, &child_reader));
-        }
+        RETURN_IF_ERROR(create(*child_schema, child_projection, true, &child_reader));
         child_output_indices.push_back(static_cast<int>(projected_child_types.size()));
         projected_child_types.push_back(make_nullable(child_reader->type()));
         projected_child_names.push_back(child_reader->name());
@@ -395,16 +391,7 @@ Status ParquetColumnReaderFactory::create_list_column_reader(
         return Status::NotSupported("Parquet LIST projection for column {} contains no element",
                                     column_schema.name);
     }
-    if (element_schema.kind == ParquetColumnSchemaKind::PRIMITIVE) {
-        if (format::is_partial_projection(element_projection)) {
-            return Status::InvalidArgument(
-                    "Parquet LIST scalar element projection is invalid for column {}",
-                    column_schema.name);
-        }
-        RETURN_IF_ERROR(create_nested_scalar_column_reader(element_schema, &element_reader));
-    } else {
-        RETURN_IF_ERROR(create(element_schema, element_projection, &element_reader));
-    }
+    RETURN_IF_ERROR(create(element_schema, element_projection, true, &element_reader));
     DataTypePtr type = column_schema.type;
     if (format::is_partial_projection(element_projection)) {
         type = std::make_shared<DataTypeArray>(element_reader->type());
@@ -435,23 +422,18 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
                                     column_schema.name);
     }
     std::unique_ptr<ParquetColumnReader> key_reader;
-    RETURN_IF_ERROR(create_nested_scalar_column_reader(*key_value_schema.children[0], &key_reader));
+    const auto& key_schema = *key_value_schema.children[0];
+    const auto* key_projection =
+            format::find_child_projection(key_value_projection, key_schema.local_id);
+    RETURN_IF_ERROR(create(key_schema, key_projection, true, &key_reader));
     std::unique_ptr<ParquetColumnReader> value_reader;
     const auto& value_schema = *key_value_schema.children[1];
     const auto* value_projection =
             format::find_child_projection(key_value_projection, value_schema.local_id);
-    if (value_schema.kind == ParquetColumnSchemaKind::PRIMITIVE) {
-        if (format::is_partial_projection(value_projection)) {
-            return Status::InvalidArgument(
-                    "Parquet MAP scalar value projection is invalid for column {}",
-                    column_schema.name);
-        }
-        RETURN_IF_ERROR(create_nested_scalar_column_reader(value_schema, &value_reader));
-    } else {
-        RETURN_IF_ERROR(create(value_schema, value_projection, &value_reader));
-    }
+    RETURN_IF_ERROR(create(value_schema, value_projection, true, &value_reader));
     DataTypePtr type = column_schema.type;
-    if (format::is_partial_projection(value_projection)) {
+    if (format::is_partial_projection(key_projection) ||
+        format::is_partial_projection(value_projection)) {
         type = std::make_shared<DataTypeMap>(make_nullable(key_reader->type()),
                                              make_nullable(value_reader->type()));
         if (column_schema.type != nullptr && column_schema.type->is_nullable()) {
@@ -467,11 +449,25 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
 Status ParquetColumnReaderFactory::create(const ParquetColumnSchema& column_schema,
                                           const format::LocalColumnIndex* projection,
                                           std::unique_ptr<ParquetColumnReader>* reader) const {
+    return create(column_schema, projection, false, reader);
+}
+
+Status ParquetColumnReaderFactory::create(const ParquetColumnSchema& column_schema,
+                                          const format::LocalColumnIndex* projection,
+                                          bool is_nested,
+                                          std::unique_ptr<ParquetColumnReader>* reader) const {
     if (reader == nullptr) {
         return Status::InvalidArgument("reader is null");
     }
     switch (column_schema.kind) {
     case ParquetColumnSchemaKind::PRIMITIVE:
+        if (is_nested) {
+            if (format::is_partial_projection(projection)) {
+                return Status::InvalidArgument("Parquet scalar projection is invalid for column {}",
+                                               column_schema.name);
+            }
+            return create_nested_scalar_column_reader(column_schema, reader);
+        }
         return create_scalar_column_reader(column_schema, reader);
     case ParquetColumnSchemaKind::STRUCT:
         return create_struct_column_reader(column_schema, projection, reader);

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -210,7 +210,7 @@ std::unique_ptr<ParquetColumnReader> ParquetColumnReaderFactory::create_global_r
                                                      _column_reader_profile);
 }
 
-Status ParquetColumnReaderFactory::create_scalar_reader(
+Status ParquetColumnReaderFactory::make_scalar_column_reader(
         const ParquetColumnSchema& column_schema,
         std::shared_ptr<::parquet::internal::RecordReader> record_reader,
         std::unique_ptr<ParquetColumnReader>* reader) const {
@@ -226,42 +226,12 @@ Status ParquetColumnReaderFactory::create_scalar_reader(
 }
 
 Status ParquetColumnReaderFactory::create_scalar_column_reader(
-        const ParquetColumnSchema& column_schema,
+        const ParquetColumnSchema& column_schema, bool is_nested,
         std::unique_ptr<ParquetColumnReader>* reader) const {
     if (reader == nullptr) {
         return Status::InvalidArgument("reader is null");
     }
-    if (column_schema.leaf_column_id < 0 ||
-        column_schema.leaf_column_id >= static_cast<int>(_record_readers.size())) {
-        return Status::InvalidArgument("Invalid parquet leaf column id {} for column {}",
-                                       column_schema.leaf_column_id, column_schema.name);
-    }
-    if (column_schema.descriptor == nullptr ||
-        column_schema.descriptor->max_repetition_level() != 0 ||
-        column_schema.descriptor->max_definition_level() > 1) {
-        return Status::NotSupported(
-                "Current parquet scalar reader only supports flat primitive columns; column {} is "
-                "not supported",
-                column_schema.name);
-    }
-    if (!column_schema.type_descriptor.supports_record_reader) {
-        return Status::NotSupported("Current parquet scalar reader does not support column {}",
-                                    column_schema.name);
-    }
-    std::shared_ptr<::parquet::internal::RecordReader> record_reader;
-    RETURN_IF_ERROR(get_record_reader(column_schema.leaf_column_id, column_schema.descriptor,
-                                      column_schema.name, &record_reader));
-    return create_scalar_reader(column_schema, std::move(record_reader), reader);
-}
-
-// TODO: Unify with `create_scalar_column_reader`
-Status ParquetColumnReaderFactory::create_nested_scalar_column_reader(
-        const ParquetColumnSchema& column_schema,
-        std::unique_ptr<ParquetColumnReader>* reader) const {
-    if (reader == nullptr) {
-        return Status::InvalidArgument("reader is null");
-    }
-    if (column_schema.kind != ParquetColumnSchemaKind::PRIMITIVE) {
+    if (is_nested && column_schema.kind != ParquetColumnSchemaKind::PRIMITIVE) {
         return Status::InvalidArgument("Parquet nested scalar reader requires primitive column {}",
                                        column_schema.name);
     }
@@ -270,15 +240,27 @@ Status ParquetColumnReaderFactory::create_nested_scalar_column_reader(
         return Status::InvalidArgument("Invalid parquet leaf column id {} for column {}",
                                        column_schema.leaf_column_id, column_schema.name);
     }
-    if (!supports_nested_scalar_record_reader(column_schema)) {
+    if (!is_nested && (column_schema.descriptor == nullptr ||
+                       column_schema.descriptor->max_repetition_level() != 0 ||
+                       column_schema.descriptor->max_definition_level() > 1)) {
+        return Status::NotSupported(
+                "Current parquet scalar reader only supports flat primitive columns; column {} is "
+                "not supported",
+                column_schema.name);
+    }
+    if (is_nested && !supports_nested_scalar_record_reader(column_schema)) {
         return Status::NotSupported(
                 "Current parquet nested scalar reader does not support column {}",
                 column_schema.name);
     }
+    if (!is_nested && !column_schema.type_descriptor.supports_record_reader) {
+        return Status::NotSupported("Current parquet scalar reader does not support column {}",
+                                    column_schema.name);
+    }
     std::shared_ptr<::parquet::internal::RecordReader> record_reader;
     RETURN_IF_ERROR(get_record_reader(column_schema.leaf_column_id, column_schema.descriptor,
                                       column_schema.name, &record_reader));
-    return create_scalar_reader(column_schema, std::move(record_reader), reader);
+    return make_scalar_column_reader(column_schema, std::move(record_reader), reader);
 }
 
 Status ParquetColumnReaderFactory::get_record_reader(
@@ -344,7 +326,7 @@ Status ParquetColumnReaderFactory::create_struct_column_reader(
             continue;
         }
         std::unique_ptr<ParquetColumnReader> child_reader;
-        RETURN_IF_ERROR(create(*child_schema, child_projection, true, &child_reader));
+        RETURN_IF_ERROR(create_column_reader(*child_schema, child_projection, true, &child_reader));
         child_output_indices.push_back(static_cast<int>(projected_child_types.size()));
         projected_child_types.push_back(make_nullable(child_reader->type()));
         projected_child_names.push_back(child_reader->name());
@@ -391,7 +373,8 @@ Status ParquetColumnReaderFactory::create_list_column_reader(
         return Status::NotSupported("Parquet LIST projection for column {} contains no element",
                                     column_schema.name);
     }
-    RETURN_IF_ERROR(create(element_schema, element_projection, true, &element_reader));
+    RETURN_IF_ERROR(
+            create_column_reader(element_schema, element_projection, true, &element_reader));
     DataTypePtr type = column_schema.type;
     if (format::is_partial_projection(element_projection)) {
         type = std::make_shared<DataTypeArray>(element_reader->type());
@@ -425,12 +408,12 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
     const auto& key_schema = *key_value_schema.children[0];
     const auto* key_projection =
             format::find_child_projection(key_value_projection, key_schema.local_id);
-    RETURN_IF_ERROR(create(key_schema, key_projection, true, &key_reader));
+    RETURN_IF_ERROR(create_column_reader(key_schema, key_projection, true, &key_reader));
     std::unique_ptr<ParquetColumnReader> value_reader;
     const auto& value_schema = *key_value_schema.children[1];
     const auto* value_projection =
             format::find_child_projection(key_value_projection, value_schema.local_id);
-    RETURN_IF_ERROR(create(value_schema, value_projection, true, &value_reader));
+    RETURN_IF_ERROR(create_column_reader(value_schema, value_projection, true, &value_reader));
     DataTypePtr type = column_schema.type;
     if (format::is_partial_projection(key_projection) ||
         format::is_partial_projection(value_projection)) {
@@ -449,13 +432,12 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
 Status ParquetColumnReaderFactory::create(const ParquetColumnSchema& column_schema,
                                           const format::LocalColumnIndex* projection,
                                           std::unique_ptr<ParquetColumnReader>* reader) const {
-    return create(column_schema, projection, false, reader);
+    return create_column_reader(column_schema, projection, false, reader);
 }
 
-Status ParquetColumnReaderFactory::create(const ParquetColumnSchema& column_schema,
-                                          const format::LocalColumnIndex* projection,
-                                          bool is_nested,
-                                          std::unique_ptr<ParquetColumnReader>* reader) const {
+Status ParquetColumnReaderFactory::create_column_reader(
+        const ParquetColumnSchema& column_schema, const format::LocalColumnIndex* projection,
+        bool is_nested, std::unique_ptr<ParquetColumnReader>* reader) const {
     if (reader == nullptr) {
         return Status::InvalidArgument("reader is null");
     }
@@ -466,9 +448,9 @@ Status ParquetColumnReaderFactory::create(const ParquetColumnSchema& column_sche
                 return Status::InvalidArgument("Parquet scalar projection is invalid for column {}",
                                                column_schema.name);
             }
-            return create_nested_scalar_column_reader(column_schema, reader);
+            return create_scalar_column_reader(column_schema, true, reader);
         }
-        return create_scalar_column_reader(column_schema, reader);
+        return create_scalar_column_reader(column_schema, false, reader);
     case ParquetColumnSchemaKind::STRUCT:
         return create_struct_column_reader(column_schema, projection, reader);
     case ParquetColumnSchemaKind::LIST:

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -399,8 +399,7 @@ Status ParquetColumnReaderFactory::create_map_column_reader(
     }
     const auto& key_schema = *column_schema.children[0];
     const auto& value_schema = *column_schema.children[1];
-    const auto* value_projection =
-            format::find_child_projection(projection, value_schema.local_id);
+    const auto* value_projection = format::find_child_projection(projection, value_schema.local_id);
     if (format::is_partial_projection(projection)) {
         if (value_projection == nullptr) {
             return Status::NotSupported("Parquet MAP projection for column {} contains no value",

--- a/be/src/format_v2/parquet/reader/column_reader.h
+++ b/be/src/format_v2/parquet/reader/column_reader.h
@@ -186,8 +186,9 @@ private:
 
     // Creates a MAP reader around key and value readers. The schema builder folds the Parquet
     // key_value/entry wrapper into the MAP node, so children are direct key/value fields here.
-    // Partial value projections rebuild the output DataTypeMap; the key stream is always read
-    // because it owns entry existence and offsets.
+    // Partial MAP projection means value-subtree pruning only. The key stream is always read in
+    // full because it owns entry existence, offsets and key equality semantics; key child
+    // projection is intentionally rejected.
     Status create_map_column_reader(const ParquetColumnSchema& column_schema,
                                     const format::LocalColumnIndex* projection,
                                     std::unique_ptr<ParquetColumnReader>* reader) const;

--- a/be/src/format_v2/parquet/reader/column_reader.h
+++ b/be/src/format_v2/parquet/reader/column_reader.h
@@ -125,11 +125,17 @@ protected:
     int64_t _nested_build_level_cursor = 0;
 };
 
-// Parquet column reader 工厂。
-// 工厂绑定当前 row group，并根据 file-local schema tree 创建 Doris 自己的 column
-// reader。Arrow internal RecordReader 的创建和缓存必须封装在这里，避免泄露到
-// ParquetReader 主流程。后续 reader options、Dremel assembler、延时物化 cache/skip
-// 策略都应挂在该工厂上下文里，而不是继续扩展自由函数参数。
+// Creates Doris column readers for one Parquet row group.
+//
+// The factory owns row-group-local state that must be shared by all readers created for
+// the same row group:
+// - Arrow RecordReader instances, cached by file leaf column id.
+// - Page skip plans and page skip profile counters.
+// - Scalar materialization options such as timezone and strict mode.
+//
+// Public callers only ask for a top-level file column reader or for synthetic scan
+// columns. Recursive construction of nested children stays private so physical Parquet
+// schema details do not leak into ParquetScanScheduler or ParquetReader.
 class ParquetColumnReaderFactory {
 public:
     ParquetColumnReaderFactory(std::shared_ptr<::parquet::RowGroupReader> row_group,
@@ -140,8 +146,9 @@ public:
                                bool enable_strict_mode = false,
                                ParquetColumnReaderProfile column_reader_profile = {});
 
-    // 根据 file-local schema tree 创建 column reader。复杂类型会在这里递归创建
-    // children。该入口只理解 Parquet file schema，不处理 table/global schema。
+    // Creates a reader for a top-level file column schema. The optional projection uses
+    // file-local child ids from ParquetColumnSchema and may select only part of a nested
+    // subtree. Table/global schema mapping has already happened before this layer.
     Status create(const ParquetColumnSchema& column_schema,
                   const format::LocalColumnIndex* projection,
                   std::unique_ptr<ParquetColumnReader>* reader) const;
@@ -157,35 +164,53 @@ public:
             const format::GlobalRowIdContext& context, int64_t row_group_first_row) const;
 
 private:
-    Status create_scalar_column_reader(const ParquetColumnSchema& column_schema,
+    // Creates a primitive leaf reader. Top-level primitive columns are restricted to flat
+    // scalar layouts, while nested primitive leaves are allowed to carry def/rep levels
+    // that will be consumed by their parent LIST/MAP/STRUCT readers.
+    Status create_scalar_column_reader(const ParquetColumnSchema& column_schema, bool is_nested,
                                        std::unique_ptr<ParquetColumnReader>* reader) const;
 
-    Status create_nested_scalar_column_reader(const ParquetColumnSchema& column_schema,
-                                              std::unique_ptr<ParquetColumnReader>* reader) const;
-
+    // Creates a STRUCT reader and recursively creates readers only for projected
+    // children. For partial projections it rebuilds the output DataTypeStruct so the
+    // materialized column contains only projected child fields.
     Status create_struct_column_reader(const ParquetColumnSchema& column_schema,
                                        const format::LocalColumnIndex* projection,
                                        std::unique_ptr<ParquetColumnReader>* reader) const;
 
+    // Creates a LIST reader around the single element reader. If the element itself is
+    // partially projected, this rebuilds the output DataTypeArray with the projected
+    // element type.
     Status create_list_column_reader(const ParquetColumnSchema& column_schema,
                                      const format::LocalColumnIndex* projection,
                                      std::unique_ptr<ParquetColumnReader>* reader) const;
 
+    // Creates a MAP reader around key and value readers. The schema builder normalizes
+    // Parquet MAP layouts to an entry struct with key/value children before this point.
+    // Partial key/value projections rebuild the output DataTypeMap.
     Status create_map_column_reader(const ParquetColumnSchema& column_schema,
                                     const format::LocalColumnIndex* projection,
                                     std::unique_ptr<ParquetColumnReader>* reader) const;
 
-    Status create(const ParquetColumnSchema& column_schema,
-                  const format::LocalColumnIndex* projection, bool is_nested,
-                  std::unique_ptr<ParquetColumnReader>* reader) const;
+    // Private recursive dispatcher. is_nested is true for children of complex readers
+    // and controls primitive-leaf validation; complex readers are always created from
+    // normalized ParquetColumnSchema subtrees.
+    Status create_column_reader(const ParquetColumnSchema& column_schema,
+                                const format::LocalColumnIndex* projection, bool is_nested,
+                                std::unique_ptr<ParquetColumnReader>* reader) const;
 
+    // Lazily creates and caches the Arrow RecordReader for a file leaf column. Multiple
+    // Doris readers may need the same leaf stream through different nested parents, so
+    // RecordReader lifetime is tied to this row-group factory.
     Status get_record_reader(int leaf_column_id, const ::parquet::ColumnDescriptor* descriptor,
                              const std::string& name,
                              std::shared_ptr<::parquet::internal::RecordReader>* reader) const;
 
-    Status create_scalar_reader(const ParquetColumnSchema& column_schema,
-                                std::shared_ptr<::parquet::internal::RecordReader> record_reader,
-                                std::unique_ptr<ParquetColumnReader>* reader) const;
+    // Final ScalarColumnReader construction after schema validation and RecordReader
+    // lookup have already completed.
+    Status make_scalar_column_reader(
+            const ParquetColumnSchema& column_schema,
+            std::shared_ptr<::parquet::internal::RecordReader> record_reader,
+            std::unique_ptr<ParquetColumnReader>* reader) const;
 
     std::shared_ptr<::parquet::RowGroupReader> _row_group;
     mutable std::vector<std::shared_ptr<::parquet::internal::RecordReader>> _record_readers;

--- a/be/src/format_v2/parquet/reader/column_reader.h
+++ b/be/src/format_v2/parquet/reader/column_reader.h
@@ -184,9 +184,10 @@ private:
                                      const format::LocalColumnIndex* projection,
                                      std::unique_ptr<ParquetColumnReader>* reader) const;
 
-    // Creates a MAP reader around key and value readers. The schema builder normalizes
-    // Parquet MAP layouts to an entry struct with key/value children before this point.
-    // Partial key/value projections rebuild the output DataTypeMap.
+    // Creates a MAP reader around key and value readers. The schema builder folds the Parquet
+    // key_value/entry wrapper into the MAP node, so children are direct key/value fields here.
+    // Partial value projections rebuild the output DataTypeMap; the key stream is always read
+    // because it owns entry existence and offsets.
     Status create_map_column_reader(const ParquetColumnSchema& column_schema,
                                     const format::LocalColumnIndex* projection,
                                     std::unique_ptr<ParquetColumnReader>* reader) const;

--- a/be/src/format_v2/parquet/reader/column_reader.h
+++ b/be/src/format_v2/parquet/reader/column_reader.h
@@ -175,6 +175,10 @@ private:
                                     const format::LocalColumnIndex* projection,
                                     std::unique_ptr<ParquetColumnReader>* reader) const;
 
+    Status create(const ParquetColumnSchema& column_schema,
+                  const format::LocalColumnIndex* projection, bool is_nested,
+                  std::unique_ptr<ParquetColumnReader>* reader) const;
+
     Status get_record_reader(int leaf_column_id, const ::parquet::ColumnDescriptor* descriptor,
                              const std::string& name,
                              std::shared_ptr<::parquet::internal::RecordReader>* reader) const;

--- a/be/src/format_v2/parquet/reader/list_column_reader.h
+++ b/be/src/format_v2/parquet/reader/list_column_reader.h
@@ -44,7 +44,6 @@ public:
     const std::vector<int16_t>& nested_repetition_levels() const override;
     int64_t nested_levels_written() const override;
     bool is_or_has_repeated_child() const override;
-    ParquetColumnReader* element_reader() const { return _element_reader.get(); }
 
 private:
     std::unique_ptr<ParquetColumnReader> _element_reader;

--- a/be/src/format_v2/parquet/reader/map_column_reader.h
+++ b/be/src/format_v2/parquet/reader/map_column_reader.h
@@ -46,8 +46,6 @@ public:
     const std::vector<int16_t>& nested_repetition_levels() const override;
     int64_t nested_levels_written() const override;
     bool is_or_has_repeated_child() const override;
-    ParquetColumnReader* key_reader() const { return _key_reader.get(); }
-    ParquetColumnReader* value_reader() const { return _value_reader.get(); }
 
 private:
     std::unique_ptr<ParquetColumnReader> _key_reader;

--- a/be/src/format_v2/parquet/reader/scalar_column_reader.h
+++ b/be/src/format_v2/parquet/reader/scalar_column_reader.h
@@ -39,6 +39,8 @@ class time_zone;
 namespace doris::parquet {
 
 class ScalarColumnReader final : public ParquetColumnReader {
+    friend class MapColumnReader;
+
 public:
     ScalarColumnReader(const ParquetColumnSchema& column_schema,
                        std::shared_ptr<::parquet::internal::RecordReader> record_reader,
@@ -52,20 +54,19 @@ public:
     Status load_nested_batch(int64_t rows) override;
     Status build_nested_column(int64_t length_upper_bound, MutableColumnPtr& column,
                                int64_t* values_read) override;
-    Status append_nested_value(int64_t level_idx, MutableColumnPtr& column) const;
     const std::vector<int16_t>& nested_definition_levels() const override;
     const std::vector<int16_t>& nested_repetition_levels() const override;
     int64_t nested_levels_written() const override;
     bool is_or_has_repeated_child() const override;
 
+private:
+    Status append_nested_value(int64_t level_idx, MutableColumnPtr& column) const;
     const ::parquet::ColumnDescriptor* descriptor() const { return _descriptor; }
     ParquetLeafReader leaf_reader() const {
         return ParquetLeafReader(_descriptor, _type_descriptor, _type, _name, _record_reader,
                                  _profile, _timezone, _enable_strict_mode);
     }
     void advance_rows_read(int64_t rows);
-
-private:
     Status skip_records(int64_t rows);
     int64_t page_filtered_rows_to_skip(int64_t rows) const;
 

--- a/be/src/format_v2/parquet/reader/struct_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/struct_column_reader.cpp
@@ -29,23 +29,19 @@
 #include "format_v2/parquet/reader/scalar_column_reader.h"
 
 namespace doris::parquet {
-namespace {
-
-ParquetColumnReader* struct_shape_source_reader(const StructColumnReader& reader) {
-    for (size_t child_idx = 0; child_idx < reader.child_count(); ++child_idx) {
-        auto* child_reader = reader.child_reader(child_idx);
+ParquetColumnReader* StructColumnReader::shape_source_reader() const {
+    for (const auto& child : _children) {
+        auto* child_reader = child.get();
         DORIS_CHECK(child_reader != nullptr);
         if (!child_reader->is_or_has_repeated_child()) {
             return child_reader;
         }
     }
-    if (reader.child_count() == 0) {
+    if (_children.empty()) {
         return nullptr;
     }
-    return reader.child_reader(0);
+    return _children[0].get();
 }
-
-} // namespace
 
 Status StructColumnReader::read(int64_t rows, MutableColumnPtr& column, int64_t* rows_read) {
     RETURN_IF_ERROR(load_nested_batch(rows));
@@ -91,7 +87,7 @@ Status StructColumnReader::build_nested_column(int64_t length_upper_bound, Mutab
     auto* struct_column = struct_column_from_output(column);
     DORIS_CHECK(struct_column != nullptr);
     auto* parent_null_map = null_map_from_nullable_output(column);
-    auto* shape_reader = struct_shape_source_reader(*this);
+    auto* shape_reader = shape_source_reader();
     DORIS_CHECK(shape_reader != nullptr);
     const auto& def_levels = shape_reader->nested_definition_levels();
     const auto& rep_levels = shape_reader->nested_repetition_levels();
@@ -203,25 +199,25 @@ Status StructColumnReader::build_nested_column(int64_t length_upper_bound, Mutab
 }
 
 const std::vector<int16_t>& StructColumnReader::nested_definition_levels() const {
-    auto* shape_reader = struct_shape_source_reader(*this);
+    auto* shape_reader = shape_source_reader();
     DORIS_CHECK(shape_reader != nullptr);
     return shape_reader->nested_definition_levels();
 }
 
 const std::vector<int16_t>& StructColumnReader::nested_repetition_levels() const {
-    auto* shape_reader = struct_shape_source_reader(*this);
+    auto* shape_reader = shape_source_reader();
     DORIS_CHECK(shape_reader != nullptr);
     return shape_reader->nested_repetition_levels();
 }
 
 int64_t StructColumnReader::nested_levels_written() const {
-    auto* shape_reader = struct_shape_source_reader(*this);
+    auto* shape_reader = shape_source_reader();
     DORIS_CHECK(shape_reader != nullptr);
     return shape_reader->nested_levels_written();
 }
 
 bool StructColumnReader::is_or_has_repeated_child() const {
-    auto* shape_reader = struct_shape_source_reader(*this);
+    auto* shape_reader = shape_source_reader();
     return shape_reader != nullptr && shape_reader->is_or_has_repeated_child();
 }
 

--- a/be/src/format_v2/parquet/reader/struct_column_reader.h
+++ b/be/src/format_v2/parquet/reader/struct_column_reader.h
@@ -50,11 +50,8 @@ public:
     int64_t nested_levels_written() const override;
     bool is_or_has_repeated_child() const override;
 
-    size_t child_count() const { return _children.size(); }
-    ParquetColumnReader* child_reader(size_t child_idx) const { return _children[child_idx].get(); }
-    int child_output_index(size_t child_idx) const { return _child_output_indices[child_idx]; }
-
 private:
+    ParquetColumnReader* shape_source_reader() const;
     std::vector<std::unique_ptr<ParquetColumnReader>> _children;
     std::vector<int> _child_output_indices;
 };

--- a/be/src/format_v2/schema_projection.cpp
+++ b/be/src/format_v2/schema_projection.cpp
@@ -28,39 +28,56 @@
 #include "core/data_type/data_type_struct.h"
 
 namespace doris::format {
+namespace {
 
-Status rebuild_projected_type(const DataTypePtr& original_type,
-                              const std::vector<DataTypePtr>& child_types,
-                              const std::vector<std::string>& child_names,
-                              DataTypePtr* projected_type) {
+// Rebuild the complex DataType for one already-pruned semantic ColumnDefinition node.
+//
+// The caller has already matched the projection against ColumnDefinition::children and preserved
+// the file-local child order. This helper only mirrors those projected semantic children into the
+// node type. It intentionally does not understand physical format wrappers. In particular, a MAP
+// node is expected to have semantic children [key, value], even if the underlying format stores a
+// wrapper such as Parquet key_value/entry.
+Status rebuild_semantic_projected_type(const DataTypePtr& original_type,
+                                       const std::vector<ColumnDefinition>& projected_children,
+                                       DataTypePtr* projected_type) {
     DORIS_CHECK(original_type != nullptr);
     DORIS_CHECK(projected_type != nullptr);
-    DORIS_CHECK(child_types.size() == child_names.size());
 
     DataTypePtr nested_projected_type;
     const auto primitive_type = remove_nullable(original_type)->get_primitive_type();
     switch (primitive_type) {
-    case TYPE_STRUCT:
+    case TYPE_STRUCT: {
+        DataTypes child_types;
+        Strings child_names;
+        child_types.reserve(projected_children.size());
+        child_names.reserve(projected_children.size());
+        for (const auto& child : projected_children) {
+            child_types.push_back(child.type);
+            child_names.push_back(child.name);
+        }
         nested_projected_type = std::make_shared<DataTypeStruct>(child_types, child_names);
         break;
+    }
     case TYPE_ARRAY:
-        DORIS_CHECK(child_types.size() == 1);
-        nested_projected_type = std::make_shared<DataTypeArray>(child_types[0]);
+        DORIS_CHECK(projected_children.size() == 1);
+        nested_projected_type = std::make_shared<DataTypeArray>(projected_children[0].type);
         break;
     case TYPE_MAP: {
-        // TODO: ?
-        DORIS_CHECK(child_types.size() == 1);
-        DORIS_CHECK(remove_nullable(child_types[0])->get_primitive_type() == TYPE_STRUCT);
         DORIS_CHECK(remove_nullable(original_type)->get_primitive_type() == TYPE_MAP);
-        const auto* entry_type =
-                assert_cast<const DataTypeStruct*>(remove_nullable(child_types[0]).get());
-        DORIS_CHECK(entry_type->get_elements().size() == 1 ||
-                    entry_type->get_elements().size() == 2);
-        const auto value_idx = entry_type->get_elements().size() == 1 ? 0 : 1;
-        nested_projected_type = std::make_shared<DataTypeMap>(
-                assert_cast<const DataTypeMap*>(remove_nullable(original_type).get())
-                        ->get_key_type(),
-                entry_type->get_element(value_idx));
+        const auto* original_map_type =
+                assert_cast<const DataTypeMap*>(remove_nullable(original_type).get());
+        DataTypePtr key_type = original_map_type->get_key_type();
+        DataTypePtr value_type;
+        for (const auto& child : projected_children) {
+            if (child.file_local_id() == 1 || child.name == "value") {
+                value_type = child.type;
+            }
+        }
+        if (value_type == nullptr) {
+            return Status::NotSupported("MAP projection for type {} contains no value child",
+                                        original_type->get_name());
+        }
+        nested_projected_type = std::make_shared<DataTypeMap>(key_type, value_type);
         break;
     }
     default:
@@ -72,6 +89,8 @@ Status rebuild_projected_type(const DataTypePtr& original_type,
                                                    : nested_projected_type;
     return Status::OK();
 }
+
+} // namespace
 
 Status project_column_definition(const ColumnDefinition& field, const LocalColumnIndex& projection,
                                  ColumnDefinition* projected_field) {
@@ -113,15 +132,8 @@ Status project_column_definition(const ColumnDefinition& field, const LocalColum
         return Status::NotSupported("Projection for field {} contains no children", field.name);
     }
 
-    DataTypes child_types;
-    Strings child_names;
-    child_types.reserve(projected_field->children.size());
-    child_names.reserve(projected_field->children.size());
-    for (const auto& child : projected_field->children) {
-        child_types.push_back(child.type);
-        child_names.push_back(child.name);
-    }
-    return rebuild_projected_type(field.type, child_types, child_names, &projected_field->type);
+    return rebuild_semantic_projected_type(field.type, projected_field->children,
+                                           &projected_field->type);
 }
 
 } // namespace doris::format

--- a/be/src/format_v2/schema_projection.cpp
+++ b/be/src/format_v2/schema_projection.cpp
@@ -69,6 +69,15 @@ Status rebuild_semantic_projected_type(const DataTypePtr& original_type,
         DataTypePtr key_type = original_map_type->get_key_type();
         DataTypePtr value_type;
         for (const auto& child : projected_children) {
+            // Partial MAP projection only prunes the value subtree. The key stream must remain
+            // complete because it defines entry existence and offsets when materializing ColumnMap;
+            // the projected DataTypeMap also preserves the original key type instead of rebuilding
+            // it from children.
+            if (child.file_local_id() == 0 || child.name == "key") {
+                return Status::NotSupported(
+                        "MAP projection for type {} does not support key child projection",
+                        original_type->get_name());
+            }
             if (child.file_local_id() == 1 || child.name == "value") {
                 value_type = child.type;
             }

--- a/be/src/format_v2/schema_projection.h
+++ b/be/src/format_v2/schema_projection.h
@@ -46,9 +46,11 @@ namespace doris::format {
 //   self-consistent. STRUCT uses projected child names/types, ARRAY uses the projected element
 //   type, and MAP preserves the original key type while rebuilding the projected value type.
 //
-// A full projection copies `field` unchanged. Partial MAP projection must include the value child;
-// key-only projection is rejected because Doris MAP materialization needs values and because the
-// key type is carried by the original DataTypeMap instead of being rebuilt from projected children.
+// A full projection copies `field` unchanged. Partial MAP projection is intentionally limited to
+// the value child. MAP is materialized as offsets + keys + values, so the reader must still read
+// the complete key stream to build entry shape and offsets. The projected DataTypeMap keeps the
+// original key type and only rebuilds the value type from the projected value child; key-only or
+// key-pruned MAP projections are rejected.
 Status project_column_definition(const ColumnDefinition& field, const LocalColumnIndex& projection,
                                  ColumnDefinition* projected_field);
 

--- a/be/src/format_v2/schema_projection.h
+++ b/be/src/format_v2/schema_projection.h
@@ -17,26 +17,38 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
-
 #include "common/status.h"
-#include "core/data_type/data_type.h"
 #include "format_v2/file_reader.h"
 
 namespace doris::format {
 
-Status rebuild_projected_type(const DataTypePtr& original_type,
-                              const std::vector<DataTypePtr>& child_types,
-                              const std::vector<std::string>& child_names,
-                              DataTypePtr* projected_type);
-
-// Build the file-local column definition after applying a LocalColumnIndex projection.
+// Build a projected file-local semantic schema node from a full schema node and a nested
+// LocalColumnIndex projection.
 //
-// The projection is matched by ColumnDefinition::file_local_id(), not by vector ordinal. This keeps
-// nested schema evolution semantics in the common helper and lets callers use the same projection
-// tree for type rebuilding and file block layout.
+// This module is deliberately about semantic ColumnDefinition trees, not physical file-format
+// trees. FileReader::get_schema() returns file-local columns after type conversion to Doris
+// DataType, and their children must follow Doris semantics:
+//
+//   STRUCT children = fields
+//   ARRAY children = [element]
+//   MAP children = [key, value]
+//
+// Format-specific wrappers, such as Parquet MAP key_value/entry nodes, are intentionally hidden
+// from this API. A format reader that needs those wrappers for its physical reader tree should
+// translate the semantic projection back to its physical layout internally.
+//
+// The function does three things:
+// - Copies `field` metadata to `projected_field`.
+// - Recursively prunes children according to `projection.children`, matching children by
+//   ColumnDefinition::file_local_id() rather than vector ordinal. The root projection id is not
+//   interpreted here because the caller has already selected `field`.
+// - Rebuilds the node DataType from the projected semantic children so the returned definition is
+//   self-consistent. STRUCT uses projected child names/types, ARRAY uses the projected element
+//   type, and MAP preserves the original key type while rebuilding the projected value type.
+//
+// A full projection copies `field` unchanged. Partial MAP projection must include the value child;
+// key-only projection is rejected because Doris MAP materialization needs values and because the
+// key type is carried by the original DataTypeMap instead of being rebuilt from projected children.
 Status project_column_definition(const ColumnDefinition& field, const LocalColumnIndex& projection,
                                  ColumnDefinition* projected_field);
 

--- a/be/src/format_v2/table/iceberg_reader.cpp
+++ b/be/src/format_v2/table/iceberg_reader.cpp
@@ -34,10 +34,10 @@
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/field.h"
+#include "exprs/vslot_ref.h"
 #include "format/table/deletion_vector_reader.h"
 #include "format_v2/expr/cast.h"
 #include "format_v2/expr/equality_delete_predicate.h"
-#include "exprs/vslot_ref.h"
 #include "format_v2/parquet/parquet_reader.h"
 #include "format_v2/parquet/reader/column_reader.h"
 #include "format_v2/table_reader.h"
@@ -61,8 +61,7 @@ static std::string join_values_for_debug(const std::vector<T>& values) {
 
 static std::string iceberg_delete_file_debug_string(const TIcebergDeleteFileDesc& delete_file) {
     std::ostringstream out;
-    out << "TIcebergDeleteFileDesc{path="
-        << (delete_file.__isset.path ? delete_file.path : "null")
+    out << "TIcebergDeleteFileDesc{path=" << (delete_file.__isset.path ? delete_file.path : "null")
         << ", content=" << (delete_file.__isset.content ? delete_file.content : -1)
         << ", file_format="
         << (delete_file.__isset.file_format ? static_cast<int>(delete_file.file_format) : -1)
@@ -444,8 +443,8 @@ Status IcebergTableReader::_append_equality_delete_predicates(format::FileScanRe
             _append_file_scan_column(request, field_column_id, &request->predicate_columns);
             const auto block_position = request->local_positions.at(field_column_id).value();
             auto slot = VSlotRef::create_shared(cast_set<int>(block_position),
-                                                    cast_set<int>(block_position), -1,
-                                                    field_it->type, field_it->name);
+                                                cast_set<int>(block_position), -1, field_it->type,
+                                                field_it->name);
             if (field_it->type->equals(*filter.key_types[idx])) {
                 delete_predicate->add_child(std::move(slot));
             } else {

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -751,8 +751,7 @@ protected:
                 RETURN_IF_ERROR(
                         _materialize_complex_mapping_column(mapping, *column, rows, column));
             } else {
-                RETURN_IF_ERROR(_cast_column_to_type(column, mapping.file_type,
-                                                     mapping.table_type,
+                RETURN_IF_ERROR(_cast_column_to_type(column, mapping.file_type, mapping.table_type,
                                                      mapping.file_column_name));
             }
         }
@@ -904,8 +903,8 @@ protected:
                     _file_child_ordinal_for_mapping(mapping, child_mapping, file_ordered_children);
             DORIS_CHECK(file_child_idx < file_struct->get_columns().size());
             ColumnPtr child_column = file_struct->get_column_ptr(file_child_idx);
-            RETURN_IF_ERROR(_materialize_present_child_mapping_column(
-                    child_mapping, child_column, rows, &child_column));
+            RETURN_IF_ERROR(_materialize_present_child_mapping_column(child_mapping, child_column,
+                                                                      rows, &child_column));
             child_columns.push_back(std::move(child_column));
         }
         MutableColumns mutable_child_columns;

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -967,11 +967,6 @@ protected:
     Status _materialize_map_mapping_column(const ColumnMapping& mapping,
                                            const ColumnPtr& file_column, const size_t rows,
                                            ColumnPtr* column) {
-        DORIS_CHECK(mapping.child_mappings.size() == 1);
-        const auto& entry_mapping = mapping.child_mappings[0];
-        DORIS_CHECK(entry_mapping.child_mappings.size() == 1 ||
-                    entry_mapping.child_mappings.size() == 2);
-
         const auto full_file_column = file_column->convert_to_full_column_if_const();
         const NullMap* parent_null_map = nullptr;
         const auto* nested_file_column =
@@ -982,7 +977,7 @@ protected:
 
         const ColumnMapping* key_mapping = nullptr;
         const ColumnMapping* value_mapping = nullptr;
-        for (const auto& child_mapping : entry_mapping.child_mappings) {
+        for (const auto& child_mapping : mapping.child_mappings) {
             if (!child_mapping.file_local_id.has_value()) {
                 continue;
             }

--- a/be/test/exec/scan/vfile_scanner_exception_test.cpp
+++ b/be/test/exec/scan/vfile_scanner_exception_test.cpp
@@ -623,8 +623,8 @@ TEST(FileScannerV2Test, BuildNestedChildrenExpandsFullProjectionFromSchemaColumn
     const auto int_type = std::make_shared<DataTypeInt32>();
     const auto string_type = std::make_shared<DataTypeString>();
 
-    const auto struct_type = std::make_shared<DataTypeStruct>(
-            DataTypes {string_type, string_type}, Strings {"country", "city"});
+    const auto struct_type = std::make_shared<DataTypeStruct>(DataTypes {string_type, string_type},
+                                                              Strings {"country", "city"});
     format::ColumnDefinition struct_column {
             .identifier = Field::create_field<TYPE_INT>(100),
             .name = "struct_column",
@@ -658,8 +658,8 @@ TEST(FileScannerV2Test, BuildNestedChildrenExpandsFullProjectionFromSchemaColumn
     EXPECT_EQ(struct_column.children[1].get_identifier_field_id(), 205);
     EXPECT_EQ(struct_column.children[1].name_mapping, std::vector<std::string>({"old_city"}));
 
-    const auto element_type = std::make_shared<DataTypeStruct>(
-            DataTypes {string_type, int_type}, Strings {"item", "quantity"});
+    const auto element_type = std::make_shared<DataTypeStruct>(DataTypes {string_type, int_type},
+                                                               Strings {"item", "quantity"});
     const auto array_type = std::make_shared<DataTypeArray>(element_type);
     format::ColumnDefinition array_column {
             .identifier = Field::create_field<TYPE_INT>(200),
@@ -688,8 +688,8 @@ TEST(FileScannerV2Test, BuildNestedChildrenExpandsFullProjectionFromSchemaColumn
                     },
     };
     std::vector<TColumnAccessPath> array_paths {data_access_path({"array_column"})};
-    status = FileScannerV2::TEST_build_nested_children_from_access_paths(
-            &array_column, array_paths, &array_schema);
+    status = FileScannerV2::TEST_build_nested_children_from_access_paths(&array_column, array_paths,
+                                                                         &array_schema);
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_EQ(array_column.children.size(), 1);
     const auto& element = array_column.children[0];
@@ -700,8 +700,8 @@ TEST(FileScannerV2Test, BuildNestedChildrenExpandsFullProjectionFromSchemaColumn
     EXPECT_EQ(element.children[0].name_mapping, std::vector<std::string>({"old_item"}));
     EXPECT_EQ(element.children[1].get_identifier_field_id(), 203);
 
-    const auto value_type = std::make_shared<DataTypeStruct>(
-            DataTypes {string_type, int_type}, Strings {"full_name", "age"});
+    const auto value_type = std::make_shared<DataTypeStruct>(DataTypes {string_type, int_type},
+                                                             Strings {"full_name", "age"});
     const auto map_type = std::make_shared<DataTypeMap>(string_type, value_type);
     format::ColumnDefinition map_column {
             .identifier = Field::create_field<TYPE_INT>(300),

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -419,6 +419,20 @@ TEST(ColumnMapperSchemaProjectionTest, ProjectsMapValueStructLeaf) {
     EXPECT_EQ(projected_value->get_element_name(0), "b");
 }
 
+TEST(ColumnMapperSchemaProjectionTest, RejectsMapKeyProjection) {
+    auto key = field_id_col("key", 1, str(), 0);
+    auto value = field_id_col("value", 2, i32(), 1);
+    auto map = map_col("m", 100, {key, value}, str(), i32(), 9);
+
+    LocalColumnIndex projection = LocalColumnIndex::partial_local(9);
+    projection.children.push_back(LocalColumnIndex::local(0));
+
+    ColumnDefinition projected;
+    const auto status = project_column_definition(map, projection, &projected);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("does not support key child projection"), std::string::npos);
+}
+
 TEST(ColumnMapperSchemaProjectionTest, RejectsInvalidProjectionChildIdWithFieldName) {
     auto root = struct_col("s", 100, {field_id_col("a", 101, i32(), 0)}, 7);
 

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -909,8 +909,8 @@ TEST(ColumnMapperCreateMappingTest, ByNameUsesNameMappingForNestedSchemaEvolutio
     table_full_name.name_mapping = {"name"};
     auto table_age = name_col("age", int_type);
     auto table_value = struct_name_col("value", {table_full_name, table_age});
-    auto table_entry = struct_name_col("entries", {table_key, table_value});
-    auto table_map = map_col("new_map_column", -1, table_entry, string_type, table_value.type);
+    auto table_map =
+            map_col("new_map_column", -1, {table_key, table_value}, string_type, table_value.type);
     table_map.name_mapping = {"map_column"};
     set_name_identifiers(&table_map, -1);
 
@@ -928,8 +928,8 @@ TEST(ColumnMapperCreateMappingTest, ByNameUsesNameMappingForNestedSchemaEvolutio
     auto file_name = name_col("name", string_type, 0);
     auto file_age = name_col("age", int_type, 1);
     auto file_value = struct_name_col("value", {file_name, file_age}, 1);
-    auto file_entry = struct_name_col("key_value", {file_key, file_value}, 0);
-    auto file_map = map_col("map_column", -1, file_entry, string_type, file_value.type, 5);
+    auto file_map =
+            map_col("map_column", -1, {file_key, file_value}, string_type, file_value.type, 5);
     set_name_identifiers(&file_map, 5);
 
     TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
@@ -962,14 +962,10 @@ TEST(ColumnMapperCreateMappingTest, ByNameUsesNameMappingForNestedSchemaEvolutio
     const auto& map_mapping = mapper.mappings()[2];
     expect_mapping(map_mapping, 2, "new_map_column", 5, "map_column", file_map.type,
                    table_map.type);
-    ASSERT_EQ(map_mapping.child_mappings.size(), 1);
-    const auto& entry_mapping = map_mapping.child_mappings[0];
-    EXPECT_EQ(entry_mapping.file_column_name, "key_value");
-    EXPECT_EQ(*entry_mapping.file_local_id, 0);
-    ASSERT_EQ(entry_mapping.child_mappings.size(), 2);
-    EXPECT_EQ(entry_mapping.child_mappings[0].file_column_name, "key");
-    EXPECT_EQ(*entry_mapping.child_mappings[0].file_local_id, 0);
-    const auto& value_mapping = entry_mapping.child_mappings[1];
+    ASSERT_EQ(map_mapping.child_mappings.size(), 2);
+    EXPECT_EQ(map_mapping.child_mappings[0].file_column_name, "key");
+    EXPECT_EQ(*map_mapping.child_mappings[0].file_local_id, 0);
+    const auto& value_mapping = map_mapping.child_mappings[1];
     EXPECT_EQ(value_mapping.file_column_name, "value");
     EXPECT_EQ(*value_mapping.file_local_id, 1);
     ASSERT_EQ(value_mapping.child_mappings.size(), 2);
@@ -993,8 +989,7 @@ TEST(ColumnMapperCreateMappingTest, ByFieldIdDoesNotFallbackToNameAndUsesFirstDu
             field_id_col("negative_file", -7, int_type, 3),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_FIELD_ID});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
 
     ASSERT_EQ(mapper.mappings().size(), 3);
@@ -1012,8 +1007,7 @@ TEST(ColumnMapperCreateMappingTest, ByFieldIdTreatsSameNameDifferentFieldIdAsMis
             field_id_col("same_name", 20, int_type, 0),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_FIELD_ID});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     const auto status = mapper.create_mapping(table_schema, {}, file_schema);
     ASSERT_TRUE(status.ok()) << status.to_string();
 
@@ -1029,8 +1023,7 @@ TEST(ColumnMapperCreateMappingTest, NestedFieldIdTreatsSameNameDifferentFieldIdA
     auto file_child = field_id_col("child", 20, int_type, 0);
     auto file_root = struct_col("root", 1, {file_child}, 0);
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_FIELD_ID});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     const auto status = mapper.create_mapping({table_root}, {}, {file_root});
     ASSERT_TRUE(status.ok()) << status.to_string();
 
@@ -1127,8 +1120,7 @@ TEST(ColumnMapperCreateMappingTest, ByIndexOutOfRangeFallsBackToDefaultOrMissing
             field_id_col("_col1", 101, int_type, 1),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_INDEX});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_INDEX});
     ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
 
     ASSERT_EQ(mapper.mappings().size(), 3);
@@ -1153,8 +1145,7 @@ TEST(ColumnMapperCreateMappingTest, ByIndexMissingIdentifierFallsBackToDefaultOr
             field_id_col("_col0", 100, int_type, 0),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_INDEX});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_INDEX});
     ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
 
     ASSERT_EQ(mapper.mappings().size(), 3);
@@ -1174,8 +1165,7 @@ TEST(ColumnMapperCreateMappingTest, ByIndexOutOfRangeFallsBackToMissing) {
             field_id_col("_col0", 100, int_type, 0),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_INDEX});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_INDEX});
     const auto status = mapper.create_mapping(table_schema, {}, file_schema);
     ASSERT_TRUE(status.ok()) << status.to_string();
 
@@ -1220,8 +1210,7 @@ TEST(ColumnMapperCreateMappingTest, ByIndexIgnoresFileColumnNames) {
 }
 
 TEST(ColumnMapperCreateMappingTest, MissingColumnFallsBackToMissingMapping) {
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_NAME});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
     const auto status = mapper.create_mapping({name_col("missing", i32())}, {},
                                               {name_col("present", i32(), 0)});
     ASSERT_TRUE(status.ok()) << status.to_string();
@@ -1324,8 +1313,7 @@ TEST(ColumnMapperConstantTest, MissingRowLineageDefaultExprStillUsesVirtualMappi
             field_id_col("name", 2, make_nullable(str()), 1),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_FIELD_ID});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
 
     ASSERT_EQ(mapper.mappings().size(), 3);
@@ -1349,8 +1337,7 @@ TEST(ColumnMapperConstantTest, ByFieldIdDoesNotTreatSameNameDifferentIdAsRowLine
             field_id_col("_last_updated_sequence_number", 101, make_nullable(i64()), 1),
     };
 
-    TableColumnMapper mapper(
-            {.mode = TableColumnMappingMode::BY_FIELD_ID});
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
 
     ASSERT_EQ(mapper.mappings().size(), 2);

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -137,12 +137,12 @@ ColumnDefinition array_col(const std::string& name, int32_t field_id, ColumnDefi
     return column;
 }
 
-ColumnDefinition map_col(const std::string& name, int32_t field_id, ColumnDefinition entry,
-                         const DataTypePtr& key_type, const DataTypePtr& value_type,
-                         int32_t local_id = -1) {
+ColumnDefinition map_col(const std::string& name, int32_t field_id,
+                         std::vector<ColumnDefinition> children, const DataTypePtr& key_type,
+                         const DataTypePtr& value_type, int32_t local_id = -1) {
     auto column = field_id_col(name, field_id, std::make_shared<DataTypeMap>(key_type, value_type),
                                local_id);
-    column.children = {std::move(entry)};
+    column.children = std::move(children);
     return column;
 }
 
@@ -399,25 +399,18 @@ TEST(ColumnMapperSchemaProjectionTest, ProjectsMapValueStructLeaf) {
             std::make_shared<DataTypeStruct>(DataTypes {i32(), str()}, Strings {"a", "b"});
     ColumnDefinition value = field_id_col("value", 4, value_type, 1);
     value.children = {value_a, value_b};
-    auto entry_type = std::make_shared<DataTypeStruct>(DataTypes {str(), value_type},
-                                                       Strings {"key", "value"});
-    ColumnDefinition entry = field_id_col("entries", 5, entry_type, 0);
-    entry.children = {key, value};
-    auto map = map_col("m", 100, entry, str(), value_type, 9);
+    auto map = map_col("m", 100, {key, value}, str(), value_type, 9);
 
     LocalColumnIndex projection = LocalColumnIndex::partial_local(9);
-    auto entry_projection = LocalColumnIndex::partial_local(0);
     auto value_projection = LocalColumnIndex::partial_local(1);
     value_projection.children.push_back(LocalColumnIndex::local(1));
-    entry_projection.children.push_back(std::move(value_projection));
-    projection.children.push_back(std::move(entry_projection));
+    projection.children.push_back(std::move(value_projection));
 
     ColumnDefinition projected;
     ASSERT_TRUE(project_column_definition(map, projection, &projected).ok());
     ASSERT_EQ(projected.children.size(), 1);
     ASSERT_EQ(projected.children[0].children.size(), 1);
-    ASSERT_EQ(projected.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(projected.children[0].children[0].children[0].name, "b");
+    EXPECT_EQ(projected.children[0].children[0].name, "b");
 
     const auto* map_type = assert_cast<const DataTypeMap*>(remove_nullable(projected.type).get());
     const auto* projected_value =
@@ -451,11 +444,15 @@ TEST(ColumnMapperSchemaProjectionTest, RejectsEmptyProjectionPathWithFieldName) 
     EXPECT_NE(status.to_string().find("Empty projection path for field s"), std::string::npos);
 }
 
-TEST(ColumnMapperSchemaProjectionTest, RejectsChildProjectionForPrimitiveType) {
-    DataTypePtr projected_type;
-    const auto status = rebuild_projected_type(i32(), {i32()}, {"a"}, &projected_type);
+TEST(ColumnMapperSchemaProjectionTest, RejectsInvalidChildProjectionForPrimitiveField) {
+    auto root = field_id_col("i", 1, i32(), 7);
+    LocalColumnIndex projection = LocalColumnIndex::partial_local(7);
+    projection.children.push_back(LocalColumnIndex::local(0));
+
+    ColumnDefinition projected;
+    const auto status = project_column_definition(root, projection, &projected);
     ASSERT_FALSE(status.ok());
-    EXPECT_NE(status.to_string().find("Cannot project children from non-complex type"),
+    EXPECT_NE(status.to_string().find("Invalid projection child id 0 for field i"),
               std::string::npos);
 }
 
@@ -1965,8 +1962,7 @@ TEST(ColumnMapperScanRequestTest, MapValueStructProjectionPrunesValueChildren) {
 
     auto table_value_b = name_col("b", string_type);
     auto table_value = struct_name_col("value", {table_value_b});
-    auto table_entry = struct_name_col("entries", {table_value});
-    auto table_map = map_col("m", -1, table_entry, key_type, table_value.type);
+    auto table_map = map_col("m", -1, {table_value}, key_type, table_value.type);
     table_map.identifier = Field::create_field<TYPE_STRING>("m");
     set_name_identifiers(&table_map, -1);
 
@@ -1974,8 +1970,7 @@ TEST(ColumnMapperScanRequestTest, MapValueStructProjectionPrunesValueChildren) {
     auto file_value_a = name_col("a", int_type, 0);
     auto file_value_b = name_col("b", string_type, 1);
     auto file_value = struct_name_col("value", {file_value_a, file_value_b}, 1);
-    auto file_entry = struct_name_col("key_value", {file_key, file_value}, 0);
-    auto file_map = map_col("m", -1, file_entry, key_type, file_value.type, 6);
+    auto file_map = map_col("m", -1, {file_key, file_value}, key_type, file_value.type, 6);
     file_map.identifier = Field::create_field<TYPE_STRING>("m");
     set_name_identifiers(&file_map, 6);
 
@@ -1990,11 +1985,9 @@ TEST(ColumnMapperScanRequestTest, MapValueStructProjectionPrunesValueChildren) {
     EXPECT_EQ(projection.column_id(), LocalColumnId(6));
     ASSERT_FALSE(projection.project_all_children);
     ASSERT_EQ(projection.children.size(), 1);
-    EXPECT_EQ(projection.children[0].local_id(), 0);
+    EXPECT_EQ(projection.children[0].local_id(), 1);
     ASSERT_EQ(projection.children[0].children.size(), 1);
     EXPECT_EQ(projection.children[0].children[0].local_id(), 1);
-    ASSERT_EQ(projection.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(projection.children[0].children[0].children[0].local_id(), 1);
 
     const auto* mapped_map =
             assert_cast<const DataTypeMap*>(remove_nullable(mapper.mappings()[0].file_type).get());

--- a/be/test/format_v2/parquet/parquet_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_column_reader_test.cpp
@@ -2375,6 +2375,25 @@ TEST_F(ParquetColumnReaderTest, ReadProjectedMapStructValueChildren) {
     EXPECT_EQ(b_data.get_data_at(3).to_string(), "me");
 }
 
+TEST_F(ParquetColumnReaderTest, RejectMapKeyProjection) {
+    const auto field_idx = find_field_idx("nullable_map_int_struct_col");
+    ASSERT_LT(field_idx, _fields.size());
+    const auto& map_schema = *_fields[field_idx];
+    ASSERT_EQ(map_schema.children.size(), 2);
+    const auto& key_schema = *map_schema.children[0];
+    const auto& value_schema = *map_schema.children[1];
+
+    auto projection = format::LocalColumnIndex::partial_local(map_schema.local_id);
+    projection.children.push_back(format::LocalColumnIndex::local(key_schema.local_id));
+    projection.children.push_back(format::LocalColumnIndex::local(value_schema.local_id));
+
+    ParquetColumnReaderFactory factory(_row_group, _file_reader->metadata()->num_columns());
+    std::unique_ptr<ParquetColumnReader> reader;
+    const auto st = factory.create(map_schema, &projection, &reader);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("does not support key child"), std::string::npos);
+}
+
 TEST_F(ParquetColumnReaderTest, ReadProjectedStructListChildOnly) {
     const auto field_idx = find_field_idx("nullable_struct_list_col");
     ASSERT_LT(field_idx, _fields.size());

--- a/be/test/format_v2/parquet/parquet_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_column_reader_test.cpp
@@ -2323,26 +2323,20 @@ TEST_F(ParquetColumnReaderTest, ReadProjectedMapStructValueChildren) {
     ASSERT_LT(field_idx, _fields.size());
     const auto& map_schema = *_fields[field_idx];
     ASSERT_EQ(map_schema.name, "nullable_map_int_struct_col");
-    ASSERT_EQ(map_schema.children.size(), 1);
-    const auto& key_value_schema = *map_schema.children[0];
-    ASSERT_EQ(key_value_schema.children.size(), 2);
-    const auto& value_schema = *key_value_schema.children[1];
+    ASSERT_EQ(map_schema.children.size(), 2);
+    const auto& value_schema = *map_schema.children[1];
     ASSERT_EQ(value_schema.children.size(), 2);
 
     format::LocalColumnIndex projection;
     projection.index = map_schema.local_id;
     projection.project_all_children = false;
-    format::LocalColumnIndex entry_projection;
-    entry_projection.index = key_value_schema.local_id;
-    entry_projection.project_all_children = false;
     format::LocalColumnIndex value_projection;
     value_projection.index = value_schema.local_id;
     value_projection.project_all_children = false;
     format::LocalColumnIndex child_projection;
     child_projection.index = value_schema.children[1]->local_id;
     value_projection.children.push_back(std::move(child_projection));
-    entry_projection.children.push_back(std::move(value_projection));
-    projection.children.push_back(std::move(entry_projection));
+    projection.children.push_back(std::move(value_projection));
 
     ParquetColumnReaderFactory factory(_row_group, _file_reader->metadata()->num_columns());
     std::unique_ptr<ParquetColumnReader> reader;

--- a/be/test/format_v2/parquet/parquet_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_column_reader_test.cpp
@@ -62,6 +62,15 @@ std::shared_ptr<arrow::Array> finish_array(arrow::ArrayBuilder* builder) {
     return array;
 }
 
+template <typename ColumnType>
+const ColumnType& get_nullable_nested_column(const IColumn& column) {
+    // File-local schema exposed by the parquet reader follows Doris external-table semantics:
+    // nested STRUCT fields, LIST elements, and MAP keys/values are nullable even when the parquet
+    // field is required.
+    const auto& nullable_column = assert_cast<const ColumnNullable&>(column);
+    return assert_cast<const ColumnType&>(nullable_column.get_nested_column());
+}
+
 class ParquetColumnReaderTest : public testing::Test {
 protected:
     void SetUp() override {
@@ -1042,9 +1051,9 @@ protected:
                       const auto& struct_column = assert_cast<const ColumnStruct&>(column);
                       ASSERT_EQ(struct_column.get_columns().size(), 2);
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       const auto& b_values =
-                              assert_cast<const ColumnString&>(struct_column.get_column(1));
+                              get_nullable_nested_column<ColumnString>(struct_column.get_column(1));
                       EXPECT_EQ(a_values.get_element(0), 101);
                       EXPECT_EQ(a_values.get_element(4), 105);
                       EXPECT_EQ(b_values.get_data_at(1).to_string(), "sb");
@@ -1071,7 +1080,7 @@ protected:
                               assert_cast<const ColumnStruct&>(nullable_column.get_nested_column());
                       ASSERT_EQ(struct_column.get_columns().size(), 2);
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       const auto& b_values =
                               assert_cast<const ColumnNullable&>(struct_column.get_column(1));
                       const auto& b_nested =
@@ -1106,7 +1115,7 @@ protected:
                               assert_cast<const ColumnStruct&>(nullable_column.get_nested_column());
                       ASSERT_EQ(struct_column.get_columns().size(), 2);
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       const auto& d_values =
                               assert_cast<const ColumnNullable&>(struct_column.get_column(1));
                       const auto& d_nested =
@@ -1141,7 +1150,7 @@ protected:
                               assert_cast<const ColumnStruct&>(nullable_column.get_nested_column());
                       ASSERT_EQ(struct_column.get_columns().size(), 2);
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       EXPECT_EQ(a_values.get_element(0), 301);
                       EXPECT_EQ(a_values.get_element(2), 303);
                       EXPECT_EQ(a_values.get_element(3), 304);
@@ -1198,7 +1207,7 @@ protected:
                               assert_cast<const ColumnStruct&>(nullable_column.get_nested_column());
                       ASSERT_EQ(struct_column.get_columns().size(), 2);
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       EXPECT_EQ(a_values.get_element(0), 401);
                       EXPECT_EQ(a_values.get_element(2), 403);
                       EXPECT_EQ(a_values.get_element(3), 404);
@@ -1220,7 +1229,7 @@ protected:
                       EXPECT_EQ(offsets[2], 2);
                       EXPECT_EQ(offsets[3], 2);
                       EXPECT_EQ(offsets[4], 3);
-                      const auto& keys = assert_cast<const ColumnInt32&>(kv_map.get_keys());
+                      const auto& keys = get_nullable_nested_column<ColumnInt32>(kv_map.get_keys());
                       const auto& values = assert_cast<const ColumnNullable&>(kv_map.get_values());
                       const auto& value_data =
                               assert_cast<const ColumnString&>(values.get_nested_column());
@@ -1285,7 +1294,8 @@ protected:
                       EXPECT_EQ(array_size_at(1), 1);
                       EXPECT_EQ(array_size_at(2), 3);
                       EXPECT_EQ(array_size_at(4), 2);
-                      const auto& values = assert_cast<const ColumnInt32&>(array_column.get_data());
+                      const auto& values =
+                              get_nullable_nested_column<ColumnInt32>(array_column.get_data());
                       ASSERT_EQ(values.size(), 9);
                       EXPECT_EQ(values.get_element(0), 1);
                       EXPECT_EQ(values.get_element(5), 6);
@@ -1374,7 +1384,7 @@ protected:
                       const auto& struct_column =
                               assert_cast<const ColumnStruct&>(elements.get_nested_column());
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       const auto& b_values =
                               assert_cast<const ColumnNullable&>(struct_column.get_column(1));
                       const auto& b_data =
@@ -1474,9 +1484,10 @@ protected:
                       EXPECT_EQ(map_size_at(1), 1);
                       EXPECT_EQ(map_size_at(2), 3);
                       EXPECT_EQ(map_size_at(4), 2);
-                      const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+                      const auto& keys =
+                              get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
                       const auto& values =
-                              assert_cast<const ColumnString&>(map_column.get_values());
+                              get_nullable_nested_column<ColumnString>(map_column.get_values());
                       ASSERT_EQ(keys.size(), 9);
                       ASSERT_EQ(values.size(), 9);
                       EXPECT_EQ(keys.get_element(0), 1);
@@ -1507,7 +1518,8 @@ protected:
                     EXPECT_EQ(offsets[2], 2);
                     EXPECT_EQ(offsets[3], 3);
                     EXPECT_EQ(offsets[4], 4);
-                    const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+                    const auto& keys =
+                            get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
                     const auto& values =
                             assert_cast<const ColumnNullable&>(map_column.get_values());
                     const auto& value_data =
@@ -1572,13 +1584,14 @@ protected:
                       EXPECT_EQ(offsets[3], 3);
                       EXPECT_EQ(offsets[4], 4);
 
-                      const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+                      const auto& keys =
+                              get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
                       const auto& values =
                               assert_cast<const ColumnNullable&>(map_column.get_values());
                       const auto& struct_column =
                               assert_cast<const ColumnStruct&>(values.get_nested_column());
                       const auto& a_values =
-                              assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+                              get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
                       const auto& b_values =
                               assert_cast<const ColumnNullable&>(struct_column.get_column(1));
                       const auto& b_data =
@@ -1625,7 +1638,8 @@ protected:
                     EXPECT_EQ(map_offsets[3], 4);
                     EXPECT_EQ(map_offsets[4], 5);
 
-                    const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+                    const auto& keys =
+                            get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
                     ASSERT_EQ(keys.size(), 5);
                     EXPECT_EQ(keys.get_element(0), 201);
                     EXPECT_EQ(keys.get_element(1), 202);
@@ -1705,7 +1719,8 @@ protected:
                       EXPECT_EQ(map_offsets[2], 2);
                       EXPECT_EQ(map_offsets[3], 3);
                       EXPECT_EQ(map_offsets[4], 4);
-                      const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+                      const auto& keys =
+                              get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
                       const auto& values =
                               assert_cast<const ColumnNullable&>(map_column.get_values());
                       const auto& value_data =
@@ -1722,66 +1737,67 @@ protected:
                   });
         auto nested_map_type =
                 arrow::map(arrow::int32(), arrow::field("value", arrow::utf8(), true));
-        add_field(
-                arrow::field(
-                        "nullable_map_int_map_int_string_col",
-                        arrow::map(arrow::int32(), arrow::field("value", nested_map_type, true)),
-                        true),
-                build_nullable_int_map_map_array(),
-                [](const ParquetColumnSchema& schema, const IColumn& column) {
-                    EXPECT_TRUE(schema.type->is_nullable());
-                    const auto& nullable_column = assert_cast<const ColumnNullable&>(column);
-                    ASSERT_EQ(nullable_column.size(), ROW_COUNT);
-                    EXPECT_FALSE(nullable_column.is_null_at(0));
-                    EXPECT_TRUE(nullable_column.is_null_at(1));
-                    EXPECT_FALSE(nullable_column.is_null_at(2));
-                    EXPECT_FALSE(nullable_column.is_null_at(3));
-                    EXPECT_FALSE(nullable_column.is_null_at(4));
+        add_field(arrow::field(
+                          "nullable_map_int_map_int_string_col",
+                          arrow::map(arrow::int32(), arrow::field("value", nested_map_type, true)),
+                          true),
+                  build_nullable_int_map_map_array(),
+                  [](const ParquetColumnSchema& schema, const IColumn& column) {
+                      EXPECT_TRUE(schema.type->is_nullable());
+                      const auto& nullable_column = assert_cast<const ColumnNullable&>(column);
+                      ASSERT_EQ(nullable_column.size(), ROW_COUNT);
+                      EXPECT_FALSE(nullable_column.is_null_at(0));
+                      EXPECT_TRUE(nullable_column.is_null_at(1));
+                      EXPECT_FALSE(nullable_column.is_null_at(2));
+                      EXPECT_FALSE(nullable_column.is_null_at(3));
+                      EXPECT_FALSE(nullable_column.is_null_at(4));
 
-                    const auto& outer_map =
-                            assert_cast<const ColumnMap&>(nullable_column.get_nested_column());
-                    const auto& outer_offsets = outer_map.get_offsets();
-                    ASSERT_EQ(outer_offsets.size(), ROW_COUNT);
-                    EXPECT_EQ(outer_offsets[0], 2);
-                    EXPECT_EQ(outer_offsets[1], 2);
-                    EXPECT_EQ(outer_offsets[2], 2);
-                    EXPECT_EQ(outer_offsets[3], 4);
-                    EXPECT_EQ(outer_offsets[4], 4);
+                      const auto& outer_map =
+                              assert_cast<const ColumnMap&>(nullable_column.get_nested_column());
+                      const auto& outer_offsets = outer_map.get_offsets();
+                      ASSERT_EQ(outer_offsets.size(), ROW_COUNT);
+                      EXPECT_EQ(outer_offsets[0], 2);
+                      EXPECT_EQ(outer_offsets[1], 2);
+                      EXPECT_EQ(outer_offsets[2], 2);
+                      EXPECT_EQ(outer_offsets[3], 4);
+                      EXPECT_EQ(outer_offsets[4], 4);
 
-                    const auto& outer_keys = assert_cast<const ColumnInt32&>(outer_map.get_keys());
-                    ASSERT_EQ(outer_keys.size(), 4);
-                    EXPECT_EQ(outer_keys.get_element(0), 10);
-                    EXPECT_EQ(outer_keys.get_element(1), 20);
-                    EXPECT_EQ(outer_keys.get_element(2), 30);
-                    EXPECT_EQ(outer_keys.get_element(3), 40);
+                      const auto& outer_keys =
+                              get_nullable_nested_column<ColumnInt32>(outer_map.get_keys());
+                      ASSERT_EQ(outer_keys.size(), 4);
+                      EXPECT_EQ(outer_keys.get_element(0), 10);
+                      EXPECT_EQ(outer_keys.get_element(1), 20);
+                      EXPECT_EQ(outer_keys.get_element(2), 30);
+                      EXPECT_EQ(outer_keys.get_element(3), 40);
 
-                    const auto& inner_values =
-                            assert_cast<const ColumnNullable&>(outer_map.get_values());
-                    ASSERT_EQ(inner_values.size(), 4);
-                    EXPECT_FALSE(inner_values.is_null_at(0));
-                    EXPECT_FALSE(inner_values.is_null_at(1));
-                    EXPECT_TRUE(inner_values.is_null_at(2));
-                    EXPECT_FALSE(inner_values.is_null_at(3));
+                      const auto& inner_values =
+                              assert_cast<const ColumnNullable&>(outer_map.get_values());
+                      ASSERT_EQ(inner_values.size(), 4);
+                      EXPECT_FALSE(inner_values.is_null_at(0));
+                      EXPECT_FALSE(inner_values.is_null_at(1));
+                      EXPECT_TRUE(inner_values.is_null_at(2));
+                      EXPECT_FALSE(inner_values.is_null_at(3));
 
-                    const auto& inner_map =
-                            assert_cast<const ColumnMap&>(inner_values.get_nested_column());
-                    const auto& inner_offsets = inner_map.get_offsets();
-                    ASSERT_EQ(inner_offsets.size(), 4);
-                    EXPECT_EQ(inner_offsets[0], 1);
-                    EXPECT_EQ(inner_offsets[1], 1);
-                    EXPECT_EQ(inner_offsets[2], 1);
-                    EXPECT_EQ(inner_offsets[3], 2);
-                    const auto& inner_keys = assert_cast<const ColumnInt32&>(inner_map.get_keys());
-                    const auto& inner_strings =
-                            assert_cast<const ColumnNullable&>(inner_map.get_values());
-                    const auto& inner_string_data =
-                            assert_cast<const ColumnString&>(inner_strings.get_nested_column());
-                    ASSERT_EQ(inner_keys.size(), 2);
-                    EXPECT_EQ(inner_keys.get_element(0), 101);
-                    EXPECT_EQ(inner_keys.get_element(1), 401);
-                    EXPECT_EQ(inner_string_data.get_data_at(0).to_string(), "aa");
-                    EXPECT_TRUE(inner_strings.is_null_at(1));
-                });
+                      const auto& inner_map =
+                              assert_cast<const ColumnMap&>(inner_values.get_nested_column());
+                      const auto& inner_offsets = inner_map.get_offsets();
+                      ASSERT_EQ(inner_offsets.size(), 4);
+                      EXPECT_EQ(inner_offsets[0], 1);
+                      EXPECT_EQ(inner_offsets[1], 1);
+                      EXPECT_EQ(inner_offsets[2], 1);
+                      EXPECT_EQ(inner_offsets[3], 2);
+                      const auto& inner_keys =
+                              get_nullable_nested_column<ColumnInt32>(inner_map.get_keys());
+                      const auto& inner_strings =
+                              assert_cast<const ColumnNullable&>(inner_map.get_values());
+                      const auto& inner_string_data =
+                              assert_cast<const ColumnString&>(inner_strings.get_nested_column());
+                      ASSERT_EQ(inner_keys.size(), 2);
+                      EXPECT_EQ(inner_keys.get_element(0), 101);
+                      EXPECT_EQ(inner_keys.get_element(1), 401);
+                      EXPECT_EQ(inner_string_data.get_data_at(0).to_string(), "aa");
+                      EXPECT_TRUE(inner_strings.is_null_at(1));
+                  });
         auto deep_list_value_type = arrow::list(arrow::field("element", arrow::int32(), true));
         auto deep_list_map_type =
                 arrow::map(arrow::int32(), arrow::field("value", deep_list_value_type, true));
@@ -1839,7 +1855,8 @@ protected:
                       EXPECT_EQ(map_offsets[2], 2);
                       EXPECT_EQ(map_offsets[3], 2);
                       EXPECT_EQ(map_offsets[4], 4);
-                      const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+                      const auto& keys =
+                              get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
                       ASSERT_EQ(keys.size(), 4);
                       EXPECT_EQ(keys.get_element(0), 1);
                       EXPECT_EQ(keys.get_element(1), 2);
@@ -1899,7 +1916,8 @@ protected:
                     EXPECT_EQ(outer_offsets[2], 2);
                     EXPECT_EQ(outer_offsets[3], 4);
                     EXPECT_EQ(outer_offsets[4], 5);
-                    const auto& outer_keys = assert_cast<const ColumnInt32&>(outer_map.get_keys());
+                    const auto& outer_keys =
+                            get_nullable_nested_column<ColumnInt32>(outer_map.get_keys());
                     ASSERT_EQ(outer_keys.size(), 5);
                     EXPECT_EQ(outer_keys.get_element(0), 10);
                     EXPECT_EQ(outer_keys.get_element(1), 20);
@@ -1944,7 +1962,7 @@ protected:
                     EXPECT_EQ(inner_offsets[4], 3);
                     EXPECT_EQ(inner_offsets[5], 4);
                     const auto& inner_keys =
-                            assert_cast<const ColumnInt32&>(inner_map_column.get_keys());
+                            get_nullable_nested_column<ColumnInt32>(inner_map_column.get_keys());
                     ASSERT_EQ(inner_keys.size(), 4);
                     EXPECT_EQ(inner_keys.get_element(0), 1);
                     EXPECT_EQ(inner_keys.get_element(1), 2);
@@ -2212,7 +2230,7 @@ TEST_F(ParquetColumnReaderTest, ReadProjectedStructChildren) {
     ASSERT_EQ(rows_read, ROW_COUNT);
     const auto& struct_column = assert_cast<const ColumnStruct&>(*column);
     ASSERT_EQ(struct_column.get_columns().size(), 1);
-    const auto& values = assert_cast<const ColumnString&>(struct_column.get_column(0));
+    const auto& values = get_nullable_nested_column<ColumnString>(struct_column.get_column(0));
     EXPECT_EQ(values.get_data_at(0).to_string(), "sa");
     EXPECT_EQ(values.get_data_at(4).to_string(), "se");
 }
@@ -2358,7 +2376,7 @@ TEST_F(ParquetColumnReaderTest, ReadProjectedMapStructValueChildren) {
 
     const auto& nullable_column = assert_cast<const ColumnNullable&>(*column);
     const auto& map_column = assert_cast<const ColumnMap&>(nullable_column.get_nested_column());
-    const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+    const auto& keys = get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
     const auto& values = assert_cast<const ColumnNullable&>(map_column.get_values());
     const auto& struct_column = assert_cast<const ColumnStruct&>(values.get_nested_column());
     ASSERT_EQ(struct_column.get_columns().size(), 1);
@@ -2566,7 +2584,7 @@ TEST_F(ParquetColumnReaderTest, ReadProjectedStructMapChildOnly) {
     EXPECT_EQ(offsets[2], 2);
     EXPECT_EQ(offsets[3], 2);
     EXPECT_EQ(offsets[4], 3);
-    const auto& keys = assert_cast<const ColumnInt32&>(kv_map.get_keys());
+    const auto& keys = get_nullable_nested_column<ColumnInt32>(kv_map.get_keys());
     const auto& values = assert_cast<const ColumnNullable&>(kv_map.get_values());
     const auto& value_data = assert_cast<const ColumnString&>(values.get_nested_column());
     ASSERT_EQ(keys.size(), 3);
@@ -2711,7 +2729,7 @@ TEST_F(ParquetColumnReaderTest, SelectProjectedStructMapChildOnly) {
     EXPECT_EQ(offsets[0], 2);
     EXPECT_EQ(offsets[1], 2);
     EXPECT_EQ(offsets[2], 3);
-    const auto& keys = assert_cast<const ColumnInt32&>(kv_map.get_keys());
+    const auto& keys = get_nullable_nested_column<ColumnInt32>(kv_map.get_keys());
     ASSERT_EQ(keys.size(), 3);
     EXPECT_EQ(keys.get_element(0), 1);
     EXPECT_EQ(keys.get_element(1), 2);
@@ -2848,7 +2866,7 @@ TEST_F(ParquetColumnReaderTest, SelectStructListWithOverflow) {
     EXPECT_FALSE(nullable_column.is_null_at(2));
     const auto& struct_column =
             assert_cast<const ColumnStruct&>(nullable_column.get_nested_column());
-    const auto& a_values = assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+    const auto& a_values = get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
     EXPECT_EQ(a_values.get_element(0), 301);
     EXPECT_EQ(a_values.get_element(1), 304);
     EXPECT_EQ(a_values.get_element(2), 305);
@@ -2931,7 +2949,7 @@ TEST_F(ParquetColumnReaderTest, SelectStructMapWithOverflow) {
     EXPECT_FALSE(nullable_column.is_null_at(2));
     const auto& struct_column =
             assert_cast<const ColumnStruct&>(nullable_column.get_nested_column());
-    const auto& a_values = assert_cast<const ColumnInt32&>(struct_column.get_column(0));
+    const auto& a_values = get_nullable_nested_column<ColumnInt32>(struct_column.get_column(0));
     EXPECT_EQ(a_values.get_element(0), 401);
     EXPECT_EQ(a_values.get_element(1), 404);
     EXPECT_EQ(a_values.get_element(2), 405);
@@ -2946,7 +2964,7 @@ TEST_F(ParquetColumnReaderTest, SelectStructMapWithOverflow) {
     EXPECT_EQ(offsets[0], 2);
     EXPECT_EQ(offsets[1], 2);
     EXPECT_EQ(offsets[2], 3);
-    const auto& keys = assert_cast<const ColumnInt32&>(kv_map.get_keys());
+    const auto& keys = get_nullable_nested_column<ColumnInt32>(kv_map.get_keys());
     const auto& values = assert_cast<const ColumnNullable&>(kv_map.get_values());
     const auto& value_data = assert_cast<const ColumnString&>(values.get_nested_column());
     ASSERT_EQ(keys.size(), 3);
@@ -3385,7 +3403,7 @@ TEST_F(ParquetColumnReaderTest, SkipDeepListStructMapListThenRead) {
     EXPECT_EQ(map_offsets[0], 0);
     EXPECT_EQ(map_offsets[1], 0);
     EXPECT_EQ(map_offsets[2], 2);
-    const auto& keys = assert_cast<const ColumnInt32&>(map_column.get_keys());
+    const auto& keys = get_nullable_nested_column<ColumnInt32>(map_column.get_keys());
     ASSERT_EQ(keys.size(), 2);
     EXPECT_EQ(keys.get_element(0), 3);
     EXPECT_EQ(keys.get_element(1), 4);
@@ -3493,7 +3511,7 @@ TEST_F(ParquetColumnReaderTest, SkipDeepMapListMapThenRead) {
     EXPECT_EQ(outer_offsets[1], 0);
     EXPECT_EQ(outer_offsets[2], 2);
     EXPECT_EQ(outer_offsets[3], 3);
-    const auto& outer_keys = assert_cast<const ColumnInt32&>(outer_map.get_keys());
+    const auto& outer_keys = get_nullable_nested_column<ColumnInt32>(outer_map.get_keys());
     ASSERT_EQ(outer_keys.size(), 3);
     EXPECT_EQ(outer_keys.get_element(0), 30);
     EXPECT_EQ(outer_keys.get_element(1), 40);
@@ -3540,7 +3558,7 @@ TEST_F(ParquetColumnReaderTest, SelectDeepMapListMap) {
     EXPECT_EQ(outer_offsets[0], 2);
     EXPECT_EQ(outer_offsets[1], 4);
     EXPECT_EQ(outer_offsets[2], 5);
-    const auto& outer_keys = assert_cast<const ColumnInt32&>(outer_map.get_keys());
+    const auto& outer_keys = get_nullable_nested_column<ColumnInt32>(outer_map.get_keys());
     ASSERT_EQ(outer_keys.size(), 5);
     EXPECT_EQ(outer_keys.get_element(0), 10);
     EXPECT_EQ(outer_keys.get_element(1), 20);

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1408,17 +1408,11 @@ TEST(TableColumnMapperTest, CreatesComplexProjectionForMapValueStructChildren) {
     value_field.name = "value";
     value_field.type = value_type;
     value_field.children = {a_field, b_field};
-    format::ColumnDefinition entry_field;
-    entry_field.identifier = Field::create_field<TYPE_INT>(0);
-    entry_field.name = "key_value";
-    entry_field.type = std::make_shared<DataTypeStruct>(DataTypes {key_type, value_type},
-                                                        Strings {"key", "value"});
-    entry_field.children = {key_field, value_field};
     format::ColumnDefinition map_field;
     map_field.identifier = Field::create_field<TYPE_INT>(0);
     map_field.name = "m";
     map_field.type = std::make_shared<DataTypeMap>(key_type, value_type);
-    map_field.children = {entry_field};
+    map_field.children = {key_field, value_field};
 
     format::ColumnDefinition table_value_child;
     table_value_child.identifier = Field::create_field<TYPE_INT>(103);
@@ -1429,17 +1423,11 @@ TEST(TableColumnMapperTest, CreatesComplexProjectionForMapValueStructChildren) {
     table_value.name = "value";
     table_value.type = std::make_shared<DataTypeStruct>(DataTypes {b_type}, Strings {"b"});
     table_value.children = {table_value_child};
-    format::ColumnDefinition table_entry;
-    table_entry.identifier = Field::create_field<TYPE_INT>(101);
-    table_entry.name = "entries";
-    table_entry.type =
-            std::make_shared<DataTypeStruct>(DataTypes {table_value.type}, Strings {"value"});
-    table_entry.children = {table_value};
     format::ColumnDefinition table_column;
     table_column.identifier = Field::create_field<TYPE_INT>(100);
     table_column.name = "m";
     table_column.type = std::make_shared<DataTypeMap>(key_type, table_value.type);
-    table_column.children = {table_entry};
+    table_column.children = {table_value};
 
     format::TableColumnMapperOptions options;
     options.mode = format::TableColumnMappingMode::BY_NAME;
@@ -1456,11 +1444,9 @@ TEST(TableColumnMapperTest, CreatesComplexProjectionForMapValueStructChildren) {
     EXPECT_EQ(projection.index, 0);
     ASSERT_FALSE(projection.project_all_children);
     ASSERT_EQ(projection.children.size(), 1);
-    EXPECT_EQ(projection.children[0].index, 0);
+    EXPECT_EQ(projection.children[0].index, 1);
     ASSERT_EQ(projection.children[0].children.size(), 1);
     EXPECT_EQ(projection.children[0].children[0].index, 1);
-    ASSERT_EQ(projection.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(projection.children[0].children[0].children[0].index, 1);
 
     ASSERT_EQ(mapper.mappings().size(), 1);
     const auto* projected_type =
@@ -1551,17 +1537,11 @@ TEST(TableColumnMapperTest, MapFilterOnlyStructChildIsPredicateProjectionOnly) {
     value_field.name = "value";
     value_field.type = full_value_type;
     value_field.children = {a_field, b_field};
-    format::ColumnDefinition entry_field;
-    entry_field.identifier = Field::create_field<TYPE_INT>(0);
-    entry_field.name = "entries";
-    entry_field.type = std::make_shared<DataTypeStruct>(DataTypes {key_type, full_value_type},
-                                                        Strings {"key", "value"});
-    entry_field.children = {key_field, value_field};
     format::ColumnDefinition map_field;
     map_field.identifier = Field::create_field<TYPE_INT>(0);
     map_field.name = "m";
     map_field.type = std::make_shared<DataTypeMap>(key_type, full_value_type);
-    map_field.children = {entry_field};
+    map_field.children = {key_field, value_field};
 
     format::ColumnDefinition table_value_child;
     table_value_child.identifier = Field::create_field<TYPE_INT>(103);
@@ -1572,26 +1552,18 @@ TEST(TableColumnMapperTest, MapFilterOnlyStructChildIsPredicateProjectionOnly) {
     table_value.name = "value";
     table_value.type = std::make_shared<DataTypeStruct>(DataTypes {b_type}, Strings {"b"});
     table_value.children = {table_value_child};
-    format::ColumnDefinition table_entry;
-    table_entry.identifier = Field::create_field<TYPE_INT>(101);
-    table_entry.name = "entries";
-    table_entry.type =
-            std::make_shared<DataTypeStruct>(DataTypes {table_value.type}, Strings {"value"});
-    table_entry.children = {table_value};
     format::ColumnDefinition table_column;
     table_column.identifier = Field::create_field<TYPE_INT>(100);
     table_column.name = "m";
     table_column.type = std::make_shared<DataTypeMap>(key_type, table_value.type);
-    table_column.children = {table_entry};
+    table_column.children = {table_value};
 
     auto filter_expr = std::make_shared<TestFunctionExpr>(
             "gt", std::make_shared<DataTypeUInt8>(), TExprNodeType::BINARY_PRED, TExprOpcode::GT);
-    auto full_entry_type = entry_field.type;
-    auto entries_expr = struct_element_expr(
+    auto value_expr = struct_element_expr(
             VSlotRef::create_shared(0, 0, -1,
                                     std::make_shared<DataTypeMap>(key_type, full_value_type), "m"),
-            full_entry_type, "entries");
-    auto value_expr = struct_element_expr(entries_expr, full_value_type, "value");
+            full_value_type, "value");
     filter_expr->add_child(struct_element_expr(value_expr, a_type, "a"));
     filter_expr->add_child(VLiteral::create_shared(a_type, Field::create_field<TYPE_INT>(5)));
     format::TableFilter table_filter {
@@ -1615,12 +1587,9 @@ TEST(TableColumnMapperTest, MapFilterOnlyStructChildIsPredicateProjectionOnly) {
     EXPECT_EQ(projection.index, 0);
     ASSERT_FALSE(projection.project_all_children);
     ASSERT_EQ(projection.children.size(), 1);
-    EXPECT_EQ(projection.children[0].index, 0);
+    EXPECT_EQ(projection.children[0].index, 1);
     ASSERT_EQ(projection.children[0].children.size(), 1);
-    EXPECT_EQ(projection.children[0].children[0].index, 1);
-    ASSERT_EQ(projection.children[0].children[0].children.size(), 2);
-    EXPECT_EQ(projection.children[0].children[0].children[0].index, 1);
-    EXPECT_EQ(projection.children[0].children[0].children[1].index, 0);
+    EXPECT_EQ(projection.children[0].children[0].index, 0);
     EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -1968,20 +1968,15 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackForProjectedMapValueStructLeaf) {
     const auto key_type = std::make_shared<DataTypeInt32>();
     const auto string_type = std::make_shared<DataTypeString>();
     const auto nullable_string_type = make_nullable(string_type);
-    auto key_child = make_table_column(0, "key", key_type);
     auto b_child = make_table_column(1, "b", nullable_string_type);
     auto value_type =
             std::make_shared<DataTypeStruct>(DataTypes {nullable_string_type}, Strings {"b"});
     auto nullable_value_type = make_nullable(value_type);
     auto value_child = make_table_column(1, "value", nullable_value_type);
     value_child.children = {b_child};
-    auto entry_type = std::make_shared<DataTypeStruct>(DataTypes {key_type, nullable_value_type},
-                                                       Strings {"key", "value"});
-    auto entry_child = make_table_column(0, "key_value", entry_type);
-    entry_child.children = {key_child, value_child};
     auto map_column = make_table_column(
             100, "kv", std::make_shared<DataTypeMap>(key_type, nullable_value_type));
-    map_column.children = {entry_child};
+    map_column.children = {value_child};
     std::vector<ColumnDefinition> projected_columns = {map_column};
 
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
@@ -2046,7 +2041,6 @@ TEST(TableReaderTest, ProjectedMapValueStructReordersRenamedAndMissingChildren) 
     const auto nullable_int_type = make_nullable(int_type);
     const auto string_type = std::make_shared<DataTypeString>();
     const auto nullable_string_type = make_nullable(string_type);
-    auto key_child = make_table_column(0, "key", key_type);
     auto b_child = make_table_column(1, "renamed_b", nullable_string_type);
     b_child.name_mapping = {"b"};
     auto missing_child = make_table_column(99, "missing_child", string_type);
@@ -2058,13 +2052,9 @@ TEST(TableReaderTest, ProjectedMapValueStructReordersRenamedAndMissingChildren) 
     auto nullable_value_type = make_nullable(value_type);
     auto value_child = make_table_column(1, "value", nullable_value_type);
     value_child.children = {b_child, missing_child, a_child};
-    auto entry_type = std::make_shared<DataTypeStruct>(DataTypes {key_type, nullable_value_type},
-                                                       Strings {"key", "value"});
-    auto entry_child = make_table_column(0, "key_value", entry_type);
-    entry_child.children = {key_child, value_child};
     auto map_column = make_table_column(
             100, "kv", std::make_shared<DataTypeMap>(key_type, nullable_value_type));
-    map_column.children = {entry_child};
+    map_column.children = {value_child};
     std::vector<ColumnDefinition> projected_columns = {map_column};
 
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
@@ -2163,16 +2153,13 @@ TEST(TableReaderTest, MaterializeMapKeyStructReordersRenamedChildren) {
     value_mapping.file_type = int_type;
     value_mapping.is_trivial = true;
 
-    ColumnMapping entry_mapping;
-    entry_mapping.child_mappings = {key_mapping, value_mapping};
-
     ColumnMapping map_mapping;
     map_mapping.table_column_name = "kv";
     map_mapping.file_column_name = "kv";
     map_mapping.table_type = table_map_type;
     map_mapping.file_type = file_map_type;
     map_mapping.is_trivial = false;
-    map_mapping.child_mappings = {entry_mapping};
+    map_mapping.child_mappings = {key_mapping, value_mapping};
 
     auto a_keys = ColumnInt32::create();
     a_keys->insert_value(10);

--- a/docs/parquet-list-map-compat-design.md
+++ b/docs/parquet-list-map-compat-design.md
@@ -1,0 +1,656 @@
+# Parquet LIST/MAP Compatibility Design
+
+本文描述如何参考 Arrow Parquet 的 LIST/MAP 兼容策略，在 Doris new parquet reader 中支持更多 Parquet 标准和 legacy 复杂类型 schema。
+
+目标不是改变 `ListColumnReader` / `MapColumnReader` 的读取模型，而是在 schema 构建阶段把不同物理 schema 归一化成 Doris 当前 reader 可以消费的统一 `ParquetColumnSchema` tree。
+
+## 背景
+
+Parquet 的复杂类型是通过 group schema、logical/converted annotation、definition levels 和 repetition levels 共同表达的。
+
+标准 LIST/MAP schema 比较明确，但历史 writer 产生过多种 legacy 形态。例如 LIST 可能缺少标准 `list.element` wrapper，MAP entry group 可能叫 `key_value`、`entries` 或其它名字。
+
+Arrow C++ 的处理思路是：
+
+1. 在 Parquet schema conversion 阶段识别标准和 legacy schema。
+2. 将这些 schema 归一化为 Arrow `ListType` / `MapType` / `StructType`。
+3. 后续 reader 只消费归一化后的 nested field tree，不在读取阶段继续判断 legacy schema 名字。
+
+Doris new parquet reader 应采用相同边界：
+
+1. `parquet_column_schema.cpp` 负责兼容不同 LIST/MAP physical schema。
+2. `ParquetColumnSchema` 输出统一的 LIST/MAP child tree。
+3. `ListColumnReader` / `MapColumnReader` / `ParquetLeafReader` 不感知 legacy schema 形态。
+
+## 当前 Doris 限制
+
+当前 `build_node_schema()` 的 LIST 分支只支持标准 3-level LIST：
+
+```text
+optional group a (LIST) {
+  repeated group list {
+    optional int32 element;
+  }
+}
+```
+
+当前限制：
+
+- outer LIST group 必须只有一个 child。
+- repeated child 必须是 group。
+- repeated group 必须只有一个 child。
+- 不支持 repeated primitive list。
+- 不支持 repeated group 多字段 struct element。
+- 不支持 `array` / `<parent>_tuple` 这类 legacy structural name。
+
+当前 MAP 分支支持标准 MAP 结构：
+
+```text
+optional group m (MAP) {
+  repeated group key_value {
+    required binary key;
+    optional int32 value;
+  }
+}
+```
+
+当前限制：
+
+- outer MAP group 必须只有一个 child。
+- entry child 必须 repeated group。
+- entry group 必须正好两个 children。
+- key 必须 required。
+- 不支持 key-only map。
+- 不支持没有 repeated entry layer 的非标准 MAP。
+
+## 设计原则
+
+1. 兼容逻辑只放在 schema 构建阶段。
+2. reader 层继续消费统一 schema tree。
+3. 不支持会改变 reader model 的格式，例如没有 repeated entry layer 的 MAP。
+4. 第一阶段不支持 key-only map，因为 Doris `ColumnMap` 需要 values column。
+5. 对容易误判的 schema 保持严格，避免把普通 struct 错解析成 LIST/MAP。
+6. 支持范围对齐 Arrow 的稳定 legacy compatibility 规则，而不是无限放宽。
+
+## LIST 兼容规则
+
+对于 outer group annotated as `LIST`：
+
+```text
+optional group a (LIST) {
+  repeated ... repeated_child;
+}
+```
+
+先要求：
+
+- outer LIST group 必须只有一个 child。
+- child 必须是 repeated。
+
+然后根据 repeated child 形态判断 element schema node。
+
+### 1. 标准 3-level LIST
+
+```text
+optional group a (LIST) {
+  repeated group list {
+    optional int32 element;
+  }
+}
+```
+
+解析：
+
+- repeated child 是 wrapper。
+- element 是 wrapper 的唯一 child：`list.element`。
+- `ParquetColumnSchema(LIST).children[0]` 指向 element schema。
+
+### 2. Repeated primitive legacy LIST
+
+```text
+optional group a (LIST) {
+  repeated int32 element;
+}
+```
+
+解析：
+
+- repeated primitive 本身是 element。
+- element 本身不 nullable，因为 repeated primitive 不提供额外 optional element level。
+- array 自身 nullable 仍由 outer LIST group 决定。
+
+### 3. Repeated group as struct element
+
+```text
+optional group a (LIST) {
+  repeated group element {
+    optional int32 x;
+    optional binary y;
+  }
+}
+```
+
+解析：
+
+- repeated group 有多个 children。
+- repeated group 本身是 element。
+- element type 是 `STRUCT<x, y>`。
+
+### 4. Legacy structural name
+
+Arrow 会将某些名字视作 structural element，而不是标准 wrapper。
+
+```text
+optional group a (LIST) {
+  repeated group array {
+    optional int32 item;
+  }
+}
+```
+
+```text
+optional group a (LIST) {
+  repeated group a_tuple {
+    optional int32 item;
+  }
+}
+```
+
+解析：
+
+- repeated group 名为 `array`，或名为 `<list_name>_tuple`。
+- repeated group 本身是 element。
+- 即使它只有一个 child，也不要剥掉这一层。
+
+### 5. One-child repeated group wrapper
+
+```text
+optional group a (LIST) {
+  repeated group list {
+    optional int32 element;
+  }
+}
+```
+
+如果 repeated group 只有一个 child，且不是 legacy structural name，则按 wrapper 处理：
+
+- element 是 repeated group 的唯一 child。
+
+但这里不能只按 child 数量判断。需要额外保持 Arrow / parquet-format 的 backward compatibility 规则：
+
+- 如果 repeated group 自身带 `LIST` 或 `MAP` annotation，则 repeated group 本身是 element，不剥 wrapper。
+- 如果 repeated group 的唯一 child 也是 repeated，则 repeated group 本身是 element，不剥 wrapper。
+- 只有当 repeated group 无 logical annotation、唯一 child 非 repeated、且不是 legacy structural name 时，才把它当作标准 wrapper 剥掉。
+
+这样可以避免把 two-level `List<List<T>>`、two-level `List<Map<K, V>>` 或单字段 repeated struct element 错解析成少一层的结构。
+
+## LIST schema resolver
+
+建议在 `parquet_column_schema.cpp` 中新增 helper：
+
+```cpp
+struct ListElementResolution {
+    const parquet::schema::Node* repeated_node = nullptr;
+    const parquet::schema::Node* element_node = nullptr;
+    SchemaBuildContext repeated_context;
+    SchemaBuildContext element_context;
+    bool element_is_repeated_node = false;
+};
+
+Status resolve_list_element_node(
+        const parquet::SchemaDescriptor& schema,
+        const parquet::schema::GroupNode& list_group,
+        const SchemaBuildContext& list_context,
+        ListElementResolution* result);
+```
+
+Resolver 逻辑：
+
+```text
+if list_group.field_count != 1:
+    reject
+
+repeated_node = list_group.field(0)
+if !repeated_node.is_repeated:
+    reject
+
+repeated_context = child_context(list_context, repeated_node, 0)
+
+if repeated_node.is_primitive:
+    element_node = repeated_node
+    element_context = repeated_context
+    element_is_repeated_node = true
+    return
+
+repeated_group = as_group(repeated_node)
+if repeated_group.field_count == 0:
+    reject
+
+if repeated_group.field_count > 1:
+    element_node = repeated_node
+    element_context = repeated_context
+    element_is_repeated_node = true
+    return
+
+if has_structural_list_name(list_group.name, repeated_group.name):
+    element_node = repeated_node
+    element_context = repeated_context
+    element_is_repeated_node = true
+    return
+
+if repeated_group has LIST or MAP annotation:
+    element_node = repeated_node
+    element_context = repeated_context
+    element_is_repeated_node = true
+    return
+
+only_child = repeated_group.field(0)
+if only_child.is_repeated:
+    element_node = repeated_node
+    element_context = repeated_context
+    element_is_repeated_node = true
+    return
+
+element_node = only_child
+element_context = child_context(repeated_context, only_child, 0)
+element_is_repeated_node = false
+```
+
+`has_structural_list_name()` 对齐 Arrow 的 legacy rule：
+
+```text
+name == "array" || name == list_name + "_tuple"
+```
+
+## LIST schema build
+
+`build_node_schema()` 的 LIST 分支改为：
+
+```text
+resolve_list_element_node(...)
+
+column_schema.kind = LIST
+column_schema.definition_level = repeated_context.definition_level
+column_schema.repetition_level = repeated_context.repetition_level
+column_schema.repeated_repetition_level = repeated_context.repeated_repetition_level
+
+build child schema from resolved element_node and element_context
+column_schema.type = nullable_if_needed(DataTypeArray(child.type), list_node)
+column_schema.children = [child]
+propagate_child_levels(column_schema)
+```
+
+### repeated group itself as element
+
+当 element 是 repeated group 本身时，需要注意不要把这个 repeated group 再解释成一层 LIST。
+
+预期效果：
+
+```text
+optional group a (LIST) {
+  repeated group element {
+    optional int32 x;
+    optional binary y;
+  }
+}
+```
+
+应构造成：
+
+```text
+LIST
+  child: STRUCT<x, y>
+```
+
+而不是：
+
+```text
+LIST
+  child: LIST or extra repeated container
+```
+
+实现上可以新增一个 internal build mode：
+
+```cpp
+enum class SchemaBuildMode {
+    NORMAL,
+    REPEATED_GROUP_AS_LIST_ELEMENT,
+};
+```
+
+当 mode 是 `REPEATED_GROUP_AS_LIST_ELEMENT`：
+
+- 当前 repeated group 作为 element 本身构造成 STRUCT 或 annotated logical type。
+- 它的 repeated level 已经由 list entry 层消费，不再把 repeated 当作额外 array 层。
+- 如果当前 repeated group 是普通 group，则构造成 `STRUCT` element。
+- 如果当前 repeated group 带 `LIST` annotation，则继续按 LIST 解析它的 child repeated layer，构造成 nested list element。
+- 如果当前 repeated group 带 `MAP` 或 `MAP_KEY_VALUE` annotation，则继续按 MAP 解析它的 child repeated entry layer，构造成 map element。
+- 构造当前 element schema 时，不得再次因为“当前节点本身是 repeated”引入隐式 list；只有它内部的 child repeated layer 才能产生下一层 list/map repetition 语义。
+
+如果希望保持改动更小，也可以新增专用函数：
+
+```cpp
+Status build_repeated_group_as_list_element_schema(...);
+```
+
+该函数至少需要处理 repeated group 作为普通 struct element 的场景；如果选择不用通用 build mode，则还需要显式覆盖 repeated group annotated as LIST/MAP 的场景。
+
+## MAP 兼容规则
+
+对于 outer group annotated as `MAP` 或 legacy `MAP_KEY_VALUE`：
+
+```text
+optional group m (MAP) {
+  repeated group entries {
+    required binary key;
+    optional int32 value;
+  }
+}
+```
+
+支持：
+
+- 只有 outer group 带 `MAP` / `MAP_KEY_VALUE` annotation 时，才进入 MAP 兼容解析。
+- entry group 名字可以是 `key_value`、`entries` 或其它。
+- key/value 字段名不强制必须叫 `key` / `value`。
+- 第一个 child 是 key。
+- 第二个 child 是 value。
+- key 必须 required。
+- value 可以 required 或 optional。
+
+不支持：
+
+- outer MAP group 多个 children。
+- entry child 非 repeated。
+- entry child 是 primitive。
+- entry group 没有 value，即 key-only map。
+- 没有 repeated entry layer 的 MAP。
+- nullable key。
+
+## MAP schema resolver
+
+建议新增 helper：
+
+```cpp
+struct MapEntryResolution {
+    const parquet::schema::GroupNode* entry_group = nullptr;
+    SchemaBuildContext entry_context;
+};
+
+Status resolve_map_entry_group(
+        const parquet::schema::GroupNode& map_group,
+        const SchemaBuildContext& map_context,
+        MapEntryResolution* result);
+```
+
+Resolver 逻辑：
+
+```text
+if map_group.field_count != 1:
+    reject
+
+entry_node = map_group.field(0)
+if !entry_node.is_repeated:
+    reject
+if entry_node.is_primitive:
+    reject
+
+entry_group = as_group(entry_node)
+if entry_group.field_count != 2:
+    reject
+
+key_node = entry_group.field(0)
+value_node = entry_group.field(1)
+if key_node.repetition != REQUIRED:
+    reject
+
+entry_context = child_context(map_context, entry_node, 0)
+return
+```
+
+## MAP schema build
+
+`build_node_schema()` 的 MAP 分支继续输出当前 reader 需要的结构：
+
+```text
+MAP
+  child[0]: STRUCT(key, value)   // entry / key_value schema
+      child[0]: key
+      child[1]: value
+```
+
+构造流程：
+
+```text
+resolve_map_entry_group(...)
+
+column_schema.kind = MAP
+column_schema.definition_level = entry_context.definition_level
+column_schema.repetition_level = entry_context.repetition_level
+column_schema.repeated_repetition_level = entry_context.repeated_repetition_level
+
+build key child from entry_group.field(0)
+build value child from entry_group.field(1)
+
+entry_schema.kind = STRUCT
+entry_schema.children = [key, value]
+entry_schema.type = DataTypeStruct([nullable(key.type), nullable(value.type)], names)
+
+column_schema.type = nullable_if_needed(DataTypeMap(nullable(key.type), nullable(value.type)), map_node)
+column_schema.children = [entry_schema]
+propagate_child_levels(column_schema)
+```
+
+这里保持当前 `MapColumnReader` 的假设：
+
+- `column_schema.children[0]` 是 entry struct。
+- `entry.children[0]` 是 key。
+- `entry.children[1]` 是 value。
+
+注意：`DataTypeStruct` / `DataTypeMap` 中把 key type 包成 nullable 是 Doris nested column materialization 的内部类型约定，不代表 Parquet nullable key 被支持。Schema resolver 仍必须在 `key_node.repetition != REQUIRED` 时 reject。
+
+## 不支持 key-only map 的原因
+
+Key-only map 可能长这样：
+
+```text
+optional group m (MAP) {
+  repeated group entries {
+    required binary key;
+  }
+}
+```
+
+理论上可以解释为 set-like map 或 `MAP<K, NULL>`，但 Doris `ColumnMap` 需要 keys column 和 values column。
+
+若要支持，需要额外设计：
+
+- synthetic null value schema。
+- constant-null value reader。
+- `MapColumnReader` value stream 缺失时的特殊路径。
+
+这会改变 reader tree，不属于本次 schema compatibility 的最小范围。因此第一阶段明确 reject。
+
+## 不支持 no-entry MAP 的原因
+
+No-entry MAP 可能长这样：
+
+```text
+optional group m (MAP) {
+  required binary key;
+  optional int32 value;
+}
+```
+
+它缺少 repeated entry layer，因此没有 repetition level 可以表达多个 map entries，也无法生成 Doris `ColumnMap` offsets。
+
+这不是标准 MAP，也不是 Arrow 主要兼容的 legacy 形态。第一阶段应 reject。
+
+## 对 reader 层的影响
+
+预期不修改 reader 层核心逻辑。
+
+保持：
+
+- `ListColumnReader` 只读取 `column_schema.children[0]` 作为 element reader。
+- `MapColumnReader` 只读取 `column_schema.children[0].children[0/1]` 作为 key/value reader。
+- `ParquetLeafReader` 只负责 leaf records/levels/values 读取和 batch materialization。
+- `nested_column_materializer.*` 只负责 Doris nested Column 构造 helper。
+
+风险点在 LIST repeated group as element：
+
+- 如果该 repeated group 是 struct element，需要确保 schema builder 不把 repeated group 再解释成一个额外 repeated container。
+- 这个风险应通过专用 build mode 或专用 helper 解决。
+
+## 错误处理策略
+
+错误信息应明确指出具体 unsupported schema 原因：
+
+- LIST outer group child count invalid。
+- LIST child is not repeated。
+- LIST repeated group has no child。
+- MAP outer group child count invalid。
+- MAP entry is not repeated group。
+- MAP entry child count is not 2。
+- MAP key is nullable。
+
+不要用过于笼统的 `Unsupported parquet LIST encoding` 覆盖所有错误，否则后续排查文件兼容性问题会困难。
+
+## 测试计划
+
+### LIST 正例
+
+1. 标准 3-level LIST：
+
+```text
+optional group a (LIST) {
+  repeated group list {
+    optional int32 element;
+  }
+}
+```
+
+2. Repeated primitive legacy LIST：
+
+```text
+optional group a (LIST) {
+  repeated int32 element;
+}
+```
+
+3. Repeated group struct element：
+
+```text
+optional group a (LIST) {
+  repeated group element {
+    optional int32 x;
+    optional binary y;
+  }
+}
+```
+
+4. Legacy `array` name：
+
+```text
+optional group a (LIST) {
+  repeated group array {
+    optional int32 item;
+  }
+}
+```
+
+5. Legacy `<parent>_tuple` name：
+
+```text
+optional group a (LIST) {
+  repeated group a_tuple {
+    optional int32 item;
+  }
+}
+```
+
+6. Repeated group annotated as nested LIST：
+
+```text
+optional group a (LIST) {
+  repeated group array (LIST) {
+    repeated int32 array;
+  }
+}
+```
+
+预期解析为 `ARRAY<ARRAY<INT>>`，不要剥掉 `array (LIST)` 这一层。
+
+7. Repeated group annotated as MAP：
+
+```text
+optional group a (LIST) {
+  repeated group array (MAP) {
+    repeated group key_value {
+      required binary key;
+      optional int32 value;
+    }
+  }
+}
+```
+
+预期解析为 `ARRAY<MAP<STRING, INT>>`，不要剥掉 `array (MAP)` 这一层。
+
+8. One-child repeated group whose child is repeated：
+
+```text
+optional group a (LIST) {
+  repeated group element {
+    repeated int32 items;
+  }
+}
+```
+
+预期 repeated group 本身是 struct element，解析为 `ARRAY<STRUCT<items: ARRAY<INT>>>`，不要把 `items` 提升成 list element。
+
+### LIST 反例
+
+1. outer LIST group 多 child。
+2. outer LIST child 非 repeated。
+3. repeated group 无 child。
+4. repeated LIST-annotated outer group，除非它作为 another two-level LIST 的 element 被专门支持。
+
+### MAP 正例
+
+1. 标准 `key_value` entry group。
+2. `entries` entry group name。
+3. entry group 任意名字，但结构为 repeated group with required key and value。
+4. `MAP_KEY_VALUE` legacy converted type。
+5. key/value 字段名非 `key`/`value`，但位置正确。
+
+### MAP 反例
+
+1. nullable key。
+2. outer MAP group 多 child。
+3. entry child 非 repeated。
+4. entry child 是 primitive。
+5. key-only map。
+6. no-entry MAP。
+
+## 实施步骤
+
+1. 在 `parquet_column_schema.cpp` 增加 LIST helper：
+   - `has_structural_list_name()`
+   - `resolve_list_element_node()`
+   - 必要时增加 repeated group as element 的 build helper。
+2. 改造 LIST 分支，输出统一 `ParquetColumnSchemaKind::LIST` schema tree。
+3. 增加 LIST schema/unit/regression 测试。
+   - 覆盖 repeated primitive、multi-field struct element、`array` / `<parent>_tuple` structural name。
+   - 覆盖 two-level `List<List<T>>`、two-level `List<Map<K, V>>`、单 child repeated group 且 child repeated 的 struct element。
+   - read 测试至少覆盖 null list、empty list、单元素、多元素，验证 def/rep materialization。
+4. 增加 MAP helper：
+   - `resolve_map_entry_group()`
+5. 改造 MAP 分支，放宽 entry group 名字限制，但保持 key/value 结构严格。
+6. 增加 MAP schema/unit/regression 测试。
+7. 如后续确有需求，再单独设计 key-only map 支持。
+
+## 预期收益
+
+- 支持更多由 Arrow、Spark、Hive、旧 Parquet writer 产生的 LIST/MAP schema。
+- 兼容逻辑集中在 schema builder，reader 层保持稳定。
+- 为后续 complex parquet reader 的兼容性测试建立清晰边界。

--- a/docs/parquet-list-map-compat-design.md
+++ b/docs/parquet-list-map-compat-design.md
@@ -72,6 +72,12 @@ optional group m (MAP) {
 5. 对容易误判的 schema 保持严格，避免把普通 struct 错解析成 LIST/MAP。
 6. 支持范围对齐 Arrow 的稳定 legacy compatibility 规则，而不是无限放宽。
 
+MAP projection 语义也保持收敛：
+
+- partial MAP projection 只表示 value subtree pruning，例如 `MAP<K, STRUCT<a,b>>` 投影 `value.b` 后输出 `MAP<K, STRUCT<b>>`。
+- key 不作为可裁剪 projection 子树。reader 始终读取完整 key stream，因为 key stream 决定 entry existence、offsets，并且 key 本身承载 MAP 的 key equality 语义。
+- schema projection 重建 `DataTypeMap` 时保留原始 key type，只根据 projected value child 重建 value type。
+
 ## LIST 兼容规则
 
 对于 outer group annotated as `LIST`：
@@ -410,13 +416,14 @@ return
 
 ## MAP schema build
 
-`build_node_schema()` 的 MAP 分支继续输出当前 reader 需要的结构：
+`build_node_schema()` 的 MAP 分支应和 LIST 一样在 schema 构建阶段折叠物理 wrapper。
+`key_value` / `entries` / 任意合法 entry group 只用于解析 repeated entry level，不出现在
+最终 `ParquetColumnSchema.children` 中：
 
 ```text
 MAP
-  child[0]: STRUCT(key, value)   // entry / key_value schema
-      child[0]: key
-      child[1]: value
+  child[0]: key
+  child[1]: value
 ```
 
 构造流程：
@@ -432,22 +439,19 @@ column_schema.repeated_repetition_level = entry_context.repeated_repetition_leve
 build key child from entry_group.field(0)
 build value child from entry_group.field(1)
 
-entry_schema.kind = STRUCT
-entry_schema.children = [key, value]
-entry_schema.type = DataTypeStruct([nullable(key.type), nullable(value.type)], names)
-
 column_schema.type = nullable_if_needed(DataTypeMap(nullable(key.type), nullable(value.type)), map_node)
-column_schema.children = [entry_schema]
+column_schema.children = [key_schema, value_schema]
 propagate_child_levels(column_schema)
 ```
 
-这里保持当前 `MapColumnReader` 的假设：
+这里保持 `MapColumnReader` 的直接 key/value 假设：
 
-- `column_schema.children[0]` 是 entry struct。
-- `entry.children[0]` 是 key。
-- `entry.children[1]` 是 value。
+- `column_schema.children[0]` 是 key。
+- `column_schema.children[1]` 是 value。
+- MAP node 自身保存 entry repeated group 的 `definition_level` / `repetition_level` /
+  `repeated_repetition_level`，用于 materialize offsets、null map 和 empty map。
 
-注意：`DataTypeStruct` / `DataTypeMap` 中把 key type 包成 nullable 是 Doris nested column materialization 的内部类型约定，不代表 Parquet nullable key 被支持。Schema resolver 仍必须在 `key_node.repetition != REQUIRED` 时 reject。
+注意：`DataTypeMap` 中把 key type 包成 nullable 是 Doris nested column materialization 的内部类型约定，不代表 Parquet nullable key 被支持。Schema resolver 仍必须在 `key_node.repetition != REQUIRED` 时 reject。
 
 ## 不支持 key-only map 的原因
 
@@ -493,7 +497,8 @@ optional group m (MAP) {
 保持：
 
 - `ListColumnReader` 只读取 `column_schema.children[0]` 作为 element reader。
-- `MapColumnReader` 只读取 `column_schema.children[0].children[0/1]` 作为 key/value reader。
+- `MapColumnReader` 读取 `column_schema.children[0/1]` 作为 key/value reader。
+- `MapColumnReader` 对 partial MAP projection 只接受 value child projection，显式 key child projection 应 reject；即使只裁剪 value，reader 也必须完整读取 key stream。
 - `ParquetLeafReader` 只负责 leaf records/levels/values 读取和 batch materialization。
 - `nested_column_materializer.*` 只负责 Doris nested Column 构造 helper。
 
@@ -645,9 +650,12 @@ optional group a (LIST) {
    - read 测试至少覆盖 null list、empty list、单元素、多元素，验证 def/rep materialization。
 4. 增加 MAP helper：
    - `resolve_map_entry_group()`
-5. 改造 MAP 分支，放宽 entry group 名字限制，但保持 key/value 结构严格。
+5. 改造 MAP 分支，放宽 entry group 名字限制，但保持 key/value 结构严格，并在 schema build 阶段折叠 entry wrapper，输出 `MAP -> key,value`。
 6. 增加 MAP schema/unit/regression 测试。
-7. 如后续确有需求，再单独设计 key-only map 支持。
+   - 覆盖 entry group 名字兼容。
+   - 覆盖 `ParquetColumnSchema(MAP).children == [key, value]`。
+   - 覆盖 partial MAP projection 只允许 value child，key child projection reject。
+7. 如后续确有需求，再单独设计 key-only map 或 key subtree projection 支持。
 
 ## 预期收益
 


### PR DESCRIPTION
### What problem does this PR solve?

This PR refactors the new parquet reader complex-column path around schema projection and reader creation.

It clarifies `ParquetColumnReaderFactory` recursion, keeps schema projection as a single public helper, normalizes file-local `ColumnDefinition` children to Doris semantic children, and folds the Parquet MAP `key_value/entry` wrapper into the MAP schema node during parquet schema construction. With that shape, MAP and LIST both expose direct semantic children to the table/file reader boundary, and ParquetReader no longer needs a semantic-to-physical projection translation layer for MAP.

### Release note

None

### Check List

- Test: Manual test
    - Ran `git diff --check`.
    - Tried `./run-be-ut.sh -j 8 --run --filter="ParquetColumnReaderTest.ReadProjectedMapStructValueChildren:ColumnMapperScanRequestTest.MapValueStructProjectionPrunesValueChildren"`, but local toolchain failed before tests with `ld: library 'c++' not found`.
- Behavior changed: No
- Does this need documentation: No
