### PR TITLE
[fix](be) Fix sliced FixedSizeBinary Arrow string reads

### DIFF
--- a/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
@@ -144,12 +144,11 @@ Status DataTypeJsonbSerDe::read_column_from_arrow(IColumn& column, const arrow::
     } else if (arrow_array->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
         const auto* concrete_array = dynamic_cast<const arrow::FixedSizeBinaryArray*>(arrow_array);
         uint32_t width = concrete_array->byte_width();
-        const auto* array_data = concrete_array->GetValue(start);
 
         JsonBinaryValue value;
-        for (size_t offset_i = 0; offset_i < end - start; ++offset_i) {
+        for (auto offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
-                const auto* raw_data = array_data + (offset_i * width);
+                const auto* raw_data = concrete_array->GetValue(offset_i);
 
                 RETURN_IF_ERROR(
                         value.from_json_string(reinterpret_cast<const char*>(raw_data), width));

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -281,11 +281,10 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
     } else if (arrow_array->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
         const auto* concrete_array = dynamic_cast<const arrow::FixedSizeBinaryArray*>(arrow_array);
         uint32_t width = concrete_array->byte_width();
-        const auto* array_data = concrete_array->GetValue(start);
 
-        for (size_t offset_i = 0; offset_i < end - start; ++offset_i) {
+        for (auto offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
-                const auto* raw_data = array_data + (offset_i * width);
+                const auto* raw_data = concrete_array->GetValue(offset_i);
                 assert_cast<ColumnType&>(column).insert_data((char*)raw_data, width);
             } else {
                 assert_cast<ColumnType&>(column).insert_default();

--- a/be/test/core/data_type_serde/data_type_jsonb_serde_test.cpp
+++ b/be/test/core/data_type_serde/data_type_jsonb_serde_test.cpp
@@ -25,7 +25,9 @@
 #include <lz4/lz4.h>
 #include <streamvbyte.h>
 
+#include <array>
 #include <cstddef>
+#include <cstring>
 #include <iostream>
 #include <limits>
 #include <type_traits>
@@ -273,6 +275,50 @@ TEST_F(DataTypeJsonbSerDeTest, ArrowMemNotAligned) {
     cctz::time_zone tz;
     auto st = serde_jsonb->read_column_from_arrow(*column_jsonb, arr.get(), 0, 1, tz);
     EXPECT_TRUE(st.ok());
+}
+
+TEST_F(DataTypeJsonbSerDeTest, FixedSizeBinaryReadColumnFromArrowWithNonZeroStart) {
+    constexpr int64_t num_elements = 4;
+    constexpr int byte_width = 7;
+    auto data_buf_result = arrow::AllocateBuffer(num_elements * byte_width);
+    ASSERT_TRUE(data_buf_result.ok());
+    std::shared_ptr<arrow::Buffer> data_buf = std::move(data_buf_result.ValueOrDie());
+
+    auto* data = data_buf->mutable_data();
+    const std::array<std::string, num_elements> values = {"{\"a\":1}", "{\"b\":2}", "{\"c\":3}",
+                                                          "{\"d\":4}"};
+    for (int64_t i = 0; i < num_elements; ++i) {
+        memcpy(data + i * byte_width, values[i].data(), byte_width);
+    }
+
+    auto null_bitmap_result = arrow::AllocateBuffer(1);
+    ASSERT_TRUE(null_bitmap_result.ok());
+    std::shared_ptr<arrow::Buffer> null_bitmap = std::move(null_bitmap_result.ValueOrDie());
+    memset(null_bitmap->mutable_data(), 0, null_bitmap->size());
+    arrow::bit_util::ClearBit(null_bitmap->mutable_data(), 0);
+    arrow::bit_util::SetBit(null_bitmap->mutable_data(), 1);
+    arrow::bit_util::SetBit(null_bitmap->mutable_data(), 2);
+    arrow::bit_util::SetBit(null_bitmap->mutable_data(), 3);
+
+    auto type = std::make_shared<arrow::FixedSizeBinaryType>(byte_width);
+    auto arr = std::make_shared<arrow::FixedSizeBinaryArray>(type, num_elements, data_buf,
+                                                             null_bitmap, 1);
+
+    auto column = ColumnString::create();
+    cctz::time_zone tz;
+    auto st = serde_jsonb->read_column_from_arrow(*column, arr.get(), 1, 4, tz);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(column->size(), 3);
+
+    DataTypeSerDe::FormatOptions options;
+    for (size_t i = 0; i < column->size(); ++i) {
+        auto serialized_column = ColumnString::create();
+        VectorBufferWriter buffer_writer(*serialized_column);
+        st = serde_jsonb->serialize_one_cell_to_json(*column, i, buffer_writer, options);
+        ASSERT_TRUE(st.ok());
+        buffer_writer.commit();
+        EXPECT_EQ(serialized_column->get_data_at(0).to_string(), values[i + 1]);
+    }
 }
 
 } // namespace doris

--- a/be/test/core/data_type_serde/data_type_serde_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_string_test.cpp
@@ -23,7 +23,9 @@
 #include <lz4/lz4.h>
 #include <streamvbyte.h>
 
+#include <array>
 #include <cstddef>
+#include <cstring>
 #include <iostream>
 #include <limits>
 #include <type_traits>
@@ -317,6 +319,42 @@ TEST_F(DataTypeStringSerDeTest, ArrowMemNotAlignedNestedArr) {
     auto serde_list = std::make_shared<DataTypeArraySerDe>(serde_nullable_str);
     auto st = serde_list->read_column_from_arrow(*ser_col, arr.get(), 0, 1, tz);
     EXPECT_TRUE(st.ok());
+}
+
+TEST_F(DataTypeStringSerDeTest, FixedSizeBinaryReadColumnFromArrowWithNonZeroStart) {
+    constexpr int64_t num_elements = 4;
+    constexpr int byte_width = 4;
+    auto data_buf_result = arrow::AllocateBuffer(num_elements * byte_width);
+    ASSERT_TRUE(data_buf_result.ok());
+    std::shared_ptr<arrow::Buffer> data_buf = std::move(data_buf_result.ValueOrDie());
+
+    auto* data = data_buf->mutable_data();
+    const std::array<std::string, num_elements> values = {"aaaa", "bbbb", "cccc", "dddd"};
+    for (int64_t i = 0; i < num_elements; ++i) {
+        memcpy(data + i * byte_width, values[i].data(), byte_width);
+    }
+
+    auto null_bitmap_result = arrow::AllocateBuffer(1);
+    ASSERT_TRUE(null_bitmap_result.ok());
+    std::shared_ptr<arrow::Buffer> null_bitmap = std::move(null_bitmap_result.ValueOrDie());
+    memset(null_bitmap->mutable_data(), 0, null_bitmap->size());
+    arrow::bit_util::ClearBit(null_bitmap->mutable_data(), 0);
+    arrow::bit_util::SetBit(null_bitmap->mutable_data(), 1);
+    arrow::bit_util::SetBit(null_bitmap->mutable_data(), 2);
+    arrow::bit_util::SetBit(null_bitmap->mutable_data(), 3);
+
+    auto type = std::make_shared<arrow::FixedSizeBinaryType>(byte_width);
+    auto arr = std::make_shared<arrow::FixedSizeBinaryArray>(type, num_elements, data_buf,
+                                                             null_bitmap, 1);
+
+    auto column = ColumnString::create();
+    cctz::time_zone tz;
+    auto st = serde_str->read_column_from_arrow(*column, arr.get(), 1, 4, tz);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(column->size(), 3);
+    EXPECT_EQ(column->get_data_at(0).to_string(), "bbbb");
+    EXPECT_EQ(column->get_data_at(1).to_string(), "cccc");
+    EXPECT_EQ(column->get_data_at(2).to_string(), "dddd");
 }
 
 } // namespace doris


### PR DESCRIPTION

### What problem does this PR solve?


Reading Arrow FIXED_SIZE_BINARY arrays into Doris string columns used mixed index bases when `read_column_from_arrow` was called with a non-zero `start`. The data pointer was advanced to `start`, but null checks still used indexes beginning at 0. As a result, nullable sliced reads could apply the wrong null bitmap entries and insert default values for non-null rows.

Root cause: the FIXED_SIZE_BINARY branch used relative offsets for data access while calling `IsNull()` with the same relative offset. This change reads each row with the absolute Arrow index for both `IsNull(offset_i)` and `GetValue(offset_i)`.

A unit test covers a nullable FIXED_SIZE_BINARY array read from `[1, 4)`, which failed before the fix and now reads the expected values.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

