### PR TITLE
[fix](fe) Show warm-up timestamps with date

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/JobWarmUpStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/JobWarmUpStats.java
@@ -32,7 +32,7 @@ import java.time.format.DateTimeFormatter;
  * across all matched tables, then computes gap = requested - finished.
  */
 public class JobWarmUpStats {
-    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     // Aggregated requested
     public long requestedSegmentNum5m;
@@ -277,7 +277,7 @@ public class JobWarmUpStats {
         }
         try {
             return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMs), ZoneId.systemDefault())
-                    .format(TIME_FMT);
+                    .format(DATETIME_FMT);
         } catch (Exception e) {
             return "";
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/CloudWarmUpJobTableFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/CloudWarmUpJobTableFilterTest.java
@@ -365,6 +365,7 @@ public class CloudWarmUpJobTableFilterTest {
         stats.finishIndexSize30m = 512;
         stats.failSegmentNum30m = 1;
         stats.lastTriggerTs = 5000;
+        stats.lastFinishTs = 4800;
         stats.progressTriggerTs = 4200;
         stats.computeGap();
 
@@ -380,6 +381,10 @@ public class CloudWarmUpJobTableFilterTest {
         Assertions.assertEquals(4, segNum.get("finish_30m").getAsLong());
         Assertions.assertEquals(2, segNum.get("gap_30m").getAsLong());
         Assertions.assertEquals(800, detailStats.get("trigger_gap_ms").getAsLong());
+        String dateTimePattern = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}";
+        Assertions.assertTrue(detailStats.get("last_trigger_ts").getAsString().matches(dateTimePattern));
+        Assertions.assertTrue(detailStats.get("last_finish_ts").getAsString().matches(dateTimePattern));
+        Assertions.assertTrue(detailStats.get("progress_trigger_ts").getAsString().matches(dateTimePattern));
         Assertions.assertFalse(detailStats.has("window"));
 
         List<String> summary = job.getJobInfo(stats, false);

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/WarmUpStatsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/WarmUpStatsTest.java
@@ -22,6 +22,10 @@ import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,6 +35,7 @@ import java.util.Map;
  * - JobWarmUpStats: aggregate requested/finished, compute gap, serialize
  */
 public class WarmUpStatsTest {
+    private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     // ==================== TableWarmUpWindowedStats ====================
 
@@ -314,6 +319,29 @@ public class WarmUpStatsTest {
     }
 
     @Test
+    public void testToJsonStringFormatsTimestampsWithDate() {
+        long lastTriggerTs = 1700000000000L;
+        long lastFinishTs = 1700000001000L;
+        long progressTriggerTs = 1699999999000L;
+
+        JobWarmUpStats job = new JobWarmUpStats();
+        job.lastTriggerTs = lastTriggerTs;
+        job.lastFinishTs = lastFinishTs;
+        job.progressTriggerTs = progressTriggerTs;
+
+        JsonObject root = JsonParser.parseString(job.toJsonString()).getAsJsonObject();
+
+        Assertions.assertEquals(formatExpectedDateTime(lastTriggerTs),
+                root.get("last_trigger_ts").getAsString());
+        Assertions.assertEquals(formatExpectedDateTime(lastFinishTs),
+                root.get("last_finish_ts").getAsString());
+        Assertions.assertEquals(formatExpectedDateTime(progressTriggerTs),
+                root.get("progress_trigger_ts").getAsString());
+        Assertions.assertTrue(root.get("last_trigger_ts").getAsString()
+                .matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"));
+    }
+
+    @Test
     public void testToSummaryJsonStringMergesDataAndIndexSize() {
         JobWarmUpStats job = new JobWarmUpStats();
         job.requestedSegmentSize30m = 1048576; // 1 MB
@@ -493,5 +521,10 @@ public class WarmUpStatsTest {
         Assertions.assertEquals(1536, stats.gapSegmentSize30m + stats.gapIndexSize30m);
         Assertions.assertEquals(1000, stats.lastTriggerTs);
         Assertions.assertEquals(1200, stats.lastFinishTs);
+    }
+
+    private static String formatExpectedDateTime(long epochMs) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMs), ZoneId.systemDefault())
+                .format(DATETIME_FMT);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Event-driven warm-up detailed SyncStats serialized last_trigger_ts, last_finish_ts, and progress_trigger_ts with only HH:mm:ss. When a job spans dates, the output cannot identify which day the event happened. BE reports these values as epoch milliseconds, so FE can render them directly as yyyy-MM-dd HH:mm:ss while preserving empty strings for unset timestamps.

### Release note

SHOW WARM UP JOB detailed SyncStats now displays warm-up timestamp fields with full date and time.

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.cloud.WarmUpStatsTest,org.apache.doris.cloud.CloudWarmUpJobTableFilterTest
- Behavior changed: Yes. Detailed warm-up timestamp strings now include the date.
- Does this need documentation: No
