### PR TITLE
branch-4.1: [fix](test) skip test_temp_table (temp table feature no longer maintained, backport of #64525)

### DIFF
--- a/regression-test/suites/temp_table_p0/test_temp_table.groovy
+++ b/regression-test/suites/temp_table_p0/test_temp_table.groovy
@@ -16,6 +16,10 @@
 // under the License.
 
 suite('test_temp_table', 'p0') {
+    if (true) {
+        // temp table feature is no longer mantains. skip this case
+        return
+    }
     sql """
         DROP TABLE IF EXISTS `t_test_table_with_data`
     """


### PR DESCRIPTION
## What problem does this PR solve?

Back-ports the `skip temp_table_p0/test_temp_table.groovy` decision from
branch-4.0 #64525 to branch-4.1. The temporary-table feature is **no longer
maintained**, so the suite is skipped (early `return`) rather than kept as a
chronically-flaky Cloud-P0 case (it is the highest-frequency muted failure on
branch-4.1 Cloud-P0).

```groovy
suite('test_temp_table', 'p0') {
    if (true) {
        // temp table feature is no longer mantains. skip this case
        return
    }
    ...
```

Test-only change.

## Cherry-picked from branch-4.0 #64525 (with `-x` provenance)
- `skip temp_table_p0/test_temp_table.groovy`

## Note
Supersedes the temp_table replica-detection deflake that is part of #64597 — once
this lands, that commit in #64597 becomes dead code (unreachable after the early
return) and can be dropped from #64597.

## Release note
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
