### PR TITLE
[fix](be) Fix timestamptz protobuf test type

### DIFF
--- a/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
@@ -648,7 +648,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTestDateTime) {
 }
 
 TEST(DataTypeSerDePbTest, DataTypeTimeStampTzToProtobufKeepsScale) {
-    auto data_type = std::make_shared<DataTypeTimeStampTz>(6);
+    DataTypePtr data_type(std::make_shared<DataTypeTimeStampTz>(6));
     PTypeDesc type_desc;
     data_type->to_protobuf(&type_desc);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The TimeStampTz protobuf unit test constructed the type with auto, so the static type was std::shared_ptr<DataTypeTimeStampTz>. Calling to_protobuf(PTypeDesc*) through that concrete type failed because the three-argument override hides the base-class one-argument wrapper. Use DataTypePtr so the test exercises the IDataType public interface that owns the one-argument wrapper.

### Release note

None

### Check List (For Author)

- Test: Style check / Manual test
    - Ran build-support/check-format.sh with llvm@16 on PATH
    - Ran git diff --check
    - Unit Test: attempted targeted run-be-ut for DataTypeSerDePbTest.DataTypeTimeStampTzToProtobufKeepsScale, but it could not complete because the sandbox could not update submodule metadata or resolve github.com for missing datasketches-cpp dependency
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

