### PR TITLE
[fix](regression) stabilize colocate column order plan test

### DIFF
--- a/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
+++ b/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
@@ -103,7 +103,7 @@ suite("test_colocate_join_of_column_order") {
 
     waitForColocateGroupStable("group_column_order3")
     explain {
-        sql("""select /*+ set_var(disable_join_reorder=true) */ * from test_colocate_join_of_column_order_ta join [shuffle] (select cast((c2 + 1) as bigint) c2 from test_colocate_join_of_column_order_tb) test_colocate_join_of_column_order_tb  on test_colocate_join_of_column_order_ta.c1 = test_colocate_join_of_column_order_tb.c2 join [shuffle] test_colocate_join_of_column_order_tc on test_colocate_join_of_column_order_tb.c2 = test_colocate_join_of_column_order_tc.c1;""");
+        sql("""select /*+ set_var(disable_join_reorder=true, parallel_pipeline_task_num=1) */ * from test_colocate_join_of_column_order_ta join [shuffle] (select cast((c2 + 1) as bigint) c2 from test_colocate_join_of_column_order_tb) test_colocate_join_of_column_order_tb  on test_colocate_join_of_column_order_ta.c1 = test_colocate_join_of_column_order_tb.c2 join [shuffle] test_colocate_join_of_column_order_tc on test_colocate_join_of_column_order_tb.c2 = test_colocate_join_of_column_order_tc.c1;""");
         contains "COLOCATE"
     }
 


### PR DESCRIPTION
## Proposed changes

Pin `parallel_pipeline_task_num=1` in the three-table `test_colocate_join_of_column_order` explain query.

The case already waits for `group_column_order3` to become stable, but Cloud P0 history still shows intermittent `HAS_COLO_PLAN_NODE: false` / `INNER JOIN(PARTITIONED)` after the wait. The detailed failures share the same plan shape: the first join is planned as a partitioned shuffle, so its output no longer keeps the `NATURAL` hash distribution needed by the second join's colocate check.

This is driven by physical-plan selection rather than statistics readiness. One sampled failure already executed `ALTER TABLE ... SET STATS` and still produced the same `INNER JOIN(PARTITIONED)` plan. Pinning `parallel_pipeline_task_num=1` removes the bucket-shuffle downgrade nondeterminism while preserving the original colocate planner coverage.

## Testing

- `git diff --check -- regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy`
- Not run: Cloud P0 case rerun is still pending.
