### PR TITLE
[fix](be) Validate Arrow arrays before column conversion

### DIFF
--- a/be/benchmark/benchmark_arrow_validate.hpp
+++ b/be/benchmark/benchmark_arrow_validate.hpp
@@ -1,0 +1,280 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <arrow/array.h>
+#include <arrow/buffer.h>
+#include <arrow/status.h>
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/data_type/data_type.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "core/data_type_serde/data_type_serde.h"
+
+namespace doris {
+namespace {
+
+enum class ArrowValidateCaseKind {
+    INT32,
+    STRING,
+    NULLABLE_STRING,
+    ARRAY_STRING,
+};
+
+enum class ArrowValidateMode {
+    VALIDATE,
+    VALIDATE_FULL,
+    READ_ONLY,
+    VALIDATE_THEN_READ,
+    VALIDATE_FULL_THEN_READ,
+};
+
+struct ArrowValidateCase {
+    DataTypePtr data_type;
+    std::shared_ptr<arrow::Array> array;
+    std::vector<int32_t> int32_values;
+    std::vector<int32_t> string_offsets;
+    std::vector<int32_t> list_offsets;
+    std::vector<uint8_t> validity_bitmap;
+    std::string string_values;
+    int64_t rows = 0;
+    int64_t value_bytes = 0;
+};
+
+static void set_valid(std::vector<uint8_t>& bitmap, size_t index) {
+    bitmap[index >> 3] |= static_cast<uint8_t>(1U << (index & 7));
+}
+
+static void fill_string_data(ArrowValidateCase& data, int64_t rows, int64_t string_length) {
+    data.string_offsets.clear();
+    data.string_values.clear();
+    data.string_offsets.reserve(rows + 1);
+    data.string_values.reserve(rows * string_length);
+    data.string_offsets.push_back(0);
+    for (int64_t i = 0; i < rows; ++i) {
+        for (int64_t j = 0; j < string_length; ++j) {
+            data.string_values.push_back(static_cast<char>('a' + (i + j) % 26));
+        }
+        data.string_offsets.push_back(static_cast<int32_t>(data.string_values.size()));
+    }
+    data.value_bytes = static_cast<int64_t>(data.string_values.size());
+}
+
+static std::shared_ptr<arrow::Array> make_string_array(ArrowValidateCase& data, int64_t rows,
+                                                       const std::shared_ptr<arrow::Buffer>& nulls,
+                                                       int64_t null_count) {
+    auto offsets = arrow::Buffer::Wrap(data.string_offsets);
+    auto values = arrow::Buffer::Wrap(reinterpret_cast<const uint8_t*>(data.string_values.data()),
+                                      data.string_values.size());
+    return std::make_shared<arrow::StringArray>(rows, offsets, values, nulls, null_count);
+}
+
+static std::shared_ptr<ArrowValidateCase> make_arrow_validate_case(ArrowValidateCaseKind kind,
+                                                                   int64_t rows,
+                                                                   int64_t string_length) {
+    auto data = std::make_shared<ArrowValidateCase>();
+    data->rows = rows;
+    switch (kind) {
+    case ArrowValidateCaseKind::INT32: {
+        data->data_type = std::make_shared<DataTypeInt32>();
+        data->int32_values.reserve(rows);
+        for (int64_t i = 0; i < rows; ++i) {
+            data->int32_values.push_back(static_cast<int32_t>(i));
+        }
+        auto values = arrow::Buffer::Wrap(data->int32_values);
+        data->array = std::make_shared<arrow::Int32Array>(rows, values);
+        data->value_bytes = rows * sizeof(int32_t);
+        break;
+    }
+    case ArrowValidateCaseKind::STRING: {
+        data->data_type = std::make_shared<DataTypeString>();
+        fill_string_data(*data, rows, string_length);
+        data->array = make_string_array(*data, rows, nullptr, 0);
+        break;
+    }
+    case ArrowValidateCaseKind::NULLABLE_STRING: {
+        data->data_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
+        fill_string_data(*data, rows, string_length);
+        data->validity_bitmap.assign((rows + 7) / 8, 0);
+        int64_t null_count = 0;
+        for (int64_t i = 0; i < rows; ++i) {
+            if (i % 7 == 0) {
+                ++null_count;
+            } else {
+                set_valid(data->validity_bitmap, static_cast<size_t>(i));
+            }
+        }
+        auto nulls = arrow::Buffer::Wrap(data->validity_bitmap);
+        data->array = make_string_array(*data, rows, nulls, null_count);
+        break;
+    }
+    case ArrowValidateCaseKind::ARRAY_STRING: {
+        static constexpr int64_t elements_per_row = 4;
+        const int64_t values_count = rows * elements_per_row;
+        data->data_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
+        fill_string_data(*data, values_count, string_length);
+        auto values_array = make_string_array(*data, values_count, nullptr, 0);
+        data->list_offsets.reserve(rows + 1);
+        for (int64_t i = 0; i <= rows; ++i) {
+            data->list_offsets.push_back(static_cast<int32_t>(i * elements_per_row));
+        }
+        auto offsets = arrow::Buffer::Wrap(data->list_offsets);
+        data->array = std::make_shared<arrow::ListArray>(arrow::list(arrow::utf8()), rows, offsets,
+                                                         values_array, nullptr, 0);
+        break;
+    }
+    }
+    return data;
+}
+
+static void check_arrow_status(benchmark::State& state, const arrow::Status& status) {
+    if (!status.ok()) {
+        state.SkipWithError(status.ToString().c_str());
+    }
+}
+
+static void check_doris_status(benchmark::State& state, const Status& status) {
+    if (!status.ok()) {
+        state.SkipWithError(status.to_string().c_str());
+    }
+}
+
+static void run_arrow_validate_only(benchmark::State& state, ArrowValidateCaseKind kind,
+                                    ArrowValidateMode mode) {
+    const auto data = make_arrow_validate_case(kind, state.range(0), state.range(1));
+    for (auto _ : state) {
+        auto status = mode == ArrowValidateMode::VALIDATE ? data->array->Validate()
+                                                          : data->array->ValidateFull();
+        check_arrow_status(state, status);
+        benchmark::DoNotOptimize(status);
+    }
+    state.SetItemsProcessed(state.iterations() * data->rows);
+    state.SetBytesProcessed(state.iterations() * data->value_bytes);
+}
+
+static void run_arrow_read(benchmark::State& state, ArrowValidateCaseKind kind,
+                           ArrowValidateMode mode) {
+    const auto data = make_arrow_validate_case(kind, state.range(0), state.range(1));
+    auto serde = data->data_type->get_serde();
+    const auto timezone = cctz::utc_time_zone();
+    for (auto _ : state) {
+        if (mode == ArrowValidateMode::VALIDATE_THEN_READ) {
+            auto arrow_status = data->array->Validate();
+            check_arrow_status(state, arrow_status);
+            benchmark::DoNotOptimize(arrow_status);
+        } else if (mode == ArrowValidateMode::VALIDATE_FULL_THEN_READ) {
+            auto arrow_status = data->array->ValidateFull();
+            check_arrow_status(state, arrow_status);
+            benchmark::DoNotOptimize(arrow_status);
+        }
+        auto column = data->data_type->create_column();
+        auto status =
+                serde->read_column_from_arrow(*column, data->array.get(), 0, data->rows, timezone);
+        check_doris_status(state, status);
+        benchmark::DoNotOptimize(status);
+        auto column_size = column->size();
+        benchmark::DoNotOptimize(column_size);
+    }
+    state.SetItemsProcessed(state.iterations() * data->rows);
+    state.SetBytesProcessed(state.iterations() * data->value_bytes);
+}
+
+static void BM_ArrowValidateOnly(benchmark::State& state, ArrowValidateCaseKind kind,
+                                 ArrowValidateMode mode) {
+    run_arrow_validate_only(state, kind, mode);
+}
+
+static void BM_ArrowValidateRead(benchmark::State& state, ArrowValidateCaseKind kind,
+                                 ArrowValidateMode mode) {
+    run_arrow_read(state, kind, mode);
+}
+
+static void apply_arrow_validate_args(benchmark::internal::Benchmark* benchmark, int64_t str_len) {
+    benchmark->Args({4096, str_len})->Args({65536, str_len})->Unit(benchmark::kMicrosecond);
+}
+
+BENCHMARK_CAPTURE(BM_ArrowValidateOnly, Int32_Validate, ArrowValidateCaseKind::INT32,
+                  ArrowValidateMode::VALIDATE)
+        ->Args({4096, 0})
+        ->Args({65536, 0})
+        ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_ArrowValidateOnly, Int32_ValidateFull, ArrowValidateCaseKind::INT32,
+                  ArrowValidateMode::VALIDATE_FULL)
+        ->Args({4096, 0})
+        ->Args({65536, 0})
+        ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_ArrowValidateRead, Int32_ReadOnly, ArrowValidateCaseKind::INT32,
+                  ArrowValidateMode::READ_ONLY)
+        ->Args({4096, 0})
+        ->Args({65536, 0})
+        ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_ArrowValidateRead, Int32_ValidateThenRead, ArrowValidateCaseKind::INT32,
+                  ArrowValidateMode::VALIDATE_THEN_READ)
+        ->Args({4096, 0})
+        ->Args({65536, 0})
+        ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_ArrowValidateRead, Int32_ValidateFullThenRead, ArrowValidateCaseKind::INT32,
+                  ArrowValidateMode::VALIDATE_FULL_THEN_READ)
+        ->Args({4096, 0})
+        ->Args({65536, 0})
+        ->Unit(benchmark::kMicrosecond);
+
+#define REGISTER_ARROW_VALIDATE_STRING_CASES(kind_name, kind, str_len)                        \
+    BENCHMARK_CAPTURE(BM_ArrowValidateOnly, kind_name##_Validate_##str_len, kind,             \
+                      ArrowValidateMode::VALIDATE)                                            \
+            ->Apply([](benchmark::internal::Benchmark* b) {                                   \
+                apply_arrow_validate_args(b, str_len);                                        \
+            });                                                                               \
+    BENCHMARK_CAPTURE(BM_ArrowValidateOnly, kind_name##_ValidateFull_##str_len, kind,         \
+                      ArrowValidateMode::VALIDATE_FULL)                                       \
+            ->Apply([](benchmark::internal::Benchmark* b) {                                   \
+                apply_arrow_validate_args(b, str_len);                                        \
+            });                                                                               \
+    BENCHMARK_CAPTURE(BM_ArrowValidateRead, kind_name##_ReadOnly_##str_len, kind,             \
+                      ArrowValidateMode::READ_ONLY)                                           \
+            ->Apply([](benchmark::internal::Benchmark* b) {                                   \
+                apply_arrow_validate_args(b, str_len);                                        \
+            });                                                                               \
+    BENCHMARK_CAPTURE(BM_ArrowValidateRead, kind_name##_ValidateThenRead_##str_len, kind,     \
+                      ArrowValidateMode::VALIDATE_THEN_READ)                                  \
+            ->Apply([](benchmark::internal::Benchmark* b) {                                   \
+                apply_arrow_validate_args(b, str_len);                                        \
+            });                                                                               \
+    BENCHMARK_CAPTURE(BM_ArrowValidateRead, kind_name##_ValidateFullThenRead_##str_len, kind, \
+                      ArrowValidateMode::VALIDATE_FULL_THEN_READ)                             \
+            ->Apply([](benchmark::internal::Benchmark* b) {                                   \
+                apply_arrow_validate_args(b, str_len);                                        \
+            })
+
+REGISTER_ARROW_VALIDATE_STRING_CASES(String, ArrowValidateCaseKind::STRING, 8);
+REGISTER_ARROW_VALIDATE_STRING_CASES(String, ArrowValidateCaseKind::STRING, 128);
+REGISTER_ARROW_VALIDATE_STRING_CASES(NullableString, ArrowValidateCaseKind::NULLABLE_STRING, 8);
+REGISTER_ARROW_VALIDATE_STRING_CASES(NullableString, ArrowValidateCaseKind::NULLABLE_STRING, 128);
+REGISTER_ARROW_VALIDATE_STRING_CASES(ArrayString, ArrowValidateCaseKind::ARRAY_STRING, 8);
+REGISTER_ARROW_VALIDATE_STRING_CASES(ArrayString, ArrowValidateCaseKind::ARRAY_STRING, 128);
+
+#undef REGISTER_ARROW_VALIDATE_STRING_CASES
+
+} // namespace
+} // namespace doris

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -17,6 +17,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include "benchmark_arrow_validate.hpp"
 #include "benchmark_bit_pack.hpp"
 #include "benchmark_bits.hpp"
 #include "benchmark_block_bloom_filter.hpp"

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -779,6 +779,9 @@ DEFINE_mInt32(arrow_flight_result_sink_buffer_size_rows, "32768");
 // The timeout for ADBC Client to wait for data using arrow flight reader.
 // If the query is very complex and no result is generated after this time, consider increasing this timeout.
 DEFINE_mInt32(arrow_flight_reader_brpc_controller_timeout_ms, "300000");
+// Enable full Arrow array validation before converting Arrow data to Doris columns.
+// Lightweight Arrow validation is always enabled on the external Arrow read path.
+DEFINE_mBool(enable_arrow_read_validate_full, "false");
 
 // the increased frequency of priority for remaining tasks in BlockingPriorityQueue
 DEFINE_mInt32(priority_queue_remaining_tasks_increased_frequency, "512");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -838,6 +838,9 @@ DECLARE_mInt32(arrow_flight_result_sink_buffer_size_rows);
 // The timeout for ADBC Client to wait for data using arrow flight reader.
 // If the query is very complex and no result is generated after this time, consider increasing this timeout.
 DECLARE_mInt32(arrow_flight_reader_brpc_controller_timeout_ms);
+// Enable full Arrow array validation before converting Arrow data to Doris columns.
+// Lightweight Arrow validation is always enabled on the external Arrow read path.
+DECLARE_mBool(enable_arrow_read_validate_full);
 
 // the increased frequency of priority for remaining tasks in BlockingPriorityQueue
 DECLARE_mInt32(priority_queue_remaining_tasks_increased_frequency);

--- a/be/src/core/data_type_serde/data_type_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_serde.cpp
@@ -16,7 +16,11 @@
 // under the License.
 #include "core/data_type_serde/data_type_serde.h"
 
+#include <arrow/array/array_base.h>
+#include <arrow/type.h>
+
 #include "common/cast_set.h"
+#include "common/config.h"
 #include "common/exception.h"
 #include "common/status.h"
 #include "core/column/column.h"
@@ -33,6 +37,21 @@
 #include "util/jsonb_writer.h"
 namespace doris {
 DataTypeSerDe::~DataTypeSerDe() = default;
+
+Status DataTypeSerDeArrowUtils::read_column_from_arrow(const DataTypeSerDe& serde, IColumn& column,
+                                                       const arrow::Array* arrow_array,
+                                                       int64_t start, int64_t end,
+                                                       const cctz::time_zone& ctz) {
+    auto validate_status = config::enable_arrow_read_validate_full ? arrow_array->ValidateFull()
+                                                                   : arrow_array->Validate();
+    if (!validate_status.ok()) {
+        return Status::InternalError(
+                "Arrow array validation failed before read_column_from_arrow, arrow type: {}, "
+                "column: {}, error: {}",
+                arrow_array->type()->ToString(), column.get_name(), validate_status.ToString());
+    }
+    return serde.read_column_from_arrow(column, arrow_array, start, end, ctz);
+}
 
 DataTypeSerDeSPtrs create_data_type_serdes(const DataTypes& types) {
     DataTypeSerDeSPtrs serdes;

--- a/be/src/core/data_type_serde/data_type_serde.h
+++ b/be/src/core/data_type_serde/data_type_serde.h
@@ -91,6 +91,17 @@ struct CastParameters;
 class DataTypeSerDe;
 using DataTypeSerDeSPtr = std::shared_ptr<DataTypeSerDe>;
 using DataTypeSerDeSPtrs = std::vector<DataTypeSerDeSPtr>;
+class DataTypeArraySerDe;
+class DataTypeMapSerDe;
+class DataTypeNullableSerDe;
+class DataTypeStructSerDe;
+
+class DataTypeSerDeArrowUtils {
+public:
+    static Status read_column_from_arrow(const DataTypeSerDe& serde, IColumn& column,
+                                         const arrow::Array* arrow_array, int64_t start,
+                                         int64_t end, const cctz::time_zone& ctz);
+};
 
 /// Info that represents a scalar or array field in a decomposed view.
 /// It allows to recreate field with different number
@@ -481,10 +492,19 @@ public:
     virtual Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                          arrow::ArrayBuilder* array_builder, int64_t start,
                                          int64_t end, const cctz::time_zone& ctz) const = 0;
+
+private:
+    friend class DataTypeSerDeArrowUtils;
+    friend class DataTypeArraySerDe;
+    friend class DataTypeMapSerDe;
+    friend class DataTypeNullableSerDe;
+    friend class DataTypeStructSerDe;
+
     virtual Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array,
                                           int64_t start, int64_t end,
                                           const cctz::time_zone& ctz) const = 0;
 
+public:
     // ORC serializer
     virtual Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                        const NullMap* null_map,

--- a/be/src/exec/common/arrow_column_to_doris_column.cpp
+++ b/be/src/exec/common/arrow_column_to_doris_column.cpp
@@ -46,6 +46,7 @@
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/data_type/data_type_nullable.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "core/types.h"
 #include "core/value/vdatetime_value.h"
 #include "util/timezone_utils.h"
@@ -101,9 +102,10 @@ Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arr
                                     ColumnPtr& doris_column, const DataTypePtr& type,
                                     size_t num_elements, const cctz::time_zone& ctz) {
     auto mutable_column = IColumn::mutate(std::move(doris_column));
-    auto status = type->get_serde()->read_column_from_arrow(
-            *mutable_column, arrow_column, arrow_batch_cur_idx, arrow_batch_cur_idx + num_elements,
-            ctz);
+    auto serde = type->get_serde();
+    auto status = DataTypeSerDeArrowUtils::read_column_from_arrow(
+            *serde, *mutable_column, arrow_column, arrow_batch_cur_idx,
+            arrow_batch_cur_idx + num_elements, ctz);
     doris_column = std::move(mutable_column);
     return status;
 }

--- a/be/src/exprs/table_function/python_udtf_function.cpp
+++ b/be/src/exprs/table_function/python_udtf_function.cpp
@@ -32,6 +32,7 @@
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_factory.hpp"
 #include "core/data_type_serde/data_type_array_serde.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "exprs/function/array/function_array_utils.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
@@ -272,8 +273,8 @@ Status PythonUDTFFunction::_convert_list_array_to_array_column(
     // Use read_column_from_arrow for optimized conversion
     // This directly converts Arrow ListArray to Doris ColumnArray
     // No struct unwrapping needed - Python server sends the correct format!
-    RETURN_IF_ERROR(array_serde->read_column_from_arrow(*array_col, list_array.get(), 0,
-                                                        num_input_rows, _timezone_obj));
+    RETURN_IF_ERROR(DataTypeSerDeArrowUtils::read_column_from_arrow(
+            *array_serde, *array_col, list_array.get(), 0, num_input_rows, _timezone_obj));
 
     // Handle nullable wrapper: all array elements are non-null
     // (empty arrays [] are non-null, different from NULL)

--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -42,6 +42,7 @@
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_nullable.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "core/value/vdatetime_value.h"
 #include "format/arrow/arrow_row_batch.h"
 #include "format/arrow/arrow_utils.h"
@@ -122,8 +123,9 @@ Status FromRecordBatchToBlockConverter::convert(Block* block) {
         auto doris_column = doris_type->create_column();
         auto arrow_column = _batch->column(idx);
         DCHECK_EQ(arrow_column->length(), num_rows);
-        RETURN_IF_ERROR(doris_type->get_serde()->read_column_from_arrow(
-                *doris_column, &*arrow_column, 0, num_rows, _timezone_obj));
+        auto serde = doris_type->get_serde();
+        RETURN_IF_ERROR(DataTypeSerDeArrowUtils::read_column_from_arrow(
+                *serde, *doris_column, &*arrow_column, 0, num_rows, _timezone_obj));
         _columns.emplace_back(std::move(doris_column), std::move(doris_type), std::to_string(idx));
     }
 

--- a/be/src/format/arrow/arrow_stream_reader.cpp
+++ b/be/src/format/arrow/arrow_stream_reader.cpp
@@ -26,6 +26,7 @@
 #include "common/status.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "exec/common/arrow_column_to_doris_column.h"
 #include "format/arrow/arrow_pip_input_stream.h"
 #include "io/fs/stream_load_pipe.h"
@@ -114,10 +115,9 @@ Status ArrowStreamReader::_do_get_next_block(Block* block, size_t* read_rows, bo
                                                  column_name_in_block, column_name);
                 }
 
-                RETURN_IF_ERROR(
-                        columns_guard.get_datatype_by_position(c)
-                                ->get_serde()
-                                ->read_column_from_arrow(*columns[c], column, 0, num_rows, _ctzz));
+                auto serde = columns_guard.get_datatype_by_position(c)->get_serde();
+                RETURN_IF_ERROR(DataTypeSerDeArrowUtils::read_column_from_arrow(
+                        *serde, *columns[c], column, 0, num_rows, _ctzz));
             } catch (Exception& e) {
                 return Status::InternalError("Failed to convert from arrow to block: {}", e.what());
             }

--- a/be/src/format/lance/lance_rust_reader.cpp
+++ b/be/src/format/lance/lance_rust_reader.cpp
@@ -36,6 +36,7 @@
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/primitive_type.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "format/lance/lance_ffi.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
@@ -242,11 +243,10 @@ Status LanceRustReader::_do_get_next_block(Block* block, size_t* read_rows, bool
 
         const auto block_pos = it->second;
         try {
-            RETURN_IF_ERROR(columns_guard.get_datatype_by_position(block_pos)
-                                    ->get_serde()
-                                    ->read_column_from_arrow(*columns[block_pos],
-                                                             record_batch->column(c).get(), 0,
-                                                             num_rows, _ctzz));
+            auto serde = columns_guard.get_datatype_by_position(block_pos)->get_serde();
+            RETURN_IF_ERROR(DataTypeSerDeArrowUtils::read_column_from_arrow(
+                    *serde, *columns[block_pos], record_batch->column(c).get(), 0, num_rows,
+                    _ctzz));
         } catch (Exception& e) {
             return Status::InternalError("Failed to convert Lance arrow to block: {}", e.what());
         }

--- a/be/src/format/table/paimon_cpp_reader.cpp
+++ b/be/src/format/table/paimon_cpp_reader.cpp
@@ -28,6 +28,7 @@
 #include "arrow/result.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "format/table/paimon_doris_file_system.h"
 #include "format/table/partition_column_filler.h"
 #include "paimon/defs.h"
@@ -178,11 +179,10 @@ Status PaimonCppReader::_do_get_next_block(Block* block, size_t* read_rows, bool
         }
         const auto block_pos = it->second;
         try {
-            RETURN_IF_ERROR(columns_guard.get_datatype_by_position(block_pos)
-                                    ->get_serde()
-                                    ->read_column_from_arrow(*columns[block_pos],
-                                                             record_batch->column(c).get(), 0,
-                                                             num_rows, _ctzz));
+            auto serde = columns_guard.get_datatype_by_position(block_pos)->get_serde();
+            RETURN_IF_ERROR(DataTypeSerDeArrowUtils::read_column_from_arrow(
+                    *serde, *columns[block_pos], record_batch->column(c).get(), 0, num_rows,
+                    _ctzz));
         } catch (Exception& e) {
             return Status::InternalError("Failed to convert from arrow to block: {}", e.what());
         }

--- a/be/src/format/table/remote_doris_reader.cpp
+++ b/be/src/format/table/remote_doris_reader.cpp
@@ -31,6 +31,7 @@
 #include "common/status.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "core/types.h"
 #include "format/arrow/arrow_utils.h"
 #include "runtime/descriptors.h"
@@ -86,10 +87,9 @@ Status RemoteDorisReader::_do_get_next_block(Block* block, size_t* read_rows, bo
 
         try {
             auto block_pos = (*_col_name_to_block_idx)[column_name];
-            RETURN_IF_ERROR(columns_guard.get_datatype_by_position(block_pos)
-                                    ->get_serde()
-                                    ->read_column_from_arrow(*columns[block_pos], column, 0,
-                                                             num_rows, _ctzz));
+            auto serde = columns_guard.get_datatype_by_position(block_pos)->get_serde();
+            RETURN_IF_ERROR(DataTypeSerDeArrowUtils::read_column_from_arrow(
+                    *serde, *columns[block_pos], column, 0, num_rows, _ctzz));
         } catch (Exception& e) {
             return Status::InternalError(
                     "Failed to convert from arrow to block, column_name: {}, e: {}", column_name,

--- a/be/test/core/data_type_serde/data_type_serde_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_string_test.cpp
@@ -29,6 +29,7 @@
 #include <type_traits>
 
 #include "agent/be_exec_version_manager.h"
+#include "common/config.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
 #include "core/column/column_array.h"
@@ -41,6 +42,7 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/define_primitive_type.h"
+#include "core/data_type_serde/data_type_serde.h"
 #include "core/field.h"
 #include "core/types.h"
 #include "storage/olap_common.h"
@@ -237,6 +239,25 @@ TEST_F(DataTypeStringSerDeTest, ArrowMemNotAligned) {
     cctz::time_zone tz;
     auto st = serde_str->read_column_from_arrow(*column_str32, arr.get(), 0, 1, tz);
     EXPECT_TRUE(st.ok());
+}
+
+TEST_F(DataTypeStringSerDeTest, ArrowValidateFullBeforeRead) {
+    std::vector<int32_t> offsets = {0, 4, 2};
+    std::string values = "abcd";
+    auto offset_buffer = arrow::Buffer::Wrap(offsets.data(), offsets.size() * sizeof(int32_t));
+    auto value_buffer =
+            arrow::Buffer::Wrap(reinterpret_cast<const uint8_t*>(values.data()), values.size());
+    auto invalid_array = std::make_shared<arrow::StringArray>(2, offset_buffer, value_buffer);
+    ASSERT_FALSE(invalid_array->ValidateFull().ok());
+
+    auto column = ColumnString::create();
+    auto old_enable_arrow_read_validate_full = config::enable_arrow_read_validate_full;
+    config::enable_arrow_read_validate_full = true;
+    auto st = DataTypeSerDeArrowUtils::read_column_from_arrow(
+            *serde_str, *column, invalid_array.get(), 0, invalid_array->length(),
+            cctz::utc_time_zone());
+    config::enable_arrow_read_validate_full = old_enable_arrow_read_validate_full;
+    EXPECT_FALSE(st.ok());
 }
 
 // Run with UBSan enabled to catch misalignment errors.


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

Doris converts Arrow arrays from several external read paths into Doris columns through `DataTypeSerDe::read_column_from_arrow`. If an upstream Arrow array has invalid internal metadata, such as invalid string offsets, the current conversion code can enter the serde implementation directly and only fail later in a less controlled way.

Root cause: `read_column_from_arrow` was a public virtual entry point and external callers invoked it directly. There was no common boundary where Doris validated the Arrow array before entering the type-specific serde code.

This PR adds `DataTypeSerDeArrowUtils::read_column_from_arrow` as the public Arrow-read entry. External Arrow conversion callers now go through this utility. The utility always runs lightweight Arrow `Validate()` before conversion. The original virtual `DataTypeSerDe::read_column_from_arrow` is kept private so nested serde recursion can continue to use the original implementation without repeatedly validating every nested child array.

`ValidateFull()` is available through the BE config `enable_arrow_read_validate_full`, defaulting to `false`. It is intentionally not enabled by default because benchmark results show that full validation is much more expensive on string and nested string arrays, while lightweight `Validate()` is effectively negligible.

Benchmark results, 65536 rows, mean real time:

| Case | Validate only | Read only | Validate + read | ValidateFull + read | ValidateFull overhead |
| --- | ---: | ---: | ---: | ---: | ---: |
| Int32 | 0.025 us | 8.02 us | 8.09 us | 7.99 us | -0.4% |
| String len 8 | 0.031 us | 564 us | 572 us | 809 us | +43.4% |
| String len 128 | 0.031 us | 3241 us | 3108 us | 3770 us | +16.3% |
| Nullable String len 8 | 0.032 us | 595 us | 600 us | 859 us | +44.4% |
| Nullable String len 128 | 0.031 us | 2895 us | 2955 us | 4260 us | +47.2% |
| `Array<String len 8>` | 0.059 us | 4158 us | 4233 us | 5836 us | +40.4% |
| `Array<String len 128>` | 0.058 us | 17826 us | 18340 us | 21896 us | +22.8% |
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

