### PR TITLE
[fix](regression): stabilize push_down_filter_through_set_operation_with_unique_function plan shape

### DIFF
--- a/regression-test/suites/nereids_rules_p0/unique_function/push_down_filter_through_set_operation_with_unique_function.groovy
+++ b/regression-test/suites/nereids_rules_p0/unique_function/push_down_filter_through_set_operation_with_unique_function.groovy
@@ -19,6 +19,7 @@ suite('push_down_filter_through_set_operation_with_unique_function') {
     sql 'SET enable_nereids_planner=true'
     sql 'SET runtime_filter_mode=OFF'
     sql 'SET enable_fallback_to_original_planner=false'
+    sql 'SET parallel_pipeline_task_num=2'
     sql "SET ignore_shape_nodes='PhysicalDistribute'"
     sql "SET detail_shape_nodes='PhysicalProject'"
     sql 'SET disable_nereids_rules=PRUNE_EMPTY_PARTITION'


### PR DESCRIPTION
## Problem

The regression test `push_down_filter_through_set_operation_with_unique_function` in `nereids_rules_p0/unique_function/` is unstable across different pipeline environments.

When the cluster has only one pipeline executor (`parallel=1`), `SplitAggWithoutDistinct` skips two-phase aggregation (introduced in  #63732), and `hashAgg[LOCAL]` is not generated. This causes the plan shape to diverge from the expected output:

```
Expected: ------hashAgg[LOCAL]
Actual:   ------PhysicalUnion
```

## Fix

Add `SET parallel_pipeline_task_num=2` to the test suite to lock non-single-instance mode, ensuring `hashAgg[LOCAL]` is always generated regardless of BE hardware.

## Related PR

- #62742

🤖 Generated with [Claude Code](https://claude.com/claude-code)