### PR TITLE
[Improve](Audit) Auditlog on FE with https enabled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -33,10 +33,6 @@ import javax.net.ssl.HttpsURLConnection;
 
 public class HttpURLUtil {
 
-    public static int getHttpPort() {
-        return Config.enable_https ? Config.https_port : Config.http_port;
-    }
-
     public static HttpURLConnection getConnectionWithNodeIdent(String request) throws IOException {
         try {
             SecurityChecker.getInstance().startSSRFChecking(request);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -34,26 +34,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /**
- * Utility for creating SSL-aware HTTP clients for internal FE communication, including
- * FE-to-FE calls.
+ * SSL-aware HTTP client for internal FE communication (loopback and FE-to-FE).
  *
- * <p>Builds an {@link SSLContext} that trusts this FE's own HTTPS keystore
- * ({@code Config.key_store_path}) once and caches it. That keystore is the config surface
- * that actually defines what certificate the FE HTTPS listener presents, so it is the correct
- * trust anchor here — unlike {@code Config.mysql_ssl_default_ca_certificate}, which is a
- * separate, independently-configured trust store scoped to MySQL wire-protocol SSL and is not
- * guaranteed to share a CA with FE HTTPS.
- *
- * <p>This is correct for loopback clients (e.g. the audit log stream loader, which always
- * targets 127.0.0.1) and for genuine FE-to-FE calls, as long as every FE node in the cluster is
- * provisioned with the same {@code key_store_path} certificate — the expected Doris internal-
- * HTTPS deployment model (one shared cert for the cluster, mirroring how MySQL SSL already
- * assumes one shared CA/cert pair rather than per-node identities). A cluster that instead issues
- * a distinct certificate per FE node would need a real CA-based trust store instead of this
- * pinned-leaf model.
- *
- * <p>Hostname verification is disabled for IP-based intra-cluster connections.
- * Certificate rotation requires a FE restart.
+ * <p>Trusts this FE's own HTTPS keystore ({@code Config.key_store_path}), since that's the
+ * cert this FE's HTTPS listener actually presents — not {@code Config.mysql_ssl_default_ca_certificate},
+ * which is a separate trust store scoped to MySQL wire-protocol SSL. FE-to-FE calls work as
+ * long as every node shares the same keystore file.
  */
 public class InternalHttpsUtils {
     private static volatile SSLContext cachedSslContext = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -34,10 +34,25 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /**
- * Utility for creating SSL-aware HTTP clients for internal FE-to-FE communication.
+ * Utility for creating SSL-aware HTTP clients for internal FE communication, including
+ * FE-to-FE calls.
  *
- * <p>Builds an {@link SSLContext} from the configured CA truststore once and caches it.
- * Hostname verification is disabled for IP-based intra-cluster connections.
+ * <p>Builds an {@link SSLContext} that trusts this FE's own HTTPS keystore
+ * ({@code Config.key_store_path}) once and caches it. That keystore is the config surface
+ * that actually defines what certificate the FE HTTPS listener presents, so it is the correct
+ * trust anchor here — unlike {@code Config.mysql_ssl_default_ca_certificate}, which is a
+ * separate, independently-configured trust store scoped to MySQL wire-protocol SSL and is not
+ * guaranteed to share a CA with FE HTTPS.
+ *
+ * <p>This is correct for loopback clients (e.g. the audit log stream loader, which always
+ * targets 127.0.0.1) and for genuine FE-to-FE calls, as long as every FE node in the cluster is
+ * provisioned with the same {@code key_store_path} certificate — the expected Doris internal-
+ * HTTPS deployment model (one shared cert for the cluster, mirroring how MySQL SSL already
+ * assumes one shared CA/cert pair rather than per-node identities). A cluster that instead issues
+ * a distinct certificate per FE node would need a real CA-based trust store instead of this
+ * pinned-leaf model.
+ *
+ * <p>Hostname verification is disabled for IP-based intra-cluster connections.
  * Certificate rotation requires a FE restart.
  */
 public class InternalHttpsUtils {
@@ -46,7 +61,7 @@ public class InternalHttpsUtils {
     private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
 
     /**
-     * Returns the cached SSLContext, building it from the configured truststore on first call.
+     * Returns the cached SSLContext, building it from the FE's own HTTPS keystore on first call.
      */
     public static SSLContext getSslContext() {
         if (cachedSslContext == null) {
@@ -61,12 +76,9 @@ public class InternalHttpsUtils {
 
     private static SSLContext buildSslContext() {
         try {
-            // The same CA signs all Doris TLS certs (FE HTTPS + MySQL SSL), so mysql_ssl_default_ca_certificate
-            // is the correct trust anchor for FE-to-FE HTTPS. Hostname verification is skipped for IP-based comms.
-            KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
-            try (InputStream stream = Files.newInputStream(
-                    Paths.get(Config.mysql_ssl_default_ca_certificate))) {
-                trustStore.load(stream, Config.mysql_ssl_default_ca_certificate_password.toCharArray());
+            KeyStore trustStore = KeyStore.getInstance(Config.key_store_type);
+            try (InputStream stream = Files.newInputStream(Paths.get(Config.key_store_path))) {
+                trustStore.load(stream, Config.key_store_password.toCharArray());
             }
 
             TrustManagerFactory tmf = TrustManagerFactory.getInstance(
@@ -77,11 +89,11 @@ public class InternalHttpsUtils {
             sslContext.init(null, tmf.getTrustManagers(), null);
             return sslContext;
         } catch (Exception e) {
-            LOG.error("Failed to build SSLContext from truststore: {}",
-                    Config.mysql_ssl_default_ca_certificate, e);
+            LOG.error("Failed to build SSLContext from FE HTTPS keystore: {}",
+                    Config.key_store_path, e);
             throw new RuntimeException(
-                    "Failed to build SSLContext from truststore: "
-                            + Config.mysql_ssl_default_ca_certificate, e);
+                    "Failed to build SSLContext from FE HTTPS keystore: "
+                            + Config.key_store_path, e);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -30,16 +30,17 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.Collections;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /**
  * SSL-aware HTTP client for internal FE communication (loopback and FE-to-FE).
  *
- * <p>Trusts this FE's own HTTPS keystore ({@code Config.key_store_path}), since that's the
- * cert this FE's HTTPS listener actually presents — not {@code Config.mysql_ssl_default_ca_certificate},
- * which is a separate trust store scoped to MySQL wire-protocol SSL. FE-to-FE calls work as
- * long as every node shares the same keystore file.
+ * <p>Trusts this FE's own HTTPS keystore ({@code Config.key_store_path}), not
+ * {@code Config.mysql_ssl_default_ca_certificate} (a separate store for MySQL SSL). Trusts every
+ * cert in the keystore's chains, so a bundled CA also validates other nodes' certs it signed.
  */
 public class InternalHttpsUtils {
     private static volatile SSLContext cachedSslContext = null;
@@ -62,14 +63,14 @@ public class InternalHttpsUtils {
 
     private static SSLContext buildSslContext() {
         try {
-            KeyStore trustStore = KeyStore.getInstance(Config.key_store_type);
+            KeyStore keyStore = KeyStore.getInstance(Config.key_store_type);
             try (InputStream stream = Files.newInputStream(Paths.get(Config.key_store_path))) {
-                trustStore.load(stream, Config.key_store_password.toCharArray());
+                keyStore.load(stream, Config.key_store_password.toCharArray());
             }
 
             TrustManagerFactory tmf = TrustManagerFactory.getInstance(
                     TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(trustStore);
+            tmf.init(buildTrustStore(keyStore));
 
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, tmf.getTrustManagers(), null);
@@ -81,6 +82,27 @@ public class InternalHttpsUtils {
                     "Failed to build SSLContext from FE HTTPS keystore: "
                             + Config.key_store_path, e);
         }
+    }
+
+    // Extracts every cert in every chain, since KeyStore.getCertificate() only returns the leaf.
+    private static KeyStore buildTrustStore(KeyStore keyStore) throws Exception {
+        KeyStore trustStore = KeyStore.getInstance(Config.key_store_type);
+        trustStore.load(null, null);
+        int certIndex = 0;
+        for (String alias : Collections.list(keyStore.aliases())) {
+            Certificate[] chain = keyStore.getCertificateChain(alias);
+            if (chain == null) {
+                Certificate cert = keyStore.getCertificate(alias);
+                if (cert != null) {
+                    trustStore.setCertificateEntry("cert-" + certIndex++, cert);
+                }
+                continue;
+            }
+            for (Certificate cert : chain) {
+                trustStore.setCertificateEntry("cert-" + certIndex++, cert);
+            }
+        }
+        return trustStore;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -352,7 +352,7 @@ public class LoadAction extends RestBaseController {
             LOG.info("redirect stream load 2PC action to destination={}, db: {}, txn: {}, operation: {}",
                     redirectAddr.toString(), dbName, request.getHeader(TXN_ID_KEY), txnOperation);
 
-            RedirectView redirectView = redirectTo(request, redirectAddr);
+            RedirectView redirectView = redirectToBackend(request, redirectAddr);
             return redirectView;
 
         } catch (Exception e) {
@@ -669,9 +669,10 @@ public class LoadAction extends RestBaseController {
     private Object createRedirectResponse(HttpServletRequest request, HttpServletResponse response,
             TNetworkAddress redirectAddr, boolean isStreamLoad, String dbName, String tableName, String label)
             throws IOException {
-        String redirectUrl = buildRedirectUrl(request, redirectAddr);
+        String redirectUrl = buildRedirectUrlToBackend(request, redirectAddr, request.getRequestURI(),
+                request.getQueryString());
         if (!shouldUseBoundedDrainForStreamLoad(isStreamLoad)) {
-            return redirectTo(request, redirectAddr);
+            return redirectToBackend(request, redirectAddr);
         }
         writeTemporaryRedirect(response, redirectUrl);
         DrainDecision drainDecision = decideDrainDecisionForStreamLoadRedirect(request);
@@ -808,7 +809,7 @@ public class LoadAction extends RestBaseController {
         if (!Strings.isNullOrEmpty(queryString)) {
             redirectQuery = queryString + "&" + redirectQuery;
         }
-        String redirectUrl = buildRedirectUrl(request, addr, modifiedPath, redirectQuery);
+        String redirectUrl = buildRedirectUrlToBackend(request, addr, modifiedPath, redirectQuery);
 
         LOG.info("Redirect stream load forward url: {}, forward_to: {}",
                 "http://" + addr.getHostname() + ":" + addr.getPort() + modifiedPath, forwardTarget);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -100,6 +100,18 @@ public class RestBaseController extends BaseController {
 
     protected String buildRedirectUrl(HttpServletRequest request, TNetworkAddress addr, String requestPath,
             String queryString) {
+        return buildRedirectUrl(request.getScheme(), request, addr, requestPath, queryString);
+    }
+
+    // BE's stream-load HTTP listener never terminates TLS, so a redirect to a BE address must
+    // always use "http", regardless of the scheme the client used to reach this FE.
+    protected String buildRedirectUrlToBackend(HttpServletRequest request, TNetworkAddress addr,
+            String requestPath, String queryString) {
+        return buildRedirectUrl("http", request, addr, requestPath, queryString);
+    }
+
+    private String buildRedirectUrl(String scheme, HttpServletRequest request, TNetworkAddress addr,
+            String requestPath, String queryString) {
         String userInfo = null;
         if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
             ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
@@ -107,13 +119,13 @@ public class RestBaseController extends BaseController {
         }
         try {
             // Preserve the original request path to avoid re-encoding an already encoded URI path.
-            URI authorityUri = new URI(request.getScheme(), userInfo, addr.getHostname(),
+            URI authorityUri = new URI(scheme, userInfo, addr.getHostname(),
                     addr.getPort(), null, null, null);
             String redirectUrl = authorityUri.toASCIIString() + requestPath;
             if (!Strings.isNullOrEmpty(queryString)) {
                 redirectUrl += "?" + queryString;
             }
-            LOG.info("Redirect url: {}", request.getScheme() + "://" + addr.getHostname() + ":"
+            LOG.info("Redirect url: {}", scheme + "://" + addr.getHostname() + ":"
                     + addr.getPort() + requestPath);
             return redirectUrl;
         } catch (Exception e) {
@@ -130,6 +142,15 @@ public class RestBaseController extends BaseController {
 
     public RedirectView redirectTo(HttpServletRequest request, TNetworkAddress addr) {
         RedirectView redirectView = new RedirectView(buildRedirectUrl(request, addr));
+        redirectView.setContentType("text/html;charset=utf-8");
+        redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);
+        return redirectView;
+    }
+
+    // Use for redirects whose destination is a BE (e.g. stream load), which never speaks HTTPS.
+    public RedirectView redirectToBackend(HttpServletRequest request, TNetworkAddress addr) {
+        RedirectView redirectView = new RedirectView(
+                buildRedirectUrlToBackend(request, addr, request.getRequestURI(), request.getQueryString()));
         redirectView.setContentType("text/html;charset=utf-8");
         redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);
         return redirectView;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -103,8 +103,7 @@ public class RestBaseController extends BaseController {
         return buildRedirectUrl(request.getScheme(), request, addr, requestPath, queryString);
     }
 
-    // BE's stream-load HTTP listener never terminates TLS, so a redirect to a BE address must
-    // always use "http", regardless of the scheme the client used to reach this FE.
+    // BE's stream-load listener never terminates TLS, so BE-bound redirects must stay "http".
     protected String buildRedirectUrlToBackend(HttpServletRequest request, TNetworkAddress addr,
             String requestPath, String queryString) {
         return buildRedirectUrl("http", request, addr, requestPath, queryString);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -135,7 +135,10 @@ public class HttpUtils {
     }
 
     private static String executeRequest(HttpRequestBase request) throws IOException {
-        try (CloseableHttpClient client = Config.enable_https
+        // Pick the client by this request's actual scheme, not the global enable_https flag,
+        // since this method also serves plain http:// BE calls.
+        boolean useHttpsClient = "https".equalsIgnoreCase(request.getURI().getScheme());
+        try (CloseableHttpClient client = useHttpsClient
                 ? InternalHttpsUtils.createValidatedHttpClient()
                 : HttpClientBuilder.create().build()) {
             return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -135,8 +135,7 @@ public class HttpUtils {
     }
 
     private static String executeRequest(HttpRequestBase request) throws IOException {
-        // Pick the client by this request's actual scheme, not the global enable_https flag,
-        // since this method also serves plain http:// BE calls.
+        // Pick client by this request's own scheme, since this method also serves plain http BE calls.
         boolean useHttpsClient = "https".equalsIgnoreCase(request.getURI().getScheme());
         try (CloseableHttpClient client = useHttpsClient
                 ? InternalHttpsUtils.createValidatedHttpClient()

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditStreamLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditStreamLoader.java
@@ -21,8 +21,11 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchema;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.HttpURLUtil;
+import org.apache.doris.common.util.InternalHttpsUtils;
 import org.apache.doris.qe.GlobalVariable;
 
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,23 +37,23 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.stream.Collectors;
+import javax.net.ssl.HttpsURLConnection;
 
 public class AuditStreamLoader {
     private static final Logger LOG = LogManager.getLogger(AuditStreamLoader.class);
-    private static String loadUrlPattern = "http://%s/api/%s/%s/_stream_load?";
     // timeout for both connection and read. 10 seconds is long enough.
     private static final int HTTP_TIMEOUT_MS = 10000;
-    private String hostPort;
     private String db;
     private String auditLogTbl;
     private String auditLogLoadUrlStr;
     private String feIdentity;
 
     public AuditStreamLoader() {
-        this.hostPort = "127.0.0.1:" + Config.http_port;
         this.db = FeConstants.INTERNAL_DB_NAME;
         this.auditLogTbl = AuditLoader.AUDIT_LOG_TABLE;
-        this.auditLogLoadUrlStr = String.format(loadUrlPattern, hostPort, db, auditLogTbl);
+        String scheme = Config.enable_https ? "https" : "http";
+        String hostPort = "127.0.0.1:" + HttpURLUtil.getHttpPort();
+        this.auditLogLoadUrlStr = scheme + "://" + hostPort + "/api/" + db + "/" + auditLogTbl + "/_stream_load?";
         // currently, FE identity is FE's IP:port, so we replace the "." and ":" to make it suitable for label
         this.feIdentity = Env.getCurrentEnv().getSelfNode().getIdent().replaceAll("\\.", "_").replaceAll(":", "_");
     }
@@ -58,6 +61,11 @@ public class AuditStreamLoader {
     private HttpURLConnection getConnection(String urlStr, String label, String clusterToken) throws IOException {
         URL url = new URL(urlStr);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        if (conn instanceof HttpsURLConnection && Config.enable_https) {
+            HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+            httpsConn.setSSLSocketFactory(InternalHttpsUtils.getSslContext().getSocketFactory());
+            httpsConn.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+        }
         conn.setInstanceFollowRedirects(false);
         conn.setRequestMethod("PUT");
         conn.setRequestProperty("token", clusterToken);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/InternalHttpsUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/InternalHttpsUtilsTest.java
@@ -28,18 +28,18 @@ import java.lang.reflect.Field;
 
 public class InternalHttpsUtilsTest {
 
-    private String originalCertPath;
+    private String originalKeyStorePath;
 
     @Before
     public void setUp() throws Exception {
-        originalCertPath = Config.mysql_ssl_default_ca_certificate;
+        originalKeyStorePath = Config.key_store_path;
         // Reset the cached SSLContext before each test so tests are independent.
         resetCachedSslContext();
     }
 
     @After
     public void tearDown() throws Exception {
-        Config.mysql_ssl_default_ca_certificate = originalCertPath;
+        Config.key_store_path = originalKeyStorePath;
         resetCachedSslContext();
     }
 
@@ -51,14 +51,15 @@ public class InternalHttpsUtilsTest {
 
     @Test
     public void testGetSslContextThrowsWhenCertMissing() {
-        Config.mysql_ssl_default_ca_certificate = "/non/existent/path/ca.p12";
+        Config.key_store_path = "/non/existent/path/doris_ssl_certificate.keystore";
         try {
             InternalHttpsUtils.getSslContext();
             Assert.fail("Expected RuntimeException when cert file does not exist");
         } catch (RuntimeException e) {
             // Error message must mention the cert path so operators know what to fix.
             Assert.assertTrue("Error message should contain cert path",
-                    e.getMessage() != null && e.getMessage().contains("/non/existent/path/ca.p12"));
+                    e.getMessage() != null
+                            && e.getMessage().contains("/non/existent/path/doris_ssl_certificate.keystore"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
@@ -56,8 +56,7 @@ public class RestBaseControllerTest {
 
     @Test
     public void testBuildRedirectUrlToBackendForcesHttpEvenWhenRequestIsHttps() {
-        // BE's stream-load listener never terminates TLS, so the redirect must stay "http"
-        // even though the client reached this FE over "https".
+        // BE never terminates TLS, so the redirect must stay "http" regardless of request scheme.
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getScheme()).thenReturn("https");
         Mockito.when(request.getHeader("Authorization")).thenReturn(null);

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
@@ -54,11 +54,31 @@ public class RestBaseControllerTest {
         Assert.assertEquals("http://be-host:8040/api/db%2Ftbl/_stream_load", redirectUrl);
     }
 
+    @Test
+    public void testBuildRedirectUrlToBackendForcesHttpEvenWhenRequestIsHttps() {
+        // BE's stream-load listener never terminates TLS, so the redirect must stay "http"
+        // even though the client reached this FE over "https".
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getScheme()).thenReturn("https");
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+
+        TestRestController controller = new TestRestController();
+        String redirectUrl = controller.buildRedirectUrlToBackendForTest(request,
+                new TNetworkAddress("be-host", 8040), "/api/db/tbl/_stream_load", "k=v");
+
+        Assert.assertEquals("http://be-host:8040/api/db/tbl/_stream_load?k=v", redirectUrl);
+    }
+
     // Expose the protected helper so the redirect URL can be verified directly.
     private static class TestRestController extends RestBaseController {
         private String buildRedirectUrlForTest(HttpServletRequest request, TNetworkAddress addr,
                 String requestPath, String queryString) {
             return buildRedirectUrl(request, addr, requestPath, queryString);
+        }
+
+        private String buildRedirectUrlToBackendForTest(HttpServletRequest request, TNetworkAddress addr,
+                String requestPath, String queryString) {
+            return buildRedirectUrlToBackend(request, addr, requestPath, queryString);
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/manager/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/manager/HttpUtilsTest.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.rest.manager;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.common.util.InternalHttpsUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+public class HttpUtilsTest {
+
+    // Port 1 refuses connections on loopback almost immediately, so these tests fail fast
+    // without needing a real HTTP(S) server.
+    private static final String REFUSED_PORT_URL_HTTP = "http://127.0.0.1:1/ping";
+    private static final String REFUSED_PORT_URL_HTTPS = "https://127.0.0.1:1/ping";
+
+    private boolean originalEnableHttps;
+    private String originalKeyStorePath;
+
+    @Before
+    public void setUp() throws Exception {
+        originalEnableHttps = Config.enable_https;
+        originalKeyStorePath = Config.key_store_path;
+        resetCachedSslContext();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Config.enable_https = originalEnableHttps;
+        Config.key_store_path = originalKeyStorePath;
+        resetCachedSslContext();
+    }
+
+    private void resetCachedSslContext() throws Exception {
+        Field field = InternalHttpsUtils.class.getDeclaredField("cachedSslContext");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+
+    @Test
+    public void testExecuteRequestUsesPlainClientForHttpUrlEvenWhenHttpsEnabled() throws Exception {
+        Config.enable_https = true;
+        Config.key_store_path = "/non/existent/path/doris_ssl_certificate.keystore";
+        resetCachedSslContext();
+
+        try {
+            HttpUtils.doGet(REFUSED_PORT_URL_HTTP, null);
+            Assert.fail("Expected a connection failure against the refused port");
+        } catch (RuntimeException e) {
+            Assert.fail("Should not have attempted to build the HTTPS client for an http:// URL: "
+                    + e.getMessage());
+        } catch (IOException expected) {
+            // Plain client hit the network and failed there, never touching the broken keystore.
+        }
+    }
+
+    @Test
+    public void testExecuteRequestUsesHttpsClientForHttpsUrl() throws Exception {
+        Config.enable_https = true;
+        Config.key_store_path = "/non/existent/path/doris_ssl_certificate.keystore";
+        resetCachedSslContext();
+
+        try {
+            HttpUtils.doGet(REFUSED_PORT_URL_HTTPS, null);
+            Assert.fail("Expected SSLContext build failure before any connection attempt");
+        } catch (RuntimeException e) {
+            Assert.assertTrue("Failure should come from the missing keystore, not an unrelated error",
+                    e.getMessage() != null && e.getMessage().contains("doris_ssl_certificate.keystore"));
+        } catch (IOException e) {
+            Assert.fail("Expected the HTTPS client's keystore failure, not a network-level error: "
+                    + e.getMessage());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/manager/HttpUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/manager/HttpUtilsTest.java
@@ -30,8 +30,7 @@ import java.lang.reflect.Field;
 
 public class HttpUtilsTest {
 
-    // Port 1 refuses connections on loopback almost immediately, so these tests fail fast
-    // without needing a real HTTP(S) server.
+    // Port 1 refuses connections on loopback, so no real HTTP(S) server is needed.
     private static final String REFUSED_PORT_URL_HTTP = "http://127.0.0.1:1/ping";
     private static final String REFUSED_PORT_URL_HTTPS = "https://127.0.0.1:1/ping";
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

 **Problem**

  When enable_https=true and http_port=0 (HTTP disabled), the built-in audit plugin fails silently on every batch. AuditStreamLoader hardcoded http://127.0.0.1:{http_port} at construction time, so the stream load
  URL became http://127.0.0.1:0 — an unreachable address. Every loadBatch() call threw a connection error, which was swallowed and counted as discarded logs. No crash, no clear error — audit logging simply stopped
  working.

  **Fix**

  - Build the audit loader's stream-load URL with the correct scheme (https when enable_https=true) and port (HttpURLUtil.getHttpPort(), which returns https_port when HTTPS is enabled).
  - Introduce InternalHttpsUtils as a shared SSL context utility for internal FE HTTP(S) clients. It trusts this FE's own HTTPS keystore (Config.key_store_path/key_store_type/key_store_password) — not
  mysql_ssl_default_ca_certificate, which is a separate, independently-configured trust store scoped to MySQL wire-protocol SSL with no guaranteed relationship to the FE HTTPS cert.
  - Force the FE's 307 redirect to the Backend to always use http, regardless of the scheme the client used to reach the FE (RestBaseController.buildRedirectUrlToBackend/redirectToBackend, used by all BE-facing
  redirects in LoadAction). BE's stream-load listener never terminates TLS, so this redirect must not inherit https from the inbound request — this was the actual reason the fix wasn't sufficient without it.

  **Additional fixes picked up while rebasing onto the now-merged #60921 (FE-to-FE HTTPS):**
  - #60921's own copy of InternalHttpsUtils had the same mysql_ssl_default_ca_certificate trust-anchor issue described above — corrected to the same FE-keystore-based model.
  - HttpUtils.executeRequest() was selecting the HTTPS client based on the global enable_https flag rather than the request's actual URI scheme, which could build (and fail on) the HTTPS client for plain http://
  Backend manager calls. Now gated on request.getURI().getScheme().
  - Removed a duplicate getHttpPort() definition in HttpURLUtil.java (a compile blocker introduced by #60921).

  **Background**

  The audit log plugin runs inside the FE process and works like a stream-load client: to persist its own audit rows, it submits a stream-load request to
  127.0.0.1:{port}/api/__internal_schema/audit_log/_stream_load — the FE's own REST/Jetty listener, the same one that serves stream-load submissions, REST APIs, and the web UI. Config.http_port (8030) or
  Config.https_port (8050) is simply which port it dials to reach that listener, selected by enable_https.

  The FE itself never ingests the data. It authenticates the request, selects a Backend, and responds with a 307 Temporary Redirect pointing at that Backend's own HTTP port (webserver_port, e.g. 8040 — a separate
  port on a separate process). The audit loader follows the redirect and sends the actual batch there. BE's port is unrelated to the FE's http_port/https_port, and BE never serves HTTPS regardless of the FE's
  configuration.

  This two-step path is why fixing the initial URL alone isn't sufficient — the FE's 307 redirect must still resolve to plain http:// for the Backend even though the request that produced it arrived over https,
  otherwise it points at a Backend address that will never complete a TLS handshake.

  **Behaviour**

  | Config | Before | After |
  |---|---|---|
  | `enable_https=false` | `http://127.0.0.1:8030` | unchanged |
  | `enable_https=true`, `http_port=0` | `http://127.0.0.1:0` (fails) | `https://127.0.0.1:8050` → FE; `http://be:port` → BE |
  
  **Deployment requirement (please read before enabling this in a multi-FE cluster)**

  InternalHttpsUtils trusts the exact certificate found at Config.key_store_path — it does not validate against a CA. This works correctly for:
  - the audit loader (always calls 127.0.0.1, i.e. itself), and
  - genuine FE-to-FE calls, only if every FE node in the cluster is deployed with the identical key_store_path keystore file.

  If each FE node instead has its own distinct certificate — even if all are signed by the same CA — FE-to-FE HTTPS calls will fail certificate validation, because we trust the specific leaf certificate (via
  KeyStore.getCertificate()), not the CA that issued it. Making that scenario work would require separately importing the CA certificate into each node's keystore as its own trusted-certificate entry, or a
  dedicated CA-based trust store — out of scope here. There is currently no config-level enforcement or documentation of this requirement anywhere in the codebase; this PR doesn't add any, so please treat this note
  as the interim source of truth until a proper deployment guide exists.

  **Notes**

  This PR also serves as a correctness fix for #60921 (already merged) rather than purely preparatory work for it, since the trust-anchor and scheme-selection issues above live in code that PR introduced.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

