### PR TITLE
branch-4.1: [fix](fe) Detect Doris-compatible MySQL JDBC targets #64389

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -36,6 +36,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -58,7 +59,7 @@ public class JdbcMySQLClient extends JdbcClient {
             rs = stmt.executeQuery("SHOW VARIABLES LIKE 'version_comment'");
             if (rs.next()) {
                 String versionComment = rs.getString("Value");
-                isDoris = versionComment.toLowerCase().contains("doris");
+                isDoris = isDorisCompatibleVersionComment(versionComment);
             }
         } catch (SQLException | JdbcClientException e) {
             closeClient();
@@ -72,6 +73,18 @@ public class JdbcMySQLClient extends JdbcClient {
         super(jdbcClientConfig);
         convertDateToNull = isConvertDatetimeToNull(jdbcClientConfig);
         this.dbType = dbType;
+    }
+
+    static boolean isDorisCompatibleVersionComment(String versionComment) {
+        if (Strings.isNullOrEmpty(versionComment)) {
+            return false;
+        }
+        String lowerVersionComment = versionComment.toLowerCase(Locale.ROOT);
+        return lowerVersionComment.contains("doris")
+                || lowerVersionComment.contains("selectdb")
+                || lowerVersionComment.contains("velodb")
+                || (lowerVersionComment.contains("enterprise version")
+                    && lowerVersionComment.contains("cloud mode"));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClientTest.java
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.jdbc.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JdbcMySQLClientTest {
+
+    @Test
+    public void testIsDorisCompatibleVersionComment() {
+        Assert.assertTrue(JdbcMySQLClient.isDorisCompatibleVersionComment("Apache Doris version 3.1.0"));
+        Assert.assertTrue(JdbcMySQLClient.isDorisCompatibleVersionComment("SelectDB Cloud version 4.0.5"));
+        Assert.assertTrue(JdbcMySQLClient.isDorisCompatibleVersionComment("VeloDB version 2.1.0"));
+        Assert.assertTrue(JdbcMySQLClient.isDorisCompatibleVersionComment(
+                "enterprise version enterprise-4.0.5-rc01-0724569463d (Cloud Mode)"));
+
+        Assert.assertFalse(JdbcMySQLClient.isDorisCompatibleVersionComment("MySQL Community Server - GPL"));
+        Assert.assertFalse(JdbcMySQLClient.isDorisCompatibleVersionComment(""));
+        Assert.assertFalse(JdbcMySQLClient.isDorisCompatibleVersionComment(null));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64389

Problem Summary: Pick #64389 to branch-4.1. JDBC catalog initializes the MySQL client as a plain MySQL-compatible target unless the remote version_comment contains the word Doris. Doris-compatible deployments can expose version comments such as SelectDB, VeloDB, or enterprise cloud strings, so Doris-specific column type overrides are skipped. As a result, Doris complex types reported through MySQL metadata can be mapped as scalar MySQL types and fail during scan. This pick recognizes Doris-compatible version comments and keeps using the existing SHOW FULL COLUMNS based type override path.

Note: branch-4.1 does not have the newer fe-connector-jdbc module from master, so this manual pick keeps only the existing fe-core JDBC client and unit test changes.

### Release note

Fix JDBC catalog type mapping for Doris-compatible MySQL endpoints whose version_comment does not contain Doris.

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh org.apache.doris.datasource.jdbc.client.JdbcMySQLClientTest
- Behavior changed: Yes. JDBC MySQL catalog now treats SelectDB, VeloDB, and enterprise cloud version comments as Doris-compatible for column type mapping.
- Does this need documentation: No