### PR TITLE
[refine](column) add opt-in column and Arrow sanity checks

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1456,6 +1456,8 @@ DEFINE_Bool(enable_snapshot_action, "false");
 DEFINE_mInt32(variant_max_merged_tablet_schema_size, "2048");
 
 DEFINE_mBool(enable_column_type_check, "true");
+DEFINE_mBool(enable_column_sanity_check, "false");
+DEFINE_mBool(enable_arrow_validate_full, "false");
 // 128 MB
 DEFINE_mInt64(local_exchange_buffer_mem_limit, "134217728");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1553,6 +1553,8 @@ DECLARE_mInt32(variant_max_merged_tablet_schema_size);
 DECLARE_mInt64(local_exchange_buffer_mem_limit);
 
 DECLARE_mBool(enable_column_type_check);
+DECLARE_mBool(enable_column_sanity_check);
+DECLARE_mBool(enable_arrow_validate_full);
 
 // Tolerance for the number of partition id 0 in rowset, default 0
 DECLARE_Int32(ignore_invalid_partition_id_rowset_num);

--- a/be/src/core/column/column_string.cpp
+++ b/be/src/core/column/column_string.cpp
@@ -45,7 +45,11 @@ static constexpr auto CONVERT_COLUMN_IF_OVERFLOW_DEBUG_POINT =
 
 template <typename T>
 void ColumnStr<T>::sanity_check() const {
-#ifndef NDEBUG
+#ifdef NDEBUG
+    if (!config::enable_column_sanity_check) {
+        return;
+    }
+#endif
     sanity_check_simple();
     auto count = cast_set<int64_t>(offsets.size());
     for (int64_t i = 0; i < count; ++i) {
@@ -54,7 +58,6 @@ void ColumnStr<T>::sanity_check() const {
                                                   count, i, offsets[i], i - 1, offsets[i - 1]));
         }
     }
-#endif
 }
 
 template <typename T>

--- a/be/src/core/column/column_string.h
+++ b/be/src/core/column/column_string.h
@@ -31,6 +31,7 @@
 
 #include "common/cast_set.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "common/config.h"
 #include "common/exception.h"
 #include "common/status.h"
 #include "core/assert_cast.h"
@@ -118,7 +119,11 @@ public:
 
     void sanity_check() const override;
     void sanity_check_simple() const {
-#ifndef NDEBUG
+#ifdef NDEBUG
+        if (!config::enable_column_sanity_check) {
+            return;
+        }
+#endif
         auto count = cast_set<int64_t>(offsets.size());
         if (chars.size() != offsets[count - 1]) {
             throw Exception(Status::InternalError("row count: {}, chars.size(): {}, offset[{}]: {}",
@@ -128,7 +133,6 @@ public:
         if (offsets[-1] != 0) {
             throw Exception(Status::InternalError("wrong offsets[-1]: {}", offsets[-1]));
         }
-#endif
     }
 
     std::string get_name() const override { return "String"; }

--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -317,9 +317,10 @@ Status DataTypeArraySerDe::write_column_to_arrow(const IColumn& column, const Nu
     return Status::OK();
 }
 
-Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                  int64_t start, int64_t end,
-                                                  const cctz::time_zone& ctz) const {
+Status DataTypeArraySerDe::read_column_from_arrow_impl(IColumn& column,
+                                                       const arrow::Array* arrow_array,
+                                                       int64_t start, int64_t end,
+                                                       const cctz::time_zone& ctz) const {
     auto& column_array = static_cast<ColumnArray&>(column);
     auto& offsets_data = column_array.get_offsets();
     const auto* concrete_array = dynamic_cast<const arrow::ListArray*>(arrow_array);
@@ -339,7 +340,7 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
         // convert to doris offset, start from offsets.back()
         offsets_data.emplace_back(prev_size + current_offset - arrow_nested_start_offset);
     }
-    return nested_serde->read_column_from_arrow(
+    return nested_serde->read_column_from_arrow_impl(
             column_array.get_data(), concrete_array->values().get(), arrow_nested_start_offset,
             arrow_nested_end_offset, ctz);
 }

--- a/be/src/core/data_type_serde/data_type_array_serde.h
+++ b/be/src/core/data_type_serde/data_type_array_serde.h
@@ -92,8 +92,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_bitmap_serde.h
+++ b/be/src/core/data_type_serde/data_type_bitmap_serde.h
@@ -65,8 +65,9 @@ public:
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
 
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "read_column_from_arrow with type " + column.get_name());
     }

--- a/be/src/core/data_type_serde/data_type_date_or_datetime_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_date_or_datetime_serde.cpp
@@ -137,10 +137,10 @@ Status DataTypeDateTimeSerDe::deserialize_one_cell_from_json(IColumn& column, Sl
     return Status::OK();
 }
 
-Status DataTypeDateTimeSerDe::read_column_from_arrow(IColumn& column,
-                                                     const arrow::Array* arrow_array, int64_t start,
-                                                     int64_t end,
-                                                     const cctz::time_zone& ctz) const {
+Status DataTypeDateTimeSerDe::read_column_from_arrow_impl(IColumn& column,
+                                                          const arrow::Array* arrow_array,
+                                                          int64_t start, int64_t end,
+                                                          const cctz::time_zone& ctz) const {
     return _read_column_from_arrow<false>(column, arrow_array, start, end, ctz);
 }
 
@@ -250,9 +250,10 @@ Status DataTypeDateSerDe<T>::_read_column_from_arrow(IColumn& column,
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::read_column_from_arrow(IColumn& column,
-                                                    const arrow::Array* arrow_array, int64_t start,
-                                                    int64_t end, const cctz::time_zone& ctz) const {
+Status DataTypeDateSerDe<T>::read_column_from_arrow_impl(IColumn& column,
+                                                         const arrow::Array* arrow_array,
+                                                         int64_t start, int64_t end,
+                                                         const cctz::time_zone& ctz) const {
     return _read_column_from_arrow<true>(column, arrow_array, start, end, ctz);
 }
 

--- a/be/src/core/data_type_serde/data_type_date_or_datetime_serde.h
+++ b/be/src/core/data_type_serde/data_type_date_or_datetime_serde.h
@@ -102,8 +102,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,
                                         const FormatOptions& options) const override;
@@ -142,7 +143,8 @@ public:
     Status deserialize_column_from_json_vector(IColumn& column, std::vector<Slice>& slices,
                                                uint64_t* num_deserialized,
                                                const FormatOptions& options) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 };
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
@@ -393,10 +393,10 @@ Status DataTypeDateTimeV2SerDe::write_column_to_arrow(const IColumn& column,
     return Status::OK();
 }
 
-Status DataTypeDateTimeV2SerDe::read_column_from_arrow(IColumn& column,
-                                                       const arrow::Array* arrow_array,
-                                                       int64_t start, int64_t end,
-                                                       const cctz::time_zone& ctz) const {
+Status DataTypeDateTimeV2SerDe::read_column_from_arrow_impl(IColumn& column,
+                                                            const arrow::Array* arrow_array,
+                                                            int64_t start, int64_t end,
+                                                            const cctz::time_zone& ctz) const {
     auto& col_data = static_cast<ColumnDateTimeV2&>(column).get_data();
     int64_t divisor = 1;
     if (arrow_array->type()->id() == arrow::Type::TIMESTAMP) {

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.h
@@ -86,8 +86,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_datev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.cpp
@@ -107,9 +107,10 @@ Status DataTypeDateV2SerDe::write_column_to_arrow(const IColumn& column, const N
     return Status::OK();
 }
 
-Status DataTypeDateV2SerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                   int64_t start, int64_t end,
-                                                   const cctz::time_zone& ctz) const {
+Status DataTypeDateV2SerDe::read_column_from_arrow_impl(IColumn& column,
+                                                        const arrow::Array* arrow_array,
+                                                        int64_t start, int64_t end,
+                                                        const cctz::time_zone& ctz) const {
     auto& col_data = static_cast<ColumnDateV2&>(column).get_data();
     const auto* concrete_array = dynamic_cast<const arrow::Date32Array*>(arrow_array);
     const auto* base_ptr = reinterpret_cast<const uint8_t*>(concrete_array->raw_values());

--- a/be/src/core/data_type_serde/data_type_datev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.h
@@ -84,8 +84,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,
                                         const FormatOptions& options) const override;

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -327,10 +327,10 @@ Status DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column,
 }
 
 template <PrimitiveType T>
-Status DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
-                                                       const arrow::Array* arrow_array,
-                                                       int64_t start, int64_t end,
-                                                       const cctz::time_zone& ctz) const {
+Status DataTypeDecimalSerDe<T>::read_column_from_arrow_impl(IColumn& column,
+                                                            const arrow::Array* arrow_array,
+                                                            int64_t start, int64_t end,
+                                                            const cctz::time_zone& ctz) const {
     auto& column_data = static_cast<ColumnDecimal<T>&>(column).get_data();
     // Decimal<Int128> for decimalv2
     // Decimal<Int128I> for deicmalv3

--- a/be/src/core/data_type_serde/data_type_decimal_serde.h
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.h
@@ -105,8 +105,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,
                                         const FormatOptions& options) const override;

--- a/be/src/core/data_type_serde/data_type_hll_serde.h
+++ b/be/src/core/data_type_serde/data_type_hll_serde.h
@@ -59,8 +59,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "read_column_from_arrow with type " + column.get_name());
     }

--- a/be/src/core/data_type_serde/data_type_ipv4_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_ipv4_serde.cpp
@@ -110,9 +110,10 @@ Status DataTypeIPv4SerDe::write_column_to_arrow(const IColumn& column, const Nul
     return Status::OK();
 }
 
-Status DataTypeIPv4SerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                 int64_t start, int64_t end,
-                                                 const cctz::time_zone& ctz) const {
+Status DataTypeIPv4SerDe::read_column_from_arrow_impl(IColumn& column,
+                                                      const arrow::Array* arrow_array,
+                                                      int64_t start, int64_t end,
+                                                      const cctz::time_zone& ctz) const {
     auto& col_data = assert_cast<ColumnIPv4&>(column).get_data();
     int64_t row_count = end - start;
     /// buffers[0] is a null bitmap and buffers[1] are actual values

--- a/be/src/core/data_type_serde/data_type_ipv4_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv4_serde.h
@@ -53,8 +53,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status from_string_batch(const ColumnString& str, ColumnNullable& column,
                              const FormatOptions& options) const override;

--- a/be/src/core/data_type_serde/data_type_ipv6_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_ipv6_serde.cpp
@@ -140,9 +140,10 @@ Status DataTypeIPv6SerDe::write_column_to_arrow(const IColumn& column, const Nul
     return Status::OK();
 }
 
-Status DataTypeIPv6SerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                 int64_t start, int64_t end,
-                                                 const cctz::time_zone& ctz) const {
+Status DataTypeIPv6SerDe::read_column_from_arrow_impl(IColumn& column,
+                                                      const arrow::Array* arrow_array,
+                                                      int64_t start, int64_t end,
+                                                      const cctz::time_zone& ctz) const {
     auto& col_data = assert_cast<ColumnIPv6&>(column).get_data();
     const auto* concrete_array = assert_cast<const arrow::StringArray*>(arrow_array);
     std::shared_ptr<arrow::Buffer> buffer = concrete_array->value_data();

--- a/be/src/core/data_type_serde/data_type_ipv6_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv6_serde.h
@@ -59,8 +59,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
     void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
     void write_one_cell_to_jsonb(const IColumn& column, JsonbWriterT<JsonbOutStream>& result,
                                  Arena& mem_pool, int unique_id, int64_t row_num,

--- a/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
@@ -114,9 +114,10 @@ Status DataTypeJsonbSerDe::write_column_to_arrow(const IColumn& column, const Nu
     return Status::OK();
 }
 
-Status DataTypeJsonbSerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                  int64_t start, int64_t end,
-                                                  const cctz::time_zone& ctz) const {
+Status DataTypeJsonbSerDe::read_column_from_arrow_impl(IColumn& column,
+                                                       const arrow::Array* arrow_array,
+                                                       int64_t start, int64_t end,
+                                                       const cctz::time_zone& ctz) const {
     if (arrow_array->type_id() == arrow::Type::STRING ||
         arrow_array->type_id() == arrow::Type::BINARY) {
         const auto* concrete_array = dynamic_cast<const arrow::BinaryArray*>(arrow_array);

--- a/be/src/core/data_type_serde/data_type_jsonb_serde.h
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.h
@@ -46,8 +46,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status serialize_one_cell_to_json(const IColumn& column, int64_t row_num, BufferWritable& bw,
                                       FormatOptions& options) const override;

--- a/be/src/core/data_type_serde/data_type_map_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_map_serde.cpp
@@ -383,9 +383,10 @@ Status DataTypeMapSerDe::write_column_to_arrow(const IColumn& column, const Null
     return Status::OK();
 }
 
-Status DataTypeMapSerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                int64_t start, int64_t end,
-                                                const cctz::time_zone& ctz) const {
+Status DataTypeMapSerDe::read_column_from_arrow_impl(IColumn& column,
+                                                     const arrow::Array* arrow_array, int64_t start,
+                                                     int64_t end,
+                                                     const cctz::time_zone& ctz) const {
     auto& column_map = static_cast<ColumnMap&>(column);
     auto& offsets_data = column_map.get_offsets();
     const auto* concrete_map = dynamic_cast<const arrow::MapArray*>(arrow_array);
@@ -405,10 +406,10 @@ Status DataTypeMapSerDe::read_column_from_arrow(IColumn& column, const arrow::Ar
         // convert to doris offset, start from offsets.back()
         offsets_data.emplace_back(prev_size + current_offset - arrow_nested_start_offset);
     }
-    RETURN_IF_ERROR(key_serde->read_column_from_arrow(
+    RETURN_IF_ERROR(key_serde->read_column_from_arrow_impl(
             column_map.get_keys(), concrete_map->keys().get(), arrow_nested_start_offset,
             arrow_nested_end_offset, ctz));
-    RETURN_IF_ERROR(value_serde->read_column_from_arrow(
+    RETURN_IF_ERROR(value_serde->read_column_from_arrow_impl(
             column_map.get_values(), concrete_map->items().get(), arrow_nested_start_offset,
             arrow_nested_end_offset, ctz));
     return Status::OK();

--- a/be/src/core/data_type_serde/data_type_map_serde.h
+++ b/be/src/core/data_type_serde/data_type_map_serde.h
@@ -82,8 +82,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_nothing_serde.h
+++ b/be/src/core/data_type_serde/data_type_nothing_serde.h
@@ -85,8 +85,9 @@ public:
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "write_column_to_arrow with type " + column.get_name());
     }
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "read_column_from_arrow with type " + column.get_name());
     }

--- a/be/src/core/data_type_serde/data_type_nullable_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_nullable_serde.cpp
@@ -336,18 +336,18 @@ Status DataTypeNullableSerDe::write_column_to_arrow(const IColumn& column, const
                                                start, end, ctz);
 }
 
-Status DataTypeNullableSerDe::read_column_from_arrow(IColumn& column,
-                                                     const arrow::Array* arrow_array, int64_t start,
-                                                     int64_t end,
-                                                     const cctz::time_zone& ctz) const {
+Status DataTypeNullableSerDe::read_column_from_arrow_impl(IColumn& column,
+                                                          const arrow::Array* arrow_array,
+                                                          int64_t start, int64_t end,
+                                                          const cctz::time_zone& ctz) const {
     auto& col = reinterpret_cast<ColumnNullable&>(column);
     NullMap& map_data = col.get_null_map_data();
     for (auto i = start; i < end; ++i) {
         auto is_null = arrow_array->IsNull(i);
         map_data.emplace_back(is_null);
     }
-    return nested_serde->read_column_from_arrow(col.get_nested_column(), arrow_array, start, end,
-                                                ctz);
+    return nested_serde->read_column_from_arrow_impl(col.get_nested_column(), arrow_array, start,
+                                                     end, ctz);
 }
 
 bool DataTypeNullableSerDe::write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,

--- a/be/src/core/data_type_serde/data_type_nullable_serde.h
+++ b/be/src/core/data_type_serde/data_type_nullable_serde.h
@@ -84,8 +84,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,
                                         const FormatOptions& options) const override;

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -230,10 +230,10 @@ Status DataTypeNumberSerDe<T>::deserialize_column_from_json_vector(
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::read_column_from_arrow(IColumn& column,
-                                                      const arrow::Array* arrow_array,
-                                                      int64_t start, int64_t end,
-                                                      const cctz::time_zone& ctz) const {
+Status DataTypeNumberSerDe<T>::read_column_from_arrow_impl(IColumn& column,
+                                                           const arrow::Array* arrow_array,
+                                                           int64_t start, int64_t end,
+                                                           const cctz::time_zone& ctz) const {
     auto row_count = end - start;
     auto& col_data = static_cast<ColumnType&>(column).get_data();
 

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -114,8 +114,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_quantilestate_serde.h
+++ b/be/src/core/data_type_serde/data_type_quantilestate_serde.h
@@ -120,8 +120,9 @@ public:
         }
         return Status::OK();
     }
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "read_column_from_arrow with type " + column.get_name());
     }

--- a/be/src/core/data_type_serde/data_type_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_serde.cpp
@@ -16,7 +16,10 @@
 // under the License.
 #include "core/data_type_serde/data_type_serde.h"
 
+#include <arrow/array.h>
+
 #include "common/cast_set.h"
+#include "common/config.h"
 #include "common/exception.h"
 #include "common/status.h"
 #include "core/column/column.h"
@@ -33,6 +36,20 @@
 #include "util/jsonb_writer.h"
 namespace doris {
 DataTypeSerDe::~DataTypeSerDe() = default;
+
+Status DataTypeSerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
+                                             int64_t start, int64_t end,
+                                             const cctz::time_zone& ctz) const {
+    if (config::enable_arrow_validate_full) {
+        auto status = arrow_array->ValidateFull();
+        if (!status.ok()) {
+            return Status::InternalError(
+                    "arrow validate full failed with arrow: {} with column : {} with error msg: {}",
+                    arrow_array->type()->name(), column.get_name(), status.ToString());
+        }
+    }
+    return read_column_from_arrow_impl(column, arrow_array, start, end, ctz);
+}
 
 DataTypeSerDeSPtrs create_data_type_serdes(const DataTypes& types) {
     DataTypeSerDeSPtrs serdes;

--- a/be/src/core/data_type_serde/data_type_serde.h
+++ b/be/src/core/data_type_serde/data_type_serde.h
@@ -481,9 +481,12 @@ public:
     virtual Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                          arrow::ArrayBuilder* array_builder, int64_t start,
                                          int64_t end, const cctz::time_zone& ctz) const = 0;
-    virtual Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                          int64_t start, int64_t end,
-                                          const cctz::time_zone& ctz) const = 0;
+    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
+                                  int64_t end, const cctz::time_zone& ctz) const;
+
+    virtual Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                               int64_t start, int64_t end,
+                                               const cctz::time_zone& ctz) const = 0;
 
     // ORC serializer
     virtual Status write_column_to_orc(const std::string& timezone, const IColumn& column,

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -254,7 +254,7 @@ Status DataTypeStringSerDeBase<ColumnType>::write_column_to_arrow(
 }
 
 template <typename ColumnType>
-Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
+Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow_impl(
         IColumn& column, const arrow::Array* arrow_array, int64_t start, int64_t end,
         const cctz::time_zone& ctz) const {
     if (arrow_array->type_id() == arrow::Type::STRING ||

--- a/be/src/core/data_type_serde/data_type_string_serde.h
+++ b/be/src/core/data_type_serde/data_type_string_serde.h
@@ -200,8 +200,9 @@ public:
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
 
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& result,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_struct_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_struct_serde.cpp
@@ -416,14 +416,15 @@ Status DataTypeStructSerDe::write_column_to_arrow(const IColumn& column, const N
     return Status::OK();
 }
 
-Status DataTypeStructSerDe::read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
-                                                   int64_t start, int64_t end,
-                                                   const cctz::time_zone& ctz) const {
+Status DataTypeStructSerDe::read_column_from_arrow_impl(IColumn& column,
+                                                        const arrow::Array* arrow_array,
+                                                        int64_t start, int64_t end,
+                                                        const cctz::time_zone& ctz) const {
     auto& struct_column = static_cast<ColumnStruct&>(column);
     const auto* concrete_struct = dynamic_cast<const arrow::StructArray*>(arrow_array);
     DCHECK_EQ(struct_column.tuple_size(), concrete_struct->num_fields());
     for (auto i = 0; i < struct_column.tuple_size(); ++i) {
-        RETURN_IF_ERROR(elem_serdes_ptrs[i]->read_column_from_arrow(
+        RETURN_IF_ERROR(elem_serdes_ptrs[i]->read_column_from_arrow_impl(
                 struct_column.get_column(i), concrete_struct->field(i).get(), start, end, ctz));
     }
     return Status::OK();

--- a/be/src/core/data_type_serde/data_type_struct_serde.h
+++ b/be/src/core/data_type_serde/data_type_struct_serde.h
@@ -83,8 +83,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override;
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_varbinary_serde.h
+++ b/be/src/core/data_type_serde/data_type_varbinary_serde.h
@@ -75,8 +75,9 @@ public:
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
 
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "read_column_from_arrow with type " + column.get_name());
     }

--- a/be/src/core/data_type_serde/data_type_variant_serde.h
+++ b/be/src/core/data_type_serde/data_type_variant_serde.h
@@ -65,8 +65,9 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
+    Status read_column_from_arrow_impl(IColumn& column, const arrow::Array* arrow_array,
+                                       int64_t start, int64_t end,
+                                       const cctz::time_zone& ctz) const override {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
                              "read_column_from_arrow with type " + column.get_name());
     }

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -1015,6 +1015,9 @@ Status VExpr::execute_column(VExprContext* context, const Block* block, const Se
             }
         }
     }
+    if (config::enable_column_sanity_check) {
+        result_column->sanity_check();
+    }
     return Status::OK();
 }
 

--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -111,9 +111,6 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
         }
     }
     *out = arrow::RecordBatch::Make(_schema, actual_rows, std::move(_arrays));
-    if (config::enable_arrow_validate_full) {
-        RETURN_IF_ERROR(to_doris_status((*out)->ValidateFull()));
-    }
     return Status::OK();
 }
 

--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -36,12 +36,14 @@
 #include <utility>
 #include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_nullable.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "core/value/vdatetime_value.h"
 #include "format/arrow/arrow_row_batch.h"
 #include "format/arrow/arrow_utils.h"
@@ -102,8 +104,16 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
         if (!arrow_st.ok()) {
             return to_doris_status(arrow_st);
         }
+        if (config::enable_arrow_validate_full) {
+            RETURN_IF_ERROR(checkArrowStatus(_arrays[_cur_field_idx]->ValidateFull(),
+                                             _block.get_by_position(idx).name,
+                                             _arrays[_cur_field_idx]->type()->name()));
+        }
     }
     *out = arrow::RecordBatch::Make(_schema, actual_rows, std::move(_arrays));
+    if (config::enable_arrow_validate_full) {
+        RETURN_IF_ERROR(to_doris_status((*out)->ValidateFull()));
+    }
     return Status::OK();
 }
 

--- a/be/test/core/column/column_string_test.cpp
+++ b/be/test/core/column/column_string_test.cpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "common/config.h"
 #include "core/block/block.h"
 #include "core/column/column_vector.h"
 #include "core/column/common_column_test.h"
@@ -191,15 +192,19 @@ TEST_F(ColumnStringTest, is_variable_length) {
     EXPECT_TRUE(col64->is_variable_length());
 }
 TEST_F(ColumnStringTest, sanity_check) {
+    auto old_enable_column_sanity_check = config::enable_column_sanity_check;
+    config::enable_column_sanity_check = true;
+    Defer defer {[&] { config::enable_column_sanity_check = old_enable_column_sanity_check; }};
+
     auto test_func = [](auto& col) {
         auto& chars = col->get_chars();
         auto& offsets = col->get_offsets();
 
-        col->sanity_check();
+        EXPECT_NO_THROW(col->sanity_check());
 
         std::string data = "123";
         col->insert_data(data.data(), data.size());
-        col->sanity_check();
+        EXPECT_NO_THROW(col->sanity_check());
 
         offsets[0] = 1;
         // chars.size() != offsets[count - 1]

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -42,6 +42,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/config.h"
 #include "core/block/block.h"
 #include "core/column/column.h"
 #include "core/column/column_complex.h"
@@ -76,6 +77,7 @@
 #include "format/arrow/arrow_block_convertor.h"
 #include "format/arrow/arrow_row_batch.h"
 #include "runtime/descriptors.cpp"
+#include "util/defer_op.h"
 #include "util/string_parser.hpp"
 
 namespace doris {
@@ -527,6 +529,27 @@ TEST(DataTypeSerDeArrowTest, BlockConverterTest) {
     };
     block_converter_test(cols, 7, true);
     block_converter_test(cols, 7, false);
+}
+
+TEST(DataTypeSerDeArrowTest, ReadColumnFromArrowValidateFullRejectsInvalidStringOffsets) {
+    const bool origin_enable_arrow_validate_full = config::enable_arrow_validate_full;
+    config::enable_arrow_validate_full = true;
+    Defer defer {[&]() { config::enable_arrow_validate_full = origin_enable_arrow_validate_full; }};
+
+    std::vector<int32_t> offsets = {0, 4, 2};
+    std::string values = "abcd";
+    auto offset_buffer = arrow::Buffer::Wrap(offsets);
+    auto value_buffer =
+            arrow::Buffer::Wrap(reinterpret_cast<const uint8_t*>(values.data()), values.size());
+    auto invalid_array = std::make_shared<arrow::StringArray>(2, offset_buffer, value_buffer);
+    ASSERT_FALSE(invalid_array->ValidateFull().ok());
+
+    DataTypePtr data_type = std::make_shared<DataTypeString>();
+    auto column = data_type->create_column();
+    cctz::time_zone default_timezone;
+    Status status = data_type->get_serde()->read_column_from_arrow(
+            *column, invalid_array.get(), 0, invalid_array->length(), default_timezone);
+    EXPECT_FALSE(status.ok());
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

This is a staged change to make existing column and Arrow data validity checks available outside debug-only paths while keeping them disabled by default.

Root cause: ColumnString::sanity_check() was guarded by NDEBUG, so release builds could not enable the existing offset and chars consistency checks. Arrow conversion paths also accepted invalid Arrow arrays without a shared validation gate, and nested Arrow serde reads would repeat validation if validation were placed directly in every nested call.

This change adds two opt-in BE configs:

- enable_column_sanity_check: enables column sanity checks in release builds.
- enable_arrow_validate_full: enables Arrow ValidateFull() checks on Arrow read/write conversion paths.

The column path keeps the existing sanity_check() API name and semantics. Debug builds still run ColumnString sanity checks as before, while release builds return early unless enable_column_sanity_check is enabled. Expression evaluation calls sanity_check() after producing result columns when the config is enabled.

The Arrow read path now uses a non-virtual DataTypeSerDe::read_column_from_arrow() wrapper to run ValidateFull() once at the top-level entry, then delegates to read_column_from_arrow_impl(). Nested array/map/nullable/struct serde reads call the impl method directly to avoid repeated validation. The Arrow write path validates finished arrays and the final record batch when enable_arrow_validate_full is enabled, without adding another serde write implementation layer.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

