### PR TITLE
[refactor](be) Add file meta cache persistent interface

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1213,6 +1213,8 @@ DEFINE_Bool(enable_file_cache, "false");
 // Both will use the directory "memory" on the disk instead of the real RAM.
 DEFINE_String(file_cache_path, "[{\"path\":\"${DORIS_HOME}/file_cache\"}]");
 DEFINE_Int64(file_cache_each_block_size, "1048576"); // 1MB
+DEFINE_Bool(enable_external_file_meta_disk_cache, "false");
+DEFINE_mInt64(external_file_meta_disk_cache_max_entry_bytes, "67108864"); // 64MB
 
 DEFINE_Bool(clear_file_cache, "false");
 DEFINE_mBool(enable_file_cache_query_limit, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1258,6 +1258,8 @@ DECLARE_Bool(enable_file_cache);
 // Both will use the directory "memory" on the disk instead of the real RAM.
 DECLARE_String(file_cache_path);
 DECLARE_Int64(file_cache_each_block_size);
+DECLARE_Bool(enable_external_file_meta_disk_cache);
+DECLARE_mInt64(external_file_meta_disk_cache_max_entry_bytes);
 DECLARE_Bool(clear_file_cache);
 DECLARE_mBool(enable_file_cache_query_limit);
 DECLARE_Int32(file_cache_enter_disk_resource_limit_mode_percent);

--- a/be/src/io/fs/file_meta_cache.cpp
+++ b/be/src/io/fs/file_meta_cache.cpp
@@ -17,7 +17,26 @@
 
 #include "io/fs/file_meta_cache.h"
 
+#include <utility>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "util/stopwatch.hpp"
+
 namespace doris {
+namespace {
+
+void update_profile_counter(int64_t* counter, int64_t value = 1) {
+    if (counter != nullptr) {
+        *counter += value;
+    }
+}
+
+} // namespace
+
+FileMetaCache::FileMetaCache(int64_t capacity,
+                             std::unique_ptr<FileMetaPersistentCache> persistent_cache)
+        : _cache(capacity), _persistent_cache(std::move(persistent_cache)) {}
 
 std::string FileMetaCache::get_key(const std::string file_name, int64_t modification_time,
                                    int64_t file_size) {
@@ -38,6 +57,97 @@ std::string FileMetaCache::get_key(io::FileReaderSPtr file_reader,
     return FileMetaCache::get_key(
             file_reader->path().native(), _file_description.mtime,
             _file_description.file_size == -1 ? file_reader->size() : _file_description.file_size);
+}
+
+bool FileMetaCache::is_persistent_cache_enabled() {
+    return config::enable_external_file_meta_disk_cache &&
+           config::external_file_meta_disk_cache_max_entry_bytes > 0;
+}
+
+bool FileMetaCache::is_persistent_cache_payload_size_allowed(uint64_t payload_size) {
+    const int64_t max_entry_bytes = config::external_file_meta_disk_cache_max_entry_bytes;
+    return config::enable_external_file_meta_disk_cache && max_entry_bytes > 0 &&
+           payload_size <= static_cast<uint64_t>(max_entry_bytes);
+}
+
+FileMetaCacheLookupResult FileMetaCache::lookup(const FileMetaCacheContext& context,
+                                                ObjLRUCache::CacheHandle* handle,
+                                                std::string* serialized_meta,
+                                                FileMetaCacheProfile* profile) {
+    DCHECK(handle != nullptr);
+    DCHECK(serialized_meta != nullptr);
+    if (context.enable_memory_cache && lookup(context.key, handle)) {
+        serialized_meta->clear();
+        if (profile != nullptr) {
+            update_profile_counter(profile->hit_cache);
+            update_profile_counter(profile->hit_memory_cache);
+        }
+        return {.state = FileMetaCacheLookupState::MEMORY_HIT};
+    }
+
+    FileMetaCacheLookupResult result;
+    int64_t persisted_read_time = 0;
+    if (lookup_persistent_cache(context, serialized_meta, &persisted_read_time)) {
+        result.state = FileMetaCacheLookupState::PERSISTED_HIT;
+        if (profile != nullptr) {
+            update_profile_counter(profile->hit_cache);
+            update_profile_counter(profile->hit_disk_cache);
+            update_profile_counter(profile->read_disk_cache_time, persisted_read_time);
+        }
+    } else if (is_persistent_cache_enabled() && profile != nullptr) {
+        update_profile_counter(profile->miss_disk_cache);
+    }
+    return result;
+}
+
+void FileMetaCache::invalidate_persistent_cache(const FileMetaCacheContext& context) {
+    if (_persistent_cache != nullptr) {
+        _persistent_cache->remove(context.format, context.key);
+    }
+}
+
+bool FileMetaCache::lookup_persistent_cache(const FileMetaCacheContext& context,
+                                            std::string* payload, int64_t* read_time) {
+    DCHECK(payload != nullptr);
+    DCHECK(read_time != nullptr);
+    payload->clear();
+    *read_time = 0;
+    if (!is_persistent_cache_enabled() || _persistent_cache == nullptr) {
+        return false;
+    }
+
+    MonotonicStopWatch watch;
+    watch.start();
+    Status status = _persistent_cache->read(context.format, context.key, context.modification_time,
+                                            context.file_size, payload);
+    *read_time = watch.elapsed_time();
+    if (!status.ok()) {
+        payload->clear();
+        VLOG_DEBUG << "lookup file meta persistent cache failed: " << status;
+        return false;
+    }
+    return true;
+}
+
+bool FileMetaCache::insert_persistent_cache(const FileMetaCacheContext& context,
+                                            std::string_view payload, int64_t* write_time) {
+    DCHECK(write_time != nullptr);
+    *write_time = 0;
+    if (!is_persistent_cache_payload_size_allowed(static_cast<uint64_t>(payload.size())) ||
+        _persistent_cache == nullptr) {
+        return false;
+    }
+
+    MonotonicStopWatch watch;
+    watch.start();
+    Status status = _persistent_cache->write(context.format, context.key, context.modification_time,
+                                             context.file_size, payload);
+    *write_time = watch.elapsed_time();
+    if (!status.ok()) {
+        VLOG_DEBUG << "insert file meta persistent cache failed: " << status;
+        return false;
+    }
+    return true;
 }
 
 } // namespace doris

--- a/be/src/io/fs/file_meta_cache.cpp
+++ b/be/src/io/fs/file_meta_cache.cpp
@@ -67,7 +67,7 @@ bool FileMetaCache::is_persistent_cache_enabled() {
 bool FileMetaCache::is_persistent_cache_payload_size_allowed(uint64_t payload_size) {
     const int64_t max_entry_bytes = config::external_file_meta_disk_cache_max_entry_bytes;
     return config::enable_external_file_meta_disk_cache && max_entry_bytes > 0 &&
-           payload_size <= static_cast<uint64_t>(max_entry_bytes);
+           std::cmp_less_equal(payload_size, max_entry_bytes);
 }
 
 FileMetaCacheLookupResult FileMetaCache::lookup(const FileMetaCacheContext& context,
@@ -76,6 +76,7 @@ FileMetaCacheLookupResult FileMetaCache::lookup(const FileMetaCacheContext& cont
                                                 FileMetaCacheProfile* profile) {
     DCHECK(handle != nullptr);
     DCHECK(serialized_meta != nullptr);
+    *handle = ObjLRUCache::CacheHandle();
     if (context.enable_memory_cache && lookup(context.key, handle)) {
         serialized_meta->clear();
         if (profile != nullptr) {
@@ -124,6 +125,11 @@ bool FileMetaCache::lookup_persistent_cache(const FileMetaCacheContext& context,
     if (!status.ok()) {
         payload->clear();
         VLOG_DEBUG << "lookup file meta persistent cache failed: " << status;
+        return false;
+    }
+    if (!is_persistent_cache_payload_size_allowed(static_cast<uint64_t>(payload->size()))) {
+        payload->clear();
+        _persistent_cache->remove(context.format, context.key);
         return false;
     }
     return true;

--- a/be/src/io/fs/file_meta_cache.h
+++ b/be/src/io/fs/file_meta_cache.h
@@ -17,18 +17,77 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "common/status.h"
 #include "io/file_factory.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "util/obj_lru_cache.h"
 
 namespace doris {
 
+enum class FileMetaCacheFormat : uint8_t {
+    PARQUET = 1,
+    ORC = 2,
+};
+
+struct FileMetaCacheContext {
+    FileMetaCacheFormat format;
+    const std::string& key;
+    int64_t modification_time = 0;
+    int64_t file_size = 0;
+    bool enable_memory_cache = true;
+};
+
+enum class FileMetaCacheLookupState {
+    MEMORY_HIT,
+    PERSISTED_HIT,
+    MISS,
+};
+
+struct FileMetaCacheLookupResult {
+    FileMetaCacheLookupState state = FileMetaCacheLookupState::MISS;
+};
+
+struct FileMetaCacheInsertResult {
+    bool memory_inserted = false;
+    bool persisted_inserted = false;
+};
+
+struct FileMetaCacheProfile {
+    int64_t* hit_cache = nullptr;
+    int64_t* hit_memory_cache = nullptr;
+    int64_t* hit_disk_cache = nullptr;
+    int64_t* miss_disk_cache = nullptr;
+    int64_t* write_disk_cache = nullptr;
+    int64_t* read_disk_cache_time = nullptr;
+    int64_t* write_disk_cache_time = nullptr;
+};
+
+class FileMetaPersistentCache {
+public:
+    virtual ~FileMetaPersistentCache() = default;
+
+    virtual Status read(FileMetaCacheFormat format, const std::string& key,
+                        int64_t modification_time, int64_t file_size, std::string* payload) = 0;
+
+    virtual Status write(FileMetaCacheFormat format, const std::string& key,
+                         int64_t modification_time, int64_t file_size,
+                         std::string_view payload) = 0;
+
+    virtual void remove(FileMetaCacheFormat format, const std::string& key) = 0;
+};
+
 // A file meta cache depends on a LRU cache.
 // Such as parsed parquet footer.
 // The capacity will limit the number of cache entries in cache.
 class FileMetaCache {
 public:
-    FileMetaCache(int64_t capacity) : _cache(capacity) {}
+    explicit FileMetaCache(int64_t capacity,
+                           std::unique_ptr<FileMetaPersistentCache> persistent_cache = nullptr);
 
     FileMetaCache(const FileMetaCache&) = delete;
     const FileMetaCache& operator=(const FileMetaCache&) = delete;
@@ -41,6 +100,9 @@ public:
     static std::string get_key(io::FileReaderSPtr file_reader,
                                const io::FileDescription& _file_description);
 
+    static bool is_persistent_cache_enabled();
+    static bool is_persistent_cache_payload_size_allowed(uint64_t payload_size);
+
     bool lookup(const std::string& key, ObjLRUCache::CacheHandle* handle) {
         return _cache.lookup({key}, handle);
     }
@@ -50,10 +112,56 @@ public:
         _cache.insert({key}, value, handle);
     }
 
+    template <typename T>
+    bool insert(const std::string& key, std::unique_ptr<T>& value,
+                ObjLRUCache::CacheHandle* handle) {
+        DCHECK(value != nullptr);
+        if (!_cache.enabled()) {
+            return false;
+        }
+        _cache.insert({key}, value.release(), handle);
+        return true;
+    }
+
     bool enabled() const { return _cache.enabled(); }
 
+    FileMetaCacheLookupResult lookup(const FileMetaCacheContext& context,
+                                     ObjLRUCache::CacheHandle* handle, std::string* serialized_meta,
+                                     FileMetaCacheProfile* profile = nullptr);
+
+    void invalidate_persistent_cache(const FileMetaCacheContext& context);
+
+    template <typename T>
+    FileMetaCacheInsertResult insert(const FileMetaCacheContext& context, std::unique_ptr<T>& value,
+                                     ObjLRUCache::CacheHandle* handle,
+                                     std::string_view serialized_meta,
+                                     FileMetaCacheProfile* profile = nullptr) {
+        FileMetaCacheInsertResult result;
+        int64_t persisted_write_time = 0;
+        result.persisted_inserted =
+                insert_persistent_cache(context, serialized_meta, &persisted_write_time);
+        if (result.persisted_inserted && profile != nullptr) {
+            if (profile->write_disk_cache != nullptr) {
+                ++(*profile->write_disk_cache);
+            }
+            if (profile->write_disk_cache_time != nullptr) {
+                *profile->write_disk_cache_time += persisted_write_time;
+            }
+        }
+        if (context.enable_memory_cache) {
+            result.memory_inserted = insert(context.key, value, handle);
+        }
+        return result;
+    }
+
 private:
+    bool lookup_persistent_cache(const FileMetaCacheContext& context, std::string* payload,
+                                 int64_t* read_time);
+    bool insert_persistent_cache(const FileMetaCacheContext& context, std::string_view payload,
+                                 int64_t* write_time);
+
     ObjLRUCache _cache;
+    std::unique_ptr<FileMetaPersistentCache> _persistent_cache;
 };
 
 } // namespace doris

--- a/be/test/format/file_reader/file_meta_cache_test.cpp
+++ b/be/test/format/file_reader/file_meta_cache_test.cpp
@@ -31,7 +31,7 @@ namespace {
 class MockFileReader : public io::FileReader {
 public:
     MockFileReader(const std::string& file_name, size_t size)
-            : _file_name(file_name), _size(size), _closed(false) {}
+            : _file_name(file_name), _size(size) {}
     ~MockFileReader() override = default;
 
     const io::Path& path() const override {
@@ -60,7 +60,7 @@ protected:
 private:
     std::string _file_name;
     size_t _size;
-    bool _closed;
+    bool _closed = false;
 };
 
 class TestPersistentFileMetaCache final : public FileMetaPersistentCache {
@@ -246,6 +246,67 @@ TEST(FileMetaCacheTest, ContextLookupReportsMemoryHit) {
     EXPECT_EQ(miss_disk_cache, 0);
 }
 
+TEST(FileMetaCacheTest, ContextLookupClearsReusedMemoryHandle) {
+    const bool old_enable_external_file_meta_disk_cache =
+            config::enable_external_file_meta_disk_cache;
+    const int64_t old_external_file_meta_disk_cache_max_entry_bytes =
+            config::external_file_meta_disk_cache_max_entry_bytes;
+    Defer defer {[&] {
+        config::enable_external_file_meta_disk_cache = old_enable_external_file_meta_disk_cache;
+        config::external_file_meta_disk_cache_max_entry_bytes =
+                old_external_file_meta_disk_cache_max_entry_bytes;
+    }};
+    config::enable_external_file_meta_disk_cache = true;
+    config::external_file_meta_disk_cache_max_entry_bytes = 1024;
+
+    auto persistent_cache = std::make_unique<TestPersistentFileMetaCache>();
+    auto* persistent_cache_ptr = persistent_cache.get();
+    FileMetaCache cache(1024, std::move(persistent_cache));
+
+    const std::string memory_key =
+            FileMetaCache::get_key("s3://bucket/memory-handle.parquet", 123, 456);
+    const FileMetaCacheContext memory_context {.format = FileMetaCacheFormat::PARQUET,
+                                               .key = memory_key,
+                                               .modification_time = 123,
+                                               .file_size = 456};
+    auto memory_value = std::make_unique<std::string>("parsed memory footer");
+    ObjLRUCache::CacheHandle insert_handle;
+    ASSERT_TRUE(
+            cache.insert(memory_context, memory_value, &insert_handle, "serialized memory footer")
+                    .memory_inserted);
+
+    ObjLRUCache::CacheHandle reused_handle;
+    std::string serialized_meta;
+    ASSERT_EQ(cache.lookup(memory_context, &reused_handle, &serialized_meta).state,
+              FileMetaCacheLookupState::MEMORY_HIT);
+    ASSERT_TRUE(reused_handle.valid());
+
+    const std::string persistent_key =
+            FileMetaCache::get_key("s3://bucket/persistent-handle.parquet", 123, 456);
+    const FileMetaCacheContext persistent_context {.format = FileMetaCacheFormat::PARQUET,
+                                                   .key = persistent_key,
+                                                   .modification_time = 123,
+                                                   .file_size = 456};
+    persistent_cache_ptr->has_value = true;
+    persistent_cache_ptr->stored_format = persistent_context.format;
+    persistent_cache_ptr->stored_key = persistent_context.key;
+    persistent_cache_ptr->stored_modification_time = persistent_context.modification_time;
+    persistent_cache_ptr->stored_file_size = persistent_context.file_size;
+    persistent_cache_ptr->stored_payload = "serialized persistent footer";
+
+    EXPECT_EQ(cache.lookup(persistent_context, &reused_handle, &serialized_meta).state,
+              FileMetaCacheLookupState::PERSISTED_HIT);
+    EXPECT_FALSE(reused_handle.valid());
+
+    ASSERT_EQ(cache.lookup(memory_context, &reused_handle, &serialized_meta).state,
+              FileMetaCacheLookupState::MEMORY_HIT);
+    ASSERT_TRUE(reused_handle.valid());
+    persistent_cache_ptr->has_value = false;
+    EXPECT_EQ(cache.lookup(persistent_context, &reused_handle, &serialized_meta).state,
+              FileMetaCacheLookupState::MISS);
+    EXPECT_FALSE(reused_handle.valid());
+}
+
 TEST(FileMetaCacheTest, ContextInsertCanSkipMemoryCacheWithoutPersistentStore) {
     const bool old_enable_external_file_meta_disk_cache =
             config::enable_external_file_meta_disk_cache;
@@ -381,6 +442,46 @@ TEST(FileMetaCacheTest, PersistentCacheFailureFallsBackToMiss) {
     EXPECT_NE(parsed_value, nullptr);
     EXPECT_EQ(persistent_cache_ptr->write_count, 1);
     EXPECT_EQ(write_disk_cache, 0);
+}
+
+TEST(FileMetaCacheTest, OversizedPersistentReadFallsBackToMiss) {
+    const bool old_enable_external_file_meta_disk_cache =
+            config::enable_external_file_meta_disk_cache;
+    const int64_t old_external_file_meta_disk_cache_max_entry_bytes =
+            config::external_file_meta_disk_cache_max_entry_bytes;
+    Defer defer {[&] {
+        config::enable_external_file_meta_disk_cache = old_enable_external_file_meta_disk_cache;
+        config::external_file_meta_disk_cache_max_entry_bytes =
+                old_external_file_meta_disk_cache_max_entry_bytes;
+    }};
+    config::enable_external_file_meta_disk_cache = true;
+    config::external_file_meta_disk_cache_max_entry_bytes = 4;
+
+    const std::string meta_key = FileMetaCache::get_key("s3://bucket/oversized.parquet", 123, 456);
+    const FileMetaCacheContext context {.format = FileMetaCacheFormat::PARQUET,
+                                        .key = meta_key,
+                                        .modification_time = 123,
+                                        .file_size = 456,
+                                        .enable_memory_cache = false};
+    auto persistent_cache = std::make_unique<TestPersistentFileMetaCache>();
+    auto* persistent_cache_ptr = persistent_cache.get();
+    persistent_cache_ptr->has_value = true;
+    persistent_cache_ptr->stored_format = context.format;
+    persistent_cache_ptr->stored_key = context.key;
+    persistent_cache_ptr->stored_modification_time = context.modification_time;
+    persistent_cache_ptr->stored_file_size = context.file_size;
+    persistent_cache_ptr->stored_payload = "oversized payload";
+    FileMetaCache cache(0, std::move(persistent_cache));
+
+    ObjLRUCache::CacheHandle handle;
+    std::string serialized_meta = "stale output";
+    EXPECT_EQ(cache.lookup(context, &handle, &serialized_meta).state,
+              FileMetaCacheLookupState::MISS);
+    EXPECT_FALSE(handle.valid());
+    EXPECT_TRUE(serialized_meta.empty());
+    EXPECT_EQ(persistent_cache_ptr->read_count, 1);
+    EXPECT_EQ(persistent_cache_ptr->remove_count, 1);
+    EXPECT_FALSE(persistent_cache_ptr->has_value);
 }
 
 } // namespace doris

--- a/be/test/format/file_reader/file_meta_cache_test.cpp
+++ b/be/test/format/file_reader/file_meta_cache_test.cpp
@@ -62,6 +62,57 @@ private:
     size_t _size;
     bool _closed;
 };
+
+class TestPersistentFileMetaCache final : public FileMetaPersistentCache {
+public:
+    Status read(FileMetaCacheFormat format, const std::string& key, int64_t modification_time,
+                int64_t file_size, std::string* payload) override {
+        ++read_count;
+        if (fail_read) {
+            return Status::IOError("injected persistent cache read failure");
+        }
+        if (!has_value || format != stored_format || key != stored_key ||
+            modification_time != stored_modification_time || file_size != stored_file_size) {
+            return Status::NotFound("persistent cache entry not found");
+        }
+        *payload = stored_payload;
+        return Status::OK();
+    }
+
+    Status write(FileMetaCacheFormat format, const std::string& key, int64_t modification_time,
+                 int64_t file_size, std::string_view payload) override {
+        ++write_count;
+        if (fail_write) {
+            return Status::IOError("injected persistent cache write failure");
+        }
+        stored_format = format;
+        stored_key = key;
+        stored_modification_time = modification_time;
+        stored_file_size = file_size;
+        stored_payload = payload;
+        has_value = true;
+        return Status::OK();
+    }
+
+    void remove(FileMetaCacheFormat format, const std::string& key) override {
+        ++remove_count;
+        if (has_value && format == stored_format && key == stored_key) {
+            has_value = false;
+        }
+    }
+
+    bool fail_read = false;
+    bool fail_write = false;
+    bool has_value = false;
+    int read_count = 0;
+    int write_count = 0;
+    int remove_count = 0;
+    FileMetaCacheFormat stored_format = FileMetaCacheFormat::PARQUET;
+    std::string stored_key;
+    int64_t stored_modification_time = 0;
+    int64_t stored_file_size = 0;
+    std::string stored_payload;
+};
 } // anonymous namespace
 
 TEST(FileMetaCacheTest, KeyGenerationFromParams) {
@@ -224,6 +275,112 @@ TEST(FileMetaCacheTest, ContextInsertCanSkipMemoryCacheWithoutPersistentStore) {
 
     ObjLRUCache::CacheHandle lookup_handle;
     EXPECT_FALSE(cache.lookup(meta_key, &lookup_handle));
+}
+
+TEST(FileMetaCacheTest, PersistentCacheRoundTripUsesFileMetaBoundary) {
+    const bool old_enable_external_file_meta_disk_cache =
+            config::enable_external_file_meta_disk_cache;
+    const int64_t old_external_file_meta_disk_cache_max_entry_bytes =
+            config::external_file_meta_disk_cache_max_entry_bytes;
+    Defer defer {[&] {
+        config::enable_external_file_meta_disk_cache = old_enable_external_file_meta_disk_cache;
+        config::external_file_meta_disk_cache_max_entry_bytes =
+                old_external_file_meta_disk_cache_max_entry_bytes;
+    }};
+    config::enable_external_file_meta_disk_cache = true;
+    config::external_file_meta_disk_cache_max_entry_bytes = 1024;
+
+    auto persistent_cache = std::make_unique<TestPersistentFileMetaCache>();
+    auto* persistent_cache_ptr = persistent_cache.get();
+    FileMetaCache cache(0, std::move(persistent_cache));
+    const std::string meta_key = FileMetaCache::get_key("s3://bucket/persistent.parquet", 123, 456);
+    const FileMetaCacheContext context {.format = FileMetaCacheFormat::PARQUET,
+                                        .key = meta_key,
+                                        .modification_time = 123,
+                                        .file_size = 456,
+                                        .enable_memory_cache = false};
+    auto parsed_value = std::make_unique<std::string>("parsed footer");
+    ObjLRUCache::CacheHandle handle;
+    int64_t hit_cache = 0;
+    int64_t hit_disk_cache = 0;
+    int64_t miss_disk_cache = 0;
+    int64_t write_disk_cache = 0;
+    FileMetaCacheProfile profile {.hit_cache = &hit_cache,
+                                  .hit_disk_cache = &hit_disk_cache,
+                                  .miss_disk_cache = &miss_disk_cache,
+                                  .write_disk_cache = &write_disk_cache};
+
+    const FileMetaCacheInsertResult insert_result =
+            cache.insert(context, parsed_value, &handle, "serialized footer", &profile);
+    ASSERT_TRUE(insert_result.persisted_inserted);
+    EXPECT_FALSE(insert_result.memory_inserted);
+    EXPECT_NE(parsed_value, nullptr);
+    EXPECT_EQ(persistent_cache_ptr->write_count, 1);
+    EXPECT_EQ(write_disk_cache, 1);
+
+    std::string serialized_meta;
+    const FileMetaCacheLookupResult lookup_result =
+            cache.lookup(context, &handle, &serialized_meta, &profile);
+    EXPECT_EQ(lookup_result.state, FileMetaCacheLookupState::PERSISTED_HIT);
+    EXPECT_EQ(serialized_meta, "serialized footer");
+    EXPECT_EQ(persistent_cache_ptr->read_count, 1);
+    EXPECT_EQ(hit_cache, 1);
+    EXPECT_EQ(hit_disk_cache, 1);
+    EXPECT_EQ(miss_disk_cache, 0);
+
+    cache.invalidate_persistent_cache(context);
+    EXPECT_EQ(persistent_cache_ptr->remove_count, 1);
+    EXPECT_FALSE(persistent_cache_ptr->has_value);
+    EXPECT_EQ(cache.lookup(context, &handle, &serialized_meta, &profile).state,
+              FileMetaCacheLookupState::MISS);
+    EXPECT_EQ(miss_disk_cache, 1);
+}
+
+TEST(FileMetaCacheTest, PersistentCacheFailureFallsBackToMiss) {
+    const bool old_enable_external_file_meta_disk_cache =
+            config::enable_external_file_meta_disk_cache;
+    const int64_t old_external_file_meta_disk_cache_max_entry_bytes =
+            config::external_file_meta_disk_cache_max_entry_bytes;
+    Defer defer {[&] {
+        config::enable_external_file_meta_disk_cache = old_enable_external_file_meta_disk_cache;
+        config::external_file_meta_disk_cache_max_entry_bytes =
+                old_external_file_meta_disk_cache_max_entry_bytes;
+    }};
+    config::enable_external_file_meta_disk_cache = true;
+    config::external_file_meta_disk_cache_max_entry_bytes = 1024;
+
+    auto persistent_cache = std::make_unique<TestPersistentFileMetaCache>();
+    auto* persistent_cache_ptr = persistent_cache.get();
+    persistent_cache_ptr->fail_read = true;
+    persistent_cache_ptr->fail_write = true;
+    FileMetaCache cache(0, std::move(persistent_cache));
+    const std::string meta_key = FileMetaCache::get_key("s3://bucket/failure.orc", 123, 456);
+    const FileMetaCacheContext context {.format = FileMetaCacheFormat::ORC,
+                                        .key = meta_key,
+                                        .modification_time = 123,
+                                        .file_size = 456,
+                                        .enable_memory_cache = false};
+    int64_t miss_disk_cache = 0;
+    int64_t write_disk_cache = 0;
+    FileMetaCacheProfile profile {.miss_disk_cache = &miss_disk_cache,
+                                  .write_disk_cache = &write_disk_cache};
+    ObjLRUCache::CacheHandle handle;
+    std::string serialized_meta = "stale output";
+
+    EXPECT_EQ(cache.lookup(context, &handle, &serialized_meta, &profile).state,
+              FileMetaCacheLookupState::MISS);
+    EXPECT_TRUE(serialized_meta.empty());
+    EXPECT_EQ(persistent_cache_ptr->read_count, 1);
+    EXPECT_EQ(miss_disk_cache, 1);
+
+    auto parsed_value = std::make_unique<std::string>("parsed footer");
+    const FileMetaCacheInsertResult insert_result =
+            cache.insert(context, parsed_value, &handle, "serialized footer", &profile);
+    EXPECT_FALSE(insert_result.persisted_inserted);
+    EXPECT_FALSE(insert_result.memory_inserted);
+    EXPECT_NE(parsed_value, nullptr);
+    EXPECT_EQ(persistent_cache_ptr->write_count, 1);
+    EXPECT_EQ(write_disk_cache, 0);
 }
 
 } // namespace doris

--- a/be/test/format/file_reader/file_meta_cache_test.cpp
+++ b/be/test/format/file_reader/file_meta_cache_test.cpp
@@ -17,9 +17,13 @@
 
 #include "io/fs/file_meta_cache.h"
 
+#include <memory>
+
+#include "common/config.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "io/fs/file_reader.h"
+#include "util/defer_op.h"
 
 namespace doris {
 namespace {
@@ -153,6 +157,73 @@ TEST(FileMetaCacheTest, InsertAndLookupWithIntValue) {
     const int* cached_val2 = handle2.data<int>();
     ASSERT_NE(cached_val2, nullptr);
     EXPECT_EQ(*cached_val2, 12345);
+}
+
+TEST(FileMetaCacheTest, ContextLookupReportsMemoryHit) {
+    FileMetaCache cache(1024 * 1024);
+    const std::string meta_key = FileMetaCache::get_key("s3://bucket/memory.parquet", 123, 456);
+    const FileMetaCacheContext context {.format = FileMetaCacheFormat::PARQUET,
+                                        .key = meta_key,
+                                        .modification_time = 123,
+                                        .file_size = 456};
+
+    auto value = std::make_unique<std::string>("serialized footer payload");
+    ObjLRUCache::CacheHandle insert_handle;
+    ASSERT_TRUE(cache.insert(meta_key, value, &insert_handle));
+    ASSERT_TRUE(insert_handle.valid());
+
+    int64_t hit_cache = 0;
+    int64_t hit_memory_cache = 0;
+    int64_t hit_disk_cache = 0;
+    int64_t miss_disk_cache = 0;
+    FileMetaCacheProfile profile {.hit_cache = &hit_cache,
+                                  .hit_memory_cache = &hit_memory_cache,
+                                  .hit_disk_cache = &hit_disk_cache,
+                                  .miss_disk_cache = &miss_disk_cache};
+
+    ObjLRUCache::CacheHandle lookup_handle;
+    std::string serialized_meta;
+    const FileMetaCacheLookupResult result =
+            cache.lookup(context, &lookup_handle, &serialized_meta, &profile);
+
+    EXPECT_EQ(result.state, FileMetaCacheLookupState::MEMORY_HIT);
+    EXPECT_TRUE(lookup_handle.valid());
+    EXPECT_TRUE(serialized_meta.empty());
+    EXPECT_EQ(hit_cache, 1);
+    EXPECT_EQ(hit_memory_cache, 1);
+    EXPECT_EQ(hit_disk_cache, 0);
+    EXPECT_EQ(miss_disk_cache, 0);
+}
+
+TEST(FileMetaCacheTest, ContextInsertCanSkipMemoryCacheWithoutPersistentStore) {
+    const bool old_enable_external_file_meta_disk_cache =
+            config::enable_external_file_meta_disk_cache;
+    Defer defer {[&] {
+        config::enable_external_file_meta_disk_cache = old_enable_external_file_meta_disk_cache;
+    }};
+    config::enable_external_file_meta_disk_cache = false;
+
+    FileMetaCache cache(1024 * 1024);
+    const std::string meta_key =
+            FileMetaCache::get_key("s3://bucket/skip-memory.parquet", 123, 456);
+    const FileMetaCacheContext context {.format = FileMetaCacheFormat::PARQUET,
+                                        .key = meta_key,
+                                        .modification_time = 123,
+                                        .file_size = 456,
+                                        .enable_memory_cache = false};
+    auto value = std::make_unique<std::string>("serialized footer payload");
+    ObjLRUCache::CacheHandle handle;
+
+    const FileMetaCacheInsertResult result =
+            cache.insert(context, value, &handle, std::string_view(*value));
+
+    EXPECT_FALSE(result.persisted_inserted);
+    EXPECT_FALSE(result.memory_inserted);
+    EXPECT_FALSE(handle.valid());
+    EXPECT_NE(value, nullptr);
+
+    ObjLRUCache::CacheHandle lookup_handle;
+    EXPECT_FALSE(cache.lookup(meta_key, &lookup_handle));
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63376

Problem Summary:
External file metadata disk cache needs to add persistent storage behind the existing `FileMetaCache` boundary without exposing a generic complete-value put/get API from `BlockFileCache` or changing file-cache internals in this preparatory PR.

This PR adds a narrow `FileMetaCache` persistent-cache interface and the shared plumbing needed by the disk-backed implementation:
- Add `FileMetaPersistentCache` with `read`, `write`, and `remove` methods scoped to file metadata.
- Add `FileMetaCacheContext`, lookup/insert result types, and profile counters for memory vs persisted cache paths.
- Add config gates for enabling persistent file metadata cache and bounding persisted payload size.
- Keep existing memory-only `FileMetaCache` behavior compatible when no persistent cache is installed.

`BlockFileCache` is intentionally not modified by this PR. The disk-backed `FileMetaPersistentCache` implementation that reuses the existing file cache is added in #63376.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - Added focused `FileMetaCache` interface tests under `be/test/format/file_reader/file_meta_cache_test.cpp`.
    - `./run-be-ut.sh --run --filter=FileMetaCache* -j 4`
- Behavior changed: No
- Does this need documentation: No
