### PR TITLE
branch-4.0: [fix](mtmv) Avoid mutating excluded trigger tables (#62984)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
@@ -93,6 +93,7 @@ public class MTMVPartitionUtil {
             Set<TableName> excludedTriggerTables) throws AnalysisException {
         MTMV mtmv = refreshContext.getMtmv();
         Map<MTMVRelatedTableIf, Set<String>> partitionMappings = refreshContext.getByPartitionName(partitionName);
+        Set<TableName> excludedTriggerTablesToCheck = Sets.newHashSet(excludedTriggerTables);
         if (mtmv.getMvPartitionInfo().getPartitionType() != MTMVPartitionType.SELF_MANAGE) {
             if (MapUtils.isEmpty(partitionMappings)) {
                 LOG.warn("can not found pct partition, partitionName: {}, mtmvName: {}",
@@ -103,7 +104,7 @@ public class MTMVPartitionUtil {
             for (MTMVRelatedTableIf pctTable : pctTables) {
                 Set<String> relatedPartitionNames = partitionMappings.getOrDefault(pctTable, Sets.newHashSet());
                 // if follow base table, not need compare with related table, only should compare with related partition
-                excludedTriggerTables.add(new TableName(pctTable));
+                excludedTriggerTablesToCheck.add(new TableName(pctTable));
                 if (!isSyncWithPartitions(refreshContext, partitionName, relatedPartitionNames, pctTable)) {
                     return false;
                 }
@@ -111,7 +112,7 @@ public class MTMVPartitionUtil {
 
         }
         return isSyncWithAllBaseTables(refreshContext, partitionName, tables,
-                excludedTriggerTables);
+                excludedTriggerTablesToCheck);
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -238,6 +239,34 @@ public class MTMVPartitionUtilTest {
         boolean isSyncWithPartition = MTMVPartitionUtil
                 .isSyncWithPartitions(context, "name1", Sets.newHashSet("name2"), baseOlapTable);
         Assert.assertFalse(isSyncWithPartition);
+    }
+
+    @Test
+    public void testIsMTMVPartitionSyncWithImmutableExcludedTriggerTables() throws AnalysisException {
+        Map<MTMVRelatedTableIf, Set<String>> partitionMappings = Maps.newHashMap();
+        partitionMappings.put(baseOlapTable, Sets.newHashSet("name2"));
+        new Expectations() {
+            {
+                context.getByPartitionName("name1");
+                minTimes = 0;
+                result = partitionMappings;
+
+                mtmvPartitionInfo.getPartitionType();
+                minTimes = 0;
+                result = MTMVPartitionType.FOLLOW_BASE_TABLE;
+
+                mtmvPartitionInfo.getPctTables();
+                minTimes = 0;
+                result = Sets.newHashSet(baseOlapTable);
+            }
+        };
+
+        Set<TableName> excludedTriggerTables = ImmutableSet.of();
+        boolean isMTMVPartitionSync = MTMVPartitionUtil.isMTMVPartitionSync(context, "name1", baseTables,
+                excludedTriggerTables);
+
+        Assert.assertTrue(isMTMVPartitionSync);
+        Assert.assertTrue(excludedTriggerTables.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
pr: #62984
commitId: 464d89c5f62

Backport #62984 to branch-4.0.

This fixes isMTMVPartitionSync mutating caller-owned excluded trigger table sets. The backport adapts the upstream TableNameInfo change to branch-4.0, which still uses TableName in this code path, by copying the input set into a local mutable Set<TableName> before adding followed PCT tables.

Conflict resolution:
- fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java: kept branch-4.0 TableName API and applied the local-copy behavior.
- fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java: adapted the upstream immutable-set test to branch-4.0 JMockit style and TableName type.

Tests:
- git diff --check upstream/branch-4.0..HEAD
- ./run-fe-ut.sh --run org.apache.doris.mtmv.MTMVPartitionUtilTest