### PR TITLE
[fix](case) test_partition_instance_query_cache: gate plan-shape checks to single BE

### DIFF
--- a/regression-test/suites/query_p0/cache/test_partition_instance_query_cache.groovy
+++ b/regression-test/suites/query_p0/cache/test_partition_instance_query_cache.groovy
@@ -93,6 +93,20 @@ suite("test_partition_instance_query_cache") {
         contains("DIGEST")
     }
 
+    // The "one scan instance per partition" plan shape asserted below only holds when the
+    // scan runs on a single BE. On a multi-BE cluster the query-cache partition parallelism
+    // legitimately produces one instance per (partition, BE) -- or, when
+    // totalTablets <= parallelExecInstanceNum * numBE, falls back to default per-tablet
+    // parallelization (see UnassignedScanSingleOlapTableJob). The result-correctness and
+    // cache-consistency checks above already ran on any topology; only the single-BE-only
+    // plan-shape checks are gated here. Multi-BE behavior should have a dedicated test.
+    def aliveBeNum = sql("show backends").count { it[9].toString() == "true" }
+    if (aliveBeNum != 1) {
+        logger.info("Skip partition-instance plan-shape assertions: requires a single BE, found ${aliveBeNum}.")
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        return
+    }
+
     def distributedRows = sql("EXPLAIN DISTRIBUTED PLAN ${querySql}")
     def distributedPlan = distributedRows.collect { it[0].toString() }.join("\n")
     assertTrue(distributedPlan.contains("UnassignedScanSingleOlapTableJob"))


### PR DESCRIPTION
## Problem
`test_partition_instance_query_cache` is flaky/failing on the branch-4.1 P0 regression. It asserts the query-cache **partition-parallelism** plan shape: `scanInstanceCount == partitionCount` and that all of a partition's tablets land in **one** scan instance. That shape only holds when the scan runs on a **single BE**.

On a multi-BE cluster the optimization (`UnassignedScanSingleOlapTableJob`) legitimately produces **one instance per (partition, BE)** — or, when `totalTablets <= parallelExecInstanceNum * numBE`, falls back to default per-tablet parallelization. So on the multi-BE P0 cluster the case fails for the wrong reason (verified: `partitions=3/3` but `scanInstanceCount=24`).

## Fix
Gate the single-BE-only plan-shape assertions on a single-BE topology (`show backends`). The result-correctness and cache-consistency checks above still run on **any** topology. Multi-BE behavior should be covered by a dedicated test.

## Verification
Verified on a branch-4.1 cluster: on the multi-BE topology the gated branch is skipped and the suite passes; the data/cache assertions still execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)