### PR TITLE
[fix](regression) keep variant_doc_mode_p2 load in the p2 group with its queries

### DIFF
--- a/regression-test/suites/variant_doc_mode_p2/load.groovy
+++ b/regression-test/suites/variant_doc_mode_p2/load.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_doc_value_p2", "nonConcurrent,p2"){
+suite("test_doc_value_p2", "p2"){
     sql """ set default_variant_enable_doc_mode = true """
     boolean random = new Random().nextBoolean()
     if (random) {


### PR DESCRIPTION
### What problem does this PR solve?

In `regression_test_variant_doc_mode_p2`, `load.groovy` (which creates and loads the `github_events` table) is tagged `nonConcurrent,p2`, while the 76 `sql/*.sql` query cases in the same directory fall back to the path-derived default group `variant_doc_mode_p2` (no `nonConcurrent`).

`nonConcurrent` is a **separate pipeline**, so the load step and the queries get routed to different runs/clusters. In the P2 run the load never executes, and every query fails instantly with:

```
Table [github_events] does not exist in database [regression_test_variant_doc_mode_p2]
```

This produced **66 cascade failures in a single branch-4.1 P2 build** (e.g. build #35 / 198091), all from the same root cause.

### Root cause

The `nonConcurrent` tag was applied only to `load.groovy`, not to the dependent queries. The correct nonConcurrent sibling (`variant_github_events_nonConcurrent_p2`) encodes it in the **directory name** so the whole suite (load + queries) routes together; `variant_doc_mode_p2` instead split the data-prep away from its queries.

The load only sets **session variables** and does no global-state mutation (no `set global` / FE-BE config / debug points), so it does not actually need `nonConcurrent` isolation.

### Fix

Drop `nonConcurrent` so `load.groovy` shares the `p2` group/pipeline with its queries. `load.groovy` sorts before `sql/`, runs first, and `github_events` is present when the queries execute.

```diff
-suite("test_doc_value_p2", "nonConcurrent,p2"){
+suite("test_doc_value_p2", "p2"){
```

> Note: the identical structure exists on master (`#59183`); a follow-up there is advisable.

### Release note

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)