### PR TITLE
[fix](be) Check block column and type pointers

### DIFF
--- a/be/src/core/block/block.cpp
+++ b/be/src/core/block/block.cpp
@@ -343,6 +343,21 @@ Status Block::check_type_and_column() const {
     return Status::OK();
 }
 
+Status Block::check_column_and_type_not_null() const {
+    for (size_t i = 0; i != data.size(); ++i) {
+        const auto& elem = data[i];
+        if (!elem.column) {
+            return Status::InternalError("Column in block is nullptr, column index: {}, name: {}",
+                                         i, elem.name);
+        }
+        if (!elem.type) {
+            return Status::InternalError("Type in block is nullptr, column index: {}, name: {}", i,
+                                         elem.name);
+        }
+    }
+    return Status::OK();
+}
+
 size_t Block::rows() const {
     for (const auto& elem : data) {
         if (elem.column) {

--- a/be/src/core/block/block.h
+++ b/be/src/core/block/block.h
@@ -183,6 +183,8 @@ public:
 
     Status check_type_and_column() const;
 
+    Status check_column_and_type_not_null() const;
+
     /// Approximate number of bytes used by column data in memory.
     /// This reflects the actual data footprint (e.g. string contents, numeric arrays)
     /// and is the metric used by adaptive batch size byte budgets.

--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -616,6 +616,7 @@ public:
     }
 
     [[nodiscard]] Status sink(RuntimeState* state, Block* block, bool eos) {
+        RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_type_and_column());
         return sink_impl(state, block, eos);
     }
@@ -877,6 +878,7 @@ public:
     Status terminate(RuntimeState* state) override;
     [[nodiscard]] Status get_block(RuntimeState* state, Block* block, bool* eos) {
         RETURN_IF_ERROR(get_block_impl(state, block, eos));
+        RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_type_and_column());
         return Status::OK();
     }

--- a/be/test/core/data_type/block_check_type.cpp
+++ b/be/test/core/data_type/block_check_type.cpp
@@ -39,4 +39,22 @@ TEST(BlockCheckType, test1) {
     EXPECT_FALSE(st.ok());
     std::cout << st.msg() << std::endl;
 }
+
+TEST(BlockCheckType, CheckColumnAndTypeNotNull) {
+    auto block = Block {
+            ColumnHelper::create_column_with_name<DataTypeInt32>({1, 2, 3, 4}),
+            ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3, 4}),
+    };
+
+    EXPECT_TRUE(block.check_column_and_type_not_null());
+
+    block.get_by_position(0).column = nullptr;
+    auto st = block.check_column_and_type_not_null();
+    EXPECT_FALSE(st.ok());
+
+    block.get_by_position(0).column = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3, 4});
+    block.get_by_position(1).type = nullptr;
+    st = block.check_column_and_type_not_null();
+    EXPECT_FALSE(st.ok());
+}
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?


Add an explicit block check to reject null column or type pointers at operator sink/get_block boundaries, while keeping the existing type compatibility check unchanged.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

