### PR TITLE
[fix](fe) Stabilize optimize available MV unit test

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/OptimizeGetAvailableMvsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/OptimizeGetAvailableMvsTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -57,6 +58,21 @@ import java.util.Set;
  * Test get available mvs after rewrite by rules
  */
 public class OptimizeGetAvailableMvsTest extends SqlTestBase {
+
+    @Override
+    protected void runBeforeEach() throws Exception {
+        dropTestMvs();
+    }
+
+    @AfterEach
+    void dropTestMvsAfterEach() throws Exception {
+        dropTestMvs();
+    }
+
+    private void dropTestMvs() throws Exception {
+        dropMvByNereids("drop materialized view if exists mv1");
+        dropMvByNereids("drop materialized view if exists mv2");
+    }
 
     @Test
     void testWhenNotPartitionPrune() throws Exception {
@@ -165,8 +181,6 @@ public class OptimizeGetAvailableMvsTest extends SqlTestBase {
         Assertions.assertEquals(1, mvCanRewritePartitionsMap.size());
         Assertions.assertTrue(mvCanRewritePartitionsMap.keySet().iterator().next().getTableName()
                 .equalsIgnoreCase("mv1"));
-
-        dropMvByNereids("drop materialized view mv1");
     }
 
     @Test
@@ -233,6 +247,13 @@ public class OptimizeGetAvailableMvsTest extends SqlTestBase {
             }
         };
 
+        new MockUp<MTMV>() {
+            @Mock
+            public boolean canBeCandidate() {
+                return true;
+            }
+        };
+
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         createMvByNereids("create materialized view mv2 "
@@ -278,7 +299,5 @@ public class OptimizeGetAvailableMvsTest extends SqlTestBase {
         Assertions.assertEquals(1, mvCanRewritePartitionsMap.size());
         Assertions.assertTrue(mvCanRewritePartitionsMap.keySet().iterator().next().getTableName()
                 .equalsIgnoreCase("mv2"));
-
-        dropMvByNereids("drop materialized view mv2");
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:
`OptimizeGetAvailableMvsTest` could fail intermittently because `TestWithFeService` reuses the same FE environment across test methods. If a materialized view survived a failed assertion, a later case could see an extra rewrite candidate. The partition-prune case also depended on asynchronous MTMV refresh state before the materialized view became a rewrite candidate, so the candidate map could be empty.

Root cause: In `OptimizeGetAvailableMvsTest`, test methods created materialized views with fixed names and only dropped them at the end of the happy path, so failed assertions could leave state behind for later test methods. The partition-prune case also did not mock `MTMV.canBeCandidate()`, which made the test depend on asynchronous MTMV refresh state.

Change Summary:

| File | Change Description |
|------|--------------------|
| `OptimizeGetAvailableMvsTest.java` | Drop test materialized views before and after each test. |
| `OptimizeGetAvailableMvsTest.java` | Mock `MTMV.canBeCandidate()` in the partition-prune case. |

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
