### PR TITLE
[fix](be) Stabilize conjunct cost ordering

### DIFF
--- a/be/src/exec/operator/operator.cpp
+++ b/be/src/exec/operator/operator.cpp
@@ -17,6 +17,8 @@
 
 #include "exec/operator/operator.h"
 
+#include <algorithm>
+
 #include "common/status.h"
 #include "exec/common/util.hpp"
 #include "exec/exchange/local_exchange_sink_operator.h"
@@ -245,7 +247,7 @@ Status OperatorXBase::prepare(RuntimeState* state) {
         RETURN_IF_ERROR(conjunct->prepare(state, intermediate_row_desc()));
     }
     if (state->enable_adjust_conjunct_order_by_cost()) {
-        std::ranges::sort(_conjuncts, [](const auto& a, const auto& b) {
+        std::ranges::stable_sort(_conjuncts, [](const auto& a, const auto& b) {
             return a->execute_cost() < b->execute_cost();
         });
     };

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -21,6 +21,7 @@
 #include <gen_cpp/Exprs_types.h>
 #include <gen_cpp/Metrics_types.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 
@@ -78,7 +79,7 @@ Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* stat
     RETURN_IF_ERROR(_helper.try_append_late_arrival_runtime_filter(state, _parent->row_descriptor(),
                                                                    arrived_rf_num, _conjuncts));
     if (state->enable_adjust_conjunct_order_by_cost()) {
-        std::ranges::sort(_conjuncts, [](const auto& a, const auto& b) {
+        std::ranges::stable_sort(_conjuncts, [](const auto& a, const auto& b) {
             return a->execute_cost() < b->execute_cost();
         });
     };

--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -208,7 +208,7 @@ Status RowGroupReader::init(
     }
     // _state is nullptr in some ut.
     if (_state && _state->enable_adjust_conjunct_order_by_cost()) {
-        std::ranges::sort(_filter_conjuncts, [](const auto& a, const auto& b) {
+        std::ranges::stable_sort(_filter_conjuncts, [](const auto& a, const auto& b) {
             return a->execute_cost() < b->execute_cost();
         });
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: When `enable_adjust_conjunct_order_by_cost` is enabled, conjuncts are sorted by `execute_cost` with `std::ranges::sort`. Equal-cost conjuncts may have their original relative order changed, which can introduce unnecessary evaluation-order side effects. This patch switches the cost ordering paths to `std::ranges::stable_sort` so lower-cost conjuncts are still prioritized while equal-cost conjuncts keep their original order.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran `clang-format` v16 on changed C++ files
    - Ran `git diff --check`
    - BE build was started but interrupted per request; not used as validation
- Behavior changed: Yes. Equal-cost conjuncts now preserve their original order when `enable_adjust_conjunct_order_by_cost` is enabled.
- Does this need documentation: No
