### PR TITLE
[fix](binlog compaction): cumu policy may be null

### DIFF
--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -1209,7 +1209,8 @@ bool Tablet::suitable_for_compaction(
         CompactionType compaction_type,
         std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
 #ifndef BE_TEST
-    if (compaction_type == CompactionType::CUMULATIVE_COMPACTION &&
+    if ((compaction_type == CompactionType::CUMULATIVE_COMPACTION ||
+         compaction_type == CompactionType::BINLOG_COMPACTION) &&
         cumulative_compaction_policy != nullptr) {
         std::lock_guard wrlock(_meta_lock);
         if (_cumulative_compaction_policy == nullptr ||

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -814,11 +814,8 @@ std::vector<TabletCompactionContext> TabletManager::find_best_tablets_to_compact
                 return;
             }
         }
-        std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy;
-        if (compaction_type != CompactionType::BINLOG_COMPACTION) {
-            cumulative_compaction_policy = all_cumulative_compaction_policies.at(
-                    tablet_ptr->tablet_meta()->compaction_policy());
-        }
+        auto cumulative_compaction_policy = all_cumulative_compaction_policies.at(
+                tablet_ptr->tablet_meta()->compaction_policy());
         int8_t prefer_compaction_level = -1;
         uint32_t current_compaction_score =
                 tablet_ptr->calc_compaction_score(compaction_type, &prefer_compaction_level);


### PR DESCRIPTION
### What problem does this PR solve?

ensure cumu policy is not null if do binlog compaction first.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

