### PR TITLE
branch-4.0: [fix](test) deflake test_iot_auto_detect_fail by accepting equivalent error messages

### DIFF
--- a/regression-test/suites/compaction/test_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys.groovy
@@ -113,7 +113,7 @@ suite("test_compaction_agg_keys") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys.groovy
@@ -17,6 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_agg_keys") {
     def tableName = "compaction_agg_keys_regression_test"
@@ -104,26 +105,33 @@ suite("test_compaction_agg_keys") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,QueryHits,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
 
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                String tablet_id = tablet.TabletId
 
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default2 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_agg_keys_with_array_map.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys_with_array_map.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_agg_keys_with_array_map") {
     def tableName = "compaction_agg_keys_regression_test_complex"
@@ -95,26 +97,33 @@ suite("test_compaction_agg_keys_with_array_map") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,QueryHits,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
 
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                String tablet_id = tablet.TabletId
 
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default2 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_agg_keys_with_array_map.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys_with_array_map.groovy
@@ -105,7 +105,7 @@ suite("test_compaction_agg_keys_with_array_map") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_agg_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys_with_delete.groovy
@@ -124,7 +124,7 @@ suite("test_compaction_agg_keys_with_delete") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_agg_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys_with_delete.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_agg_keys_with_delete") {
     def tableName = "test_compaction_agg_keys_with_delete_regression_test"
@@ -114,26 +116,33 @@ suite("test_compaction_agg_keys_with_delete") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,QueryHits,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
 
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                String tablet_id = tablet.TabletId
 
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default2 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
@@ -112,7 +112,7 @@ suite("test_compaction_uniq_keys") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
@@ -17,6 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_uniq_keys") {
     def tableName = "compaction_uniq_keys_regression_test"
@@ -103,25 +104,30 @@ suite("test_compaction_uniq_keys") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,QueryHits,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
 
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default2 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_ck.groovy
@@ -112,12 +112,14 @@ suite("test_compaction_uniq_keys_ck") {
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
 
-        // BE only picks rowsets whose version is already visible as cumulative
-        // compaction candidates, and the visible version is pushed from FE
-        // asynchronously. Right after a burst of loads it may lag, so a single
-        // cumulative round can merge only the visible prefix of rowsets. Retry
-        // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        // BE only treats a rowset as a cumulative compaction candidate once the BE has
+        // the FE-pushed visible version covering it (Tablet::_pick_visible_rowsets_to_compaction).
+        // The fast incremental push from FE (PublishVersionDaemon) can be missed; the
+        // periodic fallback then syncs it, bounded by partition_info_update_interval_secs
+        // (60s) + report_tablet_interval_seconds (60s), i.e. up to ~120s. So keep triggering
+        // + recounting -- the merge happens the instant the visible version lands -- and give
+        // the loop budget well above that ~120s ceiling so it stays deterministic.
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_ck.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_uniq_keys_ck") {
     def tableName = "compaction_uniq_keys_ck"
@@ -107,24 +109,30 @@ suite("test_compaction_uniq_keys_ck") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,QueryHits,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default2 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         // try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_row_store_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_row_store_ck.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 
 suite("test_compaction_uniq_keys_row_store_ck", "p0") {
@@ -186,24 +188,31 @@ suite("test_compaction_uniq_keys_row_store_ck", "p0") {
 
         checkValue()
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                String tablet_id = tablet.TabletId
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         checkValue()
         qt_sql_row_size "select sum(length(__DORIS_ROW_STORE_COL__)) from ${tableName}"
     } finally {

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_row_store_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_row_store_ck.groovy
@@ -196,7 +196,7 @@ suite("test_compaction_uniq_keys_row_store_ck", "p0") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -128,7 +128,7 @@ suite("test_compaction_uniq_keys_with_delete") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_uniq_keys_with_delete") {
     def tableName = "test_compaction_uniq_keys_with_delete_regression_test"
@@ -118,24 +120,30 @@ suite("test_compaction_uniq_keys_with_delete") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_uniq_keys_with_delete_ck") {
     def tableName = "test_compaction_uniq_keys_with_delete_ck"
@@ -135,24 +137,30 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         // try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -145,7 +145,7 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_with_empty_rowset.groovy
+++ b/regression-test/suites/compaction/test_compaction_with_empty_rowset.groovy
@@ -66,7 +66,7 @@ suite("test_compaction_mow_with_empty_rowset", "p0") {
     // asynchronously. Right after a burst of loads it may lag, so a single
     // cumulative round can merge only the visible prefix of rowsets. Retry
     // trigger + recount until the rows are fully merged.
-    Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+    Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
         // trigger compactions for all tablets in ${tableName}
         trigger_and_wait_compaction(tableName, "cumulative")
         int rowCount = 0
@@ -95,7 +95,7 @@ suite("test_compaction_mow_with_empty_rowset", "p0") {
     // asynchronously. Right after a burst of loads it may lag, so a single
     // cumulative round can merge only the visible prefix of rowsets. Retry
     // trigger + recount until the rows are fully merged.
-    Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+    Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
         // trigger compactions for all tablets in ${tableName}
         trigger_and_wait_compaction(tableName, "cumulative")
         int rowCount = 0

--- a/regression-test/suites/compaction/test_compaction_with_empty_rowset.groovy
+++ b/regression-test/suites/compaction/test_compaction_with_empty_rowset.groovy
@@ -17,6 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_compaction_mow_with_empty_rowset", "p0") {
     def tableName = "test_compaction_with_empty_rowset"
@@ -60,21 +61,28 @@ suite("test_compaction_mow_with_empty_rowset", "p0") {
     def replicaNum = get_table_replica_num(tableName)
     logger.info("get table replica num: " + replicaNum)
 
-    // trigger compactions for all tablets in ${tableName}
-    trigger_and_wait_compaction(tableName, "cumulative")
-    int rowCount = 0
-    for (def tablet in tablets) {
-        String tablet_id = tablet.TabletId
-        def (code, out, err) = curl("GET", tablet.CompactionStatus)
-        logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-        assertEquals(code, 0)
-        def tabletJson = parseJson(out.trim())
-        assert tabletJson.rowsets instanceof List
-        for (String rowset in (List<String>) tabletJson.rowsets) {
-            rowCount += Integer.parseInt(rowset.split(" ")[1])
+    // BE only picks rowsets whose version is already visible as cumulative
+    // compaction candidates, and the visible version is pushed from FE
+    // asynchronously. Right after a burst of loads it may lag, so a single
+    // cumulative round can merge only the visible prefix of rowsets. Retry
+    // trigger + recount until the rows are fully merged.
+    Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        // trigger compactions for all tablets in ${tableName}
+        trigger_and_wait_compaction(tableName, "cumulative")
+        int rowCount = 0
+        for (def tablet in tablets) {
+            String tablet_id = tablet.TabletId
+            def (code, out, err) = curl("GET", tablet.CompactionStatus)
+            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+            assertEquals(code, 0)
+            def tabletJson = parseJson(out.trim())
+            assert tabletJson.rowsets instanceof List
+            for (String rowset in (List<String>) tabletJson.rowsets) {
+                rowCount += Integer.parseInt(rowset.split(" ")[1])
+            }
         }
-    }
-    assert (rowCount < 10 * replicaNum)
+        return rowCount < 10 * replicaNum
+    })
     qt_sql2 """ select * from ${tableName} order by k1, k2, k3 """
 
     for (int i = 0; i < 10; i++) {
@@ -82,20 +90,27 @@ suite("test_compaction_mow_with_empty_rowset", "p0") {
                 'a', 'b', 'c', '2021-10-30', '2021-10-30 00:00:00') """
     }   
 
-    // trigger compactions for all tablets in ${tableName}
-    trigger_and_wait_compaction(tableName, "cumulative")
-    rowCount = 0
-    for (def tablet in tablets) {
-        String tablet_id = tablet.TabletId
-        def (code, out, err) = curl("GET", tablet.CompactionStatus)
-        logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-        assertEquals(code, 0)
-        def tabletJson = parseJson(out.trim())
-        assert tabletJson.rowsets instanceof List
-        for (String rowset in (List<String>) tabletJson.rowsets) {
-            rowCount += Integer.parseInt(rowset.split(" ")[1])
+    // BE only picks rowsets whose version is already visible as cumulative
+    // compaction candidates, and the visible version is pushed from FE
+    // asynchronously. Right after a burst of loads it may lag, so a single
+    // cumulative round can merge only the visible prefix of rowsets. Retry
+    // trigger + recount until the rows are fully merged.
+    Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        // trigger compactions for all tablets in ${tableName}
+        trigger_and_wait_compaction(tableName, "cumulative")
+        int rowCount = 0
+        for (def tablet in tablets) {
+            String tablet_id = tablet.TabletId
+            def (code, out, err) = curl("GET", tablet.CompactionStatus)
+            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+            assertEquals(code, 0)
+            def tabletJson = parseJson(out.trim())
+            assert tabletJson.rowsets instanceof List
+            for (String rowset in (List<String>) tabletJson.rowsets) {
+                rowCount += Integer.parseInt(rowset.split(" ")[1])
+            }
         }
-    }
-    assert (rowCount < 20 * replicaNum)
+        return rowCount < 20 * replicaNum
+    })
     qt_sql3 """ select * from ${tableName} order by k1, k2, k3 """
 }

--- a/regression-test/suites/compaction/test_vertical_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_agg_keys.groovy
@@ -125,7 +125,7 @@ suite("test_vertical_compaction_agg_keys") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_vertical_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_agg_keys.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_vertical_compaction_agg_keys") {
     def tableName = "vertical_compaction_agg_keys_regression_test"
@@ -115,24 +117,31 @@ suite("test_vertical_compaction_agg_keys") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,QueryHits,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                String tablet_id = tablet.TabletId
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_vertical_compaction_agg_state.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_agg_state.groovy
@@ -86,7 +86,7 @@ suite("test_vertical_compaction_agg_state") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_vertical_compaction_agg_state.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_agg_state.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_vertical_compaction_agg_state") {
     def tableName = "vertical_compaction_agg_state_regression_test"
@@ -76,24 +78,31 @@ suite("test_vertical_compaction_agg_state") {
 
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                String tablet_id = tablet.TabletId
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default """ SELECT user_id,array_sort(collect_set_merge(agg_user_id)) FROM ${tableName} t group by user_id ORDER BY user_id;"""
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_vertical_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_uniq_keys.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_vertical_compaction_uniq_keys") {
     def tableName = "vertical_compaction_uniq_keys_regression_test"
@@ -112,24 +114,30 @@ suite("test_vertical_compaction_uniq_keys") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,QueryHits,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/compaction/test_vertical_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_uniq_keys.groovy
@@ -122,7 +122,7 @@ suite("test_vertical_compaction_uniq_keys") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_vertical_compaction_uniq_keys_ck.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_uniq_keys_ck.groovy
@@ -124,7 +124,7 @@ suite("test_vertical_compaction_uniq_keys_ck") {
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets. Retry
         // trigger + recount until the rows are fully merged.
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
             int rowCount = 0

--- a/regression-test/suites/compaction/test_vertical_compaction_uniq_keys_ck.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_uniq_keys_ck.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+import java.util.concurrent.TimeUnit
 
 suite("test_vertical_compaction_uniq_keys_ck") {
     def tableName = "test_vertical_compaction_uniq_keys_ck"
@@ -114,24 +116,30 @@ suite("test_vertical_compaction_uniq_keys_ck") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,QueryHits,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        // trigger compactions for all tablets in ${tableName}
-        trigger_and_wait_compaction(tableName, "cumulative")
-
         def replicaNum = get_table_replica_num(tableName)
         logger.info("get table replica num: " + replicaNum)
-        int rowCount = 0
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            (code, out, err) = curl("GET", tablet.CompactionStatus)
-            logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def tabletJson = parseJson(out.trim())
-            assert tabletJson.rowsets instanceof List
-            for (String rowset in (List<String>) tabletJson.rowsets) {
-                rowCount += Integer.parseInt(rowset.split(" ")[1])
+
+        // BE only picks rowsets whose version is already visible as cumulative
+        // compaction candidates, and the visible version is pushed from FE
+        // asynchronously. Right after a burst of loads it may lag, so a single
+        // cumulative round can merge only the visible prefix of rowsets. Retry
+        // trigger + recount until the rows are fully merged.
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            // trigger compactions for all tablets in ${tableName}
+            trigger_and_wait_compaction(tableName, "cumulative")
+            int rowCount = 0
+            for (def tablet in tablets) {
+                (code, out, err) = curl("GET", tablet.CompactionStatus)
+                logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
+                assertEquals(code, 0)
+                def tabletJson = parseJson(out.trim())
+                assert tabletJson.rowsets instanceof List
+                for (String rowset in (List<String>) tabletJson.rowsets) {
+                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                }
             }
-        }
-        assert (rowCount < 8 * replicaNum)
+            return rowCount < 8 * replicaNum
+        })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {
         try_sql("DROP TABLE IF EXISTS ${tableName}")

--- a/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
+++ b/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
@@ -100,20 +100,12 @@ suite("test_colocate_join_of_column_order") {
     sql """insert into test_colocate_join_of_column_order_tb values(1,1);"""
     sql """insert into test_colocate_join_of_column_order_tc values(1,1);"""
 
-    // Pin column statistics so the cost-based COLOCATE-vs-PARTITIONED choice is deterministic.
-    // Freshly-created tables have rowCountReported=false (only the async CloudTabletStatMgr sets it,
-    // up to a full tick after INSERT); with unreliable stats the optimizer can fall back to a
-    // PARTITIONED shuffle join, which makes the COLOCATE assertion below flaky. Injecting stats
-    // (userInjected) bypasses the async-report dependency. See nereids_p0/join/initial_join_order.
-    sql """alter table test_colocate_join_of_column_order_ta modify column c1 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_ta modify column c2 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tb modify column c1 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tb modify column c2 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tc modify column c1 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tc modify column c2 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-
+    // parallel_pipeline_task_num=1 keeps the bucket-shuffle downgrade from firing: with the default
+    // fuzzed value (0 -> auto ~cores/2) the heuristic totalBucketNum(10) < backEndNum*paraNum*0.8 can
+    // trip on a single-BE cloud cluster, turning ta's NATURAL distribution into EXECUTION_BUCKETED and
+    // forbidding the downstream COLOCATE. Pinning paraNum=1 makes the condition always false.
     explain {
-        sql("""select /*+ set_var(disable_join_reorder=true) */ * from test_colocate_join_of_column_order_ta join [shuffle] (select cast((c2 + 1) as bigint) c2 from test_colocate_join_of_column_order_tb) test_colocate_join_of_column_order_tb  on test_colocate_join_of_column_order_ta.c1 = test_colocate_join_of_column_order_tb.c2 join [shuffle] test_colocate_join_of_column_order_tc on test_colocate_join_of_column_order_tb.c2 = test_colocate_join_of_column_order_tc.c1;""");
+        sql("""select /*+ set_var(disable_join_reorder=true,parallel_pipeline_task_num=1) */ * from test_colocate_join_of_column_order_ta join [shuffle] (select cast((c2 + 1) as bigint) c2 from test_colocate_join_of_column_order_tb) test_colocate_join_of_column_order_tb  on test_colocate_join_of_column_order_ta.c1 = test_colocate_join_of_column_order_tb.c2 join [shuffle] test_colocate_join_of_column_order_tc on test_colocate_join_of_column_order_tb.c2 = test_colocate_join_of_column_order_tc.c1;""");
         contains "COLOCATE"
     }
 

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning.groovy
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
+
 suite("test_iceberg_runtime_filter_partition_pruning", "p0,external,doris,external_docker,external_docker_doris") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
@@ -39,6 +42,32 @@ suite("test_iceberg_runtime_filter_partition_pruning", "p0,external,doris,extern
         "s3.endpoint" = "http://${externalEnvIp}:${minio_port}",
         "s3.region" = "us-east-1"
     );"""
+
+    // All tables in partition_db are pre-created by the docker preinstalled script (run18.sql)
+    // and are only read here. A freshly created Iceberg REST catalog can occasionally return an
+    // incomplete table list on its first metadata fetch (REST client cold start), which made this
+    // test flaky with "Table xxx does not exist in database [partition_db]". Wait until all
+    // expected tables are visible (refresh to drop any cached partial list) before querying.
+    def expectedTables = ["date_partitioned", "int_partitioned", "float_partitioned",
+                          "string_partitioned", "timestamp_partitioned", "timestamp_ntz_partitioned",
+                          "boolean_partitioned", "decimal_partitioned", "binary_partitioned",
+                          "null_str_partition_table"] as Set
+    Awaitility.await("wait for ${db_name} tables to be visible")
+            .atMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until {
+        try {
+            sql """refresh catalog ${catalog_name}"""
+            def actualTables = sql("""show tables from `${catalog_name}`.`${db_name}`""")
+                    .collect { it[0] as String } as Set
+            if (!actualTables.containsAll(expectedTables)) {
+                logger.warn("${db_name} not ready yet, missing tables: ${expectedTables - actualTables}")
+                return false
+            }
+            return true
+        } catch (Exception e) {
+            logger.warn("waiting for ${db_name} tables to be visible: ${e.getMessage()}")
+            return false
+        }
+    }
 
     sql """switch ${catalog_name}"""
     sql """use ${db_name}"""

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning_transform.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning_transform.groovy
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
+
 suite("test_iceberg_runtime_filter_partition_pruning_transform", "p0,external,doris,external_docker,external_docker_doris") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
@@ -39,6 +42,33 @@ suite("test_iceberg_runtime_filter_partition_pruning_transform", "p0,external,do
         "s3.endpoint" = "http://${externalEnvIp}:${minio_port}",
         "s3.region" = "us-east-1"
     );"""
+
+    // All tables in transform_partition_db are pre-created by the docker preinstalled script
+    // (run19.sql) and are only read here. A freshly created Iceberg REST catalog can occasionally
+    // return an incomplete table list on its first metadata fetch (REST client cold start), which can
+    // make this test flaky with "Table xxx does not exist in database [transform_partition_db]". Wait
+    // until all expected tables are visible (refresh to drop any cached partial list) before querying.
+    def expectedTables = ["bucket_int_4", "bucket_bigint_4", "bucket_string_4", "bucket_date_4",
+                          "bucket_timestamp_4", "bucket_timestamp_ntz_4", "bucket_binary_4",
+                          "truncate_string_3", "truncate_binary_4", "truncate_int_10",
+                          "truncate_bigint_100", "truncate_decimal_10", "day_partitioned",
+                          "year_partitioned", "month_partitioned", "hour_partitioned"] as Set
+    Awaitility.await("wait for ${db_name} tables to be visible")
+            .atMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until {
+        try {
+            sql """refresh catalog ${catalog_name}"""
+            def actualTables = sql("""show tables from `${catalog_name}`.`${db_name}`""")
+                    .collect { it[0] as String } as Set
+            if (!actualTables.containsAll(expectedTables)) {
+                logger.warn("${db_name} not ready yet, missing tables: ${expectedTables - actualTables}")
+                return false
+            }
+            return true
+        } catch (Exception e) {
+            logger.warn("waiting for ${db_name} tables to be visible: ${e.getMessage()}")
+            return false
+        }
+    }
 
     sql """switch ${catalog_name}"""
     sql """use ${db_name}"""

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
+
 suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,external_docker,external_docker_doris") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
@@ -36,8 +39,34 @@ suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,externa
                     's3.path.style.access' = 'true'
             );
         """
+        // All tables in partition_db are pre-created by the docker preinstalled paimon script and are
+        // only read here. A freshly created Paimon catalog can occasionally return an incomplete table
+        // list on its first metadata fetch (catalog cold start), which can make this test flaky with
+        // "Table xxx does not exist in database [partition_db]". Wait until all expected tables are
+        // visible (refresh to drop any cached partial list) before querying.
+        // Note: binary_partitioned is intentionally excluded (its queries are skipped below).
+        def expectedTables = ["decimal_partitioned", "int_partitioned", "string_partitioned",
+                              "date_partitioned", "timestamp_partitioned", "bigint_partitioned",
+                              "boolean_partitioned", "float_partitioned",
+                              "null_str_partition_table"] as Set
+        Awaitility.await("wait for ${db_name} tables to be visible")
+                .atMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until {
+            try {
+                sql """refresh catalog ${catalog_name}"""
+                def actualTables = sql("""show tables from `${catalog_name}`.`${db_name}`""")
+                        .collect { it[0] as String } as Set
+                if (!actualTables.containsAll(expectedTables)) {
+                    logger.warn("${db_name} not ready yet, missing tables: ${expectedTables - actualTables}")
+                    return false
+                }
+                return true
+            } catch (Exception e) {
+                logger.warn("waiting for ${db_name} tables to be visible: ${e.getMessage()}")
+                return false
+            }
+        }
         sql """use `${catalog_name}`.`${db_name}`;"""
-        
+
         def test_runtime_filter_partition_pruning = {
             qt_runtime_filter_partition_pruning_decimal1 """
                 select count(*) from decimal_partitioned where partition_key =

--- a/regression-test/suites/insert_overwrite_p0/test_iot_auto_detect_fail.groovy
+++ b/regression-test/suites/insert_overwrite_p0/test_iot_auto_detect_fail.groovy
@@ -160,12 +160,12 @@ PROPERTIES (
     // reported). Accept all of them, same as insert_overwrite_auto_detect.groovy. The point is
     // that the statement fails (not silently creating a partition / succeeding).
     def checkOverwriteFail = { result, exception, startTime, endTime ->
-        assertTrue("expect insert-overwrite auto-detect to fail (no matching origin partition), "
-                + "but got result=${result}, exception=${exception?.getMessage()}",
-            exception != null && (
+        assertTrue(exception != null && (
                 exception.getMessage().contains('Cannot found origin partitions')
                 || exception.getMessage().contains('no partition for this tuple')
-                || exception.getMessage().contains('Insert has filtered data in strict mode')))
+                || exception.getMessage().contains('Insert has filtered data in strict mode')),
+            "expect insert-overwrite auto-detect to fail (no matching origin partition), "
+                + "but got result=${result}, exception=${exception?.getMessage()}")
     }
     test {
         sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"

--- a/regression-test/suites/insert_overwrite_p0/test_iot_auto_detect_fail.groovy
+++ b/regression-test/suites/insert_overwrite_p0/test_iot_auto_detect_fail.groovy
@@ -152,16 +152,31 @@ PROPERTIES (
 );
     """
 
-    test {
-        sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
-        exception "Cannot found origin partitions"
+    // The overwrite must FAIL because the source rows (dt='20241128') fall into a
+    // partition that does not exist in fail_tag and enable_auto_create_when_overwrite=false.
+    // With multiple parallel sink instances this single logical failure can surface as any
+    // of several equivalent messages (the semantic "Cannot found origin partitions" error and
+    // the collateral "no partition for this tuple" / strict-mode filtered-data error race to be
+    // reported). Accept all of them, same as insert_overwrite_auto_detect.groovy. The point is
+    // that the statement fails (not silently creating a partition / succeeding).
+    def checkOverwriteFail = { result, exception, startTime, endTime ->
+        assertTrue("expect insert-overwrite auto-detect to fail (no matching origin partition), "
+                + "but got result=${result}, exception=${exception?.getMessage()}",
+            exception != null && (
+                exception.getMessage().contains('Cannot found origin partitions')
+                || exception.getMessage().contains('no partition for this tuple')
+                || exception.getMessage().contains('Insert has filtered data in strict mode')))
     }
     test {
         sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
-        exception "Cannot found origin partitions"
+        check checkOverwriteFail
     }
     test {
         sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
-        exception "Cannot found origin partitions"
+        check checkOverwriteFail
+    }
+    test {
+        sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
+        check checkOverwriteFail
     }
 }

--- a/regression-test/suites/query_profile/s3_load_profile_test.groovy
+++ b/regression-test/suites/query_profile/s3_load_profile_test.groovy
@@ -17,6 +17,8 @@
 
 import groovy.json.JsonSlurper
 import org.apache.doris.regression.action.ProfileAction
+import org.awaitility.Awaitility
+import static java.util.concurrent.TimeUnit.SECONDS
 
 def getProfile = { masterHTTPAddr, id ->
     def dst = 'http://' + masterHTTPAddr
@@ -197,7 +199,20 @@ PROPERTIES (
     def masterAddress = masterIP + ":" + masterHTTPPort
     logger.info("masterIP:masterHTTPPort is:${masterAddress}")
 
-    def profileString = getProfile(masterAddress, jobId.toString())
+    // The BE reports the detailed execution profile to FE asynchronously, after
+    // the load job has already finished (the Summary section is pushed
+    // synchronously on txn VISIBLE, but the Fragments/operators are filled only
+    // when the coordinator BE's report lands). Fetching too early yields a
+    // profile whose MergedProfile carries no operators, so the scan counters
+    // are not present yet. Poll until they show up, i.e. the execution profile
+    // has landed; the await times out and fails loudly if it never does.
+    def profileString = ""
+    Awaitility.await().atMost(60, SECONDS).pollInterval(1, SECONDS).until {
+        profileString = getProfile(masterAddress, jobId.toString())
+        return profileString.contains("NumScanners") &&
+                profileString.contains("RowsProduced") &&
+                profileString.contains("RowsRead")
+    }
     logger.info("profileDataString:" + profileString)
     assertTrue(profileString.contains("NumScanners"))
     assertTrue(profileString.contains("RowsProduced"))


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: None

Problem Summary:

A branch-4.0 **test-only** PR that deflakes four flaky regression tests. No product/source code is changed — every change is confined to `regression-test/`. The PR bundles four independent fixes (one per commit):

#### 1. `test_iot_auto_detect_fail` — accept equivalent error messages

`INSERT OVERWRITE ... PARTITION(*)` auto-detect into an auto-partition table whose source rows match no existing partition (`enable_auto_create_when_overwrite=false`) correctly fails every time. But with multiple parallel sink instances the surfaced error message races between the semantic `"Cannot found origin partitions in auto detect overwriting"` (`vrow_distribution.cpp`) and the collateral `"no partition for this tuple"` (`vtablet_finder.cpp`) that gets wrapped into a node-channel `"add batch ... status isn't ok"` error. One instance cancels the shared node channels, the other instance's in-flight `add_batch` then reports the wrapped variant; which one FE reports to the client is non-deterministic.

The test pinned the strict `"Cannot found origin partitions"` message, so it failed intermittently when the wrapped variant won the race (CloudP0 build 971274: same SQL run 3×, 2 pass / 1 fail; single-sender loads are deterministic, ≥2 sender loads race). Relax the assertion to accept all equivalent failure messages (matching the sibling `insert_overwrite_auto_detect.groovy`), while still requiring the statement to fail — this still guards against silently creating a partition or succeeding.

#### 2. `test_iot_auto_detect_fail` — fix `assertTrue` argument order

Fix #1 added `assertTrue("message", condition)` with the message first. The bare `assertTrue` in a regression `Suite` resolves to JUnit Jupiter's `assertTrue(boolean, String)` (condition first), so passing `(String, boolean)` matched no overload and threw `MissingMethodException` at check time — failing the test even when the expected error was present. Swap to condition-first to match the JUnit Jupiter signature and the dominant codebase convention.

#### 3. runtime_filter_partition_pruning external tests — add a readiness gate

A freshly created Iceberg REST / Paimon catalog can occasionally return an incomplete table list on its first metadata fetch (catalog cold start). These tests queried tables immediately after creating the catalog with no tolerance for the race, so a single metadata hiccup failed them with `"Table xxx does not exist in database [...]"`. Wait (Awaitility: refresh catalog + `show tables`) until all expected tables are visible before running the queries. Applied to the iceberg, iceberg-transform and paimon variants; each waits for exactly the tables it queries.

#### 4. `test_colocate_join_of_column_order` — pin `parallel_pipeline_task_num`

The multi-table COLOCATE assertion was flaky in cloud: with the default fuzzed `parallel_pipeline_task_num` (`0` → auto ~cores/2), the bucket-shuffle downgrade heuristic in `ChildrenPropertiesRegulator` (`totalBucketNum(10) < backEndNum * paraNum * 0.8`) can fire on a single-BE cluster. That turns `ta`'s NATURAL distribution into EXECUTION_BUCKETED, which cascades to forbid the downstream COLOCATE join, so the plan comes out fully PARTITIONED. Pin `parallel_pipeline_task_num=1` in the query hint so the downgrade condition is always false regardless of the fuzzed value or CI core count (the same lever used to deflake `prune_bucket_with_bucket_shuffle_join`). Also drop the earlier inert set-stats injection (that path reads no column statistics, so the injected stats were a no-op for this failure).

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
