### PR TITLE
[fix](show frontends) show effective HTTP/HTTPS port

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.DiskUtils;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.FeDiskInfo;
@@ -123,7 +124,7 @@ public class FrontendsProcNode implements ProcNodeInterface {
             info.add(fe.getNodeName());
             info.add(fe.getHost());
             info.add(Integer.toString(fe.getEditLogPort()));
-            info.add(Integer.toString(Config.http_port));
+            info.add(Integer.toString(HttpURLUtil.getHttpPort()));
 
             if (fe.getNodeName().equals(env.getNodeName())) {
                 info.add(Integer.toString(Config.query_port));

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.security.SecurityChecker;
+import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.collect.Maps;
@@ -29,6 +30,10 @@ import java.net.URL;
 import java.util.Map;
 
 public class HttpURLUtil {
+
+    public static int getHttpPort() {
+        return Config.enable_https ? Config.https_port : Config.http_port;
+    }
 
     public static HttpURLConnection getConnectionWithNodeIdent(String request) throws IOException {
         try {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`show frontends;` always show only `http_port` even though for cases like when enable_https=true, this PR fix the port visibility to show HTTPS port if `enable_https` enabled.

Also, this serves as preparatory for #60921 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [X] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

