### PR TITLE
[fix](sdk) Enable TLS certificate verification by default in Go SDK

### DIFF
--- a/sdk/go-doris-sdk/pkg/load/client/doris_load_client.go
+++ b/sdk/go-doris-sdk/pkg/load/client/doris_load_client.go
@@ -81,7 +81,7 @@ func NewDorisClient(cfg *config.Config) (*DorisLoadClient, error) {
 	}
 
 	return &DorisLoadClient{
-		streamLoader: loader.NewStreamLoader(),
+		streamLoader: loader.NewStreamLoader(cfg.InsecureSkipVerify),
 		config:       cfg,
 	}, nil
 }

--- a/sdk/go-doris-sdk/pkg/load/config/load_config.go
+++ b/sdk/go-doris-sdk/pkg/load/config/load_config.go
@@ -106,18 +106,19 @@ type Retry struct {
 
 // Config contains all configuration for stream load operations
 type Config struct {
-	Endpoints    []string
-	User         string
-	Password     string
-	Database     string
-	Table        string
-	LabelPrefix  string
-	Label        string
-	Format       Format // Can be &JSONFormat{...} or &CSVFormat{...}
-	Retry        *Retry
-	GroupCommit  GroupCommitMode
-	EnableGzip   bool // If true, the SDK compresses the request body with gzip and sets compress_type=gz
-	Options      map[string]string
+	Endpoints           []string
+	User                string
+	Password            string
+	Database            string
+	Table               string
+	LabelPrefix         string
+	Label               string
+	Format              Format // Can be &JSONFormat{...} or &CSVFormat{...}
+	Retry               *Retry
+	GroupCommit          GroupCommitMode
+	EnableGzip          bool // If true, the SDK compresses the request body with gzip and sets compress_type=gz
+	InsecureSkipVerify  bool // If true, TLS certificate verification is skipped (not recommended for production)
+	Options             map[string]string
 }
 
 // ValidateInternal validates the configuration

--- a/sdk/go-doris-sdk/pkg/load/loader/stream_loader.go
+++ b/sdk/go-doris-sdk/pkg/load/loader/stream_loader.go
@@ -38,9 +38,9 @@ type StreamLoader struct {
 }
 
 // NewStreamLoader creates a new StreamLoader
-func NewStreamLoader() *StreamLoader {
+func NewStreamLoader(insecureSkipVerify bool) *StreamLoader {
 	return &StreamLoader{
-		httpClient: util.GetHttpClient(),
+		httpClient: util.BuildHttpClient(insecureSkipVerify),
 		json:       jsoniter.ConfigCompatibleWithStandardLibrary,
 	}
 }

--- a/sdk/go-doris-sdk/pkg/load/util/http_client.go
+++ b/sdk/go-doris-sdk/pkg/load/util/http_client.go
@@ -20,38 +20,23 @@ package util
 import (
 	"crypto/tls"
 	"net/http"
-	"sync"
 	"time"
 )
 
-var (
-	client *http.Client
-	once   sync.Once
-)
-
-func GetHttpClient() *http.Client {
-	once.Do(func() {
-		client = buildHttpClient()
-	})
-	return client
-}
-
-func buildHttpClient() *http.Client {
+func BuildHttpClient(insecureSkipVerify bool) *http.Client {
 
 	transport := &http.Transport{
-		MaxIdleConnsPerHost: 30, // Maximum idle connections per host for connection reuse to reduce overhead
-		MaxConnsPerHost:     50, // Maximum total connections (active + idle) per host, controls concurrency, excess will queue
-		MaxIdleConns:        50, // Global maximum idle connections
-
-		// TLS configuration for Doris HTTP endpoints
+		MaxIdleConnsPerHost: 30,
+		MaxConnsPerHost:     50,
+		MaxIdleConns:        50,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // Allow insecure connections for Doris HTTP endpoints
+			InsecureSkipVerify: insecureSkipVerify,
 		},
 	}
 
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   120 * time.Second, // Total request timeout
+		Timeout:   120 * time.Second,
 	}
 
 	return client

--- a/sdk/go-doris-sdk/pkg/load/util/http_client_test.go
+++ b/sdk/go-doris-sdk/pkg/load/util/http_client_test.go
@@ -18,7 +18,6 @@
 package util
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,12 +29,9 @@ import (
 // createTestClient creates an HTTP client with custom connection limits for testing
 func createTestClient(maxIdleConnsPerHost, maxConnsPerHost int) *http.Client {
 	transport := &http.Transport{
-		MaxIdleConnsPerHost: maxIdleConnsPerHost, // Idle connection pool size, affects connection reuse efficiency
-		MaxConnsPerHost:     maxConnsPerHost,     // Maximum concurrent connections, excess will queue
-		MaxIdleConns:        50,                  // Global idle connection limit
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		MaxIdleConnsPerHost: maxIdleConnsPerHost,
+		MaxConnsPerHost:     maxConnsPerHost,
+		MaxIdleConns:        50,
 	}
 
 	return &http.Client{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64570

Related PR: N/A

Problem Summary:
The Go SDK HTTP client (`pkg/load/util/http_client.go`) hardcodes `InsecureSkipVerify: true` in its default TLS configuration. All SDK API calls, including those carrying authentication credentials, skip TLS certificate verification. This exposes Doris database credentials to man-in-the-middle attacks on any Go SDK client connection (CWE-295).

The fix enables TLS verification by default (the Go standard library default behavior) and adds a configurable `InsecureSkipVerify` field to `Config` for environments that use self-signed certificates.

Since `InsecureSkipVerify` is a `bool`, its zero value is `false`, so existing callers that don't set the field get the secure default without code changes.

### Release note

Fixed a security issue in the Go SDK where TLS certificate verification was disabled by default, exposing credentials to potential MITM attacks. TLS verification is now enabled by default. Users who need to connect to Doris clusters with self-signed certificates can set `InsecureSkipVerify: true` in their `Config`.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
      - Verified that the test in `http_client_test.go` still passes (it uses `httptest.NewServer` which is plain HTTP, so TLS config is not exercised). The `InsecureSkipVerify` field was also removed from the test helper since it is not needed for the HTTP test server.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. TLS certificate verification is now enabled by default. Clusters using self-signed certificates will need to set `InsecureSkipVerify: true` in their SDK config to maintain the previous behavior.

- Does this need documentation?
    - [x] Yes. The new `InsecureSkipVerify` config field should be documented in the Go SDK README.