### PR TITLE
[fix](remote-doris) Fix metadata read timeout unit

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/doris/RemoteDorisExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/doris/RemoteDorisExternalCatalog.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class RemoteDorisExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(RemoteDorisExternalCatalog.class);
@@ -188,7 +189,7 @@ public class RemoteDorisExternalCatalog extends ExternalCatalog {
                 + " please check your Doris cluster or your Doris catalog configuration.");
         }
         client = new FeServiceClient(name, getFeThriftNodes(), getUsername(), getPassword(),
-                getMetadataSyncRetryCount(), getMetadataReadTimeoutSec());
+                getMetadataSyncRetryCount(), (int) TimeUnit.SECONDS.toMillis(getMetadataReadTimeoutSec()));
     }
 
     protected List<String> listDatabaseNames() {


### PR DESCRIPTION
### What problem does this PR solve?

The remote Doris catalog property `metadata_read_timeout_sec` is configured in seconds, but the value is passed directly to `ClientPool.frontendPool.borrowObject`, whose timeout parameter is in milliseconds. As a result, the default 10 second timeout becomes 10 milliseconds and remote metadata calls can fail with `SocketTimeoutException: Read timed out` under load.

### What is changed and how does it work?

Convert `metadata_read_timeout_sec` from seconds to milliseconds before creating `FeServiceClient`.

### Check List

- [ ] Tests

### Test Plan

Not run, per request.