### PR TITLE
master: [build](variant) Support SelectDB release extra modules

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -160,12 +160,17 @@ option(ENABLE_TDE "Enable TDE feature module" OFF)
 set(TDE_MODULE_DIR "" CACHE STRING "TDE feature module directory under be/src")
 option(ENABLE_TLS "Enable TLS feature module" OFF)
 set(TLS_MODULE_DIR "" CACHE STRING "TLS feature module directory under be/src")
+option(ENABLE_VARIANT_NESTED_GROUP "Enable Variant NestedGroup feature module" OFF)
+set(VARIANT_NESTED_GROUP_MODULE_DIR "" CACHE STRING "Variant NestedGroup feature module directory under be/src")
 
 if (ENABLE_TDE AND "${TDE_MODULE_DIR}" STREQUAL "")
     message(FATAL_ERROR "ENABLE_TDE requires TDE_MODULE_DIR")
 endif()
 if (ENABLE_TLS AND "${TLS_MODULE_DIR}" STREQUAL "")
     message(FATAL_ERROR "ENABLE_TLS requires TLS_MODULE_DIR")
+endif()
+if (ENABLE_VARIANT_NESTED_GROUP AND "${VARIANT_NESTED_GROUP_MODULE_DIR}" STREQUAL "")
+    message(FATAL_ERROR "ENABLE_VARIANT_NESTED_GROUP requires VARIANT_NESTED_GROUP_MODULE_DIR")
 endif()
 
 # Allow env to override when reconfiguring (avoid picking /usr/local).

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -29,6 +29,14 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS *.cpp)
 # and linked by Storage.
 list(FILTER SRC_FILES EXCLUDE REGEX ".*/storage/index/ann/.*\\.cpp$")
 
+if (ENABLE_VARIANT_NESTED_GROUP)
+    list(REMOVE_ITEM SRC_FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/segment/variant/nested_group_provider.cpp")
+    file(GLOB_RECURSE VARIANT_NESTED_GROUP_SOURCES CONFIGURE_DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/../${VARIANT_NESTED_GROUP_MODULE_DIR}/*.cpp")
+    list(APPEND SRC_FILES ${VARIANT_NESTED_GROUP_SOURCES})
+endif()
+
 add_library(Storage STATIC ${SRC_FILES})
 target_link_libraries(Storage PRIVATE ann_index)
 

--- a/build-for-release-selectdb-cloud.sh
+++ b/build-for-release-selectdb-cloud.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+echo "Begin to build for selectdb cloud with $*"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+export DORIS_HOME="${ROOT}"
+
+. "${DORIS_HOME}/build-support/selectdb-release-common.sh"
+
+usage() {
+    echo "
+Usage: $0 <options> [-- <build.sh options>]
+  Optional options:
+    --vendor <vendor>                  build version prefix, default cloud
+    --disable-tde                      disable TDE feature modules
+    --disable-tls                      disable TLS feature modules
+    --disable-variant-nested-group     disable Variant NestedGroup feature module
+    --disable-snapshot                 disable Snapshot feature modules
+    --help                             print this help message
+
+  Eg.
+    $0 --vendor selectdb
+    $0 --vendor selectdb --disable-tls
+    $0 --vendor selectdb -- --cloud
+"
+}
+
+VENDOR=
+HELP=0
+ENABLE_TDE=1
+ENABLE_TLS=1
+ENABLE_VARIANT_NESTED_GROUP=1
+ENABLE_SNAPSHOT=1
+args_remain=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --vendor)
+        VENDOR="$2"
+        shift 2
+        ;;
+    --help)
+        HELP=1
+        shift
+        ;;
+    --disable-tde)
+        ENABLE_TDE=0
+        shift
+        ;;
+    --disable-tls)
+        ENABLE_TLS=0
+        shift
+        ;;
+    --disable-variant-nested-group)
+        ENABLE_VARIANT_NESTED_GROUP=0
+        shift
+        ;;
+    --disable-snapshot)
+        ENABLE_SNAPSHOT=0
+        shift
+        ;;
+    --)
+        shift
+        args_remain+=("$@")
+        break
+        ;;
+    *)
+        args_remain+=("$1")
+        shift
+        ;;
+    esac
+done
+
+if [[ "${HELP}" -eq 1 ]]; then
+    usage
+    exit 0
+fi
+
+export DISABLE_BUILD_UI="${DISABLE_BUILD_UI:-ON}"
+export ENABLE_HDFS_STORAGE_VAULT="${ENABLE_HDFS_STORAGE_VAULT:-OFF}"
+
+# These env vars are used by gensrc/script/gen_build_version.sh.
+export DORIS_BUILD_VERSION_PREFIX="${VENDOR:-cloud}"
+export DORIS_BUILD_VERSION_MAJOR="${DORIS_BUILD_VERSION_MAJOR:-26}"
+export DORIS_BUILD_VERSION_MINOR="${DORIS_BUILD_VERSION_MINOR:-1}"
+export DORIS_BUILD_VERSION_PATCH="${DORIS_BUILD_VERSION_PATCH:-0}"
+export DORIS_BUILD_VERSION_HOTFIX="${DORIS_BUILD_VERSION_HOTFIX:-0}"
+export DORIS_BUILD_VERSION_RC_VERSION="${DORIS_BUILD_VERSION_RC_VERSION:-}"
+
+selectdb_configure_extra_modules \
+    "${ENABLE_TDE}" \
+    "${ENABLE_TLS}" \
+    "${ENABLE_VARIANT_NESTED_GROUP}" \
+    "${ENABLE_SNAPSHOT}"
+
+echo "Get params:
+    VENDOR                      -- ${VENDOR:-cloud}
+    ENABLE_TDE                  -- ${ENABLE_TDE}
+    ENABLE_TLS                  -- ${ENABLE_TLS}
+    ENABLE_VARIANT_NESTED_GROUP -- ${ENABLE_VARIANT_NESTED_GROUP}
+    ENABLE_SNAPSHOT             -- ${ENABLE_SNAPSHOT}
+    EXTRA_FE_MODULES            -- ${EXTRA_FE_MODULES}
+    EXTRA_BE_MODULES            -- ${EXTRA_BE_MODULES}
+    EXTRA_CLOUD_MODULES         -- ${EXTRA_CLOUD_MODULES}
+    build.sh args               -- ${args_remain[*]}
+"
+
+sh build.sh "${args_remain[@]}"
+selectdb_copy_extra_fe_libs output
+
+if [[ -f output/ms/lib/doris_cloud ]]; then
+    ln -srf output/ms/lib/doris_cloud output/ms/lib/selectdb_cloud
+fi
+if [[ -f "${DORIS_HOME}/cloud/script/custom_start.sh" && -d output/ms/bin ]]; then
+    cp "${DORIS_HOME}/cloud/script/custom_start.sh" output/ms/bin/
+fi
+
+echo "Succeed to build for selectdb cloud with $*"

--- a/build-for-release-selectdb.sh
+++ b/build-for-release-selectdb.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+export DORIS_HOME="${ROOT}"
+
+. "${DORIS_HOME}/build-support/selectdb-release-common.sh"
+
+usage() {
+    echo "
+Usage: $0 --vendor <vendor> --version <version> <options>
+  Optional options:
+     --noavx2                         build without avx2
+     --tar                            pack the output
+     --disable-tde                    disable TDE feature modules
+     --disable-tls                    disable TLS feature modules
+     --disable-variant-nested-group   disable Variant NestedGroup feature module
+     --disable-snapshot               disable Snapshot feature modules
+     --build_only                     build only without packaging
+
+  Eg.
+    $0 --vendor selectdb --version 1.2.0
+    $0 --vendor selectdb --version 1.2.0 --disable-tls
+    $0 --vendor selectdb --build_only --version 1.2.0
+"
+    exit 1
+}
+
+if ! OPTS="$(getopt \
+    -n "$0" \
+    -o '' \
+    -l 'noavx2' \
+    -l 'tar' \
+    -l 'disable-tde' \
+    -l 'disable-tls' \
+    -l 'disable-variant-nested-group' \
+    -l 'disable-snapshot' \
+    -l 'version:' \
+    -l 'vendor:' \
+    -l 'help' \
+    -l 'build_only' \
+    -- "$@")"; then
+    usage
+fi
+
+eval set -- "${OPTS}"
+
+_USE_AVX2=1
+TAR=0
+HELP=0
+VERSION=
+VENDOR=
+BUILD_ONLY=0
+ENABLE_TDE=1
+ENABLE_TLS=1
+ENABLE_VARIANT_NESTED_GROUP=1
+ENABLE_SNAPSHOT=1
+
+while true; do
+    case "$1" in
+    --noavx2)
+        _USE_AVX2=0
+        shift
+        ;;
+    --tar)
+        TAR=1
+        shift
+        ;;
+    --disable-tde)
+        ENABLE_TDE=0
+        shift
+        ;;
+    --disable-tls)
+        ENABLE_TLS=0
+        shift
+        ;;
+    --disable-variant-nested-group)
+        ENABLE_VARIANT_NESTED_GROUP=0
+        shift
+        ;;
+    --disable-snapshot)
+        ENABLE_SNAPSHOT=0
+        shift
+        ;;
+    --version)
+        VERSION="$2"
+        shift 2
+        ;;
+    --vendor)
+        VENDOR="$2"
+        shift 2
+        ;;
+    --build_only)
+        BUILD_ONLY=1
+        shift
+        ;;
+    --help)
+        HELP=1
+        shift
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo "Internal error"
+        exit 1
+        ;;
+    esac
+done
+
+if [[ "${HELP}" -eq 1 ]]; then
+    usage
+fi
+if [[ -z "${VENDOR}" ]]; then
+    echo "--vendor must be specified, choose one of selectdb, velodb"
+    usage
+fi
+if [[ -z "${VERSION}" && "${BUILD_ONLY}" -eq 0 ]]; then
+    echo "Must specify version"
+    usage
+fi
+
+# These env vars are used by gensrc/script/gen_build_version.sh.
+export DORIS_BUILD_VERSION_PREFIX="${VENDOR}"
+export DORIS_BUILD_VERSION_MAJOR="${DORIS_BUILD_VERSION_MAJOR:-4}"
+export DORIS_BUILD_VERSION_MINOR="${DORIS_BUILD_VERSION_MINOR:-0}"
+export DORIS_BUILD_VERSION_PATCH="${DORIS_BUILD_VERSION_PATCH:-4}"
+export DORIS_BUILD_VERSION_HOTFIX="${DORIS_BUILD_VERSION_HOTFIX:-0}"
+export DORIS_BUILD_VERSION_RC_VERSION="${DORIS_BUILD_VERSION_RC_VERSION:-rc01}"
+
+selectdb_configure_extra_modules \
+    "${ENABLE_TDE}" \
+    "${ENABLE_TLS}" \
+    "${ENABLE_VARIANT_NESTED_GROUP}" \
+    "${ENABLE_SNAPSHOT}"
+
+echo "Get params:
+    VERSION                     -- ${VERSION}
+    VENDOR                      -- ${VENDOR}
+    USE_AVX2                    -- ${_USE_AVX2}
+    TAR                         -- ${TAR}
+    BUILD_ONLY                  -- ${BUILD_ONLY}
+    ENABLE_TDE                  -- ${ENABLE_TDE}
+    ENABLE_TLS                  -- ${ENABLE_TLS}
+    ENABLE_VARIANT_NESTED_GROUP -- ${ENABLE_VARIANT_NESTED_GROUP}
+    ENABLE_SNAPSHOT             -- ${ENABLE_SNAPSHOT}
+    EXTRA_FE_MODULES            -- ${EXTRA_FE_MODULES}
+    EXTRA_BE_MODULES            -- ${EXTRA_BE_MODULES}
+    EXTRA_CLOUD_MODULES         -- ${EXTRA_CLOUD_MODULES}
+"
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" == "aarch64" ]]; then
+    ARCH="arm64"
+elif [[ "${ARCH}" == "x86_64" ]]; then
+    ARCH="x64"
+else
+    echo "Unknown arch: ${ARCH}"
+    exit 1
+fi
+
+export USE_AVX2="${_USE_AVX2}"
+ORI_OUTPUT="${ROOT}/output"
+
+if [[ "${BUILD_ONLY}" -eq 1 ]]; then
+    sh build.sh
+    selectdb_copy_extra_fe_libs "${ORI_OUTPUT}"
+    exit 0
+fi
+
+PACKAGE_NAME="${VENDOR}-doris-${VERSION}-bin-${ARCH}"
+if [[ "${_USE_AVX2}" == "0" && "${ARCH}" == "x64" ]]; then
+    PACKAGE_NAME="${PACKAGE_NAME}-noavx2"
+fi
+OUTPUT="${ORI_OUTPUT}/${PACKAGE_NAME}"
+
+rm -rf "${OUTPUT}"
+mkdir -p "${OUTPUT}"
+
+sh build.sh
+sh build.sh --be --meta-tool --cloud
+selectdb_copy_extra_fe_libs "${ORI_OUTPUT}"
+
+cp -r "${ORI_OUTPUT}/fe" "${OUTPUT}/fe"
+cp -r "${ORI_OUTPUT}/be" "${OUTPUT}/be"
+cp -r "${ORI_OUTPUT}/ms" "${OUTPUT}/ms"
+cp -r "${ORI_OUTPUT}/apache_hdfs_broker" "${OUTPUT}/apache_hdfs_broker"
+cp -r "${ORI_OUTPUT}/tools" "${OUTPUT}/tools"
+
+if [[ "${TAR}" -eq 1 ]]; then
+    echo "Begin to compress"
+    cd "${ORI_OUTPUT}"
+    tar -cf - "${PACKAGE_NAME}" | xz -T0 -z - >"${PACKAGE_NAME}.tar.xz"
+    cd -
+fi
+
+echo "Output dir: ${OUTPUT}"

--- a/build-support/selectdb-release-common.sh
+++ b/build-support/selectdb-release-common.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+selectdb_append_extra_module_spec() {
+    local var_name="$1"
+    local feature_name="$2"
+    local module_path="$3"
+    local current_value="${!var_name:-}"
+
+    if [[ -n "${current_value}" ]]; then
+        current_value+=","
+    fi
+    current_value+="${feature_name}=${module_path}"
+    printf -v "${var_name}" '%s' "${current_value}"
+}
+
+selectdb_configure_extra_modules() {
+    local enable_tde="$1"
+    local enable_tls="$2"
+    local enable_variant_nested_group="$3"
+    local enable_snapshot="$4"
+
+    EXTRA_FE_MODULES="${EXTRA_FE_MODULES:-}"
+    EXTRA_BE_MODULES="${EXTRA_BE_MODULES:-}"
+    EXTRA_CLOUD_MODULES="${EXTRA_CLOUD_MODULES:-}"
+
+    if [[ "${enable_tde}" -eq 1 ]]; then
+        selectdb_append_extra_module_spec EXTRA_FE_MODULES tde fe-enterprise/fe-tde
+        selectdb_append_extra_module_spec EXTRA_BE_MODULES tde enterprise/tde
+    fi
+    if [[ "${enable_tls}" -eq 1 ]]; then
+        selectdb_append_extra_module_spec EXTRA_FE_MODULES tls fe-enterprise/fe-tls
+        selectdb_append_extra_module_spec EXTRA_BE_MODULES tls enterprise/tls
+        selectdb_append_extra_module_spec EXTRA_CLOUD_MODULES tls enterprise/tls
+    fi
+    if [[ "${enable_variant_nested_group}" -eq 1 ]]; then
+        selectdb_append_extra_module_spec EXTRA_BE_MODULES variant-nested-group enterprise/variant-nested-group
+    fi
+    if [[ "${enable_snapshot}" -eq 1 ]]; then
+        selectdb_append_extra_module_spec EXTRA_FE_MODULES snapshot fe-enterprise/fe-snapshot
+        selectdb_append_extra_module_spec EXTRA_CLOUD_MODULES snapshot enterprise/snapshot
+    fi
+
+    export EXTRA_FE_MODULES
+    export EXTRA_BE_MODULES
+    export EXTRA_CLOUD_MODULES
+}
+
+selectdb_copy_extra_fe_libs() {
+    local output_root="${1:-output}"
+    local extra_module module_path target_dir jar_file jar_name
+
+    if [[ -z "${EXTRA_FE_MODULES:-}" ]]; then
+        return
+    fi
+
+    mkdir -p "${output_root}/fe/lib"
+    IFS=',' read -r -a extra_modules <<<"${EXTRA_FE_MODULES}"
+    for extra_module in "${extra_modules[@]}"; do
+        module_path="${extra_module#*=}"
+        target_dir="${DORIS_HOME}/fe/${module_path}/target"
+
+        if [[ -d "${target_dir}/lib" ]]; then
+            cp -r -p "${target_dir}/lib/." "${output_root}/fe/lib/"
+        fi
+
+        shopt -s nullglob
+        for jar_file in "${target_dir}"/*.jar; do
+            jar_name="$(basename "${jar_file}")"
+            case "${jar_name}" in
+            *-sources.jar | *-javadoc.jar | *-test-sources.jar | *tests.jar | original-*.jar)
+                continue
+                ;;
+            esac
+            cp -r -p "${jar_file}" "${output_root}/fe/lib/"
+        done
+        shopt -u nullglob
+    done
+}


### PR DESCRIPTION
## Summary
- add SelectDB release build entry scripts that configure optional enterprise modules through existing EXTRA_*_MODULES hooks
- add a shared release helper for extra module specs and FE extra module jar copying
- add the BE CMake hook for the Variant NestedGroup enterprise storage provider

## Verification
- `bash -n build-for-release-selectdb-cloud.sh build-for-release-selectdb.sh build-support/selectdb-release-common.sh`
- `git diff --check HEAD~1..HEAD`
- created a fresh validation worktree from this commit, copied enterprise directories from `upstream-eld-selectdb-core/branch-selectdb-doris-4.1-nested-compile`, and ran `./build-for-release-selectdb-cloud.sh`; the script expanded TDE/TLS/SNAPSHOT/VARIANT_NESTED_GROUP extra modules and entered `build.sh` successfully. Stopped before full thirdparty build per request to publish PR first.