### PR TITLE
[fix](cloud) Stabilize UtilTest delay case

### DIFF
--- a/cloud/test/util_test.cpp
+++ b/cloud/test/util_test.cpp
@@ -139,7 +139,8 @@ TEST(UtilTest, stage_wrapper) {
 }
 
 TEST(UtilTest, delay) {
-    auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
+    // Keep the two delayed tasks occupying the pool before the cancel task can run.
+    auto s3_producer_pool = std::make_shared<SimpleThreadPool>(2);
     s3_producer_pool->start();
     // test normal execute
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64455

Problem Summary: Cloud UT can fail in `UtilTest.delay` because the test uses the default recycler pool parallelism and assumes the two delayed tasks begin before the cancel task runs. With many workers, the cancel task can set the `SyncExecutor` stop token before the delayed tasks enter their task bodies, making them invalid and causing `when_all()` to return an empty result.

This patch uses a two-worker pool in this test so the delayed tasks occupy the workers before the cancel task can execute. That makes the intended cancellation ordering deterministic without changing product code.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `PATH=/mnt/disk6/common/ldb_toolchain_toucan/bin:$PATH CLANG_FORMAT_BINARY=/mnt/disk6/common/ldb_toolchain_toucan/bin/clang-format ./build-support/clang-format.sh`
    - `./run-cloud-ut.sh --run --filter=util_test:UtilTest.delay -j 90`
    - `DORIS_JAVA_HOME=${DORIS_JAVA_HOME:-/mnt/disk6/common/jdk-17.0.16} LD_LIBRARY_PATH=${DORIS_JAVA_HOME:-/mnt/disk6/common/jdk-17.0.16}/lib/server:${LD_LIBRARY_PATH:-} ./util_test --gtest_filter=UtilTest.delay --gtest_repeat=20 --gtest_break_on_failure`
    - `PATH=/mnt/disk6/common/ldb_toolchain_toucan/bin:$PATH CLANG_FORMAT_BINARY=/mnt/disk6/common/ldb_toolchain_toucan/bin/clang-format ./build-support/check-format.sh`
    - `git diff --check`
    - `/mnt/disk6/common/ldb_toolchain_toucan/bin/clang-tidy -p cloud/ut_build_ASAN cloud/test/util_test.cpp --quiet`
- Behavior changed: No
- Does this need documentation: No
