### PR TITLE
[fix](data traits) Fix data trait propagation for logical CTE anchors

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEAnchor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEAnchor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -25,7 +26,6 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 
@@ -39,8 +39,7 @@ import java.util.Optional;
  * LogicalCTEAnchor
  */
 public class LogicalCTEAnchor<LEFT_CHILD_TYPE extends Plan,
-        RIGHT_CHILD_TYPE extends Plan> extends LogicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> implements
-        PropagateFuncDeps {
+        RIGHT_CHILD_TYPE extends Plan> extends LogicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
 
     private final CTEId cteId;
 
@@ -113,5 +112,34 @@ public class LogicalCTEAnchor<LEFT_CHILD_TYPE extends Plan,
     @Override
     public int hashCode() {
         return Objects.hash(cteId);
+    }
+
+    @Override
+    public DataTrait computeDataTrait() {
+        return right().getLogicalProperties().getTrait();
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeUnique(DataTrait.Builder builder) {
+        builder.addUniqueSlot(right().getLogicalProperties().getTrait());
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(right().getLogicalProperties().getTrait());
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(right().getLogicalProperties().getTrait());
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(right().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEAnchor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEAnchor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.physical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
@@ -26,7 +27,6 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.Statistics;
@@ -44,8 +44,7 @@ import java.util.Optional;
 public class PhysicalCTEAnchor<
         LEFT_CHILD_TYPE extends Plan,
         RIGHT_CHILD_TYPE extends Plan>
-        extends PhysicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> implements
-        PropagateFuncDeps {
+        extends PhysicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
     private final CTEId cteId;
 
     public PhysicalCTEAnchor(CTEId cteId, LogicalProperties logicalProperties,
@@ -145,5 +144,34 @@ public class PhysicalCTEAnchor<
     public PhysicalCTEAnchor<Plan, Plan> resetLogicalProperties() {
         return new PhysicalCTEAnchor<>(cteId, groupExpression, null, physicalProperties,
                 statistics, child(0), child(1));
+    }
+
+    @Override
+    public DataTrait computeDataTrait() {
+        return right().getLogicalProperties().getTrait();
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeUnique(DataTrait.Builder builder) {
+        builder.addUniqueSlot(right().getLogicalProperties().getTrait());
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(right().getLogicalProperties().getTrait());
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(right().getLogicalProperties().getTrait());
+    }
+
+    // This function is useless, actually.
+    @Override
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(right().getLogicalProperties().getTrait());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalCTEAnchor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.PlanChecker;
@@ -28,7 +29,6 @@ import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class DataTraitTest extends TestWithFeService {
@@ -333,16 +333,23 @@ class DataTraitTest extends TestWithFeService {
                 .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
     }
 
-    @Disabled
     @Test
     void testCTE() {
-        Plan plan = PlanChecker.from(connectContext)
-                .analyze("with t as (select * from agg) select id from t where id = 1")
-                .getPlan();
-        System.out.println(plan.treeString());
-        System.out.println(plan.getLogicalProperties().getTrait());
-        Assertions.assertTrue(plan.getLogicalProperties()
-                .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
+        int oldInlineCTEReferencedThreshold = connectContext.getSessionVariable().inlineCTEReferencedThreshold;
+        connectContext.getSessionVariable().inlineCTEReferencedThreshold = 0;
+        try {
+            Plan plan = PlanChecker.from(connectContext)
+                    .analyze("with t as (select * from agg) select id from t where id = 1")
+                    .rewrite()
+                    .getPlan();
+            Assertions.assertInstanceOf(LogicalCTEAnchor.class, plan);
+            Assertions.assertTrue(plan.getLogicalProperties()
+                    .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
+            Assertions.assertEquals(plan.getLogicalProperties().getTrait(),
+                    plan.child(1).getLogicalProperties().getTrait());
+        } finally {
+            connectContext.getSessionVariable().inlineCTEReferencedThreshold = oldInlineCTEReferencedThreshold;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCTEAnchor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalCTEAnchor;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.utframe.TestWithFeService;
@@ -347,6 +348,17 @@ class DataTraitTest extends TestWithFeService {
                     .getTrait().isUniformAndNotNull(plan.getOutput().get(0)));
             Assertions.assertEquals(plan.getLogicalProperties().getTrait(),
                     plan.child(1).getLogicalProperties().getTrait());
+
+            Plan physicalPlan= PlanChecker.from(connectContext)
+                    .analyze("with t as (select * from agg) select id from t where id = 1")
+                    .rewrite()
+                    .optimize()
+                    .getBestPlanTree();
+            Assertions.assertInstanceOf(PhysicalCTEAnchor.class, physicalPlan);
+            Assertions.assertTrue(physicalPlan.getLogicalProperties()
+                    .getTrait().isUniformAndNotNull(physicalPlan.getOutput().get(0)));
+            Assertions.assertEquals(physicalPlan.getLogicalProperties().getTrait(),
+                    physicalPlan.child(1).getLogicalProperties().getTrait());
         } finally {
             connectContext.getSessionVariable().inlineCTEReferencedThreshold = oldInlineCTEReferencedThreshold;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
@@ -349,7 +349,7 @@ class DataTraitTest extends TestWithFeService {
             Assertions.assertEquals(plan.getLogicalProperties().getTrait(),
                     plan.child(1).getLogicalProperties().getTrait());
 
-            Plan physicalPlan= PlanChecker.from(connectContext)
+            Plan physicalPlan = PlanChecker.from(connectContext)
                     .analyze("with t as (select * from agg) select id from t where id = 1")
                     .rewrite()
                     .optimize()


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`LogicalCTEAnchor` previously implemented `PropagateFuncDeps`. Since it is a binary plan node, the default implementation merged data traits from both the CTE producer and the right child.

However, a logical CTE anchor exposes only the output of its right child. Merging the producer's data traits could therefore introduce traits associated with slots that are not part of the anchor output, leading to incorrect logical properties.

This change makes `LogicalCTEAnchor` propagate data traits exclusively from its right child. It also enables and extends the CTE unit test to keep the CTE anchor from being inlined and verify the propagated traits.

### Release note

None


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

