### PR TITLE
[fix](cloud) Align snapshot handler submit job signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/snapshot/CloudSnapshotHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/snapshot/CloudSnapshotHandler.java
@@ -62,7 +62,7 @@ public class CloudSnapshotHandler extends MasterDaemon {
         // do nothing
     }
 
-    public void submitJob(long ttl, String label, String vaultName) throws Exception {
+    public void submitJob(long ttl, String label) throws Exception {
         throw new NotImplementedException("submitJob is not implemented");
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommand.java
@@ -45,13 +45,11 @@ public class AdminCreateClusterSnapshotCommand extends Command implements Forwar
 
     public static final String PROP_TTL = "ttl";
     public static final String PROP_LABEL = "label";
-    public static final String PROP_VAULT_NAME = "vault_name";
     private static final Logger LOG = LogManager.getLogger(AdminCreateClusterSnapshotCommand.class);
 
     private Map<String, String> properties;
     private long ttl;
     private String label = null;
-    private String vaultName = null;
 
     /**
      * AdminCreateClusterSnapshotCommand
@@ -66,7 +64,7 @@ public class AdminCreateClusterSnapshotCommand extends Command implements Forwar
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         validate(ctx);
         CloudSnapshotHandler cloudSnapshotHandler = ((CloudEnv) ctx.getEnv()).getCloudSnapshotHandler();
-        cloudSnapshotHandler.submitJob(ttl, label, vaultName);
+        cloudSnapshotHandler.submitJob(ttl, label);
     }
 
     /**
@@ -107,11 +105,6 @@ public class AdminCreateClusterSnapshotCommand extends Command implements Forwar
                 label = entry.getValue();
                 if (label == null || label.isEmpty()) {
                     throw new AnalysisException("Property 'label' cannot be empty");
-                }
-            } else if (entry.getKey().equalsIgnoreCase(PROP_VAULT_NAME)) {
-                vaultName = entry.getValue();
-                if (vaultName == null || vaultName.isEmpty()) {
-                    throw new AnalysisException("Property 'vault_name' cannot be empty");
                 }
             } else {
                 throw new AnalysisException("Unknown property: " + entry.getKey());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommandTest.java
@@ -97,13 +97,10 @@ public class AdminCreateClusterSnapshotCommandTest {
         properties.add(Pair.of(ImmutableMap.of("ttl", "a", "label", "a"), "Invalid value"));
         properties.add(Pair.of(ImmutableMap.of("ttl", "0", "label", "a"), "Property 'ttl' must be positive"));
         properties.add(Pair.of(ImmutableMap.of("ttl", "3600", "label", ""), "Property 'label' cannot be empty"));
-        properties.add(Pair.of(ImmutableMap.of("ttl", "3600", "label", "a", "vault_name", ""),
-                "Property 'vault_name' cannot be empty"));
         // unknown property
         properties.add(Pair.of(ImmutableMap.of("ttl", "0", "a", "b"), "Unknown property"));
         // normal case
         properties.add(Pair.of(ImmutableMap.of("ttl", "3600", "label", "abc"), ""));
-        properties.add(Pair.of(ImmutableMap.of("ttl", "3600", "label", "abc", "vault_name", "vault_1"), ""));
 
         for (Pair<Map<String, String>, String> entry : properties) {
             AdminCreateClusterSnapshotCommand command0 = new AdminCreateClusterSnapshotCommand(entry.first);


### PR DESCRIPTION
## Proposed changes

Align cloud snapshot job submission with the `branch-selectdb-doris-4.1` signature by removing the `vaultName` parameter from `CloudSnapshotHandler.submitJob`.

Also update `AdminCreateClusterSnapshotCommand` and its unit test so the Apache master caller compiles against the two-argument handler API and no longer accepts the removed `vault_name` property.

## Checklist

- [x] `git diff --check`
- [x] `sh build.sh --fe`
- [x] `sh run-fe-ut.sh --run "org.apache.doris.nereids.trees.plans.commands.AdminCreateClusterSnapshotCommandTest"`
