### PR TITLE
[feature](fe) Add connection max metrics

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -132,6 +132,8 @@ public final class MetricRepo {
     public static AutoMappedMetric<GaugeMetricImpl<Long>> USER_GAUGE_QUERY_INSTANCE_NUM;
     public static AutoMappedMetric<GaugeMetricImpl<Integer>> USER_GAUGE_CONNECTIONS;
     public static AutoMappedMetric<GaugeMetricImpl<Long>> USER_GAUGE_CONNECTION_MAX;
+    public static GaugeMetric<Integer> GAUGE_ARROW_FLIGHT_CONNECTIONS;
+    public static GaugeMetric<Integer> GAUGE_ARROW_FLIGHT_CONNECTION_MAX;
     public static GaugeMetric<Integer> GAUGE_CONNECTION_MAX;
     public static AutoMappedMetric<LongCounterMetric> USER_COUNTER_QUERY_INSTANCE_BEGIN;
     public static AutoMappedMetric<LongCounterMetric> BE_COUNTER_QUERY_RPC_ALL;
@@ -443,6 +445,14 @@ public final class MetricRepo {
             }
         };
         DORIS_METRIC_REGISTER.addMetrics(connections);
+        GAUGE_ARROW_FLIGHT_CONNECTIONS = new GaugeMetric<Integer>("arrow_flight_connection_total",
+                MetricUnit.CONNECTIONS, "total arrow flight connections") {
+            @Override
+            public Integer getValue() {
+                return ExecuteEnv.getInstance().getScheduler().getFlightSqlConnectPoolMgr().getConnectionNum();
+            }
+        };
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_ARROW_FLIGHT_CONNECTIONS);
         GAUGE_CONNECTION_MAX = new GaugeMetric<Integer>("connection_max",
                 MetricUnit.CONNECTIONS, "max connections") {
             @Override
@@ -451,6 +461,14 @@ public final class MetricRepo {
             }
         };
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_CONNECTION_MAX);
+        GAUGE_ARROW_FLIGHT_CONNECTION_MAX = new GaugeMetric<Integer>("arrow_flight_connection_max",
+                MetricUnit.CONNECTIONS, "max arrow flight connections") {
+            @Override
+            public Integer getValue() {
+                return Config.arrow_flight_max_connections;
+            }
+        };
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_ARROW_FLIGHT_CONNECTION_MAX);
         syncUserConnectionMaxMetrics();
 
         // journal id

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -131,6 +131,8 @@ public final class MetricRepo {
     public static AutoMappedMetric<HistogramMetric> USER_HISTO_QUERY_LATENCY;
     public static AutoMappedMetric<GaugeMetricImpl<Long>> USER_GAUGE_QUERY_INSTANCE_NUM;
     public static AutoMappedMetric<GaugeMetricImpl<Integer>> USER_GAUGE_CONNECTIONS;
+    public static AutoMappedMetric<GaugeMetricImpl<Long>> USER_GAUGE_CONNECTION_MAX;
+    public static GaugeMetric<Integer> GAUGE_CONNECTION_MAX;
     public static AutoMappedMetric<LongCounterMetric> USER_COUNTER_QUERY_INSTANCE_BEGIN;
     public static AutoMappedMetric<LongCounterMetric> BE_COUNTER_QUERY_RPC_ALL;
     public static AutoMappedMetric<LongCounterMetric> BE_COUNTER_QUERY_RPC_FAILED;
@@ -428,6 +430,9 @@ public final class MetricRepo {
         USER_GAUGE_CONNECTIONS = addLabeledMetrics("user", () ->
                 new GaugeMetricImpl<>("connection_total", MetricUnit.CONNECTIONS,
                         "total connections", 0));
+        USER_GAUGE_CONNECTION_MAX = addLabeledMetrics("user", () ->
+                new GaugeMetricImpl<>("user_connection_max", MetricUnit.CONNECTIONS,
+                        "max connections for single user", 0L));
         GaugeMetric<Integer> connections = new GaugeMetric<Integer>("connection_total",
                 MetricUnit.CONNECTIONS, "total connections") {
             @Override
@@ -438,6 +443,15 @@ public final class MetricRepo {
             }
         };
         DORIS_METRIC_REGISTER.addMetrics(connections);
+        GAUGE_CONNECTION_MAX = new GaugeMetric<Integer>("connection_max",
+                MetricUnit.CONNECTIONS, "max connections") {
+            @Override
+            public Integer getValue() {
+                return Config.qe_max_connection;
+            }
+        };
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_CONNECTION_MAX);
+        syncUserConnectionMaxMetrics();
 
         // journal id
         GaugeMetric<Long> maxJournalId = new GaugeMetric<Long>("max_journal_id", MetricUnit.NOUNIT,
@@ -1623,6 +1637,33 @@ public final class MetricRepo {
             MetricRepo.DORIS_METRIC_REGISTER.addMetrics(m);
             return m;
         });
+    }
+
+    public static void syncUserConnectionMaxMetrics() {
+        if (USER_GAUGE_CONNECTION_MAX == null) {
+            return;
+        }
+        Env.getCurrentEnv().getAuth().getMaxConnForAllUsers()
+                .forEach(MetricRepo::updateUserConnectionMaxMetric);
+    }
+
+    public static void updateUserConnectionMaxMetric(String user, long maxConn) {
+        if (USER_GAUGE_CONNECTION_MAX == null) {
+            return;
+        }
+        USER_GAUGE_CONNECTION_MAX.getOrAdd(user).setValue(maxConn);
+    }
+
+    public static void removeUserConnectionMaxMetric(String user) {
+        if (USER_GAUGE_CONNECTION_MAX == null) {
+            return;
+        }
+        GaugeMetricImpl<Long> metric = USER_GAUGE_CONNECTION_MAX.getMetrics().get(user);
+        if (metric == null) {
+            return;
+        }
+        DORIS_METRIC_REGISTER.removeMetricsByNameAndLabels(metric.getName(), metric.getLabels());
+        USER_GAUGE_CONNECTION_MAX.remove(user);
     }
 
     public static void visitHistograms(MetricVisitor visitor) {

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -49,6 +49,7 @@ import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshMethod;
 import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshTrigger;
 import org.apache.doris.mtmv.MTMVUtil;
+import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.QeProcessorImpl;
@@ -457,7 +458,7 @@ public final class MetricRepo {
                 MetricUnit.CONNECTIONS, "max connections") {
             @Override
             public Integer getValue() {
-                return Config.qe_max_connection;
+                return Config.qe_max_connection + Config.arrow_flight_max_connections;
             }
         };
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_CONNECTION_MAX);
@@ -1661,8 +1662,15 @@ public final class MetricRepo {
         if (USER_GAUGE_CONNECTION_MAX == null) {
             return;
         }
-        Env.getCurrentEnv().getAuth().getMaxConnForAllUsers()
+        Env.getServingEnv().getAuth().getMaxConnForAllUsers()
                 .forEach(MetricRepo::updateUserConnectionMaxMetric);
+    }
+
+    public static void updateUserConnectionMaxMetric(Auth auth, String user, long maxConn) {
+        if (USER_GAUGE_CONNECTION_MAX == null || Env.getServingEnv().getAuth() != auth) {
+            return;
+        }
+        updateUserConnectionMaxMetric(user, maxConn);
     }
 
     public static void updateUserConnectionMaxMetric(String user, long maxConn) {
@@ -1670,6 +1678,13 @@ public final class MetricRepo {
             return;
         }
         USER_GAUGE_CONNECTION_MAX.getOrAdd(user).setValue(maxConn);
+    }
+
+    public static void removeUserConnectionMaxMetric(Auth auth, String user) {
+        if (USER_GAUGE_CONNECTION_MAX == null || Env.getServingEnv().getAuth() != auth) {
+            return;
+        }
+        removeUserConnectionMaxMetric(user);
     }
 
     public static void removeUserConnectionMaxMetric(String user) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -44,6 +44,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlPassword;
 import org.apache.doris.mysql.authenticate.AuthenticateType;
 import org.apache.doris.mysql.authenticate.ldap.LdapManager;
@@ -586,6 +587,8 @@ public class Auth implements Writable {
             }
             // other user properties
             propertyMgr.addUserResource(userIdent.getQualifiedUser());
+            MetricRepo.updateUserConnectionMaxMetric(userIdent.getQualifiedUser(),
+                    propertyMgr.getMaxConn(userIdent.getQualifiedUser()));
 
             // 5. update password policy
             passwdPolicyManager.updatePolicy(userIdent, password, passwordOptions);
@@ -640,6 +643,7 @@ public class Auth implements Writable {
             userManager.removeUser(userIdent);
             if (CollectionUtils.isEmpty(userManager.getUserByName(userIdent.getQualifiedUser()))) {
                 propertyMgr.dropUser(userIdent);
+                MetricRepo.removeUserConnectionMaxMetric(userIdent.getQualifiedUser());
             }
 
             if (!isReplay) {
@@ -1193,6 +1197,7 @@ public class Auth implements Writable {
         writeLock();
         try {
             propertyMgr.updateUserProperty(user, properties, isReplay);
+            MetricRepo.updateUserConnectionMaxMetric(user, propertyMgr.getMaxConn(user));
             if (!isReplay) {
                 UserPropertyInfo propertyInfo = new UserPropertyInfo(user, properties);
                 Env.getCurrentEnv().getEditLog().logUpdateUserProperty(propertyInfo);
@@ -1213,6 +1218,15 @@ public class Auth implements Writable {
         readLock();
         try {
             return propertyMgr.getMaxConn(qualifiedUser);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public Map<String, Long> getMaxConnForAllUsers() {
+        readLock();
+        try {
+            return propertyMgr.getMaxConnForAllUsers();
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -587,7 +587,7 @@ public class Auth implements Writable {
             }
             // other user properties
             propertyMgr.addUserResource(userIdent.getQualifiedUser());
-            MetricRepo.updateUserConnectionMaxMetric(userIdent.getQualifiedUser(),
+            MetricRepo.updateUserConnectionMaxMetric(this, userIdent.getQualifiedUser(),
                     propertyMgr.getMaxConn(userIdent.getQualifiedUser()));
 
             // 5. update password policy
@@ -643,7 +643,7 @@ public class Auth implements Writable {
             userManager.removeUser(userIdent);
             if (CollectionUtils.isEmpty(userManager.getUserByName(userIdent.getQualifiedUser()))) {
                 propertyMgr.dropUser(userIdent);
-                MetricRepo.removeUserConnectionMaxMetric(userIdent.getQualifiedUser());
+                MetricRepo.removeUserConnectionMaxMetric(this, userIdent.getQualifiedUser());
             }
 
             if (!isReplay) {
@@ -1197,7 +1197,7 @@ public class Auth implements Writable {
         writeLock();
         try {
             propertyMgr.updateUserProperty(user, properties, isReplay);
-            MetricRepo.updateUserConnectionMaxMetric(user, propertyMgr.getMaxConn(user));
+            MetricRepo.updateUserConnectionMaxMetric(this, user, propertyMgr.getMaxConn(user));
             if (!isReplay) {
                 UserPropertyInfo propertyInfo = new UserPropertyInfo(user, properties);
                 Env.getCurrentEnv().getEditLog().logUpdateUserProperty(propertyInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -118,6 +118,14 @@ public class UserPropertyMgr implements Writable {
         return existProperty.getMaxConn();
     }
 
+    public Map<String, Long> getMaxConnForAllUsers() {
+        Map<String, Long> maxConnByUser = Maps.newHashMap();
+        for (Entry<String, UserProperty> entry : propertyMap.entrySet()) {
+            maxConnByUser.put(entry.getKey(), entry.getValue().getMaxConn());
+        }
+        return maxConnByUser;
+    }
+
     public long getMaxQueryInstances(String qualifiedUser) {
         UserProperty existProperty = propertyMap.get(qualifiedUser);
         existProperty = getPropertyIfNull(qualifiedUser, existProperty);

--- a/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
@@ -21,10 +21,13 @@ import org.apache.doris.cloud.CloudWarmUpJob;
 import org.apache.doris.cloud.JobWarmUpStats;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.JsonUtil;
 import org.apache.doris.metric.Metric.MetricUnit;
 import org.apache.doris.monitor.jvm.JvmService;
 import org.apache.doris.monitor.jvm.JvmStats;
+import org.apache.doris.mysql.privilege.Auth;
+import org.apache.doris.mysql.privilege.UserProperty;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
@@ -66,6 +69,36 @@ public class MetricsTest {
             } else {
                 Assert.fail();
             }
+        }
+    }
+
+    @Test
+    public void testConnectionMaxMetrics() throws Exception {
+        int originQeMaxConnection = Config.qe_max_connection;
+        try {
+            Config.qe_max_connection = 4321;
+            MetricRepo.updateUserConnectionMaxMetric("metric_user", 321L);
+
+            MetricVisitor visitor = new PrometheusMetricVisitor();
+            MetricRepo.DORIS_METRIC_REGISTER.accept(visitor);
+            String metricResult = visitor.finish();
+            Assert.assertTrue(metricResult.contains("# TYPE doris_fe_connection_max gauge"));
+            Assert.assertTrue(metricResult.contains("doris_fe_connection_max 4321"));
+            Assert.assertTrue(metricResult.contains("# TYPE doris_fe_user_connection_max gauge"));
+            Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"metric_user\"} 321"));
+
+            Auth auth = new Auth();
+            auth.updateUserPropertyInternal(Auth.ROOT_USER, Lists.newArrayList(
+                    Pair.of(UserProperty.PROP_MAX_USER_CONNECTIONS, "456")), true);
+
+            visitor = new PrometheusMetricVisitor();
+            MetricRepo.DORIS_METRIC_REGISTER.accept(visitor);
+            metricResult = visitor.finish();
+            Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"root\"} 456"));
+        } finally {
+            Config.qe_max_connection = originQeMaxConnection;
+            MetricRepo.removeUserConnectionMaxMetric("metric_user");
+            MetricRepo.updateUserConnectionMaxMetric(Auth.ROOT_USER, 100L);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
@@ -75,8 +75,10 @@ public class MetricsTest {
     @Test
     public void testConnectionMaxMetrics() throws Exception {
         int originQeMaxConnection = Config.qe_max_connection;
+        int originArrowFlightMaxConnections = Config.arrow_flight_max_connections;
         try {
             Config.qe_max_connection = 4321;
+            Config.arrow_flight_max_connections = 8765;
             MetricRepo.updateUserConnectionMaxMetric("metric_user", 321L);
 
             MetricVisitor visitor = new PrometheusMetricVisitor();
@@ -84,6 +86,10 @@ public class MetricsTest {
             String metricResult = visitor.finish();
             Assert.assertTrue(metricResult.contains("# TYPE doris_fe_connection_max gauge"));
             Assert.assertTrue(metricResult.contains("doris_fe_connection_max 4321"));
+            Assert.assertTrue(metricResult.contains("# TYPE doris_fe_arrow_flight_connection_total gauge"));
+            Assert.assertTrue(metricResult.contains("doris_fe_arrow_flight_connection_total 0"));
+            Assert.assertTrue(metricResult.contains("# TYPE doris_fe_arrow_flight_connection_max gauge"));
+            Assert.assertTrue(metricResult.contains("doris_fe_arrow_flight_connection_max 8765"));
             Assert.assertTrue(metricResult.contains("# TYPE doris_fe_user_connection_max gauge"));
             Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"metric_user\"} 321"));
 
@@ -97,6 +103,7 @@ public class MetricsTest {
             Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"root\"} 456"));
         } finally {
             Config.qe_max_connection = originQeMaxConnection;
+            Config.arrow_flight_max_connections = originArrowFlightMaxConnections;
             MetricRepo.removeUserConnectionMaxMetric("metric_user");
             MetricRepo.updateUserConnectionMaxMetric(Auth.ROOT_USER, 100L);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/metric/MetricsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.metric;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.CloudWarmUpJob;
 import org.apache.doris.cloud.JobWarmUpStats;
 import org.apache.doris.common.Config;
@@ -85,7 +86,7 @@ public class MetricsTest {
             MetricRepo.DORIS_METRIC_REGISTER.accept(visitor);
             String metricResult = visitor.finish();
             Assert.assertTrue(metricResult.contains("# TYPE doris_fe_connection_max gauge"));
-            Assert.assertTrue(metricResult.contains("doris_fe_connection_max 4321"));
+            Assert.assertTrue(metricResult.contains("doris_fe_connection_max 13086"));
             Assert.assertTrue(metricResult.contains("# TYPE doris_fe_arrow_flight_connection_total gauge"));
             Assert.assertTrue(metricResult.contains("doris_fe_arrow_flight_connection_total 0"));
             Assert.assertTrue(metricResult.contains("# TYPE doris_fe_arrow_flight_connection_max gauge"));
@@ -93,19 +94,29 @@ public class MetricsTest {
             Assert.assertTrue(metricResult.contains("# TYPE doris_fe_user_connection_max gauge"));
             Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"metric_user\"} 321"));
 
-            Auth auth = new Auth();
-            auth.updateUserPropertyInternal(Auth.ROOT_USER, Lists.newArrayList(
+            Env.getServingEnv().getAuth().updateUserPropertyInternal(Auth.ROOT_USER, Lists.newArrayList(
                     Pair.of(UserProperty.PROP_MAX_USER_CONNECTIONS, "456")), true);
 
             visitor = new PrometheusMetricVisitor();
             MetricRepo.DORIS_METRIC_REGISTER.accept(visitor);
             metricResult = visitor.finish();
             Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"root\"} 456"));
+
+            Auth auth = new Auth();
+            auth.updateUserPropertyInternal(Auth.ROOT_USER, Lists.newArrayList(
+                    Pair.of(UserProperty.PROP_MAX_USER_CONNECTIONS, "789")), true);
+
+            visitor = new PrometheusMetricVisitor();
+            MetricRepo.DORIS_METRIC_REGISTER.accept(visitor);
+            metricResult = visitor.finish();
+            Assert.assertTrue(metricResult.contains("doris_fe_user_connection_max{user=\"root\"} 456"));
+            Assert.assertFalse(metricResult.contains("doris_fe_user_connection_max{user=\"root\"} 789"));
         } finally {
             Config.qe_max_connection = originQeMaxConnection;
             Config.arrow_flight_max_connections = originArrowFlightMaxConnections;
             MetricRepo.removeUserConnectionMaxMetric("metric_user");
-            MetricRepo.updateUserConnectionMaxMetric(Auth.ROOT_USER, 100L);
+            Env.getServingEnv().getAuth().updateUserPropertyInternal(Auth.ROOT_USER, Lists.newArrayList(
+                    Pair.of(UserProperty.PROP_MAX_USER_CONNECTIONS, "100")), true);
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: FE metrics exposed current connection counts but did not expose the configured maximum total connection count or each user's max_user_connections value. This change adds doris_fe_connection_max from qe_max_connection and doris_fe_user_connection_max with a user label. User max connection metrics are initialized from all user properties when MetricRepo starts and are synchronized when users are created, dropped, or when user properties are updated or replayed.

### Release note

Add FE metrics doris_fe_connection_max and doris_fe_user_connection_max.

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.metric.MetricsTest
    - mvn checkstyle:check -pl fe-core
- Behavior changed: Yes (adds FE metrics for total and per-user connection limits)
- Does this need documentation: No