### PR TITLE
[fix](binlog) Fix nullable type mismatch for timestamp column in _fill_binlog_columns

### DIFF
--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -41,6 +41,7 @@ static const std::string SKIP_BITMAP_COL = "__DORIS_SKIP_BITMAP_COL__";
 static const std::string SEQUENCE_COL = "__DORIS_SEQUENCE_COL__";
 static const std::string BINLOG_TIMESTAMP_COL = "__DORIS_BINLOG_TIMESTAMP__";
 static const std::string BINLOG_LSN_COL = "__DORIS_BINLOG_LSN__";
+static const std::string BINLOG_OP_COL = "__DORIS_BINLOG_OP__";
 
 // 用来加速运算
 const static int32_t g_power_table[] = {1,      10,      100,      1000,      10000,

--- a/be/test/testutil/creators.h
+++ b/be/test/testutil/creators.h
@@ -38,6 +38,7 @@
 #include "runtime/query_context.h"
 #include "storage/binlog.h"
 #include "storage/tablet_info.h"
+#include "storage/utils.h"
 #include "util/uid_util.h"
 
 namespace doris {
@@ -220,6 +221,12 @@ inline void enable_row_binlog(TCreateTabletReq* request, int32_t row_binlog_sche
     row_binlog_schema.columns.push_back(
             create_tablet_column({std::string(kRowBinlogTimestampColName), TPrimitiveType::BIGINT,
                                   false, true, TAggregationType::NONE}));
+    for (auto& col : row_binlog_schema.columns) {
+        if (col.column_name == BINLOG_LSN_COL || col.column_name == BINLOG_OP_COL ||
+            col.column_name == BINLOG_TIMESTAMP_COL) {
+            col.__set_is_allow_null(true);
+        }
+    }
     request->__set_row_binlog_schema(row_binlog_schema);
 }
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: [#64494](https://github.com/apache/doris/issues/64494)


Problem Summary:

When running GroupRowsetWriterTest.sub_writer_rollback, a coredump occurs
because assert_cast<ColumnNullable*> fails - the timestamp column is not
wrapped as ColumnNullable in unit test environment.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

