### PR TITLE
[fix](join) Restrict auto salt join rewrite

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinReorderContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinReorderContext.java
@@ -40,6 +40,7 @@ public class JoinReorderContext {
     private boolean hasLeftAssociate = false;
 
     private boolean isLeadingJoin = false;
+    private boolean isSaltJoinGenerated = false;
 
     public JoinReorderContext() {
     }
@@ -55,6 +56,7 @@ public class JoinReorderContext {
         this.hasRightAssociate = joinReorderContext.hasRightAssociate;
         this.hasCommuteZigZag = joinReorderContext.hasCommuteZigZag;
         this.isLeadingJoin = joinReorderContext.isLeadingJoin;
+        this.isSaltJoinGenerated = joinReorderContext.isSaltJoinGenerated;
     }
 
     /**
@@ -68,6 +70,7 @@ public class JoinReorderContext {
         hasRightAssociate = false;
         hasLeftAssociate = false;
         isLeadingJoin = false;
+        isSaltJoinGenerated = false;
     }
 
     public boolean hasCommute() {
@@ -124,5 +127,13 @@ public class JoinReorderContext {
 
     public void setLeadingJoin(boolean leadingJoin) {
         isLeadingJoin = leadingJoin;
+    }
+
+    public boolean isSaltJoinGenerated() {
+        return isSaltJoinGenerated;
+    }
+
+    public void setSaltJoinGenerated(boolean saltJoinGenerated) {
+        isSaltJoinGenerated = saltJoinGenerated;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SaltJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SaltJoin.java
@@ -325,6 +325,7 @@ public class SaltJoin extends OneRewriteRuleFactory {
         equalTo = (EqualPredicate) TypeCoercionUtils.processComparisonPredicate(equalTo);
         JoinReorderContext joinReorderContext = new JoinReorderContext();
         joinReorderContext.setLeadingJoin(true);
+        joinReorderContext.setSaltJoinGenerated(true);
         LogicalJoin<Plan, Plan> rightJoin = new LogicalJoin<>(JoinType.RIGHT_OUTER_JOIN, ImmutableList.of(equalTo),
                 project, originPlan, joinReorderContext);
         // construct upper project

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SkewJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SkewJoin.java
@@ -54,7 +54,7 @@ public class SkewJoin extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalJoin()
                 .when(join -> join.getJoinType().isOneSideOuterJoin()
-                        || join.getJoinType().isInnerJoin() || join.getJoinType().isAsofJoin())
+                        || join.getJoinType().isInnerJoin())
                 .when(join -> join.getDistributeHint().distributeType == DistributeType.NONE)
                 .whenNot(join -> join.getJoinReorderContext().isSaltJoinGenerated())
                 .whenNot(LogicalJoin::isMarkJoin)
@@ -87,8 +87,7 @@ public class SkewJoin extends OneRewriteRuleFactory {
             equal = equal.commute();
         }
 
-        if (join.getJoinType().isInnerJoin() || join.getJoinType().isLeftOuterJoin()
-                || join.getJoinType().isAsofInnerJoin() || join.getJoinType().isAsofLeftOuterJoin()) {
+        if (join.getJoinType().isInnerJoin() || join.getJoinType().isLeftOuterJoin()) {
             Expression leftEqHand = equal.child(0);
             if (left.getStats().findColumnStatistics(leftEqHand) != null) {
                 ColumnStatistic leftColStats = left.getStats().findColumnStatistics(leftEqHand);
@@ -99,7 +98,7 @@ public class SkewJoin extends OneRewriteRuleFactory {
                     hotValues.addAll(filtered.keySet());
                 }
             }
-        } else if (join.getJoinType().isRightOuterJoin() || join.getJoinType().isAsofRightOuterJoin()) {
+        } else if (join.getJoinType().isRightOuterJoin()) {
             Expression rightEqHand = equal.child(1);
             if (right.getStats().findColumnStatistics(rightEqHand) != null) {
                 ColumnStatistic rightColStats = right.getStats().findColumnStatistics(rightEqHand);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SkewJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SkewJoin.java
@@ -56,6 +56,7 @@ public class SkewJoin extends OneRewriteRuleFactory {
                 .when(join -> join.getJoinType().isOneSideOuterJoin()
                         || join.getJoinType().isInnerJoin() || join.getJoinType().isAsofJoin())
                 .when(join -> join.getDistributeHint().distributeType == DistributeType.NONE)
+                .whenNot(join -> join.getJoinReorderContext().isSaltJoinGenerated())
                 .whenNot(LogicalJoin::isMarkJoin)
                 .thenApply(SkewJoin::transform).toRule(RuleType.SALT_JOIN);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/SaltJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/SaltJoinTest.java
@@ -136,11 +136,14 @@ public class SaltJoinTest extends TestWithFeService implements MemoPatternMatchS
                                                         logicalGenerate(
                                                                 logicalUnion())),
                                                 logicalOlapScan()
-                                        ).when(join -> join.getJoinType() == JoinType.RIGHT_OUTER_JOIN)
+                                        ).when(join -> join.getJoinType() == JoinType.RIGHT_OUTER_JOIN
+                                                && join.getJoinReorderContext().isSaltJoinGenerated())
                                 ),
                                 logicalProject(
                                         logicalOlapScan())
-                        ).when(join -> join.getHashJoinConjuncts().size() == 2 && join.getJoinType() == JoinType.RIGHT_OUTER_JOIN)
+                        ).when(join -> join.getHashJoinConjuncts().size() == 2
+                                && join.getJoinType() == JoinType.RIGHT_OUTER_JOIN
+                                && !join.getJoinReorderContext().isSaltJoinGenerated())
                 );
     }
 
@@ -265,11 +268,14 @@ public class SaltJoinTest extends TestWithFeService implements MemoPatternMatchS
                                                         logicalGenerate(
                                                                 logicalUnion())),
                                                 logicalOlapScan()
-                                        ).when(join -> join.getJoinType() == JoinType.RIGHT_OUTER_JOIN)
+                                        ).when(join -> join.getJoinType() == JoinType.RIGHT_OUTER_JOIN
+                                                && join.getJoinReorderContext().isSaltJoinGenerated())
                                 ),
                                 logicalProject(
                                         logicalOlapScan())
-                        ).when(join -> join.getHashJoinConjuncts().size() == 2 && join.getJoinType() == JoinType.RIGHT_OUTER_JOIN)
+                        ).when(join -> join.getHashJoinConjuncts().size() == 2
+                                && join.getJoinType() == JoinType.RIGHT_OUTER_JOIN
+                                && !join.getJoinReorderContext().isSaltJoinGenerated())
                 );
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx
Related PR: #59591 #54207
Problem Summary:

This PR restricts the auto salt join rewrite in two cases.

First, ASOF joins are excluded from automatic salt join optimization because the current rewrite may introduce large build-side expansion and is not cost guarded for ASOF semantics.

Second, SaltJoin now marks internally generated helper joins with `isSaltJoinGenerated` in `JoinReorderContext`. `SkewJoin` skips these generated joins to avoid applying salt rewrite recursively on SaltJoin's own expansion plan.

### Release note

None

### Check List (For Author)

- Test: Manual test
- Behavior changed: Yes. The optimizer no longer applies automatic salt join rewrite to ASOF joins or SaltJoin-generated helper joins.
- Does this need documentation: No