### PR TITLE
[fix](regression) Increase variant export load timeout

### DIFF
--- a/regression-test/suites/export_p2/test_export_variant_10k_columns.groovy
+++ b/regression-test/suites/export_p2/test_export_variant_10k_columns.groovy
@@ -17,6 +17,7 @@
 
 import java.io.File
 import org.awaitility.Awaitility
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 suite("test_export_variant_10k_columns", "p0") {
@@ -189,10 +190,11 @@ suite("test_export_variant_10k_columns", "p0") {
             );
         """
         
-        Awaitility.await().atMost(240, SECONDS).pollInterval(5, SECONDS).until({
+        Awaitility.await().atMost(20, MINUTES).pollInterval(5, SECONDS).until({
             def loadResult = sql """
            show load where label = '${load_label}'
            """
+            logger.info("load state: " + loadResult.get(0).get(2))
             if (loadResult.get(0).get(2) == 'CANCELLED' || loadResult.get(0).get(2) == 'FAILED') {
                 println("load failed: " + loadResult.get(0))
                 throw new RuntimeException("load failed"+ loadResult.get(0))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The variant 10k export regression can spend more than four minutes waiting for the load job to finish in the CloudP0 environment. A failed TeamCity occurrence shows the suite timing out at the 240-second Awaitility wait while the load job is still running. Increase the load wait timeout to 20 minutes and log the current load state while polling so future timeout failures preserve useful progress evidence.

### Release note

None

### Check List (For Author)

- Test: Not run
    - Not run per request. This change only adjusts the regression case timeout and logging.
- Behavior changed: No
- Does this need documentation: No