### PR TITLE
[fix](fe) Serialize workload policy session updates

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -26,6 +26,7 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.ResourceTypeEnum;
+import org.apache.doris.analysis.SetVar;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.authentication.Principal;
@@ -103,6 +104,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
 
@@ -181,6 +183,8 @@ public class ConnectContext {
     protected volatile Set<String> authenticatedRoles = Collections.emptySet();
     // Variables belong to this session.
     protected volatile SessionVariable sessionVariable;
+    // Serializes session variable access with workload policies that update idle connections.
+    private final ReentrantLock sessionVariableLock = new ReentrantLock();
     // Store user variable in this connection
     private Map<String, LiteralExpr> userVars = new HashMap<>();
     // Connection attributes provided by the MySQL client during handshake.
@@ -739,6 +743,37 @@ public class ConnectContext {
 
     public void setSessionVariable(SessionVariable sessionVariable) {
         this.sessionVariable = sessionVariable;
+    }
+
+    /**
+     * Lock session variables for the complete lifecycle of one command.
+     */
+    public void lockSessionVariableForCommand() {
+        sessionVariableLock.lock();
+    }
+
+    public void unlockSessionVariableForCommand() {
+        sessionVariableLock.unlock();
+    }
+
+    /**
+     * Apply a workload policy session variable only when this connection is idle.
+     *
+     * @return true if the value was applied; false if the connection is executing a command
+     */
+    public boolean trySetSessionVariableFromWorkloadPolicy(String varName, String varValue) throws DdlException {
+        if (!sessionVariableLock.tryLock()) {
+            return false;
+        }
+        try {
+            if (command != MysqlCommand.COM_SLEEP) {
+                return false;
+            }
+            VariableMgr.setVar(sessionVariable, new SetVar(varName, new StringLiteral(varValue)), false);
+            return true;
+        } finally {
+            sessionVariableLock.unlock();
+        }
     }
 
     public ConnectScheduler getConnectScheduler() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -678,6 +678,15 @@ public abstract class ConnectProcessor {
     }
 
     public TMasterOpResult proxyExecute(TMasterOpRequest request) throws TException {
+        ctx.lockSessionVariableForCommand();
+        try {
+            return proxyExecuteWithSessionVariableLock(request);
+        } finally {
+            ctx.unlockSessionVariableForCommand();
+        }
+    }
+
+    private TMasterOpResult proxyExecuteWithSessionVariableLock(TMasterOpRequest request) throws TException {
         ctx.setDatabase(request.db);
         ctx.setEnv(Env.getCurrentEnv());
         ctx.getState().reset();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -409,14 +409,19 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             return;
         }
 
-        // dispatch
-        dispatch();
-        // finalize
-        finalizeCommand();
+        ctx.lockSessionVariableForCommand();
+        try {
+            // dispatch
+            dispatch();
+            // finalize
+            finalizeCommand();
 
-        ctx.setCommand(MysqlCommand.COM_SLEEP);
-        ctx.clear();
-        executor = null;
+            ctx.setCommand(MysqlCommand.COM_SLEEP);
+            ctx.clear();
+            executor = null;
+        } finally {
+            ctx.unlockSessionVariableForCommand();
+        }
     }
 
     public void loop() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -315,6 +315,14 @@ public class VariableMgr {
     //      setVar: variable information that needs to be set
     public static void setVar(SessionVariable sessionVariable, SetVar setVar)
             throws DdlException {
+        setVar(sessionVariable, setVar, true);
+    }
+
+    /**
+     * Set a session variable and optionally record its original value for statement-level rollback.
+     */
+    public static void setVar(SessionVariable sessionVariable, SetVar setVar, boolean recordOriginValue)
+            throws DdlException {
         VarContext varCtx = getVarContext(setVar.getVariable());
         if (varCtx == null) {
             // Silently ignore variables that have been removed from SessionVariable.
@@ -334,7 +342,8 @@ public class VariableMgr {
                     findSimilarSessionVarNames(setVar.getVariable()));
         }
         checkUpdate(setVar, varCtx.getFlag());
-        setVarInternal(sessionVariable, setVar, varCtx);
+        setVarInternal(sessionVariable, setVar, varCtx,
+                recordOriginValue && sessionVariable.getIsSingleSetVar());
     }
 
     /**
@@ -381,7 +390,7 @@ public class VariableMgr {
             }
             ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable());
         }
-        setVarInternal(sessionVariable, setVar, varCtx);
+        setVarInternal(sessionVariable, setVar, varCtx, sessionVariable.getIsSingleSetVar());
     }
 
     @Nullable
@@ -409,7 +418,8 @@ public class VariableMgr {
         return ctx;
     }
 
-    private static void setVarInternal(SessionVariable sessionVariable, SetVar setVar, VarContext ctx)
+    private static void setVarInternal(SessionVariable sessionVariable, SetVar setVar, VarContext ctx,
+            boolean recordOriginValue)
             throws DdlException {
         // To modify to default value.
         VarAttrDef.VarAttr attr = ctx.getField().getAnnotation(VarAttrDef.VarAttr.class);
@@ -432,7 +442,7 @@ public class VariableMgr {
         Field field = ctx.getField();
         SessionVariableField sessionVariableField = new SessionVariableField(field);
         // if stmt is "Select /*+ SET_VAR(...)*/"
-        if (sessionVariable.getIsSingleSetVar()) {
+        if (recordOriginValue) {
             try {
                 sessionVariable.addSessionOriginValue(sessionVariableField, field.get(sessionVariable).toString());
             } catch (Exception e) {
@@ -792,7 +802,7 @@ public class VariableMgr {
                 LOG.debug("no need to set var for non master fe: {}", setVar.getVariable(), e);
                 continue;
             }
-            setVarInternal(sessionVariable, setVar, varCtx);
+            setVarInternal(sessionVariable, setVar, varCtx, sessionVariable.getIsSingleSetVar());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadActionSetSessionVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadActionSetSessionVar.java
@@ -17,10 +17,7 @@
 
 package org.apache.doris.resource.workloadschedpolicy;
 
-import org.apache.doris.analysis.SetVar;
-import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.common.UserException;
-import org.apache.doris.qe.VariableMgr;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -41,8 +38,7 @@ public class WorkloadActionSetSessionVar implements WorkloadAction {
     @Override
     public void exec(WorkloadQueryInfo queryInfo) {
         try {
-            SetVar var = new SetVar(varName, new StringLiteral(varValue));
-            VariableMgr.setVar(queryInfo.context.getSessionVariable(), var);
+            queryInfo.context.trySetSessionVariableFromWorkloadPolicy(varName, varValue);
         } catch (Throwable t) {
             LOG.error("error happens when exec {}", WorkloadActionType.SET_SESSION_VARIABLE, t);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
@@ -60,6 +60,7 @@ import java.util.concurrent.TimeoutException;
 public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoCloseable {
     private static final Logger LOG = LogManager.getLogger(FlightSqlConnectProcessor.class);
     private Schema arrowSchema;
+    private boolean sessionVariableLocked;
 
     public FlightSqlConnectProcessor(ConnectContext context) {
         super(context);
@@ -86,6 +87,8 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
         if (LOG.isDebugEnabled()) {
             LOG.debug("arrow flight sql handle command {}", command);
         }
+        ctx.lockSessionVariableForCommand();
+        sessionVariableLocked = true;
         ctx.setCommand(command);
         ctx.setStartTime();
     }
@@ -195,13 +198,20 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
 
     @Override
     public void close() throws Exception {
-        ctx.setCommand(MysqlCommand.COM_SLEEP);
-        for (StmtExecutor asynExecutor : returnResultFromRemoteExecutor) {
-            asynExecutor.finalizeQuery();
+        try {
+            ctx.setCommand(MysqlCommand.COM_SLEEP);
+            for (StmtExecutor asynExecutor : returnResultFromRemoteExecutor) {
+                asynExecutor.finalizeQuery();
+            }
+            returnResultFromRemoteExecutor.clear();
+            executor.finalizeQuery();
+            ctx.clear();
+            ConnectContext.remove();
+        } finally {
+            if (sessionVariableLocked) {
+                ctx.unlockSessionVariableForCommand();
+                sessionVariableLocked = false;
+            }
         }
-        returnResultFromRemoteExecutor.clear();
-        executor.finalizeQuery();
-        ctx.clear();
-        ConnectContext.remove();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -56,7 +56,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ConnectContextTest {
     private StmtExecutor executor = Mockito.mock(StmtExecutor.class);
@@ -152,6 +156,40 @@ public class ConnectContextTest {
         processor.handleResetConnection();
 
         Assert.assertEquals(0, ctx.getState().serverStatus);
+    }
+
+    @Test
+    public void testWorkloadPolicySessionVariableUpdatesOnlyIdleConnection() throws Exception {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setCommand(MysqlCommand.COM_SLEEP);
+
+        ctx.lockSessionVariableForCommand();
+        AtomicBoolean updated = new AtomicBoolean();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch finished = new CountDownLatch(1);
+        Thread policyThread = new Thread(() -> {
+            try {
+                updated.set(ctx.trySetSessionVariableFromWorkloadPolicy(SessionVariable.SQL_SELECT_LIMIT, "100"));
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                finished.countDown();
+            }
+        });
+        policyThread.start();
+        Assert.assertTrue(finished.await(5, TimeUnit.SECONDS));
+        Assert.assertNull(failure.get());
+        Assert.assertFalse(updated.get());
+        ctx.unlockSessionVariableForCommand();
+
+        Assert.assertTrue(ctx.trySetSessionVariableFromWorkloadPolicy(SessionVariable.SQL_SELECT_LIMIT, "100"));
+        Assert.assertEquals(100, ctx.getSessionVariable().getSqlSelectLimit());
+
+        ctx.getSessionVariable().setIsSingleSetVar(true);
+        VariableMgr.setVar(ctx.getSessionVariable(),
+                new SetVar(SessionVariable.SQL_SELECT_LIMIT, new StringLiteral("200")), false);
+        Assert.assertTrue(ctx.getSessionVariable().getSessionOriginValue().isEmpty());
+        Assert.assertEquals(200, ctx.getSessionVariable().getSqlSelectLimit());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: Workload policies updated a connection SessionVariable from the policy daemon while the connection thread could record or revert statement-scoped variables. Concurrent access to sessionOriginValue could throw ConcurrentModificationException, and a policy value could be overwritten by statement cleanup. Serialize session variable access for each command, apply policy updates only while the connection is idle, and explicitly exclude policy updates from statement rollback tracking.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.qe.ConnectContextTest
    - mvn checkstyle:check -pl fe-core
- Behavior changed: Yes (policy session-variable updates wait for an idle connection)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

