### PR TITLE
[fix](regression) stabilize multi leading shape check

### DIFF
--- a/regression-test/data/query_p0/hint/multi_leading.out
+++ b/regression-test/data/query_p0/hint/multi_leading.out
@@ -295,26 +295,3 @@ SyntaxError:
 
 -- !sql4_res_7 --
 6224
-
--- !sql5_2 --
-PhysicalCteAnchor ( cteId=CTEId#0 )
---PhysicalCteProducer ( cteId=CTEId#0 )
-----PhysicalOlapScan[t1]
---PhysicalResultSink
-----PhysicalDistribute[DistributionSpecGather]
-------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > 0.05 * avg(t1.c11))
---------hashAgg[GLOBAL]
-----------PhysicalDistribute[DistributionSpecHash]
-------------PhysicalCteConsumer ( cteId=CTEId#0 )
---------hashAgg[GLOBAL]
-----------PhysicalDistribute[DistributionSpecGather]
-------------hashAgg[LOCAL]
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((t1.c1 = cte.c11)) otherCondition=()
-----------------PhysicalCteConsumer ( cteId=CTEId#0 )
-----------------PhysicalOlapScan[t1]
-
-Hint log:
-Used: leading(cte t1 )
-UnUsed:
-SyntaxError:
-

--- a/regression-test/suites/query_p0/hint/multi_leading.groovy
+++ b/regression-test/suites/query_p0/hint/multi_leading.groovy
@@ -138,5 +138,17 @@ suite("multi_leading") {
     qt_sql4_res_7 """select /*+ leading(t3 alias1) */ count(*) from (select /*+ leading(alias2 t1) */ c1, c11 from t1 join (select /*+ leading(t4 t2) */ c2, c22 from t2 join t4 on c2 = c4) as alias2 on c1 = alias2.c2) as alias1 join t3 on alias1.c1 = t3.c3;"""
 
     // // use cte in scalar query
-    qt_sql5_2 """explain shape plan with  cte as (select c11, c1 from t1)  SELECT c1 FROM cte group by c1 having sum(cte.c11) > (select /*+ leading(cte t1) */ 0.05 * avg(t1.c11) from t1 join cte on t1.c1 = cte.c11 )"""
+    explain {
+        sql """shape plan with cte as (select c11, c1 from t1) SELECT c1 FROM cte group by c1 having sum(cte.c11) > (select /*+ leading(cte t1) */ 0.05 * avg(t1.c11) from t1 join cte on t1.c1 = cte.c11 )"""
+        check { plan ->
+            def innerJoin = "hashJoin[INNER_JOIN shuffle] hashCondition=((t1.c1 = cte.c11)) otherCondition=()"
+            def joinIdx = plan.indexOf(innerJoin)
+            def cteIdx = joinIdx < 0 ? -1 : plan.indexOf("PhysicalCteConsumer", joinIdx)
+            def t1Idx = joinIdx < 0 ? -1 : plan.indexOf("PhysicalOlapScan[t1]", joinIdx)
+            return plan.contains("PhysicalCteAnchor")
+                    && plan.contains("NestedLoopJoin[INNER_JOIN]")
+                    && plan.contains("Used: leading(cte t1 )")
+                    && joinIdx >= 0 && cteIdx > joinIdx && t1Idx > cteIdx
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- replace the exact `qt_sql5_2` shape-output comparison with a targeted `explain { check { ... } }`
- keep the test focused on the scalar-subquery `leading(cte t1)` behavior by checking CTE shape, used hint, and inner join child order
- remove the obsolete `sql5_2` expected block from `multi_leading.out`

## Testing

- [x] `git diff --check`
- [ ] not run locally; full regression requires a Doris regression environment
