### PR TITLE
[fix](nereids) Fix divide-by-zero guard in divideDecimal constant folding

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
@@ -278,7 +278,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "divide")
     public static Expression divideDecimal(DecimalLiteral first, DecimalLiteral second) {
-        if (first.getValue().compareTo(BigDecimal.ZERO) == 0) {
+        if (second.getValue().compareTo(BigDecimal.ZERO) == 0) {
             return new NullLiteral(first.getDataType());
         }
         BigDecimal result = first.getValue().divide(second.getValue());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -703,6 +703,27 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
     }
 
     @Test
+    void testFoldDivideDecimalV2() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(FoldConstantRuleOnFE.VISITOR_INSTANCE)
+        ));
+        // 0 / 5 over DecimalV2 literals must fold to decimal 0 through the full FoldConstantRuleOnFE
+        // dispatch (which selects NumericArithmetic.divideDecimal), not NULL.
+        Divide divide = new Divide(new DecimalLiteral(new BigDecimal(0)), new DecimalLiteral(new BigDecimal(5)));
+        Expression rewritten = executor.rewrite(divide, context);
+        Assertions.assertFalse(rewritten instanceof NullLiteral, "0 / 5 must not fold to NULL, got " + rewritten);
+        Assertions.assertTrue(rewritten instanceof DecimalLiteral,
+                "0 / 5 should fold to a decimal literal, got " + rewritten);
+        Assertions.assertEquals(0, ((DecimalLiteral) rewritten).getValue().compareTo(BigDecimal.ZERO),
+                "0 / 5 should fold to 0");
+
+        // 5 / 0 over DecimalV2 literals must fold to NULL (Doris/MySQL divide-by-zero semantics).
+        divide = new Divide(new DecimalLiteral(new BigDecimal(5)), new DecimalLiteral(new BigDecimal(0)));
+        rewritten = executor.rewrite(divide, context);
+        Assertions.assertTrue(rewritten instanceof NullLiteral, "5 / 0 should fold to NULL, got " + rewritten);
+    }
+
+    @Test
     void testleFoldNumeric() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
             bottomUp(FoldConstantRuleOnFE.VISITOR_INSTANCE)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmeticTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmeticTest.java
@@ -17,10 +17,12 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.executable;
 
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.types.DecimalV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
 
@@ -45,6 +47,29 @@ public class NumericArithmeticTest {
                 DecimalV2Type.createDecimalV2Type(10, 0), new BigDecimal(1));
         DecimalLiteral result = (DecimalLiteral) NumericArithmetic.abs(decimalV3Literal);
         Assertions.assertEquals(DecimalV2Type.createDecimalV2Type(10, 0), result.getDataType());
+    }
+
+    @Test
+    public void testDivideDecimalZeroNumerator() {
+        // 0 / 5 must fold to decimal 0, not NULL. The zero-guard must check the
+        // denominator (second), not the numerator (first).
+        DecimalLiteral zero = new DecimalLiteral(DecimalV2Type.createDecimalV2Type(10, 0), new BigDecimal(0));
+        DecimalLiteral five = new DecimalLiteral(DecimalV2Type.createDecimalV2Type(10, 0), new BigDecimal(5));
+        Expression result = NumericArithmetic.divideDecimal(zero, five);
+        Assertions.assertTrue(result instanceof DecimalLiteral,
+                "0 / 5 should fold to a decimal, but got " + result);
+        Assertions.assertEquals(0, ((DecimalLiteral) result).getValue().compareTo(BigDecimal.ZERO),
+                "0 / 5 should fold to 0");
+    }
+
+    @Test
+    public void testDivideDecimalZeroDenominator() {
+        // 5 / 0 must fold to NULL (SQL divide-by-zero semantics), not throw.
+        DecimalLiteral five = new DecimalLiteral(DecimalV2Type.createDecimalV2Type(10, 0), new BigDecimal(5));
+        DecimalLiteral zero = new DecimalLiteral(DecimalV2Type.createDecimalV2Type(10, 0), new BigDecimal(0));
+        Expression result = NumericArithmetic.divideDecimal(five, zero);
+        Assertions.assertTrue(result instanceof NullLiteral,
+                "5 / 0 should fold to NULL, but got " + result);
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64681

Problem Summary:

`NumericArithmetic.divideDecimal` (the DECIMALV2 constant-folding `divide` function) guarded against division by zero by checking the **numerator** (`first`) instead of the **denominator** (`second`):

```java
public static Expression divideDecimal(DecimalLiteral first, DecimalLiteral second) {
    if (first.getValue().compareTo(BigDecimal.ZERO) == 0) {   // wrong operand
        return new NullLiteral(first.getDataType());
    }
    BigDecimal result = first.getValue().divide(second.getValue());
    return new DecimalLiteral(result);
}
```

As a result, when both operands are DECIMALV2 literals:

- `0 / x` folded to **NULL** instead of `0` — a silent wrong result.
- `x / 0` skipped the guard and called `BigDecimal.divide(ZERO)`, throwing `ArithmeticException`. This is caught by `ExpressionEvaluator.invoke` and the expression is left unfolded (BE then evaluates it and returns NULL), so it is not a crash, but the FE folding path is incorrect.

The sibling functions `divideDouble` and `divideDecimalV3` both correctly check `second`. This PR aligns `divideDecimal` with them by checking the denominator. Division by zero continues to return NULL, matching Doris/MySQL semantics (Doris is MySQL-compatible here; it does not raise the ANSI `division by zero` error).

### Release note

Fix incorrect constant folding of DECIMALV2 division: `0 / x` was folded to NULL instead of 0.

### Check List (For Author)

- Test
    - [x] Unit Test (added `testDivideDecimalZeroNumerator` and `testDivideDecimalZeroDenominator` in `NumericArithmeticTest`)

- Behavior changed:
    - [x] Yes. `0 / x` over constant DECIMALV2 values now correctly folds to `0` instead of `NULL`. Division by zero still returns NULL (unchanged).

- Does this need documentation?
    - [x] No.
