### PR TITLE
[fix](arrow-flight) Preserve array item nullability

### DIFF
--- a/be/src/format/arrow/arrow_row_batch.cpp
+++ b/be/src/format/arrow/arrow_row_batch.cpp
@@ -124,7 +124,9 @@ Status convert_to_arrow_type(const DataTypePtr& origin_type,
         const auto* type_arr = assert_cast<const DataTypeArray*>(remove_nullable(type).get());
         std::shared_ptr<arrow::DataType> item_type;
         RETURN_IF_ERROR(convert_to_arrow_type(type_arr->get_nested_type(), &item_type, timezone));
-        *result = std::make_shared<arrow::ListType>(item_type);
+        auto item_field =
+                arrow::field("item", item_type, type_arr->get_nested_type()->is_nullable());
+        *result = arrow::list(item_field);
         break;
     }
     case TYPE_MAP: {

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <arrow/array/array_nested.h>
+#include <arrow/array/array_primitive.h>
 #include <arrow/array/builder_base.h>
 #include <arrow/array/builder_binary.h>
 #include <arrow/array/builder_decimal.h>
@@ -452,6 +454,57 @@ TEST(DataTypeSerDeArrowTest, DataTypeCollectionSerDeTest) {
     std::vector<PrimitiveType> cols = {TYPE_ARRAY, TYPE_MAP, TYPE_STRUCT};
     serialize_and_deserialize_arrow_test(cols, 7, true);
     serialize_and_deserialize_arrow_test(cols, 7, false);
+}
+
+TEST(DataTypeSerDeArrowTest, ArrayNullableSmallIntArrowSerDeTest) {
+    auto block = std::make_shared<Block>();
+    DataTypePtr array_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt16>());
+    MutableColumnPtr array_column = array_type->create_column();
+
+    Array values;
+    values.push_back(Field());
+    values.push_back(Field::create_field<TYPE_SMALLINT>(1));
+    values.push_back(Field());
+    array_column->insert(Field::create_field<TYPE_ARRAY>(values));
+
+    block->insert(ColumnWithTypeAndName(array_column->get_ptr(), array_type, "0"));
+
+    std::shared_ptr<arrow::Schema> schema;
+    Status status = get_arrow_schema_from_block(*block, &schema, TimezoneUtils::default_time_zone);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+    ASSERT_TRUE(schema);
+
+    const auto& value_field = assert_cast<const arrow::ListType&>(*schema->field(0)->type())
+                                      .value_field();
+    ASSERT_TRUE(value_field->nullable());
+
+    std::shared_ptr<arrow::RecordBatch> record_batch;
+    cctz::time_zone default_timezone;
+    status = convert_to_arrow_batch(*block, schema, arrow::default_memory_pool(), &record_batch,
+                                    default_timezone);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+    ASSERT_TRUE(record_batch);
+
+    auto list_array = std::dynamic_pointer_cast<arrow::ListArray>(record_batch->column(0));
+    ASSERT_TRUE(list_array);
+    ASSERT_EQ(1, list_array->length());
+    ASSERT_EQ(0, list_array->value_offset(0));
+    ASSERT_EQ(3, list_array->value_offset(1));
+
+    auto values_array = std::dynamic_pointer_cast<arrow::Int16Array>(list_array->values());
+    ASSERT_TRUE(values_array);
+    ASSERT_EQ(3, values_array->length());
+    ASSERT_EQ(2, values_array->null_count());
+    EXPECT_TRUE(values_array->IsNull(0));
+    EXPECT_FALSE(values_array->IsNull(1));
+    EXPECT_EQ(1, values_array->Value(1));
+    EXPECT_TRUE(values_array->IsNull(2));
+
+    auto assert_block = std::make_shared<Block>(block->clone_empty());
+    status = convert_from_arrow_batch(record_batch, block->get_data_types(), assert_block.get(),
+                                      default_timezone);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+    CommonDataTypeSerdeTest::compare_two_blocks(block, assert_block);
 }
 
 TEST(DataTypeSerDeArrowTest, DataTypeMapNullKeySerDeTest) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Arrow Flight SQL can crash in the JDBC client when returning an array whose child values contain nulls. One reproduced case is:

```sql
select cast([32768, 1, 7777777] as array<smallint>);
```

The expected result is `[null, 1, null]`, but the Arrow Flight JDBC path throws while reading `SmallIntVector.isSet(0)` from `ArrowFlightJdbcArray`.

Doris `DataTypeArray` stores array item types as nullable, but the Arrow schema conversion created `arrow::ListType` from only the child data type. This loses the nested field nullability contract. This PR creates the Arrow list with an explicit `item` field whose nullability matches the Doris nested type.

The PR also adds a BE Arrow serde UT covering:

- nullable array child field in the generated Arrow schema
- child vector offsets and null count for `[null, 1, null]`
- Arrow-to-Doris round trip

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Static check performed:

```bash
git diff --check
```

Local BE UT was not executed before opening this PR.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
