### PR TITLE
[refine](column) separate mutable subcolumn mutation from read-only traversal

### DIFF
--- a/be/src/core/column/column.h
+++ b/be/src/core/column/column.h
@@ -563,11 +563,27 @@ public:
 
     /// If the column contains subcolumns (such as Array, Nullable, etc), do callback on them.
     /// Shallow: doesn't do recursive calls; don't do call for itself.
-    using MutableColumnCallback = std::function<void(WrappedPtr&)>;
     using ColumnCallback = std::function<void(const IColumn&)>;
-    virtual void for_each_subcolumn(MutableColumnCallback) {}
     virtual void for_each_subcolumn(ColumnCallback) const {}
 
+protected:
+    virtual void mutate_subcolumns() {}
+
+    static void mutate_subcolumn(WrappedPtr& subcolumn) {
+        static_cast<IColumn::Ptr&>(subcolumn) =
+                std::move(*static_cast<const IColumn::Ptr&>(subcolumn)).mutate();
+    }
+
+    template <typename ColumnType>
+    static void mutate_subcolumn(typename ColumnType::WrappedPtr& subcolumn) {
+        auto mutated = std::move(*static_cast<const typename ColumnType::Ptr&>(subcolumn)).mutate();
+        auto typed_mutated = ColumnType::cast_to_column_mutptr(
+                assert_cast<ColumnType*, TypeCheckOnRelease::DISABLE>(mutated.get()));
+        mutated = nullptr;
+        static_cast<typename ColumnType::Ptr&>(subcolumn) = std::move(typed_mutated);
+    }
+
+public:
     /// Columns have equal structure.
     /// If true - you can use "compare_at", "insert_from", etc. methods.
     virtual bool structure_equals(const IColumn&) const {
@@ -581,10 +597,7 @@ public:
     // exclusive nodes are reused through the COW fast path.
     MutablePtr mutate() const&& {
         MutablePtr res = shallow_mutate();
-        res->for_each_subcolumn([](WrappedPtr& subcolumn) {
-            static_cast<IColumn::Ptr&>(subcolumn) =
-                    std::move(*static_cast<const IColumn::Ptr&>(subcolumn)).mutate();
-        });
+        res->mutate_subcolumns();
         return res;
     }
 
@@ -595,10 +608,7 @@ public:
     static MutablePtr mutate(Ptr ptr) {
         MutablePtr res = ptr->shallow_mutate(); /// Now use_count is 2.
         ptr.reset();                            /// Reset use_count to 1.
-        res->for_each_subcolumn([](WrappedPtr& subcolumn) {
-            static_cast<IColumn::Ptr&>(subcolumn) =
-                    std::move(*static_cast<const IColumn::Ptr&>(subcolumn)).mutate();
-        });
+        res->mutate_subcolumns();
         return res;
     }
 

--- a/be/src/core/column/column_array.h
+++ b/be/src/core/column/column_array.h
@@ -37,7 +37,6 @@
 #include "core/field.h"
 #include "core/string_ref.h"
 #include "core/types.h"
-#include "util/defer_op.h"
 
 class SipHash;
 
@@ -216,14 +215,9 @@ public:
         return get_offsets()[i] - get_offsets()[i - 1];
     }
 
-    void for_each_subcolumn(MutableColumnCallback callback) override {
-        IColumn::WrappedPtr offsets_column(std::move(static_cast<ColumnOffsets::Ptr&>(offsets)));
-        Defer defer([&] {
-            static_cast<ColumnOffsets::Ptr&>(offsets) =
-                    cast_to_column<ColumnOffsets>(static_cast<const IColumn::Ptr&>(offsets_column));
-        });
-        callback(offsets_column);
-        callback(data);
+    void mutate_subcolumns() override {
+        mutate_subcolumn<ColumnOffsets>(offsets);
+        mutate_subcolumn(data);
     }
 
     void for_each_subcolumn(ColumnCallback callback) const override {

--- a/be/src/core/column/column_const.h
+++ b/be/src/core/column/column_const.h
@@ -261,7 +261,7 @@ public:
         }
     }
 
-    void for_each_subcolumn(MutableColumnCallback callback) override { callback(data); }
+    void mutate_subcolumns() override { mutate_subcolumn(data); }
 
     void for_each_subcolumn(ColumnCallback callback) const override {
         callback(*static_cast<const IColumn::Ptr&>(data));

--- a/be/src/core/column/column_map.h
+++ b/be/src/core/column/column_map.h
@@ -43,7 +43,6 @@
 #include "core/string_ref.h"
 #include "core/types.h"
 #include "exec/common/sip_hash.h"
-#include "util/defer_op.h"
 
 class SipHash;
 
@@ -74,15 +73,10 @@ public:
 
     std::string get_name() const override;
 
-    void for_each_subcolumn(MutableColumnCallback callback) override {
-        IColumn::WrappedPtr offsets(std::move(static_cast<COffsets::Ptr&>(offsets_column)));
-        Defer defer([&] {
-            static_cast<COffsets::Ptr&>(offsets_column) =
-                    cast_to_column<COffsets>(static_cast<const IColumn::Ptr&>(offsets));
-        });
-        callback(keys_column);
-        callback(values_column);
-        callback(offsets);
+    void mutate_subcolumns() override {
+        mutate_subcolumn(keys_column);
+        mutate_subcolumn(values_column);
+        mutate_subcolumn<COffsets>(offsets_column);
     }
 
     void for_each_subcolumn(ColumnCallback callback) const override {

--- a/be/src/core/column/column_nullable.h
+++ b/be/src/core/column/column_nullable.h
@@ -32,7 +32,6 @@
 #include "core/typeid_cast.h"
 #include "core/types.h"
 #include "storage/olap_common.h"
-#include "util/defer_op.h"
 
 class SipHash;
 
@@ -250,14 +249,9 @@ public:
         return get_ptr();
     }
 
-    void for_each_subcolumn(MutableColumnCallback callback) override {
-        callback(_nested_column);
-
-        IColumn::WrappedPtr null_map(std::move(static_cast<ColumnUInt8::Ptr&>(_null_map)));
-        Defer defer([&] {
-            _null_map = cast_to_column<ColumnUInt8>(static_cast<const IColumn::Ptr&>(null_map));
-        });
-        callback(null_map);
+    void mutate_subcolumns() override {
+        mutate_subcolumn(_nested_column);
+        mutate_subcolumn<ColumnUInt8>(_null_map);
     }
 
     void for_each_subcolumn(ColumnCallback callback) const override {

--- a/be/src/core/column/column_struct.cpp
+++ b/be/src/core/column/column_struct.cpp
@@ -379,9 +379,9 @@ bool ColumnStruct::has_enough_capacity(const IColumn& src) const {
     return true;
 }
 
-void ColumnStruct::for_each_subcolumn(MutableColumnCallback callback) {
+void ColumnStruct::mutate_subcolumns() {
     for (auto& column : columns) {
-        callback(column);
+        mutate_subcolumn(column);
     }
 }
 

--- a/be/src/core/column/column_struct.h
+++ b/be/src/core/column/column_struct.h
@@ -155,7 +155,7 @@ public:
     size_t byte_size() const override;
     size_t allocated_bytes() const override;
     bool has_enough_capacity(const IColumn& src) const override;
-    void for_each_subcolumn(MutableColumnCallback callback) override;
+    void mutate_subcolumns() override;
     void for_each_subcolumn(ColumnCallback callback) const override;
     bool structure_equals(const IColumn& rhs) const override;
 

--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -68,7 +68,6 @@
 #include "exprs/aggregate/aggregate_function.h"
 #include "exprs/json_functions.h"
 #include "storage/olap_common.h"
-#include "util/defer_op.h"
 #include "util/json/path_in_data.h"
 #include "util/jsonb_document.h"
 #include "util/jsonb_document_cast.h"
@@ -826,15 +825,14 @@ size_t ColumnVariant::allocated_bytes() const {
     return res;
 }
 
-void ColumnVariant::for_each_subcolumn(MutableColumnCallback callback) {
+void ColumnVariant::mutate_subcolumns() {
     for (auto& entry : subcolumns) {
         for (auto& part : entry->data.data) {
-            callback(part);
+            mutate_subcolumn(part);
         }
     }
-    callback(serialized_sparse_column);
-    callback(serialized_doc_value_column);
-    // callback may be filter, so the row count may be changed
+    mutate_subcolumn(serialized_sparse_column);
+    mutate_subcolumn(serialized_doc_value_column);
     num_rows = serialized_sparse_column->size();
     ENABLE_CHECK_CONSISTENCY(this);
 }
@@ -2385,7 +2383,7 @@ size_t ColumnVariant::filter(const Filter& filter) {
         for (auto& subcolumn : subcolumns) {
             subcolumn->data.num_rows = count;
         }
-        MutableColumnCallback callback = [&](IColumn::WrappedPtr& part) {
+        auto filter_part = [&](IColumn::WrappedPtr& part) {
             if (part->size() != count) {
                 if (part->is_exclusive()) {
                     const auto result_size = part->filter(filter);
@@ -2401,7 +2399,13 @@ size_t ColumnVariant::filter(const Filter& filter) {
                 }
             }
         };
-        for_each_subcolumn(callback);
+        for (auto& entry : subcolumns) {
+            for (auto& part : entry->data.data) {
+                filter_part(part);
+            }
+        }
+        filter_part(serialized_sparse_column);
+        filter_part(serialized_doc_value_column);
     }
     num_rows = count;
     ENABLE_CHECK_CONSISTENCY(this);

--- a/be/src/core/column/column_variant.h
+++ b/be/src/core/column/column_variant.h
@@ -469,7 +469,7 @@ public:
 
     bool has_enough_capacity(const IColumn& src) const override { return false; }
 
-    void for_each_subcolumn(MutableColumnCallback callback) override;
+    void mutate_subcolumns() override;
     void for_each_subcolumn(ColumnCallback callback) const override;
 
     // Do nothing, call try_insert instead

--- a/be/test/core/column/column_array_test.cpp
+++ b/be/test/core/column/column_array_test.cpp
@@ -15,11 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "core/column/column_array.h"
+
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
 #include "core/column/column.h"
+#include "core/column/column_vector.h"
 #include "core/column/common_column_test.h"
 #include "core/types.h"
 #include "exprs/function/function_test_util.h"
@@ -28,6 +31,26 @@
 // for example column_ip should test these functions
 
 namespace doris {
+
+TEST(ColumnArrayCowTest, MutateKeepsExclusiveSubcolumns) {
+    auto data = ColumnInt64::create();
+    data->insert_value(10);
+
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert_value(1);
+
+    ColumnPtr array = ColumnArray::create(std::move(data), std::move(offsets));
+    const auto& array_ref = assert_cast<const ColumnArray&>(*array);
+    const auto* data_raw = array_ref.get_data_ptr().get();
+    const auto* offsets_raw = array_ref.get_offsets_ptr().get();
+
+    auto mutated = IColumn::mutate(std::move(array));
+    const auto& mutated_array = assert_cast<const ColumnArray&>(*mutated);
+
+    EXPECT_EQ(mutated_array.get_data_ptr().get(), data_raw);
+    EXPECT_EQ(mutated_array.get_offsets_ptr().get(), offsets_raw);
+}
+
 static std::string test_result_dir;
 class ColumnArrayTest : public CommonColumnTest {
 protected:

--- a/be/test/core/column/column_array_test.cpp
+++ b/be/test/core/column/column_array_test.cpp
@@ -32,6 +32,25 @@
 
 namespace doris {
 
+TEST(ColumnArrayCowTest, MutateDetachesSharedSubcolumns) {
+    auto data_mut = ColumnInt64::create();
+    data_mut->insert_value(10);
+    ColumnPtr data = std::move(data_mut);
+    ColumnPtr data_alias = data;
+
+    auto offsets_mut = ColumnArray::ColumnOffsets::create();
+    offsets_mut->insert_value(1);
+    ColumnPtr offsets = std::move(offsets_mut);
+    ColumnPtr offsets_alias = offsets;
+
+    ColumnPtr array = ColumnArray::create(data, offsets);
+    auto mutated = IColumn::mutate(array);
+    const auto& mutated_array = assert_cast<const ColumnArray&>(*mutated);
+
+    EXPECT_NE(mutated_array.get_data_ptr().get(), data_alias.get());
+    EXPECT_NE(mutated_array.get_offsets_ptr().get(), offsets_alias.get());
+}
+
 TEST(ColumnArrayCowTest, MutateKeepsExclusiveSubcolumns) {
     auto data = ColumnInt64::create();
     data->insert_value(10);

--- a/be/test/core/column/column_const_test.cpp
+++ b/be/test/core/column/column_const_test.cpp
@@ -33,6 +33,33 @@
 
 namespace doris {
 
+TEST(ColumnConstCowTest, MutateDetachesSharedDataColumn) {
+    auto data_mut = ColumnInt64::create();
+    data_mut->insert_value(7);
+    ColumnPtr data = std::move(data_mut);
+    ColumnPtr data_alias = data;
+
+    ColumnPtr column_const = ColumnConst::create(data, 3);
+    auto mutated = IColumn::mutate(column_const);
+    const auto& mutated_const = assert_cast<const ColumnConst&>(*mutated);
+
+    EXPECT_NE(mutated_const.get_data_column_ptr().get(), data_alias.get());
+    EXPECT_EQ(assert_cast<const ColumnInt64&>(*data_alias).get_element(0), 7);
+    EXPECT_EQ(mutated_const.get_data_column().get_int(0), 7);
+}
+
+TEST(ColumnConstCowTest, MutateKeepsExclusiveDataColumn) {
+    auto data = ColumnInt64::create();
+    data->insert_value(7);
+    const auto* data_raw = data.get();
+
+    ColumnPtr column_const = ColumnConst::create(std::move(data), 3);
+    auto mutated = IColumn::mutate(std::move(column_const));
+    const auto& mutated_const = assert_cast<const ColumnConst&>(*mutated);
+
+    EXPECT_EQ(mutated_const.get_data_column_ptr().get(), data_raw);
+}
+
 TEST(ColumnConstTest, TestCreate) {
     auto column_data = ColumnHelper::create_column<DataTypeInt64>({7});
     auto column_const = ColumnConst::create(column_data, 10);

--- a/be/test/core/column/column_map_test.cpp
+++ b/be/test/core/column/column_map_test.cpp
@@ -43,6 +43,55 @@
 
 namespace doris {
 
+TEST(ColumnMapCowTest, MutateDetachesSharedSubcolumns) {
+    auto keys_mut = ColumnInt64::create();
+    keys_mut->insert_value(10);
+    ColumnPtr keys = std::move(keys_mut);
+    ColumnPtr keys_alias = keys;
+
+    auto values_mut = ColumnInt64::create();
+    values_mut->insert_value(100);
+    ColumnPtr values = std::move(values_mut);
+    ColumnPtr values_alias = values;
+
+    auto offsets_mut = ColumnMap::COffsets::create();
+    offsets_mut->insert_value(1);
+    ColumnPtr offsets = std::move(offsets_mut);
+    ColumnPtr offsets_alias = offsets;
+
+    ColumnPtr map = ColumnMap::create(keys, values, offsets);
+    auto mutated = IColumn::mutate(map);
+    const auto& mutated_map = assert_cast<const ColumnMap&>(*mutated);
+
+    EXPECT_NE(mutated_map.get_keys_ptr().get(), keys_alias.get());
+    EXPECT_NE(mutated_map.get_values_ptr().get(), values_alias.get());
+    EXPECT_NE(mutated_map.get_offsets_ptr().get(), offsets_alias.get());
+}
+
+TEST(ColumnMapCowTest, MutateKeepsExclusiveSubcolumns) {
+    auto keys = ColumnInt64::create();
+    keys->insert_value(10);
+
+    auto values = ColumnInt64::create();
+    values->insert_value(100);
+
+    auto offsets = ColumnMap::COffsets::create();
+    offsets->insert_value(1);
+
+    ColumnPtr map = ColumnMap::create(std::move(keys), std::move(values), std::move(offsets));
+    const auto& map_ref = assert_cast<const ColumnMap&>(*map);
+    const auto* keys_raw = map_ref.get_keys_ptr().get();
+    const auto* values_raw = map_ref.get_values_ptr().get();
+    const auto* offsets_raw = map_ref.get_offsets_ptr().get();
+
+    auto mutated = IColumn::mutate(std::move(map));
+    const auto& mutated_map = assert_cast<const ColumnMap&>(*mutated);
+
+    EXPECT_EQ(mutated_map.get_keys_ptr().get(), keys_raw);
+    EXPECT_EQ(mutated_map.get_values_ptr().get(), values_raw);
+    EXPECT_EQ(mutated_map.get_offsets_ptr().get(), offsets_raw);
+}
+
 class ColumnMapTest : public ::testing::Test {
 protected:
     void SetUp() override {}

--- a/be/test/core/column/column_nullable_test.cpp
+++ b/be/test/core/column/column_nullable_test.cpp
@@ -130,6 +130,49 @@ TEST(ColumnNullableTest, SharedCreatePreservesImmutableSubcolumns) {
     EXPECT_EQ(null_map_alias->size(), 1);
 }
 
+TEST(ColumnNullableTest, MutateDetachesTypedNullMap) {
+    auto nested_mut = ColumnInt64::create();
+    nested_mut->insert_value(10);
+    ColumnPtr nested = std::move(nested_mut);
+    ColumnPtr nested_alias = nested;
+
+    auto null_map_mut = ColumnUInt8::create();
+    null_map_mut->insert_value(0);
+    ColumnPtr null_map = std::move(null_map_mut);
+    ColumnPtr null_map_alias = null_map;
+
+    ColumnPtr nullable = ColumnNullable::create(nested, null_map);
+    auto mutated = IColumn::mutate(nullable);
+    auto& mutated_nullable = assert_cast<ColumnNullable&>(*mutated);
+
+    EXPECT_NE(mutated_nullable.get_nested_column_ptr().get(), nested_alias.get());
+    EXPECT_NE(mutated_nullable.get_null_map_column_ptr().get(), null_map_alias.get());
+    EXPECT_EQ(mutated_nullable.get_null_map_data()[0], 0);
+
+    mutated_nullable.get_null_map_data()[0] = 1;
+    const auto& original_null_map = assert_cast<const ColumnUInt8&>(*null_map_alias);
+    EXPECT_EQ(original_null_map.get_data()[0], 0);
+}
+
+TEST(ColumnNullableTest, MutateKeepsExclusiveSubcolumns) {
+    auto nested_mut = ColumnInt64::create();
+    nested_mut->insert_value(10);
+
+    auto null_map_mut = ColumnUInt8::create();
+    null_map_mut->insert_value(0);
+
+    ColumnPtr nullable = ColumnNullable::create(std::move(nested_mut), std::move(null_map_mut));
+    const auto& nullable_ref = assert_cast<const ColumnNullable&>(*nullable);
+    const auto* nested_raw = nullable_ref.get_nested_column_ptr().get();
+    const auto* null_map_raw = nullable_ref.get_null_map_column_ptr().get();
+
+    auto mutated = IColumn::mutate(std::move(nullable));
+    const auto& mutated_nullable = assert_cast<const ColumnNullable&>(*mutated);
+
+    EXPECT_EQ(mutated_nullable.get_nested_column_ptr().get(), nested_raw);
+    EXPECT_EQ(mutated_nullable.get_null_map_column_ptr().get(), null_map_raw);
+}
+
 TEST(ColumnNullableTest, append_data_by_selector) {
     auto srt_column = ColumnHelper::create_nullable_column<DataTypeInt64>(
             {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},

--- a/be/test/core/column/column_struct_test.cpp
+++ b/be/test/core/column/column_struct_test.cpp
@@ -43,6 +43,53 @@
 
 namespace doris {
 
+TEST(ColumnStructCowTest, MutateDetachesSharedSubcolumns) {
+    auto first_mut = ColumnInt64::create();
+    first_mut->insert_value(10);
+    ColumnPtr first = std::move(first_mut);
+    ColumnPtr first_alias = first;
+
+    auto second_mut = ColumnInt64::create();
+    second_mut->insert_value(100);
+    ColumnPtr second = std::move(second_mut);
+    ColumnPtr second_alias = second;
+
+    Columns columns = {first, second};
+    ColumnPtr column_struct = ColumnStruct::create(columns);
+    auto mutated = IColumn::mutate(column_struct);
+    auto& mutated_struct = assert_cast<ColumnStruct&>(*mutated);
+
+    EXPECT_NE(mutated_struct.get_column_ptr(0).get(), first_alias.get());
+    EXPECT_NE(mutated_struct.get_column_ptr(1).get(), second_alias.get());
+
+    assert_cast<ColumnInt64&>(mutated_struct.get_column(0)).get_data()[0] = 20;
+    assert_cast<ColumnInt64&>(mutated_struct.get_column(1)).get_data()[0] = 200;
+
+    EXPECT_EQ(assert_cast<const ColumnInt64&>(*first_alias).get_element(0), 10);
+    EXPECT_EQ(assert_cast<const ColumnInt64&>(*second_alias).get_element(0), 100);
+}
+
+TEST(ColumnStructCowTest, MutateKeepsExclusiveSubcolumns) {
+    auto first = ColumnInt64::create();
+    first->insert_value(10);
+    const auto* first_raw = first.get();
+
+    auto second = ColumnInt64::create();
+    second->insert_value(100);
+    const auto* second_raw = second.get();
+
+    MutableColumns columns;
+    columns.push_back(std::move(first));
+    columns.push_back(std::move(second));
+
+    ColumnPtr column_struct = ColumnStruct::create(std::move(columns));
+    auto mutated = IColumn::mutate(std::move(column_struct));
+    const auto& mutated_struct = assert_cast<const ColumnStruct&>(*mutated);
+
+    EXPECT_EQ(mutated_struct.get_column_ptr(0).get(), first_raw);
+    EXPECT_EQ(mutated_struct.get_column_ptr(1).get(), second_raw);
+}
+
 class ColumnStructTest : public ::testing::Test {
 protected:
     void SetUp() override {}


### PR DESCRIPTION

### What problem does this PR solve?

Column wrappers used `for_each_subcolumn` for both read-only traversal and mutable subcolumn detachment during COW mutation. This mixed two different contracts in one callback API and forced typed subcolumns such as `ColumnNullable::_null_map`, `ColumnArray::offsets`, and `ColumnMap::offsets_column` to move through temporary base `IColumn::WrappedPtr` bridges.

Root cause: the mutable callback accepted `IColumn::WrappedPtr&`, but several subcolumns are stored as strongly typed wrappers. Binding typed wrapper references to the base wrapper callback is unsafe, so each implementation needed ad-hoc move/defer/cast code.

This PR keeps `for_each_subcolumn` as a const read-only traversal API and adds `mutate_subcolumns()` for the COW mutation path. Common `mutate_subcolumn` helpers handle generic and strongly typed subcolumns, so `ColumnArray`, `ColumnMap`, `ColumnNullable`, `ColumnStruct`, and `ColumnVariant` can detach children without exposing a mutable traversal callback. The added BEUT cases also verify that mutating exclusive subcolumns does not introduce an extra copy.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

