### PR TITLE
[fix](case) one_col_range_partition: query a date range that has data

### DIFF
--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_col_range_partition.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_col_range_partition.groovy
@@ -254,9 +254,9 @@ suite("one_col_range_partition") {
         contains("partitions=417/1826")
     }
     explain {
-        sql """SELECT * FROM one_col_range_partition_date WHERE case when dt<'2021-1-01 00:00:00' then false when dt<'2021-5-01' then false
+        sql """SELECT * FROM one_col_range_partition_date WHERE case when dt<'2021-1-01 00:00:00' then false when dt<'2021-1-15' then false
         else true end;"""
-        contains("partitions=417/1826")
+        contains("partitions=37/1826")
     }
     explain {
         sql """SELECT * FROM one_col_range_partition_date WHERE case when dt<'2022-1-01 00:00:00' then dt


### PR DESCRIPTION
## Problem
`one_col_range_partition` fails on branch-4.1 P0 at the multi-branch CASE WHEN assertion (~line 256). The CASE WHEN simplifies to `dt >= '2021-05-01'`, but the table's data only spans 2020-01-01 ~ 2021-02-20 (10000 hours), so that range contains **no data**. The optimizer now correctly prunes the all-empty partitions to `0:VEMPTYSET`, so the stale `contains("partitions=417/1826")` no longer matches.

**This is not a correctness bug** — the result is correct (0 rows, nothing matches). Verified on a branch-4.1 cluster:
- a plain `WHERE dt >= '2021-05-01'` also prunes to `VEMPTYSET` (data-driven empty-partition pruning);
- inserting a row `dt = '2021-06-15'` immediately flips the plan to `partitions=1/1826` and the row is returned — so VEMPTYSET never drops real data.

## Fix
Change the CASE WHEN's second threshold to `'2021-1-15'` (inside the data range) so it prunes to a real, non-empty partition set, and update the expected count to `partitions=37/1826`. This keeps the assertion verifying that a multi-branch CASE WHEN is correctly pushed into partition pruning.

Scope check: this is the **only** stale assertion in the suite — the sibling CASE WHEN near line 261 still yields `417/1826` and is left unchanged.

## Verification
On a branch-4.1 cluster the rewritten CASE WHEN deterministically prunes to `partitions=37/1826` (matching `dt >= '2021-01-15'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)