### PR TITLE
[fix](case) test_delete_bitmap_metrics: warm agg cache on every replica

### DIFF
--- a/regression-test/suites/metrics_p0/test_delete_bitmap_metrics.groovy
+++ b/regression-test/suites/metrics_p0/test_delete_bitmap_metrics.groovy
@@ -189,6 +189,18 @@ suite("test_delete_bitmap_metrics", "p0") {
         def ms_delete_bitmap_count = 0
         def local_delete_bitmap_cardinality = 0;
         def ms_delete_bitmap_cardinality = 0;
+        // The aggregated delete-bitmap cache is populated lazily, and only on the
+        // replica that actually served a query. On a multi-replica cluster
+        // (force_olap_table_replication_num) the qt_sql above warms only one replica,
+        // so the per-replica agg-cache assertions below fail on the other replicas.
+        // Warm every replica by pinning the read to each replica ordinal in turn.
+        int warm_replica_num = tablets.size()
+        for (int ri = 0; ri < warm_replica_num; ri++) {
+            sql "set use_fix_replica=${ri};"
+            sql "select * from ${testTable};"
+        }
+        sql "set use_fix_replica=-1;"
+        sql "sync"
         for (def tablet in tablets) {
             String tablet_id = tablet.TabletId
             def tablet_info = sql_return_maparray """ show tablet ${tablet_id}; """


### PR DESCRIPTION
## Problem
`test_delete_bitmap_metrics` is flaky on the branch-4.1 P0 regression. It reads the per-replica aggregated delete-bitmap cache (`/api/delete_bitmap/count_agg_cache`) and asserts `delete_bitmap_count == 8` on **every** replica of the tablet. But that agg cache is populated **lazily, only on the replica that actually served a query**. On a multi-replica cluster (`force_olap_table_replication_num`), the `qt_sql` select before the loop warms only one replica, so the other replicas still report `0` → the assertion fails. Which replica serves the query is non-deterministic → flaky.

## Fix
Before the per-replica assertions, warm every replica by pinning the read to each replica ordinal (`use_fix_replica`) and running a select, so each replica's agg cache is populated. The assertions themselves are unchanged.

## Verification
Reproduced and verified directly on a branch-4.1 cluster (force-3 replicas) via `count_agg_cache`:
- before any select: all replicas report agg=0
- after one default select: only the serving replica reports 8 (others 0)
- after warming all replicas: all report 8

The suite passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)