### PR TITLE
[fix](connection) Prevent timeout checker from stopping after an exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectPoolMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectPoolMgr.java
@@ -53,7 +53,12 @@ public class ConnectPoolMgr {
 
     public void timeoutChecker(long now) {
         for (ConnectContext connectContext : connectionMap.values()) {
-            connectContext.checkTimeout(now);
+            try {
+                connectContext.checkTimeout(now);
+            } catch (Throwable t) {
+                LOG.warn("failed to check timeout for connection, connectionId: {}, user: {}",
+                        connectContext.getConnectionId(), connectContext.getQualifiedUser(), t);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -160,9 +160,13 @@ public class ConnectScheduler {
     private class TimeoutChecker extends TimerTask {
         @Override
         public void run() {
-            long now = System.currentTimeMillis();
-            connectPoolMgr.timeoutChecker(now);
-            flightSqlConnectPoolMgr.timeoutChecker(now);
+            try {
+                long now = System.currentTimeMillis();
+                connectPoolMgr.timeoutChecker(now);
+                flightSqlConnectPoolMgr.timeoutChecker(now);
+            } catch (Throwable t) {
+                LOG.warn("failed to check connection timeout", t);
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.channels.SocketChannel;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ConnectSchedulerTest {
@@ -97,5 +98,40 @@ public class ConnectSchedulerTest {
         ConnectScheduler scheduler = new ConnectScheduler(0);
         ConnectContext context = new ConnectContext();
         Assert.assertTrue(scheduler.submit(context));
+    }
+
+    @Test
+    public void testTimeoutCheckerContinuesAfterContextException() {
+        ConnectPoolMgr connectPoolMgr = new ConnectPoolMgr(10);
+        ThrowingConnectContext throwingContext = new ThrowingConnectContext();
+        CountingConnectContext countingContext = new CountingConnectContext();
+        throwingContext.setConnectionId(1);
+        countingContext.setConnectionId(2);
+        connectPoolMgr.getConnectionMap().put(throwingContext.getConnectionId(), throwingContext);
+        connectPoolMgr.getConnectionMap().put(countingContext.getConnectionId(), countingContext);
+
+        connectPoolMgr.timeoutChecker(System.currentTimeMillis());
+
+        Assert.assertEquals(1, throwingContext.checkCount.get());
+        Assert.assertEquals(1, countingContext.checkCount.get());
+    }
+
+    private static class ThrowingConnectContext extends ConnectContext {
+        private final AtomicInteger checkCount = new AtomicInteger(0);
+
+        @Override
+        public void checkTimeout(long now) {
+            checkCount.incrementAndGet();
+            throw new RuntimeException("mock check timeout exception");
+        }
+    }
+
+    private static class CountingConnectContext extends ConnectContext {
+        private final AtomicInteger checkCount = new AtomicInteger(0);
+
+        @Override
+        public void checkTimeout(long now) {
+            checkCount.incrementAndGet();
+        }
     }
 }


### PR DESCRIPTION


### What problem does this PR solve?

Problem Summary:

The connection timeout checker is scheduled with `scheduleAtFixedRate`. If an unchecked exception escapes from the task, `ScheduledThreadPoolExecutor` suppresses all subsequent executions. As a result, expired connections may no longer be cleaned up.

This PR:

- Isolates exceptions from each `ConnectContext`, so one broken connection does not prevent other connections from being checked.
- Adds an outer exception boundary to keep the periodic timeout checker alive.
- Logs the stack trace together with the connection ID and user for diagnosis.
- Adds a unit test verifying that timeout checking continues after one context throws an exception.

This applies to both MySQL and Arrow Flight SQL connection pools.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

