### PR TITLE
[optimize](iceberg) avoid full scan when inferring file format for migrated tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -79,9 +79,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
@@ -106,6 +108,7 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.Unbound;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -133,6 +136,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -1184,16 +1188,30 @@ public class IcebergUtils {
     }
 
     private static String inferFileFormatFromDataFiles(Table icebergTable) {
-        if (icebergTable.currentSnapshot() == null) {
+        Snapshot snapshot = icebergTable.currentSnapshot();
+        if (snapshot == null) {
             LOG.info("Iceberg table {} has no snapshot, defaulting to {}", icebergTable.name(), PARQUET_NAME);
             return PARQUET_NAME;
         }
-        try (CloseableIterable<FileScanTask> files = icebergTable.newScan().planFiles()) {
-            java.util.Iterator<FileScanTask> it = files.iterator();
-            if (it.hasNext()) {
-                String format = it.next().file().format().name().toLowerCase();
-                LOG.info("Iceberg table {} inferred file format {} from data files", icebergTable.name(), format);
-                return format;
+        FileIO io = icebergTable.io();
+        try {
+            for (ManifestFile manifest : snapshot.dataManifests(io)) {
+                // Read the `file_format` field from a single data manifest entry.
+                // To avoid many synchronous IO hanging FE planning.
+                if (manifest.addedFilesCount() != null && manifest.existingFilesCount() != null
+                        && manifest.addedFilesCount() == 0 && manifest.existingFilesCount() == 0) {
+                    continue;
+                }
+                try (CloseableIterable<DataFile> entries = ManifestFiles.read(manifest, io)
+                        .select(Collections.singletonList(DataFile.FILE_FORMAT.name()))) {
+                    java.util.Iterator<DataFile> it = entries.iterator();
+                    if (it.hasNext()) {
+                        String format = it.next().format().name().toLowerCase();
+                        LOG.info("Iceberg table {} inferred file format {} from manifest {}",
+                                icebergTable.name(), format, manifest.path());
+                        return format;
+                    }
+                }
             }
         } catch (Exception e) {
             LOG.warn("Failed to infer file format from data files for table {}, defaulting to {}",

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.iceberg.source.IcebergTableQueryInfo;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.GenericPartitionFieldSummary;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ManifestContent;
@@ -710,5 +711,34 @@ public class IcebergUtilsTest {
         Assert.assertEquals(expectSnapshotId, queryInfo.getSnapshotId());
         Assert.assertEquals(expectSchemaId, queryInfo.getSchemaId());
         Assert.assertEquals(expectRef, queryInfo.getRef());
+    }
+
+    @Test
+    public void testGetFileFormatHonorsWriteFormatProperty() {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(ImmutableMap.of(IcebergUtils.WRITE_FORMAT, "ORC"));
+        Assert.assertEquals(FileFormat.ORC, IcebergUtils.getFileFormat(table));
+        // No snapshot lookup should be needed when properties are sufficient.
+        Mockito.verify(table, Mockito.never()).currentSnapshot();
+    }
+
+    @Test
+    public void testGetFileFormatHonorsDefaultFormatProperty() {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(
+                ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, "parquet"));
+        Assert.assertEquals(FileFormat.PARQUET, IcebergUtils.getFileFormat(table));
+        Mockito.verify(table, Mockito.never()).currentSnapshot();
+    }
+
+    @Test
+    public void testGetFileFormatFallsBackToParquetWhenNoSnapshotAndNoProperties() {
+        // Migrated tables without write-format / write.format.default and no snapshot
+        // must not throw and must default to parquet.
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(ImmutableMap.of());
+        Mockito.when(table.currentSnapshot()).thenReturn(null);
+        Mockito.when(table.name()).thenReturn("test_no_snapshot_table");
+        Assert.assertEquals(FileFormat.PARQUET, IcebergUtils.getFileFormat(table));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

PR #64134 added a fallback in `IcebergUtils.getFileFormat()` that infers the data file format from the actual data files when the table properties `write-format` / `write.format.default` are missing.

But using `newScan().planFiles()` just to read a single field `file_format` is expensive. Sometimes it has many synchronous IO to hang FE planning(Such as using Iceberg on S3/COS/OSS/OFS remote storage).

This commit replace `newScan().planFiles()` with a direct manifest read the `file_format` field

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

