### PR TITLE
[fix](fe)add needForward for PARALLEL_EXCHANGE_INSTANCE_NUM and LOAD_STREAM_PER_NODE to take effect in insert select

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1320,7 +1320,7 @@ public class SessionVariable implements Serializable, Writable {
             setter = "setLcTimeNames")
     public String lcTimeNames = "en_US";
 
-    @VarAttrDef.VarAttr(name = PARALLEL_EXCHANGE_INSTANCE_NUM)
+    @VarAttrDef.VarAttr(name = PARALLEL_EXCHANGE_INSTANCE_NUM, needForward = true)
     public int exchangeInstanceParallel = 256;
 
     @VarAttrDef.VarAttr(name = SQL_SAFE_UPDATES)
@@ -2594,7 +2594,7 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = ENABLE_MEMTABLE_ON_SINK_NODE, needForward = true)
     public boolean enableMemtableOnSinkNode = true;
 
-    @VarAttrDef.VarAttr(name = LOAD_STREAM_PER_NODE)
+    @VarAttrDef.VarAttr(name = LOAD_STREAM_PER_NODE, needForward = true)
     public int loadStreamPerNode = 2;
 
     @VarAttrDef.VarAttr(name = GROUP_COMMIT, needForward = true)

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -134,6 +134,33 @@ public class SessionVariablesTest extends TestWithFeService {
     }
 
     @Test
+    public void testParallelExchangeInstanceNumForward() {
+        Map<String, String> forwardVars = sessionVariable.getForwardVariables();
+        Assertions.assertTrue(
+                forwardVars.containsKey(SessionVariable.PARALLEL_EXCHANGE_INSTANCE_NUM),
+                "parallel_exchange_instance_num should be in forward variables after needForward=true");
+
+        Assertions.assertEquals(256, sessionVariable.getExchangeInstanceParallel());
+
+        forwardVars.put(SessionVariable.PARALLEL_EXCHANGE_INSTANCE_NUM, "300");
+        sessionVariable.setForwardedSessionVariables(forwardVars);
+        Assertions.assertEquals(300, sessionVariable.getExchangeInstanceParallel());
+
+        forwardVars.put(SessionVariable.PARALLEL_EXCHANGE_INSTANCE_NUM, "201");
+        sessionVariable.setForwardedSessionVariables(forwardVars);
+        Assertions.assertEquals(201, sessionVariable.getExchangeInstanceParallel());
+    }
+
+    @Test
+    public void testCloneSessionVariablesWithSessionOriginValueNotEmpty() throws NoSuchFieldException {
+        Field txIsolation = SessionVariable.class.getField("txIsolation");
+        SessionVariableField txIsolationSessionVariableField = new SessionVariableField(txIsolation);
+        sessionVariable.addSessionOriginValue(txIsolationSessionVariableField, "test");
+
+        SessionVariable sessionVariableClone = VariableMgr.cloneSessionVariable(sessionVariable);
+    }
+
+    @Test
     public void testInsertVisibleTimeoutReturnModeDefaultsAndCheckerBranches() {
         // Cover the default branch and the helper methods used by setter/checker paths.
         SessionVariable sessionVar = new SessionVariable();


### PR DESCRIPTION
### What problem does this PR solve?
  Problem Summary:

  When executing INSERT SELECT on a non-master FE, the statement is forwarded to the master
  FE via ForwardWithSync. During forwarding, only session variables annotated with
  needForward=true are propagated. Two session variables used during LOAD execution were
  missing this annotation, causing them to always use default values on the master FE:

  1. `parallel_exchange_instance_num` — controls Fragment 0 (OLAP_TABLE_SINK) instance count.
     UnassignedShuffleJob.degreeOfParallelism() reads this from
     statementContext.getConnectContext() during planning on the master FE. Without needForward,
     Fragment 0 always defaults to 256 instances regardless of SET value.

  2. `load_stream_per_node` — controls per-BE load stream concurrency for OLAP_TABLE_SINK.
     ThriftPlansBuilder.setParamsForOlapTableSink() reads this on the master FE during LOAD
     execution. Without needForward, it always defaults to 2.

  The root cause pattern is that these variables are used during FE-side planning/execution
  on the master FE node (after forwarding), not just on the original client FE. The
  ForwardWithSync mechanism only propagates variables marked needForward=true, so the
  master FE never sees the user-configured values.

  ### Release note

  None

  ### Check List (For Author)

  - Test
      - [ ] Regression test
      - [x] Unit Test
      - [ ] Manual test (add detailed scripts or steps below)
      - [ ] No need to test or manual test. Explain why:
          - [ ] This is a refactor/code format and no logic has been changed.
          - [ ] Previous test can cover this change.
          - [ ] No code files have been changed.
          - [ ] Other reason

  - Behavior changed:
      - [x] No.
      - [ ] Yes.

  - Does this need documentation?
      - [x] No.
      - [ ] Yes.

  ### Check List (For Reviewer who merge this PR)

  - [ ] Confirm the release note
  - [ ] Confirm test cases
  - [ ] Confirm document
  - [ ] Add branch pick label