### PR TITLE
[fix](function) Align constant folding with BE results

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -747,12 +747,20 @@ public class DateTimeExtractAndTransform {
             hourValue = hourValue > 0 ? 838 : -838;
             minuteValue = 59;
             secondValue = 59;
-        } else if (Math.abs(hourValue) == 838 && secondValue > 59) {
-            secondValue = 59;
         }
 
-        return new TimeV2Literal((int) Math.abs(hourValue), (int) minuteValue, (int) secondValue,
-                            (int) Math.round(secondValue * 1000000) % 1000000, 6, hourValue < 0);
+        long totalMicrosecond = Math.abs(hourValue) * 3600L * 1000000
+                + minuteValue * 60L * 1000000 + Math.round(secondValue * 1000000);
+        long maxMicrosecond = 838L * 3600L * 1000000 + 59L * 60L * 1000000 + 59999999L;
+        totalMicrosecond = Math.min(totalMicrosecond, maxMicrosecond);
+
+        int newHour = (int) (totalMicrosecond / 3600L / 1000000);
+        totalMicrosecond %= 3600L * 1000000;
+        int newMinute = (int) (totalMicrosecond / 60L / 1000000);
+        totalMicrosecond %= 60L * 1000000;
+        int newSecond = (int) (totalMicrosecond / 1000000);
+        int microsecond = (int) (totalMicrosecond % 1000000);
+        return new TimeV2Literal(newHour, newMinute, newSecond, microsecond, 6, hourValue < 0);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -441,28 +441,6 @@ public class StringArithmetic {
      * Executable arithmetic functions ConcatWs
      */
     @ExecFunction(name = "concat_ws")
-    public static Expression concatWsVarcharLiteral(StringLikeLiteral first, Literal... second) {
-        StringBuilder sb = new StringBuilder();
-        boolean hasValue = false;
-        for (Literal value : second) {
-            if (value instanceof ArrayLiteral) {
-                throw new AnalysisException("Unsupported concat_ws array varargs to fold const by fe");
-            }
-            if (!(value instanceof NullLiteral)) {
-                if (hasValue) {
-                    sb.append(first.getValue());
-                }
-                sb.append(value.getValue());
-                hasValue = true;
-            }
-        }
-        return castStringLikeLiteral(first, sb.toString());
-    }
-
-    /**
-     * Executable arithmetic functions ConcatWs
-     */
-    @ExecFunction(name = "concat_ws")
     public static Expression concatWsVarcharVarchar(StringLikeLiteral first, StringLikeLiteral... second) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < second.length; i++) {
@@ -577,8 +555,10 @@ public class StringArithmetic {
     }
 
     private static int compareFloatLiteral(FloatLiteral first, FloatLiteral... second) {
+        float firstValue = first.getValue();
         for (int i = 0; i < second.length; i++) {
-            if (second[i].getValue() == first.getValue()) {
+            float secondValue = second[i].getValue();
+            if (secondValue == firstValue) {
                 return i + 1;
             }
         }
@@ -586,8 +566,10 @@ public class StringArithmetic {
     }
 
     private static int compareDoubleLiteral(DoubleLiteral first, DoubleLiteral... second) {
+        double firstValue = first.getValue();
         for (int i = 0; i < second.length; i++) {
-            if (second[i].getValue() == first.getValue()) {
+            double secondValue = second[i].getValue();
+            if (secondValue == firstValue) {
                 return i + 1;
             }
         }
@@ -691,12 +673,23 @@ public class StringArithmetic {
     }
 
     private static int findStringInSet(String target, String input) {
-        String[] split = input.split(",", -1);
-        for (int i = 0; i < split.length; i++) {
-            if (split[i].equals(target)) {
-                return i + 1;
-            }
+        if (target.indexOf(',') >= 0) {
+            return 0;
         }
+
+        int tokenIndex = 1;
+        int start = 0;
+        do {
+            int end = start;
+            while (end < input.length() && input.charAt(end) != ',') {
+                ++end;
+            }
+            if (input.substring(start, end).equals(target)) {
+                return tokenIndex;
+            }
+            start = end + 1;
+            ++tokenIndex;
+        } while (start < input.length());
         return 0;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -46,9 +46,6 @@ import com.google.common.collect.Lists;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -56,6 +53,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -136,11 +134,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "lower")
     public static Expression lowerVarchar(StringLikeLiteral first) {
-        StringBuilder result = new StringBuilder(first.getValue().length());
-        for (char c : first.getValue().toCharArray()) {
-            result.append(Character.toLowerCase(c));
-        }
-        return castStringLikeLiteral(first, result.toString());
+        return castStringLikeLiteral(first, first.getValue().toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -148,11 +142,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "upper")
     public static Expression upperVarchar(StringLikeLiteral first) {
-        StringBuilder result = new StringBuilder(first.getValue().length());
-        for (char c : first.getValue().toCharArray()) {
-            result.append(Character.toUpperCase(c));
-        }
-        return castStringLikeLiteral(first, result.toString());
+        return castStringLikeLiteral(first, first.getValue().toUpperCase(Locale.ROOT));
     }
 
     private static String trimImpl(String first, String second, boolean left, boolean right) {
@@ -327,7 +317,8 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "right")
     public static Expression right(StringLikeLiteral first, IntegerLiteral second) {
-        int inputLength = first.getValue().codePointCount(0, first.getValue().length());
+        String input = first.getValue();
+        int inputLength = input.codePointCount(0, input.length());
         if (second.getValue() < (- inputLength) || Math.abs(second.getValue()) == 0) {
             return castStringLikeLiteral(first, "");
         } else if (second.getValue() >= inputLength) {
@@ -335,13 +326,11 @@ public class StringArithmetic {
         } else {
             // at here second can not be exceeding boundary
             if (second.getValue() >= 0) {
-                int index = first.getValue().offsetByCodePoints(0, second.getValue());
-                return castStringLikeLiteral(first, first.getValue().substring(
-                    inputLength - index, inputLength));
+                int index = input.offsetByCodePoints(0, inputLength - second.getValue());
+                return castStringLikeLiteral(first, input.substring(index));
             } else {
-                int index = first.getValue().offsetByCodePoints(0, Math.abs(second.getValue()) - 1);
-                return castStringLikeLiteral(first, first.getValue().substring(
-                    index, inputLength));
+                int index = input.offsetByCodePoints(0, Math.abs(second.getValue()) - 1);
+                return castStringLikeLiteral(first, input.substring(index));
             }
         }
     }
@@ -400,7 +389,11 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "instr")
     public static Expression instr(StringLikeLiteral first, StringLikeLiteral second) {
-        return new IntegerLiteral(first.getValue().indexOf(second.getValue()) + 1);
+        int index = first.getValue().indexOf(second.getValue());
+        if (index < 0) {
+            return new IntegerLiteral(0);
+        }
+        return new IntegerLiteral(first.getValue().codePointCount(0, index) + 1);
     }
 
     /**
@@ -494,19 +487,22 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "initcap")
     public static Expression initCap(StringLikeLiteral first) {
-        StringBuilder result = new StringBuilder(first.getValue().length());
+        String lower = first.getValue().toLowerCase(Locale.ROOT);
+        StringBuilder result = new StringBuilder(lower.length());
         boolean capitalizeNext = true;
 
-        for (char c : first.getValue().toCharArray()) {
-            if (!Character.isLetterOrDigit(c)) {
-                result.append(c);
+        for (int i = 0; i < lower.length();) {
+            int codePoint = lower.codePointAt(i);
+            if (!Character.isLetterOrDigit(codePoint)) {
+                result.appendCodePoint(codePoint);
                 capitalizeNext = true;  // Next character should be capitalized
             } else if (capitalizeNext) {
-                result.append(Character.toUpperCase(c));
+                result.appendCodePoint(Character.toUpperCase(codePoint));
                 capitalizeNext = false;
             } else {
-                result.append(Character.toLowerCase(c));
+                result.appendCodePoint(codePoint);
             }
+            i += Character.charCount(codePoint);
         }
         return castStringLikeLiteral(first, result.toString());
     }
@@ -580,6 +576,24 @@ public class StringArithmetic {
         return 0;
     }
 
+    private static int compareFloatLiteral(FloatLiteral first, FloatLiteral... second) {
+        for (int i = 0; i < second.length; i++) {
+            if (second[i].getValue() == first.getValue()) {
+                return i + 1;
+            }
+        }
+        return 0;
+    }
+
+    private static int compareDoubleLiteral(DoubleLiteral first, DoubleLiteral... second) {
+        for (int i = 0; i < second.length; i++) {
+            if (second[i].getValue() == first.getValue()) {
+                return i + 1;
+            }
+        }
+        return 0;
+    }
+
     /**
      * Executable arithmetic functions field
      */
@@ -625,7 +639,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "field")
     public static Expression fieldFloat(FloatLiteral first, FloatLiteral... second) {
-        return new IntegerLiteral(compareLiteral(first, second));
+        return new IntegerLiteral(compareFloatLiteral(first, second));
     }
 
     /**
@@ -633,7 +647,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "field")
     public static Expression fieldDouble(DoubleLiteral first, DoubleLiteral... second) {
-        return new IntegerLiteral(compareLiteral(first, second));
+        return new IntegerLiteral(compareDoubleLiteral(first, second));
     }
 
     /**
@@ -858,7 +872,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "strcmp")
     public static Expression strcmp(StringLikeLiteral first, StringLikeLiteral second) {
-        int result = first.getValue().compareTo(second.getValue());
+        int result = compareUtf8Bytes(first.getValue(), second.getValue());
         if (result == 0) {
             return new TinyIntLiteral((byte) 0);
         } else if (result < 0) {
@@ -866,6 +880,19 @@ public class StringArithmetic {
         } else {
             return new TinyIntLiteral((byte) 1);
         }
+    }
+
+    private static int compareUtf8Bytes(String left, String right) {
+        byte[] leftBytes = left.getBytes(StandardCharsets.UTF_8);
+        byte[] rightBytes = right.getBytes(StandardCharsets.UTF_8);
+        int minLength = Math.min(leftBytes.length, rightBytes.length);
+        for (int i = 0; i < minLength; i++) {
+            int diff = Byte.toUnsignedInt(leftBytes[i]) - Byte.toUnsignedInt(rightBytes[i]);
+            if (diff != 0) {
+                return diff;
+            }
+        }
+        return leftBytes.length - rightBytes.length;
     }
 
     /**
@@ -897,93 +924,137 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "parse_url")
     public static Expression parseurl(StringLikeLiteral first, StringLikeLiteral second) {
-        URI uri = null;
-        try {
-            uri = new URI(first.getValue());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        StringBuilder sb = new StringBuilder();
-        if (uri.getScheme() == null) {
+        String value = parseUrlRaw(first.getValue(), second.getValue());
+        if (value == null) {
             return new NullLiteral(first.getDataType());
         }
-        switch (second.getValue().toUpperCase()) {
+        return castStringLikeLiteral(first, value);
+    }
+
+    private static String parseUrlRaw(String url, String part) {
+        String trimmedUrl = url.trim();
+        int protocolPos = trimmedUrl.indexOf("://");
+        if (protocolPos < 0) {
+            return null;
+        }
+        String protocolEnd = trimmedUrl.substring(protocolPos + "://".length());
+        switch (part.toUpperCase(Locale.ROOT)) {
             case "PROTOCOL":
-                String scheme = uri.getScheme();
-                if (scheme == null) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(scheme); // e.g., http, https
-                break;
+                return trimmedUrl.substring(0, protocolPos);
             case "HOST":
-                String host = uri.getHost();
-                if (host == null) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(host);  // e.g., www.example.com
-                break;
+                return parseUrlHost(protocolEnd);
             case "PATH":
-                String path = uri.getPath();
-                if (path == null) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(path);  // e.g., /page
-                break;
+                return parseUrlPath(protocolEnd);
             case "REF":
-                try {
-                    String ref = uri.toURL().getRef();
-                    if (ref == null) {
-                        return new NullLiteral(first.getDataType());
-                    }
-                    sb.append(ref);  // e.g., /page
-                } catch (MalformedURLException e) {
-                    throw new RuntimeException(e);
-                }
-                break;
+                return parseUrlRef(protocolEnd);
             case "AUTHORITY":
-                String authority = uri.getAuthority();
-                if (authority == null) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(authority);  // e.g., param1=value1&param2=value2
-                break;
+                return parseUrlAuthority(protocolEnd);
             case "FILE":
-                try {
-                    String file = uri.toURL().getFile();
-                    if (file == null) {
-                        return new NullLiteral(first.getDataType());
-                    }
-                    sb.append(file);  // e.g., param1=value1&param2=value2
-                } catch (MalformedURLException e) {
-                    throw new RuntimeException(e);
-                }
-                break;
+                return parseUrlFile(protocolEnd);
             case "QUERY":
-                String query = uri.getQuery();
-                if (query == null) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(query);  // e.g., param1=value1&param2=value2
-                break;
+                return parseUrlQuery(protocolEnd);
             case "PORT":
-                int port = uri.getPort();
-                if (port == -1) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(port);
-                break;
+                return parseUrlPort(protocolEnd);
             case "USERINFO":
-                String userInfo = uri.getUserInfo();
-                if (userInfo == null) {
-                    return new NullLiteral(first.getDataType());
-                }
-                sb.append(userInfo);  // e.g., user:pass
-                break;
+                return parseUrlUserInfo(protocolEnd);
             default:
                 throw new RuntimeException("Valid URL parts are 'PROTOCOL', 'HOST', "
                         + "'PATH', 'REF', 'AUTHORITY', 'FILE', 'USERINFO', 'PORT' and 'QUERY'");
         }
-        return castStringLikeLiteral(first, sb.toString());
+    }
+
+    private static int firstIndexOf(String value, char first, char second) {
+        int firstIndex = value.indexOf(first);
+        int secondIndex = value.indexOf(second);
+        if (firstIndex < 0) {
+            return secondIndex;
+        }
+        if (secondIndex < 0) {
+            return firstIndex;
+        }
+        return Math.min(firstIndex, secondIndex);
+    }
+
+    private static String substringEnd(String value, int end) {
+        return end < 0 ? value : value.substring(0, end);
+    }
+
+    private static String parseUrlAuthority(String protocolEnd) {
+        return substringEnd(protocolEnd, protocolEnd.indexOf('/'));
+    }
+
+    private static String parseUrlPath(String protocolEnd) {
+        int startPos = protocolEnd.indexOf('/');
+        if (startPos < 0) {
+            return "";
+        }
+        String pathStart = protocolEnd.substring(startPos);
+        return substringEnd(pathStart, firstIndexOf(pathStart, '?', '#'));
+    }
+
+    private static String parseUrlFile(String protocolEnd) {
+        int startPos = protocolEnd.indexOf('/');
+        if (startPos < 0) {
+            return "";
+        }
+        String pathStart = protocolEnd.substring(startPos);
+        return substringEnd(pathStart, pathStart.indexOf('#'));
+    }
+
+    private static String parseUrlHost(String protocolEnd) {
+        int startPos = protocolEnd.indexOf('@');
+        startPos = startPos < 0 ? 0 : startPos + 1;
+        String hostStart = protocolEnd.substring(startPos);
+        int queryStartPos = hostStart.indexOf('?');
+        if (queryStartPos > 0) {
+            hostStart = hostStart.substring(0, queryStartPos);
+        }
+        int endPos = hostStart.indexOf(':');
+        if (endPos < 0) {
+            endPos = hostStart.indexOf('/');
+        }
+        return substringEnd(hostStart, endPos);
+    }
+
+    private static String parseUrlQuery(String protocolEnd) {
+        int startPos = protocolEnd.indexOf('?');
+        if (startPos < 0) {
+            return null;
+        }
+        String queryStart = protocolEnd.substring(startPos + 1);
+        return substringEnd(queryStart, queryStart.indexOf('#'));
+    }
+
+    private static String parseUrlRef(String protocolEnd) {
+        int startPos = protocolEnd.indexOf('#');
+        if (startPos < 0) {
+            return null;
+        }
+        return protocolEnd.substring(startPos + 1);
+    }
+
+    private static String parseUrlUserInfo(String protocolEnd) {
+        int endPos = protocolEnd.indexOf('@');
+        if (endPos < 0) {
+            return null;
+        }
+        return protocolEnd.substring(0, endPos);
+    }
+
+    private static String parseUrlPort(String protocolEnd) {
+        int startPos = protocolEnd.indexOf('@');
+        startPos = startPos < 0 ? 0 : startPos + 1;
+        String hostStart = protocolEnd.substring(startPos);
+        int endPos = hostStart.indexOf(':');
+        if (endPos < 0) {
+            return null;
+        }
+        String portStart = hostStart.substring(endPos + 1);
+        int portEndPos = portStart.indexOf('/');
+        if (portEndPos < 0) {
+            portEndPos = portStart.indexOf('?');
+        }
+        return substringEnd(portStart, portEndPos);
     }
 
     /**
@@ -1042,25 +1113,26 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "extract_url_parameter")
     public static Expression extractUrlParameter(StringLikeLiteral first, StringLikeLiteral second) {
-        if (first.getValue() == null || first.getValue().indexOf('?') == -1) {
+        if (second.getValue().isEmpty()) {
             return castStringLikeLiteral(first, "");
         }
-        URI uri;
-        try {
-            uri = new URI(first.getValue());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+        String trimmedUrl = first.getValue().trim();
+        int questionPos = trimmedUrl.indexOf('?');
+        if (questionPos < 0) {
+            return castStringLikeLiteral(first, "");
         }
-
-        String query = uri.getQuery();
-        if (query != null) {
-            String[] pairs = query.split("&", -1);
-
-            for (String pair : pairs) {
-                String[] keyValue = pair.split("=", -1);
-                if (second.getValue().equals(keyValue[0])) {
-                    return castStringLikeLiteral(first, keyValue[1]);
-                }
+        int hashPos = trimmedUrl.indexOf('#');
+        String subUrl = hashPos < 0
+                ? trimmedUrl.substring(questionPos + 1)
+                : trimmedUrl.substring(questionPos + 1, hashPos);
+        String[] pairs = subUrl.split("&", -1);
+        for (String pair : pairs) {
+            int eqPos = pair.indexOf('=');
+            if (eqPos < 0) {
+                continue;
+            }
+            if (second.getValue().equals(pair.substring(0, eqPos))) {
+                return castStringLikeLiteral(first, pair.substring(eqPos + 1));
             }
         }
         return castStringLikeLiteral(first, "");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -431,13 +431,38 @@ public class StringArithmetic {
     @ExecFunction(name = "concat_ws")
     public static Expression concatWsVarcharArray(StringLikeLiteral first, ArrayLiteral second) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < second.getValue().size() - 1; i++) {
-            if (!(second.getValue().get(i) instanceof NullLiteral)) {
-                sb.append(second.getValue().get(i).getValue());
-                sb.append(first.getValue());
+        boolean hasValue = false;
+        for (Literal value : second.getValue()) {
+            if (!(value instanceof NullLiteral)) {
+                if (hasValue) {
+                    sb.append(first.getValue());
+                }
+                sb.append(value.getValue());
+                hasValue = true;
             }
         }
-        sb.append(second.getValue().get(second.getValue().size() - 1).getValue());
+        return castStringLikeLiteral(first, sb.toString());
+    }
+
+    /**
+     * Executable arithmetic functions ConcatWs
+     */
+    @ExecFunction(name = "concat_ws")
+    public static Expression concatWsVarcharLiteral(StringLikeLiteral first, Literal... second) {
+        StringBuilder sb = new StringBuilder();
+        boolean hasValue = false;
+        for (Literal value : second) {
+            if (value instanceof ArrayLiteral) {
+                throw new AnalysisException("Unsupported concat_ws array varargs to fold const by fe");
+            }
+            if (!(value instanceof NullLiteral)) {
+                if (hasValue) {
+                    sb.append(first.getValue());
+                }
+                sb.append(value.getValue());
+                hasValue = true;
+            }
+        }
         return castStringLikeLiteral(first, sb.toString());
     }
 
@@ -447,11 +472,12 @@ public class StringArithmetic {
     @ExecFunction(name = "concat_ws")
     public static Expression concatWsVarcharVarchar(StringLikeLiteral first, StringLikeLiteral... second) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < second.length - 1; i++) {
+        for (int i = 0; i < second.length; i++) {
+            if (i > 0) {
+                sb.append(first.getValue());
+            }
             sb.append(second[i].getValue());
-            sb.append(first.getValue());
         }
-        sb.append(second[second.length - 1].getValue());
         return castStringLikeLiteral(first, sb.toString());
     }
 
@@ -493,7 +519,7 @@ public class StringArithmetic {
         try {
             MessageDigest md = MessageDigest.getInstance("MD5");
             // Update the digest with the input bytes
-            md.update(first.getValue().getBytes());
+            md.update(first.getValue().getBytes(StandardCharsets.UTF_8));
             return castStringLikeLiteral(first, bytesToHex(md.digest()));
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
@@ -516,7 +542,7 @@ public class StringArithmetic {
             }
 
             // Step 3: Convert the combined string to a byte array and pass it to the digest() method
-            byte[] messageDigest = md.digest(combinedInput.toString().getBytes());
+            byte[] messageDigest = md.digest(combinedInput.toString().getBytes(StandardCharsets.UTF_8));
 
             // Step 4: Convert the byte array into a hexadecimal string
             StringBuilder hexString = new StringBuilder();

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_func_time.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_func_time.groovy
@@ -42,6 +42,7 @@ suite("test_func_time") {
     testFoldConst("select time(cast('2025-1-1 00:00:00.4321' as datetime(4)));")
     testFoldConst("select time(cast('2025-1-1 00:00:00.54321' as datetime(5)));")
     testFoldConst("select time(cast('2025-1-1 00:00:00.654321' as datetime(6)));")
+    testFoldConst("select maketime(1, 2, 3.9999995), maketime(1, 2, 59.9999995);")
 
     def tableName = "test_time_function"
 

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_all.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_all.groovy
@@ -117,6 +117,13 @@ suite("string_functions_all") {
     testFoldConst("SELECT CONCAT_WS(',', 'Name', 'Age', 'City'), CONCAT_WS('/', 'home', 'user', 'documents', 'file.txt');")
     testFoldConst("SELECT CONCAT_WS(',', ['a', NULL]), CONCAT_WS(',', [NULL, 'a', NULL]), CONCAT_WS(',', [NULL]);")
     testFoldConst("SELECT CONCAT_WS(',', 'a', NULL), CONCAT_WS(',', NULL, 'a', NULL), CONCAT_WS(',', NULL);")
+    testFoldConst("SELECT RIGHT('😀a', 1), INSTR('😀a', 'a');")
+    testFoldConst("SELECT UPPER('éßi'), LOWER('ÉİA'), INITCAP('ßETA İSTANBUL');")
+    testFoldConst("SELECT STRCMP('😀', ''), FIND_IN_SET('', 'a,');")
+    testFoldConst("""SELECT PARSE_URL('http://h/p%20x?q=a+b%20c&k=v#r', 'PATH'),
+        PARSE_URL('http://h/p%20x?q=a+b%20c&k=v#r', 'QUERY'),
+        EXTRACT_URL_PARAMETER('http://h/p%20x?q=a+b%20c&k=v#r', 'q');""")
+    testFoldConst("SELECT FIELD(CAST('-0.0' AS DOUBLE), CAST('0.0' AS DOUBLE), CAST('-0.0' AS DOUBLE));")
 
     // CONCAT tests
     qt_concat_43 "SELECT CONCAT('a', 'b'), CONCAT('a', 'b', 'c');"

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_all.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_all.groovy
@@ -115,6 +115,8 @@ suite("string_functions_all") {
     testFoldConst("SELECT CONCAT_WS('x', 'ṭṛì', 'ḍḍumai'), CONCAT_WS('→', ['ṭṛì', 'ḍḍumai', 'hello']);")
     qt_concat_ws_42 "SELECT CONCAT_WS(',', 'Name', 'Age', 'City'), CONCAT_WS('/', 'home', 'user', 'documents', 'file.txt');"
     testFoldConst("SELECT CONCAT_WS(',', 'Name', 'Age', 'City'), CONCAT_WS('/', 'home', 'user', 'documents', 'file.txt');")
+    testFoldConst("SELECT CONCAT_WS(',', ['a', NULL]), CONCAT_WS(',', [NULL, 'a', NULL]), CONCAT_WS(',', [NULL]);")
+    testFoldConst("SELECT CONCAT_WS(',', 'a', NULL), CONCAT_WS(',', NULL, 'a', NULL), CONCAT_WS(',', NULL);")
 
     // CONCAT tests
     qt_concat_43 "SELECT CONCAT('a', 'b'), CONCAT('a', 'b', 'c');"
@@ -435,6 +437,9 @@ suite("string_functions_all") {
     testFoldConst("SELECT LTRIM('000123', '0'), LTRIM('123abc123', '123');")
     qt_ltrim_185 "SELECT LTRIM('---text---', '-'), LTRIM('@@hello@@', '@');"
     testFoldConst("SELECT LTRIM('---text---', '-'), LTRIM('@@hello@@', '@');")
+
+    // MD5 tests
+    testFoldConst("SELECT MD5('doris'), MD5('ṭṛì'), MD5SUM('do', 'ris'), MD5SUM('ṭ', 'ṛ', 'ì');")
 
     // MAKE_SET tests
     qt_make_set_186 "SELECT make_set(3, 'dog', 'cat', 'bird');"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: FE constant folding produced results different from BE execution for several string, URL, time, and floating-point expressions. This PR aligns the FE executable folding paths with BE behavior and adds `testFoldConst` coverage for the mismatched expressions.

### Mismatched expressions

| Expression | FE result before this PR | BE result | Root cause |
| --- | --- | --- | --- |
| `CONCAT_WS(',', ['a', NULL])` | `a,` | `a` | FE appended the separator while iterating array elements even when later elements were `NULL`; BE skips `NULL` arguments and only inserts separators between retained values. |
| `RIGHT('😀a', 1)` | `😀` | `a` | FE mixed Java UTF-16 indexes with SQL character positions after counting code points, so the substring start was computed from incompatible units. |
| `INSTR('😀a', 'a')` | `3` | `2` | FE returned `String.indexOf(...) + 1`, which is a UTF-16 char offset; BE returns the 1-based character position. |
| `UPPER('éßi')` | `ÉßI` | `ÉSSI` | FE used per-`char` `Character.toUpperCase`, which cannot perform Unicode string mappings such as `ß -> SS`; BE uses ICU string case conversion. |
| `LOWER('ÉİA')` | `éia` | `éi̇a` (`U+00E9 U+0069 U+0307 U+0061`) | FE used per-`char` lowercasing and lost the combining dot from `İ`; BE/ICU lowercases `İ` to `i + U+0307`. |
| `INITCAP('ßETA İSTANBUL')` | `ßeta İstanbul` | `ßeta İStanbul` (`İ` lowercases to `i + U+0307`, then the combining mark starts a new word for `S`) | FE did per-`char` case conversion directly on the original string; BE lowercases the whole string first with ICU, then uppercases the first alphanumeric code point after each non-alphanumeric code point. |
| `STRCMP('😀','')` | `-1` | `1` | FE used Java UTF-16 lexical ordering; BE compares string bytes, so the UTF-8 byte sequence for `😀` sorts after ``. |
| `FIND_IN_SET('', 'a,')` | `2` | `0` | FE used Java `split(',', -1)`, which preserves the trailing empty token; BE's scan loop stops when the next token would start at the string length, so the trailing empty token is not matched. |
| `PARSE_URL('http://h/p%20x?q=a+b%20c&k=v#r', 'PATH')` | `/p x` | `/p%20x` | FE used `java.net.URI`, which decodes escaped bytes; BE `UrlParser` returns raw URL substrings. |
| `PARSE_URL('http://h/p%20x?q=a+b%20c&k=v#r', 'QUERY')` | `q=a+b c&k=v` | `q=a+b%20c&k=v` | Same raw-substring vs decoded-URI mismatch. |
| `EXTRACT_URL_PARAMETER('http://h/p%20x?q=a+b%20c&k=v#r', 'q')` | `a+b c` | `a+b%20c` | FE extracted from the decoded URI query; BE extracts the raw parameter value from the original query string. |
| `MAKETIME(1, 2, 3.9999995)` | `01:02:03.000000` | `01:02:04.000000` | FE truncated the integer seconds and then took rounded microseconds modulo `1000000`, losing the carry into seconds; BE rounds total seconds to microsecond precision before constructing the time value. |
| `MAKETIME(1, 2, 59.9999995)` | `01:02:59.000000` | `01:03:00.000000` | Same lost microsecond carry, this time across the minute boundary. |
| `FIELD(CAST('-0.0' AS DOUBLE), CAST('0.0' AS DOUBLE), CAST('-0.0' AS DOUBLE))` | `2` | `1` | FE used boxed floating equality semantics that distinguish `-0.0` from `0.0`; BE compares floating values numerically, so `-0.0 == 0.0` and the first candidate matches. |

The PR also makes `MD5`/`MD5SUM` folding explicitly use UTF-8 bytes, matching BE and avoiding JVM-default-charset dependent folding results.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `mvn checkstyle:check -pl fe-core`
    - `mvn -pl fe-core -am -DskipTests compile`
- Behavior changed: No
- Does this need documentation: No
