### PR TITLE
[enhancement](CI) Force inject required AGENTS guides into review prompt

### DIFF
--- a/.github/scripts/prepare_review_agents.py
+++ b/.github/scripts/prepare_review_agents.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Prepare the AGENTS.md guide list for automated PR review prompts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path, PurePosixPath
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        type=Path,
+        help="Newline-delimited PR changed file paths.",
+    )
+    parser.add_argument(
+        "--required-agents",
+        required=True,
+        type=Path,
+        help="Output file containing one required AGENTS.md path per line.",
+    )
+    parser.add_argument(
+        "--prompt-block",
+        required=True,
+        type=Path,
+        help="Output file containing the bullet list inserted into the review prompt.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path("."),
+        type=Path,
+        help="Repository root. Defaults to the current working directory.",
+    )
+    return parser.parse_args()
+
+
+def valid_changed_path(path: str) -> PurePosixPath | None:
+    value = path.strip()
+    if not value:
+        return None
+
+    candidate = PurePosixPath(value)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ValueError(f"Changed file path escapes the repository: {path!r}")
+    return candidate
+
+
+def add_if_present(repo_root: Path, agents: list[str], seen: set[str], path: PurePosixPath) -> None:
+    text_path = path.as_posix()
+    if text_path in seen:
+        return
+    if (repo_root / Path(text_path)).is_file():
+        agents.append(text_path)
+        seen.add(text_path)
+
+
+def required_agents(repo_root: Path, changed_files: list[PurePosixPath]) -> list[str]:
+    agents: list[str] = []
+    seen: set[str] = set()
+
+    add_if_present(repo_root, agents, seen, PurePosixPath("AGENTS.md"))
+    for changed_file in changed_files:
+        for index in range(1, len(changed_file.parts)):
+            directory = PurePosixPath(*changed_file.parts[:index])
+            add_if_present(repo_root, agents, seen, directory / "AGENTS.md")
+
+    return agents
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    changed_files = [
+        path
+        for path in (valid_changed_path(line) for line in args.changed_files.read_text().splitlines())
+        if path is not None
+    ]
+    agents = required_agents(repo_root, changed_files)
+
+    args.required_agents.write_text("".join(f"{path}\n" for path in agents))
+    if agents:
+        args.prompt_block.write_text("".join(f"- {path}\n" for path in agents))
+    else:
+        args.prompt_block.write_text("- No AGENTS.md files were found for the changed file ancestors.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -1,6 +1,21 @@
 name: Code Review Runner
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      head_sha:
+        required: true
+        type: string
+      base_sha:
+        required: true
+        type: string
+      review_focus:
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       pr_number:
@@ -204,9 +219,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          HELPER_REF: ${{ github.workflow_sha || github.sha }}
         run: |
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename' > "$REVIEW_CONTEXT_DIR/pr_changed_files.txt"
-          python3 .github/scripts/prepare_review_agents.py \
+
+          helper="$RUNNER_TEMP/prepare_review_agents.py"
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            "repos/${REPO}/contents/.github/scripts/prepare_review_agents.py?ref=${HELPER_REF}" \
+            > "$helper"
+          chmod 700 "$helper"
+
+          python3 "$helper" \
             --changed-files "$REVIEW_CONTEXT_DIR/pr_changed_files.txt" \
             --required-agents "$REVIEW_CONTEXT_DIR/required_agents.txt" \
             --prompt-block "$REVIEW_CONTEXT_DIR/required_agents_prompt.txt"

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -199,6 +199,21 @@ jobs:
             printf 'No additional user-provided review focus.\n' > "$REVIEW_CONTEXT_DIR/review_focus.txt"
           fi
 
+      - name: Prepare required AGENTS guides
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename' > "$REVIEW_CONTEXT_DIR/pr_changed_files.txt"
+          python3 .github/scripts/prepare_review_agents.py \
+            --changed-files "$REVIEW_CONTEXT_DIR/pr_changed_files.txt" \
+            --required-agents "$REVIEW_CONTEXT_DIR/required_agents.txt" \
+            --prompt-block "$REVIEW_CONTEXT_DIR/required_agents_prompt.txt"
+
+          echo "Required AGENTS.md files for this review:"
+          sed 's/^/  /' "$REVIEW_CONTEXT_DIR/required_agents.txt"
+
       - name: Prepare review prompt
         run: |
           cat > "$REVIEW_CONTEXT_DIR/review_prompt.txt" <<'PROMPT'
@@ -216,8 +231,13 @@ jobs:
           - Existing inline review threads: PLACEHOLDER_CONTEXT_DIR/pr_review_threads.md
           - Raw inline review comments JSON: PLACEHOLDER_CONTEXT_DIR/pr_review_comments.json
           - User review focus: PLACEHOLDER_CONTEXT_DIR/review_focus.txt
+          - PR changed files: PLACEHOLDER_CONTEXT_DIR/pr_changed_files.txt
+          - Required AGENTS.md files: PLACEHOLDER_CONTEXT_DIR/required_agents.txt
 
           Before reviewing any code, you MUST read and follow the code review skill in this repository. During review, you must strictly follow those instructions.
+          Before inspecting the PR diff or related code, you MUST read the contents of every AGENTS.md file listed below. These paths are computed from the PR changed file ancestors in this checkout. Searching for or listing paths is not sufficient; read each listed file directly.
+          Required AGENTS.md files for this PR:
+          PLACEHOLDER_REQUIRED_AGENTS_BLOCK
           Before proposing any new issue, you MUST read PLACEHOLDER_CONTEXT_DIR/pr_review_threads.md and treat every existing inline comment thread and reply as already-known review context.
           Do NOT submit the same or substantially similar issue again if it has already been raised in the existing review threads, even if you would phrase it differently.
           Only raise a similar concern when the PR introduces a genuinely different instance in another location that is not already covered by the existing thread, and explain why it is distinct.
@@ -243,6 +263,16 @@ jobs:
           sed -i "s|PLACEHOLDER_HEAD_SHA|${HEAD_SHA}|g" "$REVIEW_CONTEXT_DIR/review_prompt.txt"
           sed -i "s|PLACEHOLDER_BASE_SHA|${BASE_SHA}|g" "$REVIEW_CONTEXT_DIR/review_prompt.txt"
           sed -i "s|PLACEHOLDER_CONTEXT_DIR|${REVIEW_CONTEXT_REL}|g" "$REVIEW_CONTEXT_DIR/review_prompt.txt"
+          python3 - "$REVIEW_CONTEXT_DIR/review_prompt.txt" "$REVIEW_CONTEXT_DIR/required_agents_prompt.txt" <<'PY'
+          import sys
+          from pathlib import Path
+
+          prompt_path = Path(sys.argv[1])
+          required_agents_path = Path(sys.argv[2])
+          prompt = prompt_path.read_text()
+          required_agents = required_agents_path.read_text().rstrip()
+          prompt_path.write_text(prompt.replace("PLACEHOLDER_REQUIRED_AGENTS_BLOCK", required_agents))
+          PY
         env:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
Problem Summary: Automated code review runs relied on the reviewer to infer which module-specific AGENTS.md files apply to a pull request. Recent Litefuse traces showed that reviews often skipped ancestor guides such as the repository root AGENTS.md, fe/AGENTS.md, and be/test/AGENTS.md even when the changed files made them applicable. This change fetches the PR changed file list, derives every existing AGENTS.md file from the changed file ancestor directories, records the list in the review context, and injects the required guide paths directly into the first Codex review prompt.

We tested 5 PRs that did not read the AGENTS.md file during previous pipeline runs, and the new results are as follows:

| Origin PR | Test PR | Run | Litefuse Trace | Result |
|---|---:|---:|---|---|
| apache/doris#64478 | zclllyybb/doris#36 | `27536249602` | `d76b77ac4e0d52d96f413b154c9f2571` | Read All |
| apache/doris#64458 | zclllyybb/doris#37 | `27536258049` | `8db34388a8379acdcd9e48720f11225f` | Read All |
| apache/doris#64392 | zclllyybb/doris#38 | `27536266784` | `a5e37fba03375a9517f7a67e33f70d39` | Read All |
| apache/doris#64489 | zclllyybb/doris#39 | `27536275680` | `22ace18d70ece96b0ca7fa73123b62da` | Read All |
| apache/doris#64419 | zclllyybb/doris#41 | `27538239601` | `1803c040e4140d61e840e4e1526190e7` | Read All |
