### PR TITLE
[fix](iceberg) Support nested decimal promotion schema change

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -193,8 +193,9 @@ public abstract class ColumnType {
     // This method checks if a primitive type change is allowed in nested complex types.
     // Supports:
     // 1. VARCHAR length increase
-    // 2. Safe numeric type promotions (INT -> BIGINT, FLOAT -> DOUBLE, etc.)
-    // 3. Exact type match
+    // 2. Decimal precision increase with unchanged scale
+    // 3. Safe numeric type promotions (INT -> BIGINT, FLOAT -> DOUBLE, etc.)
+    // 4. Exact type match
     private static boolean checkSupportSchemaChangeForNestedPrimitive(Type checkType, Type other) throws DdlException {
         // 1. Check VARCHAR length increase
         if (checkType.getPrimitiveType() == PrimitiveType.VARCHAR
@@ -208,7 +209,12 @@ public abstract class ColumnType {
             return true;
         }
 
-        // 3. Check safe numeric type promotions for nested types
+        // 3. Check decimal precision promotion with unchanged scale for nested types
+        if (isSupportedNestedDecimalPromotion(checkType, other)) {
+            return true;
+        }
+
+        // 4. Check safe numeric type promotions for nested types
         // These are safe promotions that don't lose precision:
         // - INT -> BIGINT, LARGEINT
         // - FLOAT -> DOUBLE
@@ -246,6 +252,20 @@ public abstract class ColumnType {
         }
 
         return false;
+    }
+
+    private static boolean isSupportedNestedDecimalPromotion(Type src, Type dst) {
+        if (!(src instanceof ScalarType) || !(dst instanceof ScalarType)) {
+            return false;
+        }
+        if (!(src.isDecimalV2() || src.isDecimalV3()) || !(dst.isDecimalV2() || dst.isDecimalV3())) {
+            return false;
+        }
+
+        ScalarType srcDecimal = (ScalarType) src;
+        ScalarType dstDecimal = (ScalarType) dst;
+        return srcDecimal.getScalarScale() == dstDecimal.getScalarScale()
+                && srcDecimal.getScalarPrecision() <= dstDecimal.getScalarPrecision();
     }
 
     private static void validateStructFieldCompatibility(StructField originalField, StructField newField)

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnTest.java
@@ -157,6 +157,53 @@ public class ColumnTest {
         oldColumn.checkSchemaChangeAllowed(newColumn);
     }
 
+    @Test
+    public void testSchemaChangeArrayDecimalPrecisionPromotion() throws DdlException {
+        Column oldColumn = new Column("a", ArrayType.create(ScalarType.createDecimalV3Type(5, 2), true),
+                false, null, true, "0", "");
+        Column newColumn = new Column("a", ArrayType.create(ScalarType.createDecimalV3Type(10, 2), true),
+                false, null, true, "0", "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+    }
+
+    @Test
+    public void testSchemaChangeMapDecimalValuePrecisionPromotion() throws DdlException {
+        Column oldColumn = new Column("a", new MapType(Type.INT, ScalarType.createDecimalV3Type(5, 2)),
+                false, null, true, "0", "");
+        Column newColumn = new Column("a", new MapType(Type.INT, ScalarType.createDecimalV3Type(10, 2)),
+                false, null, true, "0", "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+    }
+
+    @Test
+    public void testSchemaChangeStructDecimalFieldPrecisionPromotion() throws DdlException {
+        Column oldColumn = new Column("a", new StructType(new StructField("d", ScalarType.createDecimalV3Type(5, 2))),
+                false, null, true, "0", "");
+        Column newColumn = new Column("a", new StructType(new StructField("d", ScalarType.createDecimalV3Type(10, 2))),
+                false, null, true, "0", "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testSchemaChangeArrayDecimalPrecisionNarrowing() throws DdlException {
+        Column oldColumn = new Column("a", ArrayType.create(ScalarType.createDecimalV3Type(10, 2), true),
+                false, null, true, "0", "");
+        Column newColumn = new Column("a", ArrayType.create(ScalarType.createDecimalV3Type(5, 2), true),
+                false, null, true, "0", "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = DdlException.class)
+    public void testSchemaChangeArrayDecimalScaleChange() throws DdlException {
+        Column oldColumn = new Column("a", ArrayType.create(ScalarType.createDecimalV3Type(5, 2), true),
+                false, null, true, "0", "");
+        Column newColumn = new Column("a", ArrayType.create(ScalarType.createDecimalV3Type(10, 3), true),
+                false, null, true, "0", "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+        Assert.fail("No exception throws.");
+    }
+
     @Test(expected = DdlException.class)
     public void testSchemaChangeArrayToArrayDowngrade() throws DdlException {
         Column oldColumn = new Column("a", ArrayType.create(Type.INT, true), false, null, true, "0", "");

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_on_hdfs.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_on_hdfs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_rest_on_hdfs", "external,iceberg,external_docker,external_docker_iceberg_rest,new_catalog_property") {
+suite("iceberg_rest_on_hdfs", "p2,external") {
 
     def testQueryAndInsert = { String catalogProperties, String prefix ->
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #60993

Problem Summary:
- Nested complex type schema change validation currently supports varchar length growth and safe numeric promotions, but rejects decimal precision promotion.
- This PR allows nested decimal precision widening when scale is unchanged, for example `array<decimal(5,2)>` to `array<decimal(10,2)>`.
- The same validation path covers array item types, map key/value types, and struct fields.

### Release note

Support nested decimal precision promotion in Iceberg schema change validation.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Nested decimal precision widening with unchanged scale is now allowed in complex type schema change validation.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

### Test

```bash
MAVEN_OPTS='-Xmx2g -XX:ActiveProcessorCount=2' mvn -pl fe-core -am -DfailIfNoTests=false -Dtest=ColumnTest test
```

Result: `Tests run: 14, Failures: 0, Errors: 0`, `BUILD SUCCESS`.