### PR TITLE
[fix](agg push down) guard Count(*) child access with arity() check in PushDownAggThroughJoinOnPkFk

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFk.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFk.java
@@ -215,6 +215,7 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
             }
             if (expression instanceof Alias
                     && expression.child(0) instanceof Count
+                    && expression.child(0).arity() > 0
                     && expression.child(0).child(0) instanceof Slot) {
                 // count(slot) can be rewritten by circle deps
                 Slot slot = (Slot) expression.child(0).child(0);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFkTest.java
@@ -157,6 +157,20 @@ class PushDownAggThroughJoinOnPkFkTest extends TestWithFeService implements Memo
     }
 
     @Test
+    void testCountStar() {
+        // Regression: COUNT(*) has no children, and calling child(0) on it
+        // would throw ArrayIndexOutOfBoundsException if not guarded by arity() > 0
+        String sql = "select count(*), pri.name from pri inner join foreign_not_null\n"
+                + "on pri.id1 = foreign_not_null.id2\n"
+                + "group by pri.id1, pri.name, foreign_not_null.id2";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin(logicalAggregate(), any()))
+                .printlnTree();
+    }
+
+    @Test
     void testMissSlot() {
         String sql = "select count(pri.name) from pri inner join foreign_not_null on pri.name = foreign_not_null.name";
         PlanChecker.from(connectContext)


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #36035

Problem Summary:

COUNT(*) has no arguments; calling child(0) on it throws ArrayIndexOutOfBoundsException. Added arity() > 0 guard before accessing Count's child slot for FK rewrite.

Regression test testCountStar() added to verify COUNT(*) with PK/FK join does not crash.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

