### PR TITLE
[fix](regression) stabilize multi leading scalar predicate

### DIFF
--- a/regression-test/data/query_p0/hint/multi_leading.out
+++ b/regression-test/data/query_p0/hint/multi_leading.out
@@ -302,7 +302,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----PhysicalOlapScan[t1]
 --PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
-------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > 0.05 * avg(t1.c11))
+------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > avg(t1.c11) / 20.0)
 --------hashAgg[GLOBAL]
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------PhysicalCteConsumer ( cteId=CTEId#0 )

--- a/regression-test/suites/query_p0/hint/multi_leading.groovy
+++ b/regression-test/suites/query_p0/hint/multi_leading.groovy
@@ -138,5 +138,5 @@ suite("multi_leading") {
     qt_sql4_res_7 """select /*+ leading(t3 alias1) */ count(*) from (select /*+ leading(alias2 t1) */ c1, c11 from t1 join (select /*+ leading(t4 t2) */ c2, c22 from t2 join t4 on c2 = c4) as alias2 on c1 = alias2.c2) as alias1 join t3 on alias1.c1 = t3.c3;"""
 
     // // use cte in scalar query
-    qt_sql5_2 """explain shape plan with  cte as (select c11, c1 from t1)  SELECT c1 FROM cte group by c1 having sum(cte.c11) > (select /*+ leading(cte t1) */ 0.05 * avg(t1.c11) from t1 join cte on t1.c1 = cte.c11 )"""
+    qt_sql5_2 """explain shape plan with  cte as (select c11, c1 from t1)  SELECT c1 FROM cte group by c1 having sum(cte.c11) > (select /*+ leading(cte t1) */ avg(t1.c11) / 20.0 from t1 join cte on t1.c1 = cte.c11 )"""
 }


### PR DESCRIPTION
## Summary

- avoid commutative multiplication rendering drift in `multi_leading` scalar subquery shape output
- rewrite the scalar predicate from `0.05 * avg(t1.c11)` to `avg(t1.c11) / 20.0`
- update the expected shape text for `sql5_2`

## Testing

- [x] `git diff --cached --check`
- [ ] not run locally: requires an available Doris regression environment
