### PR TITLE
[fix](build): respect CLANG_FORMAT_BINARY env var in version check

### DIFF
--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,7 +31,7 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:-clang-format}"
 
 if [[ -z $(command -v "${CLANG_FORMAT}") ]]; then
     echo "clang-format not found, please install clang-format"

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,18 +31,18 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-if [[ -z $(command -v clang-format) ]]; then
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
+
+if [[ -z $(command -v "${CLANG_FORMAT}") ]]; then
     echo "clang-format not found, please install clang-format"
     exit 1
 fi
 
-CLANG_FORMAT_VERSION=$(clang-format --version | perl -nle 'print $& if m{version \K[0-9]+}')
+CLANG_FORMAT_VERSION=$("${CLANG_FORMAT}" --version | perl -nle 'print $& if m{version \K[0-9]+}')
 if [[ ${CLANG_FORMAT_VERSION} -ne 16 ]]; then
     echo "clang-format version is not 16, please install clang-format version 16 or upgrade your clang-format version to 16"
     exit 1
 fi
-
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
 
 if command -v python3 &>/dev/null; then
     PYTHON=python3

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -43,12 +43,12 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     export PATH=$(brew --prefix llvm@16)/bin:$PATH
 fi
 
-if [[ -z $(command -v clang-format) ]]; then
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
+
+if [[ -z $(command -v "${CLANG_FORMAT}") ]]; then
     echo "clang-format not found, please install clang-format"
     exit 1
 fi
-
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
 
 CLANG_FORMAT_VERSION=$("${CLANG_FORMAT}" --version | perl -nle 'print $& if m{version \K[0-9]+}')
 if [[ ${CLANG_FORMAT_VERSION} -ne 16 ]]; then

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -48,13 +48,13 @@ if [[ -z $(command -v clang-format) ]]; then
     exit 1
 fi
 
-CLANG_FORMAT_VERSION=$(clang-format --version | perl -nle 'print $& if m{version \K[0-9]+}')
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
+
+CLANG_FORMAT_VERSION=$("${CLANG_FORMAT}" --version | perl -nle 'print $& if m{version \K[0-9]+}')
 if [[ ${CLANG_FORMAT_VERSION} -ne 16 ]]; then
     echo "clang-format version is not 16, please install clang-format version 16 or upgrade your clang-format version to 16"
     exit 1
 fi
-
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
 
 if command -v python3 &>/dev/null; then
     PYTHON=python3


### PR DESCRIPTION
Move CLANG_FORMAT resolution before the version check so that CLANG_FORMAT_BINARY=clang-format-16 actually gets version-checked instead of always checking the default clang-format.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

In `build-support/clang-format.sh`, the `CLANG_FORMAT` variable (which respects the `CLANG_FORMAT_BINARY` env var) was resolved **after** the version check. This means the version check always ran against the default `clang-format` in `PATH`, ignoring the `CLANG_FORMAT_BINARY` override.

For example, when a user has `clang-format` v21 in PATH (e.g. from `ldb_toolchain`) and `clang-format-16` installed at `/usr/bin/clang-format-16`, running:

```bash
CLANG_FORMAT_BINARY=clang-format-16 ./build-support/clang-format.sh
```

would still check the version of the default `clang-format` (v21) and fail, even though `clang-format-16` is available and specified.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Before fix: `CLANG_FORMAT_BINARY=clang-format-16 ./build-support/clang-format.sh` fails with "clang-format version is not 16"
        - After fix: `CLANG_FORMAT_BINARY=clang-format-16 ./build-support/clang-format.sh` correctly uses v16 and passes the version check
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason? -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
