### PR TITLE
[fix](case) test_admin_compact_table: count distinct tablets for multi-replica clusters

### DIFF
--- a/regression-test/suites/compaction/test_admin_compact_table.groovy
+++ b/regression-test/suites/compaction/test_admin_compact_table.groovy
@@ -45,7 +45,10 @@ suite("test_admin_compact_table", "p0") {
     """
 
     def tablets = sql_return_maparray "SHOW TABLETS FROM ${tableName}"
-    assertEquals(1, tablets.size())
+    // SHOW TABLETS returns one row per (tablet, replica); on a multi-replica
+    // cluster (e.g. force_olap_table_replication_num=3) BUCKETS 1 yields 3 rows.
+    // Assert on the distinct tablet count, then pick any replica below.
+    assertEquals(1, tablets.collect { it.TabletId }.unique().size())
     def tabletId = tablets[0].TabletId
     def backendId = tablets[0].BackendId
 


### PR DESCRIPTION
## Problem
On a multi-replica test cluster (e.g. `force_olap_table_replication_num=3`), `SHOW TABLETS` returns one row per (tablet, replica). A table created with `BUCKETS 1` therefore yields 3 rows, so `assertEquals(1, tablets.size())` fails (expected 1, got 3). The assertion implicitly assumes a single replica.

## Fix
Assert on the distinct tablet count: `tablets.collect { it.TabletId }.unique().size()`. The subsequent code already picks one replica via `tablets[0]`.

## Verification
Ran the suite on a branch-4.1 local cluster (3 FE + 4 BE, force-3 replicas) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)