### PR TITLE
[Fix](test) Allow bitmap base64 serialization variants

### DIFF
--- a/regression-test/data/doc/sql-manual/sql-functions/doc_bitmap_functions_test.out
+++ b/regression-test/data/doc/sql-manual/sql-functions/doc_bitmap_functions_test.out
@@ -4,10 +4,3 @@
 
 -- !bitmap_to_base64_empty --
 AA==
-
--- !bitmap_to_base64_single --
-BQEBAAAAAAAAAA==
-
--- !bitmap_to_base64_multi --
-BQIBAAAAAAAAAH+WmAAAAAAA
-

--- a/regression-test/suites/doc/sql-manual/sql-functions/doc_bitmap_functions_test.groovy
+++ b/regression-test/suites/doc/sql-manual/sql-functions/doc_bitmap_functions_test.groovy
@@ -30,16 +30,23 @@ suite("doc_bitmap_functions_test") {
         SELECT bitmap_to_base64(bitmap_empty());
     ''')
 
-    qt_bitmap_to_base64_single '''
+    def bitmapToBase64Single = sql '''
         SELECT bitmap_to_base64(to_bitmap(1));
     '''
+    def bitmapToBase64SingleExpected = ["BQEBAAAAAAAAAA==", "AQEAAAA="]
+    assertTrue(bitmapToBase64SingleExpected.contains(bitmapToBase64Single[0][0].toString()),
+            "Unexpected bitmap_to_base64 single result: ${bitmapToBase64Single}")
     testFoldConst('''
         SELECT bitmap_to_base64(to_bitmap(1));
     ''')
 
-    qt_bitmap_to_base64_multi '''
+    def bitmapToBase64Multi = sql '''
         SELECT bitmap_to_base64(bitmap_from_string("1,9999999"));
     '''
+    def bitmapToBase64MultiExpected = ["BQIBAAAAAAAAAH+WmAAAAAAA",
+            "AjowAAACAAAAAAAAAJgAAAAYAAAAGgAAAAEAf5Y="]
+    assertTrue(bitmapToBase64MultiExpected.contains(bitmapToBase64Multi[0][0].toString()),
+            "Unexpected bitmap_to_base64 multi result: ${bitmapToBase64Multi}")
     testFoldConst('''
         SELECT bitmap_to_base64(bitmap_from_string("1,9999999"));
     ''')


### PR DESCRIPTION
### Release note

Allow doc bitmap function tests to accept both SET and SINGLE bitmap serialization outputs.

In fuzzy BE config mode, bitmap values may be serialized with different valid internal representations, causing bitmap_to_base64 golden output to vary for single-value and small bitmap cases. Replace fixed qt checks with explicit allowed-result assertions and remove the unstable golden entries.