### PR TITLE
[fix](cloud) Reset FDB test globals before exit

### DIFF
--- a/cloud/test/fdb_injection_test.cpp
+++ b/cloud/test/fdb_injection_test.cpp
@@ -103,6 +103,7 @@ int main(int argc, char** argv) {
     int ret = RUN_ALL_TESTS();
     if (ret != 0) {
         std::cerr << "run first round of tests failed" << std::endl;
+        meta_service.reset();
         return ret;
     }
 
@@ -169,6 +170,7 @@ int main(int argc, char** argv) {
             if (ret != 0) {
                 std::cerr << "run test failed, sync_point=" << name << ", err=" << err
                           << ", msg=" << fdb_get_error(err) << std::endl;
+                meta_service.reset();
                 return ret;
             }
         }

--- a/cloud/test/mem_txn_kv_test.cpp
+++ b/cloud/test/mem_txn_kv_test.cpp
@@ -48,12 +48,10 @@ int main(int argc, char** argv) {
         std::cout << "exit inti FdbTxnKv error" << std::endl;
         return -1;
     }
-    DORIS_CLOUD_DEFER {
-        fdb_txn_kv.reset();
-    };
-
     ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    int ret = RUN_ALL_TESTS();
+    fdb_txn_kv.reset();
+    return ret;
 }
 
 static void put_and_get_test(std::shared_ptr<cloud::TxnKv> txn_kv) {

--- a/cloud/test/txn_kv_test.cpp
+++ b/cloud/test/txn_kv_test.cpp
@@ -59,10 +59,9 @@ int main(int argc, char** argv) {
     config::init(nullptr, true);
     ::testing::InitGoogleTest(&argc, argv);
     init_txn_kv();
-    DORIS_CLOUD_DEFER {
-        txn_kv.reset();
-    };
-    return RUN_ALL_TESTS();
+    int ret = RUN_ALL_TESTS();
+    txn_kv.reset();
+    return ret;
 }
 
 TEST(TxnKvTest, Network) {

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -101,9 +101,6 @@ int main(int argc, char** argv) {
 
     // Initialize FDB
     get_fdb_txn_kv();
-    DORIS_CLOUD_DEFER {
-        txn_kv.reset();
-    };
 
     auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
     s3_producer_pool->start();
@@ -116,7 +113,10 @@ int main(int argc, char** argv) {
             RecyclerThreadPoolGroup(std::move(s3_producer_pool), std::move(recycle_tablet_pool),
                                     std::move(group_recycle_function_pool));
 
-    return RUN_ALL_TESTS();
+    int ret = RUN_ALL_TESTS();
+    thread_group = RecyclerThreadPoolGroup();
+    txn_kv.reset();
+    return ret;
 }
 namespace doris::cloud {
 


### PR DESCRIPTION
### What
The affected cloud tests keep FDB-related objects in global/static storage. Reset them explicitly before returning from test main or before early return paths so FoundationDB resources are destroyed before process teardown.

### Validation

- sh format_code.sh cloud/test/fdb_injection_test.cpp
- sh format_code.sh cloud/test/mem_txn_kv_test.cpp
- sh format_code.sh cloud/test/txn_kv_test.cpp
- sh format_code.sh cloud/test/txn_lazy_commit_test.cpp
- sh run-cloud-ut.sh --run --fdb "fdb_cluster0:cluster0@10.26.20.4:4500" --filter "fdb_injection_test:*"
- sh run-cloud-ut.sh --run --fdb "fdb_cluster0:cluster0@10.26.20.4:4500" --filter "mem_txn_kv_test:*"
- sh run-cloud-ut.sh --run --fdb "fdb_cluster0:cluster0@10.26.20.4:4500" --filter "txn_kv_test:*"
- sh run-cloud-ut.sh --run --fdb "fdb_cluster0:cluster0@10.26.20.4:4500" --filter "txn_lazy_commit_test:*"