### PR TITLE
[fix](be) avoid LeakSanitizer false positive on BE startup failure

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -314,6 +314,21 @@ struct Checker {
 #endif
         ;
 
+// A startup failure that happens after ExecEnv::init() has run must terminate the
+// process the same way normal shutdown does (see the _exit(0) at the end of main):
+// in the default mode we _exit() immediately, skipping global destructors and the
+// LeakSanitizer atexit check. Init-time singletons (e.g. the internal workload
+// group's task scheduler) intentionally live for the whole process lifetime, so
+// running the leak check on this abnormal-exit path reports them as false-positive
+// leaks. enable_graceful_exit_check is honored so memleak-check mode still runs LSAN.
+[[noreturn]] static void exit_on_startup_failure() {
+    google::FlushLogFiles(google::GLOG_INFO);
+    if (!doris::config::enable_graceful_exit_check) {
+        _exit(1);
+    }
+    exit(1);
+}
+
 int main(int argc, char** argv) {
     doris::signal::InstallFailureSignalHandler();
     // create StackTraceCache Instance, at the beginning, other static destructors may use.
@@ -598,7 +613,7 @@ int main(int argc, char** argv) {
     status = doris::ExecEnv::init(doris::ExecEnv::GetInstance(), paths, spill_paths, broken_paths);
     if (status != Status::OK()) {
         std::cerr << "failed to init doris storage engine, res=" << status;
-        return 0;
+        exit_on_startup_failure();
     }
 
     // Start concurrency stats manager
@@ -613,7 +628,7 @@ int main(int argc, char** argv) {
         if (!status.ok()) {
             std::cerr << msg << '\n';
             service->stop_works();
-            exit(-1);
+            exit_on_startup_failure();
         }
     };
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When BE startup fails after `ExecEnv::init()` has run (e.g. a transient thrift
timeout while starting the backend/heartbeat services), `main()` exits via
`return 0` (init failure) or `exit(-1)` (in `stop_work_if_error`). Both run libc
`exit` / global destructors, which triggers the LeakSanitizer atexit check. That
check reports init-time singletons that are still alive -- most visibly the
internal workload group's task scheduler created in `ExecEnv::init()` ->
`create_internal_wg()` -> `upsert_task_scheduler()` -> `HybridTaskScheduler` --
as leaks, even though they are intended to live for the whole process lifetime.

Normal shutdown deliberately avoids this by calling `_exit(0)` (gated on
`enable_graceful_exit_check`) so the leak check never runs. The startup-failure
paths did not follow that policy, so a transient startup failure on an ASAN build
produces a spurious `detected memory leaks` report and fails CI (observed as
"lsan fail (new)" with 0 test failures; the BE that produced it had hit a single
`thrift error THRIFT_EAGAIN (timed out)` during startup).

Fix: add `exit_on_startup_failure()` and use it on the post-init startup-failure
paths. It flushes logs and `_exit(1)` in the default mode (skipping destructors
and the LSAN atexit check), while honoring `enable_graceful_exit_check` so
memleak-check mode keeps running LSAN -- symmetric with the normal shutdown path.
This also fixes init failure incorrectly returning a success (0) exit code.

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: This only changes the abnormal process-exit path of BE
          `main()` (startup failure). There is no standard test harness in Doris to
          inject an init/startup failure; correctness is covered by the CI
          LeakSanitizer gate. The success path is unchanged.

- Behavior changed:
    - [x] Yes. On a startup failure after init, BE now terminates via `_exit(1)`
      in the default mode (skipping global destructors and the LSAN atexit check)
      instead of running them. Init failure now returns a non-zero exit code
      instead of 0. Normal/graceful shutdown is unchanged.

- Does this need documentation?
    - [x] No.
