### PR TITLE
[opt](function) avoid cloning struct element columns

### DIFF
--- a/be/src/exprs/function/array/function_array_element.h
+++ b/be/src/exprs/function/array/function_array_element.h
@@ -262,9 +262,8 @@ private:
                 res_null_map[i] |= outer[i];
             }
         }
-        block.replace_by_position(
-                result, ColumnNullable::create(res_nested->clone_resized(input_rows_count),
-                                               std::move(res_null_column)));
+        block.replace_by_position(result,
+                                  ColumnNullable::create(res_nested, std::move(res_null_column)));
         return Status::OK();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

`element_at` / `struct_element` on a struct field built the result nullable column by cloning the selected field column with `clone_resized(input_rows_count)`. Root cause: the struct access path treated the selected field as a result data copy even though the column is only shared into the result and Doris column wrappers support shared subcolumns through COW. This change reuses the selected nested field column directly and only builds the merged result null map, avoiding an unnecessary data-column clone.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

