### PR TITLE
[test](regression) Add malformed percent-encoding test cases for url_decode

### DIFF
--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_url_decode.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_url_decode.groovy
@@ -44,4 +44,30 @@ suite("test_url_decode") {
     order_qt_const_nullable "select url_decode('') from test_url_decode" // choose one case to test const multi-rows
     order_qt_const_not_nullable "select url_decode('%2Fhome%2Fdoris%2Fdirectory%2F')"
     order_qt_const_nullable_no_null "select url_decode('%2Fhome%2Fdoris%2Fdirectory%2F')"
+
+    // malformed percent-encoding: url_decode should raise an error
+    test {
+        sql """ select url_decode('%2') """
+        exception "Decode url failed"
+    }
+    test {
+        sql """ select url_decode('%') """
+        exception "Decode url failed"
+    }
+    test {
+        sql """ select url_decode('hello%') """
+        exception "Decode url failed"
+    }
+    test {
+        sql """ select url_decode('%GG') """
+        exception "Decode url failed"
+    }
+    test {
+        sql """ select url_decode('%20%GG%41') """
+        exception "Decode url failed"
+    }
+    test {
+        sql """ select url_decode('%%20') """
+        exception "Decode url failed"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

The `url_decode` regression test mainly covers valid URL decoding cases, but malformed percent-encoding inputs are not explicitly covered.

Malformed inputs such as truncated percent sequences or invalid hex characters should return an error. Without regression coverage, this behavior may be changed accidentally in future updates.

### What is changed?

This PR adds regression test cases for malformed percent-encoding inputs in `test_url_decode.groovy`, including:

* truncated percent sequence: `'%2'`
* bare percent sign: `'%'`
* trailing percent sign: `'hello%'`
* invalid hex characters: `'%GG'`
* mixed valid and invalid encoding: `'%20%GG%41'`
* consecutive percent signs: `'%%20'`

Each case verifies that `url_decode` raises the expected error:

    Decode url failed

### Behavior change

No behavior is changed.

This PR only adds regression test coverage for the existing error behavior of `url_decode`.

### Impact

Test-only change. It does not affect build behavior, runtime behavior, SQL execution logic, storage behavior, or compatibility.

### Check

* Added malformed input cases to the existing `url_decode` regression test.
* No core code was modified.
* No `.out` file update is required because these are error assertion cases.