### PR TITLE
[fix](be) prevent SIGFPE in int_divide for signed min value

### DIFF
--- a/be/src/exprs/function/int_div.cpp
+++ b/be/src/exprs/function/int_div.cpp
@@ -23,7 +23,6 @@
 #include <limits>
 #include <utility>
 
-#include "common/exception.h"
 #include "core/data_type/data_type_number.h"
 #include "exprs/function/simple_function_factory.h"
 
@@ -122,14 +121,11 @@ struct DivideIntegralImpl {
                 std::make_shared<typename PrimitiveTypeTraits<Type>::DataType>()};
     }
 
-    static void throw_if_division_leads_to_fpe(Arg a, Arg b) {
+    static bool division_leads_to_fpe(Arg a, Arg b) {
         if constexpr (std::is_signed_v<Arg>) {
-            if (b == -1 && a == std::numeric_limits<Arg>::min()) {
-                throw Exception(ErrorCode::INVALID_ARGUMENT,
-                                "Division of minimal signed number by minus one is an undefined "
-                                "behavior, {} DIV {}. ",
-                                a, b);
-            }
+            return b == -1 && a == std::numeric_limits<Arg>::min();
+        } else {
+            return false;
         }
     }
 
@@ -144,8 +140,14 @@ struct DivideIntegralImpl {
             if constexpr (std::is_signed_v<Arg>) {
                 if (b == -1) {
                     for (size_t i = 0; i < size; i++) {
-                        throw_if_division_leads_to_fpe(a[i], b);
+                        null_map[i] = division_leads_to_fpe(a[i], b);
+                        if (!null_map[i]) {
+                            c[i] = typename PrimitiveTypeTraits<ResultType>::CppType(a[i] / b);
+                        } else {
+                            c[i] = {};
+                        }
                     }
+                    return;
                 }
             }
             if constexpr (!std::is_floating_point_v<Arg> && !std::is_same_v<Arg, Int128> &&
@@ -164,9 +166,10 @@ struct DivideIntegralImpl {
 
     static inline typename PrimitiveTypeTraits<ResultType>::CppType apply(Arg a, Arg b,
                                                                           UInt8& is_null) {
-        is_null = b == 0;
-        b += is_null;
-        throw_if_division_leads_to_fpe(a, b);
+        is_null = b == 0 || division_leads_to_fpe(a, b);
+        if (is_null) {
+            return {};
+        }
         return typename PrimitiveTypeTraits<ResultType>::CppType(a / b);
     }
 

--- a/be/src/exprs/function/int_div.cpp
+++ b/be/src/exprs/function/int_div.cpp
@@ -20,8 +20,10 @@
 
 #include <libdivide.h>
 
+#include <limits>
 #include <utility>
 
+#include "common/exception.h"
 #include "core/data_type/data_type_number.h"
 #include "exprs/function/simple_function_factory.h"
 
@@ -120,6 +122,17 @@ struct DivideIntegralImpl {
                 std::make_shared<typename PrimitiveTypeTraits<Type>::DataType>()};
     }
 
+    static void throw_if_division_leads_to_fpe(Arg a, Arg b) {
+        if constexpr (std::is_signed_v<Arg>) {
+            if (b == -1 && a == std::numeric_limits<Arg>::min()) {
+                throw Exception(ErrorCode::INVALID_ARGUMENT,
+                                "Division of minimal signed number by minus one is an undefined "
+                                "behavior, {} DIV {}. ",
+                                a, b);
+            }
+        }
+    }
+
     static void apply(const typename ColumnType::Container& a, Arg b,
                       typename PrimitiveTypeTraits<ResultType>::ColumnType::Container& c,
                       PaddedPODArray<UInt8>& null_map) {
@@ -128,6 +141,13 @@ struct DivideIntegralImpl {
         memset(null_map.data(), is_null, size);
 
         if (!is_null) {
+            if constexpr (std::is_signed_v<Arg>) {
+                if (b == -1) {
+                    for (size_t i = 0; i < size; i++) {
+                        throw_if_division_leads_to_fpe(a[i], b);
+                    }
+                }
+            }
             if constexpr (!std::is_floating_point_v<Arg> && !std::is_same_v<Arg, Int128> &&
                           !std::is_same_v<Arg, Int8> && !std::is_same_v<Arg, UInt8>) {
                 const auto divider = libdivide::divider<Arg>(Arg(b));
@@ -145,7 +165,9 @@ struct DivideIntegralImpl {
     static inline typename PrimitiveTypeTraits<ResultType>::CppType apply(Arg a, Arg b,
                                                                           UInt8& is_null) {
         is_null = b == 0;
-        return typename PrimitiveTypeTraits<ResultType>::CppType(a / (b + is_null));
+        b += is_null;
+        throw_if_division_leads_to_fpe(a, b);
+        return typename PrimitiveTypeTraits<ResultType>::CppType(a / b);
     }
 
     static ColumnPtr constant_constant(Arg a, Arg b) {

--- a/be/src/exprs/function/int_div.cpp
+++ b/be/src/exprs/function/int_div.cpp
@@ -115,6 +115,7 @@ struct DivideIntegralImpl {
     using Arg = typename PrimitiveTypeTraits<Type>::CppType;
     using ColumnType = typename PrimitiveTypeTraits<Type>::ColumnType;
     static constexpr PrimitiveType ResultType = Type;
+    static constexpr bool is_signed_integer = std::is_signed_v<Arg> || std::is_same_v<Arg, Int128>;
 
     static DataTypes get_variadic_argument_types() {
         return {std::make_shared<typename PrimitiveTypeTraits<Type>::DataType>(),
@@ -122,7 +123,7 @@ struct DivideIntegralImpl {
     }
 
     static bool division_leads_to_fpe(Arg a, Arg b) {
-        if constexpr (std::is_signed_v<Arg>) {
+        if constexpr (is_signed_integer) {
             return b == -1 && a == std::numeric_limits<Arg>::min();
         } else {
             return false;
@@ -137,7 +138,7 @@ struct DivideIntegralImpl {
         memset(null_map.data(), is_null, size);
 
         if (!is_null) {
-            if constexpr (std::is_signed_v<Arg>) {
+            if constexpr (is_signed_integer) {
                 if (b == -1) {
                     for (size_t i = 0; i < size; i++) {
                         null_map[i] = division_leads_to_fpe(a[i], b);

--- a/be/test/exprs/function/function_arithmetic_test.cpp
+++ b/be/test/exprs/function/function_arithmetic_test.cpp
@@ -56,54 +56,42 @@ TEST(function_arithmetic_test, function_arithmetic_divide_test) {
 
 TEST(function_arithmetic_test, function_arithmetic_int_divide_min_signed_by_minus_one_test) {
     std::string func_name = "int_divide";
+    const auto min_int32 = std::numeric_limits<int32_t>::min();
     const auto min_int64 = std::numeric_limits<int64_t>::min();
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};
+        DataSet data_set = {{{int32_t {1}, int32_t {-1}}, int32_t {-1}},
+                            {{min_int32, int32_t {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    }
 
     {
         InputTypeSet input_types = {Consted {PrimitiveType::TYPE_BIGINT},
                                     Consted {PrimitiveType::TYPE_BIGINT}};
         DataSet data_set = {{{min_int64, int64_t {-1}}, Null()}};
-        auto st =
-                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
-        EXPECT_NE(
-                std::string::npos,
-                st.to_string().find(
-                        "Division of minimal signed number by minus one is an undefined behavior"));
+        static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
 
     {
         InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT,
                                     Consted {PrimitiveType::TYPE_BIGINT}};
         DataSet data_set = {{{min_int64, int64_t {-1}}, Null()}};
-        auto st =
-                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
-        EXPECT_NE(
-                std::string::npos,
-                st.to_string().find(
-                        "Division of minimal signed number by minus one is an undefined behavior"));
+        static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
 
     {
         InputTypeSet input_types = {Consted {PrimitiveType::TYPE_BIGINT},
                                     PrimitiveType::TYPE_BIGINT};
         DataSet data_set = {{{min_int64, int64_t {-1}}, Null()}};
-        auto st =
-                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
-        EXPECT_NE(
-                std::string::npos,
-                st.to_string().find(
-                        "Division of minimal signed number by minus one is an undefined behavior"));
+        static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
 
     {
         InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT, PrimitiveType::TYPE_BIGINT};
         DataSet data_set = {{{int64_t {1}, int64_t {-1}}, int64_t {-1}},
                             {{min_int64, int64_t {-1}}, Null()}};
-        auto st =
-                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
-        EXPECT_NE(
-                std::string::npos,
-                st.to_string().find(
-                        "Division of minimal signed number by minus one is an undefined behavior"));
+        static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
 }
 

--- a/be/test/exprs/function/function_arithmetic_test.cpp
+++ b/be/test/exprs/function/function_arithmetic_test.cpp
@@ -56,9 +56,25 @@ TEST(function_arithmetic_test, function_arithmetic_divide_test) {
 
 TEST(function_arithmetic_test, function_arithmetic_int_divide_min_signed_by_minus_one_test) {
     std::string func_name = "int_divide";
+    const auto min_int8 = std::numeric_limits<int8_t>::min();
+    const auto min_int16 = std::numeric_limits<int16_t>::min();
     const auto min_int32 = std::numeric_limits<int32_t>::min();
     const auto min_int64 = std::numeric_limits<int64_t>::min();
     const auto min_int128 = std::numeric_limits<Int128>::min();
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_TINYINT, PrimitiveType::TYPE_TINYINT};
+        DataSet data_set = {{{int8_t {1}, int8_t {-1}}, int8_t {-1}},
+                            {{min_int8, int8_t {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
+    }
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_SMALLINT, PrimitiveType::TYPE_SMALLINT};
+        DataSet data_set = {{{int16_t {1}, int16_t {-1}}, int16_t {-1}},
+                            {{min_int16, int16_t {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt16, true>(func_name, input_types, data_set));
+    }
 
     {
         InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};

--- a/be/test/exprs/function/function_arithmetic_test.cpp
+++ b/be/test/exprs/function/function_arithmetic_test.cpp
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include <iomanip>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -50,6 +51,59 @@ TEST(function_arithmetic_test, function_arithmetic_divide_test) {
         InputTypeSet input_types = {PrimitiveType::TYPE_DOUBLE, PrimitiveType::TYPE_DOUBLE};
         DataSet data_set = {{{1234.1, 34.6}, 35.667630057803464}, {{1234.34, 0.0}, Null()}};
         static_cast<void>(check_function<DataTypeFloat64, true>(func_name, input_types, data_set));
+    }
+}
+
+TEST(function_arithmetic_test, function_arithmetic_int_divide_min_signed_by_minus_one_test) {
+    std::string func_name = "int_divide";
+    const auto min_int64 = std::numeric_limits<int64_t>::min();
+
+    {
+        InputTypeSet input_types = {Consted {PrimitiveType::TYPE_BIGINT},
+                                    Consted {PrimitiveType::TYPE_BIGINT}};
+        DataSet data_set = {{{min_int64, int64_t {-1}}, Null()}};
+        auto st =
+                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
+        EXPECT_NE(
+                std::string::npos,
+                st.to_string().find(
+                        "Division of minimal signed number by minus one is an undefined behavior"));
+    }
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT,
+                                    Consted {PrimitiveType::TYPE_BIGINT}};
+        DataSet data_set = {{{min_int64, int64_t {-1}}, Null()}};
+        auto st =
+                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
+        EXPECT_NE(
+                std::string::npos,
+                st.to_string().find(
+                        "Division of minimal signed number by minus one is an undefined behavior"));
+    }
+
+    {
+        InputTypeSet input_types = {Consted {PrimitiveType::TYPE_BIGINT},
+                                    PrimitiveType::TYPE_BIGINT};
+        DataSet data_set = {{{min_int64, int64_t {-1}}, Null()}};
+        auto st =
+                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
+        EXPECT_NE(
+                std::string::npos,
+                st.to_string().find(
+                        "Division of minimal signed number by minus one is an undefined behavior"));
+    }
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT, PrimitiveType::TYPE_BIGINT};
+        DataSet data_set = {{{int64_t {1}, int64_t {-1}}, int64_t {-1}},
+                            {{min_int64, int64_t {-1}}, Null()}};
+        auto st =
+                check_function<DataTypeInt64, true>(func_name, input_types, data_set, -1, -1, true);
+        EXPECT_NE(
+                std::string::npos,
+                st.to_string().find(
+                        "Division of minimal signed number by minus one is an undefined behavior"));
     }
 }
 

--- a/be/test/exprs/function/function_arithmetic_test.cpp
+++ b/be/test/exprs/function/function_arithmetic_test.cpp
@@ -58,6 +58,7 @@ TEST(function_arithmetic_test, function_arithmetic_int_divide_min_signed_by_minu
     std::string func_name = "int_divide";
     const auto min_int32 = std::numeric_limits<int32_t>::min();
     const auto min_int64 = std::numeric_limits<int64_t>::min();
+    const auto min_int128 = std::numeric_limits<Int128>::min();
 
     {
         InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};
@@ -92,6 +93,34 @@ TEST(function_arithmetic_test, function_arithmetic_int_divide_min_signed_by_minu
         DataSet data_set = {{{int64_t {1}, int64_t {-1}}, int64_t {-1}},
                             {{min_int64, int64_t {-1}}, Null()}};
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
+    }
+
+    {
+        InputTypeSet input_types = {Consted {PrimitiveType::TYPE_LARGEINT},
+                                    Consted {PrimitiveType::TYPE_LARGEINT}};
+        DataSet data_set = {{{min_int128, Int128 {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt128, true>(func_name, input_types, data_set));
+    }
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_LARGEINT,
+                                    Consted {PrimitiveType::TYPE_LARGEINT}};
+        DataSet data_set = {{{min_int128, Int128 {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt128, true>(func_name, input_types, data_set));
+    }
+
+    {
+        InputTypeSet input_types = {Consted {PrimitiveType::TYPE_LARGEINT},
+                                    PrimitiveType::TYPE_LARGEINT};
+        DataSet data_set = {{{min_int128, Int128 {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt128, true>(func_name, input_types, data_set));
+    }
+
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_LARGEINT, PrimitiveType::TYPE_LARGEINT};
+        DataSet data_set = {{{Int128 {1}, Int128 {-1}}, Int128 {-1}},
+                            {{min_int128, Int128 {-1}}, Null()}};
+        static_cast<void>(check_function<DataTypeInt128, true>(func_name, input_types, data_set));
     }
 }
 


### PR DESCRIPTION

### What problem does this PR solve?

`BIGINT_MIN DIV -1` can trigger signed integer overflow in BE `int_divide` and terminate the backend with `SIGFPE`. Root cause: `DivideIntegralImpl` only handled division by zero, but did not guard the undefined signed case where the minimal signed integer is divided by `-1`. This change follows the existing `mod`/`pmod` behavior and returns `INVALID_ARGUMENT` before executing the unsafe division. The guard covers const/const, vector/const, const/vector, and vector/vector paths.


https://godbolt.org/z/YPq9W581e

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

