### PR TITLE
[fix](mtmv): serialize alterJob with running tasks to prevent concurrent refresh on same MTMV

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -143,8 +143,18 @@ public class MTMVJobManager implements MTMVHookService {
     }
 
     public void alterJob(MTMV mtmv, boolean isReplay) {
-        dropJob(mtmv, isReplay);
-        createJob(mtmv, isReplay);
+        MTMVJob oldJob = getJobByMTMV(mtmv);
+        if (!isReplay && oldJob != null) {
+            oldJob.writeLock();
+        }
+        try {
+            dropJob(mtmv, isReplay);
+            createJob(mtmv, isReplay);
+        } finally {
+            if (!isReplay && oldJob != null) {
+                oldJob.writeUnlock();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

ALTER MTMV REFRESH ON COMMIT calls `alterJob()` which does `dropJob()` + `createJob()`, creating a new MTMVJob instance with a new ReentrantReadWriteLock. If the CREATE MTMV immediate build task is still running under the old job's writeLock, the new on-commit task can acquire the new job's writeLock concurrently, causing two refresh tasks to operate on the same MTMV simultaneously.

This race triggers "partition not found" when the on-commit task reads partition metadata via `UpdateMvByPartitionCommand.constructTableWithPredicates()`, while the immediate build task is in the middle of replacing partitions.

## Root Cause

- `alterJob()` drops the old job and creates a new one
- The new job has a brand new `ReentrantReadWriteLock` instance
- `MTMVTask.runTask()` acquires the writeLock from `getJobOrJobException()`
- After drop+create, `getJobOrJobException()` returns the new job with a different lock
- Two tasks can hold two different locks → no mutual exclusion

## Fix

In `alterJob()`, acquire the existing job's writeLock before drop+create, ensuring all running tasks complete before the job is rebuilt. This serializes the alter with any in-flight tasks using the same lock instance.

## Change

Single file: `fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java`

```java
public void alterJob(MTMV mtmv, boolean isReplay) {
    MTMVJob oldJob = getJobByMTMV(mtmv);
    if (!isReplay && oldJob != null) {
        oldJob.writeLock();   // block until running tasks complete
    }
    try {
        dropJob(mtmv, isReplay);
        createJob(mtmv, isReplay);
    } finally {
        if (!isReplay && oldJob != null) {
            oldJob.writeUnlock();
        }
    }
}
```

- No deadlock risk: lock ordering is always PER-JOB → GLOBAL, no reverse path
- Replay path (`isReplay=true`) unchanged
- Null-safe on `oldJob`

🤖 Generated with [Claude Code](https://claude.com/claude-code)