### PR TITLE
[Fix](nereids) Fix month nullable datetimev2 literal binding

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Month.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Month.java
@@ -43,7 +43,7 @@ public class Month extends ScalarFunction
 
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(TinyIntType.INSTANCE).args(DateV2Type.INSTANCE),
-            FunctionSignature.ret(TinyIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT)
+            FunctionSignature.ret(TinyIntType.INSTANCE).args(DateTimeV2Type.WILDCARD)
     );
 
     /**

--- a/regression-test/data/nereids_function_p0/scalar_function/M.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/M.out
@@ -1565,6 +1565,9 @@ dc5f80c371451aa4fc81c930adc64f60
 3
 3
 
+-- !sql_month_nullable_string_literal --
+12	12	1	1	1	1	\N
+
 -- !sql_month_ceil_DateTime --
 \N
 2012-04-01T00:00
@@ -3004,4 +3007,3 @@ March
 
 -- !bugfix_months_diff_17 --
 1
-

--- a/regression-test/suites/nereids_function_p0/scalar_function/M.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/M.groovy
@@ -135,6 +135,7 @@ suite("nereids_scalar_fn_M") {
 	qt_sql_month_DateTimeV2_notnull "select month(kdtmv2s1) from fn_test_not_nullable order by kdtmv2s1"
 	qt_sql_month_DateV2 "select month(kdtv2) from fn_test order by kdtv2"
 	qt_sql_month_DateV2_notnull "select month(kdtv2) from fn_test_not_nullable order by kdtv2"
+	qt_sql_month_nullable_string_literal "select month(cast('2021-12-31 12:23:34' as datetimev2(0))), month(nullable('2021-12-31 12:23:34')), month(cast('0000-01-01 00:00:00' as datetimev2(0))), month(nullable('0000-01-01 00:00:00')), month(cast('0000-01-02 00:00:00' as datetimev2(0))), month(nullable('0000-01-02 00:00:00')), month(null)"
 	qt_sql_month_ceil_DateTime "select month_ceil(kdtm) from fn_test order by kdtm"
 	qt_sql_month_ceil_DateTime_notnull "select month_ceil(kdtm) from fn_test_not_nullable order by kdtm"
 	qt_sql_month_ceil_DateTimeV2 "select month_ceil(kdtmv2s1) from fn_test order by kdtmv2s1"


### PR DESCRIPTION
Related PR: https://github.com/apache/doris/pull/64127

Problem Summary:

`nullable('...')` string literals are unwrapped during signature search and coerced like bare literals. For:
```sql
month(nullable('2021-12-31 12:23:34'))
```
the argument is coerced to DATETIMEV2(6).

But Month declared its datetime overload as `DateTimeV2Type.SYSTEM_DEFAULT`, which is `DATETIMEV2(0)`. `DATETIMEV2(6)` does not match that narrow signature, so signature matching falls through to the DATEV2 overload and reports:
```text
ERROR 1105 (HY000): errCode = 2, detailMessage = argument 1 requires datev2 type, however 'cast(nullable('2025-02-20 12:12:12') as DATETIMEV2(6))' is of datetimev2 type
```

