### PR TITLE
[improvement](be) Hoist aggregate column type checks

### DIFF
--- a/be/src/exec/operator/aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/aggregation_sink_operator.cpp
@@ -170,7 +170,7 @@ Status AggSinkLocalState::open(RuntimeState* state) {
 
     if (!Base::_shared_state->probe_expr_ctxs.empty() /* has GROUP BY */
         && (p._aggregate_evaluators.size() == 1 &&
-            p._aggregate_evaluators[0]->function()->is_simple_count()) /* only one count(*) */
+            p._aggregate_evaluators[0]->is_simple_count()) /* only one count(*) */
         && !_should_limit_output /* no limit optimization */ &&
         !Base::_shared_state->enable_spill /* spill not enabled */) {
         _shared_state->use_simple_count = true;
@@ -283,8 +283,8 @@ void AggSinkLocalState::_update_memusage_with_serialized_key() {
 Status AggSinkLocalState::_destroy_agg_status(AggregateDataPtr data) {
     auto& shared_state = *Base::_shared_state;
     for (int i = 0; i < shared_state.aggregate_evaluators.size(); ++i) {
-        shared_state.aggregate_evaluators[i]->function()->destroy(
-                data + shared_state.offsets_of_aggregate_states[i]);
+        shared_state.aggregate_evaluators[i]->destroy(data +
+                                                      shared_state.offsets_of_aggregate_states[i]);
     }
     return Status::OK();
 }
@@ -330,8 +330,7 @@ Status AggSinkLocalState::_merge_with_serialized_key_helper(Block* block) {
                 auto column = block->get_by_position(col_id).column;
 
                 size_t buffer_size =
-                        Base::_shared_state->aggregate_evaluators[i]->function()->size_of_data() *
-                        rows;
+                        Base::_shared_state->aggregate_evaluators[i]->size_of_data() * rows;
                 if (_deserialize_buffer.size() < buffer_size) {
                     _deserialize_buffer.resize(buffer_size);
                 }
@@ -339,7 +338,6 @@ Status AggSinkLocalState::_merge_with_serialized_key_helper(Block* block) {
                 {
                     SCOPED_TIMER(_deserialize_data_timer);
                     Base::_shared_state->aggregate_evaluators[i]
-                            ->function()
                             ->deserialize_and_merge_vec_selected(
                                     _places.data(),
                                     Base::_parent->template cast<AggSinkOperatorX>()
@@ -389,24 +387,20 @@ Status AggSinkLocalState::_merge_with_serialized_key_helper(Block* block) {
                     }
                     auto column = block->get_by_position(col_id).column;
 
-                    size_t buffer_size = Base::_shared_state->aggregate_evaluators[i]
-                                                 ->function()
-                                                 ->size_of_data() *
-                                         rows;
+                    size_t buffer_size =
+                            Base::_shared_state->aggregate_evaluators[i]->size_of_data() * rows;
                     if (_deserialize_buffer.size() < buffer_size) {
                         _deserialize_buffer.resize(buffer_size);
                     }
 
                     {
                         SCOPED_TIMER(_deserialize_data_timer);
-                        Base::_shared_state->aggregate_evaluators[i]
-                                ->function()
-                                ->deserialize_and_merge_vec(
-                                        _places.data(),
-                                        Base::_parent->template cast<AggSinkOperatorX>()
-                                                ._offsets_of_aggregate_states[i],
-                                        _deserialize_buffer.data(), column.get(),
-                                        Base::_shared_state->agg_arena_pool, rows);
+                        Base::_shared_state->aggregate_evaluators[i]->deserialize_and_merge_vec(
+                                _places.data(),
+                                Base::_parent->template cast<AggSinkOperatorX>()
+                                        ._offsets_of_aggregate_states[i],
+                                _deserialize_buffer.data(), column.get(),
+                                Base::_shared_state->agg_arena_pool, rows);
                     }
                 } else {
                     RETURN_IF_ERROR(Base::_shared_state->aggregate_evaluators[i]->execute_batch_add(
@@ -444,13 +438,10 @@ Status AggSinkLocalState::_merge_without_key(Block* block) {
             auto column = block->get_by_position(col_id).column;
 
             SCOPED_TIMER(_deserialize_data_timer);
-            Base::_shared_state->aggregate_evaluators[i]
-                    ->function()
-                    ->deserialize_and_merge_from_column(
-                            _agg_data->without_key +
-                                    Base::_parent->template cast<AggSinkOperatorX>()
-                                            ._offsets_of_aggregate_states[i],
-                            *column, Base::_shared_state->agg_arena_pool);
+            Base::_shared_state->aggregate_evaluators[i]->deserialize_and_merge_from_column(
+                    _agg_data->without_key + Base::_parent->template cast<AggSinkOperatorX>()
+                                                     ._offsets_of_aggregate_states[i],
+                    *column, Base::_shared_state->agg_arena_pool);
         } else {
             RETURN_IF_ERROR(Base::_shared_state->aggregate_evaluators[i]->execute_single_add(
                     block,
@@ -956,15 +947,14 @@ Status AggSinkOperatorX::_calc_aggregate_evaluators() {
     for (size_t i = 0; i < _aggregate_evaluators.size(); ++i) {
         _offsets_of_aggregate_states[i] = _total_size_of_aggregate_states;
 
-        const auto& agg_function = _aggregate_evaluators[i]->function();
+        const auto* agg_function = _aggregate_evaluators[i];
         // aggreate states are aligned based on maximum requirement
         _align_aggregate_states = std::max(_align_aggregate_states, agg_function->align_of_data());
         _total_size_of_aggregate_states += agg_function->size_of_data();
 
         // If not the last aggregate_state, we need pad it so that next aggregate_state will be aligned.
         if (i + 1 < _aggregate_evaluators.size()) {
-            size_t alignment_of_next_state =
-                    _aggregate_evaluators[i + 1]->function()->align_of_data();
+            size_t alignment_of_next_state = _aggregate_evaluators[i + 1]->align_of_data();
             if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
                 return Status::RuntimeError("Logical error: align_of_data is not 2^N");
             }

--- a/be/src/exec/operator/aggregation_source_operator.cpp
+++ b/be/src/exec/operator/aggregation_source_operator.cpp
@@ -121,144 +121,138 @@ Status AggLocalState::_get_results_with_serialized_key(RuntimeState* state, Bloc
     }
 
     std::visit(
-            Overload {[&](std::monostate& arg) -> void {
-                          throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
-                      },
-                      [&](auto& agg_method) -> void {
-                          agg_method.init_iterator();
-                          auto& data = *agg_method.hash_table;
-                          const auto size = std::min(data.size(), size_t(state->batch_size()));
-                          using KeyType = std::decay_t<decltype(agg_method)>::Key;
-                          std::vector<KeyType> keys(size);
+            Overload {
+                    [&](std::monostate& arg) -> void {
+                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                    },
+                    [&](auto& agg_method) -> void {
+                        agg_method.init_iterator();
+                        auto& data = *agg_method.hash_table;
+                        const auto size = std::min(data.size(), size_t(state->batch_size()));
+                        using KeyType = std::decay_t<decltype(agg_method)>::Key;
+                        std::vector<KeyType> keys(size);
 
-                          if (shared_state.use_simple_count) {
-                              DCHECK_EQ(shared_state.aggregate_evaluators.size(), 1);
+                        if (shared_state.use_simple_count) {
+                            DCHECK_EQ(shared_state.aggregate_evaluators.size(), 1);
 
-                              value_data_types[0] = shared_state.aggregate_evaluators[0]
-                                                            ->function()
-                                                            ->get_serialized_type();
-                              if (mem_reuse) {
-                                  value_columns[0] = IColumn::mutate(
-                                          std::move(block->get_by_position(key_size).column));
-                              } else {
-                                  value_columns[0] = shared_state.aggregate_evaluators[0]
-                                                             ->function()
-                                                             ->create_serialize_column();
-                              }
+                            value_data_types[0] =
+                                    shared_state.aggregate_evaluators[0]->get_serialized_type();
+                            if (mem_reuse) {
+                                value_columns[0] = IColumn::mutate(
+                                        std::move(block->get_by_position(key_size).column));
+                            } else {
+                                value_columns[0] = shared_state.aggregate_evaluators[0]
+                                                           ->create_serialize_column();
+                            }
 
-                              auto& count_col =
-                                      assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
-                              uint32_t num_rows = 0;
-                              {
-                                  SCOPED_TIMER(_hash_table_iterate_timer);
-                                  auto& it = agg_method.begin;
-                                  while (it != agg_method.end && num_rows < state->batch_size()) {
-                                      keys[num_rows] = it.get_first();
-                                      auto inline_count =
-                                              reinterpret_cast<const UInt64&>(it.get_second());
-                                      count_col.insert_data(
-                                              reinterpret_cast<const char*>(&inline_count),
-                                              sizeof(UInt64));
-                                      ++it;
-                                      ++num_rows;
-                                  }
-                              }
+                            auto& count_col =
+                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
+                            uint32_t num_rows = 0;
+                            {
+                                SCOPED_TIMER(_hash_table_iterate_timer);
+                                auto& it = agg_method.begin;
+                                while (it != agg_method.end && num_rows < state->batch_size()) {
+                                    keys[num_rows] = it.get_first();
+                                    auto inline_count =
+                                            reinterpret_cast<const UInt64&>(it.get_second());
+                                    count_col.insert_data(
+                                            reinterpret_cast<const char*>(&inline_count),
+                                            sizeof(UInt64));
+                                    ++it;
+                                    ++num_rows;
+                                }
+                            }
 
-                              {
-                                  SCOPED_TIMER(_insert_keys_to_column_timer);
-                                  agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
-                              }
+                            {
+                                SCOPED_TIMER(_insert_keys_to_column_timer);
+                                agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                            }
 
-                              // Handle null key if present
-                              if (agg_method.begin == agg_method.end) {
-                                  if (agg_method.hash_table->has_null_key_data()) {
-                                      DCHECK(key_columns.size() == 1);
-                                      DCHECK(key_columns[0]->is_nullable());
-                                      if (num_rows < state->batch_size()) {
-                                          key_columns[0]->insert_data(nullptr, 0);
-                                          auto mapped =
-                                                  agg_method.hash_table->template get_null_key_data<
-                                                          AggregateDataPtr>();
-                                          count_col.resize(num_rows + 1);
-                                          *reinterpret_cast<UInt64*>(count_col.get_data().data() +
-                                                                     num_rows * sizeof(UInt64)) =
-                                                  std::bit_cast<UInt64>(mapped);
-                                          *eos = true;
-                                      }
-                                  } else {
-                                      *eos = true;
-                                  }
-                              }
-                              return;
-                          }
+                            // Handle null key if present
+                            if (agg_method.begin == agg_method.end) {
+                                if (agg_method.hash_table->has_null_key_data()) {
+                                    DCHECK(key_columns.size() == 1);
+                                    DCHECK(key_columns[0]->is_nullable());
+                                    if (num_rows < state->batch_size()) {
+                                        key_columns[0]->insert_data(nullptr, 0);
+                                        auto mapped =
+                                                agg_method.hash_table->template get_null_key_data<
+                                                        AggregateDataPtr>();
+                                        count_col.resize(num_rows + 1);
+                                        *reinterpret_cast<UInt64*>(count_col.get_data().data() +
+                                                                   num_rows * sizeof(UInt64)) =
+                                                std::bit_cast<UInt64>(mapped);
+                                        *eos = true;
+                                    }
+                                } else {
+                                    *eos = true;
+                                }
+                            }
+                            return;
+                        }
 
-                          if (shared_state.values.size() < size + 1) {
-                              shared_state.values.resize(size + 1);
-                          }
+                        if (shared_state.values.size() < size + 1) {
+                            shared_state.values.resize(size + 1);
+                        }
 
-                          uint32_t num_rows = 0;
-                          shared_state.aggregate_data_container->init_once();
-                          auto& iter = shared_state.aggregate_data_container->iterator;
+                        uint32_t num_rows = 0;
+                        shared_state.aggregate_data_container->init_once();
+                        auto& iter = shared_state.aggregate_data_container->iterator;
 
-                          {
-                              SCOPED_TIMER(_hash_table_iterate_timer);
-                              while (iter != shared_state.aggregate_data_container->end() &&
-                                     num_rows < state->batch_size()) {
-                                  keys[num_rows] = iter.template get_key<KeyType>();
-                                  shared_state.values[num_rows] = iter.get_aggregate_data();
-                                  ++iter;
-                                  ++num_rows;
-                              }
-                          }
+                        {
+                            SCOPED_TIMER(_hash_table_iterate_timer);
+                            while (iter != shared_state.aggregate_data_container->end() &&
+                                   num_rows < state->batch_size()) {
+                                keys[num_rows] = iter.template get_key<KeyType>();
+                                shared_state.values[num_rows] = iter.get_aggregate_data();
+                                ++iter;
+                                ++num_rows;
+                            }
+                        }
 
-                          {
-                              SCOPED_TIMER(_insert_keys_to_column_timer);
-                              agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
-                          }
+                        {
+                            SCOPED_TIMER(_insert_keys_to_column_timer);
+                            agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                        }
 
-                          if (iter == shared_state.aggregate_data_container->end()) {
-                              if (agg_method.hash_table->has_null_key_data()) {
-                                  // only one key of group by support wrap null key
-                                  // here need additional processing logic on the null key / value
-                                  DCHECK(key_columns.size() == 1);
-                                  DCHECK(key_columns[0]->is_nullable());
-                                  if (agg_method.hash_table->has_null_key_data()) {
-                                      key_columns[0]->insert_data(nullptr, 0);
-                                      shared_state.values[num_rows] =
-                                              agg_method.hash_table->template get_null_key_data<
-                                                      AggregateDataPtr>();
-                                      ++num_rows;
-                                      *eos = true;
-                                  }
-                              } else {
-                                  *eos = true;
-                              }
-                          }
+                        if (iter == shared_state.aggregate_data_container->end()) {
+                            if (agg_method.hash_table->has_null_key_data()) {
+                                // only one key of group by support wrap null key
+                                // here need additional processing logic on the null key / value
+                                DCHECK(key_columns.size() == 1);
+                                DCHECK(key_columns[0]->is_nullable());
+                                if (agg_method.hash_table->has_null_key_data()) {
+                                    key_columns[0]->insert_data(nullptr, 0);
+                                    shared_state.values[num_rows] =
+                                            agg_method.hash_table->template get_null_key_data<
+                                                    AggregateDataPtr>();
+                                    ++num_rows;
+                                    *eos = true;
+                                }
+                            } else {
+                                *eos = true;
+                            }
+                        }
 
-                          {
-                              SCOPED_TIMER(_insert_values_to_column_timer);
-                              for (size_t i = 0; i < shared_state.aggregate_evaluators.size();
-                                   ++i) {
-                                  value_data_types[i] = shared_state.aggregate_evaluators[i]
-                                                                ->function()
-                                                                ->get_serialized_type();
-                                  if (mem_reuse) {
-                                      value_columns[i] = IColumn::mutate(std::move(
-                                              block->get_by_position(i + key_size).column));
-                                  } else {
-                                      value_columns[i] = shared_state.aggregate_evaluators[i]
-                                                                 ->function()
-                                                                 ->create_serialize_column();
-                                  }
-                                  shared_state.aggregate_evaluators[i]
-                                          ->function()
-                                          ->serialize_to_column(
-                                                  shared_state.values,
-                                                  shared_state.offsets_of_aggregate_states[i],
-                                                  value_columns[i], num_rows);
-                              }
-                          }
-                      }},
+                        {
+                            SCOPED_TIMER(_insert_values_to_column_timer);
+                            for (size_t i = 0; i < shared_state.aggregate_evaluators.size(); ++i) {
+                                value_data_types[i] =
+                                        shared_state.aggregate_evaluators[i]->get_serialized_type();
+                                if (mem_reuse) {
+                                    value_columns[i] = IColumn::mutate(
+                                            std::move(block->get_by_position(i + key_size).column));
+                                } else {
+                                    value_columns[i] = shared_state.aggregate_evaluators[i]
+                                                               ->create_serialize_column();
+                                }
+                                shared_state.aggregate_evaluators[i]->serialize_to_column(
+                                        shared_state.values,
+                                        shared_state.offsets_of_aggregate_states[i],
+                                        value_columns[i], num_rows);
+                            }
+                        }
+                    }},
             shared_state.agg_data->method_variant);
 
     if (mem_reuse) {
@@ -473,13 +467,12 @@ Status AggLocalState::_get_results_without_key(RuntimeState* state, Block* block
     std::vector<DataTypePtr> data_types(agg_size);
     // will serialize data to string column
     for (int i = 0; i < shared_state.aggregate_evaluators.size(); ++i) {
-        data_types[i] = shared_state.aggregate_evaluators[i]->function()->get_serialized_type();
-        value_columns[i] =
-                shared_state.aggregate_evaluators[i]->function()->create_serialize_column();
+        data_types[i] = shared_state.aggregate_evaluators[i]->get_serialized_type();
+        value_columns[i] = shared_state.aggregate_evaluators[i]->create_serialize_column();
     }
 
     for (int i = 0; i < shared_state.aggregate_evaluators.size(); ++i) {
-        shared_state.aggregate_evaluators[i]->function()->serialize_without_key_to_column(
+        shared_state.aggregate_evaluators[i]->serialize_without_key_to_column(
                 shared_state.agg_data->without_key + shared_state.offsets_of_aggregate_states[i],
                 *value_columns[i]);
     }
@@ -510,7 +503,7 @@ Status AggLocalState::_get_without_key_result(RuntimeState* state, Block* block,
     MutableColumns columns(agg_size);
     std::vector<DataTypePtr> data_types(agg_size);
     for (int i = 0; i < shared_state.aggregate_evaluators.size(); ++i) {
-        data_types[i] = shared_state.aggregate_evaluators[i]->function()->get_return_type();
+        data_types[i] = shared_state.aggregate_evaluators[i]->get_return_type();
         columns[i] = data_types[i]->create_column();
     }
 
@@ -622,15 +615,14 @@ Status AggLocalState::merge_with_serialized_key_helper(Block* block) {
         auto col_id = Base::_shared_state->probe_expr_ctxs.size() + i;
         auto column = block->get_by_position(col_id).column;
 
-        size_t buffer_size =
-                Base::_shared_state->aggregate_evaluators[i]->function()->size_of_data() * rows;
+        size_t buffer_size = Base::_shared_state->aggregate_evaluators[i]->size_of_data() * rows;
         if (_deserialize_buffer.size() < buffer_size) {
             _deserialize_buffer.resize(buffer_size);
         }
 
         {
             SCOPED_TIMER(_deserialize_data_timer);
-            Base::_shared_state->aggregate_evaluators[i]->function()->deserialize_and_merge_vec(
+            Base::_shared_state->aggregate_evaluators[i]->deserialize_and_merge_vec(
                     _places.data(), _shared_state->offsets_of_aggregate_states[i],
                     _deserialize_buffer.data(), column.get(), Base::_shared_state->agg_arena_pool,
                     rows);

--- a/be/src/exec/operator/analytic_sink_operator.cpp
+++ b/be/src/exec/operator/analytic_sink_operator.cpp
@@ -128,16 +128,13 @@ Status AnalyticSinkLocalState::open(RuntimeState* state) {
             _agg_input_columns[i][j] = _agg_expr_ctxs[i][j]->root()->data_type()->create_column();
         }
         _offsets_of_aggregate_states[i] = p._offsets_of_aggregate_states[i];
-        _result_column_nullable_flags[i] =
-                !_agg_functions[i]->function()->get_return_type()->is_nullable() &&
-                _agg_functions[i]->data_type()->is_nullable();
-        _result_column_could_resize[i] =
-                _agg_functions[i]->function()->result_column_could_resize();
-        if (PARTITION_FUNCTION_SET.contains(_agg_functions[i]->function()->get_name())) {
+        _result_column_nullable_flags[i] = !_agg_functions[i]->get_return_type()->is_nullable() &&
+                                           _agg_functions[i]->data_type()->is_nullable();
+        _result_column_could_resize[i] = _agg_functions[i]->result_column_could_resize();
+        if (PARTITION_FUNCTION_SET.contains(_agg_functions[i]->get_name())) {
             _streaming_mode = false;
         }
-        _support_incremental_calculate &=
-                _agg_functions[i]->function()->supported_incremental_mode();
+        _support_incremental_calculate &= _agg_functions[i]->supported_incremental_mode();
     }
 
     _partition_exprs_size = p._partition_by_eq_expr_ctxs.size();
@@ -385,13 +382,13 @@ void AnalyticSinkLocalState::_execute_for_function(int64_t partition_start, int6
             agg_columns.push_back(_agg_input_columns[i][j].get());
         }
         if constexpr (incremental) {
-            _agg_functions[i]->function()->execute_function_with_incremental(
+            _agg_functions[i]->execute_function_with_incremental(
                     partition_start, partition_end, frame_start, frame_end,
                     _fn_place_ptr + _offsets_of_aggregate_states[i], agg_columns.data(),
                     _shared_state->agg_arena_pool, false, false, false, &_use_null_result[i],
                     &_could_use_previous_result[i]);
         } else {
-            _agg_functions[i]->function()->add_range_single_place(
+            _agg_functions[i]->add_range_single_place(
                     partition_start, partition_end, frame_start, frame_end,
                     _fn_place_ptr + _offsets_of_aggregate_states[i], agg_columns.data(),
                     _shared_state->agg_arena_pool, &(_use_null_result[i]),
@@ -410,14 +407,14 @@ void AnalyticSinkLocalState::_insert_result_info(int64_t start, int64_t end) {
                 auto* dst = assert_cast<ColumnNullable*>(_result_window_columns[i].get());
                 dst->get_null_map_data().resize_fill(
                         dst->get_null_map_data().size() + static_cast<uint32_t>(end - start), 0);
-                _agg_functions[i]->function()->insert_result_into_range(
-                        _fn_place_ptr + _offsets_of_aggregate_states[i], dst->get_nested_column(),
+                _agg_functions[i]->insert_result_info_range(
+                        _fn_place_ptr + _offsets_of_aggregate_states[i], &dst->get_nested_column(),
                         start, end);
             }
         } else {
-            _agg_functions[i]->function()->insert_result_into_range(
-                    _fn_place_ptr + _offsets_of_aggregate_states[i], *_result_window_columns[i],
-                    start, end);
+            _agg_functions[i]->insert_result_info_range(
+                    _fn_place_ptr + _offsets_of_aggregate_states[i],
+                    _result_window_columns[i].get(), start, end);
         }
     }
 }
@@ -725,13 +722,13 @@ Status AnalyticSinkOperatorX::prepare(RuntimeState* state) {
     _offsets_of_aggregate_states.resize(_agg_functions_size);
     for (size_t i = 0; i < _agg_functions_size; ++i) {
         _offsets_of_aggregate_states[i] = _total_size_of_aggregate_states;
-        const auto& agg_function = _agg_functions[i]->function();
+        const auto* agg_function = _agg_functions[i];
         // aggregate states are aligned based on maximum requirement
         _align_aggregate_states = std::max(_align_aggregate_states, agg_function->align_of_data());
         _total_size_of_aggregate_states += agg_function->size_of_data();
         // If not the last aggregate_state, we need pad it so that next aggregate_state will be aligned.
         if (i + 1 < _agg_functions_size) {
-            size_t alignment_of_next_state = _agg_functions[i + 1]->function()->align_of_data();
+            size_t alignment_of_next_state = _agg_functions[i + 1]->align_of_data();
             if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
                 return Status::RuntimeError("Logical error: align_of_data is not 2^N");
             }

--- a/be/src/exec/operator/bucketed_aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/bucketed_aggregation_sink_operator.cpp
@@ -89,8 +89,7 @@ Status BucketedAggSinkLocalState::open(RuntimeState* state) {
 
         // Detect simple_count: exactly one COUNT(*) with no args, with GROUP BY present.
         // Bucketed agg always has GROUP BY (without-key not supported).
-        if (p._aggregate_evaluators.size() == 1 &&
-            p._aggregate_evaluators[0]->function()->is_simple_count()) {
+        if (p._aggregate_evaluators.size() == 1 && p._aggregate_evaluators[0]->is_simple_count()) {
             shared_state.use_simple_count = true;
         }
         return Status::OK();
@@ -150,8 +149,7 @@ Status BucketedAggSinkLocalState::_create_agg_status(AggregateDataPtr data) {
 Status BucketedAggSinkLocalState::_destroy_agg_status(AggregateDataPtr data) {
     auto& shared_state = *Base::_shared_state;
     for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
-        _aggregate_evaluators[i]->function()->destroy(data +
-                                                      shared_state.offsets_of_aggregate_states[i]);
+        _aggregate_evaluators[i]->destroy(data + shared_state.offsets_of_aggregate_states[i]);
     }
     return Status::OK();
 }
@@ -454,12 +452,11 @@ Status BucketedAggSinkOperatorX::prepare(RuntimeState* state) {
     _offsets_of_aggregate_states.resize(_aggregate_evaluators.size());
     for (size_t i = 0; i < _aggregate_evaluators.size(); ++i) {
         _offsets_of_aggregate_states[i] = _total_size_of_aggregate_states;
-        const auto& agg_function = _aggregate_evaluators[i]->function();
+        const auto* agg_function = _aggregate_evaluators[i];
         _align_aggregate_states = std::max(_align_aggregate_states, agg_function->align_of_data());
         _total_size_of_aggregate_states += agg_function->size_of_data();
         if (i + 1 < _aggregate_evaluators.size()) {
-            size_t alignment_of_next_state =
-                    _aggregate_evaluators[i + 1]->function()->align_of_data();
+            size_t alignment_of_next_state = _aggregate_evaluators[i + 1]->align_of_data();
             if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
                 return Status::RuntimeError("Logical error: align_of_data is not 2^N");
             }

--- a/be/src/exec/operator/bucketed_aggregation_source_operator.cpp
+++ b/be/src/exec/operator/bucketed_aggregation_source_operator.cpp
@@ -103,10 +103,10 @@ static void merge_agg_states(AggregateDataPtr& dst_ref, AggregateDataPtr src, bo
     } else {
         const size_t num_fns = evaluators.size();
         for (size_t i = 0; i < num_fns; ++i) {
-            evaluators[i]->function()->merge(dst_ref + offsets[i], src + offsets[i], arena);
+            evaluators[i]->merge(dst_ref + offsets[i], src + offsets[i], arena);
         }
         for (size_t i = 0; i < num_fns; ++i) {
-            evaluators[i]->function()->destroy(src + offsets[i]);
+            evaluators[i]->destroy(src + offsets[i]);
         }
     }
 }
@@ -380,16 +380,14 @@ void BucketedAggLocalState::_build_output_block(Block* block, MutableColumns& ke
         DataTypes value_data_types(agg_size);
 
         for (size_t i = 0; i < agg_size; ++i) {
-            value_data_types[i] =
-                    shared_state.aggregate_evaluators[i]->function()->get_serialized_type();
+            value_data_types[i] = shared_state.aggregate_evaluators[i]->get_serialized_type();
             if (mem_reuse) {
                 value_columns[i] =
                         IColumn::mutate(std::move(block->get_by_position(key_size + i).column));
             } else {
-                value_columns[i] =
-                        shared_state.aggregate_evaluators[i]->function()->create_serialize_column();
+                value_columns[i] = shared_state.aggregate_evaluators[i]->create_serialize_column();
             }
-            shared_state.aggregate_evaluators[i]->function()->serialize_to_column(
+            shared_state.aggregate_evaluators[i]->serialize_to_column(
                     values, shared_state.offsets_of_aggregate_states[i], value_columns[i],
                     num_rows);
         }

--- a/be/src/exec/operator/partitioned_aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/partitioned_aggregation_sink_operator.cpp
@@ -56,8 +56,8 @@ Status PartitionedAggSinkLocalState::init(doris::RuntimeState* state,
     }
     for (const auto& aggregate_evaluator :
          Base::_shared_state->_in_mem_shared_state->aggregate_evaluators) {
-        _value_data_types.emplace_back(aggregate_evaluator->function()->get_serialized_type());
-        _value_columns.emplace_back(aggregate_evaluator->function()->create_serialize_column());
+        _value_data_types.emplace_back(aggregate_evaluator->get_serialized_type());
+        _value_columns.emplace_back(aggregate_evaluator->create_serialize_column());
     }
     _rows_in_partitions.assign(parent._partition_count, 0);
     return Status::OK();
@@ -273,12 +273,9 @@ Status PartitionedAggSinkLocalState::_to_block(HashTableCtxType& context,
 
     for (size_t i = 0; i < Base::_shared_state->_in_mem_shared_state->aggregate_evaluators.size();
          ++i) {
-        Base::_shared_state->_in_mem_shared_state->aggregate_evaluators[i]
-                ->function()
-                ->serialize_to_column(
-                        values,
-                        Base::_shared_state->_in_mem_shared_state->offsets_of_aggregate_states[i],
-                        _value_columns[i], values.size());
+        Base::_shared_state->_in_mem_shared_state->aggregate_evaluators[i]->serialize_to_column(
+                values, Base::_shared_state->_in_mem_shared_state->offsets_of_aggregate_states[i],
+                _value_columns[i], values.size());
     }
 
     ColumnsWithTypeAndName key_columns_with_schema;
@@ -294,9 +291,7 @@ Status PartitionedAggSinkLocalState::_to_block(HashTableCtxType& context,
     for (int i = 0; i < _value_columns.size(); ++i) {
         value_columns_with_schema.emplace_back(
                 std::move(_value_columns[i]), _value_data_types[i],
-                Base::_shared_state->_in_mem_shared_state->aggregate_evaluators[i]
-                        ->function()
-                        ->get_name());
+                Base::_shared_state->_in_mem_shared_state->aggregate_evaluators[i]->get_name());
     }
     _value_block = value_columns_with_schema;
 

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -101,8 +101,8 @@ Status StreamingAggLocalState::open(RuntimeState* state) {
     // Determine whether to use simple count aggregation.
     // StreamingAgg only operates in update + serialize mode: input is raw data, output is serialized intermediate state.
     // The serialization format of count is UInt64 itself, so it can be inlined into the hash table mapped slot.
-    if (_aggregate_evaluators.size() == 1 &&
-        _aggregate_evaluators[0]->function()->is_simple_count() && p._sort_limit == -1) {
+    if (_aggregate_evaluators.size() == 1 && _aggregate_evaluators[0]->is_simple_count() &&
+        p._sort_limit == -1) {
         _use_simple_count = true;
 #ifndef NDEBUG
         // Randomly enable/disable in debug mode to verify correctness of multi-phase agg promotion/demotion.
@@ -385,9 +385,8 @@ Status StreamingAggLocalState::_pre_agg_with_serialized_key(doris::Block* in_blo
         std::vector<DataTypePtr> data_types;
         MutableColumns value_columns;
         for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
-            auto data_type = _aggregate_evaluators[i]->function()->get_serialized_type();
-            value_columns.emplace_back(
-                    _aggregate_evaluators[i]->function()->create_serialize_column());
+            auto data_type = _aggregate_evaluators[i]->get_serialized_type();
+            value_columns.emplace_back(_aggregate_evaluators[i]->create_serialize_column());
             data_types.emplace_back(data_type);
         }
 
@@ -473,139 +472,135 @@ Status StreamingAggLocalState::_get_results_with_serialized_key(RuntimeState* st
     }
 
     std::visit(
-            Overload {
-                    [&](std::monostate& arg) -> void {
-                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
-                    },
-                    [&](auto& agg_method) -> void {
-                        agg_method.init_iterator();
-                        auto& data = *agg_method.hash_table;
-                        const auto size = std::min(data.size(), size_t(state->batch_size()));
-                        using KeyType = std::decay_t<decltype(agg_method)>::Key;
-                        std::vector<KeyType> keys(size);
+            Overload {[&](std::monostate& arg) -> void {
+                          throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                      },
+                      [&](auto& agg_method) -> void {
+                          agg_method.init_iterator();
+                          auto& data = *agg_method.hash_table;
+                          const auto size = std::min(data.size(), size_t(state->batch_size()));
+                          using KeyType = std::decay_t<decltype(agg_method)>::Key;
+                          std::vector<KeyType> keys(size);
 
-                        if (_use_simple_count) {
-                            DCHECK_EQ(_aggregate_evaluators.size(), 1);
+                          if (_use_simple_count) {
+                              DCHECK_EQ(_aggregate_evaluators.size(), 1);
 
-                            value_data_types[0] =
-                                    _aggregate_evaluators[0]->function()->get_serialized_type();
-                            if (mem_reuse) {
-                                value_columns[0] = IColumn::mutate(
-                                        std::move(block->get_by_position(key_size).column));
-                            } else {
-                                value_columns[0] = _aggregate_evaluators[0]
-                                                           ->function()
-                                                           ->create_serialize_column();
-                            }
+                              value_data_types[0] = _aggregate_evaluators[0]->get_serialized_type();
+                              if (mem_reuse) {
+                                  value_columns[0] = IColumn::mutate(
+                                          std::move(block->get_by_position(key_size).column));
+                              } else {
+                                  value_columns[0] =
+                                          _aggregate_evaluators[0]->create_serialize_column();
+                              }
 
-                            auto& count_col =
-                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
-                            uint32_t num_rows = 0;
-                            {
-                                SCOPED_TIMER(_hash_table_iterate_timer);
-                                auto& it = agg_method.begin;
-                                while (it != agg_method.end && num_rows < state->batch_size()) {
-                                    keys[num_rows] = it.get_first();
-                                    auto inline_count =
-                                            reinterpret_cast<const UInt64&>(it.get_second());
-                                    count_col.insert_data(
-                                            reinterpret_cast<const char*>(&inline_count),
-                                            sizeof(UInt64));
-                                    ++it;
-                                    ++num_rows;
-                                }
-                            }
+                              auto& count_col =
+                                      assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
+                              uint32_t num_rows = 0;
+                              {
+                                  SCOPED_TIMER(_hash_table_iterate_timer);
+                                  auto& it = agg_method.begin;
+                                  while (it != agg_method.end && num_rows < state->batch_size()) {
+                                      keys[num_rows] = it.get_first();
+                                      auto inline_count =
+                                              reinterpret_cast<const UInt64&>(it.get_second());
+                                      count_col.insert_data(
+                                              reinterpret_cast<const char*>(&inline_count),
+                                              sizeof(UInt64));
+                                      ++it;
+                                      ++num_rows;
+                                  }
+                              }
 
-                            {
-                                SCOPED_TIMER(_insert_keys_to_column_timer);
-                                agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
-                            }
+                              {
+                                  SCOPED_TIMER(_insert_keys_to_column_timer);
+                                  agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                              }
 
-                            // Handle null key if present
-                            if (agg_method.begin == agg_method.end) {
-                                if (agg_method.hash_table->has_null_key_data()) {
-                                    DCHECK(key_columns.size() == 1);
-                                    DCHECK(key_columns[0]->is_nullable());
-                                    if (num_rows < state->batch_size()) {
-                                        key_columns[0]->insert_data(nullptr, 0);
-                                        auto mapped =
-                                                agg_method.hash_table->template get_null_key_data<
-                                                        AggregateDataPtr>();
-                                        count_col.resize(num_rows + 1);
-                                        *reinterpret_cast<UInt64*>(count_col.get_data().data() +
-                                                                   num_rows * sizeof(UInt64)) =
-                                                std::bit_cast<UInt64>(mapped);
-                                        *eos = true;
-                                    }
-                                } else {
-                                    *eos = true;
-                                }
-                            }
-                            return;
-                        }
+                              // Handle null key if present
+                              if (agg_method.begin == agg_method.end) {
+                                  if (agg_method.hash_table->has_null_key_data()) {
+                                      DCHECK(key_columns.size() == 1);
+                                      DCHECK(key_columns[0]->is_nullable());
+                                      if (num_rows < state->batch_size()) {
+                                          key_columns[0]->insert_data(nullptr, 0);
+                                          auto mapped =
+                                                  agg_method.hash_table->template get_null_key_data<
+                                                          AggregateDataPtr>();
+                                          count_col.resize(num_rows + 1);
+                                          *reinterpret_cast<UInt64*>(count_col.get_data().data() +
+                                                                     num_rows * sizeof(UInt64)) =
+                                                  std::bit_cast<UInt64>(mapped);
+                                          *eos = true;
+                                      }
+                                  } else {
+                                      *eos = true;
+                                  }
+                              }
+                              return;
+                          }
 
-                        if (_values.size() < size + 1) {
-                            _values.resize(size + 1);
-                        }
+                          if (_values.size() < size + 1) {
+                              _values.resize(size + 1);
+                          }
 
-                        uint32_t num_rows = 0;
-                        _aggregate_data_container->init_once();
-                        auto& iter = _aggregate_data_container->iterator;
+                          uint32_t num_rows = 0;
+                          _aggregate_data_container->init_once();
+                          auto& iter = _aggregate_data_container->iterator;
 
-                        {
-                            SCOPED_TIMER(_hash_table_iterate_timer);
-                            while (iter != _aggregate_data_container->end() &&
-                                   num_rows < state->batch_size()) {
-                                keys[num_rows] = iter.template get_key<KeyType>();
-                                _values[num_rows] = iter.get_aggregate_data();
-                                ++iter;
-                                ++num_rows;
-                            }
-                        }
+                          {
+                              SCOPED_TIMER(_hash_table_iterate_timer);
+                              while (iter != _aggregate_data_container->end() &&
+                                     num_rows < state->batch_size()) {
+                                  keys[num_rows] = iter.template get_key<KeyType>();
+                                  _values[num_rows] = iter.get_aggregate_data();
+                                  ++iter;
+                                  ++num_rows;
+                              }
+                          }
 
-                        {
-                            SCOPED_TIMER(_insert_keys_to_column_timer);
-                            agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
-                        }
+                          {
+                              SCOPED_TIMER(_insert_keys_to_column_timer);
+                              agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                          }
 
-                        if (iter == _aggregate_data_container->end()) {
-                            if (agg_method.hash_table->has_null_key_data()) {
-                                // only one key of group by support wrap null key
-                                // here need additional processing logic on the null key / value
-                                DCHECK(key_columns.size() == 1);
-                                DCHECK(key_columns[0]->is_nullable());
-                                if (agg_method.hash_table->has_null_key_data()) {
-                                    key_columns[0]->insert_data(nullptr, 0);
-                                    _values[num_rows] =
-                                            agg_method.hash_table->template get_null_key_data<
-                                                    AggregateDataPtr>();
-                                    ++num_rows;
-                                    *eos = true;
-                                }
-                            } else {
-                                *eos = true;
-                            }
-                        }
+                          if (iter == _aggregate_data_container->end()) {
+                              if (agg_method.hash_table->has_null_key_data()) {
+                                  // only one key of group by support wrap null key
+                                  // here need additional processing logic on the null key / value
+                                  DCHECK(key_columns.size() == 1);
+                                  DCHECK(key_columns[0]->is_nullable());
+                                  if (agg_method.hash_table->has_null_key_data()) {
+                                      key_columns[0]->insert_data(nullptr, 0);
+                                      _values[num_rows] =
+                                              agg_method.hash_table->template get_null_key_data<
+                                                      AggregateDataPtr>();
+                                      ++num_rows;
+                                      *eos = true;
+                                  }
+                              } else {
+                                  *eos = true;
+                              }
+                          }
 
-                        {
-                            SCOPED_TIMER(_insert_values_to_column_timer);
-                            for (size_t i = 0; i < _aggregate_evaluators.size(); ++i) {
-                                value_data_types[i] =
-                                        _aggregate_evaluators[i]->function()->get_serialized_type();
-                                if (mem_reuse) {
-                                    value_columns[i] = IColumn::mutate(
-                                            std::move(block->get_by_position(i + key_size).column));
-                                } else {
-                                    value_columns[i] = _aggregate_evaluators[i]
-                                                               ->function()
-                                                               ->create_serialize_column();
-                                }
-                                _aggregate_evaluators[i]->function()->serialize_to_column(
-                                        _values, p._offsets_of_aggregate_states[i],
-                                        value_columns[i], num_rows);
-                            }
-                        }
-                    }},
+                          {
+                              SCOPED_TIMER(_insert_values_to_column_timer);
+                              for (size_t i = 0; i < _aggregate_evaluators.size(); ++i) {
+                                  value_data_types[i] =
+                                          _aggregate_evaluators[i]->get_serialized_type();
+                                  if (mem_reuse) {
+                                      value_columns[i] = IColumn::mutate(std::move(
+                                              block->get_by_position(i + key_size).column));
+                                  } else {
+                                      value_columns[i] =
+                                              _aggregate_evaluators[i]->create_serialize_column();
+                                  }
+                                  _aggregate_evaluators[i]->serialize_to_column(
+                                          _values, p._offsets_of_aggregate_states[i],
+                                          value_columns[i], num_rows);
+                              }
+                          }
+                      }},
             _agg_data->method_variant);
 
     if (mem_reuse) {
@@ -644,7 +639,7 @@ void StreamingAggLocalState::make_nullable_output_key(Block* block) {
 
 void StreamingAggLocalState::_destroy_agg_status(AggregateDataPtr data) {
     for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
-        _aggregate_evaluators[i]->function()->destroy(
+        _aggregate_evaluators[i]->destroy(
                 data + _parent->cast<StreamingAggOperatorX>()._offsets_of_aggregate_states[i]);
     }
 }
@@ -1048,15 +1043,14 @@ Status StreamingAggOperatorX::_calc_aggregate_evaluators() {
     for (size_t i = 0; i < _aggregate_evaluators.size(); ++i) {
         _offsets_of_aggregate_states[i] = _total_size_of_aggregate_states;
 
-        const auto& agg_function = _aggregate_evaluators[i]->function();
+        const auto* agg_function = _aggregate_evaluators[i];
         // aggreate states are aligned based on maximum requirement
         _align_aggregate_states = std::max(_align_aggregate_states, agg_function->align_of_data());
         _total_size_of_aggregate_states += agg_function->size_of_data();
 
         // If not the last aggregate_state, we need pad it so that next aggregate_state will be aligned.
         if (i + 1 < _aggregate_evaluators.size()) {
-            size_t alignment_of_next_state =
-                    _aggregate_evaluators[i + 1]->function()->align_of_data();
+            size_t alignment_of_next_state = _aggregate_evaluators[i + 1]->align_of_data();
             if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
                 return Status::RuntimeError("Logical error: align_of_data is not 2^N");
             }

--- a/be/src/exec/pipeline/dependency.cpp
+++ b/be/src/exec/pipeline/dependency.cpp
@@ -351,14 +351,14 @@ int AggSharedState::get_slot_column_id(const AggFnEvaluator* evaluator) {
 
 void AggSharedState::_destroy_agg_status(AggregateDataPtr data) {
     for (int i = 0; i < aggregate_evaluators.size(); ++i) {
-        aggregate_evaluators[i]->function()->destroy(data + offsets_of_aggregate_states[i]);
+        aggregate_evaluators[i]->destroy(data + offsets_of_aggregate_states[i]);
     }
 }
 
 void BucketedAggSharedState::_destroy_agg_status(AggregateDataPtr data) {
     DCHECK(!use_simple_count) << "should not call _destroy_agg_status when use_simple_count";
     for (int i = 0; i < aggregate_evaluators.size(); ++i) {
-        aggregate_evaluators[i]->function()->destroy(data + offsets_of_aggregate_states[i]);
+        aggregate_evaluators[i]->destroy(data + offsets_of_aggregate_states[i]);
     }
 }
 

--- a/be/src/exprs/aggregate/aggregate_function.h
+++ b/be/src/exprs/aggregate/aggregate_function.h
@@ -20,8 +20,11 @@
 
 #pragma once
 
+#include <string>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
+#include <vector>
 
 #include "common/exception.h"
 #include "common/status.h"
@@ -29,6 +32,7 @@
 #include "core/column/column_complex.h"
 #include "core/column/column_fixed_length_object.h"
 #include "core/column/column_string.h"
+#include "core/data_type/data_type.h"
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_string.h"
 #include "core/string_buffer.hpp"
@@ -188,6 +192,8 @@ public:
 
     /// Inserts results into a column.
     // todo: Consider whether this passes a ConstAggregateDataPtr
+    // Hot path. Callers must validate `to` with check_result_column_type() before calling
+    // insert_result_into()/insert_result_into_vec()/insert_result_into_range().
     virtual void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const = 0;
 
     virtual void insert_result_into_vec(const std::vector<AggregateDataPtr>& places,
@@ -225,6 +231,19 @@ public:
 
     virtual void streaming_agg_serialize_to_column(const IColumn** columns, MutableColumnPtr& dst,
                                                    const size_t num_rows, Arena&) const = 0;
+
+    virtual void check_input_columns_type(const IColumn** columns) const {
+        check_columns_type(argument_types, columns);
+    }
+
+    virtual void check_result_column_type(const IColumn& column) const {
+        auto status = get_return_type()->check_column(column);
+        if (UNLIKELY(!status.ok())) {
+            throw doris::Exception(
+                    Status::InternalError("Aggregate function {} result type check failed: {}",
+                                          get_name(), status.msg()));
+        }
+    }
 
     const DataTypes& get_argument_types() const { return argument_types; }
 
@@ -300,6 +319,39 @@ public:
     }
 
 protected:
+    void check_columns_type(const DataTypes& types, const IColumn** columns) const {
+        for (size_t i = 0; i < types.size(); ++i) {
+            auto status = types[i]->check_column(*columns[i]);
+            if (UNLIKELY(!status.ok())) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} argument {} type check failed: {}", get_name(), i,
+                        status.msg()));
+            }
+        }
+    }
+
+    template <typename ColumnType>
+    void check_argument_column_type(const IColumn* column) const {
+        if (UNLIKELY(check_and_get_column<ColumnType>(*column) == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument type check failed: Column type {} ({}) does "
+                    "not match expected physical column type {}",
+                    get_name(), column->get_name(), typeid(*column).name(),
+                    typeid(ColumnType).name()));
+        }
+    }
+
+    template <typename ColumnType>
+    void check_result_column_type_as(const IColumn& column) const {
+        if (UNLIKELY(check_and_get_column<ColumnType>(column) == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Column type {} ({}) does not "
+                    "match expected physical column type {}",
+                    get_name(), column.get_name(), typeid(column).name(),
+                    typeid(ColumnType).name()));
+        }
+    }
+
     DataTypes argument_types;
     int version {};
 };

--- a/be/src/exprs/aggregate/aggregate_function_ai_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_ai_agg.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "common/status.h"
+#include "core/column/column_string.h"
 #include "core/string_ref.h"
 #include "core/types.h"
 #include "exprs/aggregate/aggregate_function.h"
@@ -308,6 +309,12 @@ public:
         }
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnString>(columns[0]);
+        this->template check_argument_column_type<ColumnString>(columns[1]);
+        this->template check_argument_column_type<ColumnString>(columns[2]);
+    }
+
     void reset(AggregateDataPtr place) const override {
         data(place).reset();
         data(place).set_query_context(_ctx);
@@ -331,7 +338,13 @@ public:
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         std::string result = data(place)._execute_task();
         DCHECK(!result.empty()) << "AI returns an empty result";
-        assert_cast<ColumnString&>(to).insert_data(result.data(), result.size());
+        assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(result.data(),
+                                                                                result.size());
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        this->template check_result_column_type_as<ColumnString>(to);
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_approx_count_distinct.h
+++ b/be/src/exprs/aggregate/aggregate_function_approx_count_distinct.h
@@ -128,7 +128,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColumnInt64&>(to);
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 };

--- a/be/src/exprs/aggregate/aggregate_function_array_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_array_agg.h
@@ -81,10 +81,12 @@ struct AggregateFunctionArrayAggData {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
-        auto* col_null = assert_cast<ColumnNullable*>(&to_nested_col);
-        auto& vec = assert_cast<ColVecType&>(col_null->get_nested_column()).get_data();
+        auto* col_null = assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(&to_nested_col);
+        auto& vec =
+                assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(col_null->get_nested_column())
+                        .get_data();
         size_t num_rows = null_map->size();
         auto& nested_column_data = nested_column->get_data();
         for (size_t i = 0; i < num_rows; ++i) {
@@ -177,10 +179,11 @@ struct AggregateFunctionArrayAggData<T> {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
-        auto* col_null = assert_cast<ColumnNullable*>(&to_nested_col);
-        auto& vec = assert_cast<ColVecType&>(col_null->get_nested_column());
+        auto* col_null = assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(&to_nested_col);
+        auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(
+                col_null->get_nested_column());
         size_t num_rows = null_map->size();
         for (size_t i = 0; i < num_rows; ++i) {
             col_null->get_null_map_data().push_back((*null_map)[i]);
@@ -252,7 +255,7 @@ struct AggregateFunctionArrayAggData<T> {
     void reset() { column_data->clear(); }
 
     void insert_result_into(IColumn& to) const {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
         size_t num_rows = column_data->size();
         for (size_t i = 0; i < num_rows; ++i) {
@@ -311,7 +314,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
         DCHECK(to_nested_col.is_nullable());
         this->data(place).insert_result_into(to);
@@ -360,6 +363,9 @@ public:
 
     void streaming_agg_serialize_to_column(const IColumn** columns, MutableColumnPtr& dst,
                                            const size_t num_rows, Arena& arena) const override {
+        if constexpr (is_string_type(Data::PType)) {
+            check_array_nullable_string_column_type(*dst, true);
+        }
         auto& to_arr = assert_cast<ColumnArray&>(*dst);
         auto& to_nested_col = to_arr.get_data();
         DCHECK(num_rows == columns[0]->size());
@@ -399,7 +405,52 @@ public:
 
     DataTypePtr get_serialized_type() const override { return return_type; }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        if constexpr (is_string_type(Data::PType)) {
+            const auto* nullable_column = check_and_get_column<ColumnNullable>(*columns[0]);
+            if (UNLIKELY(nullable_column == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} argument 0 type check failed: Column type {} is "
+                        "not ColumnNullable",
+                        get_name(), columns[0]->get_name()));
+            }
+            this->template check_argument_column_type<ColumnString>(
+                    &nullable_column->get_nested_column());
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        if constexpr (is_string_type(Data::PType)) {
+            check_array_nullable_string_column_type(to, true);
+        }
+    }
+
 private:
+    void check_array_nullable_string_column_type(const IColumn& column,
+                                                 bool is_result_column) const {
+        const auto* array_column = check_and_get_column<ColumnArray>(column);
+        if (UNLIKELY(array_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} {} type check failed: Column type {} is not "
+                    "ColumnArray",
+                    get_name(), is_result_column ? "result" : "argument", column.get_name()));
+        }
+
+        const auto& nested_column = array_column->get_data();
+        const auto* nullable_column = check_and_get_column<ColumnNullable>(nested_column);
+        if (UNLIKELY(nullable_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} {} type check failed: Column type {} is not "
+                    "ColumnNullable",
+                    get_name(), is_result_column ? "result" : "argument",
+                    nested_column.get_name()));
+        }
+        this->template check_result_column_type_as<ColumnString>(
+                nullable_column->get_nested_column());
+    }
+
     DataTypePtr return_type;
 };
 

--- a/be/src/exprs/aggregate/aggregate_function_avg.h
+++ b/be/src/exprs/aggregate/aggregate_function_avg.h
@@ -225,7 +225,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColVecResult&>(to);
+        auto& column = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         if constexpr (is_decimal(T)) {
             column.get_data().push_back(this->data(place).template result<ResultType>(multiplier));
         } else {

--- a/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
+++ b/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
@@ -115,6 +115,11 @@ public:
         this->data(place).add(column.get_data()[row_num], weight.get_element(row_num));
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[1]);
+    }
+
     void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -132,7 +137,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColumnFloat64&>(to);
+        auto& column = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 };

--- a/be/src/exprs/aggregate/aggregate_function_bit.h
+++ b/be/src/exprs/aggregate/aggregate_function_bit.h
@@ -143,7 +143,8 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&>(to);
+        auto& column = assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&,
+                                   TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 };

--- a/be/src/exprs/aggregate/aggregate_function_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_bitmap.h
@@ -271,7 +271,8 @@ public:
                   std::vector<int>& rows, Arena&) const override {
         // now this only for bitmap_union function
         if constexpr (std::is_same_v<Op, AggregateFunctionBitmapUnionOp>) {
-            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            const auto& column =
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             std::vector<const BitmapValue*> values;
             for (auto row : rows) {
                 values.push_back(&(column.get_data()[row]));
@@ -284,7 +285,8 @@ public:
                          const IColumn** columns, Arena& arena, bool has_null) override {
         // now this only for bitmap_union function
         if constexpr (std::is_same_v<Op, AggregateFunctionBitmapUnionOp>) {
-            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            const auto& column =
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             std::vector<const BitmapValue*> values;
             for (size_t i = batch_begin; i <= batch_end; ++i) {
                 values.push_back(&(column.get_data()[i]));
@@ -312,7 +314,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColVecResult&>(to);
+        auto& column = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 
@@ -350,7 +352,8 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
         if constexpr (arg_is_nullable) {
-            const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
+            const auto& nullable_column =
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
                 const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                         nullable_column.get_nested_column());
@@ -367,9 +370,10 @@ public:
                   std::vector<int>& rows, Arena&) const override {
         // now this only for bitmap_union_count function
         if constexpr (arg_is_nullable && std::is_same_v<ColVecType, ColumnBitmap>) {
-            const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
-            const auto& column =
-                    assert_cast<const ColVecType&>(nullable_column.get_nested_column());
+            const auto& nullable_column =
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+            const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
+                    nullable_column.get_nested_column());
             std::vector<const BitmapValue*> values;
             for (auto row : rows) {
                 if (!nullable_column.is_null_at(row)) {
@@ -378,7 +382,8 @@ public:
             }
             this->data(place).add_batch(values);
         } else if constexpr (std::is_same_v<ColVecType, ColumnBitmap>) {
-            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            const auto& column =
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             std::vector<const BitmapValue*> values;
             for (auto row : rows) {
                 values.push_back(&(column.get_data()[row]));
@@ -403,7 +408,8 @@ public:
                 return;
             }
             auto add_batch_lambda = [&](const IColumn& data_column, const NullMap* null_map) {
-                const auto& column = assert_cast<const ColVecType&>(data_column);
+                const auto& column =
+                        assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(data_column);
                 std::vector<const BitmapValue*> values;
                 for (size_t i = 0; i < batch_size; ++i) {
                     if constexpr (arg_is_nullable) {
@@ -417,7 +423,9 @@ public:
             };
 
             if constexpr (arg_is_nullable) {
-                const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
+                const auto& nullable_column =
+                        assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                *columns[0]);
                 add_batch_lambda(nullable_column.get_nested_column(),
                                  &(nullable_column.get_null_map_data()));
             } else {
@@ -444,7 +452,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         auto& value_data = this->data(place).get();
-        auto& column = assert_cast<ColVecResult&>(to);
+        auto& column = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(value_data.cardinality());
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_bitmap_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_bitmap_agg.h
@@ -92,9 +92,10 @@ public:
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena&) const override {
         if constexpr (arg_nullable) {
-            auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
-            const auto& column =
-                    assert_cast<const ColVecType&>(nullable_column.get_nested_column());
+            auto& nullable_column =
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
+            const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
+                    nullable_column.get_nested_column());
             std::vector<typename PrimitiveTypeTraits<T>::CppType> values;
             for (int i = 0; i < batch_size; ++i) {
                 if (!nullable_column.is_null_at(i)) {
@@ -103,7 +104,8 @@ public:
             }
             this->data(place).value.add_many(values.data(), values.size());
         } else {
-            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            const auto& column =
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(*columns[0]);
             this->data(place).value.add_many(column.get_data().data(), column.size());
         }
     }
@@ -116,7 +118,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColumnBitmap&>(to);
+        auto& column = assert_cast<ColumnBitmap&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).value);
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_bool_union.h
+++ b/be/src/exprs/aggregate/aggregate_function_bool_union.h
@@ -85,6 +85,10 @@ public:
                         .get_element(row_num));
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnUInt8>(columns[0]);
+    }
+
     void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -102,7 +106,8 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        assert_cast<ColumnUInt8&>(to).insert_value(this->data(place).get());
+        assert_cast<ColumnUInt8&, TypeCheckOnRelease::DISABLE>(to).insert_value(
+                this->data(place).get());
     }
 };
 } // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_collect.h
+++ b/be/src/exprs/aggregate/aggregate_function_collect.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <new>
 #include <string>
+#include <type_traits>
 
 #include "core/assert_cast.h"
 #include "core/column/column.h"
@@ -102,7 +103,7 @@ struct AggregateFunctionCollectSetData {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& vec = assert_cast<ColVecType&>(to).get_data();
+        auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).get_data();
         vec.reserve(size());
         for (const auto& item : data_set) {
             vec.push_back(item);
@@ -170,7 +171,7 @@ struct AggregateFunctionCollectSetData<T, HasLimit> {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& vec = assert_cast<ColVecType&>(to);
+        auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to);
         vec.reserve(size());
         for (const auto& item : data_set) {
             vec.insert_data(item.data, item.size);
@@ -232,7 +233,7 @@ struct AggregateFunctionCollectListData {
     void reset() { data.clear(); }
 
     void insert_result_into(IColumn& to) const {
-        auto& vec = assert_cast<ColVecType&>(to).get_data();
+        auto& vec = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).get_data();
         size_t old_size = vec.size();
         vec.resize(old_size + size());
         std::memcpy(vec.data() + old_size, data.data(), size() * sizeof(ElementType));
@@ -298,7 +299,7 @@ struct AggregateFunctionCollectListData<T, HasLimit> {
     void reset() { data->clear(); }
 
     void insert_result_into(IColumn& to) const {
-        auto& to_str = assert_cast<ColVecType&>(to);
+        auto& to_str = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to);
         to_str.insert_range_from(*data, 0, size());
     }
 };
@@ -460,12 +461,45 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
-        auto* col_null = assert_cast<ColumnNullable*>(&to_nested_col);
+        auto* col_null = assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(&to_nested_col);
         this->data(place).insert_result_into(col_null->get_nested_column());
         col_null->get_null_map_data().resize_fill(col_null->get_nested_column().size(), 0);
         to_arr.get_offsets().push_back(to_nested_col.size());
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        if constexpr (is_string_type(Data::PType) &&
+                      std::is_same_v<AggregateFunctionCollectListData<Data::PType, HasLimit>,
+                                     Data>) {
+            this->template check_argument_column_type<ColumnString>(columns[0]);
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        if constexpr (is_string_type(Data::PType)) {
+            const auto* array_column = check_and_get_column<ColumnArray>(to);
+            if (UNLIKELY(array_column == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} result type check failed: Column type {} is not "
+                        "ColumnArray",
+                        get_name(), to.get_name()));
+            }
+
+            const auto& nested_column = array_column->get_data();
+            const auto* nullable_column = check_and_get_column<ColumnNullable>(nested_column);
+            if (UNLIKELY(nullable_column == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} result type check failed: Column type {} is not "
+                        "ColumnNullable",
+                        get_name(), nested_column.get_name()));
+            }
+            this->template check_result_column_type_as<ColumnString>(
+                    nullable_column->get_nested_column());
+        }
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_count.h
+++ b/be/src/exprs/aggregate/aggregate_function_count.h
@@ -92,7 +92,8 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).count);
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                data(place).count);
     }
 
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
@@ -239,14 +240,23 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         if (is_column_nullable(to)) {
-            auto& null_column = assert_cast<ColumnNullable&>(to);
+            auto& null_column = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
             null_column.get_null_map_data().push_back(0);
-            assert_cast<ColumnInt64&>(null_column.get_nested_column())
+            assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(null_column.get_nested_column())
                     .get_data()
                     .push_back(data(place).count);
         } else {
-            assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).count);
+            assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                    data(place).count);
         }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        if (const auto* null_column = check_and_get_column<ColumnNullable>(to)) {
+            IAggregateFunction::check_result_column_type(null_column->get_nested_column());
+            return;
+        }
+        IAggregateFunction::check_result_column_type(to);
     }
 
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,

--- a/be/src/exprs/aggregate/aggregate_function_count_by_enum.h
+++ b/be/src/exprs/aggregate/aggregate_function_count_by_enum.h
@@ -199,14 +199,17 @@ public:
             const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
             if (nullable_column == nullptr) {
                 this->data(place).add(
-                        i, static_cast<const ColumnString&>(*columns[i]).get_data_at(row_num));
+                        i,
+                        assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[i])
+                                .get_data_at(row_num));
             } else if (nullable_column->is_null_at(row_num)) {
                 // TODO create a null vector
                 this->data(place).add(i);
             } else {
-                this->data(place).add(
-                        i, static_cast<const ColumnString&>(nullable_column->get_nested_column())
-                                   .get_data_at(row_num));
+                this->data(place).add(i,
+                                      assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                              nullable_column->get_nested_column())
+                                              .get_data_at(row_num));
             }
         }
     }
@@ -229,7 +232,26 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         const std::string json_arr = this->data(place).get();
-        assert_cast<ColumnString&>(to).insert_data(json_arr.c_str(), json_arr.length());
+        assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(json_arr.c_str(),
+                                                                                json_arr.length());
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        for (int i = 0; i < arg_count; i++) {
+            if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*columns[i]);
+                nullable_column != nullptr) {
+                this->template check_argument_column_type<ColumnString>(
+                        &nullable_column->get_nested_column());
+            } else {
+                this->template check_argument_column_type<ColumnString>(columns[i]);
+            }
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        this->template check_result_column_type_as<ColumnString>(to);
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_covar.h
+++ b/be/src/exprs/aggregate/aggregate_function_covar.h
@@ -117,7 +117,7 @@ struct PopData : BaseData<T> {
     static const char* name() { return "covar"; }
 
     void insert_result_into(IColumn& to) const {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.get_data().push_back(this->get_pop_result());
     }
 };
@@ -127,7 +127,7 @@ struct SampData : BaseData<T> {
     static const char* name() { return "covar_samp"; }
 
     void insert_result_into(IColumn& to) const {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         if (this->count == 1 || this->count == 0) {
             col.insert_default();
         } else {

--- a/be/src/exprs/aggregate/aggregate_function_datasketches_hll_union_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_datasketches_hll_union_agg.h
@@ -204,7 +204,16 @@ public:
         this->data(place).read(buf);
     }
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        assert_cast<ColumnFloat64&>(to).get_data().push_back(this->data(place).get_result());
+        assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                this->data(place).get_result());
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        if constexpr (is_string_type(T) || is_varbinary(T)) {
+            this->template check_argument_column_type<typename PrimitiveTypeTraits<T>::ColumnType>(
+                    columns[0]);
+        }
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_ema.h
+++ b/be/src/exprs/aggregate/aggregate_function_ema.h
@@ -151,6 +151,12 @@ public:
         this->data(place).add(new_value, current_time, half_decay);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnFloat64>(columns[0]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[1]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[2]);
+    }
+
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
                Arena&) const override {
         this->data(place).merge(this->data(rhs));
@@ -166,7 +172,8 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        assert_cast<ColumnFloat64&>(to).get_data().push_back(this->data(place).get());
+        assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                this->data(place).get());
     }
 };
 

--- a/be/src/exprs/aggregate/aggregate_function_foreach.h
+++ b/be/src/exprs/aggregate/aggregate_function_foreach.h
@@ -208,12 +208,12 @@ public:
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         const AggregateFunctionForEachData& state = data(place);
 
-        auto& arr_to = assert_cast<ColumnArray&>(to);
+        auto& arr_to = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& offsets_to = arr_to.get_offsets();
         IColumn* elems_to = &arr_to.get_data();
         ColumnNullable* nullable_elems_to = nullptr;
         if (!nested_function->get_return_type()->is_nullable()) {
-            nullable_elems_to = assert_cast<ColumnNullable*>(elems_to);
+            nullable_elems_to = assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(elems_to);
             elems_to = nullable_elems_to->get_nested_column_ptr().get();
         }
 
@@ -227,6 +227,29 @@ public:
         }
 
         offsets_to.push_back(offsets_to.back() + state.dynamic_array_size);
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        const auto* arr_to = check_and_get_column<ColumnArray>(to);
+        if (UNLIKELY(arr_to == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Column type {} is not "
+                    "ColumnArray",
+                    get_name(), to.get_name()));
+        }
+
+        const IColumn* elems_to = &arr_to->get_data();
+        if (!nested_function->get_return_type()->is_nullable()) {
+            const auto* nullable_elems_to = check_and_get_column<ColumnNullable>(*elems_to);
+            if (UNLIKELY(nullable_elems_to == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} result type check failed: Array nested column "
+                        "type {} is not ColumnNullable",
+                        get_name(), elems_to->get_name()));
+            }
+            elems_to = &nullable_elems_to->get_nested_column();
+        }
+        nested_function->check_result_column_type(*elems_to);
     }
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
@@ -266,6 +289,21 @@ public:
             nested_function->add(nested_state, nested.data(), i, arena);
             nested_state += nested_size_of_data;
         }
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        std::vector<const IColumn*> nested(num_arguments);
+        for (size_t i = 0; i < num_arguments; ++i) {
+            const auto* array_column = check_and_get_column<ColumnArray>(*columns[i]);
+            if (UNLIKELY(array_column == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} argument {} type check failed: Column type {} is "
+                        "not ColumnArray",
+                        get_name(), i, columns[i]->get_name()));
+            }
+            nested[i] = &array_column->get_data();
+        }
+        nested_function->check_input_columns_type(nested.data());
     }
 };
 } // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_foreachv2.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_foreachv2.cpp
@@ -48,14 +48,16 @@ public:
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         const AggregateFunctionForEachData& state = data(place);
 
-        auto& arr_to = assert_cast<ColumnArray&>(to);
+        auto& arr_to = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& offsets_to = arr_to.get_offsets();
         IColumn& elems_nullable = arr_to.get_data();
 
         DCHECK(is_column_nullable(elems_nullable));
-        auto& elems_to = assert_cast<ColumnNullable&>(elems_nullable).get_nested_column();
+        auto& elems_to = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(elems_nullable)
+                                 .get_nested_column();
         auto& elements_null_map =
-                assert_cast<ColumnNullable&>(elems_nullable).get_null_map_column();
+                assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(elems_nullable)
+                        .get_null_map_column();
 
         if (nested_function->get_return_type()->is_nullable()) {
             char* nested_state = state.array_of_aggregate_datas;

--- a/be/src/exprs/aggregate/aggregate_function_group_array_set_op.h
+++ b/be/src/exprs/aggregate/aggregate_function_group_array_set_op.h
@@ -22,8 +22,12 @@
 #include <string>
 
 #include "core/assert_cast.h"
+#include "core/column/column.h"
 #include "core/column/column_array.h"
 #include "core/column/column_decimal.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_date_or_datetime_v2.h"
 #include "core/data_type/data_type_nullable.h"
@@ -105,7 +109,7 @@ struct GroupArraySetOpNumericBaseData {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& arr_to = assert_cast<ColumnArray&>(to);
+        auto& arr_to = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         ColumnArray::Offsets64& offsets_to = arr_to.get_offsets();
         auto& to_nested_col = arr_to.get_data();
         DCHECK(to_nested_col.is_nullable())
@@ -133,8 +137,9 @@ struct GroupArraySetOpNumericBaseData {
             }
         };
 
-        auto* col_null = assert_cast<ColumnNullable*>(&to_nested_col);
-        auto& nested_col = assert_cast<ColVecType&>(col_null->get_nested_column());
+        auto* col_null = assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(&to_nested_col);
+        auto& nested_col = assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(
+                col_null->get_nested_column());
         offsets_to.push_back(offsets_to.back() + this->set->size() +
                              (this->set->contain_null() ? 1 : 0));
         insert_values(nested_col, this->set, col_null);
@@ -157,9 +162,11 @@ struct GroupArrayNumericIntersectData : public GroupArraySetOpNumericBaseData<T>
         } else if (!this->set->empty()) {
             // for intersect, need to create a new set to store the intersection result
             Set new_set = std::make_unique<NullableNumericOrDateSetType>();
-            const auto& col_nullable = assert_cast<const ColumnNullable&>(*column_data);
+            const auto& col_nullable =
+                    assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*column_data);
             const ColVecType& nested_column_data =
-                    assert_cast<const ColVecType&>(col_nullable.get_nested_column());
+                    assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
+                            col_nullable.get_nested_column());
             for (size_t i = 0; i < arr_size; ++i) {
                 const bool is_null_element = col_nullable.is_null_at(offset + i);
                 const typename PrimitiveTypeTraits<T>::CppType* src_data =
@@ -238,6 +245,7 @@ public:
 };
 
 struct GroupArraySetOpStringBaseData {
+    using ColVecType = ColumnString;
     using Set = std::unique_ptr<NullableStringSet>;
 
     GroupArraySetOpStringBaseData() : set(std::make_unique<NullableStringSet>()) {}
@@ -279,10 +287,10 @@ struct GroupArraySetOpStringBaseData {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& arr_to = assert_cast<ColumnArray&>(to);
+        auto& arr_to = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         ColumnArray::Offsets64& offsets_to = arr_to.get_offsets();
         auto& data_to = arr_to.get_data();
-        auto* col_null = assert_cast<ColumnNullable*>(&data_to);
+        auto* col_null = assert_cast<ColumnNullable*, TypeCheckOnRelease::DISABLE>(&data_to);
         auto res_size = this->set->size();
 
         if (this->set->contain_null()) {
@@ -307,9 +315,11 @@ struct GroupArrayStringIntersectData : public GroupArraySetOpStringBaseData {
     static std::string get_name() { return "group_array_intersect"; }
 
     void process_col_data(const auto& column_data, size_t offset, size_t arr_size) {
-        const auto* col_null = assert_cast<const ColumnNullable*>(column_data.get());
+        const auto* col_null =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(column_data.get());
         const auto& nested_column_data =
-                assert_cast<const ColumnString&>(col_null->get_nested_column());
+                assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                        col_null->get_nested_column());
 
         if (!init) {
             for (size_t i = 0; i < arr_size; ++i) {
@@ -376,9 +386,11 @@ struct GroupArrayStringUnionData : public GroupArraySetOpStringBaseData {
     static std::string get_name() { return "group_array_union"; }
 
     void process_col_data(const auto& column_data, size_t offset, size_t arr_size) {
-        const auto* col_null = assert_cast<const ColumnNullable*>(column_data.get());
+        const auto* col_null =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(column_data.get());
         const auto& nested_column_data =
-                assert_cast<const ColumnString&>(col_null->get_nested_column());
+                assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                        col_null->get_nested_column());
 
         for (size_t i = 0; i < arr_size; ++i) {
             if (col_null->is_null_at(offset + i)) {
@@ -429,6 +441,69 @@ public:
     DataTypePtr get_return_type() const override { return argument_type; }
 
     void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        const IColumn* column = columns[0];
+        if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*column)) {
+            column = &nullable_column->get_nested_column();
+        }
+
+        const auto* array_column = check_and_get_column<ColumnArray>(*column);
+        if (UNLIKELY(array_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument 0 type check failed: Column type {} ({}) is "
+                    "not ColumnArray or Nullable(ColumnArray)",
+                    get_name(), columns[0]->get_name(), typeid(*columns[0]).name()));
+        }
+
+        const IColumn& array_data_column = array_column->get_data();
+        const auto* nullable_nested = check_and_get_column<ColumnNullable>(array_data_column);
+        if (UNLIKELY(nullable_nested == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument 0 type check failed: Array nested column "
+                    "type {} ({}) is not ColumnNullable",
+                    get_name(), array_data_column.get_name(), typeid(array_data_column).name()));
+        }
+
+        const IColumn& nested_data_column = nullable_nested->get_nested_column();
+        if (UNLIKELY(check_and_get_column<typename ImplData::ColVecType>(nested_data_column) ==
+                     nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument 0 type check failed: Array nested data column "
+                    "type {} ({}) does not match expected physical column type {}",
+                    get_name(), nested_data_column.get_name(), typeid(nested_data_column).name(),
+                    typeid(typename ImplData::ColVecType).name()));
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        const auto* array_column = check_and_get_column<ColumnArray>(to);
+        if (UNLIKELY(array_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Column type {} ({}) is not "
+                    "ColumnArray",
+                    get_name(), to.get_name(), typeid(to).name()));
+        }
+
+        const IColumn& array_data_column = array_column->get_data();
+        const auto* nullable_nested = check_and_get_column<ColumnNullable>(array_data_column);
+        if (UNLIKELY(nullable_nested == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Array nested column type {} "
+                    "({}) is not ColumnNullable",
+                    get_name(), array_data_column.get_name(), typeid(array_data_column).name()));
+        }
+
+        const IColumn& nested_data_column = nullable_nested->get_nested_column();
+        if (UNLIKELY(check_and_get_column<typename ImplData::ColVecType>(nested_data_column) ==
+                     nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Array nested data column "
+                    "type {} ({}) does not match expected physical column type {}",
+                    get_name(), nested_data_column.get_name(), typeid(nested_data_column).name(),
+                    typeid(typename ImplData::ColVecType).name()));
+        }
+    }
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena& arena) const override {

--- a/be/src/exprs/aggregate/aggregate_function_group_concat.h
+++ b/be/src/exprs/aggregate/aggregate_function_group_concat.h
@@ -145,6 +145,16 @@ public:
         Impl::add(this->data(place), columns, row_num);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        for (size_t i = 0; i < this->argument_types.size(); ++i) {
+            this->template check_argument_column_type<ColumnString>(columns[i]);
+        }
+    }
+
+    void check_result_column_type(const IColumn& column) const override {
+        this->template check_result_column_type_as<ColumnString>(column);
+    }
+
     void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -163,7 +173,8 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         const auto result = this->data(place).get();
-        assert_cast<ColumnString&>(to).insert_data(result.data, result.size);
+        assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(result.data,
+                                                                                result.size);
     }
 };
 

--- a/be/src/exprs/aggregate/aggregate_function_histogram.h
+++ b/be/src/exprs/aggregate/aggregate_function_histogram.h
@@ -29,6 +29,7 @@
 #include "core/column/column.h"
 #include "core/column/column_decimal.h"
 #include "core/column/column_string.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_string.h"
 #include "core/string_ref.h"
 #include "core/types.h"
@@ -123,10 +124,11 @@ struct AggregateFunctionHistogramData {
         for (auto i = 0; i < pair_vector.size(); i++) {
             const auto& element = pair_vector[i];
             if constexpr (is_string_type(T)) {
-                assert_cast<ColumnString&>(to).insert_data(element.second.c_str(),
-                                                           element.second.length());
+                assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(
+                        element.second.c_str(), element.second.length());
             } else {
-                assert_cast<ColVecType&>(to).get_data().push_back(element.second);
+                assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                        element.second);
             }
         }
     }
@@ -179,7 +181,8 @@ public:
              Arena&) const override {
         if constexpr (has_input_param) {
             Int32 input_max_num_buckets =
-                    assert_cast<const ColumnInt32*>(columns[1])->get_element(row_num);
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[1])
+                            ->get_element(row_num);
             if (input_max_num_buckets <= 0 || input_max_num_buckets > 1000000) {
                 throw doris::Exception(
                         ErrorCode::INVALID_ARGUMENT,
@@ -203,6 +206,13 @@ public:
         }
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<typename Data::ColVecType>(columns[0]);
+        if constexpr (has_input_param) {
+            this->template check_argument_column_type<ColumnInt32>(columns[1]);
+        }
+    }
+
     void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -221,7 +231,13 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         const std::string bucket_json = this->data(place).get(_argument_type);
-        assert_cast<ColumnString&>(to).insert_data(bucket_json.c_str(), bucket_json.length());
+        assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(
+                bucket_json.c_str(), bucket_json.length());
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        this->template check_result_column_type_as<ColumnString>(to);
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_hll_union_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_hll_union_agg.h
@@ -78,7 +78,7 @@ struct AggregateFunctionHLLData {
 template <typename Data>
 struct AggregateFunctionHLLUnionImpl : Data {
     void insert_result_into(IColumn& to) const {
-        ColumnHLL& column = assert_cast<ColumnHLL&>(to);
+        ColumnHLL& column = assert_cast<ColumnHLL&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(this->get());
     }
 
@@ -90,7 +90,7 @@ struct AggregateFunctionHLLUnionImpl : Data {
 template <typename Data>
 struct AggregateFunctionHLLUnionAggImpl : Data {
     void insert_result_into(IColumn& to) const {
-        ColumnInt64& column = assert_cast<ColumnInt64&>(to);
+        ColumnInt64& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(this->get_cardinality());
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_linear_histogram.h
+++ b/be/src/exprs/aggregate/aggregate_function_linear_histogram.h
@@ -24,6 +24,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "core/column/column_string.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/types.h"
 #include "exprs/aggregate/aggregate_function.h"
@@ -171,7 +173,7 @@ public:
         rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
         doc.Accept(writer);
 
-        auto& column = assert_cast<ColumnString&>(to);
+        auto& column = assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to);
         column.insert_data(buffer.GetString(), buffer.GetSize());
     }
 };
@@ -232,6 +234,14 @@ public:
                 scale);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[1]);
+        if constexpr (has_offset) {
+            this->template check_argument_column_type<ColumnFloat64>(columns[2]);
+        }
+    }
+
     void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -250,6 +260,11 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(place).insert_result_into(to);
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        this->template check_result_column_type_as<ColumnString>(to);
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_map.h
+++ b/be/src/exprs/aggregate/aggregate_function_map.h
@@ -22,6 +22,7 @@
 #include "core/assert_cast.h"
 #include "core/column/column_decimal.h"
 #include "core/column/column_map.h"
+#include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/data_type/data_type_map.h"
 #include "core/string_ref.h"
@@ -120,10 +121,11 @@ struct AggregateFunctionMapAggData {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& dst = assert_cast<ColumnMap&>(to);
+        auto& dst = assert_cast<ColumnMap&, TypeCheckOnRelease::DISABLE>(to);
         size_t num_rows = _key_column->size();
         auto& offsets = dst.get_offsets();
-        auto& dst_key_column = assert_cast<ColumnNullable&>(dst.get_keys());
+        auto& dst_key_column =
+                assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(dst.get_keys());
         dst_key_column.get_null_map_data().resize_fill(dst_key_column.get_null_map_data().size() +
                                                        num_rows);
         dst_key_column.get_nested_column().insert_range_from(*_key_column, 0, num_rows);
@@ -307,6 +309,17 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(place).insert_result_into(to);
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        if constexpr (is_string_type(K)) {
+            const IColumn* key_column = columns[0];
+            if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*key_column)) {
+                key_column = &nullable_column->get_nested_column();
+            }
+            this->template check_argument_column_type<ColumnString>(key_column);
+        }
     }
 
     [[nodiscard]] MutableColumnPtr create_serialize_column() const override {

--- a/be/src/exprs/aggregate/aggregate_function_map_combinator.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_map_combinator.cpp
@@ -193,7 +193,8 @@ public:
             actual_row = 0;
         }
 
-        const auto& map_column = assert_cast<const ColumnMap&>(*column);
+        const auto& map_column =
+                assert_cast<const ColumnMap&, TypeCheckOnRelease::DISABLE>(*column);
         const auto& offsets = map_column.get_offsets();
         const size_t offset = actual_row == 0 ? 0 : offsets[actual_row - 1];
         const size_t size = offsets[actual_row] - offset;
@@ -265,7 +266,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& map_column = assert_cast<ColumnMap&>(to);
+        auto& map_column = assert_cast<ColumnMap&, TypeCheckOnRelease::DISABLE>(to);
         auto& key_column = map_column.get_keys();
         auto& value_column = map_column.get_values();
         auto& offsets = map_column.get_offsets();
@@ -282,6 +283,49 @@ public:
         }
 
         offsets.push_back(value_column.size());
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        const IColumn* column = columns[0];
+        if (const auto* const_column = check_and_get_column<ColumnConst>(*column)) {
+            column = &const_column->get_data_column();
+        }
+
+        const IColumn* checked_columns[1] = {column};
+        this->check_columns_type(this->argument_types, checked_columns);
+
+        const auto* map_column = check_and_get_column<ColumnMap>(*column);
+        if (UNLIKELY(map_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument 0 type check failed: Column type {} is not "
+                    "ColumnMap",
+                    get_name(), column->get_name()));
+        }
+        check_key_column_type(map_column->get_keys(), false);
+
+        const IColumn* nested_columns[1] = {&map_column->get_values()};
+        _nested_function->check_input_columns_type(nested_columns);
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+
+        const auto* map_column = check_and_get_column<ColumnMap>(to);
+        if (UNLIKELY(map_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Column type {} is not "
+                    "ColumnMap",
+                    get_name(), to.get_name()));
+        }
+        check_key_column_type(map_column->get_keys(), true);
+
+        const IColumn* value_column = &map_column->get_values();
+        if (!_nested_function->get_return_type()->is_nullable()) {
+            if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*value_column)) {
+                value_column = &nullable_column->get_nested_column();
+            }
+        }
+        _nested_function->check_result_column_type(*value_column);
     }
 
 private:
@@ -314,6 +358,30 @@ private:
             return nullable_column->get_nested_column();
         }
         return key_column;
+    }
+
+    void check_key_column_type(const IColumn& key_column, bool is_result_column) const {
+        if constexpr (is_string_type(KeyType)) {
+            const auto* nullable_column = check_and_get_column<ColumnNullable>(key_column);
+            if (!is_result_column && nullable_column == nullptr) {
+                this->template check_argument_column_type<ColumnString>(&key_column);
+                return;
+            }
+            if (UNLIKELY(nullable_column == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} {} type check failed: Key column type {} is not "
+                        "ColumnNullable",
+                        get_name(), is_result_column ? "result" : "argument",
+                        key_column.get_name()));
+            }
+            if (is_result_column) {
+                this->template check_result_column_type_as<ColumnString>(
+                        nullable_column->get_nested_column());
+            } else {
+                this->template check_argument_column_type<ColumnString>(
+                        &nullable_column->get_nested_column());
+            }
+        }
     }
 
     static LookupKey get_key(const IColumn& key_column, size_t row) {

--- a/be/src/exprs/aggregate/aggregate_function_map_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_map_v2.h
@@ -104,10 +104,11 @@ struct AggregateFunctionMapAggDataV2 {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& dst = assert_cast<ColumnMap&>(to);
+        auto& dst = assert_cast<ColumnMap&, TypeCheckOnRelease::DISABLE>(to);
         size_t num_rows = _key_column->size();
         auto& offsets = dst.get_offsets();
-        auto& dst_key_column = assert_cast<ColumnNullable&>(dst.get_keys());
+        auto& dst_key_column =
+                assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(dst.get_keys());
         dst_key_column.insert_range_from(*_key_column, 0, num_rows);
         dst.get_values().insert_range_from(*_value_column, 0, num_rows);
         if (offsets.empty()) {

--- a/be/src/exprs/aggregate/aggregate_function_min_max.h
+++ b/be/src/exprs/aggregate/aggregate_function_min_max.h
@@ -70,6 +70,9 @@ private:
     typename PrimitiveTypeTraits<T>::CppType value;
 
 public:
+    using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
+    static constexpr bool NeedCheckColumnType = true;
+
     SingleValueDataFixed() = default;
     SingleValueDataFixed(bool has_value_, typename PrimitiveTypeTraits<T>::CppType value_)
             : has_value(has_value_), value(value_) {}
@@ -96,10 +99,14 @@ public:
 
     void insert_result_into(IColumn& to) const {
         if (has()) {
-            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&>(to).get_data().push_back(
-                    value);
+            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&, TypeCheckOnRelease::DISABLE>(
+                    to)
+                    .get_data()
+                    .push_back(value);
         } else {
-            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&>(to).insert_default();
+            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&, TypeCheckOnRelease::DISABLE>(
+                    to)
+                    .insert_default();
         }
     }
 
@@ -213,6 +220,9 @@ private:
     typename PrimitiveTypeTraits<T>::CppType value;
 
 public:
+    using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
+    static constexpr bool NeedCheckColumnType = true;
+
     SingleValueDataDecimal() = default;
     SingleValueDataDecimal(bool has_value_, typename PrimitiveTypeTraits<T>::CppType value_)
             : has_value(has_value_), value(value_) {}
@@ -239,10 +249,13 @@ public:
 
     void insert_result_into(IColumn& to) const {
         if (has()) {
-            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&>(to).insert_data(
-                    (const char*)&value, 0);
+            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&, TypeCheckOnRelease::DISABLE>(
+                    to)
+                    .insert_data((const char*)&value, 0);
         } else {
-            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&>(to).insert_default();
+            assert_cast<typename PrimitiveTypeTraits<T>::ColumnType&, TypeCheckOnRelease::DISABLE>(
+                    to)
+                    .insert_default();
         }
     }
 
@@ -366,6 +379,9 @@ private:
     char small_data[MAX_SMALL_STRING_SIZE]; /// Including the terminating zero.
 
 public:
+    using ColVecType = ColumnString;
+    static constexpr bool NeedCheckColumnType = true;
+
     ~SingleValueDataString() = default;
 
     constexpr static bool IsFixedLength = false;
@@ -378,9 +394,10 @@ public:
 
     void insert_result_into(IColumn& to) const {
         if (has()) {
-            assert_cast<ColumnString&>(to).insert_data(get_data(), size);
+            assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(get_data(),
+                                                                                    size);
         } else {
-            assert_cast<ColumnString&>(to).insert_default();
+            assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_default();
         }
     }
 
@@ -533,6 +550,8 @@ private:
     int be_exec_version = -1;
 
 public:
+    static constexpr bool NeedCheckColumnType = false;
+
     SingleValueDataComplexType() = default;
     SingleValueDataComplexType(const DataTypes& argument_types, int be_version) {
         column_type = argument_types[0];
@@ -810,6 +829,20 @@ public:
         this->data(place).insert_result_into(to);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        if constexpr (Data::NeedCheckColumnType) {
+            this->template check_argument_column_type<typename Data::ColVecType>(columns[0]);
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        if constexpr (Data::NeedCheckColumnType) {
+            this->template check_result_column_type_as<typename Data::ColVecType>(to);
+        }
+    }
+
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         if constexpr (Data::IsFixedLength) {
@@ -933,7 +966,9 @@ public:
                     this->data(place).reset();
                     if (has_null) {
                         const auto& null_map_data =
-                                assert_cast<const ColumnUInt8*>(columns[1])->get_data();
+                                assert_cast<const ColumnUInt8*, TypeCheckOnRelease::DISABLE>(
+                                        columns[1])
+                                        ->get_data();
                         for (size_t i = current_frame_start; i < current_frame_end; ++i) {
                             if (null_map_data[i] == 0) {
                                 this->data(place).change_if_better(*columns[0], i, arena);

--- a/be/src/exprs/aggregate/aggregate_function_min_max_by.h
+++ b/be/src/exprs/aggregate/aggregate_function_min_max_by.h
@@ -86,9 +86,9 @@ public:
 
     void insert_result_into(IColumn& to) const {
         if (has()) {
-            assert_cast<ColumnBitmap&>(to).get_data().push_back(value);
+            assert_cast<ColumnBitmap&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(value);
         } else {
-            assert_cast<ColumnBitmap&>(to).insert_default();
+            assert_cast<ColumnBitmap&, TypeCheckOnRelease::DISABLE>(to).insert_default();
         }
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_null.h
+++ b/be/src/exprs/aggregate/aggregate_function_null.h
@@ -298,7 +298,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         if constexpr (result_is_nullable) {
-            auto& to_concrete = assert_cast<ColumnNullable&>(to);
+            auto& to_concrete = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
             if (get_flag(place)) {
                 nested_function->insert_result_into(nested_place(place),
                                                     to_concrete.get_nested_column());
@@ -308,6 +308,22 @@ public:
             }
         } else {
             nested_function->insert_result_into(nested_place(place), to);
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        if constexpr (result_is_nullable) {
+            const auto* to_concrete = check_and_get_column<ColumnNullable>(to);
+            if (UNLIKELY(to_concrete == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} result type check failed: Column type {} is not "
+                        "ColumnNullable",
+                        this->get_name(), to.get_name()));
+            }
+            nested_function->check_result_column_type(to_concrete->get_nested_column());
+        } else {
+            nested_function->check_result_column_type(to);
         }
     }
 };
@@ -341,6 +357,19 @@ public:
         }
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        const auto* column = check_and_get_column<ColumnNullable>(*columns[0]);
+        if (UNLIKELY(column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument 0 type check failed: Column type {} is not "
+                    "ColumnNullable",
+                    this->get_name(), columns[0]->get_name()));
+        }
+        const IColumn* nested_column = &column->get_nested_column();
+        this->nested_function->check_input_columns_type(&nested_column);
+    }
+
     IAggregateFunction* transmit_to_stable() override {
         auto f = AggregateFunctionNullBaseInline<
                          NestFuction, result_is_nullable,
@@ -356,7 +385,8 @@ public:
 
     void add_batch(size_t batch_size, AggregateDataPtr* __restrict places, size_t place_offset,
                    const IColumn** columns, Arena& arena, bool agg_many) const override {
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         const IColumn* nested_column = &column->get_nested_column();
         if (column->has_null()) {
             const auto* __restrict null_map_data = column->get_null_map_data().data();
@@ -383,7 +413,8 @@ public:
 
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena& arena) const override {
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         bool has_null = column->has_null();
 
         if (has_null) {
@@ -400,7 +431,8 @@ public:
 
     void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
                          const IColumn** columns, Arena& arena, bool has_null) override {
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
 
         if (has_null) {
             for (size_t i = batch_begin; i <= batch_end; ++i) {
@@ -431,7 +463,8 @@ public:
             *use_null_result = false;
             *could_use_previous_result = true;
         }
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         bool has_null = column->has_null();
         if (has_null) {
             for (size_t i = current_frame_start; i < current_frame_end; ++i) {
@@ -466,7 +499,8 @@ public:
         }
 
         DCHECK(is_column_nullable(*columns[0])) << columns[0]->get_name();
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         const IColumn* nested_column = &column->get_nested_column();
 
         if (!column->has_null()) {
@@ -594,6 +628,26 @@ public:
         this->set_flag(place);
         this->nested_function->add(this->nested_place(place), nested_columns.data(), row_num,
                                    arena);
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        std::vector<const IColumn*> nested_columns(number_of_arguments);
+        for (size_t i = 0; i < number_of_arguments; ++i) {
+            if (is_nullable[i]) {
+                const auto* nullable_col = check_and_get_column<ColumnNullable>(*columns[i]);
+                if (UNLIKELY(nullable_col == nullptr)) {
+                    throw doris::Exception(Status::InternalError(
+                            "Aggregate function {} argument {} type check failed: Column type {} "
+                            "is not ColumnNullable",
+                            this->get_name(), i, columns[i]->get_name()));
+                }
+                nested_columns[i] = &nullable_col->get_nested_column();
+            } else {
+                nested_columns[i] = columns[i];
+            }
+        }
+        this->nested_function->check_input_columns_type(nested_columns.data());
     }
 
 private:

--- a/be/src/exprs/aggregate/aggregate_function_null_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_null_v2.h
@@ -368,7 +368,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         if constexpr (result_is_nullable) {
-            auto& to_concrete = assert_cast<ColumnNullable&>(to);
+            auto& to_concrete = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
             if (get_flag(place)) {
                 nested_function->insert_result_into(nested_place(place),
                                                     to_concrete.get_nested_column());
@@ -378,6 +378,22 @@ public:
             }
         } else {
             nested_function->insert_result_into(nested_place(place), to);
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        IAggregateFunction::check_result_column_type(to);
+        if constexpr (result_is_nullable) {
+            const auto* to_concrete = check_and_get_column<ColumnNullable>(to);
+            if (UNLIKELY(to_concrete == nullptr)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} result type check failed: Column type {} is not "
+                        "ColumnNullable",
+                        this->get_name(), to.get_name()));
+            }
+            nested_function->check_result_column_type(to_concrete->get_nested_column());
+        } else {
+            nested_function->check_result_column_type(to);
         }
     }
 };
@@ -408,6 +424,19 @@ public:
         }
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        const auto* column = check_and_get_column<ColumnNullable>(*columns[0]);
+        if (UNLIKELY(column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} argument 0 type check failed: Column type {} is not "
+                    "ColumnNullable",
+                    this->get_name(), columns[0]->get_name()));
+        }
+        const IColumn* nested_column = &column->get_nested_column();
+        this->nested_function->check_input_columns_type(&nested_column);
+    }
+
     IAggregateFunction* transmit_to_stable() override {
         auto f = AggregateFunctionNullBaseInlineV2<
                          NestFuction, result_is_nullable,
@@ -423,7 +452,8 @@ public:
 
     void add_batch(size_t batch_size, AggregateDataPtr* __restrict places, size_t place_offset,
                    const IColumn** columns, Arena& arena, bool agg_many) const override {
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         const IColumn* nested_column = &column->get_nested_column();
         if (column->has_null()) {
             const auto* __restrict null_map_data = column->get_null_map_data().data();
@@ -450,7 +480,8 @@ public:
 
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena& arena) const override {
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         bool has_null = column->has_null();
 
         if (has_null) {
@@ -467,7 +498,8 @@ public:
 
     void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
                          const IColumn** columns, Arena& arena, bool has_null) override {
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
 
         if (has_null) {
             for (size_t i = batch_begin; i <= batch_end; ++i) {
@@ -498,7 +530,8 @@ public:
             *use_null_result = false;
             *could_use_previous_result = true;
         }
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         bool has_null = column->has_null();
         if (has_null) {
             for (size_t i = current_frame_start; i < current_frame_end; ++i) {
@@ -533,7 +566,8 @@ public:
         }
 
         DCHECK(is_column_nullable(*columns[0])) << columns[0]->get_name();
-        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         const IColumn* nested_column = &column->get_nested_column();
 
         if (!column->has_null()) {

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
@@ -28,6 +28,7 @@
 #include <type_traits>
 
 #include "core/column/column_complex.h"
+#include "core/column/column_string.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_bitmap.h"
 #include "core/data_type/data_type_number.h"
@@ -42,9 +43,6 @@ class Arena;
 class BufferReadable;
 class BufferWritable;
 class IColumn;
-template <typename T>
-class ColumnStr;
-using ColumnString = ColumnStr<UInt32>;
 
 template <PrimitiveType T>
 struct AggOrthBitmapBaseData {
@@ -52,6 +50,7 @@ public:
     using ColVecData =
             std::conditional_t<is_int_or_bool(T) || is_float_or_double(T),
                                typename PrimitiveTypeTraits<T>::ColumnType, ColumnString>;
+    static constexpr bool has_key_columns = true;
 
     void reset() {
         bitmap = {};
@@ -131,7 +130,7 @@ public:
     }
 
     void get(IColumn& to) const {
-        auto& column = assert_cast<ColumnBitmap&>(to);
+        auto& column = assert_cast<ColumnBitmap&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(result.empty() ? AggOrthBitmapBaseData<T>::bitmap.intersect()
                                                       : result);
     }
@@ -171,7 +170,7 @@ public:
     }
 
     void get(IColumn& to) const {
-        auto& column = assert_cast<ColumnInt64&>(to);
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(AggOrthBitmapBaseData<T>::bitmap.intersect_count());
     }
 };
@@ -208,7 +207,7 @@ public:
     }
 
     void get(IColumn& to) const {
-        auto& column = assert_cast<ColumnInt64&>(to);
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(result ? result
                                               : AggOrthBitmapBaseData<T>::bitmap.intersect_count());
     }
@@ -223,6 +222,7 @@ public:
     using ColVecData =
             std::conditional_t<is_int_or_bool(T) || is_float_or_double(T),
                                typename PrimitiveTypeTraits<T>::ColumnType, ColumnString>;
+    static constexpr bool has_key_columns = true;
 
     void add(const IColumn** columns, size_t row_num) {
         const auto& bitmap_col =
@@ -281,7 +281,7 @@ public:
     }
 
     void get(IColumn& to) const {
-        auto& column = assert_cast<ColumnBitmap&>(to);
+        auto& column = assert_cast<ColumnBitmap&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(!result.empty() ? result
                                                        : this->bitmap_expr_cal.bitmap_calculate());
     }
@@ -321,7 +321,7 @@ public:
     }
 
     void get(IColumn& to) const {
-        auto& column = assert_cast<ColumnInt64&>(to);
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(result ? result
                                               : this->bitmap_expr_cal.bitmap_calculate_count());
     }
@@ -337,6 +337,7 @@ private:
 
 struct OrthBitmapUnionCountData {
     static constexpr auto name = "orthogonal_bitmap_union_count";
+    static constexpr bool has_key_columns = false;
 
     static DataTypePtr get_return_type() { return std::make_shared<DataTypeInt64>(); }
     // Here no need doing anything, so only given an function declaration
@@ -357,7 +358,7 @@ struct OrthBitmapUnionCountData {
     void read(BufferReadable& buf) { buf.read_binary(result); }
 
     void get(IColumn& to) const {
-        auto& column = assert_cast<ColumnInt64&>(to);
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().emplace_back(result ? result : value.cardinality());
     }
 
@@ -393,6 +394,21 @@ public:
              Arena&) const override {
         this->data(place).init_add_key(columns, row_num, _argument_size);
         this->data(place).add(columns, row_num);
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnBitmap>(columns[0]);
+        if constexpr (Impl::has_key_columns) {
+            if (UNLIKELY(_argument_size < 2)) {
+                throw doris::Exception(Status::InternalError(
+                        "Aggregate function {} input type check failed: expected at least 2 "
+                        "arguments, but got {}",
+                        get_name(), _argument_size));
+            }
+            for (int i = 1; i < _argument_size; ++i) {
+                this->template check_argument_column_type<typename Impl::ColVecData>(columns[i]);
+            }
+        }
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,

--- a/be/src/exprs/aggregate/aggregate_function_percentile.h
+++ b/be/src/exprs/aggregate/aggregate_function_percentile.h
@@ -48,6 +48,33 @@ namespace doris {
 class Arena;
 class BufferReadable;
 
+inline void check_percentile_array_column_type(const IAggregateFunction& function,
+                                               const IColumn& column, size_t index) {
+    const auto* array_column = check_and_get_column<ColumnArray>(column);
+    if (UNLIKELY(array_column == nullptr)) {
+        throw doris::Exception(Status::InternalError(
+                "Aggregate function {} argument {} type check failed: Column type {} is not "
+                "ColumnArray",
+                function.get_name(), index, column.get_name()));
+    }
+
+    const auto* nullable_column = check_and_get_column<ColumnNullable>(array_column->get_data());
+    if (UNLIKELY(nullable_column == nullptr)) {
+        throw doris::Exception(Status::InternalError(
+                "Aggregate function {} argument {} type check failed: Array nested column type {} "
+                "is not ColumnNullable",
+                function.get_name(), index, array_column->get_data().get_name()));
+    }
+
+    if (UNLIKELY(check_and_get_column<ColumnFloat64>(nullable_column->get_nested_column()) ==
+                 nullptr)) {
+        throw doris::Exception(Status::InternalError(
+                "Aggregate function {} argument {} type check failed: Array nested data column "
+                "type {} is not ColumnFloat64",
+                function.get_name(), index, nullable_column->get_nested_column().get_name()));
+    }
+}
+
 struct PercentileApproxState {
     static constexpr double INIT_QUANTILE = -1.0;
     PercentileApproxState() = default;
@@ -171,6 +198,12 @@ public:
                      Arena&) const override {
         this->data(place).read(buf);
     }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        for (size_t i = 0; i < this->argument_types.size(); ++i) {
+            this->template check_argument_column_type<ColumnFloat64>(columns[i]);
+        }
+    }
 };
 
 class AggregateFunctionPercentileApproxTwoParams final
@@ -194,7 +227,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.get_data().push_back(this->data(place).get());
     }
 };
@@ -225,7 +258,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.get_data().push_back(this->data(place).get());
     }
 };
@@ -257,7 +290,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.get_data().push_back(this->data(place).get());
     }
 };
@@ -291,7 +324,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.get_data().push_back(this->data(place).get());
     }
 };
@@ -398,7 +431,7 @@ struct PercentileState {
     double get() const { return vec_counts.empty() ? 0 : vec_counts[0].terminate(vec_quantile[0]); }
 
     void insert_result_into(IColumn& to) const {
-        auto& column_data = assert_cast<ColumnFloat64&>(to).get_data();
+        auto& column_data = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to).get_data();
         for (int i = 0; i < vec_counts.size(); ++i) {
             column_data.push_back(vec_counts[i].terminate(vec_quantile[i]));
         }
@@ -493,7 +526,7 @@ struct PercentileExactState {
     }
 
     void insert_result_into(IColumn& to) const {
-        auto& column_data = assert_cast<ColumnFloat64&>(to).get_data();
+        auto& column_data = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to).get_data();
         if (!inited_flag || levels.empty()) {
             return;
         }
@@ -642,6 +675,11 @@ public:
                                                            quantile.get_data()[0]);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[1]);
+    }
+
     void reset(AggregateDataPtr __restrict place) const override {
         AggregateFunctionPercentile::data(place).reset();
     }
@@ -661,7 +699,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.insert_value(AggregateFunctionPercentile::data(place).get());
     }
 };
@@ -705,6 +743,11 @@ public:
                 offset_column_data.data()[row_num] - offset_column_data[(ssize_t)row_num - 1]);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        check_percentile_array_column_type(*this, *columns[1], 1);
+    }
+
     void reset(AggregateDataPtr __restrict place) const override {
         AggregateFunctionPercentileArray::data(place).reset();
     }
@@ -725,7 +768,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
         if (is_column_nullable(to_nested_col)) {
             auto col_null = reinterpret_cast<ColumnNullable*>(&to_nested_col);
@@ -788,6 +831,11 @@ public:
                 quantile.get_data()[0]);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[1]);
+    }
+
     void reset(AggregateDataPtr __restrict place) const override {
         AggregateFunctionPercentileV2::data(place).reset();
     }
@@ -807,7 +855,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& col = assert_cast<ColumnFloat64&>(to);
+        auto& col = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         col.insert_value(AggregateFunctionPercentileV2::data(place).get());
     }
 };
@@ -895,6 +943,11 @@ public:
                 cast_set<int64_t>(offset_column_data[batch_begin] - start));
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        check_percentile_array_column_type(*this, *columns[1], 1);
+    }
+
     void reset(AggregateDataPtr __restrict place) const override {
         AggregateFunctionPercentileArrayV2::data(place).reset();
     }
@@ -915,7 +968,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
         if (is_column_nullable(to_nested_col)) {
             auto* col_null = reinterpret_cast<ColumnNullable*>(&to_nested_col);

--- a/be/src/exprs/aggregate/aggregate_function_percentile_reservoir.h
+++ b/be/src/exprs/aggregate/aggregate_function_percentile_reservoir.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/primitive_type.h"
 #include "exprs/aggregate/aggregate_function.h"
@@ -94,6 +95,11 @@ public:
         auto level = assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1])
                              .get_data()[0];
         this->data(place).add(value, level);
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnFloat64>(columns[0]);
+        this->template check_argument_column_type<ColumnFloat64>(columns[1]);
     }
 
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,

--- a/be/src/exprs/aggregate/aggregate_function_product.h
+++ b/be/src/exprs/aggregate/aggregate_function_product.h
@@ -207,7 +207,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColVecResult&>(to);
+        auto& column = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_quantile_state.h
+++ b/be/src/exprs/aggregate/aggregate_function_quantile_state.h
@@ -143,7 +143,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColVecResult&>(to);
+        auto& column = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_reader_first_last.h
+++ b/be/src/exprs/aggregate/aggregate_function_reader_first_last.h
@@ -126,10 +126,10 @@ public:
     void insert_result_into(IColumn& to) const {
         if constexpr (result_is_nullable) {
             if (_data_value.is_null()) { //_ptr == nullptr || null data at row
-                auto& col = assert_cast<ColumnNullable&>(to);
+                auto& col = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
                 col.insert_default();
             } else {
-                auto& col = assert_cast<ColumnNullable&>(to);
+                auto& col = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
                 col.get_null_map_data().push_back(0);
                 if constexpr (!std::is_same_v<ColVecType, void>) {
                     _data_value.template insert_into<ColVecType>(col.get_nested_column());

--- a/be/src/exprs/aggregate/aggregate_function_reader_replace.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_reader_replace.cpp
@@ -144,7 +144,7 @@ struct ReaderReplaceData {
 
     void insert_result_into(IColumn& to, bool result_is_nullable) const {
         if (result_is_nullable) {
-            auto& nullable_col = assert_cast<ColumnNullable&>(to);
+            auto& nullable_col = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
             if (!_has_value || _store.is_null()) {
                 nullable_col.insert_default();
             } else {

--- a/be/src/exprs/aggregate/aggregate_function_regr.h
+++ b/be/src/exprs/aggregate/aggregate_function_regr.h
@@ -496,8 +496,9 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& nullable_column = assert_cast<ColumnNullable&>(to);
-        auto& nested_column = assert_cast<ResultDataType&>(nullable_column.get_nested_column());
+        auto& nullable_column = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
+        auto& nested_column = assert_cast<ResultDataType&, TypeCheckOnRelease::DISABLE>(
+                nullable_column.get_nested_column());
         const Float64 result = this->data(place).get_result();
         if (std::isnan(result)) {
             nullable_column.get_null_map_data().push_back(1);
@@ -525,7 +526,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeInt64>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& result_column = assert_cast<ResultDataType&>(to);
+        auto& result_column = assert_cast<ResultDataType&, TypeCheckOnRelease::DISABLE>(to);
         result_column.get_data().push_back(this->data(place).get_result());
     }
 };

--- a/be/src/exprs/aggregate/aggregate_function_retention.h
+++ b/be/src/exprs/aggregate/aggregate_function_retention.h
@@ -91,7 +91,7 @@ struct RetentionState {
     }
 
     void insert_result_into(IColumn& to, size_t events_size, const uint8_t* arg_events) const {
-        auto& data_to = assert_cast<ColumnUInt8&>(to).get_data();
+        auto& data_to = assert_cast<ColumnUInt8&, TypeCheckOnRelease::DISABLE>(to).get_data();
 
         ColumnArray::Offset64 current_offset = data_to.size();
         data_to.resize(current_offset + events_size);
@@ -143,6 +143,12 @@ public:
         }
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        for (size_t i = 0; i < get_argument_types().size(); ++i) {
+            this->template check_argument_column_type<ColumnUInt8>(columns[i]);
+        }
+    }
+
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
                Arena&) const override {
         this->data(place).merge(this->data(rhs));
@@ -158,7 +164,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
         auto& to_nested_col = to_arr.get_data();
         if (is_column_nullable(to_nested_col)) {
             auto col_null = reinterpret_cast<ColumnNullable*>(&to_nested_col);

--- a/be/src/exprs/aggregate/aggregate_function_sem.h
+++ b/be/src/exprs/aggregate/aggregate_function_sem.h
@@ -21,6 +21,7 @@
 
 #include "core/assert_cast.h"
 #include "core/column/column.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/data_type/define_primitive_type.h"
@@ -122,6 +123,10 @@ public:
         this->data(place).add((double)column.get_data()[row_num]);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnFloat64>(columns[0]);
+    }
+
     void reset(AggregateDataPtr place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -139,7 +144,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColumnFloat64&>(to);
+        auto& column = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).result());
     }
 };

--- a/be/src/exprs/aggregate/aggregate_function_sequence_match.h
+++ b/be/src/exprs/aggregate/aggregate_function_sequence_match.h
@@ -662,6 +662,15 @@ public:
         this->data(place).init(pattern, this->data(place).get_arg_count());
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnString>(columns[0]);
+        this->template check_argument_column_type<typename PrimitiveTypeTraits<T>::ColumnType>(
+                columns[1]);
+        for (size_t i = 2; i < arg_count; ++i) {
+            this->template check_argument_column_type<ColumnUInt8>(columns[i]);
+        }
+    }
+
 private:
     size_t arg_count;
 };
@@ -684,7 +693,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeUInt8>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& output = assert_cast<ColumnUInt8&>(to).get_data();
+        auto& output = assert_cast<ColumnUInt8&, TypeCheckOnRelease::DISABLE>(to).get_data();
         if (!this->data(place).conditions_in_pattern.any()) {
             output.push_back(false);
             return;
@@ -731,7 +740,7 @@ public:
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeInt64>(); }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& output = assert_cast<ColumnInt64&>(to).get_data();
+        auto& output = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data();
         if (!this->data(place).conditions_in_pattern.any()) {
             output.push_back(0);
             return;

--- a/be/src/exprs/aggregate/aggregate_function_sort.h
+++ b/be/src/exprs/aggregate/aggregate_function_sort.h
@@ -210,6 +210,15 @@ public:
         _nested_func->insert_result_into(get_nested_place(place), to);
     }
 
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->check_columns_type(_arguments, columns);
+        _nested_func->check_input_columns_type(columns);
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        _nested_func->check_result_column_type(to);
+    }
+
     size_t size_of_data() const override { return prefix_size + _nested_func->size_of_data(); }
 
     size_t align_of_data() const override { return _nested_func->align_of_data(); }

--- a/be/src/exprs/aggregate/aggregate_function_statistic.h
+++ b/be/src/exprs/aggregate/aggregate_function_statistic.h
@@ -118,9 +118,10 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         const auto& data = this->data(place);
-        ColumnNullable& dst_column_with_nullable = assert_cast<ColumnNullable&>(to);
-        ResultCol* dst_column =
-                assert_cast<ResultCol*>(&(dst_column_with_nullable.get_nested_column()));
+        ColumnNullable& dst_column_with_nullable =
+                assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
+        ResultCol* dst_column = assert_cast<ResultCol*, TypeCheckOnRelease::DISABLE>(
+                &(dst_column_with_nullable.get_nested_column()));
 
         switch (kind) {
         case STATISTICS_FUNCTION_KIND::SKEW_POP: {

--- a/be/src/exprs/aggregate/aggregate_function_stddev.h
+++ b/be/src/exprs/aggregate/aggregate_function_stddev.h
@@ -127,7 +127,7 @@ template <PrimitiveType T, typename Name, bool is_stddev>
 struct PopData : BaseData<T, is_stddev>, Name {
     using ColVecResult = std::conditional_t<is_decimal(T), ColumnDecimal128V2, ColumnFloat64>;
     void insert_result_into(IColumn& to) const {
-        auto& col = assert_cast<ColVecResult&>(to);
+        auto& col = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         if constexpr (is_decimal(T)) {
             col.get_data().push_back(this->get_pop_result().value());
         } else {
@@ -146,7 +146,7 @@ template <PrimitiveType T, typename Name, bool is_stddev>
 struct SampData : BaseData<T, is_stddev>, Name {
     using ColVecResult = std::conditional_t<is_decimal(T), ColumnDecimal128V2, ColumnFloat64>;
     void insert_result_into(IColumn& to) const {
-        auto& col = assert_cast<ColVecResult&>(to);
+        auto& col = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         if (this->count == 1 || this->count == 0) {
             col.insert_default();
         } else {

--- a/be/src/exprs/aggregate/aggregate_function_sum.h
+++ b/be/src/exprs/aggregate/aggregate_function_sum.h
@@ -128,7 +128,7 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& column = assert_cast<ColVecResult&>(to);
+        auto& column = assert_cast<ColVecResult&, TypeCheckOnRelease::DISABLE>(to);
         column.get_data().push_back(this->data(place).get());
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_topn.h
+++ b/be/src/exprs/aggregate/aggregate_function_topn.h
@@ -182,16 +182,14 @@ struct AggregateFunctionTopNData {
         return buffer.GetString();
     }
 
-    void insert_result_into(IColumn& to) const {
+    void insert_result_into(ColVecType& to) const {
         auto counter_vector = get_remain_vector();
         for (int i = 0; i < std::min((int)counter_vector.size(), top_num); i++) {
             const auto& element = counter_vector[i];
             if constexpr (is_string_type(T)) {
-                assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(
-                        element.second.c_str(), element.second.length());
+                to.insert_data(element.second.c_str(), element.second.length());
             } else {
-                assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
-                        element.second);
+                to.get_data().push_back(element.second);
             }
         }
     }
@@ -222,7 +220,8 @@ struct AggregateFunctionTopNImplIntInt {
                         ->get_element(row_num),
                 assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
                         ->get_element(row_num));
-        place.add(assert_cast<const ColumnString&>(*columns[0]).get_data_at(row_num));
+        place.add(assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(*columns[0])
+                          .get_data_at(row_num));
     }
 };
 
@@ -231,6 +230,8 @@ template <PrimitiveType T, bool has_default_param>
 struct AggregateFunctionTopNImplArray {
     using Data = AggregateFunctionTopNData<T>;
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
+    static constexpr bool has_default_parameter = has_default_param;
+    static constexpr bool is_weighted = false;
     static String get_name() { return "topn_array"; }
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
@@ -263,6 +264,8 @@ template <PrimitiveType T, bool has_default_param>
 struct AggregateFunctionTopNImplWeight {
     using Data = AggregateFunctionTopNData<T>;
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
+    static constexpr bool has_default_parameter = has_default_param;
+    static constexpr bool is_weighted = true;
     static String get_name() { return "topn_weighted"; }
     static void add(AggregateFunctionTopNData<T>& __restrict place, const IColumn** columns,
                     size_t row_num) {
@@ -275,7 +278,8 @@ struct AggregateFunctionTopNImplWeight {
 
         } else {
             place.set_paramenters(
-                    assert_cast<const ColumnInt32*>(columns[2])->get_element(row_num));
+                    assert_cast<const ColumnInt32*, TypeCheckOnRelease::DISABLE>(columns[2])
+                            ->get_element(row_num));
         }
         if constexpr (is_string_type(T)) {
             auto weight = assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(*columns[1])
@@ -341,7 +345,20 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         std::string result = this->data(place).get();
-        assert_cast<ColumnString&>(to).insert_data(result.c_str(), result.length());
+        assert_cast<ColumnString&, TypeCheckOnRelease::DISABLE>(to).insert_data(result.c_str(),
+                                                                                result.length());
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnString>(columns[0]);
+        this->template check_argument_column_type<ColumnInt32>(columns[1]);
+        if (this->argument_types.size() == 3) {
+            this->template check_argument_column_type<ColumnInt32>(columns[2]);
+        }
+    }
+
+    void check_result_column_type(const IColumn& column) const override {
+        this->template check_result_column_type_as<ColumnString>(column);
     }
 };
 
@@ -351,6 +368,9 @@ class AggregateFunctionTopNArray final
         : public AggregateFunctionTopNBase<Impl, AggregateFunctionTopNArray<Impl>>,
           MultiExpression,
           NullableAggregateFunction {
+private:
+    using ColVecType = typename Impl::Data::ColVecType;
+
 public:
     AggregateFunctionTopNArray(const DataTypes& argument_types_)
             : AggregateFunctionTopNBase<Impl, AggregateFunctionTopNArray<Impl>>(argument_types_),
@@ -363,19 +383,60 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        auto& to_arr = assert_cast<ColumnArray&>(to);
-        auto& to_nested_col = to_arr.get_data();
-        if (is_column_nullable(to_nested_col)) {
-            auto* col_null = assert_cast<ColumnNullable*>(&to_nested_col);
-            this->data(place).insert_result_into(col_null->get_nested_column());
-            col_null->get_null_map_data().resize_fill(col_null->get_nested_column().size(), 0);
-        } else {
-            this->data(place).insert_result_into(to_nested_col);
-        }
-        to_arr.get_offsets().push_back(to_nested_col.size());
+        auto& to_arr = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(to);
+        auto& col_null =
+                assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to_arr.get_data());
+        auto& typed_to =
+                assert_cast<ColVecType&, TypeCheckOnRelease::DISABLE>(col_null.get_nested_column());
+        this->data(place).insert_result_into(typed_to);
+        col_null.get_null_map_data().resize_fill(typed_to.size(), 0);
+        to_arr.get_offsets().push_back(typed_to.size());
     }
 
-private:
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColVecType>(columns[0]);
+        if constexpr (Impl::is_weighted) {
+            this->template check_argument_column_type<ColumnInt64>(columns[1]);
+            this->template check_argument_column_type<ColumnInt32>(columns[2]);
+            if constexpr (Impl::has_default_parameter) {
+                this->template check_argument_column_type<ColumnInt32>(columns[3]);
+            }
+        } else {
+            this->template check_argument_column_type<ColumnInt32>(columns[1]);
+            if constexpr (Impl::has_default_parameter) {
+                this->template check_argument_column_type<ColumnInt32>(columns[2]);
+            }
+        }
+    }
+
+    void check_result_column_type(const IColumn& to) const override {
+        const auto* to_arr = check_and_get_column<ColumnArray>(to);
+        if (UNLIKELY(to_arr == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Column type {} ({}) is not "
+                    "ColumnArray",
+                    get_name(), to.get_name(), typeid(to).name()));
+        }
+
+        const IColumn& data_column = to_arr->get_data();
+        const auto* nullable_column = check_and_get_column<ColumnNullable>(data_column);
+        if (UNLIKELY(nullable_column == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Array nested column type {} "
+                    "({}) is not ColumnNullable",
+                    get_name(), data_column.get_name(), typeid(data_column).name()));
+        }
+
+        const IColumn& nested_column = nullable_column->get_nested_column();
+        if (UNLIKELY(check_and_get_column<ColVecType>(nested_column) == nullptr)) {
+            throw doris::Exception(Status::InternalError(
+                    "Aggregate function {} result type check failed: Array nested data column "
+                    "type {} ({}) does not match expected physical column type {}",
+                    get_name(), nested_column.get_name(), typeid(nested_column).name(),
+                    typeid(ColVecType).name()));
+        }
+    }
+
     DataTypePtr _argument_type;
 };
 

--- a/be/src/exprs/aggregate/aggregate_function_uniq.h
+++ b/be/src/exprs/aggregate/aggregate_function_uniq.h
@@ -252,7 +252,8 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(this->data(place).set.size());
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                this->data(place).set.size());
     }
 };
 

--- a/be/src/exprs/aggregate/aggregate_function_uniq_distribute_key.h
+++ b/be/src/exprs/aggregate/aggregate_function_uniq_distribute_key.h
@@ -172,7 +172,8 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(this->data(place).count);
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                this->data(place).count);
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,

--- a/be/src/exprs/aggregate/aggregate_function_window.h
+++ b/be/src/exprs/aggregate/aggregate_function_window.h
@@ -439,10 +439,10 @@ public:
     void insert_result_into(IColumn& to) const {
         if constexpr (result_is_nullable) {
             if (_data_value.is_null()) {
-                auto& col = assert_cast<ColumnNullable&>(to);
+                auto& col = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
                 col.insert_default();
             } else {
-                auto& col = assert_cast<ColumnNullable&>(to);
+                auto& col = assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(to);
                 StringRef value = _data_value.get_value();
                 col.insert_data(value.data, value.size);
             }
@@ -482,7 +482,8 @@ public:
 
     void set_offset_value(const IColumn* column) {
         if (!_is_inited) {
-            const auto* column_number = assert_cast<const ColumnInt64*>(column);
+            const auto* column_number =
+                    assert_cast<const ColumnInt64*, TypeCheckOnRelease::DISABLE>(column);
             _offset_value = column_number->get_data()[0];
             _is_inited = true;
         }
@@ -551,7 +552,9 @@ struct WindowFunctionFirstImpl : Data {
         if constexpr (arg_ignore_null) {
             frame_end = std::min<int64_t>(frame_end, partition_end);
             if (is_column_nullable(*columns[0])) {
-                const auto& arg_nullable = assert_cast<const ColumnNullable&>(*columns[0]);
+                const auto& arg_nullable =
+                        assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                *columns[0]);
                 // the valid range is: [frame_start, frame_end)
                 while (frame_start < frame_end - 1 && arg_nullable.is_null_at(frame_start)) {
                     frame_start++;
@@ -585,7 +588,9 @@ struct WindowFunctionLastImpl : Data {
         if constexpr (arg_ignore_null) {
             frame_start = std::max<int64_t>(frame_start, partition_start);
             if (is_column_nullable(*columns[0])) {
-                const auto& arg_nullable = assert_cast<const ColumnNullable&>(*columns[0]);
+                const auto& arg_nullable =
+                        assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                *columns[0]);
                 // wants find a not null value in [frame_start, frame_end)
                 // iff has find: set_value and return directly
                 // iff not find: the while loop is finished
@@ -652,6 +657,14 @@ public:
             return make_nullable(_argument_type);
         } else {
             return _argument_type;
+        }
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        IAggregateFunction::check_input_columns_type(columns);
+        const auto function_name = get_name();
+        if (function_name == "lead" || function_name == "lag" || function_name == "nth_value") {
+            this->template check_argument_column_type<ColumnInt64>(columns[1]);
         }
     }
 

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel.h
@@ -36,6 +36,7 @@
 #include "core/assert_cast.h"
 #include "core/binary_cast.hpp"
 #include "core/column/column_string.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "core/types.h"
 #include "core/value/vdatetime_value.h"
@@ -125,11 +126,14 @@ struct WindowFunnelState {
         window = win;
         window_funnel_mode = enable_mode ? mode : WindowFunnelMode::DEFAULT;
         events_list.dt.emplace_back(
-                assert_cast<const typename PrimitiveTypeTraits<PType>::ColumnType&>(*arg_columns[2])
+                assert_cast<const typename PrimitiveTypeTraits<PType>::ColumnType&,
+                            TypeCheckOnRelease::DISABLE>(*arg_columns[2])
                         .get_data()[row_num]);
         for (int i = 0; i < event_count; i++) {
             events_list.event_columns_data[i].emplace_back(
-                    assert_cast<const ColumnUInt8&>(*arg_columns[3 + i]).get_data()[row_num]);
+                    assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(
+                            *arg_columns[3 + i])
+                            .get_data()[row_num]);
         }
     }
 
@@ -373,10 +377,22 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
-        const auto& window = assert_cast<const ColumnInt64&>(*columns[0]).get_data()[row_num];
+        const auto& window =
+                assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(*columns[0])
+                        .get_data()[row_num];
         StringRef mode = columns[1]->get_data_at(row_num);
         this->data(place).add(columns, row_num, window,
                               string_to_window_funnel_mode(mode.to_string()));
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnInt64>(columns[0]);
+        this->template check_argument_column_type<ColumnString>(columns[1]);
+        this->template check_argument_column_type<typename PrimitiveTypeTraits<T>::ColumnType>(
+                columns[2]);
+        for (size_t i = 3; i < this->argument_types.size(); ++i) {
+            this->template check_argument_column_type<ColumnUInt8>(columns[i]);
+        }
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -396,7 +412,7 @@ public:
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         // place is essentially an AggregateDataPtr, passed as a ConstAggregateDataPtr.
         this->data(const_cast<AggregateDataPtr>(place)).sort();
-        assert_cast<ColumnInt32&>(to).get_data().push_back(
+        assert_cast<ColumnInt32&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
                 IAggregateFunctionDataHelper<WindowFunnelState<T>,
                                              AggregateFunctionWindowFunnel<T>>::data(place)
                         .get());

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/column/column_string.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "core/types.h"
 #include "core/value/vdatetime_value.h"
@@ -136,10 +137,10 @@ struct WindowFunnelStateV2 {
         window = win;
         window_funnel_mode = mode;
 
-        auto timestamp =
-                assert_cast<const typename PrimitiveTypeTraits<T>::ColumnType&>(*arg_columns[2])
-                        .get_data()[row_num]
-                        .to_date_int_val();
+        auto timestamp = assert_cast<const typename PrimitiveTypeTraits<T>::ColumnType&,
+                                     TypeCheckOnRelease::DISABLE>(*arg_columns[2])
+                                 .get_data()[row_num]
+                                 .to_date_int_val();
 
         // Iterate from last event to first (reverse order).
         // This ensures that after stable_sort, events with the same timestamp
@@ -150,8 +151,9 @@ struct WindowFunnelStateV2 {
         // subsequent events from the same row have continuation=1 (bit 7 set).
         bool first_match = true;
         for (int i = event_count - 1; i >= 0; --i) {
-            auto event_val =
-                    assert_cast<const ColumnUInt8&>(*arg_columns[3 + i]).get_data()[row_num];
+            auto event_val = assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(
+                                     *arg_columns[3 + i])
+                                     .get_data()[row_num];
             if (event_val) {
                 UInt8 packed_idx = cast_set<UInt8>(i + 1);
                 if (!first_match) {
@@ -644,10 +646,21 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
-        const auto& win = assert_cast<const ColumnInt64&>(*columns[0]).get_data()[row_num];
+        const auto& win = assert_cast<const ColumnInt64&, TypeCheckOnRelease::DISABLE>(*columns[0])
+                                  .get_data()[row_num];
         StringRef mode = columns[1]->get_data_at(row_num);
         this->data(place).add(columns, row_num, win,
                               string_to_window_funnel_mode(mode.to_string()));
+    }
+
+    void check_input_columns_type(const IColumn** columns) const override {
+        this->template check_argument_column_type<ColumnInt64>(columns[0]);
+        this->template check_argument_column_type<ColumnString>(columns[1]);
+        this->template check_argument_column_type<typename PrimitiveTypeTraits<T>::ColumnType>(
+                columns[2]);
+        for (size_t i = 3; i < this->argument_types.size(); ++i) {
+            this->template check_argument_column_type<ColumnUInt8>(columns[i]);
+        }
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
@@ -666,7 +679,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(const_cast<AggregateDataPtr>(place)).sort();
-        assert_cast<ColumnInt32&>(to).get_data().push_back(
+        assert_cast<ColumnInt32&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
                 IAggregateFunctionDataHelper<WindowFunnelStateV2<T>,
                                              AggregateFunctionWindowFunnelV2<T>>::data(place)
                         .get());

--- a/be/src/exprs/function/array/function_array_aggregation.cpp
+++ b/be/src/exprs/function/array/function_array_aggregation.cpp
@@ -223,6 +223,8 @@ struct ArrayAggregateImpl {
         Arena arena;
         auto nullable_column = make_nullable(data->get_ptr());
         const IColumn* columns[] = {nullable_column.get()};
+        function->check_input_columns_type(columns);
+        function->check_result_column_type(*res_column);
         for (int64_t i = 0; i < offsets.size(); ++i) {
             auto start = offsets[i - 1]; // -1 is ok.
             auto end = offsets[i];
@@ -448,6 +450,8 @@ struct ArrayAggregateImplDecimalV3<operation, ResultType> {
         Arena arena;
         auto nullable_column = make_nullable(data->get_ptr());
         const IColumn* columns[] = {nullable_column.get()};
+        function->check_input_columns_type(columns);
+        function->check_result_column_type(*res_column);
         for (int64_t i = 0; i < offsets.size(); ++i) {
             auto start = offsets[i - 1]; // -1 is ok.
             auto end = offsets[i];

--- a/be/src/exprs/function/function_agg_state.h
+++ b/be/src/exprs/function/function_agg_state.h
@@ -84,6 +84,7 @@ public:
 
             agg_columns.push_back(column.get());
         }
+        _agg_function->check_input_columns_type(agg_columns.data());
         _agg_function->streaming_agg_serialize_to_column(agg_columns.data(), col, input_rows_count,
                                                          context->get_arena());
         block.replace_by_position(result, std::move(col));

--- a/be/src/exprs/vectorized_agg_fn.cpp
+++ b/be/src/exprs/vectorized_agg_fn.cpp
@@ -287,6 +287,7 @@ void AggFnEvaluator::destroy(AggregateDataPtr place) {
 
 Status AggFnEvaluator::execute_single_add(Block* block, AggregateDataPtr place, Arena& arena) {
     RETURN_IF_ERROR(_calc_argument_columns(block));
+    _function->check_input_columns_type(_agg_columns.data());
     _function->add_batch_single_place(block->rows(), place, _agg_columns.data(), arena);
     return Status::OK();
 }
@@ -294,6 +295,7 @@ Status AggFnEvaluator::execute_single_add(Block* block, AggregateDataPtr place, 
 Status AggFnEvaluator::execute_batch_add(Block* block, size_t offset, AggregateDataPtr* places,
                                          Arena& arena, bool agg_many) {
     RETURN_IF_ERROR(_calc_argument_columns(block));
+    _function->check_input_columns_type(_agg_columns.data());
     _function->add_batch(block->rows(), places, offset, _agg_columns.data(), arena, agg_many);
     return Status::OK();
 }
@@ -301,6 +303,7 @@ Status AggFnEvaluator::execute_batch_add(Block* block, size_t offset, AggregateD
 Status AggFnEvaluator::execute_batch_add_selected(Block* block, size_t offset,
                                                   AggregateDataPtr* places, Arena& arena) {
     RETURN_IF_ERROR(_calc_argument_columns(block));
+    _function->check_input_columns_type(_agg_columns.data());
     _function->add_batch_selected(block->rows(), places, offset, _agg_columns.data(), arena);
     return Status::OK();
 }
@@ -308,17 +311,46 @@ Status AggFnEvaluator::execute_batch_add_selected(Block* block, size_t offset,
 Status AggFnEvaluator::streaming_agg_serialize_to_column(Block* block, MutableColumnPtr& dst,
                                                          const size_t num_rows, Arena& arena) {
     RETURN_IF_ERROR(_calc_argument_columns(block));
+    _function->check_input_columns_type(_agg_columns.data());
     _function->streaming_agg_serialize_to_column(_agg_columns.data(), dst, num_rows, arena);
     return Status::OK();
 }
 
+void AggFnEvaluator::add_range_single_place(int64_t partition_start, int64_t partition_end,
+                                            int64_t frame_start, int64_t frame_end,
+                                            AggregateDataPtr place, const IColumn** columns,
+                                            Arena& arena, UInt8* use_null_result,
+                                            UInt8* could_use_previous_result) {
+    _function->check_input_columns_type(columns);
+    _function->add_range_single_place(partition_start, partition_end, frame_start, frame_end, place,
+                                      columns, arena, use_null_result, could_use_previous_result);
+}
+
+void AggFnEvaluator::execute_function_with_incremental(
+        int64_t partition_start, int64_t partition_end, int64_t frame_start, int64_t frame_end,
+        AggregateDataPtr place, const IColumn** columns, Arena& arena, bool previous_is_nul,
+        bool end_is_nul, bool has_null, UInt8* use_null_result, UInt8* could_use_previous_result) {
+    _function->check_input_columns_type(columns);
+    _function->execute_function_with_incremental(
+            partition_start, partition_end, frame_start, frame_end, place, columns, arena,
+            previous_is_nul, end_is_nul, has_null, use_null_result, could_use_previous_result);
+}
+
 void AggFnEvaluator::insert_result_info(AggregateDataPtr place, IColumn* column) {
+    _function->check_result_column_type(*column);
     _function->insert_result_into(place, *column);
 }
 
 void AggFnEvaluator::insert_result_info_vec(const std::vector<AggregateDataPtr>& places,
                                             size_t offset, IColumn* column, const size_t num_rows) {
+    _function->check_result_column_type(*column);
     _function->insert_result_into_vec(places, offset, *column, num_rows);
+}
+
+void AggFnEvaluator::insert_result_info_range(ConstAggregateDataPtr place, IColumn* column,
+                                              size_t start, size_t end) {
+    _function->check_result_column_type(*column);
+    _function->insert_result_into_range(place, *column, start, end);
 }
 
 void AggFnEvaluator::reset(AggregateDataPtr place) {
@@ -407,7 +439,7 @@ Status AggFnEvaluator::check_agg_fn_output(uint32_t key_size,
     auto name_and_types = VectorizedUtils::create_name_and_data_types(output_row_desc);
     for (uint32_t i = key_size, j = 0; i < name_and_types.size(); i++, j++) {
         auto&& [name, column_type] = name_and_types[i];
-        auto agg_return_type = agg_fn[j]->function()->get_return_type();
+        auto agg_return_type = agg_fn[j]->get_return_type();
         if (!column_type->equals(*agg_return_type)) {
             if (!column_type->is_nullable() || agg_return_type->is_nullable() ||
                 !remove_nullable(column_type)->equals(*agg_return_type)) {

--- a/be/src/exprs/vectorized_agg_fn.h
+++ b/be/src/exprs/vectorized_agg_fn.h
@@ -44,6 +44,7 @@ class Arena;
 class Block;
 class BufferWritable;
 class IColumn;
+class QueryContext;
 
 class AggFnEvaluator {
 public:
@@ -82,16 +83,71 @@ public:
     Status streaming_agg_serialize_to_column(Block* block, MutableColumnPtr& dst,
                                              const size_t num_rows, Arena& arena);
 
+    void add_range_single_place(int64_t partition_start, int64_t partition_end, int64_t frame_start,
+                                int64_t frame_end, AggregateDataPtr place, const IColumn** columns,
+                                Arena& arena, UInt8* use_null_result,
+                                UInt8* could_use_previous_result);
+
+    void execute_function_with_incremental(int64_t partition_start, int64_t partition_end,
+                                           int64_t frame_start, int64_t frame_end,
+                                           AggregateDataPtr place, const IColumn** columns,
+                                           Arena& arena, bool previous_is_nul, bool end_is_nul,
+                                           bool has_null, UInt8* use_null_result,
+                                           UInt8* could_use_previous_result);
+
     void insert_result_info(AggregateDataPtr place, IColumn* column);
 
     void insert_result_info_vec(const std::vector<AggregateDataPtr>& place, size_t offset,
                                 IColumn* column, const size_t num_rows);
 
+    void insert_result_info_range(ConstAggregateDataPtr place, IColumn* column, size_t start,
+                                  size_t end);
+
     void reset(AggregateDataPtr place);
 
     DataTypePtr& data_type() { return _data_type; }
 
-    const AggregateFunctionPtr& function() { return _function; }
+    String get_name() const { return _function->get_name(); }
+    DataTypePtr get_return_type() const { return _function->get_return_type(); }
+    size_t size_of_data() const { return _function->size_of_data(); }
+    size_t align_of_data() const { return _function->align_of_data(); }
+    bool result_column_could_resize() const { return _function->result_column_could_resize(); }
+    bool supported_incremental_mode() const { return _function->supported_incremental_mode(); }
+    bool is_simple_count() const { return _function->is_simple_count(); }
+    void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena& arena) const {
+        _function->merge(place, rhs, arena);
+    }
+    void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
+                             MutableColumnPtr& dst, const size_t num_rows) const {
+        _function->serialize_to_column(places, offset, dst, num_rows);
+    }
+    void serialize_without_key_to_column(ConstAggregateDataPtr place, IColumn& to) const {
+        _function->serialize_without_key_to_column(place, to);
+    }
+    void deserialize_and_merge_from_column(AggregateDataPtr place, const IColumn& column,
+                                           Arena& arena) const {
+        _function->deserialize_and_merge_from_column(place, column, arena);
+    }
+    void deserialize_and_merge_from_column_range(AggregateDataPtr place, const IColumn& column,
+                                                 size_t begin, size_t end, Arena& arena) const {
+        _function->deserialize_and_merge_from_column_range(place, column, begin, end, arena);
+    }
+    void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
+                                   AggregateDataPtr rhs, const IColumn* column, Arena& arena,
+                                   const size_t num_rows) const {
+        _function->deserialize_and_merge_vec(places, offset, rhs, column, arena, num_rows);
+    }
+    void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
+                                            AggregateDataPtr rhs, const IColumn* column,
+                                            Arena& arena, const size_t num_rows) const {
+        _function->deserialize_and_merge_vec_selected(places, offset, rhs, column, arena, num_rows);
+    }
+    MutableColumnPtr create_serialize_column() const {
+        return _function->create_serialize_column();
+    }
+    DataTypePtr get_serialized_type() const { return _function->get_serialized_type(); }
+    void set_query_context(QueryContext* context) { _function->set_query_context(context); }
+
     static std::string debug_string(const std::vector<AggFnEvaluator*>& exprs);
     std::string debug_string() const;
     bool is_merge() const { return _is_merge; }

--- a/be/src/load/memtable/memtable.cpp
+++ b/be/src/load/memtable/memtable.cpp
@@ -131,6 +131,10 @@ void MemTable::_init_agg_functions(const Block* block) {
         }
 
         DCHECK(function != nullptr);
+        const auto* input_column = _input_mutable_block.get_column_by_position(cid).get();
+        const IColumn* columns[] = {input_column};
+        function->check_input_columns_type(columns);
+        function->check_result_column_type(*_output_mutable_block.get_column_by_position(cid));
         _agg_functions[cid] = function;
     }
 

--- a/be/src/storage/iterator/block_reader.cpp
+++ b/be/src/storage/iterator/block_reader.cpp
@@ -512,6 +512,10 @@ Status BlockReader::_init_agg_state(const ReaderParams& read_params) {
                     read_params.tablet->tablet_id(), read_params.tablet->schema_hash(),
                     int(read_params.reader_type), read_params.version.to_string());
         }
+        const auto* column_ptr = _stored_data_columns[idx].get();
+        const IColumn* columns[] = {column_ptr};
+        function->check_input_columns_type(columns);
+        function->check_result_column_type(*column_ptr);
         _agg_functions.push_back(function);
         // create aggregate data
         AggregateDataPtr place = new char[function->size_of_data()];

--- a/be/src/storage/iterator/vertical_block_reader.cpp
+++ b/be/src/storage/iterator/vertical_block_reader.cpp
@@ -199,6 +199,10 @@ void VerticalBlockReader::_init_agg_state(const ReaderParams& read_params) {
                         .get_aggregate_function(AGG_READER_SUFFIX,
                                                 read_params.get_be_exec_version());
         DCHECK(function != nullptr);
+        const auto* column_ptr = _stored_data_columns[idx].get();
+        const IColumn* columns[] = {column_ptr};
+        function->check_input_columns_type(columns);
+        function->check_result_column_type(*column_ptr);
         _agg_functions.push_back(function);
         // create aggregate data
         auto* place = new char[function->size_of_data()];

--- a/be/src/storage/schema_change/schema_change.cpp
+++ b/be/src/storage/schema_change/schema_change.cpp
@@ -181,6 +181,10 @@ public:
                                 tablet_schema->column(i).name(),
                                 tablet_schema->column(i).aggregation());
                     }
+                    const auto* column = finalized_block.get_by_position(i).column.get();
+                    const IColumn* function_columns[] = {column};
+                    function->check_input_columns_type(function_columns);
+                    function->check_result_column_type(*column);
                     agg_functions.push_back(function);
                     // create aggregate data
                     auto* place = new char[function->size_of_data()];

--- a/be/test/exec/agg/agg_fn_evaluator_test.cpp
+++ b/be/test/exec/agg/agg_fn_evaluator_test.cpp
@@ -17,13 +17,104 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "agent/be_exec_version_manager.h"
+#include "common/exception.h"
 #include "common/object_pool.h"
+#include "core/column/column_array.h"
+#include "core/column/column_map.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_map.h"
+#include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "runtime/runtime_state.h"
 #include "testutil/column_helper.h"
 #include "testutil/mock/mock_agg_fn_evaluator.h"
 
 namespace doris {
+namespace {
+
+template <typename Action>
+void expect_exception_message_contains(Action&& action, const std::string& expected_message) {
+    try {
+        action();
+        FAIL() << "Expected doris::Exception";
+    } catch (const Exception& e) {
+        EXPECT_NE(e.to_string().find(expected_message), std::string::npos) << e.to_string();
+    }
+}
+
+MutableColumnPtr create_string64_column() {
+    auto column = ColumnString64::create();
+    column->insert_data("a", 1);
+    column->insert_data("b", 1);
+    column->insert_data("c", 1);
+    return column;
+}
+
+MutableColumnPtr create_nullable_string_column() {
+    auto nested_column = ColumnString::create();
+    nested_column->insert_data("a", 1);
+    nested_column->insert_data("b", 1);
+    nested_column->insert_data("c", 1);
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    return ColumnNullable::create(std::move(nested_column), std::move(null_map));
+}
+
+MutableColumnPtr create_nullable_string64_column() {
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    return ColumnNullable::create(create_string64_column(), std::move(null_map));
+}
+
+MutableColumnPtr create_nullable_int64_column() {
+    auto nested_column = ColumnInt64::create();
+    nested_column->insert_value(1);
+    nested_column->insert_value(2);
+    nested_column->insert_value(3);
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    return ColumnNullable::create(std::move(nested_column), std::move(null_map));
+}
+
+MutableColumnPtr create_int64_column() {
+    auto column = ColumnInt64::create();
+    column->insert_value(1);
+    column->insert_value(2);
+    column->insert_value(3);
+    return column;
+}
+
+MutableColumnPtr create_array_nullable_string64_column() {
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert_value(3);
+    return ColumnArray::create(create_nullable_string64_column(), std::move(offsets));
+}
+
+MutableColumnPtr create_map_nullable_string64_key_column(bool nullable_values) {
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert_value(3);
+    auto value_column = nullable_values ? create_nullable_int64_column() : create_int64_column();
+    return ColumnMap::create(create_nullable_string64_column(), std::move(value_column),
+                             std::move(offsets));
+}
+
+} // namespace
 
 TEST(AggFnEvaluatorTest, test_single) {
     ObjectPool pool;
@@ -33,8 +124,7 @@ TEST(AggFnEvaluatorTest, test_single) {
     Block block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3});
 
     // init place
-    AggregateDataPtr place =
-            reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->function()->size_of_data()));
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
     agg_fn->create(place);
 
@@ -58,11 +148,9 @@ TEST(AggFnEvaluatorTest, test_batch) {
     Block block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3});
 
     // init place
-    AggregateDataPtr place1 =
-            reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->function()->size_of_data()));
+    auto* place1 = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
-    AggregateDataPtr place2 =
-            reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->function()->size_of_data()));
+    auto* place2 = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
     agg_fn->create(place1);
     agg_fn->create(place2);
@@ -103,11 +191,9 @@ TEST(AggFnEvaluatorTest, test_clone) {
     Block block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3});
 
     // init place
-    AggregateDataPtr place1 =
-            reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->function()->size_of_data()));
+    auto* place1 = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
-    AggregateDataPtr place2 =
-            reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->function()->size_of_data()));
+    auto* place2 = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
     agg_fn->create(place1);
     agg_fn->create(place2);
@@ -136,6 +222,481 @@ TEST(AggFnEvaluatorTest, test_clone) {
     // reset place
     agg_fn->reset(place1);
     agg_fn->reset(place2);
+}
+
+TEST(AggFnEvaluatorTest, check_input_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_mock_agg_fn_evaluator(pool);
+    Arena arena;
+
+    Block block = ColumnHelper::create_block<DataTypeString>({"a", "b", "c"});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, check_result_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_mock_agg_fn_evaluator(pool);
+    Arena arena;
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    ColumnString result_column;
+    EXPECT_THROW(agg_fn->insert_result_info(place, &result_column), Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, group_concat_check_input_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "group_concat", {std::make_shared<DataTypeString>()},
+                                 nullptr, false);
+    Arena arena;
+
+    auto string64_column = ColumnString64::create();
+    string64_column->insert_data("a", 1);
+    string64_column->insert_data("b", 1);
+    string64_column->insert_data("c", 1);
+    Block block({ColumnWithTypeAndName(std::move(string64_column),
+                                       std::make_shared<DataTypeString>(), "bad_string")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, group_concat_check_fixed_input_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "group_concat", {std::make_shared<DataTypeInt64>()}, nullptr,
+                                 false);
+    Arena arena;
+
+    Block block({ColumnWithTypeAndName(ColumnHelper::create_column<DataTypeInt64>({1, 2, 3}),
+                                       std::make_shared<DataTypeInt64>(), "bad_string")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, group_concat_check_result_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "group_concat", {std::make_shared<DataTypeString>()},
+                                 nullptr, false);
+    Arena arena;
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    auto result_column = ColumnString64::create();
+    EXPECT_THROW(agg_fn->insert_result_info(place, result_column.get()), Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, min_max_check_string_input_physical_column_type) {
+    for (const auto* function_name : {"min", "max", "any"}) {
+        SCOPED_TRACE(function_name);
+        ObjectPool pool;
+        auto* agg_fn = create_agg_fn(pool, function_name, {std::make_shared<DataTypeString>()},
+                                     nullptr, false);
+        Arena arena;
+
+        auto string64_column = ColumnString64::create();
+        string64_column->insert_data("a", 1);
+        string64_column->insert_data("b", 1);
+        string64_column->insert_data("c", 1);
+        Block block({ColumnWithTypeAndName(std::move(string64_column),
+                                           std::make_shared<DataTypeString>(), "bad_string")});
+
+        auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+        agg_fn->create(place);
+
+        EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                     Exception);
+
+        agg_fn->destroy(place);
+    }
+}
+
+TEST(AggFnEvaluatorTest, min_max_check_string_result_physical_column_type) {
+    for (const auto* function_name : {"min", "max", "any"}) {
+        SCOPED_TRACE(function_name);
+        ObjectPool pool;
+        auto* agg_fn = create_agg_fn(pool, function_name, {std::make_shared<DataTypeString>()},
+                                     nullptr, false);
+        Arena arena;
+
+        auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+        agg_fn->create(place);
+
+        auto result_column = ColumnString64::create();
+        EXPECT_THROW(agg_fn->insert_result_info(place, result_column.get()), Exception);
+
+        agg_fn->destroy(place);
+    }
+}
+
+TEST(AggFnEvaluatorTest, count_not_null_check_nullable_result_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "count", {make_nullable(std::make_shared<DataTypeInt64>())},
+                                 std::make_shared<DataTypeInt64>(), false);
+    Arena arena;
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    auto result_column = make_nullable(std::make_shared<DataTypeInt64>())->create_column();
+    EXPECT_NO_THROW(agg_fn->insert_result_info(place, result_column.get()));
+    EXPECT_EQ(result_column->size(), 1);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, count_by_enum_check_input_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "count_by_enum", {std::make_shared<DataTypeString>()},
+                                 nullptr, false);
+    Arena arena;
+
+    auto string64_column = ColumnString64::create();
+    string64_column->insert_data("a", 1);
+    string64_column->insert_data("b", 1);
+    string64_column->insert_data("c", 1);
+    Block block({ColumnWithTypeAndName(std::move(string64_column),
+                                       std::make_shared<DataTypeString>(), "bad_string")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, count_by_enum_check_nullable_input_physical_column_type) {
+    ObjectPool pool;
+    auto input_type = make_nullable(std::make_shared<DataTypeString>());
+    auto* agg_fn = create_agg_fn(pool, "count_by_enum", {input_type}, nullptr, false);
+    Arena arena;
+
+    auto string64_column = ColumnString64::create();
+    string64_column->insert_data("a", 1);
+    string64_column->insert_data("b", 1);
+    string64_column->insert_data("c", 1);
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    null_map->insert_value(0);
+    auto nullable_column = ColumnNullable::create(std::move(string64_column), std::move(null_map));
+    Block block({ColumnWithTypeAndName(std::move(nullable_column), input_type, "bad_string")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, count_by_enum_check_result_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "count_by_enum", {std::make_shared<DataTypeString>()},
+                                 nullptr, false);
+    Arena arena;
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    auto result_column = ColumnString64::create();
+    EXPECT_THROW(agg_fn->insert_result_info(place, result_column.get()), Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, string_result_aggregates_check_physical_column_type) {
+    struct TestCase {
+        std::string function_name;
+        DataTypes argument_types;
+    };
+    std::vector<TestCase> test_cases = {
+            {"ai_agg",
+             {std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>(),
+              std::make_shared<DataTypeString>()}},
+            {"histogram", {std::make_shared<DataTypeString>()}},
+            {"linear_histogram",
+             {std::make_shared<DataTypeInt64>(), std::make_shared<DataTypeFloat64>()}}};
+
+    for (const auto& test_case : test_cases) {
+        SCOPED_TRACE(test_case.function_name);
+        ObjectPool pool;
+        auto* agg_fn = create_agg_fn(pool, test_case.function_name, test_case.argument_types,
+                                     nullptr, false);
+        Arena arena;
+
+        auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+        agg_fn->create(place);
+
+        auto result_column = ColumnString64::create();
+        expect_exception_message_contains(
+                [&]() { agg_fn->insert_result_info(place, result_column.get()); },
+                "result type check failed");
+
+        agg_fn->destroy(place);
+    }
+}
+
+TEST(AggFnEvaluatorTest, array_agg_check_string_physical_column_type) {
+    ObjectPool pool;
+    auto input_type = make_nullable(std::make_shared<DataTypeString>());
+    auto* agg_fn = create_agg_fn(pool, "array_agg", {input_type}, nullptr, false);
+    Arena arena;
+
+    Block bad_input_block(
+            {ColumnWithTypeAndName(create_nullable_string64_column(), input_type, "bad_string")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    expect_exception_message_contains(
+            [&]() {
+                static_cast<void>(agg_fn->execute_single_add(&bad_input_block, place, arena));
+            },
+            "argument type check failed");
+
+    auto bad_result_column = create_array_nullable_string64_column();
+    expect_exception_message_contains(
+            [&]() { agg_fn->insert_result_info(place, bad_result_column.get()); },
+            "result type check failed");
+
+    Block good_input_block(
+            {ColumnWithTypeAndName(create_nullable_string_column(), input_type, "good_string")});
+    auto bad_serialize_column = create_array_nullable_string64_column();
+    expect_exception_message_contains(
+            [&]() {
+                static_cast<void>(agg_fn->streaming_agg_serialize_to_column(
+                        &good_input_block, bad_serialize_column, good_input_block.rows(), arena));
+            },
+            "result type check failed");
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, collect_check_string_physical_column_type) {
+    for (const auto* function_name : {"collect_list", "collect_set"}) {
+        SCOPED_TRACE(function_name);
+        ObjectPool pool;
+        auto* agg_fn = create_agg_fn(pool, function_name, {std::make_shared<DataTypeString>()},
+                                     nullptr, false);
+        Arena arena;
+
+        auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+        agg_fn->create(place);
+
+        if (std::string_view(function_name) == "collect_list") {
+            Block block({ColumnWithTypeAndName(create_string64_column(),
+                                               std::make_shared<DataTypeString>(), "bad_string")});
+            expect_exception_message_contains(
+                    [&]() { static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                    "argument type check failed");
+        }
+
+        auto bad_result_column = create_array_nullable_string64_column();
+        expect_exception_message_contains(
+                [&]() { agg_fn->insert_result_info(place, bad_result_column.get()); },
+                "result type check failed");
+
+        agg_fn->destroy(place);
+    }
+}
+
+TEST(AggFnEvaluatorTest, datasketches_hll_union_agg_check_string_input_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(pool, "datasketches_hll_union_agg",
+                                 {std::make_shared<DataTypeString>()}, nullptr, false);
+    Arena arena;
+
+    Block block({ColumnWithTypeAndName(create_string64_column(), std::make_shared<DataTypeString>(),
+                                       "bad_string")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    expect_exception_message_contains(
+            [&]() { static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+            "argument type check failed");
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, map_agg_check_string_key_input_physical_column_type) {
+    for (bool nullable_key : {false, true}) {
+        SCOPED_TRACE(nullable_key);
+        ObjectPool pool;
+        DataTypePtr key_type = std::make_shared<DataTypeString>();
+        if (nullable_key) {
+            key_type = make_nullable(key_type);
+        }
+        auto* agg_fn = create_agg_fn(pool, "map_agg_v1",
+                                     {key_type, std::make_shared<DataTypeInt64>()}, nullptr, false);
+        Arena arena;
+
+        MutableColumnPtr key_column =
+                nullable_key ? create_nullable_string64_column() : create_string64_column();
+        Block block({ColumnWithTypeAndName(std::move(key_column), key_type, "bad_key"),
+                     ColumnWithTypeAndName(ColumnHelper::create_column<DataTypeInt64>({1, 2, 3}),
+                                           std::make_shared<DataTypeInt64>(), "value")});
+
+        auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+        agg_fn->create(place);
+
+        expect_exception_message_contains(
+                [&]() { static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                "argument type check failed");
+
+        agg_fn->destroy(place);
+    }
+}
+
+TEST(AggFnEvaluatorTest, map_combinator_check_string_key_physical_column_type) {
+    ObjectPool pool;
+    auto map_type = std::make_shared<DataTypeMap>(make_nullable(std::make_shared<DataTypeString>()),
+                                                  std::make_shared<DataTypeInt64>());
+    auto* agg_fn = create_agg_fn(pool, "sum_map", {map_type}, nullptr, false);
+    Arena arena;
+
+    Block block({ColumnWithTypeAndName(create_map_nullable_string64_key_column(false), map_type,
+                                       "bad_map")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    expect_exception_message_contains(
+            [&]() { static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+            "argument type check failed");
+
+    auto bad_result_column = create_map_nullable_string64_key_column(true);
+    expect_exception_message_contains(
+            [&]() { agg_fn->insert_result_info(place, bad_result_column.get()); },
+            "result type check failed");
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, topn_check_input_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(
+            pool, "topn", {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>()},
+            nullptr, false);
+    Arena arena;
+
+    Block block({ColumnWithTypeAndName(ColumnHelper::create_column<DataTypeInt64>({1, 2, 3}),
+                                       std::make_shared<DataTypeInt64>(), "bad_value"),
+                 ColumnWithTypeAndName(ColumnHelper::create_column<DataTypeInt32>({2, 2, 2}),
+                                       std::make_shared<DataTypeInt32>(), "top")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, topn_check_fixed_parameter_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(
+            pool, "topn", {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt64>()},
+            nullptr, false);
+    Arena arena;
+
+    Block block({ColumnWithTypeAndName(ColumnHelper::create_column<DataTypeString>({"a", "b", "c"}),
+                                       std::make_shared<DataTypeString>(), "value"),
+                 ColumnWithTypeAndName(ColumnHelper::create_column<DataTypeInt64>({2, 2, 2}),
+                                       std::make_shared<DataTypeInt64>(), "bad_top")});
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    EXPECT_THROW({ static_cast<void>(agg_fn->execute_single_add(&block, place, arena)); },
+                 Exception);
+
+    agg_fn->destroy(place);
+}
+
+TEST(AggFnEvaluatorTest, topn_check_result_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(
+            pool, "topn", {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>()},
+            nullptr, false);
+    Arena arena;
+
+    std::vector<AggregateDataPtr> places(2);
+    for (auto& place : places) {
+        place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+        agg_fn->create(place);
+    }
+
+    ColumnInt64 result_column;
+    EXPECT_THROW(agg_fn->insert_result_info_vec(places, 0, &result_column, places.size()),
+                 Exception);
+
+    for (auto place : places) {
+        agg_fn->destroy(place);
+    }
+}
+
+TEST(AggFnEvaluatorTest, group_array_intersect_check_input_physical_column_type) {
+    auto agg_function = AggregateFunctionSimpleFactory::instance().get(
+            "group_array_intersect",
+            {std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt64>())}, nullptr, false,
+            BeExecVersionManager::get_newest_version(), {.column_names = {}});
+    ASSERT_NE(agg_function, nullptr);
+
+    auto data_column = ColumnInt64::create();
+    data_column->insert_value(1);
+    data_column->insert_value(2);
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert_value(2);
+    auto array_column = ColumnArray::create(std::move(data_column), std::move(offsets));
+
+    const IColumn* columns[1] = {array_column.get()};
+    EXPECT_THROW(agg_function->check_input_columns_type(columns), Exception);
+}
+
+TEST(AggFnEvaluatorTest, group_array_intersect_check_result_physical_column_type) {
+    ObjectPool pool;
+    auto* agg_fn = create_agg_fn(
+            pool, "group_array_intersect",
+            {std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt64>())}, nullptr, false);
+    Arena arena;
+
+    auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
+    agg_fn->create(place);
+
+    auto result_column =
+            ColumnArray::create(ColumnInt64::create(), ColumnArray::ColumnOffsets::create());
+    EXPECT_THROW(agg_fn->insert_result_info(place, result_column.get()), Exception);
+
+    agg_fn->destroy(place);
 }
 
 } // namespace doris

--- a/be/test/exec/operator/agg_operator_test.cpp
+++ b/be/test/exec/operator/agg_operator_test.cpp
@@ -516,7 +516,7 @@ TEST_F(AggOperatorTestWithGroupBy, test_no_need_finalize_mem_reuse_with_shared_o
         EXPECT_TRUE(st.ok()) << st.msg();
     }
 
-    const auto& aggregate_function = sink_op->_aggregate_evaluators[0]->function();
+    const auto* aggregate_function = sink_op->_aggregate_evaluators[0];
     auto serialized_type = aggregate_function->get_serialized_type();
     Block block {ColumnHelper::create_column_with_name<DataTypeInt64>({}),
                  ColumnWithTypeAndName(aggregate_function->create_serialize_column(),

--- a/be/test/exprs/aggregate/agg_function_test.h
+++ b/be/test/exprs/aggregate/agg_function_test.h
@@ -42,8 +42,7 @@ struct AggregateFunctiontest : public testing::Test {
 private:
     void execute_single(Block block, ColumnWithTypeAndName expected_column) const {
         Arena arena;
-        auto* place =
-                reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->function()->size_of_data()));
+        auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
         agg_fn->create(place);
 
@@ -85,7 +84,7 @@ private:
         {
             QueryContext* context = nullptr;
             try {
-                agg_fn->function()->set_query_context(context);
+                agg_fn->set_query_context(context);
             } catch (const Exception& e) {
                 EXPECT_EQ(e.code(), ErrorCode::FATAL_ERROR);
                 EXPECT_THAT(
@@ -99,11 +98,10 @@ private:
 
     void execute_merge(Block block, ColumnWithTypeAndName expected_column) const {
         Arena arena;
-        MutableColumnPtr serialize_column = agg_fn->function()->create_serialize_column();
+        MutableColumnPtr serialize_column = agg_fn->create_serialize_column();
 
         {
-            auto* place = reinterpret_cast<AggregateDataPtr>(
-                    arena.alloc(agg_fn->function()->size_of_data()));
+            auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
             agg_fn->create(place);
             Defer defer([&]() { agg_fn->destroy(place); });
@@ -111,17 +109,16 @@ private:
             auto st = agg_fn->execute_single_add(&block, place, arena);
             EXPECT_TRUE(st.ok()) << st.msg();
 
-            agg_fn->function()->serialize_without_key_to_column(place, *serialize_column);
+            agg_fn->serialize_without_key_to_column(place, *serialize_column);
         }
 
         {
-            auto* place = reinterpret_cast<AggregateDataPtr>(
-                    arena.alloc(agg_fn->function()->size_of_data()));
+            auto* place = reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
             agg_fn->create(place);
             Defer defer([&]() { agg_fn->destroy(place); });
 
-            agg_fn->function()->deserialize_and_merge_from_column(place, *serialize_column, arena);
+            agg_fn->deserialize_and_merge_from_column(place, *serialize_column, arena);
 
             MutableColumnPtr result_column = expected_column.column->clone_empty();
 
@@ -149,11 +146,11 @@ private:
         };
 
         { // serialize_to_column deserialize_from_column
-            MutableColumnPtr serialize_column = agg_fn->function()->create_serialize_column();
+            MutableColumnPtr serialize_column = agg_fn->create_serialize_column();
             {
                 Arena arena;
-                auto* place = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
                 agg_fn->create(place);
                 Defer defer([&]() { agg_fn->destroy(place); });
@@ -161,12 +158,12 @@ private:
                 auto st = agg_fn->execute_single_add(&block, place, arena);
                 EXPECT_TRUE(st.ok()) << st.msg();
                 std::vector<AggregateDataPtr> places {place};
-                agg_fn->function()->serialize_to_column(places, 0, serialize_column, 1);
+                agg_fn->serialize_to_column(places, 0, serialize_column, 1);
             }
         }
 
         { // streaming_agg_serialize_to_column deserialize_and_merge_from_column_range
-            MutableColumnPtr serialize_column = agg_fn->function()->create_serialize_column();
+            MutableColumnPtr serialize_column = agg_fn->create_serialize_column();
             Arena arena;
             {
                 EXPECT_TRUE(agg_fn->streaming_agg_serialize_to_column(&block, serialize_column,
@@ -174,24 +171,24 @@ private:
             }
 
             {
-                auto* place = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
                 agg_fn->create(place);
                 Defer defer([&]() { agg_fn->destroy(place); });
-                agg_fn->function()->deserialize_and_merge_from_column_range(
-                        place, *serialize_column, 0, block.rows() - 1, arena);
+                agg_fn->deserialize_and_merge_from_column_range(place, *serialize_column, 0,
+                                                                block.rows() - 1, arena);
 
                 check_result(place);
             }
         }
 
         { // deserialize_and_merge_vec
-            MutableColumnPtr serialize_column = agg_fn->function()->create_serialize_column();
+            MutableColumnPtr serialize_column = agg_fn->create_serialize_column();
             Arena arena;
             {
-                auto* place = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
                 agg_fn->create(place);
                 Defer defer([&]() { agg_fn->destroy(place); });
@@ -199,31 +196,31 @@ private:
                 auto st = agg_fn->execute_single_add(&block, place, arena);
                 EXPECT_TRUE(st.ok()) << st.msg();
                 std::vector<AggregateDataPtr> places {place};
-                agg_fn->function()->serialize_to_column(places, 0, serialize_column, 1);
+                agg_fn->serialize_to_column(places, 0, serialize_column, 1);
             }
             {
-                auto* place1 = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place1 =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
                 agg_fn->create(place1);
                 Defer defer([&]() { agg_fn->destroy(place1); });
                 std::vector<AggregateDataPtr> places {place1};
 
-                auto* place2 = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place2 =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
-                agg_fn->function()->deserialize_and_merge_vec(places.data(), 0, place2,
-                                                              serialize_column.get(), arena, 1);
+                agg_fn->deserialize_and_merge_vec(places.data(), 0, place2, serialize_column.get(),
+                                                  arena, 1);
 
                 check_result(place1);
             }
         }
 
         { // deserialize_and_merge_vec_selected
-            MutableColumnPtr serialize_column = agg_fn->function()->create_serialize_column();
+            MutableColumnPtr serialize_column = agg_fn->create_serialize_column();
             Arena arena;
             {
-                auto* place = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
                 agg_fn->create(place);
                 Defer defer([&]() { agg_fn->destroy(place); });
@@ -231,20 +228,20 @@ private:
                 auto st = agg_fn->execute_single_add(&block, place, arena);
                 EXPECT_TRUE(st.ok()) << st.msg();
                 std::vector<AggregateDataPtr> places {place};
-                agg_fn->function()->serialize_to_column(places, 0, serialize_column, 1);
+                agg_fn->serialize_to_column(places, 0, serialize_column, 1);
             }
             {
-                auto* place1 = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place1 =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
                 agg_fn->create(place1);
                 Defer defer([&]() { agg_fn->destroy(place1); });
                 std::vector<AggregateDataPtr> places {place1};
 
-                auto* place2 = reinterpret_cast<AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
+                auto* place2 =
+                        reinterpret_cast<AggregateDataPtr>(arena.alloc(agg_fn->size_of_data()));
 
-                agg_fn->function()->deserialize_and_merge_vec_selected(
-                        places.data(), 0, place2, serialize_column.get(), arena, 1);
+                agg_fn->deserialize_and_merge_vec_selected(places.data(), 0, place2,
+                                                           serialize_column.get(), arena, 1);
 
                 check_result(place1);
             }

--- a/be/test/exprs/aggregate/agg_test.cpp
+++ b/be/test/exprs/aggregate/agg_test.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "core/column/column.h"
+#include "core/column/column_array.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
@@ -114,6 +115,119 @@ TEST(AggTest, topn_test) {
             "46,\"10\":37}";
     EXPECT_EQ(result, expect_result);
     agg_function->destroy(place);
+}
+
+TEST(AggTest, topn_insert_result_into_vec_test) {
+    Arena arena;
+    MutableColumns datas(2);
+    datas[0] = ColumnString::create();
+    datas[1] = ColumnInt32::create();
+
+    const std::vector<std::string> values = {"a", "a", "b", "c", "d", "d"};
+    int top = 2;
+    for (const auto& value : values) {
+        datas[0]->insert_data(value.c_str(), value.length());
+        datas[1]->insert_data(reinterpret_cast<const char*>(&top), sizeof(top));
+    }
+
+    AggregateFunctionSimpleFactory factory;
+    register_aggregate_function_topn(factory);
+    DataTypes data_types = {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>()};
+
+    auto agg_function = factory.get("topn", data_types, nullptr, false, -1);
+    ASSERT_NE(agg_function, nullptr);
+
+    std::vector<std::unique_ptr<char[]>> memory(2);
+    std::vector<AggregateDataPtr> places(2);
+    for (int i = 0; i < 2; ++i) {
+        memory[i].reset(new char[agg_function->size_of_data()]);
+        places[i] = memory[i].get();
+        agg_function->create(places[i]);
+    }
+
+    const IColumn* columns[2] = {datas[0].get(), datas[1].get()};
+    std::vector<AggregateDataPtr> row_places(values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+        row_places[i] = i < 3 ? places[0] : places[1];
+    }
+    agg_function->add_batch(values.size(), row_places.data(), 0, columns, arena, false);
+
+    auto result_column = ColumnString::create();
+    agg_function->insert_result_into_vec(places, 0, *result_column, places.size());
+
+    const auto& result_strings = *result_column;
+    ASSERT_EQ(result_strings.size(), 2);
+    EXPECT_EQ(result_strings.get_data_at(0).to_string(), "{\"a\":2,\"b\":1}");
+    EXPECT_EQ(result_strings.get_data_at(1).to_string(), "{\"d\":2,\"c\":1}");
+
+    for (auto place : places) {
+        agg_function->destroy(place);
+    }
+}
+
+TEST(AggTest, topn_array_insert_result_into_vec_test) {
+    Arena arena;
+    MutableColumns datas(2);
+    datas[0] = ColumnInt32::create();
+    datas[1] = ColumnInt32::create();
+
+    const std::vector<int32_t> values = {1, 1, 2, 3, 4, 4};
+    int top = 2;
+    for (int32_t value : values) {
+        datas[0]->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+        datas[1]->insert_data(reinterpret_cast<const char*>(&top), sizeof(top));
+    }
+
+    AggregateFunctionSimpleFactory factory;
+    register_aggregate_function_topn(factory);
+    DataTypes data_types = {std::make_shared<DataTypeInt32>(), std::make_shared<DataTypeInt32>()};
+
+    auto agg_function = factory.get("topn_array", data_types, nullptr, false, -1);
+    ASSERT_NE(agg_function, nullptr);
+
+    std::vector<std::unique_ptr<char[]>> memory(2);
+    std::vector<AggregateDataPtr> places(2);
+    for (int i = 0; i < 2; ++i) {
+        memory[i].reset(new char[agg_function->size_of_data()]);
+        places[i] = memory[i].get();
+        agg_function->create(places[i]);
+    }
+
+    const IColumn* columns[2] = {datas[0].get(), datas[1].get()};
+    std::vector<AggregateDataPtr> row_places(values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+        row_places[i] = i < 3 ? places[0] : places[1];
+    }
+    agg_function->add_batch(values.size(), row_places.data(), 0, columns, arena, false);
+
+    auto result_column = ColumnArray::create(
+            ColumnNullable::create(ColumnInt32::create(), ColumnUInt8::create()));
+    agg_function->insert_result_into_vec(places, 0, *result_column, places.size());
+
+    const auto& result_array = *result_column;
+    const auto& result_nullable = assert_cast<const ColumnNullable&>(result_array.get_data());
+    const auto& result_values =
+            assert_cast<const ColumnInt32&>(result_nullable.get_nested_column()).get_data();
+    const auto& result_null_map = result_nullable.get_null_map_data();
+
+    ASSERT_EQ(result_array.get_offsets().size(), 2);
+    EXPECT_EQ(result_array.get_offsets()[0], 2);
+    EXPECT_EQ(result_array.get_offsets()[1], 4);
+
+    ASSERT_EQ(result_values.size(), 4);
+    EXPECT_EQ(result_values[0], 1);
+    EXPECT_EQ(result_values[1], 2);
+    EXPECT_EQ(result_values[2], 4);
+    EXPECT_EQ(result_values[3], 3);
+
+    ASSERT_EQ(result_null_map.size(), 4);
+    for (auto is_null : result_null_map) {
+        EXPECT_EQ(is_null, 0);
+    }
+
+    for (auto place : places) {
+        agg_function->destroy(place);
+    }
 }
 
 TEST(AggTest, window_function_test) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:

Aggregate functions may contain release-disabled `assert_cast` calls in hot input/result paths. If a caller passes a column whose runtime type does not match the aggregate function signature, unchecked casts can crash the BE process. Putting checked casts inside every row-level `add` / `insert_result_into` implementation would protect the cast but would also add overhead to hot loops.

This PR hoists the validation to cold entry points instead:

- adds generic `IAggregateFunction::check_input_columns_type()` / `check_result_column_type()` hooks that validate columns against aggregate argument and return `DataType`s;
- calls those hooks from `AggFnEvaluator` before forwarding column-consuming add/result APIs;
- documents `insert_result_into` as a hot path whose result column must be validated by the caller;
- keeps aggregate `insert_result_into` implementations on unchecked `TypeCheckOnRelease::DISABLE` casts after boundary validation;
- converts remaining add-series aggregate input-column casts to unchecked `TypeCheckOnRelease::DISABLE` casts once they are covered by boundary input validation;
- adapts nullable and sorted aggregate wrappers so nullable nested columns and sort columns are also checked;
- validates direct array-aggregation helper input/result columns once before their inner loops;
- validates direct load/storage/schema-change aggregate paths when their aggregate functions are initialized;
- keeps the aggregate-state scalar serialization path covered by an input check before direct serialization.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `./run-be-ut.sh --run --filter=AggFnEvaluatorTest.*:AggTest.topn_insert_result_into_vec_test:AggTest.topn_array_insert_result_into_vec_test:VFunctionArrayAggregationTest.*`
    - `build-support/clang-format.sh`
    - `build-support/check-format.sh`
    - `git diff --check`
    - static scan: no `assert_cast` without `TypeCheckOnRelease::DISABLE` inside aggregate `insert_result_into` bodies
    - static scan: no remaining add-series aggregate input-column `assert_cast` without `TypeCheckOnRelease::DISABLE`
- Behavior changed: No
- Does this need documentation: No