### PR TITLE
[fix](stats) Include offset in TopN row count estimation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -1354,7 +1354,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
      */
     public Statistics computeTopN(TopN topN, Statistics inputStats) {
         return inputStats.cleanHotValues().build()
-                .withRowCountAndEnforceValid(Math.min(inputStats.getRowCount(), topN.getLimit()));
+                .withRowCountAndEnforceValid(Math.min(inputStats.getRowCount(), topN.getLimit() + topN.getOffset()));
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -255,9 +255,9 @@ public class StatsCalculatorTest {
         Group ownerGroup = new Group(null, groupExpression, null);
         StatsCalculator.estimate(groupExpression, null);
         Statistics topNStats = ownerGroup.getStatistics();
-        Assertions.assertEquals(1, topNStats.getRowCount());
+        Assertions.assertEquals(3, topNStats.getRowCount());
         ColumnStatistic slot1Stats = topNStats.columnStatistics().get(slot1);
-        Assertions.assertEquals(1, slot1Stats.ndv, 0.1);
+        Assertions.assertEquals(3, slot1Stats.ndv, 0.1);
         Assertions.assertEquals(1, slot1Stats.numNulls, 0.1);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: 

We found that TOPN may be handled by the optimizer as a gather sort, leading to performance degradation.
```
    PLAN FRAGMENT 0
      PARTITION: UNPARTITIONED

      VTOP-N
        order by: pay_amt_7d DESC, shop_id DESC
        offset: 200000
        limit: 10

      VEXCHANGE

    PLAN FRAGMENT 1
      STREAM DATA SINK
        UNPARTITIONED

      VOlapScanNode
        cardinality=269490531
        numNodes=1
```

The TopN statistics estimation only used `limit` to calculate the output row count, ignoring `offset`. 
For a query like `LIMIT 1 OFFSET 2`, the estimated row count was 1, but the actual operator needs to process limit + offset = 3 rows. This leads to inaccurate cost estimation and potentially suboptimal query plans.


### Release note

None

### Check List (For Author)

- Test: Unit Test
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

