### PR TITLE
[fix](agg) Fix incorrect aggregate merge with duplicate aliases

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeAggregate.java
@@ -196,10 +196,12 @@ public class MergeAggregate implements RewriteRuleFactory {
 
     private boolean canMergeAggregateWithoutProject(LogicalAggregate<LogicalAggregate<Plan>> outerAgg) {
         LogicalAggregate<Plan> innerAgg = outerAgg.child();
-        if (!new HashSet<>(innerAgg.getGroupByExpressions()).containsAll(outerAgg.getGroupByExpressions())) {
+        Set<Expression> innerGroupByExpressions = new HashSet<>(innerAgg.getGroupByExpressions());
+        Set<Expression> outerGroupByExpressions = new HashSet<>(outerAgg.getGroupByExpressions());
+        if (!innerGroupByExpressions.containsAll(outerGroupByExpressions)) {
             return false;
         }
-        boolean sameGroupBy = (innerAgg.getGroupByExpressions().size() == outerAgg.getGroupByExpressions().size());
+        boolean sameGroupBy = innerGroupByExpressions.equals(outerGroupByExpressions);
 
         return commonCheck(outerAgg, innerAgg, sameGroupBy, Optional.empty());
     }
@@ -210,7 +212,9 @@ public class MergeAggregate implements RewriteRuleFactory {
 
         List<Expression> outerAggGroupByKeys = PlanUtils.replaceExpressionByProjections(project.getProjects(),
                 outerAgg.getGroupByExpressions());
-        if (!new HashSet<>(innerAgg.getGroupByExpressions()).containsAll(outerAggGroupByKeys)) {
+        Set<Expression> innerGroupByExpressions = new HashSet<>(innerAgg.getGroupByExpressions());
+        Set<Expression> outerGroupByExpressions = new HashSet<>(outerAggGroupByKeys);
+        if (!innerGroupByExpressions.containsAll(outerGroupByExpressions)) {
             return false;
         }
         // project cannot have expressions like a+1
@@ -218,7 +222,7 @@ public class MergeAggregate implements RewriteRuleFactory {
                 expr -> !(expr instanceof SlotReference) && !(expr instanceof Alias))) {
             return false;
         }
-        boolean sameGroupBy = (innerAgg.getGroupByExpressions().size() == outerAgg.getGroupByExpressions().size());
+        boolean sameGroupBy = innerGroupByExpressions.equals(outerGroupByExpressions);
         return commonCheck(outerAgg, innerAgg, sameGroupBy, Optional.of(project));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/MergeAggregateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/MergeAggregateTest.java
@@ -27,6 +27,9 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.util.MemoPatternMatchSupported;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
@@ -40,9 +43,20 @@ import java.util.List;
  * Unit tests for {@link MergeAggregate}, specifically testing the fix for filtering
  * aggregate functions in mergeAggProjectAgg method.
  */
-public class MergeAggregateTest {
+public class MergeAggregateTest extends TestWithFeService implements MemoPatternMatchSupported {
 
     private MergeAggregate mergeAggregate;
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("merge_aggregate_test");
+        connectContext.setDatabase("merge_aggregate_test");
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        createTable("CREATE TABLE merge_aggregate_test.duplicate_alias_table ("
+                + "a INT NOT NULL, b INT NOT NULL, c INT NULL) "
+                + "DUPLICATE KEY(a, b, c) DISTRIBUTED BY HASH(a) BUCKETS 1 "
+                + "PROPERTIES('replication_num' = '1')");
+    }
 
     @BeforeEach
     public void setUp() {
@@ -120,5 +134,17 @@ public class MergeAggregateTest {
 
         LogicalAggregate<Plan> aggregate = (LogicalAggregate<Plan>) resultProject.child(0);
         Assertions.assertEquals(aggregate.getOutput().size(), 2);
+    }
+
+    @Test
+    public void testDoNotMergeDistinctAggregateWithDuplicateProjectedGroupBy() {
+        String sql = "SELECT g1, g2, SUM(s) FROM ("
+                + "SELECT a AS g1, a AS g2, COUNT(DISTINCT c) AS s "
+                + "FROM duplicate_alias_table GROUP BY a, b) t GROUP BY g1, g2";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalAggregate(logicalProject(logicalAggregate())));
     }
 }

--- a/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
+++ b/regression-test/data/nereids_rules_p0/merge_aggregate/merge_aggregate.out
@@ -302,3 +302,8 @@ PhysicalResultSink
 8	5	5
 9	3	3
 
+-- !duplicate_alias_distinct_result --
+1	1	3
+2	2	3
+3	3	0
+

--- a/regression-test/suites/nereids_rules_p0/merge_aggregate/merge_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/merge_aggregate/merge_aggregate.groovy
@@ -265,4 +265,34 @@ suite("merge_aggregate") {
         (select a,max(b) as col1, count(b) as col4, a as col10, a as col11 
         from mal_test1 group by a) t group by col10, col11 order by 1,2,3;
     """
+
+    sql "drop table if exists mal_duplicate_alias_distinct"
+    sql """
+        create table mal_duplicate_alias_distinct (
+            a int not null,
+            b int not null,
+            c int null
+        )
+        duplicate key (a, b, c)
+        distributed by hash(a) buckets 1
+        properties("replication_num" = "1");
+    """
+    sql """
+        insert into mal_duplicate_alias_distinct values
+            (1, 10, 100), (1, 10, 101), (1, 20, 100),
+            (2, 10, 200), (2, 20, 200), (2, 30, 201),
+            (3, 30, null), (3, 40, null);
+    """
+    sql "sync"
+
+    order_qt_duplicate_alias_distinct_result """
+        select g1, g2, sum(s) as total_s
+        from (
+            select a as g1, a as g2, count(distinct c) as s
+            from mal_duplicate_alias_distinct
+            group by a, b
+        ) t
+        group by g1, g2
+        order by g1, g2;
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #31811

Problem Summary:

A nested aggregate query could return incorrect results when multiple outer group-by aliases referenced the same inner grouping expression.

For example, after resolving aliases, the inner grouping keys were `(a, b)` while the outer grouping keys became `(a, a)`. `MergeAggregate` determined whether the groupings were identical by comparing their list sizes. Since both lists contained two elements, it incorrectly considered them equivalent.

This allowed `SUM(COUNT(DISTINCT c))` to be merged into `COUNT(DISTINCT c)` while removing grouping key `b`. Values repeated across different `b` groups were consequently counted only once, producing an undercount.

This change compares the unique grouping-expression sets after projection replacement. Aggregate layers containing `DISTINCT` are now merged only when their grouping semantics are actually identical.

### Release note

Fix incorrect query results for nested aggregates with duplicate group-by aliases and DISTINCT aggregate functions.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

