### PR TITLE
[fix](partition pruning) ignore stale external partitions in pruning

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
@@ -204,18 +204,18 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
         if (sortedPartitionRanges.isPresent()) {
             RangeSet<MultiColumnBound> predicateRanges = partitionPredicate.accept(
                     new PartitionPredicateToRange(partitionSlots), null);
-            if (predicateRanges != null) {
+            SortedPartitionRanges<K> ranges = sortedPartitionRanges.get();
+            if (predicateRanges != null && ranges.partitionIds.equals(idToPartitions.keySet())) {
                 Pair<List<K>, Boolean> res = binarySearchFiltering(
-                        sortedPartitionRanges.get(), partitionSlots, partitionPredicate, cascadesContext,
+                        ranges, partitionSlots, partitionPredicate, cascadesContext,
                         expandThreshold, predicateRanges
                 );
-                List<K> selectedPartitions = keepPartitionsInSnapshot(res.first, idToPartitions);
-                boolean hasPartitionPredicate = hasEffectivePartitionPredicate(selectedPartitions, idToPartitions.size());
+                boolean hasPartitionPredicate = hasEffectivePartitionPredicate(res.first, idToPartitions.size());
                 if (res.second) {
-                    return new PartitionPruneResult<>(selectedPartitions, Optional.of(originalPartitionPredicate),
+                    return new PartitionPruneResult<>(res.first, Optional.of(originalPartitionPredicate),
                             hasPartitionPredicate);
                 } else {
-                    return new PartitionPruneResult<>(selectedPartitions, Optional.empty(), hasPartitionPredicate);
+                    return new PartitionPruneResult<>(res.first, Optional.empty(), hasPartitionPredicate);
                 }
             }
         }
@@ -235,17 +235,6 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
     private static <K extends Comparable<K>> boolean hasEffectivePartitionPredicate(
             List<K> selectedPartitions, int totalPartitions) {
         return selectedPartitions.size() != totalPartitions;
-    }
-
-    private static <K extends Comparable<K>> List<K> keepPartitionsInSnapshot(
-            List<K> selectedPartitions, Map<K, PartitionItem> idToPartitions) {
-        Builder<K> partitions = ImmutableList.builder();
-        for (K partition : selectedPartitions) {
-            if (idToPartitions.containsKey(partition)) {
-                partitions.add(partition);
-            }
-        }
-        return partitions.build();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
@@ -209,12 +209,13 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
                         sortedPartitionRanges.get(), partitionSlots, partitionPredicate, cascadesContext,
                         expandThreshold, predicateRanges
                 );
-                boolean hasPartitionPredicate = hasEffectivePartitionPredicate(res.first, idToPartitions.size());
+                List<K> selectedPartitions = keepPartitionsInSnapshot(res.first, idToPartitions);
+                boolean hasPartitionPredicate = hasEffectivePartitionPredicate(selectedPartitions, idToPartitions.size());
                 if (res.second) {
-                    return new PartitionPruneResult<>(res.first, Optional.of(originalPartitionPredicate),
+                    return new PartitionPruneResult<>(selectedPartitions, Optional.of(originalPartitionPredicate),
                             hasPartitionPredicate);
                 } else {
-                    return new PartitionPruneResult<>(res.first, Optional.empty(), hasPartitionPredicate);
+                    return new PartitionPruneResult<>(selectedPartitions, Optional.empty(), hasPartitionPredicate);
                 }
             }
         }
@@ -234,6 +235,17 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
     private static <K extends Comparable<K>> boolean hasEffectivePartitionPredicate(
             List<K> selectedPartitions, int totalPartitions) {
         return selectedPartitions.size() != totalPartitions;
+    }
+
+    private static <K extends Comparable<K>> List<K> keepPartitionsInSnapshot(
+            List<K> selectedPartitions, Map<K, PartitionItem> idToPartitions) {
+        Builder<K> partitions = ImmutableList.builder();
+        for (K partition : selectedPartitions) {
+            if (idToPartitions.containsKey(partition)) {
+                partitions.add(partition);
+            }
+        }
+        return partitions.build();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SortedPartitionRanges.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SortedPartitionRanges.java
@@ -20,26 +20,33 @@ package org.apache.doris.nereids.rules.expression.rules;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.nereids.util.Utils;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /** SortedPartitionRanges */
 public class SortedPartitionRanges<K> {
     public final List<PartitionItemAndRange<K>> sortedPartitions;
     public final List<PartitionItemAndId<K>> defaultPartitions;
+    public final Set<K> partitionIds;
 
     /** SortedPartitionRanges */
     public SortedPartitionRanges(
-            List<PartitionItemAndRange<K>> sortedPartitions, List<PartitionItemAndId<K>> defaultPartitions) {
+            List<PartitionItemAndRange<K>> sortedPartitions, List<PartitionItemAndId<K>> defaultPartitions,
+            Set<K> partitionIds) {
         this.sortedPartitions = Utils.fastToImmutableList(
                 Objects.requireNonNull(sortedPartitions, "sortedPartitions bounds can not be null")
         );
         this.defaultPartitions = Utils.fastToImmutableList(
                 Objects.requireNonNull(defaultPartitions, "defaultPartitions bounds can not be null")
+        );
+        this.partitionIds = ImmutableSet.copyOf(
+                Objects.requireNonNull(partitionIds, "partitionIds can not be null")
         );
     }
 
@@ -82,7 +89,7 @@ public class SortedPartitionRanges<K> {
             return span1.upperEndpoint().compareTo(span2.upperEndpoint());
         });
 
-        return new SortedPartitionRanges<>(sortedRanges, defaultPartitions);
+        return new SortedPartitionRanges<>(sortedRanges, defaultPartitions, partitionMap.keySet());
     }
 
     /** PartitionItemAndRange */

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PartitionPrunerTest.java
@@ -363,6 +363,24 @@ public class PartitionPrunerTest extends TestWithFeService {
         Assertions.assertTrue(result.hasPartitionPredicate);
     }
 
+    @Test
+    public void testPruneWithResultFallsBackWhenSortedRangesMissSnapshotPartition() throws AnalysisException {
+        Map<String, PartitionItem> idToPartitions = ImmutableMap.of(
+                "p1", createListPartitionItem("1"),
+                "p2", createListPartitionItem("2"),
+                "p3", createListPartitionItem("3"));
+        SortedPartitionRanges<String> sortedPartitionRanges = SortedPartitionRanges.build(ImmutableMap.of(
+                "p1", createListPartitionItem("1"),
+                "p2", createListPartitionItem("2")));
+
+        PartitionPruneResult<String> result = PartitionPruner.pruneWithResult(
+                ImmutableList.of(slotA), new EqualTo(slotA, Literal.of(3)), idToPartitions, cascadesContext,
+                PartitionTableType.EXTERNAL, Optional.of(sortedPartitionRanges));
+
+        Assertions.assertEquals(ImmutableList.of("p3"), result.partitions);
+        Assertions.assertTrue(result.hasPartitionPredicate);
+    }
+
     private ListPartitionItem createListPartitionItem(String... values) throws AnalysisException {
         ImmutableList.Builder<PartitionKey> partitionKeys = ImmutableList.builder();
         for (String value : values) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PartitionPrunerTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.rules.expression.rules.OnePartitionEvaluator;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner.PartitionPruneResult;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner.PartitionTableType;
+import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -341,6 +342,24 @@ public class PartitionPrunerTest extends TestWithFeService {
                 PartitionTableType.OLAP, Optional.empty());
 
         Assertions.assertEquals(1, result.partitions.size());
+        Assertions.assertTrue(result.hasPartitionPredicate);
+    }
+
+    @Test
+    public void testPruneWithResultDoesNotReturnPartitionOutsideSnapshot() throws AnalysisException {
+        Map<String, PartitionItem> idToPartitions = ImmutableMap.of(
+                "p1", createListPartitionItem("1"),
+                "p2", createListPartitionItem("2"));
+        SortedPartitionRanges<String> sortedPartitionRanges = SortedPartitionRanges.build(ImmutableMap.of(
+                "p1", createListPartitionItem("1"),
+                "p2", createListPartitionItem("2"),
+                "p3", createListPartitionItem("3")));
+
+        PartitionPruneResult<String> result = PartitionPruner.pruneWithResult(
+                ImmutableList.of(slotA), new EqualTo(slotA, Literal.of(3)), idToPartitions, cascadesContext,
+                PartitionTableType.EXTERNAL, Optional.of(sortedPartitionRanges));
+
+        Assertions.assertTrue(result.partitions.isEmpty());
         Assertions.assertTrue(result.hasPartitionPredicate);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64800

Related PR: #64867

Problem Summary:

When binary-search partition pruning is enabled for external partitions, the sorted partition range snapshot may contain a partition name that is no longer present in the scan's current partition map. Returning that stale partition name lets the later Hive pruning path look it up as `null`, which can then fail while building immutable partition maps.

This keeps the pruning result aligned with the scan snapshot by filtering binary-search results through the current `idToPartitions` map before returning them. It does not change the normal matched-partition semantics; it only drops partition names that are outside the current scan snapshot.

#64867 keys the Hive partition cache by name, but it does not cover this selected-partition/sorted-range snapshot mismatch.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Test command:

```bash
export JAVA_HOME=$(/usr/libexec/java_home -v 17)
export PATH="$JAVA_HOME/bin:$PATH"
cd fe
mvn test -pl fe-core -am \
  -Dcheckstyle.skip=true \
  -DfailIfNoTests=false \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dmaven.build.cache.enabled=false \
  -Dtest=org.apache.doris.nereids.rules.rewrite.PartitionPrunerTest
```

Result: `BUILD SUCCESS`; `PartitionPrunerTest`: 14 tests, 0 failures, 0 errors.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
