### PR TITLE
[fix](regression) Use explicit size call in nested type plugin

### DIFF
--- a/regression-test/plugins/plugins_create_table_nested_type.groovy
+++ b/regression-test/plugins/plugins_create_table_nested_type.groovy
@@ -133,9 +133,9 @@ Suite.metaClass.get_create_table_with_nested_type { int depth, String tb_name ->
     }
 
     backtrack();
-    for (int i = 0; i < res.size; i++) {
+    for (int i = 0; i < res.size(); i++) {
         def date_type_str = ""
-        for (int j = 0; j < res[i].size; j++) {
+        for (int j = 0; j < res[i].size(); j++) {
             date_type_str += res[i][j] + " "
         }
         logger.info(date_type_str)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: regression-test/plugins/plugins_create_table_nested_type.groovy used Groovy list property access such as res.size and res[i].size while iterating generated nested type combinations. For nested lists, Groovy can treat List.property as GPath property access over the elements instead of a deterministic List.size() call. When the property lookup reaches Integer elements, evaluating size fails with MissingPropertyException. This patch uses explicit size() calls so the helper iterates list sizes directly and remains stable when all regression cases run in parallel.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - git diff --check -- regression-test/plugins/plugins_create_table_nested_type.groovy
    - groovy -e snippets reproducing the old MissingPropertyException and validating the new size() iteration
- Behavior changed: No
- Does this need documentation: No