### PR TITLE
[build](variant) Support release extra module hooks

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -160,12 +160,17 @@ option(ENABLE_TDE "Enable TDE feature module" OFF)
 set(TDE_MODULE_DIR "" CACHE STRING "TDE feature module directory under be/src")
 option(ENABLE_TLS "Enable TLS feature module" OFF)
 set(TLS_MODULE_DIR "" CACHE STRING "TLS feature module directory under be/src")
+option(ENABLE_VARIANT_NESTED_GROUP "Enable Variant NestedGroup feature module" OFF)
+set(VARIANT_NESTED_GROUP_MODULE_DIR "" CACHE STRING "Variant NestedGroup feature module directory under be/src")
 
 if (ENABLE_TDE AND "${TDE_MODULE_DIR}" STREQUAL "")
     message(FATAL_ERROR "ENABLE_TDE requires TDE_MODULE_DIR")
 endif()
 if (ENABLE_TLS AND "${TLS_MODULE_DIR}" STREQUAL "")
     message(FATAL_ERROR "ENABLE_TLS requires TLS_MODULE_DIR")
+endif()
+if (ENABLE_VARIANT_NESTED_GROUP AND "${VARIANT_NESTED_GROUP_MODULE_DIR}" STREQUAL "")
+    message(FATAL_ERROR "ENABLE_VARIANT_NESTED_GROUP requires VARIANT_NESTED_GROUP_MODULE_DIR")
 endif()
 
 # Allow env to override when reconfiguring (avoid picking /usr/local).

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -29,6 +29,14 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS *.cpp)
 # and linked by Storage.
 list(FILTER SRC_FILES EXCLUDE REGEX ".*/storage/index/ann/.*\\.cpp$")
 
+if (ENABLE_VARIANT_NESTED_GROUP)
+    list(REMOVE_ITEM SRC_FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/segment/variant/nested_group_provider.cpp")
+    file(GLOB_RECURSE VARIANT_NESTED_GROUP_SOURCES CONFIGURE_DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/../${VARIANT_NESTED_GROUP_MODULE_DIR}/*.cpp")
+    list(APPEND SRC_FILES ${VARIANT_NESTED_GROUP_SOURCES})
+endif()
+
 add_library(Storage STATIC ${SRC_FILES})
 target_link_libraries(Storage PRIVATE ann_index)
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -54,6 +54,12 @@ if (ENABLE_TLS)
     list(APPEND UT_FILES ${TLS_UT_FILES})
 endif()
 
+if (ENABLE_VARIANT_NESTED_GROUP)
+    file(GLOB_RECURSE VARIANT_NESTED_GROUP_UT_FILES CONFIGURE_DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/${VARIANT_NESTED_GROUP_MODULE_DIR}/*.cpp")
+    list(APPEND UT_FILES ${VARIANT_NESTED_GROUP_UT_FILES})
+endif()
+
 # Remove all cpp files from vector search (ANN index) subdirectory
 # Since cpp files in vector search subdirs use header files from faiss.
 # The compile check used by doris can not be applied to faiss headers.


### PR DESCRIPTION
## Summary
- add a BE CMake option for Variant NestedGroup extension modules
- let the Storage target replace the default provider with external extension sources when the option is enabled
- let BE unit tests include matching external extension test sources when the option is enabled
- keep the change limited to existing build files shared by the public and private trees