### PR TITLE
[test](schema-change) log alter job state in test_schema_change_mow_with_empty_rowset

### DIFF
--- a/regression-test/suites/schema_change_p0/test_schema_change_mow_with_empty_rowset.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_mow_with_empty_rowset.groovy
@@ -68,6 +68,7 @@ suite("test_schema_change_mow_with_empty_rowset", "p0") {
     Awaitility.await().atMost(30, TimeUnit.SECONDS).pollDelay(10, TimeUnit.MILLISECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(
         {
             String res = getJobState(tableName)
+            logger.info("alter table ${tableName} job state: ${res}")
             if (res == "FINISHED" || res == "CANCELLED") {
                 assertEquals("FINISHED", res)
                 return true


### PR DESCRIPTION
## Proposed changes

Add a `logger.info` to print the alter table job state that is polled inside the Awaitility loop in `test_schema_change_mow_with_empty_rowset.groovy`.

The test waits for the schema-change job to reach `FINISHED`/`CANCELLED` but does not log the intermediate state. When the job stalls or ends up `CANCELLED`, the regression log shows no trace of the observed state, making failures hard to diagnose. Logging the polled `res` each iteration makes such failures self-explanatory from the test output.

No behavior change to the test logic itself.

## Checklist
- [x] No new test needed (logging-only change to an existing regression test)
🤖 Generated with [Claude Code](https://claude.com/claude-code)