### PR TITLE
[fix](fe) Parse MaxCompute partition specs by name

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalTable.java
@@ -135,18 +135,37 @@ public class MaxComputeExternalTable extends ExternalTable {
      * @return all values of partitionPath
      */
     static List<String> parsePartitionValues(List<String> partitionColumns, String partitionPath) {
-        String[] partitionFragments = partitionPath.split("/");
+        String[] partitionFragments = partitionPath.split("/", -1);
         if (partitionFragments.length != partitionColumns.size()) {
             throw new RuntimeException("Failed to parse partition values of path: " + partitionPath);
         }
-        List<String> partitionValues = new ArrayList<>(partitionFragments.length);
-        for (int i = 0; i < partitionFragments.length; i++) {
-            String prefix = partitionColumns.get(i) + "=";
-            if (partitionFragments[i].startsWith(prefix)) {
-                partitionValues.add(partitionFragments[i].substring(prefix.length()));
-            } else {
-                partitionValues.add(partitionFragments[i]);
+        Map<String, String> partitionNameToValue = Maps.newHashMapWithExpectedSize(partitionFragments.length);
+        for (String partitionFragment : partitionFragments) {
+            int separatorIndex = partitionFragment.indexOf('=');
+            if (separatorIndex <= 0) {
+                throw new RuntimeException("Failed to parse partition values of path: " + partitionPath);
             }
+
+            String partitionName = partitionFragment.substring(0, separatorIndex);
+            if (!partitionColumns.contains(partitionName)) {
+                throw new RuntimeException("Unexpected partition column " + partitionName + " in path: "
+                        + partitionPath);
+            }
+
+            String partitionValue = partitionFragment.substring(separatorIndex + 1);
+            if (partitionNameToValue.put(partitionName, partitionValue) != null) {
+                throw new RuntimeException("Duplicate partition column " + partitionName + " in path: "
+                        + partitionPath);
+            }
+        }
+
+        List<String> partitionValues = new ArrayList<>(partitionColumns.size());
+        for (String partitionColumn : partitionColumns) {
+            if (!partitionNameToValue.containsKey(partitionColumn)) {
+                throw new RuntimeException("Missing partition column " + partitionColumn + " in path: "
+                        + partitionPath);
+            }
+            partitionValues.add(partitionNameToValue.get(partitionColumn));
         }
         return partitionValues;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalTableTest.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.maxcompute;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class MaxComputeExternalTableTest {
+    @Test
+    public void testParsePartitionValues() {
+        List<String> partitionColumns = Arrays.asList("p1", "p2");
+
+        Assert.assertEquals(Arrays.asList("a", "b"),
+                MaxComputeExternalTable.parsePartitionValues(partitionColumns, "p1=a/p2=b"));
+        Assert.assertEquals(Arrays.asList("a", "b"),
+                MaxComputeExternalTable.parsePartitionValues(partitionColumns, "p2=b/p1=a"));
+    }
+
+    @Test
+    public void testParsePartitionValuesRejectsInvalidSpec() {
+        List<String> partitionColumns = Arrays.asList("p1", "p2");
+
+        Assert.assertThrows(RuntimeException.class,
+                () -> MaxComputeExternalTable.parsePartitionValues(partitionColumns, "p1=a"));
+        Assert.assertThrows(RuntimeException.class,
+                () -> MaxComputeExternalTable.parsePartitionValues(partitionColumns, "p1=a/raw"));
+        Assert.assertThrows(RuntimeException.class,
+                () -> MaxComputeExternalTable.parsePartitionValues(partitionColumns, "p1=a/p1=b"));
+        Assert.assertThrows(RuntimeException.class,
+                () -> MaxComputeExternalTable.parsePartitionValues(partitionColumns, "p1=a/p3=b"));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary: MaxCompute partition specs were parsed by fragment position and silently accepted fragments whose column prefix did not match the expected partition column. If a partition spec is not ordered the same way as the table partition columns, Doris can bind values to the wrong partition columns during internal partition pruning. This change parses each fragment as name=value, rejects malformed, duplicate, or unexpected partition columns, and returns values ordered by the table partition column list.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

