### PR TITLE
[fix](be) Normalize v1 date string cast result

### DIFF
--- a/be/src/exprs/function/cast/cast_to_date_or_datetime_impl.hpp
+++ b/be/src/exprs/function/cast/cast_to_date_or_datetime_impl.hpp
@@ -434,6 +434,7 @@ inline bool CastToDateOrDatetime::from_string_strict_mode(const StringRef& str,
         has_second = true;
         if (ptr == end) {
             // no fraction or timezone part, just return.
+            cast_to_type<TargetType>(res);
             return true;
         }
         goto FRAC;
@@ -556,6 +557,7 @@ inline bool CastToDateOrDatetime::from_string_strict_mode(const StringRef& str,
                              part[0]);
     if (ptr == end) {
         // no minute part, just return.
+        cast_to_type<TargetType>(res);
         return true;
     }
     if (*ptr == ':') {

--- a/be/test/exprs/function/cast/cast_to_date_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_date_test.cpp
@@ -85,6 +85,17 @@ TEST_F(FunctionCastTest, string_to_date_valid_case_strict_mode) {
     check_function_for_cast_strict_mode<DataTypeDateV2>(input_types, data_set);
 }
 
+TEST_F(FunctionCastTest, string_to_datev1_valid_case_strict_mode) {
+    InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR};
+    DataSet data_set = {
+            // Compact formats
+            {{std::string("20240501 01")}, std::string("2024-05-01")},
+            {{std::string("20230716 1920Z")}, std::string("2023-07-16")},
+            {{std::string("20240501T0000")}, std::string("2024-05-01")},
+    };
+    check_function_for_cast_strict_mode<DataTypeDate>(input_types, data_set);
+}
+
 TEST_F(FunctionCastTest, string_to_date_invalid_cases_in_strict_mode) {
     InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR};
     DataSet data_set = {

--- a/be/test/exprs/function/cast/cast_to_date_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_date_test.cpp
@@ -92,6 +92,7 @@ TEST_F(FunctionCastTest, string_to_datev1_valid_case_strict_mode) {
             {{std::string("20240501 01")}, std::string("2024-05-01")},
             {{std::string("20230716 1920Z")}, std::string("2023-07-16")},
             {{std::string("20240501T0000")}, std::string("2024-05-01")},
+            {{std::string("20120102030405")}, std::string("2012-01-02")},
     };
     check_function_for_cast_strict_mode<DataTypeDate>(input_types, data_set);
 }


### PR DESCRIPTION
Problem Summary: Strict-mode string casts to v1 DATE can return early after parsing a compact datetime string or an hour-only time part. Those early returns skipped the common target-type normalization, so DATE results could keep non-zero time fields such as 2024-05-01 01:00:00 instead of 2024-05-01. Normalize the parsed value before both early returns so DATE clears the time fields and DATETIME keeps datetime semantics.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

