### PR TITLE
Add human_readable_seconds function (trino compatible)

### DIFF
--- a/be/src/vec/functions/function_human_readable_seconds.cpp
+++ b/be/src/vec/functions/function_human_readable_seconds.cpp
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/functions/function_human_readable_seconds.h"
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+
+namespace doris ::vectorized {
+static std::string human_readable_seconds(double input) {
+    if (std::isnan(input) || std::isinf(input) || input < 0) // 检查传入参数是否是数字和无穷大
+    {
+        return "";
+    }
+
+    constexpr long long SEC_PER_MIN = 60;
+    constexpr long long SEC_PER_HOUR = 3600;
+    constexpr long long SEC_PER_DAY = 86400;
+    constexpr long long SEC_PER_WEEK = SEC_PER_DAY * 7;
+
+    // 取绝对值和四舍五入
+    double total_seconds = std::abs(input);
+    long long total = static_cast<long long>(input);
+    double fraction_seconds = total_seconds - total;
+    // 求商取模
+    long long weeks = total / SEC_PER_WEEK;
+    total %= SEC_PER_WEEK;
+    long long days = total / SEC_PER_DAY;
+    total %= SEC_PER_DAY;
+    long long hours = total / SEC_PER_HOUR;
+    total %= SEC_PER_HOUR;
+    long long minutes = total / SEC_PER_MIN;
+    total %= SEC_PER_MIN;
+    fraction_seconds += total;
+    // 字符串拼接
+    std::ostringstream oss;
+    bool has_output = false;
+    auto append = [&](long long val, const std::string& unit) {
+        if (val > 0) {
+            if (has_output) oss << ", ";                        // 除第一个都要加上“，”
+            oss << val << " " << unit << (val == 1 ? "" : "s"); // 1second ，2seconds 复数
+            has_output = true;
+        }
+    };
+    append(weeks, "week");
+    append(days, "day");
+    append(hours, "hour");
+    append(minutes, "minute");
+    if (fraction_seconds > 0) {
+        if (has_output) oss << ", ";
+        if (fabs(fraction_seconds - round(fraction_seconds)) < 1e-9) {
+            long long tmp = static_cast<long long>(std::round(fraction_seconds));
+            oss << tmp << " second" << (tmp == 1 ? "" : "s");
+        } else {
+            oss << std::fixed << std::setprecision(3) << fraction_seconds << " seconds";
+        }
+        has_output = true;
+    }
+
+    if (!has_output) oss << "0 seconds";
+    return oss.str();
+}
+
+Status FunctionHumanReadableSeconds::execute_impl(FunctionContext* context, Block& block,
+                                                  const ColumnNumbers& arguments, uint32_t result,
+                                                  size_t input_rows_count) const {
+    const auto& src_col = block.get_by_position(arguments[0]).column;
+    const ColumnFloat64* col_f64 = check_and_get_column<ColumnFloat64>(src_col.get());
+
+    if (!col_f64) {
+        return Status::RuntimeError("unsupported type for function {}: {}", get_name(),
+                                    block.get_by_position(arguments[0]).type->get_name());
+    }
+
+    auto dst_col = ColumnString::create();
+    auto& chars = dst_col->get_chars();
+    auto& offsets = dst_col->get_offsets();
+    offsets.resize(input_rows_count);
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        double val = col_f64->get_float64(i);
+        std::string result_str = human_readable_seconds(val);
+        chars.insert(chars.end(), result_str.begin(), result_str.end());
+        chars.push_back('\0');
+        offsets[i] = chars.size();
+    }
+
+    block.replace_by_position(result, std::move(dst_col));
+    return Status::OK();
+}
+
+void register_function_human_readable_seconds(SimpleFunctionFactory& factory) {
+    factory.register_function<FunctionHumanReadableSeconds>();
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/functions/function_human_readable_seconds.h
+++ b/be/src/vec/functions/function_human_readable_seconds.h
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
+#include "vec/functions/function.h"
+
+namespace doris::vectorized {
+
+// size function for size with map and array
+class FunctionHumanReadableSeconds : public IFunction {
+public:
+    static constexpr auto name = "human_readable_seconds";
+    static FunctionPtr create() { return std::make_shared<FunctionHumanReadableSeconds>(); }
+    String get_name() const override { return name; }
+    size_t get_number_of_arguments() const override { return 1; }
+
+    DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
+        return std::make_shared<DataTypeString>();
+    }
+
+    Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                        uint32_t result, size_t input_rows_count) const override;
+};
+} // namespace doris::vectorized

--- a/be/src/vec/functions/simple_function_factory.h
+++ b/be/src/vec/functions/simple_function_factory.h
@@ -33,6 +33,7 @@ constexpr auto DECIMAL256_FUNCTION_SUFFIX {"_decimal256"};
 class SimpleFunctionFactory;
 
 void register_function_size(SimpleFunctionFactory& factory);
+void register_function_human_readable_seconds(SimpleFunctionFactory& factory);
 void register_function_comparison(SimpleFunctionFactory& factory);
 void register_function_comparison_eq_for_null(SimpleFunctionFactory& factory);
 void register_function_hll(SimpleFunctionFactory& factory);
@@ -236,6 +237,7 @@ public:
         static SimpleFunctionFactory instance;
         std::call_once(oc, []() {
             register_function_size(instance);
+            register_function_human_readable_seconds(instance);
             register_function_bitmap(instance);
             register_function_quantile_state(instance);
             register_function_bitmap_variadic(instance);

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -55,13 +55,13 @@ export TP_JAR_DIR="${TP_INSTALL_DIR}/lib/jar"
 #####################################################
 
 # libevent
-LIBEVENT_DOWNLOAD="https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz"
+LIBEVENT_DOWNLOAD="https://ghproxy.net/https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz"
 LIBEVENT_NAME=libevent-release-2.1.12-stable.tar.gz
 LIBEVENT_SOURCE=libevent-release-2.1.12-stable
 LIBEVENT_MD5SUM="0d5a27436bf7ff8253420c8cf09f47ca"
 
 # openssl
-OPENSSL_DOWNLOAD="https://github.com/openssl/openssl/archive/OpenSSL_1_1_1s.tar.gz"
+OPENSSL_DOWNLOAD="https://ghproxy.net/https://github.com/openssl/openssl/archive/OpenSSL_1_1_1s.tar.gz"
 OPENSSL_NAME=openssl-OpenSSL_1_1_1s.tar.gz
 OPENSSL_SOURCE=openssl-OpenSSL_1_1_1s
 OPENSSL_MD5SUM="7e79a7560dee77c0758baa33c61af4b4"
@@ -74,37 +74,37 @@ THRIFT_MD5SUM="44cf1b54b4ec1890576c85804acfa637"
 
 # protobuf
 # brpc is not yet compatible with protobuf >= 22
-PROTOBUF_DOWNLOAD="https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protobuf-all-21.11.tar.gz"
+PROTOBUF_DOWNLOAD="https://ghproxy.net/https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protobuf-all-21.11.tar.gz"
 PROTOBUF_NAME="protobuf-all-21.11.tar.gz"
 PROTOBUF_SOURCE=protobuf-21.11
 PROTOBUF_MD5SUM="b3b104f0374802e1add5d5d7a5a845ac"
 
 # gflags
-GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"
+GFLAGS_DOWNLOAD="https://ghproxy.net/https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"
 GFLAGS_NAME=gflags-2.2.2.tar.gz
 GFLAGS_SOURCE=gflags-2.2.2
 GFLAGS_MD5SUM="1a865b93bacfa963201af3f75b7bd64c"
 
 # glog
-GLOG_DOWNLOAD="https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"
+GLOG_DOWNLOAD="https://ghproxy.net/https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"
 GLOG_NAME="glog-v0.6.0.tar.gz"
 GLOG_SOURCE=glog-0.6.0
 GLOG_MD5SUM="c98a6068bc9b8ad9cebaca625ca73aa2"
 
 # gtest
-GTEST_DOWNLOAD="https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
+GTEST_DOWNLOAD="https://ghproxy.net/https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
 GTEST_NAME=googletest-release-1.11.0.tar.gz
 GTEST_SOURCE=googletest-release-1.11.0
 GTEST_MD5SUM="e8a8df240b6938bb6384155d4c37d937"
 
 # snappy
-SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.8.tar.gz"
+SNAPPY_DOWNLOAD="https://ghproxy.net/https://github.com/google/snappy/archive/1.1.8.tar.gz"
 SNAPPY_NAME=snappy-1.1.8.tar.gz
 SNAPPY_SOURCE=snappy-1.1.8
 SNAPPY_MD5SUM="70e48cba7fecf289153d009791c9977f"
 
 # gperftools
-GPERFTOOLS_DOWNLOAD="https://github.com/gperftools/gperftools/releases/download/gperftools-2.10/gperftools-2.10.tar.gz"
+GPERFTOOLS_DOWNLOAD="https://ghproxy.net/https://github.com/gperftools/gperftools/releases/download/gperftools-2.10/gperftools-2.10.tar.gz"
 GPERFTOOLS_NAME=gperftools-2.10.tar.gz
 GPERFTOOLS_SOURCE=gperftools-2.10
 GPERFTOOLS_MD5SUM="62bf6c76ba855ed580de5e139bd2a483"
@@ -116,25 +116,25 @@ ZLIB_SOURCE=zlib-1.2.11
 ZLIB_MD5SUM="1c9f62f0778697a09d36121ead88e08e"
 
 # lz4
-LZ4_DOWNLOAD="https://github.com/lz4/lz4/archive/v1.9.4.tar.gz"
+LZ4_DOWNLOAD="https://ghproxy.net/https://github.com/lz4/lz4/archive/v1.9.4.tar.gz"
 LZ4_NAME=lz4-1.9.4.tar.gz
 LZ4_SOURCE=lz4-1.9.4
 LZ4_MD5SUM="e9286adb64040071c5e23498bf753261"
 
 # bzip
-BZIP_DOWNLOAD="https://fossies.org/linux/misc/bzip2-1.0.8.tar.gz"
+BZIP_DOWNLOAD="https://ghproxy.net/https://fossies.org/linux/misc/bzip2-1.0.8.tar.gz"
 BZIP_NAME=bzip2-1.0.8.tar.gz
 BZIP_SOURCE=bzip2-1.0.8
 BZIP_MD5SUM="67e051268d0c475ea773822f7500d0e5"
 
 # lzo2
-LZO2_DOWNLOAD="https://fossies.org/linux/misc/lzo-2.10.tar.gz"
+LZO2_DOWNLOAD="https://ghproxy.net/https://fossies.org/linux/misc/lzo-2.10.tar.gz"
 LZO2_NAME=lzo-2.10.tar.gz
 LZO2_SOURCE=lzo-2.10
 LZO2_MD5SUM="39d3f3f9c55c87b1e5d6888e1420f4b5"
 
 # rapidjson
-RAPIDJSON_DOWNLOAD="https://github.com/Tencent/rapidjson/archive/1a803826f1197b5e30703afe4b9c0e7dd48074f5.zip"
+RAPIDJSON_DOWNLOAD="https://ghproxy.net/https://github.com/Tencent/rapidjson/archive/1a803826f1197b5e30703afe4b9c0e7dd48074f5.zip"
 RAPIDJSON_NAME=rapidjson-1a803826f1197b5e30703afe4b9c0e7dd48074f5.zip
 RAPIDJSON_SOURCE=rapidjson-1a803826f1197b5e30703afe4b9c0e7dd48074f5
 RAPIDJSON_MD5SUM="f2212a77e055a15501477f1e390007ea"
@@ -146,13 +146,13 @@ CURL_SOURCE=curl-8.2.1
 CURL_MD5SUM="b25588a43556068be05e1624e0e74d41"
 
 # RE2
-RE2_DOWNLOAD="https://github.com/google/re2/archive/2021-02-02.tar.gz"
+RE2_DOWNLOAD="https://ghproxy.net/https://github.com/google/re2/archive/2021-02-02.tar.gz"
 RE2_NAME=re2-2021-02-02.tar.gz
 RE2_SOURCE=re2-2021-02-02
 RE2_MD5SUM="48bc665463a86f68243c5af1bac75cd0"
 
 # hyperscan
-HYPERSCAN_DOWNLOAD="https://github.com/intel/hyperscan/archive/refs/tags/v5.4.2.tar.gz"
+HYPERSCAN_DOWNLOAD="https://ghproxy.net/https://github.com/intel/hyperscan/archive/refs/tags/v5.4.2.tar.gz"
 HYPERSCAN_NAME=hyperscan-5.4.2.tar.gz
 HYPERSCAN_SOURCE=hyperscan-5.4.2
 HYPERSCAN_MD5SUM="202f4b42f5dd4a7bb2506445e51a33b9"
@@ -161,7 +161,7 @@ HYPERSCAN_MD5SUM="202f4b42f5dd4a7bb2506445e51a33b9"
 MACHINE_TYPE=$(uname -m)
 if [[ "${MACHINE_TYPE}" == "aarch64" || "${MACHINE_TYPE}" == 'arm64' ]]; then
     echo "use vectorscan instead of hyperscan on aarch64"
-    HYPERSCAN_DOWNLOAD="https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.11.tar.gz"
+    HYPERSCAN_DOWNLOAD="https://ghproxy.net/https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.11.tar.gz"
     HYPERSCAN_NAME=vectorscan-5.4.11.tar.gz
     HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.11
     HYPERSCAN_MD5SUM="e67b70403cba6c1654a9fef4fd15a2f2"
@@ -180,7 +180,7 @@ BOOST_SOURCE=boost_1_81_0
 BOOST_MD5SUM="4bf02e84afb56dfdccd1e6aec9911f4b"
 
 # mysql
-MYSQL_DOWNLOAD="https://github.com/mysql/mysql-server/archive/mysql-5.7.18.tar.gz"
+MYSQL_DOWNLOAD="https://ghproxy.net/https://github.com/mysql/mysql-server/archive/mysql-5.7.18.tar.gz"
 MYSQL_NAME=mysql-5.7.18.tar.gz
 MYSQL_SOURCE=mysql-server-mysql-5.7.18
 MYSQL_MD5SUM="58598b10dce180e4d1fbdd7cf5fa68d6"
@@ -192,104 +192,104 @@ ODBC_SOURCE=unixODBC-2.3.7
 ODBC_MD5SUM="274a711b0c77394e052db6493840c6f9"
 
 # leveldb
-LEVELDB_DOWNLOAD="https://github.com/google/leveldb/archive/refs/tags/1.23.tar.gz"
+LEVELDB_DOWNLOAD="https://ghproxy.net/https://github.com/google/leveldb/archive/refs/tags/1.23.tar.gz"
 LEVELDB_NAME=leveldb-1.23.tar.gz
 LEVELDB_SOURCE=leveldb-1.23
 LEVELDB_MD5SUM="afbde776fb8760312009963f09a586c7"
 
 # brpc
-BRPC_DOWNLOAD="https://github.com/apache/brpc/archive/refs/tags/1.4.0.tar.gz"
+BRPC_DOWNLOAD="https://ghproxy.net/https://github.com/apache/brpc/archive/refs/tags/1.4.0.tar.gz"
 BRPC_NAME="brpc-1.4.0.tar.gz"
 BRPC_SOURCE="brpc-1.4.0"
 BRPC_MD5SUM="6af9d50822c33a3abc56a1ec0af0e0bc"
 
 # rocksdb
-ROCKSDB_DOWNLOAD="https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz"
+ROCKSDB_DOWNLOAD="https://ghproxy.net/https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz"
 ROCKSDB_NAME=rocksdb-5.14.2.tar.gz
 ROCKSDB_SOURCE=rocksdb-5.14.2
 ROCKSDB_MD5SUM="b72720ea3b1e9ca9e4ed0febfef65b14"
 
 # cyrus-sasl
-CYRUS_SASL_DOWNLOAD="https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz"
+CYRUS_SASL_DOWNLOAD="https://ghproxy.net/https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz"
 CYRUS_SASL_NAME=cyrus-sasl-2.1.27.tar.gz
 CYRUS_SASL_SOURCE=cyrus-sasl-2.1.27
 CYRUS_SASL_MD5SUM="a33820c66e0622222c5aefafa1581083"
 
 # librdkafka-1.9.2
-LIBRDKAFKA_DOWNLOAD="https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz"
+LIBRDKAFKA_DOWNLOAD="https://ghproxy.net/https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz"
 LIBRDKAFKA_NAME=librdkafka-1.9.2.tar.gz
 LIBRDKAFKA_SOURCE=librdkafka-1.9.2
 LIBRDKAFKA_MD5SUM="fe9624e905abbf8324b0f6be520d9c24"
 
 # zstd
-ZSTD_DOWNLOAD="https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"
+ZSTD_DOWNLOAD="https://ghproxy.net/https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"
 ZSTD_NAME=zstd-1.5.5.tar.gz
 ZSTD_SOURCE=zstd-1.5.5
 ZSTD_MD5SUM="63251602329a106220e0a5ad26ba656f"
 
 # brotli
-BROTLI_DOWNLOAD="https://github.com/google/brotli/archive/v1.0.9.tar.gz"
+BROTLI_DOWNLOAD="https://ghproxy.net/https://github.com/google/brotli/archive/v1.0.9.tar.gz"
 BROTLI_NAME="brotli-1.0.9.tar.gz"
 BROTLI_SOURCE="brotli-1.0.9"
 BROTLI_MD5SUM="c2274f0c7af8470ad514637c35bcee7d"
 
 # flatbuffers
-FLATBUFFERS_DOWNLOAD="https://github.com/google/flatbuffers/archive/v2.0.0.tar.gz"
+FLATBUFFERS_DOWNLOAD="https://ghproxy.net/https://github.com/google/flatbuffers/archive/v2.0.0.tar.gz"
 FLATBUFFERS_NAME=flatbuffers-2.0.0.tar.gz
 FLATBUFFERS_SOURCE=flatbuffers-2.0.0
 FLATBUFFERS_MD5SUM="a27992324c3cbf86dd888268a23d17bd"
 
 # c-ares
-CARES_DOWNLOAD="https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"
+CARES_DOWNLOAD="https://ghproxy.net/https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"
 CARES_NAME="c-ares-1.19.1.tar.gz"
 CARES_SOURCE=c-ares-1.19.1
 CARES_MD5SUM="dafc5825a92dc907e144570e4e75a908"
 
 # grpc
 # grpc v1.55 and above require protobuf >= 22
-GRPC_DOWNLOAD="https://github.com/grpc/grpc/archive/refs/tags/v1.54.3.tar.gz"
+GRPC_DOWNLOAD="https://ghproxy.net/https://github.com/grpc/grpc/archive/refs/tags/v1.54.3.tar.gz"
 GRPC_NAME="grpc-v1.54.3.tar.gz"
 GRPC_SOURCE=grpc-1.54.3
 GRPC_MD5SUM="af00a2edeae0f02bb25917cc3473b7de"
 
 # arrow
-ARROW_DOWNLOAD="https://github.com/apache/arrow/archive/refs/tags/apache-arrow-17.0.0.tar.gz"
+ARROW_DOWNLOAD="https://ghproxy.net/https://github.com/apache/arrow/archive/refs/tags/apache-arrow-17.0.0.tar.gz"
 ARROW_NAME="apache-arrow-17.0.0.tar.gz"
 ARROW_SOURCE="arrow-apache-arrow-17.0.0"
 ARROW_MD5SUM="ba18bf83e2164abd34b9ac4cb164f0f0"
 
 # Abseil
-ABSEIL_DOWNLOAD="https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz"
+ABSEIL_DOWNLOAD="https://ghproxy.net/https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz"
 ABSEIL_NAME="abseil-cpp-20230125.3.tar.gz"
 ABSEIL_SOURCE=abseil-cpp-20230125.3
 ABSEIL_MD5SUM="9b6dae642c4bd92f007ab2c148bc0498"
 
 # S2
-S2_DOWNLOAD="https://github.com/google/s2geometry/archive/refs/tags/v0.10.0.tar.gz"
+S2_DOWNLOAD="https://ghproxy.net/https://github.com/google/s2geometry/archive/refs/tags/v0.10.0.tar.gz"
 S2_NAME=s2geometry-0.10.0.tar.gz
 S2_SOURCE=s2geometry-0.10.0
 S2_MD5SUM="c68f3c5d326dde9255681b9201393a9f"
 
 # bitshuffle
-BITSHUFFLE_DOWNLOAD="https://github.com/kiyo-masui/bitshuffle/archive/0.5.1.tar.gz"
+BITSHUFFLE_DOWNLOAD="https://ghproxy.net/https://github.com/kiyo-masui/bitshuffle/archive/0.5.1.tar.gz"
 BITSHUFFLE_NAME=bitshuffle-0.5.1.tar.gz
 BITSHUFFLE_SOURCE=bitshuffle-0.5.1
 BITSHUFFLE_MD5SUM="b3bf6a9838927f7eb62214981c138e2f"
 
 # croaringbitmap
-CROARINGBITMAP_DOWNLOAD="https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v2.1.2.tar.gz"
+CROARINGBITMAP_DOWNLOAD="https://ghproxy.net/https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v2.1.2.tar.gz"
 CROARINGBITMAP_NAME=CRoaring-2.1.2.tar.gz
 CROARINGBITMAP_SOURCE=CRoaring-2.1.2
 CROARINGBITMAP_MD5SUM="419bfbafdf93e9a7e6cdc234454908fc"
 
 # fmt
-FMT_DOWNLOAD="https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz"
+FMT_DOWNLOAD="https://ghproxy.net/https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz"
 FMT_NAME="fmt-7.1.3.tar.gz"
 FMT_SOURCE="fmt-7.1.3"
 FMT_MD5SUM="2522ec65070c0bda0ca288677ded2831"
 
 # parallel-hashmap
-PARALLEL_HASHMAP_DOWNLOAD="https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v1.3.8.tar.gz"
+PARALLEL_HASHMAP_DOWNLOAD="https://ghproxy.net/https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v1.3.8.tar.gz"
 PARALLEL_HASHMAP_NAME="parallel-hashmap-1.3.8.tar.gz"
 PARALLEL_HASHMAP_SOURCE="parallel-hashmap-1.3.8"
 PARALLEL_HASHMAP_MD5SUM="1b8130d0b4f656257ef654699bfbf941"
@@ -301,25 +301,25 @@ ORC_SOURCE=orc-1.9.0
 ORC_MD5SUM="5dc1c91c4867e4519aab531ffc30fab7"
 
 # jemalloc for arrow
-JEMALLOC_ARROW_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+JEMALLOC_ARROW_DOWNLOAD="https://ghproxy.net/https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
 JEMALLOC_ARROW_NAME="jemalloc-5.3.0.tar.bz2"
 JEMALLOC_ARROW_SOURCE="jemalloc-5.3.0"
 JEMALLOC_ARROW_MD5SUM="09a8328574dab22a7df848eae6dbbf53"
 
 # jemalloc for doris
-JEMALLOC_DORIS_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+JEMALLOC_DORIS_DOWNLOAD="https://ghproxy.net/https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
 JEMALLOC_DORIS_NAME="jemalloc-5.3.0.tar.bz2"
 JEMALLOC_DORIS_SOURCE="jemalloc-5.3.0"
 JEMALLOC_DORIS_MD5SUM="09a8328574dab22a7df848eae6dbbf53"
 
 # libunwind
-LIBUNWIND_DOWNLOAD="https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz"
+LIBUNWIND_DOWNLOAD="https://ghproxy.net/https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz"
 LIBUNWIND_NAME="libunwind-1.6.2.tar.gz"
 LIBUNWIND_SOURCE="libunwind-1.6.2"
 LIBUNWIND_MD5SUM="f625b6a98ac1976116c71708a73dc44a"
 
 # cctz
-CCTZ_DOWNLOAD="https://github.com/google/cctz/archive/v2.3.tar.gz"
+CCTZ_DOWNLOAD="https://ghproxy.net/https://github.com/google/cctz/archive/v2.3.tar.gz"
 CCTZ_NAME="cctz-2.3.tar.gz"
 CCTZ_SOURCE="cctz-2.3"
 CCTZ_MD5SUM="209348e50b24dbbdec6d961059c2fc92"
@@ -328,7 +328,7 @@ CCTZ_MD5SUM="209348e50b24dbbdec6d961059c2fc92"
 # The origin download url is always changing: https://datatables.net/download/builder?bs-3.3.7/jq-3.3.1/dt-1.10.25
 # So we put it in our own http server.
 # If someone can offer an official url for DataTables, please update this.
-DATATABLES_DOWNLOAD="https://github.com/apache/doris-thirdparty/releases/download/datatables-1.12.1/DataTables.zip"
+DATATABLES_DOWNLOAD="https://ghproxy.net/https://github.com/apache/doris-thirdparty/releases/download/datatables-1.12.1/DataTables.zip"
 DATATABLES_NAME="DataTables.zip"
 DATATABLES_SOURCE="DataTables-1.12.1"
 DATATABLES_MD5SUM="a3dd92a2a8b7254443e102a43036d743"
@@ -346,7 +346,7 @@ BOOTSTRAP_TABLE_CSS_FILE="bootstrap-table.min.css"
 BOOTSTRAP_TABLE_CSS_MD5SUM="23389d4456da412e36bae30c469a766a"
 
 # aws sdk
-AWS_SDK_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.119.tar.gz"
+AWS_SDK_DOWNLOAD="https://ghproxy.net/https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.119.tar.gz"
 AWS_SDK_NAME="aws-sdk-cpp-1.11.119.tar.gz"
 AWS_SDK_SOURCE="aws-sdk-cpp-1.11.119"
 AWS_SDK_MD5SUM="3cd8bd51d39dc207a243a2074d11f439"
@@ -358,7 +358,7 @@ TSAN_HEADER_FILE="tsan_interface_atomic.h"
 TSAN_HEADER_MD5SUM="d72679bea167d6a513d959f5abd149dc"
 
 # lzma
-LZMA_DOWNLOAD="https://github.com/kobolabs/liblzma/archive/refs/heads/master.zip"
+LZMA_DOWNLOAD="https://ghproxy.net/https://github.com/kobolabs/liblzma/archive/refs/heads/master.zip"
 LZMA_NAME="liblzma-master.zip"
 LZMA_SOURCE="liblzma-master"
 LZMA_MD5SUM="ef11f2fbbfa6893b629f207a32bf730e"
@@ -388,13 +388,13 @@ KRB5_SOURCE="krb5-1.19"
 KRB5_MD5SUM="aaf18447a5a014aa3b7e81814923f4c9"
 
 # hdfs3
-HDFS3_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libhdfs3-v2.3.9.tar.gz"
+HDFS3_DOWNLOAD="https://ghproxy.net/https://github.com/apache/doris-thirdparty/archive/refs/tags/libhdfs3-v2.3.9.tar.gz"
 HDFS3_NAME="doris-thirdparty-libhdfs3-v2.3.9.tar.gz"
 HDFS3_SOURCE="doris-thirdparty-libhdfs3-v2.3.9"
 HDFS3_MD5SUM="b3eaa03e5b184521e5ad5bf6cabea97e"
 
 #libdivide
-LIBDIVIDE_DOWNLOAD="https://github.com/ridiculousfish/libdivide/archive/refs/tags/v5.2.0.tar.gz"
+LIBDIVIDE_DOWNLOAD="https://ghproxy.net/https://github.com/ridiculousfish/libdivide/archive/refs/tags/v5.2.0.tar.gz"
 LIBDIVIDE_NAME="libdivide-5.2.0.tar.gz"
 LIBDIVIDE_SOURCE="libdivide-5.2.0"
 LIBDIVIDE_MD5SUM="4ba77777192c295d6de2b86d88f3239a"
@@ -406,26 +406,26 @@ PDQSORT_FILE="pdqsort.h"
 PDQSORT_MD5SUM="af28f79d5d7d7a5486f54d9f1244c2b5"
 
 # benchmark
-BENCHMARK_DOWNLOAD="https://github.com/google/benchmark/archive/refs/tags/v1.8.0.tar.gz"
+BENCHMARK_DOWNLOAD="https://ghproxy.net/https://github.com/google/benchmark/archive/refs/tags/v1.8.0.tar.gz"
 BENCHMARK_NAME=benchmark-v1.8.0.tar.gz
 BENCHMARK_SOURCE=benchmark-1.8.0
 BENCHMARK_MD5SUM="8ddf8571d3f6198d37852bcbd964f817"
 
 # xsimd
 # for arrow-17.0.0, if arrow upgrade, this version may also need to be changed
-XSIMD_DOWNLOAD="https://github.com/xtensor-stack/xsimd/archive/refs/tags/13.0.0.tar.gz"
+XSIMD_DOWNLOAD="https://ghproxy.net/https://github.com/xtensor-stack/xsimd/archive/refs/tags/13.0.0.tar.gz"
 XSIMD_NAME="13.0.0.tar.gz"
 XSIMD_SOURCE=xsimd-13.0.0
 XSIMD_MD5SUM="c661deb91836e82d3070f81032014fe6"
 
 # simdjson
-SIMDJSON_DOWNLOAD="https://github.com/simdjson/simdjson/archive/refs/tags/v3.0.1.tar.gz"
+SIMDJSON_DOWNLOAD="https://ghproxy.net/https://github.com/simdjson/simdjson/archive/refs/tags/v3.0.1.tar.gz"
 SIMDJSON_NAME=simdjson-3.0.1.tar.gz
 SIMDJSON_SOURCE=simdjson-3.0.1
 SIMDJSON_MD5SUM="993576b47249f2bade2bfb2552b2896a"
 
 # nlohmann_json
-NLOHMANN_JSON_DOWNLOAD="https://github.com/nlohmann/json/archive/refs/tags/v3.10.1.tar.gz"
+NLOHMANN_JSON_DOWNLOAD="https://ghproxy.net/https://github.com/nlohmann/json/archive/refs/tags/v3.10.1.tar.gz"
 NLOHMANN_JSON_NAME=json-3.10.1.tar.gz
 NLOHMANN_JSON_SOURCE=json-3.10.1
 NLOHMANN_JSON_MD5SUM="7b369d567afc0dffdcf5800fd9abb836"
@@ -437,55 +437,55 @@ LIBBACKTRACE_SOURCE=libbacktrace-2446c66076480ce07a6bd868badcbceb3eeecc2e
 LIBBACKTRACE_MD5SUM="6c79a8012870a24610c0d9c3621b23fe"
 
 # sse2noen
-SSE2NEON_DOWNLOAD="https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.6.0.tar.gz"
+SSE2NEON_DOWNLOAD="https://ghproxy.net/https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.6.0.tar.gz"
 SSE2NEON_NAME=sse2neon-1.6.0.tar.gz
 SSE2NEON_SOURCE=sse2neon-1.6.0
 SSE2NEON_MD5SUM="dce28eb6a78f45bf98740d5fad73febb"
 
 # xxhash
-XXHASH_DOWNLOAD="https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.1.tar.gz"
+XXHASH_DOWNLOAD="https://ghproxy.net/https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.1.tar.gz"
 XXHASH_NAME=xxHash-0.8.1.tar.gz
 XXHASH_SOURCE=xxHash-0.8.1
 XXHASH_MD5SUM="b67c587f5ff4894253da0095ba7ea393"
 
 # concurrentqueue
-CONCURRENTQUEUE_DOWNLOAD="https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz"
+CONCURRENTQUEUE_DOWNLOAD="https://ghproxy.net/https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz"
 CONCURRENTQUEUE_NAME=concurrentqueue-1.0.3.tar.gz
 CONCURRENTQUEUE_SOURCE=concurrentqueue-1.0.3
 CONCURRENTQUEUE_MD5SUM="118e5bb661b567634647312991e10222"
 
 # fast_float
-FAST_FLOAT_DOWNLOAD="https://github.com/fastfloat/fast_float/archive/refs/tags/v3.9.0.tar.gz"
+FAST_FLOAT_DOWNLOAD="https://ghproxy.net/https://github.com/fastfloat/fast_float/archive/refs/tags/v3.9.0.tar.gz"
 FAST_FLOAT_NAME=fast_float-3.9.0.tar.gz
 FAST_FLOAT_SOURCE=fast_float-3.9.0
 FAST_FLOAT_MD5SUM="5656b0d8b150a3b157cfb092d214f6ea"
 
 # libhdfs
-HADOOP_LIBS_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/hadoop-3.3.6.6-for-doris.tar.gz"
+HADOOP_LIBS_DOWNLOAD="https://ghproxy.net/https://github.com/apache/doris-thirdparty/archive/refs/tags/hadoop-3.3.6.6-for-doris.tar.gz"
 HADOOP_LIBS_NAME="hadoop-3.3.6.6-for-doris.tar.gz"
 HADOOP_LIBS_SOURCE="doris-thirdparty-hadoop-3.3.6.6-for-doris"
 HADOOP_LIBS_MD5SUM="13b66d5f2abffd1740e692b65df5962e"
 
 # AvxToNeon
-AVX2NEON_DOWNLOAD="https://github.com/kunpengcompute/AvxToNeon/archive/refs/tags/v1.0.0.tar.gz"
+AVX2NEON_DOWNLOAD="https://ghproxy.net/https://github.com/kunpengcompute/AvxToNeon/archive/refs/tags/v1.0.0.tar.gz"
 AVX2NEON_NAME=v1.0.0.tar.gz
 AVX2NEON_SOURCE=AvxToNeon-1.0.0
 AVX2NEON_MD5SUM="692d0e0f8b885a86ebc5172a9d8ee8db"
 
 # libdeflate
-LIBDEFLATE_DOWNLOAD="https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.19.tar.gz"
+LIBDEFLATE_DOWNLOAD="https://ghproxy.net/https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.19.tar.gz"
 LIBDEFLATE_NAME=libdeflate-1.19.tar.gz
 LIBDEFLATE_SOURCE=libdeflate-1.19
 LIBDEFLATE_MD5SUM="c69e9193d2975a729068ffa862c81fb6"
 
 # streamvbyte
-STREAMVBYTE_DOWNLOAD="https://github.com/lemire/streamvbyte/archive/refs/tags/v1.0.0.tar.gz"
+STREAMVBYTE_DOWNLOAD="https://ghproxy.net/https://github.com/lemire/streamvbyte/archive/refs/tags/v1.0.0.tar.gz"
 STREAMVBYTE_NAME=streamvbyte-1.0.0.tar.gz
 STREAMVBYTE_SOURCE=streamvbyte-1.0.0
 STREAMVBYTE_MD5SUM="f334219db5a832b6dae3589a56a29563"
 
 # jsoncpp
-JSONCPP_DOWNLOAD="https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz"
+JSONCPP_DOWNLOAD="https://ghproxy.net/https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz"
 JSONCPP_NAME="1.9.5.tar.gz"
 JSONCPP_SOURCE="jsoncpp-1.9.5"
 JSONCPP_MD5SUM="d6c8c609f2162eff373db62b90a051c7"
@@ -497,55 +497,55 @@ LIBUUID_SOURCE="libuuid-1.0.3"
 LIBUUID_MD5SUM="d44d866d06286c08ba0846aba1086d68"
 
 # ali
-ALI_SDK_DOWNLOAD="https://github.com/aliyun/aliyun-openapi-cpp-sdk/archive/refs/tags/1.36.1586.tar.gz"
+ALI_SDK_DOWNLOAD="https://ghproxy.net/https://github.com/aliyun/aliyun-openapi-cpp-sdk/archive/refs/tags/1.36.1586.tar.gz"
 ALI_SDK_NAME="1.36.1586.tar.gz"
 ALI_SDK_SOURCE="aliyun-openapi-cpp-sdk-1.36.1586"
 ALI_SDK_MD5SUM="14623ee8e87c89615477d9bf8cb30bea"
 
 # base64
-BASE64_DOWNLOAD="https://github.com/aklomp/base64/archive/refs/tags/v0.5.2.tar.gz"
+BASE64_DOWNLOAD="https://ghproxy.net/https://github.com/aklomp/base64/archive/refs/tags/v0.5.2.tar.gz"
 BASE64_NAME="v0.5.2.tar.gz"
 BASE64_SOURCE="base64-0.5.2"
 BASE64_MD5SUM="49e5a6c98bd0192aedd16c16eec39974"
 
 # azure blob
-AZURE_DOWNLOAD="https://github.com/Azure/azure-sdk-for-cpp/archive/azure-core_1.10.3.tar.gz"
+AZURE_DOWNLOAD="https://ghproxy.net/https://github.com/Azure/azure-sdk-for-cpp/archive/azure-core_1.10.3.tar.gz"
 AZURE_NAME="azure-core_1.10.3.tar.gz"
 AZURE_SOURCE="azure-sdk-for-cpp-azure-core_1.10.3"
 AZURE_MD5SUM="aa470cfdba93dd69a6f3112a6958c13c"
 
 # libdragonbox for faster double/float to string
-DRAGONBOX_DOWNLOAD="https://github.com/jk-jeon/dragonbox/archive/refs/tags/1.1.3.tar.gz"
+DRAGONBOX_DOWNLOAD="https://ghproxy.net/https://github.com/jk-jeon/dragonbox/archive/refs/tags/1.1.3.tar.gz"
 DRAGONBOX_NAME=dragonbox-1.1.3.tar.gz
 DRAGONBOX_SOURCE=dragonbox-1.1.3
 DRAGONBOX_MD5SUM="889dc00db9612c6949a4ccf8115e0e6a"
 
 # icu
-ICU_DOWNLOAD="https://github.com/unicode-org/icu/archive/refs/tags/release-69-1.tar.gz"
+ICU_DOWNLOAD="https://ghproxy.net/https://github.com/unicode-org/icu/archive/refs/tags/release-69-1.tar.gz"
 ICU_NAME=release-69-1.tar.gz
 ICU_SOURCE=icu-release-69-1
 ICU_MD5SUM="135125f633864285d637db5c01e0388b"
 
 # jindofs
-JINDOFS_DOWNLOAD="https://github.com/apache/doris-thirdparty/releases/download/alibabacloud-jindodata-releases/jindofs-6.8.2-libs-0.1.tar.gz"
+JINDOFS_DOWNLOAD="https://ghproxy.net/https://github.com/apache/doris-thirdparty/releases/download/alibabacloud-jindodata-releases/jindofs-6.8.2-libs-0.1.tar.gz"
 JINDOFS_NAME=jindofs-6.8.2-libs-0.1.tar.gz
 JINDOFS_SOURCE=jindofs-6.8.2-libs-0.1
 JINDOFS_MD5SUM="0e5b0f71e636b8ed3f09e0bf16208fd1"
 
 # pugixml
-PUGIXML_DOWNLOAD="https://github.com/zeux/pugixml/releases/download/v1.15/pugixml-1.15.tar.gz"
+PUGIXML_DOWNLOAD="https://ghproxy.net/https://github.com/zeux/pugixml/releases/download/v1.15/pugixml-1.15.tar.gz"
 PUGIXML_NAME=pugixml-1.15.tar.gz
 PUGIXML_SOURCE=pugixml-1.15
 PUGIXML_MD5SUM="3b894c29455eb33a40b165c6e2de5895"
 
 # openblas
-OPENBLAS_DOWNLOAD="https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz"
+OPENBLAS_DOWNLOAD="https://ghproxy.net/https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz"
 OPENBLAS_NAME="OpenBLAS-0.3.29.tar.gz"
 OPENBLAS_SOURCE="OpenBLAS-0.3.29"
 OPENBLAS_MD5SUM="853a0c5c0747c5943e7ef4bbb793162d"
 
 # faiss
-FAISS_DOWNLOAD="https://github.com/facebookresearch/faiss/archive/refs/tags/v1.10.0.tar.gz"
+FAISS_DOWNLOAD="https://ghproxy.net/https://github.com/facebookresearch/faiss/archive/refs/tags/v1.10.0.tar.gz"
 FAISS_NAME="faiss-1.10.0.tar.gz"
 FAISS_SOURCE="faiss-1.10.0"
 FAISS_MD5SUM="f31edf2492808b27cc963d0ab316a205"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: This PR implements `human_readable_seconds` from the doris-future task list
(https://github.com/apache/doris/issues/#48203)

Problem Summary:

Add `human_readable_seconds` function for Trino compatibility.
Converts a double value of seconds into a human-readable string
containing weeks, days, hours, minutes, and seconds.

Example:
- human_readable_seconds(96) → "1 minute, 36 seconds"
- human_readable_seconds(3762) → "1 hour, 2 minutes, 42 seconds"
- human_readable_seconds(56363463) → "93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds"

### Release note

Add `human_readable_seconds` scalar function (Trino compatible).

### Check List (For Author)

- Test
    - [ ] Regression test        (to be added)
    - [x] Unit Test              (BE unit test passed: 9/9)
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [ ] No.
    - [x] Yes. (Documentation PR to be added)
