### PR TITLE
[fix](orc): update _tracing_file_reader when swapping RangeCacheFileReader for tiny stripes

### DIFF
--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -1429,10 +1429,9 @@ Status OrcReader::_init_orc_row_reader() {
                         std::move(prefetch_merge_ranges));
                 auto* orc_input_stream_ptr = static_cast<ORCFileInputStream*>(_reader->getStream());
                 orc_input_stream_ptr->set_all_tiny_stripes();
-                auto& orc_file_reader = orc_input_stream_ptr->get_file_reader();
                 auto orc_inner_reader = orc_input_stream_ptr->get_inner_reader();
-                orc_file_reader = std::make_shared<io::RangeCacheFileReader>(
-                        _profile, orc_inner_reader, range_finder);
+                orc_input_stream_ptr->set_file_reader(std::make_shared<io::RangeCacheFileReader>(
+                        _profile, orc_inner_reader, range_finder));
             }
         }
 

--- a/be/src/format/orc/vorc_reader.h
+++ b/be/src/format/orc/vorc_reader.h
@@ -936,6 +936,20 @@ public:
 
     io::FileReaderSPtr& get_tracing_file_reader() { return _tracing_file_reader; }
 
+    // Reassign the active file reader (e.g. wrap with RangeCacheFileReader for the
+    // all-tiny-stripe path). This MUST be used instead of mutating _file_reader
+    // directly, because _tracing_file_reader holds an independent shared_ptr
+    // captured at construction time and would otherwise keep pointing at the
+    // previous (inner) reader -- bypassing the wrapper. See vorc_reader.cpp
+    // ORCFileInputStream::read() which always reads through _tracing_file_reader.
+    void set_file_reader(io::FileReaderSPtr new_file_reader) {
+        _file_reader = std::move(new_file_reader);
+        _tracing_file_reader = _io_ctx && _io_ctx->file_reader_stats
+                                       ? std::make_shared<io::TracingFileReader>(
+                                                 _file_reader, _io_ctx->file_reader_stats)
+                                       : _file_reader;
+    }
+
 protected:
     void _collect_profile_at_runtime() override {};
     void _collect_profile_before_close() override { _collect_profile_before_close_file_stripe(); }

--- a/be/test/format/orc/orc_file_input_stream_test.cpp
+++ b/be/test/format/orc/orc_file_input_stream_test.cpp
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/orc/vorc_reader.h"
+
+#include <gtest/gtest.h>
+
+#include "io/fs/buffered_reader.h"
+#include "io/fs/tracing_file_reader.h"
+
+namespace doris {
+namespace vectorized {
+
+class MockInnerFileReader : public io::FileReader {
+public:
+    MockInnerFileReader(size_t size) : _size(size) {}
+
+    Status close() override {
+        _closed = true;
+        return Status::OK();
+    }
+    const io::Path& path() const override { return _path; }
+    size_t size() const override { return _size; }
+    bool closed() const override { return _closed; }
+    int64_t mtime() const override { return 0; }
+
+    void set_data(const std::string& data) { _data = data; }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const io::IOContext* io_ctx) override {
+        if (offset >= _data.size()) {
+            *bytes_read = 0;
+            return Status::OK();
+        }
+        *bytes_read = std::min(result.size, _data.size() - offset);
+        memcpy(result.data, _data.data() + offset, *bytes_read);
+        return Status::OK();
+    }
+
+private:
+    std::string _data;
+    size_t _size = 0;
+    bool _closed = false;
+    io::Path _path = "/tmp/mock_inner";
+};
+
+// Wraps a MockInnerFileReader and records how many read_at calls reached it,
+// so we can verify that reads go through (or bypass) the wrapper chain.
+class CountingFileReader : public io::FileReader {
+public:
+    CountingFileReader(io::FileReaderSPtr inner) : _inner(std::move(inner)) {}
+
+    Status close() override { return _inner->close(); }
+    const io::Path& path() const override { return _inner->path(); }
+    size_t size() const override { return _inner->size(); }
+    bool closed() const override { return _inner->closed(); }
+    int64_t mtime() const override { return _inner->mtime(); }
+
+    int read_at_count() const { return _read_at_count; }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const io::IOContext* io_ctx) override {
+        _read_at_count++;
+        return _inner->read_at(offset, result, bytes_read, io_ctx);
+    }
+
+private:
+    io::FileReaderSPtr _inner;
+    int _read_at_count = 0;
+};
+
+class ORCFileInputStreamTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _inner_data = std::string(2048, 'X');
+        _mock_inner = std::make_shared<MockInnerFileReader>(_inner_data.size());
+        _mock_inner->set_data(_inner_data);
+    }
+
+    std::shared_ptr<MockInnerFileReader> _mock_inner;
+    std::string _inner_data;
+};
+
+// Verify that set_file_reader updates _tracing_file_reader when IOContext is present.
+// This is the core fix — before the fix, calling set_file_reader would update
+// _file_reader but leave _tracing_file_reader pointing at the old inner reader,
+// so ORCFileInputStream::read() would bypass the RangeCacheFileReader wrapper.
+TEST_F(ORCFileInputStreamTest, set_file_reader_updates_tracing_with_io_ctx) {
+    io::FileReaderStats stats;
+    io::IOContext io_ctx;
+    io_ctx.file_reader_stats = &stats;
+
+    ORCFileInputStream stream("test_file", _mock_inner, &io_ctx, nullptr,
+                              config::orc_natural_read_size_mb << 20, 0);
+
+    // Initially _tracing_file_reader wraps _inner_reader via TracingFileReader
+    auto* initial_tracing = dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
+    ASSERT_TRUE(initial_tracing != nullptr);
+    EXPECT_EQ(initial_tracing->inner_reader().get(), _mock_inner.get());
+
+    // Count the inner reader to verify reads actually reach it through the wrapper
+    auto counting_inner = std::make_shared<CountingFileReader>(_mock_inner);
+
+    // Simulate the all-tiny-stripe path: wrap inner reader with RangeCacheFileReader
+    // via set_file_reader
+    auto ranges = std::make_shared<io::LinearProbeRangeFinder>(
+            std::vector<io::PrefetchRange> {{0, 2048}});
+    auto range_cache_reader = std::make_shared<io::RangeCacheFileReader>(
+            nullptr, counting_inner, ranges);
+
+    stream.set_file_reader(range_cache_reader);
+
+    // After set_file_reader, _tracing_file_reader should now wrap the NEW
+    // _file_reader (RangeCacheFileReader), not the old inner reader
+    auto* updated_tracing = dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
+    ASSERT_TRUE(updated_tracing != nullptr);
+    EXPECT_EQ(updated_tracing->inner_reader().get(), range_cache_reader.get());
+
+    // Verify that read() goes through the full chain: TracingFileReader →
+    // RangeCacheFileReader → CountingFileReader → MockInnerFileReader
+    char buf[128];
+    stream.read(buf, 128, 0);
+
+    // The read should have gone through the tracing → range cache → counting chain
+    EXPECT_EQ(counting_inner->read_at_count(), 1);
+    EXPECT_EQ(std::string(buf, 128), std::string(128, 'X'));
+}
+
+// Verify that set_file_reader updates _tracing_file_reader when IOContext is null.
+// Without IOContext, _tracing_file_reader should simply equal _file_reader (no
+// TracingFileReader wrapping).
+TEST_F(ORCFileInputStreamTest, set_file_reader_updates_tracing_without_io_ctx) {
+    ORCFileInputStream stream("test_file", _mock_inner, nullptr, nullptr,
+                              config::orc_natural_read_size_mb << 20, 0);
+
+    // Without IOContext, _tracing_file_reader == _file_reader == _inner_reader
+    EXPECT_EQ(stream.get_tracing_file_reader().get(), stream.get_file_reader().get());
+    EXPECT_EQ(stream.get_tracing_file_reader().get(), _mock_inner.get());
+
+    auto counting_inner = std::make_shared<CountingFileReader>(_mock_inner);
+    auto ranges = std::make_shared<io::LinearProbeRangeFinder>(
+            std::vector<io::PrefetchRange> {{0, 2048}});
+    auto range_cache_reader = std::make_shared<io::RangeCacheFileReader>(
+            nullptr, counting_inner, ranges);
+
+    stream.set_file_reader(range_cache_reader);
+
+    // _tracing_file_reader should now point to the RangeCacheFileReader directly
+    EXPECT_EQ(stream.get_tracing_file_reader().get(), range_cache_reader.get());
+    auto* tracing = dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
+    EXPECT_EQ(tracing, nullptr); // no TracingFileReader wrapping without IOContext
+
+    char buf[128];
+    stream.read(buf, 128, 0);
+
+    EXPECT_EQ(counting_inner->read_at_count(), 1);
+    EXPECT_EQ(std::string(buf, 128), std::string(128, 'X'));
+}
+
+// Verify that _inner_reader remains unchanged after set_file_reader — it always
+// holds the original reader.
+TEST_F(ORCFileInputStreamTest, set_file_reader_preserves_inner_reader) {
+    io::FileReaderStats stats;
+    io::IOContext io_ctx;
+    io_ctx.file_reader_stats = &stats;
+
+    ORCFileInputStream stream("test_file", _mock_inner, &io_ctx, nullptr,
+                              config::orc_natural_read_size_mb << 20, 0);
+
+    EXPECT_EQ(stream.get_inner_reader().get(), _mock_inner.get());
+
+    auto counting_inner = std::make_shared<CountingFileReader>(_mock_inner);
+    auto ranges = std::make_shared<io::LinearProbeRangeFinder>(
+            std::vector<io::PrefetchRange> {{0, 2048}});
+    auto range_cache_reader = std::make_shared<io::RangeCacheFileReader>(
+            nullptr, counting_inner, ranges);
+
+    stream.set_file_reader(range_cache_reader);
+
+    // _inner_reader must stay unchanged
+    EXPECT_EQ(stream.get_inner_reader().get(), _mock_inner.get());
+}
+
+} // namespace vectorized
+} // namespace doris

--- a/be/test/format/orc/orc_file_input_stream_test.cpp
+++ b/be/test/format/orc/orc_file_input_stream_test.cpp
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "format/orc/vorc_reader.h"
-
 #include <gtest/gtest.h>
 
+#include "format/orc/vorc_reader.h"
 #include "io/fs/buffered_reader.h"
 #include "io/fs/tracing_file_reader.h"
 
@@ -110,7 +109,8 @@ TEST_F(ORCFileInputStreamTest, set_file_reader_updates_tracing_with_io_ctx) {
                               config::orc_natural_read_size_mb << 20, 0);
 
     // Initially _tracing_file_reader wraps _inner_reader via TracingFileReader
-    auto* initial_tracing = dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
+    auto* initial_tracing =
+            dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
     ASSERT_TRUE(initial_tracing != nullptr);
     EXPECT_EQ(initial_tracing->inner_reader().get(), _mock_inner.get());
 
@@ -121,14 +121,15 @@ TEST_F(ORCFileInputStreamTest, set_file_reader_updates_tracing_with_io_ctx) {
     // via set_file_reader
     auto ranges = std::make_shared<io::LinearProbeRangeFinder>(
             std::vector<io::PrefetchRange> {{0, 2048}});
-    auto range_cache_reader = std::make_shared<io::RangeCacheFileReader>(
-            nullptr, counting_inner, ranges);
+    auto range_cache_reader =
+            std::make_shared<io::RangeCacheFileReader>(nullptr, counting_inner, ranges);
 
     stream.set_file_reader(range_cache_reader);
 
     // After set_file_reader, _tracing_file_reader should now wrap the NEW
     // _file_reader (RangeCacheFileReader), not the old inner reader
-    auto* updated_tracing = dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
+    auto* updated_tracing =
+            dynamic_cast<io::TracingFileReader*>(stream.get_tracing_file_reader().get());
     ASSERT_TRUE(updated_tracing != nullptr);
     EXPECT_EQ(updated_tracing->inner_reader().get(), range_cache_reader.get());
 
@@ -156,8 +157,8 @@ TEST_F(ORCFileInputStreamTest, set_file_reader_updates_tracing_without_io_ctx) {
     auto counting_inner = std::make_shared<CountingFileReader>(_mock_inner);
     auto ranges = std::make_shared<io::LinearProbeRangeFinder>(
             std::vector<io::PrefetchRange> {{0, 2048}});
-    auto range_cache_reader = std::make_shared<io::RangeCacheFileReader>(
-            nullptr, counting_inner, ranges);
+    auto range_cache_reader =
+            std::make_shared<io::RangeCacheFileReader>(nullptr, counting_inner, ranges);
 
     stream.set_file_reader(range_cache_reader);
 
@@ -188,8 +189,8 @@ TEST_F(ORCFileInputStreamTest, set_file_reader_preserves_inner_reader) {
     auto counting_inner = std::make_shared<CountingFileReader>(_mock_inner);
     auto ranges = std::make_shared<io::LinearProbeRangeFinder>(
             std::vector<io::PrefetchRange> {{0, 2048}});
-    auto range_cache_reader = std::make_shared<io::RangeCacheFileReader>(
-            nullptr, counting_inner, ranges);
+    auto range_cache_reader =
+            std::make_shared<io::RangeCacheFileReader>(nullptr, counting_inner, ranges);
 
     stream.set_file_reader(range_cache_reader);
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
The ORC tiny-stripe scan path (`OrcReader::set_fill_columns`, all-tiny-stripe branch) wraps the file reader in `io::RangeCacheFileReader` so the whole file's column-stream reads can be served from one set of pre-merged in-RAM ranges. Since #53729 (`update scan bytes metric in file_scanner`, 2025-07-28), `ORCFileInputStream::read()` issues every byte through `_tracing_file_reader` instead of directly through `_file_reader`. `_tracing_file_reader` is a `TracingFileReader` whose `_inner` `shared_ptr<FileReader>` is **captured by value in the constructor's initializer list** 

After this reassignment, `_file_reader` points at the new `RangeCacheFileReader`, but `_tracing_file_reader->_inner` still holds an independent `shared_ptr` to the original `HdfsFileReader`. Every read still hits HDFS directly. The `RangeCacheFileReader` is constructed, registers spill counters in the runtime profile (which is why `RangeCacheFileReader.ReadToCacheBytes = 0` was the truthful diagnostic), and is **never read from**. Net effect: the BE pays the stripe-merge + wrapper-construction cost, gets no caching benefit, and runs 5–9× slower than the per-stripe `OrcMergeRangeFileReader` non-tiny path on the same physical IO.

We tested it on online SQL with `orc_tiny_stripe_threshold_bytes=8388608`
| Counter | Pre-fix (4.0.5 default, buggy) | Post-fix (4.0.5 default + this PR) | Notes |
|---|---|---|---|
| Total query time | **5 min 55 s** | **1 min 18 s** | **4.55× speedup** |
| `RangeCacheFileReader.ReadToCacheBytes` | **0 B** | **146.05 GB** | Matches 2.1.6 baseline byte-for-byte |
| `RangeCacheFileReader.RequestBytes` | 415 MB (counter aliased onto `MergedSmallIO`) | 32.25 GB | Reads now flow through the wrapper |
| `RangeCacheFileReader.RequestIO` | (low, aliased) | 27.506914 M | Every ORC read goes through the cache |
| `FileReadBytes` (HDFS) | 52.84 GB | 53.22 GB | Same physical IO, confirmed |
| `FileReadCalls` (HDFS) | 27 618 259 | 27 618 259 | Identical |
| `count(*)` result | 780 797 | 780 797 | No semantic change |


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

