### PR TITLE
[fix](index) Do not allocate index id during statement analysis

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -3257,6 +3257,13 @@ public class SchemaChangeHandler extends AlterHandler {
             return true;
         }
 
+        // Allocate the persistent index id here, in the actual DDL execution path on the
+        // master, instead of during statement analysis (CreateIndexOp.validate). getNextId()
+        // may write an OP_SAVE_NEXTID edit log entry; doing that while merely analyzing a
+        // statement (e.g. when an audit plugin re-parses the SQL on a non-master FE) can crash
+        // the FE.
+        alterIndex.setIndexId(Env.getCurrentEnv().getNextId());
+
         // The restored olap table may not reset the index id, which comes from the upstream,
         // so we need to check and reset the index id here, to avoid confliction.
         // See OlapTable.resetIdsForRestore for details.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateIndexOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateIndexOp.java
@@ -78,7 +78,12 @@ public class CreateIndexOp extends AlterTableOp {
         }
 
         indexDef.validate();
-        index = indexDef.translateToCatalogStyle();
+        // Do not allocate a persistent index id here. validate() runs during statement
+        // analysis, including when an audit plugin re-parses the SQL on a non-master FE, and
+        // allocating an id would write an edit log entry that can crash a follower FE. The real
+        // index id is allocated later in SchemaChangeHandler.processAddIndex(), which only runs
+        // on the master during DDL execution.
+        index = indexDef.translateToCatalogStyleWithoutId();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/IndexDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/IndexDefinition.java
@@ -396,7 +396,24 @@ public class IndexDefinition {
     }
 
     public Index translateToCatalogStyle() {
-        return new Index(Env.getCurrentEnv().getNextId(), name, cols, indexType, properties,
+        Index index = translateToCatalogStyleWithoutId();
+        // Allocating a metadata id calls MetaIdGenerator.getNextId(), which may write an
+        // OP_SAVE_NEXTID edit log entry. This must only be done on the master during real DDL
+        // execution, never during statement analysis.
+        index.setIndexId(Env.getCurrentEnv().getNextId());
+        return index;
+    }
+
+    /**
+     * Translate to a catalog {@link Index} without allocating a persistent index id (the id
+     * keeps {@link Index#INDEX_ID_INIT_VALUE}). Analysis paths (e.g. CreateIndexOp.validate)
+     * must be side-effect free: allocating an id calls MetaIdGenerator.getNextId(), which may
+     * write an edit log entry, and that must not happen on a non-master FE (for example when an
+     * audit plugin re-parses the SQL on a follower). The real id is assigned later in the DDL
+     * execution path on the master.
+     */
+    public Index translateToCatalogStyleWithoutId() {
+        return new Index(Index.INDEX_ID_INIT_VALUE, name, cols, indexType, properties,
                 comment);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/CreateIndexOpTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/CreateIndexOpTest.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.info;
+
+import org.apache.doris.catalog.Index;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CreateIndexOpTest {
+
+    // Regression test: analyzing/validating a "CREATE INDEX" / "ALTER TABLE ... ADD INDEX"
+    // statement must not allocate a persistent index id. Allocating one calls
+    // MetaIdGenerator.getNextId(), which may
+    // write an OP_SAVE_NEXTID edit log entry. When an audit plugin re-parses such a statement on a
+    // non-master FE (follower), that edit log write can crash the FE. The real index id must be
+    // assigned only later, in the master execution path (SchemaChangeHandler.processAddIndex).
+    @Test
+    void testValidateDoesNotAllocateIndexId() throws Exception {
+        IndexDefinition indexDef = new IndexDefinition(
+                "idx_audit", false, Lists.newArrayList("col1"), "INVERTED", null, "comment");
+        // tableName is null, so validate() does not touch the ConnectContext; passing null is safe.
+        CreateIndexOp op = new CreateIndexOp(null, indexDef, true);
+        op.validate(null);
+
+        Assertions.assertNotNull(op.getIndex());
+        Assertions.assertEquals(Index.INDEX_ID_INIT_VALUE, op.getIndex().getIndexId(),
+                "CreateIndexOp.validate() must not allocate a persistent index id");
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Analyzing an `ALTER TABLE ... ADD INDEX` / `CREATE INDEX` statement allocated a
persistent index id via `Env.getNextId()` inside `CreateIndexOp.validate()`
(`IndexDefinition.translateToCatalogStyle()`). `getNextId()` may write an
`OP_SAVE_NEXTID` edit log entry.

Statement analysis is **not** master-only — audit plugins re-parse SQL on
follower FEs. Allocating an id there writes the edit log on a non-master node.
If the BDBJE journal database handle has been replicated-removed in the
meantime, `BDBJEJournal.write()` throws `DatabasePreemptedException`, retries a
few times and then exits the FE process (`System.exit(-1)`), restarting the FE.

Observed call chain on a follower FE:

```
BDBJEJournal.write()
  <- EditLog.logSaveNextId()
  <- MetaIdGenerator.getNextId() / Env.getNextId()
  <- CreateIndexOp.validate() -> IndexDefinition.translateToCatalogStyle()
  <- audit plugin re-parsing the audited SQL
  <- AuditEventProcessor.handleAuditEvent()
  <- WorkloadRuntimeStatusMgr.runAfterCatalogReady()   // runs on all FEs
```

This PR defers index id allocation from the analysis phase to the master DDL
execution path:

- `IndexDefinition`: add a side-effect-free `translateToCatalogStyleWithoutId()`
  (the id keeps `Index.INDEX_ID_INIT_VALUE`); `translateToCatalogStyle()` now
  delegates to it and then allocates the id.
- `CreateIndexOp.validate()`: use the non-allocating variant, so statement
  analysis writes no edit log.
- `SchemaChangeHandler.processAddIndex()`: allocate the real index id here,
  which only runs on the master during DDL execution.

The `CREATE TABLE` inline-index path is intentionally unchanged: its
`translateToCatalogStyle()` runs during master-side table creation, not during
analysis.

### Release note

Fix a possible FE restart: a non-master FE could exit while an audit plugin
re-parsed a `CREATE INDEX` / `ALTER TABLE ... ADD INDEX` statement, because
allocating the index id during analysis wrote an edit log entry on the follower.

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
