### PR TITLE
[fix](fe) Enable profiles for computed DML commands

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -108,7 +108,7 @@ import java.util.stream.Collectors;
 /**
  * delete from unique key table.
  */
-public class DeleteFromCommand extends Command implements ForwardWithSync, Explainable, SupportProfile {
+public class DeleteFromCommand extends Command implements ForwardWithSync, Explainable {
     private static final Logger LOG = LogManager.getLogger(DeleteFromCommand.class);
 
     protected final List<String> nameParts;
@@ -504,11 +504,6 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
             throw new AnalysisException("delete command could be only used on olap table");
         }
         return ((OlapTable) table);
-    }
-
-    @Override
-    public List<String> getTargetTableNameParts() {
-        return nameParts;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -108,7 +108,7 @@ import java.util.stream.Collectors;
 /**
  * delete from unique key table.
  */
-public class DeleteFromCommand extends Command implements ForwardWithSync, Explainable {
+public class DeleteFromCommand extends Command implements ForwardWithSync, Explainable, SupportProfile {
     private static final Logger LOG = LogManager.getLogger(DeleteFromCommand.class);
 
     protected final List<String> nameParts;
@@ -506,17 +506,9 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         return ((OlapTable) table);
     }
 
-    /**
-     * check whether the target table is OLAP table.
-     */
-    public boolean isTargetTableOlap(ConnectContext ctx) {
-        try {
-            List<String> qualifiedTableName = RelationUtil.getQualifierName(ctx, nameParts);
-            TableIf table = RelationUtil.getTable(qualifiedTableName, ctx.getEnv(), Optional.empty());
-            return table instanceof OlapTable;
-        } catch (Exception e) {
-            return false;
-        }
+    @Override
+    public List<String> getTargetTableNameParts() {
+        return nameParts;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -506,6 +506,16 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         return ((OlapTable) table);
     }
 
+    public boolean isTargetTableOlap(ConnectContext ctx) {
+        try {
+            List<String> qualifiedTableName = RelationUtil.getQualifierName(ctx, nameParts);
+            TableIf table = RelationUtil.getTable(qualifiedTableName, ctx.getEnv(), Optional.empty());
+            return table instanceof OlapTable;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     /**
      * for explain command
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -506,6 +506,9 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         return ((OlapTable) table);
     }
 
+    /**
+     * check whether the target table is OLAP table.
+     */
     public boolean isTargetTableOlap(ConnectContext ctx) {
         try {
             List<String> qualifiedTableName = RelationUtil.getQualifierName(ctx, nameParts);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromUsingCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromUsingCommand.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 /**
  * delete from unique key table.
  */
-public class DeleteFromUsingCommand extends DeleteFromCommand {
+public class DeleteFromUsingCommand extends DeleteFromCommand implements SupportProfile {
     private final Optional<LogicalPlan> cte;
     private final boolean hasOrderByLimit;
 
@@ -73,6 +73,11 @@ public class DeleteFromUsingCommand extends DeleteFromCommand {
      */
     public LogicalPlan getLogicalQuery() {
         return logicalQuery;
+    }
+
+    @Override
+    public List<String> getTargetTableNameParts() {
+        return nameParts;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/SupportProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/SupportProfile.java
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.nereids.util.RelationUtil;
+import org.apache.doris.qe.ConnectContext;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Commands that can generate query profiles.
+ */
+public interface SupportProfile {
+
+    List<String> getTargetTableNameParts();
+
+    /**
+     * Check whether the target table is an OLAP table.
+     */
+    default boolean isTargetTableOlap(ConnectContext ctx) {
+        try {
+            List<String> qualifiedTableName = RelationUtil.getQualifierName(ctx, getTargetTableNameParts());
+            TableIf table = RelationUtil.getTable(qualifiedTableName, ctx.getEnv(), Optional.empty());
+            return table instanceof OlapTable;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
@@ -295,6 +295,16 @@ public class UpdateCommand extends Command implements ForwardWithSync, Explainab
         return logicalQuery;
     }
 
+    public boolean isTargetTableOlap(ConnectContext ctx) {
+        try {
+            List<String> tableQualifier = RelationUtil.getQualifierName(ctx, nameParts);
+            TableIf table = RelationUtil.getTable(tableQualifier, ctx.getEnv(), Optional.empty());
+            return table instanceof OlapTable;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     @Override
     public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
         return visitor.visitUpdateCommand(this, context);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
@@ -76,7 +76,7 @@ import javax.annotation.Nullable;
  * =>
  *  insert into t1 (c1, c3) select t2.c1, t2.c3 * 100 from t1 join t2 inner join t3 on t2.id = t3.id where t1.id = t2.id
  */
-public class UpdateCommand extends Command implements ForwardWithSync, Explainable {
+public class UpdateCommand extends Command implements ForwardWithSync, Explainable, SupportProfile {
     private final List<EqualTo> assignments;
     private final List<String> nameParts;
     private final @Nullable String tableAlias;
@@ -295,17 +295,9 @@ public class UpdateCommand extends Command implements ForwardWithSync, Explainab
         return logicalQuery;
     }
 
-    /**
-     * check whether the target table is OLAP table.
-     */
-    public boolean isTargetTableOlap(ConnectContext ctx) {
-        try {
-            List<String> tableQualifier = RelationUtil.getQualifierName(ctx, nameParts);
-            TableIf table = RelationUtil.getTable(tableQualifier, ctx.getEnv(), Optional.empty());
-            return table instanceof OlapTable;
-        } catch (Exception e) {
-            return false;
-        }
+    @Override
+    public List<String> getTargetTableNameParts() {
+        return nameParts;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
@@ -295,6 +295,9 @@ public class UpdateCommand extends Command implements ForwardWithSync, Explainab
         return logicalQuery;
     }
 
+    /**
+     * check whether the target table is OLAP table.
+     */
     public boolean isTargetTableOlap(ConnectContext ctx) {
         try {
             List<String> tableQualifier = RelationUtil.getQualifierName(ctx, nameParts);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
@@ -54,6 +54,7 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.Command;
 import org.apache.doris.nereids.trees.plans.commands.ForwardWithSync;
 import org.apache.doris.nereids.trees.plans.commands.IcebergMergeCommand;
+import org.apache.doris.nereids.trees.plans.commands.SupportProfile;
 import org.apache.doris.nereids.trees.plans.commands.UpdateCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.DMLCommandType;
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand;
@@ -84,7 +85,7 @@ import java.util.Optional;
 /**
  * merge into table
  */
-public class MergeIntoCommand extends Command implements ForwardWithSync, Explainable {
+public class MergeIntoCommand extends Command implements ForwardWithSync, Explainable, SupportProfile {
     private static final String BRANCH_LABEL = "__DORIS_MERGE_INTO_BRANCH_LABEL__";
 
     private final List<String> targetNameParts;
@@ -153,12 +154,9 @@ public class MergeIntoCommand extends Command implements ForwardWithSync, Explai
         return RelationUtil.getTable(qualifiedTableName, ctx.getEnv(), Optional.empty());
     }
 
-    public boolean isTargetTableOlap(ConnectContext ctx) {
-        try {
-            return getTargetTableIf(ctx) instanceof OlapTable;
-        } catch (Exception e) {
-            return false;
-        }
+    @Override
+    public List<String> getTargetTableNameParts() {
+        return targetNameParts;
     }
 
     private OlapTable getTargetTable(ConnectContext ctx) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
@@ -153,6 +153,14 @@ public class MergeIntoCommand extends Command implements ForwardWithSync, Explai
         return RelationUtil.getTable(qualifiedTableName, ctx.getEnv(), Optional.empty());
     }
 
+    public boolean isTargetTableOlap(ConnectContext ctx) {
+        try {
+            return getTargetTableIf(ctx) instanceof OlapTable;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private OlapTable getTargetTable(ConnectContext ctx) {
         TableIf table = getTargetTableIf(ctx);
         if (!(table instanceof OlapTable) || !((OlapTable) table).getEnableUniqueKeyMergeOnWrite()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -109,6 +109,7 @@ import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableComma
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapGroupCommitInsertExecutor;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertExecutor;
+import org.apache.doris.nereids.trees.plans.commands.merge.MergeIntoCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
 import org.apache.doris.planner.GroupCommitScanNode;
@@ -1123,6 +1124,11 @@ public class StmtExecutor {
                     }
                 }
             }
+            return true;
+        }
+
+        if (plan instanceof UpdateCommand || plan instanceof MergeIntoCommand
+                || plan instanceof DeleteFromUsingCommand) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1127,15 +1127,11 @@ public class StmtExecutor {
             return true;
         }
 
-        if (plan instanceof UpdateCommand && ((UpdateCommand) plan).isTargetTableOlap(context)) {
-            return true;
-        }
-
-        if (plan instanceof MergeIntoCommand && ((MergeIntoCommand) plan).isTargetTableOlap(context)) {
-            return true;
-        }
-
-        if (plan instanceof DeleteFromUsingCommand) {
+        // Computed DML profiles are currently only supported for OLAP target tables.
+        if ((plan instanceof UpdateCommand && ((UpdateCommand) plan).isTargetTableOlap(context))
+                || (plan instanceof MergeIntoCommand && ((MergeIntoCommand) plan).isTargetTableOlap(context))
+                || (plan instanceof DeleteFromUsingCommand
+                        && ((DeleteFromUsingCommand) plan).isTargetTableOlap(context))) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1127,8 +1127,15 @@ public class StmtExecutor {
             return true;
         }
 
-        if (plan instanceof UpdateCommand || plan instanceof MergeIntoCommand
-                || plan instanceof DeleteFromUsingCommand) {
+        if (plan instanceof UpdateCommand && ((UpdateCommand) plan).isTargetTableOlap(context)) {
+            return true;
+        }
+
+        if (plan instanceof MergeIntoCommand && ((MergeIntoCommand) plan).isTargetTableOlap(context)) {
+            return true;
+        }
+
+        if (plan instanceof DeleteFromUsingCommand) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -102,6 +102,7 @@ import org.apache.doris.nereids.trees.plans.commands.Forward;
 import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
 import org.apache.doris.nereids.trees.plans.commands.Redirect;
+import org.apache.doris.nereids.trees.plans.commands.SupportProfile;
 import org.apache.doris.nereids.trees.plans.commands.TransactionCommand;
 import org.apache.doris.nereids.trees.plans.commands.UpdateCommand;
 import org.apache.doris.nereids.trees.plans.commands.insert.BatchInsertIntoTableCommand;
@@ -109,7 +110,6 @@ import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableComma
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapGroupCommitInsertExecutor;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertExecutor;
-import org.apache.doris.nereids.trees.plans.commands.merge.MergeIntoCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
 import org.apache.doris.planner.GroupCommitScanNode;
@@ -1128,10 +1128,7 @@ public class StmtExecutor {
         }
 
         // Computed DML profiles are currently only supported for OLAP target tables.
-        if ((plan instanceof UpdateCommand && ((UpdateCommand) plan).isTargetTableOlap(context))
-                || (plan instanceof MergeIntoCommand && ((MergeIntoCommand) plan).isTargetTableOlap(context))
-                || (plan instanceof DeleteFromUsingCommand
-                        && ((DeleteFromUsingCommand) plan).isTargetTableOlap(context))) {
+        if (plan instanceof SupportProfile && ((SupportProfile) plan).isTargetTableOlap(context)) {
             return true;
         }
 

--- a/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
+++ b/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
@@ -21,8 +21,8 @@ import groovy.json.StringEscapeUtils
 import org.apache.doris.regression.action.ProfileAction
 
 def verifyProfileContent = { suiteContext, stmt, serialReadOnLimit ->
-    // Sleep 500ms to wait for the profile collection 
-    Thread.sleep(500)
+    // Sleep 1000ms to wait for the profile collection
+    Thread.sleep(1000)
     // Get profile list by using getProfileList
     def profileAction = new ProfileAction(suiteContext)
     List profileData = profileAction.getProfileList()

--- a/regression-test/suites/query_profile/dml_profile_safe.groovy
+++ b/regression-test/suites/query_profile/dml_profile_safe.groovy
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.json.JsonSlurper
+
+def getProfileList = { masterHTTPAddr ->
+    def dst = 'http://' + masterHTTPAddr
+    def conn = new URL(dst + "/rest/v1/query_profile").openConnection()
+    conn.setRequestMethod("GET")
+    def password = context.config.feHttpPassword == null ? "" : context.config.feHttpPassword
+    def encoding = Base64.getEncoder()
+            .encodeToString((context.config.feHttpUser + ":" + password).getBytes("UTF-8"))
+    conn.setRequestProperty("Authorization", "Basic ${encoding}")
+    return conn.getInputStream().getText()
+}
+
+def getMasterHttpAddress = { allFrontends ->
+    for (def frontend : allFrontends) {
+        if (frontend[8] == "true") {
+            return frontend[1] + ":" + frontend[3]
+        }
+    }
+    throw new IllegalStateException("master frontend not found")
+}
+
+def hasProfile = { masterHTTPAddr, taskType, sqlToken ->
+    def wholeString = getProfileList(masterHTTPAddr)
+    def profileListData = new JsonSlurper().parseText(wholeString).data.rows
+    for (def profileList : profileListData) {
+        def profileTaskType = profileList["Task Type"].toString()
+        def stmt = profileList["Sql Statement"].toString().toLowerCase()
+        if (profileTaskType == taskType && stmt.contains(sqlToken.toLowerCase())) {
+            return true
+        }
+    }
+    return false
+}
+
+def waitForProfile = { masterHTTPAddr, taskType, sqlToken ->
+    for (int i = 0; i < 20; i++) {
+        if (hasProfile(masterHTTPAddr, taskType, sqlToken)) {
+            return true
+        }
+        Thread.sleep(500)
+    }
+    return false
+}
+
+suite("dml_profile_safe") {
+    sql """set enable_nereids_planner = true;"""
+    sql """set enable_fallback_to_original_planner = false;"""
+
+    sql """drop table if exists dml_profile_update_target;"""
+    sql """drop table if exists dml_profile_merge_target;"""
+    sql """drop table if exists dml_profile_merge_source;"""
+    sql """drop table if exists dml_profile_delete_using_target;"""
+    sql """drop table if exists dml_profile_delete_using_source;"""
+    sql """drop table if exists dml_profile_delete_command_target;"""
+
+    sql """
+        create table dml_profile_update_target (
+            k int,
+            v int
+        )
+        unique key(k)
+        distributed by hash(k) buckets 1
+        properties(
+            "replication_num" = "1",
+            "enable_unique_key_merge_on_write" = "true"
+        );
+    """
+
+    sql """
+        create table dml_profile_merge_target (
+            k int,
+            v int
+        )
+        unique key(k)
+        distributed by hash(k) buckets 1
+        properties(
+            "replication_num" = "1",
+            "enable_unique_key_merge_on_write" = "true"
+        );
+    """
+
+    sql """
+        create table dml_profile_merge_source (
+            k int,
+            v int
+        )
+        duplicate key(k)
+        distributed by hash(k) buckets 1
+        properties("replication_num" = "1");
+    """
+
+    sql """
+        create table dml_profile_delete_using_target (
+            k int,
+            v int
+        )
+        unique key(k)
+        distributed by hash(k) buckets 1
+        properties(
+            "replication_num" = "1",
+            "enable_unique_key_merge_on_write" = "true"
+        );
+    """
+
+    sql """
+        create table dml_profile_delete_using_source (
+            k int
+        )
+        duplicate key(k)
+        distributed by hash(k) buckets 1
+        properties("replication_num" = "1");
+    """
+
+    sql """
+        create table dml_profile_delete_command_target (
+            k int,
+            v int
+        )
+        duplicate key(k)
+        distributed by hash(k) buckets 1
+        properties("replication_num" = "1");
+    """
+
+    sql """insert into dml_profile_update_target values (1, 10), (2, 20);"""
+    sql """insert into dml_profile_merge_target values (1, 10);"""
+    sql """insert into dml_profile_merge_source values (1, 11), (2, 22);"""
+    sql """insert into dml_profile_delete_using_target values (1, 10), (2, 20);"""
+    sql """insert into dml_profile_delete_using_source values (1);"""
+    sql """insert into dml_profile_delete_command_target values (1, 10), (2, 20);"""
+    sql """sync;"""
+
+    def masterHTTPAddr = getMasterHttpAddress(sql """show frontends;""")
+
+    sql """clean all profile;"""
+    sql """set enable_profile = true;"""
+    sql """set profile_level = 2;"""
+
+    sql """update dml_profile_update_target set v = v + 1 where k = 1;"""
+    assertTrue(waitForProfile(masterHTTPAddr, "LOAD",
+            "update dml_profile_update_target set v = v + 1 where k = 1"))
+
+    sql """
+        merge into dml_profile_merge_target t
+        using dml_profile_merge_source s
+        on t.k = s.k
+        when matched then update set v = s.v
+        when not matched then insert values(s.k, s.v);
+    """
+    assertTrue(waitForProfile(masterHTTPAddr, "LOAD", "merge into dml_profile_merge_target"))
+
+    sql """
+        delete from dml_profile_delete_using_target t
+        using dml_profile_delete_using_source s
+        where t.k = s.k;
+    """
+    assertTrue(waitForProfile(masterHTTPAddr, "LOAD", "delete from dml_profile_delete_using_target"))
+
+    sql """clean all profile;"""
+    sql """delete from dml_profile_delete_command_target where k = 1;"""
+    Thread.sleep(1000)
+    assertFalse(hasProfile(masterHTTPAddr, "LOAD", "delete from dml_profile_delete_command_target"))
+    assertFalse(hasProfile(masterHTTPAddr, "QUERY", "delete from dml_profile_delete_command_target"))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Some DML statements that execute through the compute path were treated as profile-unsafe statements, so `UPDATE`, `MERGE INTO`, and `DELETE FROM ... USING` did not produce query/load profiles even when profiling was enabled.

This PR marks `UpdateCommand`, `MergeIntoCommand`, and `DeleteFromUsingCommand` as profile-safe. Regular `DeleteFromCommand` is left unchanged because it should not produce a compute profile.

### Release note

Support profiles for `UPDATE`, `MERGE INTO`, and `DELETE FROM ... USING` statements.

### Check List (For Author)

- Test: Regression test / Build
    - `./build.sh --fe`
    - `./run-regression-test.sh --run --conf /tmp/doris-regression-conf-run-path.groovy -d query_profile -s dml_profile_safe`
- Behavior changed: Yes
    - `UPDATE`, `MERGE INTO`, and `DELETE FROM ... USING` now generate profiles when profiling is enabled.
- Does this need documentation: No

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
