### PR TITLE
[fix](fe) Clear warm-up error message after successful retry

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
@@ -524,6 +524,14 @@ public class CloudWarmUpJob implements Writable {
         this.errMsg = msg;
     }
 
+    private boolean resetErrMsg() {
+        if (StringUtils.isEmpty(errMsg)) {
+            return false;
+        }
+        this.errMsg = "";
+        return true;
+    }
+
     public void setFinishedTimeMs(long timeMs) {
         this.finishedTimeMs = timeMs;
     }
@@ -969,6 +977,7 @@ public class CloudWarmUpJob implements Writable {
     }
 
     private void runEventDrivenJob() throws Exception {
+        boolean hasError = false;
         try {
             refreshEventDrivenBeToThriftAddress();
             initClients();
@@ -990,12 +999,16 @@ public class CloudWarmUpJob implements Writable {
                         hasTableFilter() ? getCurrentTableIdNames().size() : "all");
                 TWarmUpTabletsResponse response = entry.getValue().warmUpTablets(request);
                 if (response.getStatus().getStatusCode() != TStatusCode.OK) {
+                    hasError = true;
                     if (!response.getStatus().getErrorMsgs().isEmpty()) {
                         errMsg = response.getStatus().getErrorMsgs().get(0);
                     }
                     LOG.warn("send warm up request failed. job_id={}, event={}, err={}",
                             jobId, syncEvent, errMsg);
                 }
+            }
+            if (!hasError && resetErrMsg()) {
+                Env.getCurrentEnv().getEditLog().logModifyCloudWarmUpJob(this);
             }
         } catch (Exception e) {
             errMsg = e.getMessage();
@@ -1105,6 +1118,7 @@ public class CloudWarmUpJob implements Writable {
                     }
                     if (allBatchesDone) {
                         clearJobOnBEs();
+                        resetErrMsg();
                         this.finishedTimeMs = System.currentTimeMillis();
                         if (this.isPeriodic()) {
                             // wait for next schedule

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/CloudWarmUpJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/CloudWarmUpJobTest.java
@@ -22,12 +22,17 @@ import org.apache.doris.cloud.CloudWarmUpJob.JobState;
 import org.apache.doris.cloud.CloudWarmUpJob.JobType;
 import org.apache.doris.cloud.CloudWarmUpJob.SyncEvent;
 import org.apache.doris.cloud.CloudWarmUpJob.SyncMode;
+import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.GenericPool;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.BackendService;
 import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TStatus;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TWarmUpTabletsRequest;
 import org.apache.doris.thrift.TWarmUpTabletsRequestType;
 import org.apache.doris.thrift.TWarmUpTabletsResponse;
@@ -40,20 +45,31 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class CloudWarmUpJobTest {
+    private static final int COL_ERR_MSG = 11;
+
     private GenericPool<BackendService.Client> originalBackendPool;
     private GenericPool<BackendService.Client> mockBackendPool;
+    private boolean originalRunningUnitTest;
 
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() {
+        originalRunningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = true;
         originalBackendPool = ClientPool.backendPool;
         mockBackendPool = Mockito.mock(GenericPool.class);
         ClientPool.backendPool = mockBackendPool;
@@ -62,6 +78,7 @@ public class CloudWarmUpJobTest {
     @After
     public void tearDown() {
         ClientPool.backendPool = originalBackendPool;
+        FeConstants.runningUnitTest = originalRunningUnitTest;
     }
 
     @Test
@@ -140,6 +157,174 @@ public class CloudWarmUpJobTest {
         Mockito.verify(mockBackendPool).invalidateObject(unavailableAddress, null);
     }
 
+    @Test
+    public void testPendingRetryKeepsErrMsgWhenJobStarts() throws Exception {
+        CloudWarmUpJob job = new CloudWarmUpJob.Builder()
+                .setJobId(200L)
+                .setSrcClusterName("source_cluster")
+                .setDstClusterName("target_cluster")
+                .setJobType(JobType.CLUSTER)
+                .setSyncMode(SyncMode.PERIODIC)
+                .setSyncInterval(60L)
+                .build();
+        job.setErrMsg("previous failure");
+
+        CloudEnv cloudEnv = Mockito.mock(CloudEnv.class);
+        CacheHotspotManager cacheHotspotManager = Mockito.mock(CacheHotspotManager.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        Mockito.when(cloudEnv.getCacheHotspotMgr()).thenReturn(cacheHotspotManager);
+        Mockito.when(cloudEnv.getEditLog()).thenReturn(editLog);
+        Mockito.when(cacheHotspotManager.tryRegisterRunningJob(job)).thenReturn(true);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(cloudEnv);
+            invokeRunPendingJob(job);
+        }
+
+        Assert.assertEquals(JobState.RUNNING, job.getJobState());
+        Assert.assertEquals("previous failure", job.getJobInfo(null).get(COL_ERR_MSG));
+        Mockito.verify(editLog).logModifyCloudWarmUpJob(job);
+    }
+
+    @Test
+    public void testEventDrivenSuccessfulRetryClearsErrMsg() throws Exception {
+        CloudSystemInfoService cloudSystemInfoService = Mockito.mock(CloudSystemInfoService.class);
+        Backend backend = new Backend(1L, "host1", 9050);
+        backend.setBePort(9060);
+        Mockito.when(cloudSystemInfoService.getBackendsByClusterName("source_cluster"))
+                .thenReturn(Arrays.asList(backend));
+
+        TNetworkAddress address = new TNetworkAddress("host1", 9060);
+        BackendService.Client client = Mockito.mock(BackendService.Client.class);
+        Mockito.when(mockBackendPool.borrowObject(address)).thenReturn(client);
+        Mockito.when(client.warmUpTablets(Mockito.any(TWarmUpTabletsRequest.class)))
+                .thenReturn(okWarmUpResponse());
+        CloudEnv cloudEnv = Mockito.mock(CloudEnv.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        Mockito.when(cloudEnv.getEditLog()).thenReturn(editLog);
+
+        CloudWarmUpJob job = new CloudWarmUpJob.Builder()
+                .setJobId(201L)
+                .setSrcClusterName("source_cluster")
+                .setDstClusterName("target_cluster")
+                .setJobType(JobType.CLUSTER)
+                .setSyncMode(SyncMode.EVENT_DRIVEN)
+                .setSyncEvent(SyncEvent.LOAD)
+                .build();
+        job.setJobState(JobState.RUNNING);
+        setStartTimeMs(job, System.currentTimeMillis());
+        job.setErrMsg("previous failure");
+
+        boolean runningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(cloudEnv);
+            job.run();
+            job.run();
+        } finally {
+            FeConstants.runningUnitTest = runningUnitTest;
+        }
+
+        Assert.assertEquals("", job.getJobInfo(null).get(COL_ERR_MSG));
+        ArgumentCaptor<CloudWarmUpJob> jobCaptor = ArgumentCaptor.forClass(CloudWarmUpJob.class);
+        Mockito.verify(editLog, Mockito.times(1)).logModifyCloudWarmUpJob(jobCaptor.capture());
+        CloudWarmUpJob replayedJob = copyBySerialization(jobCaptor.getValue());
+        Assert.assertEquals("", replayedJob.getJobInfo(null).get(COL_ERR_MSG));
+        Mockito.verify(client, Mockito.times(2)).warmUpTablets(Mockito.any(TWarmUpTabletsRequest.class));
+        Mockito.verify(mockBackendPool, Mockito.times(2)).returnObject(address, client);
+    }
+
+    @Test
+    public void testEventDrivenFailedRetryKeepsErrMsg() throws Exception {
+        CloudSystemInfoService cloudSystemInfoService = Mockito.mock(CloudSystemInfoService.class);
+        Backend backend = new Backend(1L, "host1", 9050);
+        backend.setBePort(9060);
+        Mockito.when(cloudSystemInfoService.getBackendsByClusterName("source_cluster"))
+                .thenReturn(Arrays.asList(backend));
+
+        TNetworkAddress address = new TNetworkAddress("host1", 9060);
+        BackendService.Client client = Mockito.mock(BackendService.Client.class);
+        Mockito.when(mockBackendPool.borrowObject(address)).thenReturn(client);
+        Mockito.when(client.warmUpTablets(Mockito.any(TWarmUpTabletsRequest.class)))
+                .thenReturn(failedWarmUpResponse());
+
+        CloudWarmUpJob job = new CloudWarmUpJob.Builder()
+                .setJobId(203L)
+                .setSrcClusterName("source_cluster")
+                .setDstClusterName("target_cluster")
+                .setJobType(JobType.CLUSTER)
+                .setSyncMode(SyncMode.EVENT_DRIVEN)
+                .setSyncEvent(SyncEvent.LOAD)
+                .build();
+        job.setJobState(JobState.RUNNING);
+        setStartTimeMs(job, System.currentTimeMillis());
+        job.setErrMsg("previous failure");
+
+        boolean runningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
+            job.run();
+        } finally {
+            FeConstants.runningUnitTest = runningUnitTest;
+        }
+
+        Assert.assertEquals("previous failure", job.getJobInfo(null).get(COL_ERR_MSG));
+        Mockito.verify(client).warmUpTablets(Mockito.any(TWarmUpTabletsRequest.class));
+        Mockito.verify(mockBackendPool).returnObject(address, client);
+    }
+
+    @Test
+    public void testRunningRetryClearsErrMsgWhenJobFinishes() throws Exception {
+        TNetworkAddress address = new TNetworkAddress("127.0.0.1", 9050);
+        BackendService.Client client = Mockito.mock(BackendService.Client.class);
+        Mockito.when(mockBackendPool.borrowObject(address)).thenReturn(client);
+        Mockito.when(client.warmUpTablets(Mockito.any(TWarmUpTabletsRequest.class)))
+                .thenReturn(okWarmUpResponse());
+
+        CloudWarmUpJob job = new CloudWarmUpJob.Builder()
+                .setJobId(202L)
+                .setSrcClusterName("source_cluster")
+                .setDstClusterName("target_cluster")
+                .setJobType(JobType.CLUSTER)
+                .setSyncMode(SyncMode.PERIODIC)
+                .setSyncInterval(60L)
+                .build();
+        job.setJobState(JobState.RUNNING);
+        setStartTimeMs(job, System.currentTimeMillis());
+        setSetJobDone(job, true);
+        job.setErrMsg("previous failure");
+
+        Map<Long, List<List<Long>>> beToTabletIdBatches = new HashMap<>();
+        beToTabletIdBatches.put(1L, Collections.emptyList());
+        job.setBeToTabletIdBatches(beToTabletIdBatches);
+        Map<Long, String> beToThriftAddress = new HashMap<>();
+        beToThriftAddress.put(1L, address.getHostname() + ":" + address.getPort());
+        job.setBeToThriftAddress(beToThriftAddress);
+
+        CloudEnv cloudEnv = Mockito.mock(CloudEnv.class);
+        CacheHotspotManager cacheHotspotManager = Mockito.mock(CacheHotspotManager.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        Mockito.when(cloudEnv.getCacheHotspotMgr()).thenReturn(cacheHotspotManager);
+        Mockito.when(cloudEnv.getEditLog()).thenReturn(editLog);
+
+        boolean runningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(cloudEnv);
+            invokeRunRunningJob(job);
+        } finally {
+            FeConstants.runningUnitTest = runningUnitTest;
+        }
+
+        Assert.assertEquals(JobState.PENDING, job.getJobState());
+        Assert.assertEquals("", job.getJobInfo(null).get(COL_ERR_MSG));
+        Mockito.verify(cacheHotspotManager).notifyJobStop(job);
+        Mockito.verify(editLog, Mockito.atLeastOnce()).logModifyCloudWarmUpJob(job);
+        Mockito.verify(mockBackendPool).returnObject(address, client);
+    }
+
     private CloudWarmUpJob createRunningJob(long jobId, TNetworkAddress firstAddress,
             TNetworkAddress secondAddress) {
         CloudWarmUpJob job = new CloudWarmUpJob.Builder()
@@ -159,5 +344,52 @@ public class CloudWarmUpJobTest {
         Method method = CloudWarmUpJob.class.getDeclaredMethod("clearJobOnBEs");
         method.setAccessible(true);
         method.invoke(job);
+    }
+
+    private void invokeRunPendingJob(CloudWarmUpJob job) throws Exception {
+        Method method = CloudWarmUpJob.class.getDeclaredMethod("runPendingJob");
+        method.setAccessible(true);
+        method.invoke(job);
+    }
+
+    private void invokeRunRunningJob(CloudWarmUpJob job) throws Exception {
+        Method method = CloudWarmUpJob.class.getDeclaredMethod("runRunningJob");
+        method.setAccessible(true);
+        method.invoke(job);
+    }
+
+    private void setStartTimeMs(CloudWarmUpJob job, long startTimeMs) throws Exception {
+        java.lang.reflect.Field field = CloudWarmUpJob.class.getDeclaredField("startTimeMs");
+        field.setAccessible(true);
+        field.setLong(job, startTimeMs);
+    }
+
+    private void setSetJobDone(CloudWarmUpJob job, boolean setJobDone) throws Exception {
+        java.lang.reflect.Field field = CloudWarmUpJob.class.getDeclaredField("setJobDone");
+        field.setAccessible(true);
+        field.setBoolean(job, setJobDone);
+    }
+
+    private CloudWarmUpJob copyBySerialization(CloudWarmUpJob job) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            job.write(out);
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return CloudWarmUpJob.read(in);
+        }
+    }
+
+    private TWarmUpTabletsResponse okWarmUpResponse() {
+        TWarmUpTabletsResponse response = new TWarmUpTabletsResponse();
+        response.setStatus(new TStatus(TStatusCode.OK));
+        return response;
+    }
+
+    private TWarmUpTabletsResponse failedWarmUpResponse() {
+        TWarmUpTabletsResponse response = new TWarmUpTabletsResponse();
+        response.setStatus(new TStatus(TStatusCode.INTERNAL_ERROR));
+        response.getStatus().setErrorMsgs(Collections.emptyList());
+        return response;
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Warm-up jobs keep the previous ErrMsg in SHOW WARM UP JOB after a transient failure even when a later retry succeeds. The FE stores the message in CloudWarmUpJob.errMsg, but the successful retry paths did not clear it before exposing job info. This PR clears the message when a normal or periodic job finishes a retry run successfully and when an event-driven job successfully sends SET_JOB to all target BEs, so SHOW WARM UP JOB reflects the current successful state.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Unit test:
- ./run-fe-ut.sh --run org.apache.doris.cloud.CloudWarmUpJobTest
- ./build.sh --fe

- Behavior changed:
    - [ ] No.
    - [x] Yes. SHOW WARM UP JOB no longer shows a stale warm-up error after a later retry succeeds.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label