### PR TITLE
branch-4.1: [fix](case) fix mow compaction cases on multi-replica cluster

### DIFF
--- a/regression-test/suites/compaction/test_mow_compaction_agg_and_remove_pre_delete_bitmap.groovy
+++ b/regression-test/suites/compaction/test_mow_compaction_agg_and_remove_pre_delete_bitmap.groovy
@@ -191,7 +191,9 @@ suite("test_mow_compaction_agg_and_remove_pre_delete_bitmap", "nonConcurrent") {
 
         def tablets = sql_return_maparray """ show tablets from ${testTable}; """
         logger.info("tablets: " + tablets)
-        assertEquals(1, tablets.size())
+        // BUCKETS 1 => exactly one tablet; the cluster may create multiple replicas,
+        // so show tablets returns one row per replica. Assert by distinct tablet id.
+        assertEquals(1, tablets.collect { it.TabletId }.unique().size())
         def tablet = tablets[0]
 
         // 1. write some data
@@ -278,7 +280,9 @@ suite("test_mow_compaction_agg_and_remove_pre_delete_bitmap", "nonConcurrent") {
 
         tablets = sql_return_maparray """ show tablets from ${testTable}; """
         logger.info("tablets: " + tablets)
-        assertEquals(1, tablets.size())
+        // BUCKETS 1 => exactly one tablet; the cluster may create multiple replicas,
+        // so show tablets returns one row per replica. Assert by distinct tablet id.
+        assertEquals(1, tablets.collect { it.TabletId }.unique().size())
         tablet = tablets[0]
 
         // 1. write some data

--- a/regression-test/suites/compaction/test_mow_compaction_and_read_stale.groovy
+++ b/regression-test/suites/compaction/test_mow_compaction_and_read_stale.groovy
@@ -203,7 +203,9 @@ suite("test_mow_compaction_and_read_stale", "nonConcurrent") {
 
     def tablets = sql_return_maparray """ show tablets from ${testTable}; """
     logger.info("tablets: " + tablets)
-    assertEquals(1, tablets.size())
+    // BUCKETS 1 => exactly one tablet; the cluster may create multiple replicas,
+    // so show tablets returns one row per replica. Assert by distinct tablet id.
+    assertEquals(1, tablets.collect { it.TabletId }.unique().size())
     def tablet = tablets[0]
     String tablet_id = tablet.TabletId
 

--- a/regression-test/suites/compaction/test_mow_compaction_and_schema_change.groovy
+++ b/regression-test/suites/compaction/test_mow_compaction_and_schema_change.groovy
@@ -216,7 +216,9 @@ suite("test_mow_compaction_and_schema_change", "nonConcurrent") {
 
             def tablets = sql_return_maparray """ show tablets from ${testTable}; """
             logger.info("tablets: " + tablets)
-            assertEquals(1, tablets.size())
+            // BUCKETS 1 => exactly one tablet; the cluster may create multiple replicas,
+            // so show tablets returns one row per replica. Assert by distinct tablet id.
+            assertEquals(1, tablets.collect { it.TabletId }.unique().size())
             def tablet = tablets[0]
 
             // 1. write some data


### PR DESCRIPTION
### What problem does this PR solve?

The three nonConcurrent MOW compaction regression cases

- `test_mow_compaction_and_read_stale`
- `test_mow_compaction_and_schema_change`
- `test_mow_compaction_agg_and_remove_pre_delete_bitmap`

asserted `assertEquals(1, tablets.size())` right after `show tablets`.
`show tablets` returns **one row per replica**, so on a cluster that
materializes multiple replicas for the single bucket (the branch-4.1
`NonConcurrent` pipeline creates 3 replicas even when the table requests 1),
the assertion fails at table setup:

```
expected: <1> but was: <3>
```

The 3 rows share the same `TabletId` (one bucket, three replicas), e.g.:

```
TabletId:1781362443532 ReplicaId:...533 BackendId:...351
TabletId:1781362443532 ReplicaId:...534 BackendId:...348
TabletId:1781362443532 ReplicaId:...535 BackendId:...349
```

### What does this PR do?

Assert the real invariant instead — **exactly one distinct tablet** (`BUCKETS 1`) —
by de-duplicating on `TabletId`, which is independent of replica count:

```groovy
assertEquals(1, tablets.collect { it.TabletId }.unique().size())
```

The cases already operate on a single replica via `tablets[0]`, so the
downstream compaction / delete-bitmap inspection is unaffected.

Related to apache/doris#58662, which relaxed the same check to
`tablets.size() >= 1`; this uses a stricter distinct-tablet assertion. The
same improvement will be proposed on master so the branches reconverge.

### Release note

None

### Check List

- [x] Test <!-- At least one of the following must be checked -->
  - [x] Regression test (test-only change)