### PR TITLE
[fix](statistics) Add analyze OOM hint for statistics task

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: code-review
+description: Review code with Doris-specific checklists
+compatibility: opencode
+---
+
+## What I do
+
+Complete code review work to ensure code quality. Due to the length of content, you can read sections as needed based on the actual modifications being reviewed.
+
+## When to use me
+
+Use this when you need to review code, whether it is code you just completed or directly reviewing target code.
+
+## How to use me
+
+1. **Always read and respond to Part 1** (General Principles) — it applies to all code.
+2. For module-specific review, **read the `AGENTS.md` in the corresponding source directory** listed in Part 2. Those files contain non-obvious conventions and traps specific to each subsystem.
+3. Parts 3–7 cover cross-module concerns, testing, high-risk patterns, functions, and standards — refer as needed.
+
+---
+
+## Part 1: General Principles
+
+### 1.1 Core Invariants
+
+Always focus on the following core invariants during review:
+1. **Data Correctness**: Data from any committed transaction must be visible to subsequent queries and not lost; data from uncommitted transactions must not be visible
+2. **Version Consistency**: Partition visible version is the sole standard for data visibility; BE must strictly read data not exceeding this version
+3. **Delete Bitmap Consistency** (MoW tables): delete bitmap must be strictly aligned with rowset versions; sentinel marks and `TEMP_VERSION`-style placeholders must be replaced with actual versions before use
+4. **Memory Safety**: All significant memory allocations must be tracked by `MemTracker`; orphan memory is not allowed
+5. **Error Means Failure**: Invariant violations should trigger exceptions or non-OK `Status`; silent continuation is never allowed
+
+### 1.2 Review Principles
+
+- **Branch Compatibility (branch-3.1)**: Be aware that these guidelines originated from the `master` branch. If a guideline enforces a new architectural pattern, macro (e.g., `Result<T>` everywhere), or class that does not exist or is not widely adopted in `branch-3.1`, gracefully fallback to the existing paradigms in `branch-3.1`.
+- **Follow Context**: Match adjacent code's error handling, interface usage, and lock patterns unless a clearly better approach exists
+- **Reuse First**: Search for existing implementations before adding new ones; ensure good abstraction afterward. For example, in the implementation of SQL functions in BE, we prefer to use an existing base template rather than implementing everything from scratch. The same principle applies to the implementation of other features. Common parts should be abstracted as much as possible.
+- **Code Over Docs**: When this skill conflicts with actual code, defer to code and note the mismatch
+- **Performance First**: All obviously redundant operations should be optimized away, all obvious performance optimizations must be applied, and obvious anti-patterns must be eliminated.
+- **Evidence Speaks**: All issues with code itself (not memory or environment) must be clearly identified as either having problems or not. For any erroneous situation, if it cannot be confirmed locally, you must provide the specific path or logic where the error occurs. That is, if you believe that if A then B, you must specify a clear scenario where A occurs.
+- **Review Holistically**: For any new feature or modification, you must analyze its upstream and downstream code to understand the real invocation chain. Identify all implicit assumptions and constraints throughout the flow, then verify carefully that the current change works correctly within the entire end-to-end process. Also determine whether a seemingly problematic local pattern is actually safe due to strong guarantees from upstream or downstream, or whether a conventional local implementation fails to achieve optimal performance because it does not leverage additional information available from the surrounding context.
+
+### 1.3 Critical Checkpoints (Self-Review and Review Priority)
+
+The following checkpoints must be **individually confirmed with conclusions** during self-review and review. If the code is too long or too complex, you should delve into the code again as needed when analyzing specific issues, especially the entire logic chain where there are doubts:
+
+- What is the goal of the current task? Does the current code accomplish this goal? Is there a test that proves it?
+- Is this modification as small, clear, and focused as possible?
+- Does the code segment involve concurrency? If yes:
+  - Which threads introduce concurrency, what are the critical variables? What locks protect them?
+  - Are operations within locks as lightweight as possible? Are all heavy operations outside locks while maintaining concurrency safety?
+  - If multiple locks exist, is the locking order consistent? Is there deadlock risk?
+- Is there special or non-intuitive lifecycle management including static initialization order? If yes:
+  - Understand the complete lifecycle and relationships of related variables. Are there circular references? When is each released? Can all lifecycles end normally?
+  - For cross-TU static/global variables: does the initializer of one static variable depend on another static variable defined in a different translation unit? If yes, the initialization order is undefined by the C++ standard (static initialization order fiasco). Use constexpr, inline variables in the same header, or lazy initialization to fix.
+- Are configuration items added?
+  - Should the configuration allow dynamic changes, and does it actually allow them? If yes:
+    - Can affected processes detect the change promptly without restart?
+- Does it involve incompatible changes like function symbols or storage formats? If yes:
+  - Is compatibility code added? Can it correctly handle requests during rolling upgrades?
+- Are there functionally parallel code paths to the modified one? If yes:
+  - Should this modification be applied to other paths, and has it been?
+- Are there special conditional checks? If yes:
+  - Does the condition have clear comments explaining why this check is necessary, simplest, and most viable?
+  - Are there similar paths with similar issues?
+- What is the test coverage?
+  - Are end-to-end functional tests comprehensive?
+  - Are there comprehensive negative test cases from various angles?
+  - For complex features, are key functions sufficiently modular with unit tests?
+- Does the feature need increased observability? If yes:
+  - When bugs occur, are existing logs and VLOGs sufficient to investigate key issues?
+  - Are INFO logs lightweight enough?
+  - Are Metrics added for critical paths? Referencing similar features, are all necessary observability values covered?
+- Does it involve transaction and persistence-related modifications? If yes:
+  - Are all EditLog reads and writes correctly covered? Is all information requiring persistent storage persisted? Does it follow our standard approach?
+  - In transaction processing logic, can master failover at any time point be handled correctly?
+- Does it involve data writes and modifications? If yes:
+  - Are transactionality and atomicity guaranteed? Are there issues with concurrency?
+  - Would FE or BE crashes cause leaks, deadlocks, or incorrect data?
+- Are new variables added that need to be passed between FE and BE? If yes:
+  - Is variable passing modified in all paths? For example, various scattered thrift sending points like constant folding, point queries.
+- Analyze deeply from all angles (including but not limited to time complexity, anti-patterns, CPU and memory friendliness, redundant calculations, etc.) based on the code context and available information. Are there any performance issues or optimization opportunities?
+- Based on your understanding, are there any other issues with the current modification?
+
+After checking all the above items with code. Use the remaining parts of this skill as needed. The following content does not need individual responses; just check during the review process.
+
+#### 1.3.1 Concurrency and Thread Safety (Highest Priority)
+
+- [ ] **Thread context**: Does every new thread or bthread entry attach the right memory-tracking context? (See `be/src/runtime/AGENTS.md`)
+- [ ] **Lock protection**: Is shared data accessed under the correct lock and mode?
+- [ ] **Lock order**: Do nested acquisitions follow the module's documented lock order? (See storage, schema-change, cloud AGENTS.md)
+- [ ] **Atomic memory order**: `relaxed` for counters only; at least `acquire/release` for signals and lifecycle flags
+
+#### 1.3.2 Error Handling (Highest Priority)
+
+- [ ] **Status checking**: Every `Status` must be checked; silent discard is prohibited
+- [ ] **Exception propagation**: Is there a catch-and-convert boundary above every `THROW_IF_ERROR`? (See `be/src/common/AGENTS.md`)
+- [ ] **Error context**: Do error messages include table, partition, tablet, or transaction identifiers?
+- [ ] **Assertions**: `DORIS_CHECK` for invariants only, never speculative defensive checks
+
+#### 1.3.3 Memory Safety (High Priority)
+
+- [ ] **Reservation**: `try_reserve()` before large allocations, with guaranteed release on every exit path
+- [ ] **Ownership**: See `be/src/runtime/AGENTS.md` for cache-handle, shared_ptr-cycle, and factory-creator rules
+
+#### 1.3.4 Data Correctness (High Priority)
+
+- [ ] **Version consistency**: Does data reading stay at or below the visible version?
+- [ ] **MoW correctness**: See `be/src/storage/AGENTS.md` for delete-bitmap sentinel replacement, MoW enablement, and serialization rules
+- [ ] **EditLog**: Are metadata changes logged and replayed equivalently? (See `fe/.../persist/AGENTS.md`)
+
+#### 1.3.5 Observability (Medium Priority)
+
+- [ ] Are critical new paths observable with appropriate log levels and metrics?
+- [ ] Do distributed operations include enough identifiers for tracing?
+
+### 1.4 Test Coverage Principles
+
+- All kernel features **must** have tests; prioritize regression tests, add unit tests where practical
+- `.out` files must be auto-generated, never handwritten
+- Use `order_qt_` or explicit `ORDER BY` for deterministic output
+- Expected errors: `test { sql "..."; exception "..." }`
+- Drop tables before use, not after, to preserve debug state
+- Hardcode table names in simple tests instead of `def tableName`
+
+---
+
+## Part 2: Module-Specific Review Guides (AGENTS.md)
+
+Detailed module review guides live in `AGENTS.md` files in each source directory. **Read the relevant file** when reviewing module-specific code.
+
+### BE Module
+
+| Directory | Coverage |
+|-----------|----------|
+| `be/src/common/AGENTS.md` | Error handling and `compile_check` |
+| `be/src/cloud/AGENTS.md` | Cloud RPC and CloudTablet sync rules |
+| `be/src/runtime/AGENTS.md` | MemTracker, cache lifecycle, SIOF, workload-group memory tracking |
+| `be/src/core/AGENTS.md` | COW columns, type metadata, serialization compatibility |
+| `be/src/exec/AGENTS.md` | Pipeline execution, dependency concurrency, spill and memory pressure |
+| `be/src/storage/AGENTS.md` | Tablet locks, rowset lifecycle, MoW delete bitmap, segment writing |
+| `be/src/storage/index/inverted/AGENTS.md` | Inverted-index lifetime, CLucene boundary, three-valued bitmap |
+| `be/src/storage/schema_change/AGENTS.md` | Schema-change strategy, lock order, MoW catch-up flow |
+| `be/src/io/AGENTS.md` | Filesystem async path and remote reader caching |
+
+### FE Module
+
+| Directory | Coverage |
+|-----------|----------|
+| `fe/fe-core/AGENTS.md` | FE locking, exception model, visible-version semantics |
+| `fe/fe-core/src/main/java/org/apache/doris/persist/AGENTS.md` | EditLog write/replay path and transaction persistence modes |
+| `fe/fe-core/src/main/java/org/apache/doris/nereids/AGENTS.md` | Rule placement, mark-join constraints, property derivation |
+| `fe/fe-core/src/main/java/org/apache/doris/transaction/AGENTS.md` | Transaction lifecycle, publish semantics, cloud manager usage |
+| `fe/fe-core/src/main/java/org/apache/doris/datasource/AGENTS.md` | External catalog initialization and reset hazards |
+| `fe/fe-core/src/main/java/org/apache/doris/backup/AGENTS.md` | Backup/restore log timing and replay ordering |
+
+### Cloud Module
+
+| Directory | Coverage |
+|-----------|----------|
+| `cloud/src/meta-store/AGENTS.md` | TxnKv, key encoding, versioned values, versionstamp helpers |
+| `cloud/src/meta-service/AGENTS.md` | Cloud transaction commit paths, RPC retry contract, Cloud MoW contract |
+| `cloud/src/recycler/AGENTS.md` | Recycler safety, two-phase delete, packed-file ordering |
+
+---
+
+## Part 3: Cross-Module Concerns
+
+### 3.1 FE-BE Protocol Compatibility
+
+- [ ] Do new `TPlanNodeType` values have matching BE handling?
+- [ ] Are all FE-to-BE send paths updated when new transmitted variables are added?
+- [ ] Is mixed-version compatibility preserved for serialization or function metadata changes?
+
+### 3.2 Cloud Mode vs Shared-Nothing Mode
+
+- [ ] Does the change handle both cloud and non-cloud paths where both exist?
+- [ ] In Cloud mode, is centrally managed partition version still the visibility source of truth?
+- [ ] Are prepare/commit rowset protocols respected for Cloud writes?
+
+### 3.3 Merge-on-Write Unique Key Tables
+
+- [ ] Does the write path probe or deduplicate against the correct rowset set?
+- [ ] Is publish-side delete bitmap work correctly serialized?
+- [ ] Is query-side delete bitmap usage version-aligned?
+- [ ] Do compaction and schema-change paths preserve MoW-specific correctness steps?
+
+### 3.4 Performance
+
+- [ ] Are hot paths free of redundant copies, repeated scans, or avoidable allocations?
+- [ ] Do cloud metadata loops avoid pathological retry or scan behavior?
+
+---
+
+## Part 4: Testing Review Guide
+
+### 4.1 Regression Tests
+
+- [ ] `order_qt_` or explicit `ORDER BY` used?
+- [ ] Expected errors use `test { sql ...; exception ... }`?
+- [ ] Tables dropped before use, not after?
+- [ ] Table names hardcoded, not `def tableName`?
+- [ ] `.out` files generated, not handwritten?
+
+### 4.2 BE Unit Tests
+
+- [ ] `TEST` / `TEST_F` used appropriately, independent of execution order?
+- [ ] Memory or resource leaks covered where relevant?
+
+### 4.3 FE Unit Tests
+
+- [ ] JUnit 5 used consistently with descriptive test names?
+- [ ] Concurrency tests use latches or barriers, not timing guesses?
+
+---
+
+## Part 5: Known High-Risk Patterns Quick Reference
+
+These are cross-module patterns that cause silent or hard-to-diagnose failures. Module-specific traps are in the corresponding `AGENTS.md` files.
+
+| Pattern | Risk | Why it's dangerous |
+|--------|------|-------------|
+| Ignored `Status` | Critical | Silent failure propagation; invariant violations go undetected |
+| `THROW_IF_ERROR` in `Defer` or destructors | Critical | Terminates during stack unwinding |
+| `THROW_IF_ERROR` without catch-and-convert boundary | High | Doris exception escapes its intended scope |
+| Cross-TU static initializer dependency | High | Initialization order undefined; crashes or wrong values at startup |
+
+---
+
+## Part 6: Function System Review Guide
+
+### 6.1 FE-BE Consistency
+
+- [ ] FE and BE compute return types independently — do they agree?
+- [ ] Function names lowercase and consistent on both sides?
+- [ ] Variadic lookup depends on argument family names — do FE families match BE registration?
+- [ ] Aliases registered on both FE and BE?
+- [ ] Aggregate intermediate types match (critical for shuffle serialization)?
+
+### 6.2 Null Handling
+
+- [ ] If `use_default_implementation_for_nulls()` is disabled, is the null map fully handled manually?
+- [ ] Do FE nullable semantics match BE implementation?
+- [ ] Is `need_replace_null_data_to_default()` set correctly for garbage-payload null positions?
+- [ ] Is nested `ColumnConst(ColumnNullable(...))` handled when default null handling is disabled?
+
+### 6.3 BE Registration
+
+- [ ] `IFunction` subclasses carry no member state?
+- [ ] Order-sensitive combinators like `_foreach` placed correctly in registration?
+- [ ] Aggregate Nullable/NotNullable tags match semantic result type?
+- [ ] `ColumnString` offset maintenance exact (off-by-one corrupts later rows silently)?
+
+---
+
+## Part 7: Development Standards Supplement
+
+### 7.1 Configuration
+
+- [ ] New `config::xxx` has comments, defaults, and standard naming?
+- [ ] Dynamic configs use the mutable form and are observed without restart?
+- [ ] Cloud-visible behavior changes: does the meta-service config need updating too?
+
+### 7.2 Metrics
+
+- [ ] New metric names follow existing module naming patterns?
+
+### 7.3 bthread Safety
+
+- [ ] No long blocking under `std::mutex` on bthread paths?
+- [ ] `bthread_usleep` used instead of thread-level sleep in coroutine code?
+
+### 7.4 Error Messages and Comments
+
+- [ ] User-visible errors include identifiers needed for debugging?
+- [ ] Lock-protected members and non-obvious TODOs have precise local comments?
+
+## Finally
+
+Item-by-item responses are required only for Part 1.3. Parts 2–7 are supporting material for finding bugs, stale assumptions, and missing coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md — Apache Doris
+
+This is the codebase for Apache Doris, an MPP OLAP database. It primarily consists of the Backend module BE (be/, execution and storage engine), the Frontend module FE (fe/, optimizer and transaction core), and the Cloud module (cloud/, storage-compute separation). Your basic development workflow is: modify code, build using standard procedures, add and run tests, and submit relevant changes.
+
+## When running in a WORKTREE directory
+
+To ensure smooth test execution without interference between worktrees, the first thing to do upon entering a worktree directory is to check if `.worktree_initialized` exists. If not, execute `hooks/setup_worktree.sh`, setting `$ROOT_WORKSPACE_PATH` to the base directory (typically `${DORIS_REPO}`) beforehand. After successful execution, verify that `.worktree_initialized` has been touched and that `thirdparty/installed` dependencies exist correctly. Also check if submodules have been properly initialized; if not, do so manually.
+
+When working in worktree mode, all operations must be confined to the current worktree directory. Do not enter `${DORIS_REPO}` or use any resources there. Compilation and execution must be done within the current worktree directory. The compiled Doris cluster must use random ports not used by other worktrees (modify BE and FE conf before compilation, using a uniform offset of `${DORIS_PORT_OFFSET_RANGE}` from default ports without conflicting with other worktrees' ports). Run from the `output` directory within the worktree. To run regression tests, modify `regression-test/conf/regression-conf.groovy` and set the port numbers in jdbcUrl and other configuration items to your new ports so the corresponding worktree cluster can be used for regression testing.
+
+## Coding Standards
+
+> **Note for branch-3.1**: Since these standards were ported from the `master` branch, some cutting-edge features, error-handling macros, or architectural patterns might not be fully present in `branch-3.1`. When reviewing or writing code, **always prioritize matching the existing conventions in `branch-3.1`** over strictly forcing `master`'s new paradigms (e.g., if the old Planner is still used here, or if `Status` is preferred over `Result<T>` in certain modules).
+
+Assert correctness only—never use defensive programming with `if` or similar constructs. Any `if` check for errors must have a clearly known inevitable failure path (not speculation). If no such scenario is found, strictly avoid using `if(valid)` checks. However, you may use the `DORIS_CHECK` macro for precondition assertions (If inside performance-sensitive areas like loops, it can only be `DCHECK`). For example, if logically A=true should always imply B=true, then strictly avoid `if(A&&B)` and instead use `if(A){DORIS_CHECK(B);...}`. In short, the principle is: upon discovering errors or unexpected situations, report errors or crash—never allow the process to continue.
+
+When adding code, strictly follow existing similar code in similar contexts, including interface usage, error handling, etc., maintaining consistency. When adding any code, first try to reference existing functionality. Second, you must examine the relevant context paragraphs to fully understand the logic.
+
+After adding code, you must first conduct self-review and refactoring attempts to ensure good abstraction and reuse as much as possible.
+
+## Code Review
+
+When conducting code review (including self-review and review tasks), it is necessary to complete the key checkpoints according to our `code-review` skill and provide conclusions for each key checkpoint (if applicable) as part of the final written description. Other content does not require individual responses; just check them during the review process.
+
+## Build and Run Standards
+
+Always use only the `build.sh` script with its correct parameters to build Doris BE and FE. When building, use `-j${DORIS_PARALLELISM}` parallelism. For example, the simplest BE+FE build command is `./build.sh --be --fe -j${DORIS_PARALLELISM}`.
+Build type can be set via `BUILD_TYPE` in `custom_env.sh`, but only set it to `RELEASE` when explicitly required for performance testing; otherwise, keep it as `ASAN`.
+You may modify BE and FE ports and network settings in `conf/` before compilation to ensure correctness and avoid conflicts.
+Build artifacts are in the current directory's `output/`. If starting the service, ensure all process artifacts have their conf set with appropriate non-conflicting ports and `priority_networks = 10.16.10.3/24`. Use `--daemon` when starting. Cluster startup is slow; wait at least 30s for success. If still not ready after waiting, continue waiting. If not ready after a long time, check BE and FE logs to investigate.
+For first-time cluster startup, you may need to manually add the backend.
+
+## Testing Standards
+
+All kernel features must have corresponding tests. Prioritize adding regression tests under `regression-test/`, while also having BE unit tests (`be/test/`) and FE unit tests (`fe/fe-core/src/test/`) where possible. Interface usage in test cases must first reference similar cases.
+
+You must use the preset scripts in the codebase with their correct parameters to run tests (`run-regression-test.sh`, `run-be-ut.sh`, `run-fe-ut.sh`). Regression test result files must not be handwritten; they must be auto-generated via test scripts. When running regression tests, if using `-s` to specify a case, also try to use `-d` to specify the parent directory for faster execution. For example, for cases under `nereids_p0`, you can use `-d nereids_p0 -s xxx`, where `xxx` is the name from `suite("xxx")` in the groovy file.
+
+BE-UT compilation must use at most `${DORIS_PARALLELISM}` parallelism also.
+
+Key utility functions in BE code, as well as the core logic (functions) of complete features, must have corresponding unit tests. If it's inconvenient to add unit tests, the module design and function decomposition should be reviewed again to ensure high cohesion and low coupling are properly achieved.
+
+Added regression tests must comply with the following standards:
+1. Use `order_qt` prefix or manually add `order by` to ensure ordered results
+2. For cases expected to error, use the `test{sql,exception}` pattern
+3. After completing tests, do not drop tables; instead drop tables before using them in tests, to preserve the environment for debugging
+4. For ordinary single test tables, do not use `def tableName` form; instead hardcode your table name in all SQL
+5. Except for variables you explicitly need to adjust for testing current functionality, other variables do not need extra setup before testing. For example, nereids optimizer and pipeline engine settings can use default states
+
+## Commit Standards
+
+Files in git commit should only be related to the current modification task. Environment modifications for running (e.g., `conf/`, `AGENTS.md`, `hooks/`, etc.) must not be `git add`ed. When delivering the final task, you must ensure all actual code modifications have been committed.
+
+Commit messages must follow the format below, which mirrors the PR template (`.github/PULL_REQUEST_TEMPLATE.md`):
+
+```
+[<type>](<module>) <Short summary of the change>
+
+### What problem does this PR solve?
+
+Issue Number: close #xxx
+
+Related PR: #xxx
+
+Problem Summary: <Describe the problem this commit addresses>
+
+### Release note
+
+<If applicable, describe user-visible changes; otherwise write "None">
+
+### Check List (For Author)
+
+- Test: <Specify which testing was done>
+    - Regression test / Unit Test / Manual test / No need to test (with reason)
+- Behavior changed: No / Yes (with explanation)
+- Does this need documentation: No / Yes (with doc PR link)
+```
+
+Key rules for commit messages:
+1. The title must follow the `[type](module)` format validated by the PR title checker (`.github/workflows/title-checker.yml`). Common types include: `fix`, `feature`, `improvement`, `refactor`, `chore`, `test`, `doc`. Common modules include: `fe`, `be`, `cloud`, `regression`, `build`
+2. The short summary must be concise and written in imperative mood (e.g., `[fix](fe) Fix null pointer in scan node` not `[fix](fe) Fixed null pointer`)
+3. The `Issue Number` field must reference the corresponding GitHub Issue with `close #xxx` syntax when applicable
+4. The `Release note` section must be filled in for any user-visible behavior or feature change; write "None" for internal refactoring or test-only changes
+5. The test section must honestly reflect the testing performed; do not claim tests that were not actually run

--- a/be/src/cloud/AGENTS.md
+++ b/be/src/cloud/AGENTS.md
@@ -1,0 +1,20 @@
+# BE Cloud Module — Review Guide
+
+## Meta-Service RPC Pattern
+
+`retry_rpc` in `cloud_meta_mgr.cpp` wraps BE-to-meta-service RPC error handling.
+
+### Checkpoints
+
+- [ ] New meta-service RPCs reuse `retry_rpc` instead of open-coding retry?
+- [ ] `INVALID_ARGUMENT` returns immediately without retry?
+- [ ] `KV_TXN_CONFLICT` keeps its separate retry budget from generic retries?
+- [ ] Retry count, timeout, and backoff stay consistent with existing config pattern?
+
+## CloudTablet Sync
+
+- [ ] Lock order preserved: `_sync_meta_lock → _meta_lock`?
+- [ ] `sync_rowsets()` double-checks local max version before remote work?
+- [ ] Stale compaction-count detection checked against latest local counters before applying returned rowsets?
+- [ ] `NOT_FOUND` and full re-sync paths clear local version state before rebuilding?
+- [ ] `sync_if_not_running()` clears `_rs_version_map`, `_stale_rs_version_map`, and `_timestamped_version_tracker` before re-syncing?

--- a/be/src/common/AGENTS.md
+++ b/be/src/common/AGENTS.md
@@ -1,0 +1,29 @@
+# BE Common Module — Review Guide
+
+## Error Handling: Status / Exception / Result<T>
+
+| Type | Use | Propagation |
+|------|-----|-------------|
+| `Status` | Default error return | `RETURN_IF_ERROR` |
+| `Exception` | Vectorized hot paths | `RETURN_IF_CATCH_EXCEPTION` |
+| `Result<T>` | Value-or-error return | `DORIS_TRY` |
+
+### Checkpoints
+
+- [ ] Every `Status` return checked? Never `static_cast<void>(...)` to discard
+- [ ] Every `THROW_IF_ERROR` has a `RETURN_IF_CATCH_EXCEPTION` or `RETURN_IF_ERROR_OR_CATCH_EXCEPTION` above it?
+- [ ] `THROW_IF_ERROR` kept out of `Defer`, destructors, and stack-unwinding paths? Use `WARN_IF_ERROR` there
+- [ ] Thrift/RPC handlers convert Doris exceptions at the boundary?
+- [ ] `WARN_IF_ERROR` limited to cleanup/best-effort paths with non-empty message?
+- [ ] `DORIS_CHECK` for invariants only, never speculative defensive checks?
+- [ ] New catch blocks keep standard order: `doris::Exception` → `std::exception` → `...`?
+
+## compile_check Mechanism
+
+`compile_check_begin.h` / `compile_check_end.h` raise conversion warnings to errors.
+
+### Checkpoints
+
+- [ ] New declaration-heavy headers use paired `compile_check_begin.h` / `compile_check_end.h` matching neighbors?
+- [ ] Narrowing conversions avoided (`int64_t→int32_t`, `size_t→int`, `uint64_t→int64_t`)?
+- [ ] Third-party bypass uses `compile_check_avoid_begin.h` / `compile_check_avoid_end.h`, not local weakening?

--- a/be/src/core/AGENTS.md
+++ b/be/src/core/AGENTS.md
@@ -1,0 +1,32 @@
+# BE Core Module — Review Guide
+
+## COW Column Semantics
+
+Vectorized columns (`IColumn`) use intrusive-reference-counted copy-on-write.
+
+### Checkpoints
+
+- [ ] Exclusive ownership guaranteed before `mutate()` on hot paths? Shared ownership triggers deep copy
+- [ ] `assume_mutable_ref()` used only when exclusive ownership is already guaranteed?
+- [ ] After `Block::mutate_columns()`, columns put back with `set_columns()`?
+- [ ] `convert_to_full_column_if_const()` materializes only `ColumnConst`; ordinary columns may return shared storage?
+
+## Type System and Serialization
+
+### Upgrade/Downgrade Compatibility
+
+- [ ] Serialized block/datatype layout changes gated with `be_exec_version` where required?
+- [ ] Old and new serialization branches updated together (byte-size, serialize, deserialize)?
+
+### Decimal and Type Metadata
+
+- [ ] Decimal result types check precision growth limits, no accidental incompatible widening?
+- [ ] `DecimalV2` `original_precision`/`original_scale` set intentionally, not left as `UINT32_MAX` sentinel?
+- [ ] `TScalarType` optional fields filled for DECIMAL, CHAR/VARCHAR, DATETIMEV2?
+- [ ] Flattened `TTypeDesc.types` traversal correct for nested complex types?
+
+## Block Merge Nullable Trap
+
+`MutableBlock::merge_impl()` assumes nullable promotion shape without dynamic checking in release builds.
+
+- [ ] New block merge logic preserves nullable-promotion preconditions?

--- a/be/src/exec/AGENTS.md
+++ b/be/src/exec/AGENTS.md
@@ -1,0 +1,26 @@
+# BE Exec Module — Review Guide
+
+## Pipeline Execution
+
+### Operator Lifecycle
+
+Tasks move through `INITED → RUNNABLE → BLOCKED → FINISHED → FINALIZED`.
+
+- [ ] `SharedState` source/sink dependencies connected through `inject_shared_state()`?
+
+### Memory Reservation and Spill
+
+- [ ] Memory-heavy operators use `_try_to_reserve_memory()` before materializing large structures?
+- [ ] `_memory_sufficient_dependency` wired in where pressure should block, not overrun?
+- [ ] `revoke_memory()` preserves the existing spill path?
+
+## Dependency Concurrency
+
+- [ ] Default readiness preserved? Source starts blocked; sink starts ready
+- [ ] `set_ready()` fast-path precheck vs `is_blocked_by()` lock-first asymmetry respected?
+- [ ] New `Dependency` subclasses pair `block()` / `set_ready()` on every path?
+- [ ] `CountedFinishDependency::add()` and `sub()` under `_mtx`?
+
+## Atomics
+
+- [ ] Relaxed atomics only for statistics; lifecycle/stop flags use at least acquire/release?

--- a/be/src/io/AGENTS.md
+++ b/be/src/io/AGENTS.md
@@ -1,0 +1,4 @@
+# BE IO — Review Guide
+
+- [ ] Public `FileSystem` operations use `FILESYSTEM_M` (inline on pthreads, `AsyncIO::run_task` on bthreads)?
+- [ ] Remote-reader caching stays at `RemoteFileSystem::open_file_impl()`, not reimplemented per backend?

--- a/be/src/olap/tablet_meta_manager.cpp
+++ b/be/src/olap/tablet_meta_manager.cpp
@@ -149,10 +149,14 @@ Status TabletMetaManager::traverse_headers(
 
 Status TabletMetaManager::load_json_meta(DataDir* store, const std::string& meta_path) {
     std::ifstream infile(meta_path);
+    // Check if the file is successfully opened to prevent dead loop or reading errors
+    if (!infile.is_open()) {
+        return Status::Error<HEADER_LOAD_JSON_HEADER>("fail to open json meta file: {}", meta_path);
+    }
     char buffer[102400];
     std::string json_meta;
-    while (!infile.eof()) {
-        infile.getline(buffer, 102400);
+    // Read line by line until EOF to avoid dead loop on file read errors
+    while (infile.getline(buffer, 102400)) {
         json_meta = json_meta + buffer;
     }
     boost::algorithm::trim(json_meta);

--- a/be/src/runtime/AGENTS.md
+++ b/be/src/runtime/AGENTS.md
@@ -1,0 +1,35 @@
+# BE Runtime Module — Review Guide
+
+## MemTracker Hierarchy
+
+Two levels: `MemTrackerLimiter` (heavyweight, with limits) and `MemTracker` (lightweight, nested accounting). Thread-local state via `ThreadMemTrackerMgr`.
+
+### Checkpoints
+
+- [ ] Task-bound threads/bthreads enter with `SCOPED_ATTACH_TASK`?
+- [ ] Non-task background threads use `SCOPED_INIT_THREAD_CONTEXT`?
+- [ ] Temporary limiter switching uses `SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER`, not manual save/restore?
+- [ ] Thread-pool callbacks attach at callback entry, not deeper in the call chain?
+- [ ] Large allocations use `try_reserve()` with `DEFER_RELEASE_RESERVED()` for balanced accounting on every exit?
+- [ ] Code reachable from `ThreadMemTrackerMgr::consume` avoids operations that may allocate recursively?
+
+## Object Lifecycle
+
+- [ ] `ENABLE_FACTORY_CREATOR` classes use `create_shared()` / `create_unique()`, not raw `new`?
+- [ ] Ownership cycles broken with `weak_ptr` or raw observer pointers?
+- [ ] Single-owner paths use `unique_ptr` plus observer raw pointers?
+
+## Cache Lifecycle
+
+- [ ] Every `Cache::Handle*` released after use?
+- [ ] Cache values inherit `LRUCacheValueBase` for tracked-byte release?
+- [ ] New caches registered with `CacheManager` for global GC?
+
+## Static Initialization
+
+- [ ] New namespace-scope static/global depends on another TU's object? That is a SIOF hazard
+- [ ] Fix: `constexpr`, same-header `inline`, or function-local static?
+
+## Workload Group Memory
+
+- [ ] When precise limit enforcement matters, code uses `check_mem_used()` not just `exceed_limit()`?

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -311,13 +311,8 @@ public:
     void set_storage_engine(std::unique_ptr<BaseStorageEngine>&& engine);
     void set_inverted_index_searcher_cache(
             segment_v2::InvertedIndexSearcherCache* inverted_index_searcher_cache);
-    void set_cache_manager(CacheManager* cm) { this->_cache_manager = cm; }
     void set_process_profile(ProcessProfile* pp) { this->_process_profile = pp; }
-    void set_tablet_schema_cache(TabletSchemaCache* c) { this->_tablet_schema_cache = c; }
     void set_delete_bitmap_agg_cache(DeleteBitmapAggCache* c) { _delete_bitmap_agg_cache = c; }
-    void set_tablet_column_object_pool(TabletColumnObjectPool* c) {
-        this->_tablet_column_object_pool = c;
-    }
     void set_storage_page_cache(StoragePageCache* c) { this->_storage_page_cache = c; }
     void set_segment_loader(SegmentLoader* sl) { this->_segment_loader = sl; }
     void set_routine_load_task_executor(RoutineLoadTaskExecutor* r) {
@@ -337,6 +332,11 @@ public:
         _non_block_close_thread_pool = std::move(pool);
     }
 #endif
+    void set_cache_manager(CacheManager* cm) { this->_cache_manager = cm; }
+    void set_tablet_schema_cache(TabletSchemaCache* c) { this->_tablet_schema_cache = c; }
+    void set_tablet_column_object_pool(TabletColumnObjectPool* c) {
+        this->_tablet_column_object_pool = c;
+    }
     LoadStreamMapPool* load_stream_map_pool() { return _load_stream_map_pool.get(); }
 
     vectorized::DeltaWriterV2Pool* delta_writer_v2_pool() { return _delta_writer_v2_pool.get(); }

--- a/be/src/storage/AGENTS.md
+++ b/be/src/storage/AGENTS.md
@@ -1,0 +1,35 @@
+# BE Storage Module — Review Guide
+
+## Tablet Locks
+
+| Lock | Type | Role |
+|------|------|------|
+| `_meta_lock` | `shared_mutex` | Version maps and tablet metadata visibility |
+| `_rowset_update_lock` | `mutex` | Serializes delete bitmap updates (publish / MoW) |
+| `_base_compaction_lock` | `mutex` | Serializes base compaction |
+| `_cumulative_compaction_lock` | `mutex` | Serializes cumulative compaction |
+
+### Checkpoints
+
+- [ ] `_rs_version_map` and `_stale_rs_version_map` accessed under `_meta_lock` with correct shared/exclusive mode?
+- [ ] Tablet-meta mutations under exclusive `_meta_lock`?
+- [ ] Nested locking follows established preconditions? (`update_delete_bitmap_without_lock()` requires both `_rowset_update_lock` and `_meta_lock`)
+- [ ] TxnManager lock order: `_txn_lock → _txn_map_lock`?
+
+## Rowset and Version Lifecycle
+
+- [ ] `add_rowset()` / `modify_rowsets()` under exclusive `_meta_lock`?
+- [ ] Version continuity preserved, or intentional same-version replacement used correctly?
+- [ ] Same-version replacement: old rowset moved to unused-rowset tracking before new becomes authoritative?
+- [ ] Reader/rowset code respects split lifetime: `shared_ptr` ownership + reader `acquire()` / `release()`?
+- [ ] `StorageEngine::_unused_rowsets` deletable only when `use_count() == 1`?
+
+## Delete Bitmap (MoW)
+
+- [ ] Cloud mode: `TEMP_VERSION_COMMON` and sentinels replaced before bitmap use?
+- [ ] Bitmap calculation serialized under `_rowset_update_lock`?
+- [ ] Compaction bitmap uses latest compaction counters, not stale snapshots?
+
+## Segment Writing
+
+- [ ] MoW tables: `SegmentWriterOptions::enable_unique_key_merge_on_write` set to `true` on every path?

--- a/be/src/storage/index/inverted/AGENTS.md
+++ b/be/src/storage/index/inverted/AGENTS.md
@@ -1,0 +1,17 @@
+# Inverted Index — Review Guide
+
+## Lifecycle
+
+- [ ] Field declaration order preserves `_dir` before `_index_writer` lifetime dependency?
+- [ ] Cache-facing code uses `InvertedIndexCacheHandle` over raw handles for paired release/retention?
+
+## CLucene Boundary
+
+CLucene uses `ErrorContext` + local FINALLY helpers, not Doris exception flow.
+
+- [ ] New CLucene integrations use `ErrorContext` + `FINALLY` / `FINALLY_CLOSE` / `FINALLY_EXCEPTION`, not ad hoc try/catch?
+
+## Three-Valued Logic Bitmap
+
+- [ ] Bitmap logic preserves SQL three-valued semantics across `_data_bitmap` and `_null_bitmap`?
+- [ ] `op_not` is `const` in signature but mutates shared state — callers handle this?

--- a/be/src/storage/schema_change/AGENTS.md
+++ b/be/src/storage/schema_change/AGENTS.md
@@ -1,0 +1,25 @@
+# Schema Change — Review Guide
+
+## Strategy Selection
+
+Three strategies: `LinkedSchemaChange` (metadata-only), `VSchemaChangeDirectly` (rewrite, no sort), `VLocalSchemaChangeWithSorting` (full rewrite with sort).
+
+- [ ] Request classification flows through the existing parse-and-dispatch path?
+
+## Lock Order
+
+Required: `base_tablet push_lock → new_tablet push_lock → base_tablet header_lock → new_tablet header_lock`
+
+- [ ] Four-level order preserved?
+
+## MoW Delete Bitmap Flow
+
+Staged flow: (1) dual-write rowsets skip immediate bitmap calc → (2) converted rowsets catch up bitmaps → (3) new publish blocked during incremental catch-up → (4) state switches to `TABLET_RUNNING`.
+
+- [ ] Four-step ordering preserved exactly?
+- [ ] Base and cumulative compaction locks held before MoW delete bitmap calculation?
+
+## Dropped-Column Trap
+
+- [ ] `return_columns` derived before dropped columns merged? (Dropped columns needed for delete-predicate evaluation)
+- [ ] `ignore_schema_change_check` stays an explicit escape hatch, not normal production behavior?

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <string>
 
+#include "common/logging.h"
 #include "common/status.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/split.h"
@@ -39,9 +40,13 @@
 #include "olap/rowset/segment_v2/binary_plain_page.h"
 #include "olap/rowset/segment_v2/column_reader.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet_column_object_pool.h"
 #include "olap/tablet_meta.h"
 #include "olap/tablet_meta_manager.h"
+#include "olap/tablet_schema_cache.h"
 #include "olap/utils.h"
+#include "runtime/exec_env.h"
+#include "runtime/memory/cache_manager.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
 
@@ -114,9 +119,14 @@ void get_meta(DataDir* data_dir) {
     std::string value;
     Status s =
             TabletMetaManager::get_json_meta(data_dir, FLAGS_tablet_id, FLAGS_schema_hash, &value);
-    if (s.is<doris::ErrorCode::META_KEY_NOT_FOUND>()) {
-        std::cout << "no tablet meta for tablet_id:" << FLAGS_tablet_id
-                  << ", schema_hash:" << FLAGS_schema_hash << std::endl;
+    // Check if status is ok, and handle META_KEY_NOT_FOUND appropriately without causing coredump
+    if (!s.ok()) {
+        if (s.is<doris::ErrorCode::META_KEY_NOT_FOUND>()) {
+            std::cout << "no tablet meta for tablet_id:" << FLAGS_tablet_id
+                      << ", schema_hash:" << FLAGS_schema_hash << std::endl;
+        } else {
+            std::cout << "get meta failed: " << s.to_string() << std::endl;
+        }
         return;
     }
     std::cout << value << std::endl;
@@ -159,8 +169,8 @@ Status init_data_dir(StorageEngine& engine, const std::string& dir, std::unique_
     }
     res = p->init();
     if (!res.ok()) {
-        std::cout << "data_dir load failed" << std::endl;
-        return Status::InternalError("data_dir load failed");
+        std::cout << "data_dir load failed: " << res.to_string() << std::endl;
+        return res;
     }
 
     p.swap(*ret);
@@ -324,6 +334,44 @@ int main(int argc, char** argv) {
     std::string usage = get_usage(argv[0]);
     gflags::SetUsageMessage(usage);
     google::ParseCommandLineFlags(&argc, &argv, true);
+
+    // Initialize environment variables and configuration files for proper meta_tool operation
+    if (getenv("DORIS_HOME") == nullptr) {
+        fprintf(stderr, "you need set DORIS_HOME environment variable.\n");
+        exit(-1);
+    }
+
+    std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
+    if (!doris::config::init(conffile.c_str(), true, true, true)) {
+        fprintf(stderr, "error read config file. \n");
+        return -1;
+    }
+
+    std::string custom_conffile = doris::config::custom_config_dir + "/be_custom.conf";
+    if (!doris::config::init(custom_conffile.c_str(), true, false, false)) {
+        fprintf(stderr, "error read custom config file. \n");
+        return -1;
+    }
+
+    if (doris::config::sys_log_dir == "") {
+        std::string log_dir = std::string(getenv("DORIS_HOME")) + "/log";
+        doris::config::sys_log_dir = log_dir;
+    }
+
+    if (!doris::init_glog("meta_tool")) {
+        fprintf(stderr, "init glog failed.\n");
+        return -1;
+    }
+
+    // Initialize memory tracker and cache managers to prevent coredump during tablet operations
+    doris::ExecEnv::GetInstance()->init_mem_tracker();
+    doris::ExecEnv::GetInstance()->set_cache_manager(doris::CacheManager::create_global_instance());
+    doris::ExecEnv::GetInstance()->set_tablet_schema_cache(
+            doris::TabletSchemaCache::create_global_schema_cache(
+                    doris::config::tablet_schema_cache_capacity));
+    doris::ExecEnv::GetInstance()->set_tablet_column_object_pool(
+            doris::TabletColumnObjectPool::create_global_column_cache(
+                    doris::config::tablet_schema_cache_capacity));
 
     if (FLAGS_operation == "show_meta") {
         show_meta();

--- a/be/src/vec/data_types/serde/data_type_string_serde.h
+++ b/be/src/vec/data_types/serde/data_type_string_serde.h
@@ -56,7 +56,15 @@ inline void escape_string(const char* src, size_t* len, char escape_char) {
         if (escape_next_char) {
             ++src;
         } else {
-            *dest_ptr++ = *src++;
+            // https://github.com/apache/doris/pull/52820
+            // This conditional check serves two purposes:
+            // 1. When dest_ptr == src, skip meaningless self-assignment
+            // 2. Avoid dereference crash when both pointers are null
+            if (dest_ptr != src) {
+                *dest_ptr = *src;
+            }
+            dest_ptr++;
+            src++;
         }
     }
 

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -366,7 +366,7 @@ Status VFileScanner::_process_late_arrival_conjuncts() {
             RETURN_IF_ERROR(_conjuncts[i]->clone(_state, _push_down_conjuncts[i]));
         }
         RETURN_IF_ERROR(_process_conjuncts_for_dict_filter());
-        _discard_conjuncts();
+        // Remove _discard_conjuncts() to keep _conjuncts for unified filtering across different split types (e.g. Native + JNI)
     }
     if (_applied_rf_num == _total_rf_num) {
         _local_state->scanner_profile()->add_info_string("ApplyAllRuntimeFilters", "True");

--- a/be/test/vec/exec/vfile_scanner_exception_test.cpp
+++ b/be/test/vec/exec/vfile_scanner_exception_test.cpp
@@ -304,5 +304,59 @@ TEST_F(VfileScannerExceptionTest, failure_case) {
     WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
 }
 
+TEST_F(VfileScannerExceptionTest, process_late_arrival_conjuncts_retain) {
+    std::shared_ptr<VFileScanner> scanner = nullptr;
+    generate_scanner(scanner);
+
+    // Simulate some conjuncts in scanner
+    vectorized::VExprContextSPtrs dummy_conjuncts;
+    // We just need the size to be > 0 to trigger the logic.
+    // In real env, these would be valid expressions. Here we mock by adjusting sizes directly
+    // since building real VExpr is complex in this mock environment.
+    // However, _process_late_arrival_conjuncts tries to clone them.
+    // Since we don't have real exprs, we can't fully run _process_late_arrival_conjuncts without crashing on clone().
+    // But we can verify the core design by inspecting the class fields.
+    // The main fix was removing _discard_conjuncts() from VFileScanner::_process_late_arrival_conjuncts().
+
+    // To safely test this without complex VExpr mocking, we can just assert that
+    // calling _discard_conjuncts directly clears it, but since we removed it from the method,
+    // the semantic meaning is preserved.
+
+    // Let's create a dummy expr context to test the exact function
+    doris::TExprNode expr_node;
+    expr_node.node_type = TExprNodeType::BOOL_LITERAL;
+    expr_node.type = create_type_desc(PrimitiveType::TYPE_BOOLEAN);
+    expr_node.num_children = 0;
+    expr_node.__isset.bool_literal = true;
+    expr_node.bool_literal.value = true;
+
+    doris::TExpr texpr;
+    texpr.nodes.push_back(expr_node);
+
+    vectorized::VExprContextSPtr ctx;
+    Status st = vectorized::VExpr::create_expr_tree(texpr, ctx);
+    ASSERT_TRUE(st.ok());
+    st = ctx->prepare(&_runtime_state, RowDescriptor());
+    ASSERT_TRUE(st.ok());
+    st = ctx->open(&_runtime_state);
+    ASSERT_TRUE(st.ok());
+
+    scanner->_conjuncts.push_back(ctx);
+    ASSERT_EQ(scanner->_conjuncts.size(), 1);
+    ASSERT_EQ(scanner->_push_down_conjuncts.size(), 0);
+
+    // Call the function that used to discard conjuncts
+    st = scanner->_process_late_arrival_conjuncts();
+    ASSERT_TRUE(st.ok());
+
+    // The key assertion: _conjuncts MUST NOT be cleared after this call!
+    // This guarantees that subsequent JNI scanners or other readers will still have fallback filters.
+    ASSERT_EQ(scanner->_conjuncts.size(), 1);
+    // And push_down_conjuncts should be cloned successfully
+    ASSERT_EQ(scanner->_push_down_conjuncts.size(), 1);
+
+    WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
+}
+
 } // namespace vectorized
 } // namespace doris

--- a/cloud/src/meta-service/AGENTS.md
+++ b/cloud/src/meta-service/AGENTS.md
@@ -1,0 +1,20 @@
+# Cloud Meta-Service — Review Guide
+
+## Transaction Commit Paths
+
+Two paths: `commit_txn_immediately` and `commit_txn_eventually`.
+
+- [ ] Path selection consistent with existing rules: 2PC state, lazy-commit switches, rowset-count threshold, fuzz forcing, `TXN_BYTES_TOO_LARGE` fallback?
+- [ ] `commit_txn_immediately` restart on pending lazy-committed txns has clear timeout/termination story?
+- [ ] Begin-txn id allocation preserves label-plus-versionstamp pattern?
+
+## RPC Boundary
+
+- [ ] New handlers have `RPC_PREPROCESS` and `RPC_RATE_LIMIT`?
+- [ ] `MetaServiceCode` set on every return path?
+- [ ] Handlers idempotent under `MetaServiceProxy` retries for `KV_TXN_STORE_*_RETRYABLE`, `KV_TXN_MAYBE_COMMITTED`, `KV_TXN_TOO_OLD`, and `KV_TXN_CONFLICT` (when conflict retry enabled)?
+
+## Cloud MoW
+
+- [ ] Responses tolerate sentinel marks and `TEMP_VERSION_COMMON` that BE must rewrite before use?
+- [ ] Commit/publish changes keep version and compaction metadata consistent with BE delete bitmap calculation?

--- a/cloud/src/meta-store/AGENTS.md
+++ b/cloud/src/meta-store/AGENTS.md
@@ -1,0 +1,19 @@
+# Cloud Meta-Store — Review Guide
+
+## TxnKv
+
+- [ ] Every `TxnErrorCode` result handled?
+- [ ] `TXN_MAYBE_COMMITTED` treated as ambiguous, requiring idempotent recheck/retry at caller?
+- [ ] Transaction-size limit respected (no assumption TxnKv absorbs arbitrarily large writes)?
+
+## Key Encoding
+
+- [ ] Key families from `keys.h` helpers, not hand-built prefixes?
+- [ ] Correct space: `0x01` current metadata, `0x02` system/meta-service, `0x03` versioned historical/auxiliary?
+- [ ] `encode_bytes()` / `encode_int64()` with field order matching intended scan prefix?
+- [ ] `0x03` versioned values use existing helpers, not open-coded KV layouts?
+
+## Versionstamp
+
+- [ ] Versionstamped writes use `atomic_set_ver_key()` / `atomic_set_ver_value()` helpers?
+- [ ] `get_versionstamp()` called only after successful commit?

--- a/cloud/src/recycler/AGENTS.md
+++ b/cloud/src/recycler/AGENTS.md
@@ -1,0 +1,6 @@
+# Cloud Recycler — Review Guide
+
+- [ ] Mark-before-delete two-phase flow preserved: mark `is_recycled` first, delete physical data in later round?
+- [ ] Abort-before-delete aligned with origin: load rowsets abort txns, compaction/schema-change rowsets abort jobs?
+- [ ] Packed files: fix metadata → delete object storage → reread KV → remove KV only if still recyclable?
+- [ ] Conflict/retry paths idempotent and restart-safe? (Recycler phases often fail fast, not best-effort)

--- a/fe/AGENTS.md
+++ b/fe/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — Apache Doris FE
+
+## Build Instructions
+
+### 0. Verify protoc executable
+
+Ensure `thirdparty/installed/bin/protoc` exists and is executable. If it does not exist, **stop the build** and prompt the user to download the thirdparty libraries first.
+
+### 1. Generate sources
+
+Run from the repository root:
+
+```bash
+sh generated-source.sh
+```
+
+### 2. Build FE
+
+```bash
+cd fe && mvn clean install -DskipTests -Dskip.doc=true -T 1C
+```

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3306,6 +3306,21 @@ public class Config extends ConfigBase {
     public static String streamload_redirect_policy = "";
 
     @ConfField(mutable = true, description = {
+            "Stream Load redirect 场景下，FE 在返回 307 后额外丢弃请求体的最大字节数。"
+                    + "0 表示关闭该兼容逻辑，正数表示最大丢弃字节数。",
+            "The maximum number of request body bytes FE drains after returning 307 for Stream Load redirects. "
+                    + "0 disables the compatibility logic, and a positive value sets the byte limit."})
+    public static long stream_load_redirect_bounded_drain_max_bytes = 2L * 1024 * 1024 * 1024;
+
+    @ConfField(mutable = true, description = {
+            "Stream Load redirect 场景下，FE 在检测到请求体暂时无可读数据后继续等待的最大空闲时长，单位毫秒。"
+                    + "0 表示不额外等待，用于给慢客户端或分段到达的数据保留一个有限的缓冲窗口。",
+            "The maximum idle wait time in milliseconds after FE detects no readable request body bytes "
+                    + "during Stream Load redirect drain. 0 disables the extra idle wait, while a positive value "
+                    + "keeps a bounded grace window for slow clients or delayed request body chunks."})
+    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 10000;
+
+    @ConfField(mutable = true, description = {
             "存算分离模式下是否启用group commit的streamload BE转发功能。"
                     + "解决LB随机转发导致group commit攒批失效的问题，通过BE二次转发确保同表请求到达同一BE节点。",
             "Whether to enable group commit streamload BE forward feature in cloud mode. "

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2551,7 +2551,7 @@ public class Config extends ConfigBase {
     @ConfField
     public static int statistics_sql_parallel_exec_instance_num = 1;
 
-    @ConfField
+    @ConfField(mutable = true)
     public static long statistics_sql_mem_limit_in_bytes = 2L * 1024 * 1024 * 1024;
 
     @ConfField(mutable = true, masterOnly = true, description = {

--- a/fe/fe-core/AGENTS.md
+++ b/fe/fe-core/AGENTS.md
@@ -1,0 +1,20 @@
+# FE Core Module — Review Guide
+
+## Locking
+
+- [ ] Metadata-locking paths avoid RPC, external IO, and journal waits while holding catalog/database/table locks?
+- [ ] Multiple tables locked in ID-sorted order?
+- [ ] Existing `tryLock(timeout)` patterns preserved, not replaced with unbounded blocking?
+- [ ] No database/catalog locks taken inside broad `synchronized` blocks or async callbacks?
+- [ ] Shared `Map`/`List` traversals protected by locking, snapshots, or concurrent containers against `ConcurrentModificationException`?
+
+## Exceptions
+
+- [ ] FE-common `AnalysisException` (checked) vs Nereids' `AnalysisException` (unchecked) distinguished correctly?
+- [ ] User-visible errors use `ErrorReport`/`ErrorCode` with custom codes starting at 5000?
+- [ ] RPC boundaries convert to `TStatusCode`/`PStatus`, not leaking Java exceptions?
+
+## Visible Version
+
+- [ ] `OlapTable.getVisibleVersion()` respects cloud/non-cloud split: local in shared-nothing, RPC+TTL cache in cloud?
+- [ ] Cloud `VERSION_NOT_FOUND` normalized to `PARTITION_INIT_VERSION` — "missing" and version 1 intentionally indistinguishable?

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/AGENTS.md
@@ -1,0 +1,13 @@
+# Backup/Restore — Review Guide
+
+## BackupJob State Machine
+
+- [ ] `PENDING → SNAPSHOTING` no-EditLog transition preserved? (Restart regenerates snapshot tasks)
+- [ ] Snapshot prep writes `BarrierLog` and stores commit sequence?
+- [ ] `UPLOAD_INFO` failures retry until timeout, not cancel immediately?
+
+## RestoreJob Replay
+
+- [ ] Early redoable stages that skip EditLog remain restart-replayable from earlier persisted state?
+- [ ] `state` is persistent truth; `showState` is display-only, advanced only after finish log is durable?
+- [ ] Finish ordering preserved: `logRestoreJob(this)` → snapshot cleanup → `showState` update?

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.lang.ref.SoftReference;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Table metadata representing a catalog view or a local view from a WITH clause.
@@ -274,8 +275,10 @@ public class View extends Table implements GsonPostProcessable, ViewIf {
     public void resetViewDefForRestore(String srcDbName, String dbName) {
         // the source db name is not setted in old BackupMeta, keep compatible with the old one.
         if (srcDbName != null) {
-            // replace dbName with a regular expression
-            inlineViewDef = inlineViewDef.replaceAll("(?<=`internal`\\.`)([^`]+)(?=`\\.`)", dbName);
+            // Only replace the source database name, preserve cross-database references
+            // Pattern: `internal`.`srcDbName`.`table` -> `internal`.`dbName`.`table`
+            String pattern = "(?<=`internal`\\.`)" + Pattern.quote(srcDbName) + "(?=`\\.`)";
+            inlineViewDef = inlineViewDef.replaceAll(pattern, dbName);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/AGENTS.md
@@ -1,0 +1,8 @@
+# External Catalog — Review Guide
+
+## Initialization and Reset
+
+- [ ] Code avoids relying on `ExternalCatalog.isInitializing` as reentrancy guard? (Checked but never set to `true`)
+- [ ] `getFilteredDatabaseNames()` changes keep `lowerCaseToDatabaseName` update atomic/consistent with refill semantics?
+- [ ] `lower_case_database_names` behavior and case-insensitive lookup mapping preserved?
+- [ ] `resetToUninitialized()` avoids exposing partially torn-down state to in-flight readers?

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -589,14 +589,24 @@ public abstract class ExternalCatalog
      * @param invalidCache if {@code true}, the catalog cache will be invalidated
      *                     and reloaded during the refresh process.
      */
-    public synchronized void resetToUninitialized(boolean invalidCache) {
+    public void resetToUninitialized(boolean invalidCache) {
+        synchronized (this) {
+            resetToUninitializedInLock();
+        }
+        onRefreshCache(invalidCache);
+    }
+
+    /**
+     * Reset catalog state under catalog monitor.
+     * Cache invalidation must be executed outside catalog monitor to avoid lock-order inversion.
+     */
+    protected void resetToUninitializedInLock() {
         this.objectCreated = false;
         this.initialized = false;
         synchronized (this.confLock) {
             this.cachedConf = null;
         }
         onClose();
-        onRefreshCache(invalidCache);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -153,11 +153,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public synchronized void resetToUninitialized(boolean invalidCache) {
-        super.resetToUninitialized(invalidCache);
-    }
-
-    @Override
     public void onClose() {
         super.onClose();
         if (null != fileSystemExecutor) {
@@ -245,4 +240,3 @@ public class HMSExternalCatalog extends ExternalCatalog {
         return icebergMetadataOps;
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -130,12 +130,15 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public synchronized void resetToUninitialized(boolean invalidCache) {
-        super.resetToUninitialized(invalidCache);
-        this.identifierMapping = new JdbcIdentifierMapping(
-                (Env.isTableNamesCaseInsensitive() || Env.isStoredTableNamesLowerCase()),
-                Boolean.parseBoolean(getLowerCaseMetaNames()),
-                getMetaNamesMapping());
+    public void resetToUninitialized(boolean invalidCache) {
+        synchronized (this) {
+            resetToUninitializedInLock();
+            this.identifierMapping = new JdbcIdentifierMapping(
+                    (Env.isTableNamesCaseInsensitive() || Env.isStoredTableNamesLowerCase()),
+                    Boolean.parseBoolean(getLowerCaseMetaNames()),
+                    getMetaNamesMapping());
+        }
+        onRefreshCache(invalidCache);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
@@ -54,8 +54,6 @@ public class QueryProfileController extends BaseController {
         if (profile == null) {
             return ResponseEntityBuilder.okWithCommonError("ID " + id + " does not exist");
         }
-        profile = profile.replaceAll("\n", "</br>");
-        profile = profile.replaceAll(" ", "&nbsp;&nbsp;");
         return ResponseEntityBuilder.ok(profile);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
@@ -54,6 +54,8 @@ public class QueryProfileController extends BaseController {
         if (profile == null) {
             return ResponseEntityBuilder.okWithCommonError("ID " + id + " does not exist");
         }
+        profile = profile.replaceAll("\n", "</br>");
+        profile = profile.replaceAll(" ", "&nbsp;&nbsp;");
         return ResponseEntityBuilder.ok(profile);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
@@ -57,6 +57,15 @@ public class QueryProfileController extends BaseController {
         return ResponseEntityBuilder.ok(profile);
     }
 
+    @RequestMapping(path = "/query_profile/text/{" + ID + "}", method = RequestMethod.GET)
+    public Object text_profile(@PathVariable(value = ID) String id) {
+        String profile = ProfileManager.getInstance().getProfile(id);
+        if (profile == null) {
+            return ResponseEntityBuilder.okWithCommonError("ID " + id + " does not exist");
+        }
+        return ResponseEntityBuilder.ok(profile);
+    }
+
     @RequestMapping(path = "/query_profile", method = RequestMethod.GET)
     public Object query() {
         Map<String, Object> result = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.cloud.qe.ComputeGroupException;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
@@ -38,6 +37,7 @@ import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.entity.RestBaseResult;
 import org.apache.doris.httpv2.exception.UnauthorizedException;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
+import org.apache.doris.httpv2.util.StreamLoadRedirectDrainUtil;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.StreamLoadHandler;
 import org.apache.doris.load.loadv2.IngestionLoadJob;
@@ -77,7 +77,6 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.URI;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -210,8 +209,7 @@ public class LoadAction extends RestBaseController {
             LOG.info("redirect load action to destination={}, label: {}",
                     redirectAddr.toString(), label);
 
-            RedirectView redirectView = redirectTo(request, redirectAddr);
-            return redirectView;
+            return createRedirectResponse(request, response, redirectAddr, true, null, null, label);
         } catch (Exception e) {
             return new RestBaseResult(e.getMessage());
         }
@@ -334,11 +332,17 @@ public class LoadAction extends RestBaseController {
                         redirectAddr.toString(), isStreamLoad, dbName, tableName, label);
             }
 
-            RedirectView redirectView = redirectTo(request, redirectAddr);
-            return redirectView;
+            return createRedirectResponse(request, response, redirectAddr, isStreamLoad, dbName, tableName, label);
         } catch (StreamLoadForwardException e) {
-            // Special handling for stream load forwarding
-            return e.getRedirectView();
+            // Handle IOException from redirect response generation in the forwarding path.
+            try {
+                return createRedirectResponse(request, response, e.getRedirectView(),
+                        isStreamLoad, db, table, label);
+            } catch (IOException ioException) {
+                LOG.warn("stream load forward redirect failed, stream: {}, db: {}, tbl: {}, label: {}, err: {}",
+                        isStreamLoad, db, table, label, ioException.getMessage());
+                return new RestBaseResult(ioException.getMessage());
+            }
         } catch (Exception e) {
             LOG.warn("load failed, stream: {}, db: {}, tbl: {}, label: {}, err: {}",
                     isStreamLoad, db, table, label, e.getMessage());
@@ -672,24 +676,7 @@ public class LoadAction extends RestBaseController {
                             + "stream: {}, db: {}, tbl: {}, label: {}",
                     redirectAddr.toString(), isStreamLoad, dbName, tableName, label);
 
-            URI urlObj = null;
-            URI resultUriObj = null;
-            String urlStr = request.getRequestURI();
-            String userInfo = null;
-
-            try {
-                urlObj = new URI(urlStr);
-                resultUriObj = new URI("http", userInfo, redirectAddr.getHostname(),
-                        redirectAddr.getPort(), urlObj.getPath(), "", null);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            String redirectUrl = resultUriObj.toASCIIString();
-            if (!Strings.isNullOrEmpty(request.getQueryString())) {
-                redirectUrl += request.getQueryString();
-            }
-            LOG.info("Redirect url: {}", "http://" + redirectAddr.getHostname() + ":"
-                    + redirectAddr.getPort() + urlObj.getPath());
+            String redirectUrl = buildRedirectUrl(request, redirectAddr);
             RedirectView redirectView = new RedirectView(redirectUrl);
             redirectView.setContentType("text/html;charset=utf-8");
             redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);
@@ -712,6 +699,66 @@ public class LoadAction extends RestBaseController {
             headers.append(headerName).append(":").append(headerValue).append(", ");
         }
         return headers.toString();
+    }
+
+    private Object createRedirectResponse(HttpServletRequest request, HttpServletResponse response,
+            TNetworkAddress redirectAddr, boolean isStreamLoad, String dbName, String tableName, String label)
+            throws IOException {
+        String redirectUrl = buildRedirectUrl(request, redirectAddr);
+        if (!shouldUseBoundedDrainForStreamLoad(isStreamLoad)) {
+            return redirectTo(request, redirectAddr);
+        }
+        writeTemporaryRedirect(response, redirectUrl);
+        drainStreamLoadRequestBodyAfterRedirect(request, redirectAddr.toString(), dbName, tableName, label);
+        return null;
+    }
+
+    private Object createRedirectResponse(HttpServletRequest request, HttpServletResponse response,
+            RedirectView redirectView, boolean isStreamLoad, String dbName, String tableName, String label)
+            throws IOException {
+        if (!shouldUseBoundedDrainForStreamLoad(isStreamLoad)) {
+            return redirectView;
+        }
+        writeTemporaryRedirect(response, redirectView.getUrl());
+        drainStreamLoadRequestBodyAfterRedirect(request, redirectView.getUrl(), dbName, tableName, label);
+        return null;
+    }
+
+    private boolean shouldUseBoundedDrainForStreamLoad(boolean isStreamLoad) {
+        return isStreamLoad && Config.stream_load_redirect_bounded_drain_max_bytes > 0;
+    }
+
+    private void drainStreamLoadRequestBodyAfterRedirect(HttpServletRequest request, String redirectTarget,
+            String dbName, String tableName, String label) {
+        long drainLimit = Config.stream_load_redirect_bounded_drain_max_bytes;
+        if (!shouldDrainRequestBodyAfterRedirect(request, drainLimit)) {
+            LOG.info("skip bounded drain after stream load redirect, target: {}, db: {}, tbl: {}, label: {},"
+                            + " max_drain_bytes: {}, content_length: {}, transfer_encoding: {}",
+                    redirectTarget, dbName, tableName, label, drainLimit, request.getContentLengthLong(),
+                    request.getHeader("Transfer-Encoding"));
+            return;
+        }
+        LOG.info("write stream load redirect and start bounded drain, target: {}, db: {}, tbl: {}, label: {},"
+                        + " max_drain_bytes: {}",
+                redirectTarget, dbName, tableName, label, drainLimit);
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(request, drainLimit);
+        LOG.info("finish bounded drain after stream load redirect, target: {}, db: {}, tbl: {}, label: {},"
+                        + " drained_bytes: {}, elapsed_ms: {}, exit_reason: {}",
+                redirectTarget, dbName, tableName, label, drainResult.getDrainedBytes(),
+                drainResult.getElapsedMillis(), drainResult.getExitReason());
+    }
+
+    private boolean shouldDrainRequestBodyAfterRedirect(HttpServletRequest request, long drainLimit) {
+        long contentLength = request.getContentLengthLong();
+        if (contentLength > drainLimit) {
+            return false;
+        }
+        String transferEncoding = request.getHeader("Transfer-Encoding");
+        if (contentLength <= 0 && Strings.isNullOrEmpty(transferEncoding)) {
+            return false;
+        }
+        return true;
     }
 
     private Backend selectBackendForGroupCommit(String clusterName, HttpServletRequest req, long tableId)
@@ -959,35 +1006,13 @@ public class LoadAction extends RestBaseController {
      */
     private RedirectView redirectToStreamLoadForward(HttpServletRequest request, TNetworkAddress addr,
             String forwardTarget) {
-        URI urlObj = null;
-        URI resultUriObj = null;
-        String urlStr = request.getRequestURI();
-        String userInfo = null;
-        String modifiedPath = null;
-
-        if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
-            ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-            userInfo = ClusterNamespace.getNameFromFullName(authInfo.fullUserName)
-                    + ":" + authInfo.password;
-        }
-        try {
-            urlObj = new URI(urlStr);
-            // Replace _stream_load with _stream_load_forward in the path
-            modifiedPath = urlObj.getPath().replace("/_stream_load", "/_stream_load_forward");
-            resultUriObj = new URI("http", userInfo, addr.getHostname(),
-                    addr.getPort(), modifiedPath, "", null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        String redirectUrl = resultUriObj.toASCIIString();
-
-        // Add forward_to parameter (note: toASCIIString() already includes '?' due to empty query)
+        String modifiedPath = request.getRequestURI().replace("/_stream_load", "/_stream_load_forward");
         String queryString = request.getQueryString();
+        String redirectQuery = "forward_to=" + forwardTarget;
         if (!Strings.isNullOrEmpty(queryString)) {
-            redirectUrl += queryString + "&forward_to=" + forwardTarget;
-        } else {
-            redirectUrl += "forward_to=" + forwardTarget;
+            redirectQuery = queryString + "&" + redirectQuery;
         }
+        String redirectUrl = buildRedirectUrl(request, addr, modifiedPath, redirectQuery);
 
         LOG.info("Redirect stream load forward url: {}, forward_to: {}",
                 "http://" + addr.getHostname() + ":" + addr.getPort() + modifiedPath, forwardTarget);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -73,10 +73,12 @@ public class RestBaseController extends BaseController {
         return authInfo;
     }
 
-    public RedirectView redirectTo(HttpServletRequest request, TNetworkAddress addr) {
-        URI urlObj = null;
-        URI resultUriObj = null;
-        String urlStr = request.getRequestURI();
+    protected String buildRedirectUrl(HttpServletRequest request, TNetworkAddress addr) {
+        return buildRedirectUrl(request, addr, request.getRequestURI(), request.getQueryString());
+    }
+
+    protected String buildRedirectUrl(HttpServletRequest request, TNetworkAddress addr, String requestPath,
+            String queryString) {
         String userInfo = null;
         if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
             ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
@@ -84,18 +86,30 @@ public class RestBaseController extends BaseController {
                     + ":" + authInfo.password;
         }
         try {
-            urlObj = new URI(urlStr);
-            resultUriObj = new URI("http", userInfo, addr.getHostname(),
-                    addr.getPort(), urlObj.getPath(), "", null);
+            // Preserve the original request path to avoid re-encoding an already encoded URI path.
+            URI authorityUri = new URI("http", userInfo, addr.getHostname(),
+                    addr.getPort(), null, null, null);
+            String redirectUrl = authorityUri.toASCIIString() + requestPath;
+            if (!Strings.isNullOrEmpty(queryString)) {
+                redirectUrl += "?" + queryString;
+            }
+            LOG.info("Redirect url: {}", "http://" + addr.getHostname() + ":"
+                    + addr.getPort() + requestPath);
+            return redirectUrl;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        String redirectUrl = resultUriObj.toASCIIString();
-        if (!Strings.isNullOrEmpty(request.getQueryString())) {
-            redirectUrl += request.getQueryString();
-        }
-        LOG.info("Redirect url: {}", "http://" + addr.getHostname() + ":"
-                    + addr.getPort() + urlObj.getPath());
+    }
+
+    protected void writeTemporaryRedirect(HttpServletResponse response, String redirectUrl) throws IOException {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        response.setHeader("Location", redirectUrl);
+        response.flushBuffer();
+    }
+
+    public RedirectView redirectTo(HttpServletRequest request, TNetworkAddress addr) {
+        String redirectUrl = buildRedirectUrl(request, addr);
         RedirectView redirectView = new RedirectView(redirectUrl);
         redirectView.setContentType("text/html;charset=utf-8");
         redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.util;
+
+import org.apache.doris.common.Config;
+
+import com.google.common.base.Preconditions;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+public final class StreamLoadRedirectDrainUtil {
+    private static final Logger LOG = LogManager.getLogger(StreamLoadRedirectDrainUtil.class);
+
+    private static final int BUFFER_SIZE = 8 * 1024;
+    private static final int IDLE_SLEEP_MS = 5;
+
+    private StreamLoadRedirectDrainUtil() {
+    }
+
+    public static DrainResult drainRequestBodyAfterRedirect(HttpServletRequest request, long maxBytes) {
+        try {
+            return drainRequestBodyAfterRedirect(request.getInputStream(), maxBytes);
+        } catch (IOException e) {
+            LOG.warn("failed to get request input stream for stream load redirect drain", e);
+            return new DrainResult(0, 0, ExitReason.ERROR);
+        }
+    }
+
+    static DrainResult drainRequestBodyAfterRedirect(ServletInputStream inputStream, long maxBytes) {
+        Preconditions.checkArgument(maxBytes > 0, "maxBytes must be positive");
+
+        long startNanos = System.nanoTime();
+        long drainedBytes = 0;
+        long idleStartNanos = -1L;
+        byte[] buffer = new byte[(int) Math.min(BUFFER_SIZE, maxBytes)];
+
+        try {
+            while (drainedBytes < maxBytes) {
+                // Prefer an explicit EOF signal before relying on available() as a readiness hint.
+                if (inputStream.isFinished()) {
+                    return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.EOF);
+                }
+                int availableBytes = inputStream.available();
+                if (availableBytes <= 0) {
+                    // Allow a bounded idle window so slow clients can still deliver buffered bytes.
+                    idleStartNanos = idleStartNanos < 0 ? System.nanoTime() : idleStartNanos;
+                    DrainResult idleWaitResult = waitForMoreDataOrExit(idleStartNanos, drainedBytes, startNanos);
+                    if (idleWaitResult != null) {
+                        return idleWaitResult;
+                    }
+                    continue;
+                }
+
+                idleStartNanos = -1L;
+                int readLimit = (int) Math.min(Math.min(maxBytes - drainedBytes, buffer.length), availableBytes);
+                int readBytes = inputStream.read(buffer, 0, readLimit);
+                if (readBytes < 0) {
+                    return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.EOF);
+                }
+                if (readBytes == 0) {
+                    // Treat zero-byte reads as transient backpressure instead of busy-spinning.
+                    idleStartNanos = idleStartNanos < 0 ? System.nanoTime() : idleStartNanos;
+                    DrainResult idleWaitResult = waitForMoreDataOrExit(idleStartNanos, drainedBytes, startNanos);
+                    if (idleWaitResult != null) {
+                        return idleWaitResult;
+                    }
+                    continue;
+                }
+                drainedBytes += readBytes;
+            }
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.MAX_BYTES);
+        } catch (IOException e) {
+            LOG.warn("failed while draining request body after stream load redirect", e);
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.ERROR);
+        }
+    }
+
+    // Convert a bounded idle wait into a terminal drain result when the grace window expires or gets interrupted.
+    private static DrainResult waitForMoreDataOrExit(long idleStartNanos, long drainedBytes, long startNanos) {
+        if (elapsedMillis(idleStartNanos) >= Config.stream_load_redirect_bounded_drain_max_idle_time_ms) {
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
+        }
+        if (!sleepForIdleWindow()) {
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.INTERRUPTED);
+        }
+        return null;
+    }
+
+    private static boolean sleepForIdleWindow() {
+        try {
+            Thread.sleep(IDLE_SLEEP_MS);
+            return true;
+        } catch (InterruptedException e) {
+            LOG.warn("stream load redirect drain idle wait is interrupted", e);
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    public enum ExitReason {
+        EOF,
+        MAX_BYTES,
+        IDLE_TIMEOUT,
+        INTERRUPTED,
+        ERROR
+    }
+
+    public static final class DrainResult {
+        private final long drainedBytes;
+        private final long elapsedMillis;
+        private final ExitReason exitReason;
+
+        public DrainResult(long drainedBytes, long elapsedMillis, ExitReason exitReason) {
+            this.drainedBytes = drainedBytes;
+            this.elapsedMillis = elapsedMillis;
+            this.exitReason = exitReason;
+        }
+
+        public long getDrainedBytes() {
+            return drainedBytes;
+        }
+
+        public long getElapsedMillis() {
+            return elapsedMillis;
+        }
+
+        public ExitReason getExitReason() {
+            return exitReason;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/AGENTS.md
@@ -1,0 +1,21 @@
+# Nereids Optimizer — Review Guide
+
+## Rules
+
+- [ ] New rule has correct `RuleType` and registration path?
+- [ ] Join rewrites handle all `JoinType` values and preserve mark-join semantics (`markJoinSlotReference`)?
+- [ ] Constant predicates and `containsUniqueFunction()` handled before pushdown/inference?
+- [ ] No rewrite-loop risk from nodes recreated into a shape matched again in the same stage?
+- [ ] Wrapper-shape requirements (e.g. `project(join)`) preserved?
+
+## Stage Order
+
+- [ ] New rewrite rule placed in correct stage w.r.t. dependencies (esp. `PUSH_DOWN_FILTERS`, `InferPredicates`)?
+- [ ] Exploration/implementation rules in correct `RuleSet` entry points?
+
+## Property Derivation
+
+- [ ] New physical operator has `RequestPropertyDeriver` logic?
+- [ ] All viable property alternatives exposed, not prematurely narrowed to one distribution?
+- [ ] Mark join restriction: standalone mark join is broadcast-only?
+- [ ] `PhysicalProject` alias penetration limited to bare `SlotRef` and `Alias(SlotRef)`?

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
@@ -32,6 +32,7 @@ import org.apache.doris.planner.DataSink;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.transaction.TransactionManager;
 import org.apache.doris.transaction.TransactionStatus;
@@ -109,12 +110,15 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
                 transactionManager.commit(txnId);
             }
             summaryProfile.ifPresent(SummaryProfile::setTransactionEndTime);
-            txnStatus = TransactionStatus.COMMITTED;
             Env.getCurrentEnv().getRefreshManager().handleRefreshTable(
                     catalogName,
                     table.getDatabase().getFullName(),
                     table.getName(),
                     true);
+            // Reporting VISIBLE here only changes the success status returned to the client.
+            // If the DML and the follow-up query may hit different non-master FEs, enableStrongConsistencyRead
+            // is still required to strengthen read-after-write consistency.
+            txnStatus = getExternalTableDmlReturnStatus(ctx.getSessionVariable());
         }
     }
 
@@ -174,5 +178,11 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
                 txnStatus, loadedRows, 0);
         // update it, so that user can get loaded rows in fe.audit.log
         ctx.updateReturnRows((int) loadedRows);
+    }
+
+    static TransactionStatus getExternalTableDmlReturnStatus(SessionVariable sessionVariable) {
+        return sessionVariable.isExternalTableDmlReturnVisible()
+                ? TransactionStatus.VISIBLE
+                : TransactionStatus.COMMITTED;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/AGENTS.md
@@ -1,0 +1,21 @@
+# EditLog / Persistence — Review Guide
+
+## Write and Replay
+
+- [ ] Every metadata state change has both a write-side EditLog call and matching replay in `EditLog.loadJournal()`?
+- [ ] Replay logic equivalent to master-side transition, not approximate reconstruction?
+- [ ] New persisted objects have complete Gson annotations and image/checkpoint coverage?
+- [ ] Master failover at any point avoids duplicate state, missing state, and leaked txn metadata?
+
+## Transaction EditLog Modes
+
+`DatabaseTransactionMgr` supports inside-lock and outside-lock persistence.
+
+- [ ] Both modes kept correct for transaction changes?
+- [ ] PREPARE transactions from non-`FRONTEND` sources intentionally not journaled?
+- [ ] Outside-lock mode: all in-memory mutations complete before `submitEdit()`, since other threads observe new state immediately?
+- [ ] `awaitTransactionState()` kept outside write lock? (Unbounded wait, not timeout-based)
+
+## Fatal Errors
+
+- [ ] EditLog flush failures not swallowed? FE exits on durable-log failure to prevent split brain

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -506,6 +506,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_STRONG_CONSISTENCY = "enable_strong_consistency_read";
 
+    public static final String EXTERNAL_TABLE_DML_RETURN_STATUS = "external_table_dml_return_status";
+    public static final String EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE = "visible";
+    public static final String EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED = "committed";
+
     public static final String GROUP_COMMIT = "group_commit";
 
     public static final String ENABLE_PREPARED_STMT_AUDIT_LOG = "enable_prepared_stmt_audit_log";
@@ -1966,6 +1970,15 @@ public class SessionVariable implements Serializable, Writable {
                     + "real time. If you want strong consistent reads between sessions, set this variable to true. "
     })
     public boolean enableStrongConsistencyRead = true;
+
+    // This session variable only controls how successful external table DML reports status to the client.
+    @VariableMgr.VarAttr(name = EXTERNAL_TABLE_DML_RETURN_STATUS, needForward = true,
+            checker = "checkExternalTableDmlReturnStatus", setter = "setExternalTableDmlReturnStatus",
+            description = {"控制外表 CTAS 与 INSERT INTO SELECT 成功时返回给客户端的状态。",
+                    "Controls the status returned to the client for successful external table CTAS and "
+                            + "INSERT INTO SELECT statements."},
+            options = {EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE, EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED})
+    public String externalTableDmlReturnStatus = EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE;
 
     @VariableMgr.VarAttr(name = PARALLEL_SYNC_ANALYZE_TASK_NUM)
     public int parallelSyncAnalyzeTaskNum = 2;
@@ -3714,6 +3727,18 @@ public class SessionVariable implements Serializable, Writable {
         this.sqlDialect = sqlDialect == null ? null : sqlDialect.toLowerCase();
     }
 
+    public String getExternalTableDmlReturnStatus() {
+        return externalTableDmlReturnStatus;
+    }
+
+    public boolean isExternalTableDmlReturnVisible() {
+        return EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE.equals(externalTableDmlReturnStatus);
+    }
+
+    public void setExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {
+        this.externalTableDmlReturnStatus = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
+    }
+
     /**
      * getInsertVisibleTimeoutMs.
      **/
@@ -4478,6 +4503,8 @@ public class SessionVariable implements Serializable, Writable {
                         throw new IOException("invalid type: " + field.getType().getSimpleName());
                 }
             }
+            // Normalize serialized string enums so forwarded and restored sessions keep the same semantics.
+            externalTableDmlReturnStatus = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
         } catch (Exception e) {
             throw new IOException("failed to read session variable: " + e.getMessage());
         }
@@ -4548,6 +4575,8 @@ public class SessionVariable implements Serializable, Writable {
                         throw new IllegalArgumentException("Unknown field type: " + f.getType().getSimpleName());
                 }
             }
+            // Normalize forwarded string enums because forwarded assignments bypass dedicated setters.
+            externalTableDmlReturnStatus = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
         } catch (IllegalAccessException e) {
             LOG.error("failed to set forward variables", e);
         }
@@ -4844,11 +4873,31 @@ public class SessionVariable implements Serializable, Writable {
         }
     }
 
+    public void checkExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {
+        if (StringUtils.isEmpty(externalTableDmlReturnStatus)) {
+            throw new UnsupportedOperationException("externalTableDmlReturnStatus value is empty");
+        }
+        String normalized = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
+        if (!EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE.equals(normalized)
+                && !EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED.equals(normalized)) {
+            throw new UnsupportedOperationException(
+                    "externalTableDmlReturnStatus value is invalid, the invalid value is "
+                            + externalTableDmlReturnStatus);
+        }
+    }
+
     public void checkBatchSize(String batchSize) {
         Long batchSizeValue = Long.valueOf(batchSize);
         if (batchSizeValue < 1 || batchSizeValue > 65535) {
             throw new InvalidParameterException("batch_size should be between 1 and 65535)");
         }
+    }
+
+    // Normalize the user input so the execution path can compare the configured mode directly.
+    private String normalizeExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {
+        return externalTableDmlReturnStatus == null
+                ? null
+                : externalTableDmlReturnStatus.toLowerCase(Locale.ROOT);
     }
 
     public boolean isEnableInsertGroupCommit() {
@@ -5075,4 +5124,3 @@ public class SessionVariable implements Serializable, Writable {
         return defaultVariantMaxSparseColumnStatisticsSize;
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1965,7 +1965,7 @@ public class SessionVariable implements Serializable, Writable {
                     + "within the same session, that is, changes to data within the same session are visible in "
                     + "real time. If you want strong consistent reads between sessions, set this variable to true. "
     })
-    public boolean enableStrongConsistencyRead = false;
+    public boolean enableStrongConsistencyRead = true;
 
     @VariableMgr.VarAttr(name = PARALLEL_SYNC_ANALYZE_TASK_NUM)
     public int parallelSyncAnalyzeTaskNum = 2;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
@@ -31,6 +31,9 @@ import java.util.concurrent.FutureTask;
 public class AnalysisTaskWrapper extends FutureTask<Void> {
 
     private static final Logger LOG = LogManager.getLogger(AnalysisTaskWrapper.class);
+    private static final String STATISTICS_ANALYZE_OOM_HINT = "For statistics analyze, you can increase "
+            + "`statistics_sql_mem_limit_in_bytes`, decrease `huge_table_default_sample_rows`, "
+            + "or use `statistics_max_string_column_length` to skip large string columns.";
 
     private final BaseAnalysisTask task;
 
@@ -74,7 +77,7 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
             if (!task.killed) {
                 if (except != null) {
                     LOG.warn("Analyze {} failed.", task.toString(), except);
-                    task.job.taskFailed(task, Util.getRootCauseMessage(except));
+                    task.job.taskFailed(task, appendStatisticsAnalyzeOOMHint(Util.getRootCauseMessage(except)));
                 }
             }
         }
@@ -85,10 +88,19 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
             LOG.warn("{} cancelled, cost time:{}", task.toString(), System.currentTimeMillis() - startTime);
             task.cancel();
         } catch (Exception e) {
-            LOG.warn(String.format("Cancel job failed job info : %s", msg));
+            LOG.warn(String.format("Cancel job failed job info : %s",
+                    appendStatisticsAnalyzeOOMHint(Util.getRootCauseMessage(e))));
         }
         // Interrupt thread when it's writing metadata would cause FE crush.
         return super.cancel(false);
+    }
+
+    private String appendStatisticsAnalyzeOOMHint(String msg) {
+        if (msg == null || !msg.contains("MEM_LIMIT_EXCEEDED")
+                || msg.contains("statistics_sql_mem_limit_in_bytes")) {
+            return msg;
+        }
+        return msg + "\n" + STATISTICS_ANALYZE_OOM_HINT;
     }
 
     public long getStartTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/AGENTS.md
@@ -1,0 +1,16 @@
+# Transaction Management — Review Guide
+
+## Lifecycle
+
+State machine: `PREPARE → COMMITTED → VISIBLE` or `ABORTED`.
+
+- [ ] `PublishVersionDaemon` builds and sends publish work to every relevant backend?
+- [ ] Publish-finish semantics preserved (more complex than simple quorum check)?
+- [ ] Timeout/abort paths release state cleanly, no partially visible metadata left?
+- [ ] `TransactionState.tableIdList` (unsynchronized `ArrayList`) mutated only under external serialization?
+- [ ] Multi-table local transaction paths use ID-sorted locking?
+
+## Cloud Mode
+
+- [ ] Cloud paths use `CloudGlobalTransactionMgr` through interface methods, not concrete-type assumptions?
+- [ ] No unsafe downcasts from `GlobalTransactionMgrIface`?

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
@@ -200,4 +200,28 @@ public class CreateViewTest {
         Assert.assertEquals("SELECT `internal`.`test1`.`test`.`k2` AS `k1`, "
                 + "FROM `internal`.`test1`.`test`;", view.getInlineViewDef());
     }
+
+    @Test
+    public void testResetViewDefForRestoreWithCrossDbReference() {
+        // Test that cross-database references are preserved
+        View view = new View();
+        // View in db_b references tables from both db_a and db_b
+        view.setInlineViewDefWithSqlMode(
+                "SELECT t1.k1, t2.k2 "
+                + "FROM `internal`.`db_a`.`table1` t1 "
+                + "JOIN `internal`.`db_b`.`table2` t2 "
+                + "ON t1.id = t2.id;",
+                0L);
+
+        // Restore db_b to db_b_new
+        view.resetViewDefForRestore("db_b", "db_b_new");
+
+        // db_a reference should be preserved, only db_b should be changed to db_b_new
+        Assert.assertEquals(
+                "SELECT t1.k1, t2.k2 "
+                + "FROM `internal`.`db_a`.`table1` t1 "
+                + "JOIN `internal`.`db_b_new`.`table2` t2 "
+                + "ON t1.id = t2.id;",
+                view.getInlineViewDef());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogResetToUninitializedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogResetToUninitializedTest.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.catalog.JdbcResource;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.datasource.jdbc.JdbcExternalCatalog;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExternalCatalogResetToUninitializedTest {
+
+    @Test
+    public void testExternalCatalogRefreshRunsOutsideCatalogMonitor() {
+        LockAwareExternalCatalog catalog = new LockAwareExternalCatalog();
+
+        catalog.resetToUninitialized(true);
+
+        Assert.assertTrue(catalog.refreshCalled);
+        Assert.assertFalse(catalog.holdsCatalogMonitorInRefresh);
+    }
+
+    @Test
+    public void testJdbcCatalogRefreshRunsOutsideCatalogMonitor() throws DdlException {
+        LockAwareJdbcExternalCatalog catalog = new LockAwareJdbcExternalCatalog();
+
+        catalog.resetToUninitialized(true);
+
+        Assert.assertTrue(catalog.refreshCalled);
+        Assert.assertFalse(catalog.holdsCatalogMonitorInRefresh);
+    }
+
+    private static class LockAwareExternalCatalog extends ExternalCatalog {
+        private boolean refreshCalled;
+        private boolean holdsCatalogMonitorInRefresh;
+
+        LockAwareExternalCatalog() {
+            super(1L, "lock_test_catalog", InitCatalogLog.Type.TEST, "");
+            this.catalogProperty = new CatalogProperty("", new HashMap<>());
+        }
+
+        @Override
+        protected List<String> listTableNamesFromRemote(SessionContext ctx, String dbName) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean tableExist(SessionContext ctx, String dbName, String tblName) {
+            return false;
+        }
+
+        @Override
+        protected void initLocalObjectsImpl() {
+        }
+
+        @Override
+        protected List<String> listDatabaseNames() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void onRefreshCache(boolean invalidCache) {
+            refreshCalled = true;
+            holdsCatalogMonitorInRefresh = Thread.holdsLock(this);
+        }
+    }
+
+    private static class LockAwareJdbcExternalCatalog extends JdbcExternalCatalog {
+        private boolean refreshCalled;
+        private boolean holdsCatalogMonitorInRefresh;
+
+        LockAwareJdbcExternalCatalog() throws DdlException {
+            super(2L, "lock_test_jdbc_catalog", null, buildJdbcProperties(), "");
+        }
+
+        @Override
+        public void onRefreshCache(boolean invalidCache) {
+            refreshCalled = true;
+            holdsCatalogMonitorInRefresh = Thread.holdsLock(this);
+        }
+
+        private static Map<String, String> buildJdbcProperties() {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("type", "jdbc");
+            properties.put(JdbcResource.DRIVER_URL, "ojdbc8.jar");
+            properties.put(JdbcResource.JDBC_URL, "jdbc:oracle:thin:@127.0.0.1:1521:XE");
+            properties.put(JdbcResource.DRIVER_CLASS, "oracle.jdbc.driver.OracleDriver");
+            return properties;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogResetToUninitializedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogResetToUninitializedTest.java
@@ -61,7 +61,7 @@ public class ExternalCatalogResetToUninitializedTest {
         }
 
         @Override
-        protected List<String> listTableNamesFromRemote(SessionContext ctx, String dbName) {
+        public List<String> listTableNames(SessionContext ctx, String dbName) {
             return Collections.emptyList();
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -1,0 +1,222 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.rest;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.thrift.TNetworkAddress;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.lang.reflect.Method;
+
+public class LoadActionTest {
+
+    @AfterEach
+    public void tearDown() {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 2L * 1024 * 1024 * 1024;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
+    }
+
+    @Test
+    public void testCreateRedirectResponseReturnsRedirectViewWhenBoundedDrainDisabled() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 0;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest();
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertTrue(result instanceof RedirectView);
+        RedirectView redirectView = (RedirectView) result;
+        Assertions.assertEquals("http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar", redirectView.getUrl());
+        Mockito.verifyNoInteractions(response);
+    }
+
+    @Test
+    public void testCreateRedirectResponseWrites307WhenBoundedDrainEnabled() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(-1, "chunked", true);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseSkipsDrainWithoutRequestBody() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(-1, null, false);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request, Mockito.never()).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseSkipsDrainWhenContentLengthIsZero() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(0, null, false);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request, Mockito.never()).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseDrainsWhenContentLengthIsZeroButChunked() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(0, "chunked", true);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseSkipsDrainWhenContentLengthExceedsLimit() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(16, null, false);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request, Mockito.never()).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseKeepsNonStreamLoadBehavior() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest();
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), false, "db1", "tbl1", "label1");
+
+        Assertions.assertTrue(result instanceof RedirectView);
+        Mockito.verifyNoInteractions(response);
+    }
+
+    private Object invokeCreateRedirectResponse(LoadAction loadAction, HttpServletRequest request,
+            HttpServletResponse response, TNetworkAddress redirectAddr, boolean isStreamLoad, String dbName,
+            String tableName, String label) throws Exception {
+        Method method = LoadAction.class.getDeclaredMethod("createRedirectResponse",
+                HttpServletRequest.class, HttpServletResponse.class, TNetworkAddress.class,
+                boolean.class, String.class, String.class, String.class);
+        method.setAccessible(true);
+        return method.invoke(loadAction, request, response, redirectAddr, isStreamLoad, dbName, tableName, label);
+    }
+
+    private HttpServletRequest mockStreamLoadRequest() throws Exception {
+        return mockStreamLoadRequest(-1, null, true);
+    }
+
+    private HttpServletRequest mockStreamLoadRequest(long contentLength, String transferEncoding,
+            boolean stubInputStream) throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/api/db1/tbl1/_stream_load");
+        Mockito.when(request.getQueryString()).thenReturn("foo=bar");
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+        Mockito.when(request.getContentLengthLong()).thenReturn(contentLength);
+        Mockito.when(request.getHeader("Transfer-Encoding")).thenReturn(transferEncoding);
+        if (stubInputStream) {
+            Mockito.when(request.getInputStream()).thenReturn(new IdleServletInputStream());
+        }
+        return request;
+    }
+
+    private static class IdleServletInputStream extends ServletInputStream {
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public int available() {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.rest;
+
+import org.apache.doris.thrift.TNetworkAddress;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RestBaseControllerTest {
+
+    @Test
+    public void testBuildRedirectUrlPreservesEncodedPath() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+
+        TestRestController controller = new TestRestController();
+        String redirectUrl = controller.buildRedirectUrlForTest(request,
+                new TNetworkAddress("be-host", 8040), "/api/db%2Ftbl/_stream_load", "k=a%2Bb");
+
+        Assert.assertEquals("http://be-host:8040/api/db%2Ftbl/_stream_load?k=a%2Bb", redirectUrl);
+    }
+
+    @Test
+    public void testBuildRedirectUrlWithoutQueryString() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+
+        TestRestController controller = new TestRestController();
+        String redirectUrl = controller.buildRedirectUrlForTest(request,
+                new TNetworkAddress("be-host", 8040), "/api/db%2Ftbl/_stream_load", null);
+
+        Assert.assertEquals("http://be-host:8040/api/db%2Ftbl/_stream_load", redirectUrl);
+    }
+
+    private static class TestRestController extends RestBaseController {
+        private String buildRedirectUrlForTest(HttpServletRequest request, TNetworkAddress addr,
+                String requestPath, String queryString) {
+            return buildRedirectUrl(request, addr, requestPath, queryString);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
@@ -1,0 +1,273 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.util;
+
+import org.apache.doris.common.Config;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class StreamLoadRedirectDrainUtilTest {
+
+    @AfterEach
+    public void tearDown() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
+    }
+
+    @Test
+    public void testDrainRequestBodyWithinMaxBytes() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello".getBytes(), 5, 0, 0, 0), 16);
+
+        Assertions.assertEquals(5, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.EOF, drainResult.getExitReason());
+    }
+
+    @Test
+    // Verify delayed body chunks are still drained when they arrive within the bounded idle window.
+    public void testDrainRequestBodyAllowsDelayedArrivalWithinIdleWindow() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello".getBytes(), 0, 0, 0, 0, 0, 5), 16);
+
+        Assertions.assertEquals(5, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.EOF, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyStopsAtMaxBytes() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello world".getBytes(), 11), 5);
+
+        Assertions.assertEquals(5, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.MAX_BYTES, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyIdleTimeout() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new NeverReadyServletInputStream(), 8);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyUsesConfiguredIdleTime() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello".getBytes(), 0, 5), 16);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyInterruptedWhileWaitingForMoreData() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        try {
+            Thread.currentThread().interrupt();
+            StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                    StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new NeverReadyServletInputStream(), 8);
+
+            Assertions.assertEquals(0, drainResult.getDrainedBytes());
+            Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.INTERRUPTED,
+                    drainResult.getExitReason());
+        } finally {
+            // Clear the interrupt flag to avoid affecting later tests in the same thread.
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void testDrainRequestBodyReadError() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new ErrorServletInputStream(), 8);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.ERROR, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyEof() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new EofServletInputStream(), 8);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.EOF, drainResult.getExitReason());
+    }
+
+    private static class QueueAvailableServletInputStream extends ServletInputStream {
+        private final byte[] data;
+        private final Queue<Integer> availableValues = new ArrayDeque<>();
+        private int offset = 0;
+
+        QueueAvailableServletInputStream(byte[] data, int... availableValues) {
+            this.data = data;
+            for (int availableValue : availableValues) {
+                this.availableValues.add(availableValue);
+            }
+        }
+
+        @Override
+        public int read() {
+            if (offset >= data.length) {
+                return -1;
+            }
+            return data[offset++] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (offset >= data.length) {
+                return -1;
+            }
+            int readBytes = Math.min(len, data.length - offset);
+            System.arraycopy(data, offset, b, off, readBytes);
+            offset += readBytes;
+            return readBytes;
+        }
+
+        @Override
+        public int available() {
+            if (!availableValues.isEmpty()) {
+                return availableValues.poll();
+            }
+            return Math.max(0, data.length - offset);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return offset >= data.length;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+    private static class ErrorServletInputStream extends ServletInputStream {
+        @Override
+        public int read() throws IOException {
+            throw new IOException("read error");
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            throw new IOException("read error");
+        }
+
+        @Override
+        public int available() {
+            return 1;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+    private static class EofServletInputStream extends ServletInputStream {
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            return -1;
+        }
+
+        @Override
+        public int available() {
+            return 1;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return true;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+    // Keep reporting no readable bytes without reaching EOF to simulate a stalled client.
+    private static class NeverReadyServletInputStream extends ServletInputStream {
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public int available() {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutorTest.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.transaction.TransactionStatus;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for external table DML status selection.
+ */
+public class BaseExternalTableInsertExecutorTest {
+
+    @Test
+    public void testGetExternalTableDmlReturnStatus() {
+        SessionVariable sessionVariable = new SessionVariable();
+        Assertions.assertEquals(TransactionStatus.VISIBLE,
+                BaseExternalTableInsertExecutor.getExternalTableDmlReturnStatus(sessionVariable));
+
+        // External table DML can still report COMMITTED when the session variable requests it.
+        sessionVariable.setExternalTableDmlReturnStatus(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED);
+        Assertions.assertEquals(TransactionStatus.COMMITTED,
+                BaseExternalTableInsertExecutor.getExternalTableDmlReturnStatus(sessionVariable));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -136,8 +136,34 @@ public class SessionVariablesTest extends TestWithFeService {
         Assertions.assertEquals(numOfForwardVars, vars.size());
 
         vars.put(SessionVariable.ENABLE_PROFILE, "true");
+        // Forwarded string enums should be normalized because the forward path bypasses session setters.
+        vars.put(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS, "COMMITTED");
         sessionVariable.setForwardedSessionVariables(vars);
         Assertions.assertTrue(sessionVariable.enableProfile);
+        Assertions.assertEquals(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED,
+                sessionVariable.getExternalTableDmlReturnStatus());
+    }
+
+    @Test
+    public void testExternalTableDmlReturnStatus() throws Exception {
+        connectContext.setThreadLocalInfo();
+        SessionVariable sessionVar = connectContext.getSessionVariable();
+
+        // Explicit session settings should keep a normalized value that can be forwarded to master FE.
+        String sql = "set external_table_dml_return_status='COMMITTED'";
+        SetStmt setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);
+        SetExecutor setExecutor = new SetExecutor(connectContext, setStmt);
+        setExecutor.execute();
+        Assertions.assertEquals(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED,
+                sessionVar.getExternalTableDmlReturnStatus());
+        Assertions.assertEquals(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED,
+                sessionVar.getForwardVariables().get(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS));
+
+        sql = "set external_table_dml_return_status='invalid'";
+        setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);
+        SetExecutor invalidExecutor = new SetExecutor(connectContext, setStmt);
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "externalTableDmlReturnStatus value is invalid",
+                invalidExecutor::execute);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskWrapperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskWrapperTest.java
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class AnalysisTaskWrapperTest {
+
+    @Test
+    public void testOOMErrorMessageReplacement() throws Exception {
+        AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setJobId(1).setTaskId(2)
+                .setScheduleType(ScheduleType.ONCE).build();
+        AnalysisJob mockJob = Mockito.mock(AnalysisJob.class);
+
+        BaseAnalysisTask task = new BaseAnalysisTask() {
+            @Override
+            public void execute() throws Exception {
+                doExecute();
+            }
+
+            @Override
+            public void doExecute() throws Exception {
+                throw new Exception("(172.16.0.90)[MEM_LIMIT_EXCEEDED]PreCatch error code:11, "
+                        + "[E11] Allocator mem tracker check failed... can `set exec_mem_limit` to change limit, "
+                        + "details see be.INFO.");
+            }
+
+            @Override
+            protected void doSample() {
+            }
+
+            @Override
+            protected void deleteNotExistPartitionStats(AnalysisInfo jobInfo) throws DdlException {
+            }
+
+            @Override
+            public String toString() {
+                return "test-analysis-task";
+            }
+        };
+        task.info = analysisInfo;
+        task.job = mockJob;
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::isCheckpointThread).thenReturn(true);
+            AnalysisTaskExecutor executor = new AnalysisTaskExecutor(1);
+            AnalysisTaskWrapper wrapper = new AnalysisTaskWrapper(executor, task);
+
+            wrapper.run();
+        }
+
+        ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockJob).taskFailed(Mockito.eq(task), msgCaptor.capture());
+        String errorMsg = msgCaptor.getValue();
+        Mockito.verifyNoMoreInteractions(mockJob);
+        Assertions.assertTrue(errorMsg.contains("can `set exec_mem_limit` to change limit"));
+        Assertions.assertTrue(
+                errorMsg.contains("For statistics analyze, you can increase `statistics_sql_mem_limit_in_bytes`, "
+                        + "decrease `huge_table_default_sample_rows`, "
+                        + "or use `statistics_max_string_column_length` to skip large string columns."));
+    }
+}

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -32,7 +32,7 @@ build_version_major="${DORIS_BUILD_VERSION_MAJOR-3}"
 build_version_minor="${DORIS_BUILD_VERSION_MINOR-1}"
 build_version_patch="${DORIS_BUILD_VERSION_PATCH-4}"
 build_version_hotfix="${DORIS_BUILD_VERSION_HOTFIX-0}"
-build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"rc02"}"
+build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-rc01"}"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -32,7 +32,7 @@ build_version_major="${DORIS_BUILD_VERSION_MAJOR-3}"
 build_version_minor="${DORIS_BUILD_VERSION_MINOR-1}"
 build_version_patch="${DORIS_BUILD_VERSION_PATCH-4}"
 build_version_hotfix="${DORIS_BUILD_VERSION_HOTFIX-0}"
-build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.0-rc01"}"
+build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.1-rc01"}"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -32,7 +32,7 @@ build_version_major="${DORIS_BUILD_VERSION_MAJOR-3}"
 build_version_minor="${DORIS_BUILD_VERSION_MINOR-1}"
 build_version_patch="${DORIS_BUILD_VERSION_PATCH-4}"
 build_version_hotfix="${DORIS_BUILD_VERSION_HOTFIX-0}"
-build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-rc01"}"
+build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.0-rc01"}"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -32,7 +32,7 @@ build_version_major="${DORIS_BUILD_VERSION_MAJOR-3}"
 build_version_minor="${DORIS_BUILD_VERSION_MINOR-1}"
 build_version_patch="${DORIS_BUILD_VERSION_PATCH-4}"
 build_version_hotfix="${DORIS_BUILD_VERSION_HOTFIX-0}"
-build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.1-rc01"}"
+build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.1-rc02"}"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then

--- a/regression-test/suites/backup_restore/test_backup_restore_with_view.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_with_view.groovy
@@ -128,6 +128,159 @@ suite("test_backup_restore_with_view", "backup_restore") {
     def res = sql "SHOW VIEW FROM ${dbName1}.${tableName}"
     assertTrue(res.size() > 0)
 
+    // Test cross-database view references preservation
+    logger.info("========== Testing cross-database view references ==========")
+    
+    String baseDbName = "${suiteName}_base_db"
+    String viewDbName = "${suiteName}_view_db"
+    String restoreDbName = "${suiteName}_restore_db"
+    String baseTableName = "base_table"
+    String localTableName = "local_table"
+    String crossDbViewName = "cross_db_view"
+    String mixedViewName = "mixed_view"
+
+    try {
+        // Create base database with base table
+        sql "DROP DATABASE IF EXISTS ${baseDbName} FORCE"
+        sql "DROP DATABASE IF EXISTS ${viewDbName} FORCE"
+        sql "DROP DATABASE IF EXISTS ${restoreDbName} FORCE"
+        
+        sql "CREATE DATABASE ${baseDbName}"
+        sql "CREATE DATABASE ${viewDbName}"
+
+        sql """
+            CREATE TABLE ${baseDbName}.${baseTableName} (
+                id INT,
+                name VARCHAR(100),
+                value INT
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+
+        sql """
+            CREATE TABLE ${viewDbName}.${localTableName} (
+                id INT,
+                category VARCHAR(100)
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+
+        sql """
+            INSERT INTO ${baseDbName}.${baseTableName} VALUES
+            (1, 'Alice', 100),
+            (2, 'Bob', 200),
+            (3, 'Charlie', 300)
+        """
+
+        sql """
+            INSERT INTO ${viewDbName}.${localTableName} VALUES
+            (1, 'TypeA'),
+            (2, 'TypeB'),
+            (3, 'TypeC')
+        """
+
+        // Create cross-database view (references base_db only)
+        sql """
+            CREATE VIEW ${viewDbName}.${crossDbViewName} AS
+            SELECT id, name, value 
+            FROM `internal`.`${baseDbName}`.`${baseTableName}`
+            WHERE value > 100
+        """
+
+        // Create mixed view (references both base_db and view_db)
+        sql """
+            CREATE VIEW ${viewDbName}.${mixedViewName} AS
+            SELECT 
+                t1.id,
+                t1.name,
+                t1.value,
+                t2.category
+            FROM `internal`.`${baseDbName}`.`${baseTableName}` t1
+            JOIN `internal`.`${viewDbName}`.`${localTableName}` t2
+            ON t1.id = t2.id
+        """
+
+        // Verify original views work
+        def crossDbResult = sql "SELECT * FROM ${viewDbName}.${crossDbViewName} ORDER BY id"
+        assertTrue(crossDbResult.size() == 2)
+        assertTrue(crossDbResult[0][0] == 2)
+        assertTrue(crossDbResult[0][1] == "Bob")
+
+        def mixedResult = sql "SELECT * FROM ${viewDbName}.${mixedViewName} ORDER BY id"
+        assertTrue(mixedResult.size() == 3)
+
+        // Backup view_db
+        String crossDbSnapshot = "${suiteName}_cross_db_snapshot"
+        sql """
+            BACKUP SNAPSHOT ${viewDbName}.${crossDbSnapshot}
+            TO `${repoName}`
+        """
+
+        syncer.waitSnapshotFinish(viewDbName)
+        def crossDbSnapshotTs = syncer.getSnapshotTimestamp(repoName, crossDbSnapshot)
+        assertTrue(crossDbSnapshotTs != null)
+        logger.info("Cross-DB snapshot timestamp: ${crossDbSnapshotTs}")
+
+        // Create target database before restore (FIX: prevent database not exist error)
+        sql "CREATE DATABASE IF NOT EXISTS ${restoreDbName}"
+
+        // Restore to different database
+        sql """
+            RESTORE SNAPSHOT ${restoreDbName}.${crossDbSnapshot}
+            FROM `${repoName}`
+            PROPERTIES
+            (
+                "backup_timestamp" = "${crossDbSnapshotTs}",
+                "reserve_replica" = "true"
+            )
+        """
+
+        syncer.waitAllRestoreFinish(restoreDbName)
+
+        // Verify restore success
+        def restoreResult = sql_return_maparray """ SHOW RESTORE FROM ${restoreDbName} WHERE Label = "${crossDbSnapshot}" """
+        logger.info("Cross-DB restore result: ${restoreResult}")
+        assertTrue(restoreResult.last().State == "FINISHED")
+
+        // Critical verification: Check view definitions
+        def crossDbViewDef = sql "SHOW CREATE VIEW ${restoreDbName}.${crossDbViewName}"
+        logger.info("Cross-DB view definition after restore: ${crossDbViewDef[0][1]}")
+        
+        // Cross-DB view should still reference base_db, not restore_db
+        assertTrue(crossDbViewDef[0][1].contains("`${baseDbName}`"), 
+            "Cross-DB view should preserve base_db reference")
+        
+        // Mixed view should preserve base_db reference but update view_db to restore_db
+        def mixedViewDef = sql "SHOW CREATE VIEW ${restoreDbName}.${mixedViewName}"
+        logger.info("Mixed view definition after restore: ${mixedViewDef[0][1]}")
+        
+        assertTrue(mixedViewDef[0][1].contains("`${baseDbName}`"),
+            "Mixed view should preserve base_db reference")
+        assertTrue(mixedViewDef[0][1].contains("`${restoreDbName}`"),
+            "Mixed view should reference restore_db for local tables")
+
+        // Verify views still work after restore
+        def restoredCrossDbResult = sql "SELECT * FROM ${restoreDbName}.${crossDbViewName} ORDER BY id"
+        assertTrue(restoredCrossDbResult.size() == 2)
+        assertTrue(restoredCrossDbResult[0][0] == 2)
+        assertTrue(restoredCrossDbResult[0][1] == "Bob")
+
+        def restoredMixedResult = sql "SELECT * FROM ${restoreDbName}.${mixedViewName} ORDER BY id"
+        assertTrue(restoredMixedResult.size() == 3)
+        assertTrue(restoredMixedResult[0][0] == 1)
+        assertTrue(restoredMixedResult[0][1] == "Alice")
+    } finally {
+        // Clean up cross-DB test resources
+        sql "DROP DATABASE IF EXISTS ${baseDbName} FORCE"
+        sql "DROP DATABASE IF EXISTS ${viewDbName} FORCE"
+        sql "DROP DATABASE IF EXISTS ${restoreDbName} FORCE"
+    }
+
+    // Clean up original test resources
     sql "DROP TABLE ${dbName}.${tableName} FORCE"
     sql "DROP VIEW ${dbName}.${viewName}"
     sql "DROP DATABASE ${dbName} FORCE"

--- a/regression-test/suites/datatype_p0/datev1/test_datev1_calc.groovy
+++ b/regression-test/suites/datatype_p0/datev1/test_datev1_calc.groovy
@@ -20,6 +20,9 @@ suite("test_datev1_calc", "nonConcurrent") {
     sql """
         admin set frontend config("enable_date_conversion" = "false");
     """
+    sql """
+        admin set frontend config ("disable_datev1"="false")
+    """
 
     def table1 = "test_datev1_calc_tbl"
 

--- a/regression-test/suites/datatype_p0/datev1/test_datev1_common.groovy
+++ b/regression-test/suites/datatype_p0/datev1/test_datev1_common.groovy
@@ -20,6 +20,9 @@ suite("test_datev1_common", "nonConcurrent") {
     sql """
         admin set frontend config("enable_date_conversion" = "false");
     """
+    sql """
+        admin set frontend config ("disable_datev1"="false")
+    """
 
     def table_normal = "test_datev1_common_normal_tbl"
     def table_dup = "test_datev1_common_dup_tbl" // duplicate key

--- a/regression-test/suites/datatype_p0/datev1/test_datev1_load.groovy
+++ b/regression-test/suites/datatype_p0/datev1/test_datev1_load.groovy
@@ -23,6 +23,9 @@ suite("test_datev1_load", "nonConcurrent") {
     sql """
         admin set frontend config("enable_date_conversion" = "false");
     """
+    sql """
+        admin set frontend config ("disable_datev1"="false")
+    """
 
     def tableName = "test_datev1_load_tbl"
     sql """ DROP TABLE IF EXISTS ${tableName} """

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_agg.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_agg.groovy
@@ -20,6 +20,9 @@ suite("test_decimalv2_agg", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "false");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
 
     sql """
         drop table if exists test_decimalv2_agg;

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_calc.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_calc.groovy
@@ -20,6 +20,9 @@ suite("test_decimalv2_calc", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "false");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
     sql "set check_overflow_for_decimal=false;"
 
     def table1 = "test_decimalv2_calc_tbl"

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_calc_with_conversion.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_calc_with_conversion.groovy
@@ -20,6 +20,9 @@ suite("test_decimalv2_calc_with_conversion", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "true");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
     sql "set check_overflow_for_decimal=false;"
 
     def table1 = "test_decimalv2_calc_tbl"

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_common.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_common.groovy
@@ -20,6 +20,9 @@ suite("test_decimalv2_common", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "false");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
     sql "set check_overflow_for_decimal=false;"
 
     def table_normal = "test_decimalv2_common_normal_tbl"

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_load.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_load.groovy
@@ -23,6 +23,9 @@ suite("test_decimalv2_load", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "false");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
     sql "set check_overflow_for_decimal=false;"
 
     def tableName = "test_decimalv2_load_tbl"

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_overflow.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_overflow.groovy
@@ -19,6 +19,9 @@ suite("test_decimalv2_overflow", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "false");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
 
     sql """ set check_overflow_for_decimal=false; """
 

--- a/regression-test/suites/datatype_p0/decimalv3/test_decimalv2_v3.groovy
+++ b/regression-test/suites/datatype_p0/decimalv3/test_decimalv2_v3.groovy
@@ -19,6 +19,9 @@ suite("test_decimalv2_v3", "nonConcurrent") {
     sql """
         admin set frontend config("enable_decimal_conversion" = "false");
     """
+    sql """
+        admin set frontend config("disable_decimalv2" = "false");
+    """
 
     // test cast decimalv2 to decimal32
     def prepare_test_decimalv2_v3_1 = {

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_other.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_other.groovy
@@ -83,7 +83,7 @@ suite("test_trino_hive_other", "external,hive,external_docker,external_docker_hi
         connect('ext_catalog_user', '12345', context.config.jdbcUrl) {
             def database_lists = sql """show databases from ${catalog_name}"""
             boolean ok = false;
-            for (int i = 0; i < database_lists.size(); ++j) {
+            for (int i = 0; i < database_lists.size(); ++i) {
                 assertEquals(1, database_lists[i].size())
                 if (database_lists[i][0].equals("default")) {
                     ok = true;

--- a/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_string_to_array.groovy
+++ b/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_string_to_array.groovy
@@ -16,6 +16,10 @@
 // under the License.
 
 suite("test_cast_string_to_array", "nonConcurrent") {
+    sql """
+        admin set frontend config ("disable_datev1"="false")
+    """
+
     // cast string to array<int>
     qt_sql """ select cast ("[1,2,3]" as array<int>) """
 

--- a/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_to_datetime.groovy
+++ b/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_to_datetime.groovy
@@ -16,6 +16,10 @@
 // under the License.
 
 suite("test_cast_to_datetime", "nonConcurrent") {
+    sql """
+        admin set frontend config ("disable_datev1"="false")
+    """
+
     // cast string of invalid datetime to datetime
     qt_cast_string_to_datetime_invalid0 """ select cast("627492340" as datetime); """
     qt_cast_string_to_datetime_invalid1 """ select cast("" as datetime); """

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -479,6 +479,9 @@ export DORIS_HOME="${DORIS_TEST_BINARY_DIR}/"
 export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0
 export UBSAN_OPTIONS=print_stacktrace=1
 export JAVA_OPTS="-Xmx1024m -DlogPath=${DORIS_HOME}/log/jni.log -Xloggc:${DORIS_HOME}/log/be.gc.log.${CUR_DATE} -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDLE_TIME=300000"
+# Configure LSAN to suppress known memory leaks and avoid noise.
+# See ./conf/lsan_suppr.conf for the suppression rules.
+export LSAN_OPTIONS=suppressions=./conf/lsan_suppr.conf
 
 # find all executable test files
 test="${DORIS_TEST_BINARY_DIR}/doris_be_test"

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -69,9 +69,9 @@ export function getLog<T>(data: any): Promise<Result<T>> {
 
 //query_profile
 export function queryProfile<T>(data: any): Promise<Result<T>> {
-    let LocalUrl = '/rest/v1/query_profile/';
-    if (data.path) {
-        LocalUrl = `/rest/v1/query_profile/${data.path}`;
+    let LocalUrl = '/rest/v1/query_profile';
+    if (data.profile_id) {
+        LocalUrl = `/rest/v1/query_profile/text/${data.profile_id}`;
     }
     return request(LocalUrl, data);
 }

--- a/ui/src/pages/query-profile/index.tsx
+++ b/ui/src/pages/query-profile/index.tsx
@@ -41,7 +41,7 @@ export default function QueryProfile(params: any) {
     const history = useHistory();
     const doQueryProfile = function (ac?: AbortController) {
         const param = {
-            path: getLastPath(),
+            profile_id: getLastPath(),
             signal: ac?.signal,
         };
         queryProfile(param)
@@ -190,7 +190,9 @@ export default function QueryProfile(params: any) {
             {profile ? (
                 <pre
                     ref={container}
-                    style={{ background: '#f9f9f9', padding: '20px' }}
+                    style={{ background: '#f9f9f9', padding: '20px', whiteSpace: 'pre-wrap',
+                        fontFamily: 'Menlo, Monaco, \'Courier New\', monospace'
+                        }}
                 >
                     {/* {profile} */}
                 </pre>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #63172

Problem Summary: Backport PR #63172 to branch-3.1. Statistics analyze tasks may surface BE MEM_LIMIT_EXCEEDED errors that suggest changing exec_mem_limit, which is misleading for internal statistics SQL. This change appends a statistics-specific hint and makes statistics_sql_mem_limit_in_bytes mutable.

### Release note

Improve the error hint for statistics analyze OOM failures.

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.statistics.AnalysisTaskWrapperTest
- Behavior changed: Yes. Statistics analyze MEM_LIMIT_EXCEEDED errors include an additional statistics-specific tuning hint.
- Does this need documentation: No