### PR TITLE
[fix](be) Init thread context on AsyncIO worker threads

### DIFF
--- a/be/src/util/async_io.h
+++ b/be/src/util/async_io.h
@@ -20,6 +20,7 @@
 #include <bthread/bthread.h>
 
 #include "io/fs/file_system.h"
+#include "runtime/thread_context.h"
 #include "storage/olap_define.h"
 #include "util/cpu_info.h"
 #include "util/work_thread_pool.hpp"
@@ -79,6 +80,12 @@ public:
         PriorityThreadPool::Task task;
         task.priority = nice;
         task.work_function = [&] {
+            // The AsyncIO worker is a plain infra pthread that is not bound to any task,
+            // so it has no ThreadContext. fn() (e.g. a FILESYSTEM_M dispatched upload/read)
+            // may touch thread_context() (memory tracking, LIMIT_*_SCAN_IO, ...), which would
+            // FatalError without a context. Initialize an (unattached) ThreadContext here,
+            // same pattern as StorageEngine background threads.
+            SCOPED_INIT_THREAD_CONTEXT();
             fn();
             std::unique_lock l(mutex);
             cv.notify_one();


### PR DESCRIPTION
## Proposed changes

### Problem

`FILESYSTEM_M` dispatches IO ops from a bthread to an `AsyncIO` worker pthread that is **not bound to any task** and therefore has no `ThreadContext`. When the dispatched `fn()` reads a local file, it goes through `LocalFileReader::read_at_impl` -> `LIMIT_LOCAL_SCAN_IO` -> `thread_context()`, which raises `Status::FatalError` (aborting the BE in debug/ASAN builds) when no `ThreadContext` exists.

Observed as a Cloud P0 coredump on the load error-log S3 upload path:

```
RuntimeState::get_error_log_file_path()
  -> _s3_error_fs->upload()                 (called from a bthread)
  -> AsyncIO::run_task() on an AsyncIO worker pthread (no attached task)
  -> S3FileSystem::upload_impl()
  -> LocalFileReader::read_at_impl()
  -> LIMIT_LOCAL_SCAN_IO -> thread_context() -> FatalError -> SIGABRT
```

### Fix

Initialize an (unattached) `ThreadContext` at the `AsyncIO` worker boundary via `SCOPED_INIT_THREAD_CONTEXT()`, the same pattern used by StorageEngine background threads. This gives every `thread_context()` consumer running on an AsyncIO worker (memory tracking, `LIMIT_*_SCAN_IO`, ...) a valid context, fixing the crash at its root rather than making individual consumers tolerate a missing context.