### PR TITLE
[fix](regression) Stabilize rowsets timestamp filters

### DIFF
--- a/regression-test/suites/query_p0/system/test_query_sys_rowsets.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_rowsets.groovy
@@ -28,6 +28,11 @@ suite("test_query_sys_rowsets", "query,p0") {
     def rowsets_table_name = """ test_query_sys_rowsets.test_query_rowset """  
     sql """ drop table if exists ${rowsets_table_name}  """ 
 
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    // Use a lower bound before table creation to keep the timestamp filter stable
+    // across second-level boundary races.
+    def rowsetFilterStartTime = sdf.format(new Date(System.currentTimeMillis() - 60000L)).toString();
+
     sql """ 
         create table ${rowsets_table_name}( 
             a int , 
@@ -39,9 +44,6 @@ suite("test_query_sys_rowsets", "query,p0") {
             "disable_auto_compaction" = "true"
         );
     """
-
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    def now = sdf.format(new Date()).toString();
     
     List<List<Object>> rowsets_table_name_tablets   = sql """ show tablets from ${rowsets_table_name} """
     order_qt_rowsets1 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """ 
@@ -51,5 +53,5 @@ suite("test_query_sys_rowsets", "query,p0") {
     sql """ insert into  ${rowsets_table_name} values (3,0,"dssadasdsafafdf");  """ 
     order_qt_rowsets3 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """ 
     sql """ insert into  ${rowsets_table_name} values (4,0,"abcd");  """ 
-    order_qt_rowsets4 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]} and NEWEST_WRITE_TIMESTAMP>='${now}' group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """ 
+    order_qt_rowsets4 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]} and NEWEST_WRITE_TIMESTAMP>='${rowsetFilterStartTime}' group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """
 }

--- a/regression-test/suites/query_p0/system/test_query_sys_scan_rowsets.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_scan_rowsets.groovy
@@ -47,7 +47,10 @@ suite("test_query_sys_scan_rowsets", "query,p0") {
     """
 
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    def now = sdf.format(new Date()).toString();
+    // Keep the timestamp filter after the create-table rowset's second-level
+    // timestamp so rowsets4 consistently excludes version 0-1.
+    Thread.sleep(1100L)
+    def rowsetFilterStartTime = sdf.format(new Date()).toString();
     
     def rowsets_table_name_tablets = sql_return_maparray """ show tablets from ${rowsets_table_name}; """
     def tablet_id = rowsets_table_name_tablets[0].TabletId
@@ -66,5 +69,5 @@ suite("test_query_sys_scan_rowsets", "query,p0") {
     
     sql """ insert into  ${rowsets_table_name} values (4,0,"abcd");  """
     sql """ select * from ${rowsets_table_name};  """
-    order_qt_rowsets4 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${tablet_id} and NEWEST_WRITE_TIMESTAMP>='${now}' group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """ 
+    order_qt_rowsets4 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${tablet_id} and NEWEST_WRITE_TIMESTAMP>='${rowsetFilterStartTime}' group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary: The system rowsets regressions used second-level current timestamps as lower bounds for `NEWEST_WRITE_TIMESTAMP`. In one test, the timestamp was captured after the table was created and could filter out the initial rowset on a boundary race. In the cloud-only scan variant, the timestamp could be equal to the create-table rowset timestamp and unexpectedly include version `0-1`. Capture stable lower bounds on the intended side of table creation for each case, so the tests still exercise timestamp filters while avoiding second-level boundary races.

### Release note

None

### Check List (For Author)

- Test:
    - Regression test: `./run-regression-test.sh --run -d query_p0/system -s test_query_sys_rowsets`
    - Regression test: `./run-regression-test.sh --run -d query_p0/system -s test_query_sys_rowsets` (200 consecutive runs)
    - Regression test: `./run-regression-test.sh --run -d query_p0/system -s test_query_sys_scan_rowsets` (local non-cloud guard path)
    - Regression test: `./run-regression-test.sh --run -d query_p0/system -s test_query_sys_rowsets`
- Behavior changed: No
- Does this need documentation: No
