### PR TITLE
[fix](thread pool) do not retain ThreadPool tasks after submit failure

### DIFF
--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -471,6 +471,16 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
         _num_threads_pending_start++;
     }
 
+    if (need_a_thread && _num_threads + _num_threads_pending_start == 1) {
+        Status status = create_thread();
+        if (!status.ok()) {
+            _num_threads_pending_start--;
+            thread_pool_submit_failed->increment(1);
+            return status;
+        }
+        need_a_thread = false;
+    }
+
     Task task;
     task.runnable = std::move(r);
     task.submit_time_wather.start();
@@ -682,6 +692,12 @@ void ThreadPool::dispatch_thread() {
 }
 
 Status ThreadPool::create_thread() {
+    DBUG_EXECUTE_IF("ThreadPool.create_thread.inject_error", {
+        auto pool_name = dp->param<std::string>("name", "");
+        if (pool_name.empty() || pool_name == _name) {
+            return Status::InternalError("ThreadPool.create_thread.inject_error");
+        }
+    });
     return Thread::create("thread pool", absl::Substitute("$0 [worker]", _name),
                           &ThreadPool::dispatch_thread, this, nullptr);
 }

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -305,7 +305,9 @@ private:
     // Create new thread.
     //
     // REQUIRES: caller has incremented '_num_threads_pending_start' ahead of this call.
-    // NOTE: For performance reasons, _lock should not be held.
+    // NOTE: For performance reasons, _lock should usually not be held.
+    // do_submit() may hold it when creating the first worker, so a thread creation failure
+    // cannot leave a submitted task queued without any worker.
     Status create_thread();
 
     // Aborts if the current thread is a member of this thread pool.

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -46,6 +46,7 @@
 #include "gtest/gtest.h"
 #include "util/barrier.h"
 #include "util/countdown_latch.h"
+#include "util/debug_points.h"
 #include "util/defer_op.h"
 #include "util/random.h"
 #include "util/time.h"
@@ -174,6 +175,37 @@ TEST_F(ThreadPoolTest, TestThreadPoolWithNoMinimum) {
     EXPECT_EQ(0, _pool->_active_threads);
     _pool->shutdown();
     EXPECT_EQ(0, _pool->num_threads());
+}
+
+TEST_F(ThreadPoolTest, TestSubmitFailureDoesNotRetainTaskWithoutWorker) {
+    bool enable_debug_points = config::enable_debug_points;
+    config::enable_debug_points = true;
+    DebugPoints::instance()->clear();
+    Defer defer = [enable_debug_points] {
+        DebugPoints::instance()->clear();
+        config::enable_debug_points = enable_debug_points;
+    };
+
+    constexpr auto kPoolName = "submit_failure_without_worker";
+    EXPECT_TRUE(rebuild_pool_with_builder(
+                        ThreadPoolBuilder(kPoolName).set_min_threads(0).set_max_threads(1))
+                        .ok());
+    DebugPoints::instance()->add_with_params("ThreadPool.create_thread.inject_error",
+                                             {{"name", kPoolName}});
+
+    std::atomic<int32_t> counter(0);
+    auto st = _pool->submit_func([&counter]() { counter++; });
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(0, counter.load());
+    EXPECT_EQ(0, _pool->get_queue_size());
+    EXPECT_EQ(0, _pool->num_threads_pending_start());
+    EXPECT_EQ(0, _pool->num_threads());
+
+    DebugPoints::instance()->clear();
+    EXPECT_TRUE(_pool->submit_func([&counter]() { counter++; }).ok());
+    _pool->wait();
+    EXPECT_EQ(1, counter.load());
+    _pool->shutdown();
 }
 
 TEST_F(ThreadPoolTest, TestThreadPoolWithNoMaxThreads) {


### PR DESCRIPTION
### What problem does this PR solve?

ThreadPool::do_submit could return a non-OK status after retaining the submitted runnable in the token queue. This happened in the cold-start path when the task was queued first and lazy creation of the first worker failed. The caller would observe submit failure, but the task could still be retained and run later if another submit created a worker.
    
This change creates the first worker before queueing the submitted task. If first-worker creation fails, do_submit returns the error without retaining the runnable. Later worker-creation failures are unchanged because existing workers can still drain queued tasks.