### PR TITLE
branch-4.0: [fix](test) deflake test_curd_wlg and adapt test_single_replica_compaction_with_format_v2 to V3 default

### DIFF
--- a/regression-test/suites/inverted_index_p0/index_format_v2/test_single_replica_compaction_with_format_v2.groovy
+++ b/regression-test/suites/inverted_index_p0/index_format_v2/test_single_replica_compaction_with_format_v2.groovy
@@ -183,7 +183,12 @@ suite("test_single_replica_compaction_with_format_v2", "inverted_index_format_v2
             backend_id = tablet.BackendId
             String ip = backendId_to_backendIP.get(backend_id)
             String port = backendId_to_backendHttpPort.get(backend_id)
-            check_nested_index_file(ip, port, tablet_id, 2, 3, "V2")
+            // The default inverted_index_storage_format changed from V2 to V3 (#57252), and the
+            // post-compaction rowset count varies per replica, so derive it dynamically and check
+            // against V3 (mirrors test_cumulative_compaction_with_format_v2 / test_mow_table_with_format_v2).
+            def (tablet_status_code, tablet_status_out, tablet_status_err) = be_show_tablet_status(ip, port, tablet_id)
+            int activeRowsetCount = parseJson(tablet_status_out.trim()).rowsets.size()
+            check_nested_index_file(ip, port, tablet_id, activeRowsetCount, 3, "V3")
         }
 
         int segmentsCount = 0

--- a/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
+++ b/regression-test/suites/workload_manager_p0/test_curd_wlg.groovy
@@ -417,10 +417,15 @@ suite("test_crud_wlg") {
     // test bypass
     sql "create workload group if not exists bypass_group $forComputeGroupStr properties (  'max_concurrency'='0','max_queue_size'='0','queue_timeout'='0');"
     sql "set workload_group=bypass_group;"
+    // Disable the FE SQL cache here: `select count(1) from ${table_name}` is run repeatedly in this
+    // suite, so it can be served from the result cache and skip the Coordinator/query-queue path
+    // entirely, which makes this "queue is full" assertion flaky (the rejection never fires).
+    sql "set enable_sql_cache=false;"
     test {
         sql "select count(1) from ${table_name};"
         exception "query waiting queue is full"
     }
+    sql "set enable_sql_cache=true;"
 
     sql "set bypass_workload_group = true;"
     sql "select count(1) from information_schema.active_queries;"


### PR DESCRIPTION
## Proposed changes

Fix two pre-existing branch-4.0 P0 regression-test failures (surfaced by an internal P0 build). Both are test-side issues, unrelated to product code.

### 1. `test_single_replica_compaction_with_format_v2` — failed 100% on master/4.1/4.0, passes on 3.0

`#57252` changed the FE default `inverted_index_storage_format` from `V2` to `V3`, but this test still created its table without pinning the property and asserted `check_nested_index_file(..., 2, 3, "V2")` with a hardcoded rowset count. Its sibling `*_format_v2` tests (`test_cumulative_compaction_with_format_v2`, `test_mow_table_with_format_v2`) were already migrated to a dynamic rowset count + `"V3"`; this one was missed.

Fix: derive the post-compaction rowset count per tablet via `be_show_tablet_status` and assert `"V3"`, mirroring the sibling tests.

### 2. `test_curd_wlg` — flaky

The `bypass_group` (`max_concurrency=0`) check expects `select count(1) from wlg_test_table` to be rejected with `query waiting queue is full`. That identical query is run repeatedly earlier in the suite, so it can be served from the FE SQL result cache, which returns before a Coordinator is built and never enters the query queue — so the rejection never fires and the assertion sees no exception (`but meet 'null'`).

Fix: disable the SQL cache (`set enable_sql_cache=false`) around this assertion so the query actually executes and hits the queue, then restore it.

## Further comments

Test-only changes. Cannot be verified locally (needs a deployed cluster with >= 2 BEs); please verify via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)