### PR TITLE
[fix](inverted index) Avoid BKD skip threshold bypass in search

### DIFF
--- a/be/src/exprs/function/function_search.cpp
+++ b/be/src/exprs/function/function_search.cpp
@@ -756,6 +756,7 @@ Status FunctionSearch::build_leaf_query(const TSearchClause& clause,
         param.query_type = direct_query_type;
         param.num_rows = num_rows;
         param.roaring = std::make_shared<roaring::Roaring>();
+        param.skip_try = true;
         RETURN_IF_ERROR(iterator->read_from_index(segment_v2::IndexParam {&param}));
 
         std::shared_ptr<roaring::Roaring> null_bitmap = std::make_shared<roaring::Roaring>();

--- a/be/test/exprs/function/function_search_test.cpp
+++ b/be/test/exprs/function/function_search_test.cpp
@@ -94,6 +94,7 @@ public:
         if (i_param->query_value.get_type() == TYPE_INT) {
             last_int_value = i_param->query_value.get<TYPE_INT>();
         }
+        last_skip_try = i_param->skip_try;
         if (i_param->roaring != nullptr) {
             i_param->roaring->add(3);
         }
@@ -113,6 +114,7 @@ public:
     PrimitiveType last_query_value_type = PrimitiveType::TYPE_NULL;
     bool last_bool_value = false;
     Int32 last_int_value = 0;
+    bool last_skip_try = false;
 };
 
 class DummyInvertedIndexReader final : public segment_v2::InvertedIndexReader {
@@ -2091,6 +2093,7 @@ TEST_F(FunctionSearchTest, TestBuildLeafQueryVariantNestedIntUsesDirectIndexRead
     EXPECT_EQ(InvertedIndexQueryType::EQUAL_QUERY, iterator.last_query_type);
     EXPECT_EQ(TYPE_INT, iterator.last_query_value_type);
     EXPECT_EQ(3, iterator.last_int_value);
+    EXPECT_TRUE(iterator.last_skip_try);
 }
 
 TEST_F(FunctionSearchTest, TestMultiPhraseQueryCase) {

--- a/regression-test/suites/search/test_search_bkd_skip_threshold.groovy
+++ b/regression-test/suites/search/test_search_bkd_skip_threshold.groovy
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_search_bkd_skip_threshold", "p0") {
+    sql "set enable_inverted_index_query_cache = false"
+    sql "set inverted_index_skip_threshold = 50"
+
+    sql "DROP TABLE IF EXISTS search_bkd_skip_threshold"
+
+    sql """
+        CREATE TABLE search_bkd_skip_threshold (
+            id INT,
+            score INT,
+            INDEX idx_score (score) USING INVERTED
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "disable_auto_compaction" = "true"
+        )
+    """
+
+    sql "INSERT INTO search_bkd_skip_threshold VALUES (1, 0)"
+
+    def rows = sql """
+        SELECT id, score
+        FROM search_bkd_skip_threshold
+        WHERE search('score:0')
+        ORDER BY id
+    """
+
+    assertEquals([[1, 0]], rows)
+}


### PR DESCRIPTION
## Proposed changes

The search() direct index reader path must not let BKD skip-threshold bypass the inverted index result, because VSearchExpr has no scalar fallback after the index path is selected.

This PR:
- Sets skip_try=true for search() direct index reader.
- Adds BE unit-test coverage that nested int search sends skip_try=true to the iterator.
- Adds a non-variant regression test for a regular INT column with an inverted index and inverted_index_skip_threshold=50.

## Tests

- /mnt/disk1/claude-max/ldb_toolchain20/bin/clang-format -i be/src/exprs/function/function_search.cpp be/test/exprs/function/function_search_test.cpp
- git diff --check upstream-apache/master...HEAD
- ./run-regression-test.sh --run --conf /mnt/disk1/claude-max/doris-wt-branch-selectdb-doris-4.1-nested/tmp/regression-conf.auto.groovy -d search -s test_search_bkd_skip_threshold

Notes:
- The regression was run from the master worktree against the already rebuilt local 4.1 runtime because this fresh master worktree has no local FE/BE runtime.
- The first regression attempt failed before SQL coverage due to missing thirdparty/installed/bin/thrift in the fresh worktree. Per local workflow, thirdparty/installed was symlinked from an existing worktree rather than downloaded, then the suite passed.
- BE unit-test binary was not available in this fresh master worktree without a new full local build; the same focused BE unit test and variant nested regression passed on branch-selectdb-doris-4.1 for the same fix path.