### PR TITLE
[bug](avro) fix avro jni reader coredump with nullptr

### DIFF
--- a/be/src/exec/connector/jni_connector.cpp
+++ b/be/src/exec/connector/jni_connector.cpp
@@ -94,7 +94,9 @@ Status JniConnector::open(RuntimeState* state, RuntimeProfile* profile) {
     }
     RETURN_IF_ERROR(Jni::Env::Get(&env));
     SCOPED_RAW_TIMER(&_jni_scanner_open_watcher);
-    _scanner_params.emplace("time_zone", _state->timezone());
+    if (_state) { // maybe nullptr when init_fetch_table_schema_reader
+        _scanner_params.emplace("time_zone", _state->timezone());
+    }
     RETURN_IF_ERROR(_init_jni_scanner(env, batch_size));
     // Call org.apache.doris.common.jni.JniScanner#open
     RETURN_IF_ERROR(_jni_scanner_obj.call_void_method(env, _jni_scanner_open).call());


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
when fetch_table_schema call by FE rpc, will not pass runtime state object, so it's nullptr.
master branch have been refactor so it's no problem.
```
 1# PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0] at src/hotspot/os/posix/signals_posix.cpp:454
 2# JVM_handle_linux_signal at src/hotspot/os/posix/signals_posix.cpp:641
 3# 0x00007F93C27AB520 in /lib/x86_64-linux-gnu/libc.so.6
 4# _ZNSt4pairIKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EC2IRA10_KcRS6_Qaacl16_S_constructibleITL0__TL0_0_EEntcl10_S_danglesISD_SE_EEEEOT_OT0_ 
at /root/tools/ldb-toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_pair.h:464
 5# std::pair<std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_stri
ng<char, std::char_traits<char>, std::allocator<char> > > >, bool> std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>
 >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, 
std::allocator<char> > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic
_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >,
 std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_tr
aits<char>, std::allocator<char> > > > >::_M_emplace_unique<char const (&) [10], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>
 > const&>(char const (&) [10], std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /root/tools/ldb-toolchain/bin/../li
b/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_tree.h:3056
 6# doris::vectorized::JniConnector::open(doris::RuntimeState*, doris::RuntimeProfile*) at /root/selectdb-core/be/src/vec/exec/jni_connector.cpp:98
 7# doris::vectorized::AvroJNIReader::init_schema_reader() at /root/selectdb-core/be/src/vec/exec/format/avro/avro_jni_reader.cpp:123
 8# std::_Function_handler<void (), doris::PInternalService::fetch_table_schema(google::protobuf::RpcController*, doris::PFetchTableSchemaRequest const*, dori
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

