### PR TITLE
[fix](load) respect profile level for writer details

### DIFF
--- a/be/src/exec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.cpp
@@ -687,7 +687,10 @@ Status VTabletWriterV2::close(Status exec_status) {
             std::unordered_map<int64_t, int32_t> segments_for_tablet;
             SCOPED_TIMER(_close_writer_timer);
             // close all delta writers if this is the last user
-            auto st = _delta_writer_for_tablet->close(segments_for_tablet, _operator_profile);
+            RuntimeProfile* delta_writer_profile =
+                    (_state->enable_profile() && _state->profile_level() >= 2) ? _operator_profile
+                                                                               : nullptr;
+            auto st = _delta_writer_for_tablet->close(segments_for_tablet, delta_writer_profile);
             _delta_writer_for_tablet.reset();
             if (!st.ok()) {
                 _cancel(st);


### PR DESCRIPTION
### What problem does this PR solve?

PR #64349 removed the stored RuntimeState from shared DeltaWriterV2 to fix a valid lifetime issue. However, the master change did not move the existing detailed-writer-profile gate to the VTabletWriterV2 call site. As a result, closing tablet writer v2 always passed the operator profile into DeltaWriterV2Map, and DeltaWriterV2/MemTableWriter detailed child profiles were still emitted even when profile_level was 1. Pass the profile only when profile_level is at least 2 so level 1 keeps only merged profile counters as intended.

