### PR TITLE
[fix](build) Fix insecure Python dependency pins in doris-compose, dbt-doris, and cost_model

### DIFF
--- a/docker/runtime/doris-compose/requirements.txt
+++ b/docker/runtime/doris-compose/requirements.txt
@@ -22,7 +22,7 @@ jsonpickle
 prettytable
 pymysql
 python-dateutil
-requests<=2.31.0
+requests>=2.31.0
 
 # NOTICE: if install docker failed, specific pyyaml version and docker version
 #pyyaml==5.3.1

--- a/extension/dbt-doris/dev-requirements.txt
+++ b/extension/dbt-doris/dev-requirements.txt
@@ -37,4 +37,4 @@ pytz
 tox>=3.13
 twine
 wheel
-mysql-connector-python>=8.0.0,<8.3
+mysql-connector-python>=8.0.33,<8.3

--- a/tools/cost_model_evaluate/requirements.txt
+++ b/tools/cost_model_evaluate/requirements.txt
@@ -16,4 +16,4 @@
 # under the License.
 
 matplotlib==3.7.0
-mysql_connector_repackaged==0.3.1
+mysql-connector-python>=8.0.33,<9


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #63188

Problem Summary:
Three Python requirements files have dependency pins that allow installing versions with known security issues.

**docker/runtime/doris-compose/requirements.txt**

The `requests<=2.31.0` constraint sets an upper bound but no lower bound, so pip can resolve to any version below 2.31.0. Versions before 2.31.0 are affected by CVE-2023-32681 (Proxy-Authorization header leaked on cross-domain redirects). Changed to `requests>=2.31.0` to set a secure floor.

**extension/dbt-doris/dev-requirements.txt**

The `mysql-connector-python>=8.0.0,<8.3` lower bound allows versions with known authentication bypass issues. Raised the lower bound to `>=8.0.33` which includes the relevant fixes.

**tools/cost_model_evaluate/requirements.txt**

The `mysql_connector_repackaged==0.3.1` package is an unofficial third-party repackage of the MySQL connector whose last PyPI release was in 2014. Replaced with the official `mysql-connector-python>=8.0.33,<9` package. The code in `sql_executor.py` imports `mysql.connector` which both packages provide, so this is a drop-in replacement.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
      - Verified that `pip install -r docker/runtime/doris-compose/requirements.txt` resolves correctly with the new pin.
      - Confirmed `sql_executor.py` imports `mysql.connector` (the standard interface), not the repackaged module name.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.