### PR TITLE
[fix](multi-catalog): fix OSS bucket endpoint path normalization in SPI FS

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/SpiSwitchingFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/SpiSwitchingFileSystem.java
@@ -85,10 +85,18 @@ public class SpiSwitchingFileSystem implements FileSystem {
         if (testDelegate != null) {
             return testDelegate;
         }
-        LocationPath lp = LocationPath.of(uri, storagePropertiesMap);
-        StorageProperties sp = lp.getStorageProperties();
+        LocationPath locationPath = LocationPath.of(uri, storagePropertiesMap);
+        return forLocationPath(locationPath, uri);
+    }
+
+    @VisibleForTesting
+    FileSystem forLocationPath(LocationPath locationPath, String originalUri) throws IOException {
+        if (testDelegate != null) {
+            return testDelegate;
+        }
+        StorageProperties sp = locationPath.getStorageProperties();
         if (sp == null) {
-            throw new IOException("No StorageProperties found for path: " + uri);
+            throw new IOException("No StorageProperties found for path: " + originalUri);
         }
         try {
             return cache.computeIfAbsent(sp, props -> {
@@ -114,84 +122,94 @@ public class SpiSwitchingFileSystem implements FileSystem {
 
     @Override
     public boolean exists(Location location) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        return forLocation(normalizedLocation).exists(normalizedLocation);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        return resolvedLocation.fileSystem.exists(resolvedLocation.location);
     }
 
     @Override
     public void mkdirs(Location location) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        forLocation(normalizedLocation).mkdirs(normalizedLocation);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        resolvedLocation.fileSystem.mkdirs(resolvedLocation.location);
     }
 
     @Override
     public void delete(Location location, boolean recursive) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        forLocation(normalizedLocation).delete(normalizedLocation, recursive);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        resolvedLocation.fileSystem.delete(resolvedLocation.location, recursive);
     }
 
     @Override
     public void rename(Location src, Location dst) throws IOException {
-        Location normalizedSrc = normalizeLocation(src);
+        ResolvedLocation resolvedSrc = resolveLocation(src);
         Location normalizedDst = normalizeLocation(dst);
-        forLocation(normalizedSrc).rename(normalizedSrc, normalizedDst);
+        resolvedSrc.fileSystem.rename(resolvedSrc.location, normalizedDst);
     }
 
     @Override
     public FileIterator list(Location location) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        return forLocation(normalizedLocation).list(normalizedLocation);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        return resolvedLocation.fileSystem.list(resolvedLocation.location);
     }
 
     @Override
     public List<FileEntry> listFiles(Location dir) throws IOException {
-        Location normalizedDir = normalizeLocation(dir);
-        return forLocation(normalizedDir).listFiles(normalizedDir);
+        ResolvedLocation resolvedDir = resolveLocation(dir);
+        return resolvedDir.fileSystem.listFiles(resolvedDir.location);
     }
 
     @Override
     public List<FileEntry> listFilesRecursive(Location dir) throws IOException {
-        Location normalizedDir = normalizeLocation(dir);
-        return forLocation(normalizedDir).listFilesRecursive(normalizedDir);
+        ResolvedLocation resolvedDir = resolveLocation(dir);
+        return resolvedDir.fileSystem.listFilesRecursive(resolvedDir.location);
     }
 
     @Override
     public Set<String> listDirectories(Location dir) throws IOException {
-        Location normalizedDir = normalizeLocation(dir);
-        return forLocation(normalizedDir).listDirectories(normalizedDir);
+        ResolvedLocation resolvedDir = resolveLocation(dir);
+        return resolvedDir.fileSystem.listDirectories(resolvedDir.location);
     }
 
     @Override
     public void renameDirectory(Location src, Location dst, Runnable whenSrcNotExists)
             throws IOException {
-        Location normalizedSrc = normalizeLocation(src);
+        ResolvedLocation resolvedSrc = resolveLocation(src);
         Location normalizedDst = normalizeLocation(dst);
-        forLocation(normalizedSrc).renameDirectory(normalizedSrc, normalizedDst, whenSrcNotExists);
+        resolvedSrc.fileSystem.renameDirectory(resolvedSrc.location, normalizedDst, whenSrcNotExists);
     }
 
     @Override
     public DorisInputFile newInputFile(Location location) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        return forLocation(normalizedLocation).newInputFile(normalizedLocation);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        return resolvedLocation.fileSystem.newInputFile(resolvedLocation.location);
     }
 
     @Override
     public DorisInputFile newInputFile(Location location, long length) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        return forLocation(normalizedLocation).newInputFile(normalizedLocation, length);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        return resolvedLocation.fileSystem.newInputFile(resolvedLocation.location, length);
     }
 
     @Override
     public DorisOutputFile newOutputFile(Location location) throws IOException {
-        Location normalizedLocation = normalizeLocation(location);
-        return forLocation(normalizedLocation).newOutputFile(normalizedLocation);
+        ResolvedLocation resolvedLocation = resolveLocation(location);
+        return resolvedLocation.fileSystem.newOutputFile(resolvedLocation.location);
     }
 
     @Override
     public GlobListing globListWithLimit(Location path, String startAfter, long maxBytes,
             long maxFiles) throws IOException {
-        Location normalizedPath = normalizeLocation(path);
-        return forLocation(normalizedPath).globListWithLimit(normalizedPath, startAfter, maxBytes, maxFiles);
+        ResolvedLocation resolvedPath = resolveLocation(path);
+        return resolvedPath.fileSystem.globListWithLimit(resolvedPath.location, startAfter, maxBytes, maxFiles);
+    }
+
+    private ResolvedLocation resolveLocation(Location location) throws IOException {
+        if (testDelegate != null) {
+            return new ResolvedLocation(location, testDelegate);
+        }
+        LocationPath locationPath = LocationPath.of(location.uri(), storagePropertiesMap);
+        return new ResolvedLocation(
+                Location.of(locationPath.getNormalizedLocation()),
+                forLocationPath(locationPath, location.uri()));
     }
 
     private Location normalizeLocation(Location location) {
@@ -223,6 +241,16 @@ public class SpiSwitchingFileSystem implements FileSystem {
         }
         if (firstError != null) {
             throw firstError;
+        }
+    }
+
+    private static class ResolvedLocation {
+        private final Location location;
+        private final FileSystem fileSystem;
+
+        private ResolvedLocation(Location location, FileSystem fileSystem) {
+            this.location = location;
+            this.fileSystem = fileSystem;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/SpiSwitchingFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/SpiSwitchingFileSystem.java
@@ -114,69 +114,91 @@ public class SpiSwitchingFileSystem implements FileSystem {
 
     @Override
     public boolean exists(Location location) throws IOException {
-        return forLocation(location).exists(location);
+        Location normalizedLocation = normalizeLocation(location);
+        return forLocation(normalizedLocation).exists(normalizedLocation);
     }
 
     @Override
     public void mkdirs(Location location) throws IOException {
-        forLocation(location).mkdirs(location);
+        Location normalizedLocation = normalizeLocation(location);
+        forLocation(normalizedLocation).mkdirs(normalizedLocation);
     }
 
     @Override
     public void delete(Location location, boolean recursive) throws IOException {
-        forLocation(location).delete(location, recursive);
+        Location normalizedLocation = normalizeLocation(location);
+        forLocation(normalizedLocation).delete(normalizedLocation, recursive);
     }
 
     @Override
     public void rename(Location src, Location dst) throws IOException {
-        forLocation(src).rename(src, dst);
+        Location normalizedSrc = normalizeLocation(src);
+        Location normalizedDst = normalizeLocation(dst);
+        forLocation(normalizedSrc).rename(normalizedSrc, normalizedDst);
     }
 
     @Override
     public FileIterator list(Location location) throws IOException {
-        return forLocation(location).list(location);
+        Location normalizedLocation = normalizeLocation(location);
+        return forLocation(normalizedLocation).list(normalizedLocation);
     }
 
     @Override
     public List<FileEntry> listFiles(Location dir) throws IOException {
-        return forLocation(dir).listFiles(dir);
+        Location normalizedDir = normalizeLocation(dir);
+        return forLocation(normalizedDir).listFiles(normalizedDir);
     }
 
     @Override
     public List<FileEntry> listFilesRecursive(Location dir) throws IOException {
-        return forLocation(dir).listFilesRecursive(dir);
+        Location normalizedDir = normalizeLocation(dir);
+        return forLocation(normalizedDir).listFilesRecursive(normalizedDir);
     }
 
     @Override
     public Set<String> listDirectories(Location dir) throws IOException {
-        return forLocation(dir).listDirectories(dir);
+        Location normalizedDir = normalizeLocation(dir);
+        return forLocation(normalizedDir).listDirectories(normalizedDir);
     }
 
     @Override
     public void renameDirectory(Location src, Location dst, Runnable whenSrcNotExists)
             throws IOException {
-        forLocation(src).renameDirectory(src, dst, whenSrcNotExists);
+        Location normalizedSrc = normalizeLocation(src);
+        Location normalizedDst = normalizeLocation(dst);
+        forLocation(normalizedSrc).renameDirectory(normalizedSrc, normalizedDst, whenSrcNotExists);
     }
 
     @Override
     public DorisInputFile newInputFile(Location location) throws IOException {
-        return forLocation(location).newInputFile(location);
+        Location normalizedLocation = normalizeLocation(location);
+        return forLocation(normalizedLocation).newInputFile(normalizedLocation);
     }
 
     @Override
     public DorisInputFile newInputFile(Location location, long length) throws IOException {
-        return forLocation(location).newInputFile(location, length);
+        Location normalizedLocation = normalizeLocation(location);
+        return forLocation(normalizedLocation).newInputFile(normalizedLocation, length);
     }
 
     @Override
     public DorisOutputFile newOutputFile(Location location) throws IOException {
-        return forLocation(location).newOutputFile(location);
+        Location normalizedLocation = normalizeLocation(location);
+        return forLocation(normalizedLocation).newOutputFile(normalizedLocation);
     }
 
     @Override
     public GlobListing globListWithLimit(Location path, String startAfter, long maxBytes,
             long maxFiles) throws IOException {
-        return forLocation(path).globListWithLimit(path, startAfter, maxBytes, maxFiles);
+        Location normalizedPath = normalizeLocation(path);
+        return forLocation(normalizedPath).globListWithLimit(normalizedPath, startAfter, maxBytes, maxFiles);
+    }
+
+    private Location normalizeLocation(Location location) {
+        if (testDelegate != null || storagePropertiesMap == null) {
+            return location;
+        }
+        return Location.of(LocationPath.of(location.uri(), storagePropertiesMap).getNormalizedLocation());
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/SpiSwitchingFileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/SpiSwitchingFileSystemTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.fs;
 
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
@@ -117,19 +118,39 @@ public class SpiSwitchingFileSystemTest {
         spiFs.delete(source, true);
         Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
         Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+        Assert.assertEquals(StorageProperties.Type.OSS, delegate.selectedStorageType);
 
         spiFs.listFiles(source);
         Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
         Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+        Assert.assertEquals(StorageProperties.Type.OSS, delegate.selectedStorageType);
 
         spiFs.rename(source, dest);
         Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
         Assert.assertEquals("s3://my-bucket/path/to/dest", delegate.destLocation.uri());
         Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+        Assert.assertEquals(StorageProperties.Type.OSS, delegate.selectedStorageType);
 
         spiFs.newOutputFile(dest);
         Assert.assertEquals("s3://my-bucket/path/to/dest", delegate.location.uri());
         Assert.assertEquals("s3://my-bucket/path/to/dest", delegate.selectedLocation);
+        Assert.assertEquals(StorageProperties.Type.OSS, delegate.selectedStorageType);
+    }
+
+    @Test
+    public void testOssBucketEndpointPathSelectsOssWhenS3IsAlsoConfigured()
+            throws IOException, UserException {
+        RecordingFileSystem delegate = new RecordingFileSystem();
+        SpiSwitchingFileSystem spiFs = new RecordingSwitchingFileSystem(
+                delegate, createOssAndS3StorageProperties());
+
+        Location source = Location.of("oss://my-bucket.oss-cn-beijing-internal.aliyuncs.com/path/to/source");
+
+        spiFs.delete(source, true);
+
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+        Assert.assertEquals(StorageProperties.Type.OSS, delegate.selectedStorageType);
     }
 
     // -----------------------------------------------------------------------
@@ -281,6 +302,26 @@ public class SpiSwitchingFileSystemTest {
         return storageProperties;
     }
 
+    private static Map<StorageProperties.Type, StorageProperties> createOssAndS3StorageProperties()
+            throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put(StorageProperties.FS_OSS_SUPPORT, "true");
+        origProps.put("oss.endpoint", "oss-cn-beijing-internal.aliyuncs.com");
+        origProps.put("oss.access_key", "oss-ak");
+        origProps.put("oss.secret_key", "oss-sk");
+        origProps.put(StorageProperties.FS_S3_SUPPORT, "true");
+        origProps.put("s3.endpoint", "s3.us-east-1.amazonaws.com");
+        origProps.put("s3.access_key", "s3-ak");
+        origProps.put("s3.secret_key", "s3-sk");
+        origProps.put("s3.region", "us-east-1");
+
+        Map<StorageProperties.Type, StorageProperties> storageProperties = new HashMap<>();
+        for (StorageProperties storageProperty : StorageProperties.createAll(origProps)) {
+            storageProperties.put(storageProperty.getType(), storageProperty);
+        }
+        return storageProperties;
+    }
+
     private static class RecordingSwitchingFileSystem extends SpiSwitchingFileSystem {
         private final RecordingFileSystem delegate;
 
@@ -291,14 +332,16 @@ public class SpiSwitchingFileSystemTest {
         }
 
         @Override
-        public FileSystem forPath(String uri) {
-            delegate.selectedLocation = uri;
+        FileSystem forLocationPath(LocationPath locationPath, String originalUri) {
+            delegate.selectedLocation = locationPath.getNormalizedLocation();
+            delegate.selectedStorageType = locationPath.getStorageProperties().getType();
             return delegate;
         }
     }
 
     private static class RecordingFileSystem extends StubFileSystem {
         private String selectedLocation;
+        private StorageProperties.Type selectedStorageType;
         private Location location;
         private Location destLocation;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/SpiSwitchingFileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/SpiSwitchingFileSystemTest.java
@@ -20,7 +20,9 @@ package org.apache.doris.fs;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.FileEntry;
 import org.apache.doris.filesystem.FileSystem;
+import org.apache.doris.filesystem.Location;
 
 import com.google.common.collect.Maps;
 import org.junit.Assert;
@@ -32,7 +34,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -100,6 +104,32 @@ public class SpiSwitchingFileSystemTest {
         SpiSwitchingFileSystem spiFs = new SpiSwitchingFileSystem(mockDelegate);
         FileSystem result = spiFs.forPath("s3://bucket/key");
         Assert.assertSame("Test-delegate constructor must return the injected delegate", mockDelegate, result);
+    }
+
+    @Test
+    public void testNormalizeOssBucketEndpointPathBeforeDelegating() throws IOException {
+        RecordingFileSystem delegate = new RecordingFileSystem();
+        SpiSwitchingFileSystem spiFs = new RecordingSwitchingFileSystem(delegate, createOssStorageProperties());
+
+        Location source = Location.of("oss://my-bucket.oss-cn-beijing-internal.aliyuncs.com/path/to/source");
+        Location dest = Location.of("oss://my-bucket.oss-cn-beijing-internal.aliyuncs.com/path/to/dest");
+
+        spiFs.delete(source, true);
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+
+        spiFs.listFiles(source);
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+
+        spiFs.rename(source, dest);
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.location.uri());
+        Assert.assertEquals("s3://my-bucket/path/to/dest", delegate.destLocation.uri());
+        Assert.assertEquals("s3://my-bucket/path/to/source", delegate.selectedLocation);
+
+        spiFs.newOutputFile(dest);
+        Assert.assertEquals("s3://my-bucket/path/to/dest", delegate.location.uri());
+        Assert.assertEquals("s3://my-bucket/path/to/dest", delegate.selectedLocation);
     }
 
     // -----------------------------------------------------------------------
@@ -239,6 +269,63 @@ public class SpiSwitchingFileSystemTest {
         cache.put(key, value);
     }
 
+    private static Map<StorageProperties.Type, StorageProperties> createOssStorageProperties() {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "oss-cn-beijing-internal.aliyuncs.com");
+        origProps.put("oss.access_key", "ak");
+        origProps.put("oss.secret_key", "sk");
+        origProps.put(StorageProperties.FS_OSS_SUPPORT, "true");
+
+        Map<StorageProperties.Type, StorageProperties> storageProperties = new HashMap<>();
+        storageProperties.put(StorageProperties.Type.OSS, StorageProperties.createPrimary(origProps));
+        return storageProperties;
+    }
+
+    private static class RecordingSwitchingFileSystem extends SpiSwitchingFileSystem {
+        private final RecordingFileSystem delegate;
+
+        RecordingSwitchingFileSystem(RecordingFileSystem delegate,
+                Map<StorageProperties.Type, StorageProperties> storagePropertiesMap) {
+            super(storagePropertiesMap);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public FileSystem forPath(String uri) {
+            delegate.selectedLocation = uri;
+            return delegate;
+        }
+    }
+
+    private static class RecordingFileSystem extends StubFileSystem {
+        private String selectedLocation;
+        private Location location;
+        private Location destLocation;
+
+        @Override
+        public void delete(Location location, boolean recursive) throws IOException {
+            this.location = location;
+        }
+
+        @Override
+        public void rename(Location src, Location dst) throws IOException {
+            this.location = src;
+            this.destLocation = dst;
+        }
+
+        @Override
+        public List<FileEntry> listFiles(Location dir) throws IOException {
+            this.location = dir;
+            return Collections.emptyList();
+        }
+
+        @Override
+        public org.apache.doris.filesystem.DorisOutputFile newOutputFile(Location location) throws IOException {
+            this.location = location;
+            return null;
+        }
+    }
+
     /**
      * Minimal no-op stub that satisfies the {@link FileSystem} interface.
      * All methods throw {@link UnsupportedOperationException} except close(), which is a no-op.
@@ -271,6 +358,11 @@ public class SpiSwitchingFileSystemTest {
         @Override
         public org.apache.doris.filesystem.FileIterator list(
                 org.apache.doris.filesystem.Location location) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> listDirectories(org.apache.doris.filesystem.Location dir) throws IOException {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## Summary
- Normalize `Location` values inside `SpiSwitchingFileSystem` before delegating operations to the resolved SPI filesystem.
- Normalize both source and destination locations for rename-style operations.
- Extend `SpiSwitchingFileSystemTest` to cover OSS bucket endpoint paths such as `oss://bucket.endpoint/path`.

## Root Cause
On master, the legacy `SwitchingFileSystem` has been replaced by `SpiSwitchingFileSystem`. The SPI wrapper used `LocationPath` to choose the underlying filesystem, but still passed the original `Location` to the delegate. For OSS bucket-domain-name paths, the lower object-storage parser treats the URI authority as the bucket, so `oss://bucket.oss-cn-.../path` can be interpreted as bucket `bucket.oss-cn-...` instead of `bucket`.

## Impact
This keeps filesystem selection and delegated operation paths consistent. It protects Hive overwrite/cleanup/list/delete/rename flows when HMS stores OSS bucket endpoint locations.

## Validation
- `./run-fe-ut.sh --run org.apache.doris.fs.SpiSwitchingFileSystemTest`
