### PR TITLE
[fix](catalog) Release acquired commit locks when commitLockTables fails

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/MetaLockUtils.java
@@ -132,8 +132,9 @@ public class MetaLockUtils {
                 tableList.get(i).commitLock();
             } catch (Exception e) {
                 for (int j = i - 1; j >= 0; j--) {
-                    tableList.get(i).commitUnlock();
+                    tableList.get(j).commitUnlock();
                 }
+                throw e;
             }
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/MetaLockUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/MetaLockUtilsTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common.util;
 
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableTest;
 import org.apache.doris.common.MetaNotFoundException;
@@ -101,6 +102,33 @@ public class MetaLockUtilsTest {
             Assert.assertFalse(tableList.get(0).isWriteLockHeldByCurrentThread());
             Assert.assertFalse(tableList.get(1).isWriteLockHeldByCurrentThread());
         }
+    }
+
+    @Test
+    public void testCommitLockTablesReleasesLocksOnFailure() {
+        Table good = TableTest.newOlapTable(0, "commitGood", 0);
+        // A table whose commitLock() always fails, to exercise the rollback path.
+        Table bad = new OlapTable() {
+            @Override
+            public void commitLock() {
+                throw new RuntimeException("inject commit lock failure");
+            }
+        };
+        List<Table> tables = ImmutableList.of(good, bad);
+
+        boolean threw = false;
+        try {
+            MetaLockUtils.commitLockTables(tables);
+        } catch (RuntimeException e) {
+            threw = true;
+        }
+
+        // The failure must propagate (not be silently swallowed)...
+        Assert.assertTrue("commitLockTables must propagate the lock failure", threw);
+        // ...and the already-acquired commit lock must be rolled back, with the failing table never held.
+        Assert.assertNull("previously-locked table's commit lock must be released after rollback",
+                good.getCommitLockOwner());
+        Assert.assertNull("failing table's commit lock must not be held", bad.getCommitLockOwner());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64682

Problem Summary:

`MetaLockUtils.commitLockTables` has a rollback bug: when `commitLock()` throws for the table at index `i`, the rollback loop iterates `j` from `i-1` down to `0` but unlocks `tableList.get(i)` (the table that failed to lock) instead of `tableList.get(j)` (the previously locked tables):

```java
public static void commitLockTables(List<Table> tableList) {
    for (int i = 0; i < tableList.size(); i++) {
        try {
            tableList.get(i).commitLock();
        } catch (Exception e) {
            for (int j = i - 1; j >= 0; j--) {
                tableList.get(i).commitUnlock();   // should be get(j)
            }
        }
    }
}
```

Consequences on the failure path:

- The commit locks already acquired for tables `0..i-1` are never released (leak).
- The failing table (`i`) is `commitUnlock()`-ed repeatedly on a lock it does not hold.
- The exception is swallowed and the outer loop keeps trying to lock the remaining tables.

This PR unlocks `get(j)` and rethrows after rollback, matching the existing correct siblings `tryCommitLockTables` and `writeLockTablesOrMetaException`.

Note: in normal operation `commitLock()` → `MonitoredReentrantLock.lock()` does not throw, so this `catch` is defensive and the bug is latent. The fix makes the rare failure path correct: release the locks already acquired and fail loudly, instead of leaking locks and silently proceeding.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test (added `testCommitLockTablesReleasesLocksOnFailure` in `MetaLockUtilsTest`)

- Behavior changed:
    - [x] Yes. On a commit-lock acquisition failure, previously acquired commit locks are now released and the failure is propagated instead of swallowed.

- Does this need documentation?
    - [x] No.
