### PR TITLE
[codeowner] Update and fix codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@ be/src/storage/olap_common.h                                 @gavinchou @yiguole
 be/src/storage/cache                                         @liaoxin01 @gavinchou
 be/src/storage/compaction                                    @luwei16 @gavinchou
 be/src/storage/delete                                        @luwei16 @gavinchou
-be/src/storage/index                                         @airbone12
+be/src/storage/index                                         @airborne12
 be/src/storage/iterator                                      @yiguolei @gavinchou
 be/src/storage/predicate                                     @yiguolei @gavinchou
 be/src/storage/rowset                                        @gavinchou
@@ -79,7 +79,7 @@ be/test/storage                                              @gavinchou
 be/test/storage/cache                                        @liaoxin01 @gavinchou
 be/test/storage/compaction                                   @luwei16 @gavinchou
 be/test/storage/delete                                       @gavinchou
-be/test/storage/index                                        @airbone12
+be/test/storage/index                                        @airborne12
 be/test/storage/iterator                                     @yiguolei @gavinchou
 be/test/storage/predicate                                    @yiguolei @gavinchou
 be/test/storage/rowset                                       @gavinchou
@@ -97,7 +97,7 @@ fe/fe-core/src/main/java/org/apache/doris/cloud/alter        @luwei16 @gavinchou
 fe/fe-core/src/main/java/org/apache/doris/cloud/backup       @luwei16 @gavinchou
 fe/fe-core/src/main/java/org/apache/doris/cloud/catalog      @morningman @gavinchou
 fe/fe-core/src/main/java/org/apache/doris/cloud/common       @gavinchou
-fe/fe-core/src/main/java/org/apache/doris/cloud/datasource   @mingyuchen @gavinchou
+fe/fe-core/src/main/java/org/apache/doris/cloud/datasource   @morningman @gavinchou
 fe/fe-core/src/main/java/org/apache/doris/cloud/load         @liaoxin01 @gavinchou
 fe/fe-core/src/main/java/org/apache/doris/cloud/master       @gavinchou
 fe/fe-core/src/main/java/org/apache/doris/cloud/persist      @gavinchou

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@ be/src/load/memtable                                         @liaoxin01 @gavinch
 be/src/load/routine_load                                     @liaoxin01 @gavinchou
 be/src/load/stream_load                                      @liaoxin01 @gavinchou
 be/src/storage                                               @gavinchou
+be/src/storage/olap_common.h                                 @gavinchou @yiguolei
 be/src/storage/cache                                         @liaoxin01 @gavinchou
 be/src/storage/compaction                                    @luwei16 @gavinchou
 be/src/storage/delete                                        @luwei16 @gavinchou


### PR DESCRIPTION
## Summary
- Add @yiguolei as a CODEOWNER for be/src/storage/olap_common.h while keeping @gavinchou.
- Fix CODEOWNERS owner typos: @airbone12 -> @airborne12, @mingyuchen -> @morningman.

## Validation
- Verified GitHub CODEOWNERS API returns no errors for this branch.
- Verified every owner listed in .github/CODEOWNERS has write permission on apache/doris.

## Testing
- Not run; CODEOWNERS-only change.