### PR TITLE
[fix](test) fix flaky test_time_series_compaction_level2

### DIFF
--- a/be/src/storage/compaction/cumulative_compaction_time_series_policy.cpp
+++ b/be/src/storage/compaction/cumulative_compaction_time_series_policy.cpp
@@ -373,13 +373,15 @@ int32_t TimeSeriesCumulativeCompactionPolicy::pick_input_rowsets(
     if (compaction_level >= 2) {
         int64_t continuous_size = 0;
         std::vector<RowsetSharedPtr> level1_rowsets;
+        int64_t level2_compaction_timeout = MAX_LEVEL2_COMPACTION_TIMEOUT;
+        DBUG_EXECUTE_IF("time_series_level2_file_count", { level2_compaction_timeout = -1; });
         for (const auto& rowset : candidate_rowsets) {
             const auto& rs_meta = rowset->rowset_meta();
             if (rs_meta->compaction_level() == 0) {
                 break;
             }
             if (rs_meta->compaction_level() == 1 &&
-                (now - rs_meta->creation_time()) <= MAX_LEVEL2_COMPACTION_TIMEOUT) {
+                (now - rs_meta->creation_time()) <= level2_compaction_timeout) {
                 continue;
             }
             level1_rowsets.push_back(rowset);

--- a/regression-test/suites/compaction/test_time_series_compaction_level2.groovy
+++ b/regression-test/suites/compaction/test_time_series_compaction_level2.groovy
@@ -133,7 +133,7 @@ suite("test_time_series_compaction_level2", "nonConcurrent") {
         wait_cumulative_compaction_done.call(tablets)
 
         rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 1 + 1)
+        assert (rowsetCount == 1 + 1) : "10 level-1 rowsets should be level-2 compacted into 1; expected 2 rowsets, got ${rowsetCount}"
     } finally {
         GetDebugPoint().disableDebugPointForAllBEs("time_series_level2_file_count")
     }


### PR DESCRIPTION
## Proposed changes

Cherry-pick master fix `0f88df67964c2b3b907dba616827d18ab376111b` (#64663) to `branch-4.1`.

This fixes flaky `compaction/test_time_series_compaction_level2.groovy` in NonConcurrentRegression by making the `time_series_level2_file_count` debug point also bypass the fresh level-1 rowset timeout. Without this, the final manual cumulative compaction can return `E-2000 / _input_rowsets is empty`, leaving 11 rowsets instead of the expected 2.

## Evidence

- Failing build: http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_NonConcurrentRegression/980611?buildTab=tests&status=muted&expandedTest=build%3A%28id%3A980611%29%2Cid%3A2000000028
- Branch-isolated history: 24 failures in the latest 200 NonConcurrent occurrences, across 22 PR branches, all based on `branch-4.1`.
- Current branch-4.1 does not contain `0f88df67964`; master does.

## Validation

- `git diff --check origin/branch-4.1...HEAD`
- Cherry-pick applied cleanly.
- Runtime regression rerun not executed locally; this PR will request `run buildall`.
