### PR TITLE
[fix](function) Validate array_sort lambda arity

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArraySort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArraySort.java
@@ -72,6 +72,13 @@ public class ArraySort extends ScalarFunction
                 throw new AnalysisException("array_sort does not support types: " + argType.toSql());
             }
         }
+        if (getArgument(0) instanceof Lambda) {
+            Lambda lambda = (Lambda) getArgument(0);
+            if (lambda.getLambdaArgumentNames().size() != 2) {
+                throw new AnalysisException("When using lambda as the parameter of array_sort,"
+                        + " the lambda must be a binary comparator lambda.");
+            }
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
@@ -61,6 +61,16 @@ public class CheckExpressionLegalityTest implements MemoPatternMatchSupported {
     }
 
     @Test
+    public void testArraySortLambdaArgumentCount() {
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "the lambda must be a binary comparator lambda", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select array_sort(x -> x, [1, 2, 3])");
+                });
+    }
+
+    @Test
     public void testCountDistinctBitmap() {
         ConnectContext connectContext = MemoTestUtils.createConnectContext();
         PlanChecker.from(connectContext)

--- a/regression-test/suites/nereids_function_p0/scalar_function/Array2.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/Array2.groovy
@@ -45,6 +45,10 @@ suite("nereids_scalar_fn_Array2") {
                                IF(IPV4_STRING_TO_NUM_OR_NULL(x) = IPV4_STRING_TO_NUM_OR_NULL(y), 0, 1)),
                                ['192.168.0.3', '192.168.0.1', '192.168.0.2'])"""
     order_qt_sql_array_sort_8 """SELECT array_sort((x, y) -> IF(x < y, 1, IF(x = y, 0, -1)), [3, -2.1, 5.34, 1.2, 2.2])"""
+    test {
+        sql """SELECT array_sort(x -> x, [3, 2, 1])"""
+        exception "the lambda must be a binary comparator lambda"
+    }
 
     order_qt_sql_array_sort_Tinyint """SELECT array_sort((x, y) -> CASE WHEN x IS NULL THEN -1
                                  WHEN y IS NULL THEN 1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `array_sort` accepts a lambda comparator, but a lambda with a non-binary parameter list could pass analysis and reach later planning or execution paths. This PR validates that `array_sort` lambda arguments are exactly the two comparator parameters and adds FE and regression coverage for the invalid single-argument lambda case.

### Release note

Reject `array_sort` lambda arguments that are not binary comparator lambdas.

### Check List (For Author)

- Test: Regression test / Unit Test
    - Unit Test: `./run-fe-ut.sh --run org.apache.doris.nereids.rules.analysis.CheckExpressionLegalityTest`
    - Regression test: `./run-regression-test.sh --run -d nereids_function_p0 -s load`
    - Regression test: `./run-regression-test.sh --run -d nereids_function_p0/scalar_function -s nereids_scalar_fn_Array2`
- Behavior changed: Yes. Invalid `array_sort` lambda arity now fails during analysis.
- Does this need documentation: No