### PR TITLE
[fix](case) test_p_seq_publish_read_from_old: disable auto compaction to stabilize qt_inspect

### DIFF
--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_p_seq_publish_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_p_seq_publish_read_from_old.groovy
@@ -38,7 +38,8 @@ suite("test_p_seq_publish_read_from_old") {
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "function_column.sequence_col" = "v1",
-        "store_row_column" = "false"); """
+        "store_row_column" = "false",
+        "disable_auto_compaction" = "true"); """
     sql """insert into ${tableName} values(1,100,1,1,1,1),(2,100,2,2,2,2),(3,100,3,3,3,3),(4,100,4,4,4,4);"""
     qt_sql "select k,v1,v2,v3,v4,v5 from ${tableName} order by k;"
 


### PR DESCRIPTION
## Problem
`test_p_seq_publish_read_from_old` is flaky on the branch-4.1 P0 regression. The `qt_inspect` queries read physical rows (`skip_delete_sign` / `skip_delete_bitmap`); background auto compaction merges rowsets and changes the physical row count, so the inspected output drifts from the `.out`. The final logical data is correct — only the inspected physical rows fluctuate with compaction timing.

## Fix
Add `"disable_auto_compaction" = "true"` to the table PROPERTIES, matching the sibling cases in the same directory, so the inspection is stable.

## Verification
Ran the suite on a branch-4.1 local cluster (3 FE + 4 BE) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)