### PR TITLE
branch-4.0: [fix](fe) Handle generated columns in delete partial update

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -159,6 +159,7 @@ public class BindSink implements AnalysisRuleFactory {
         Database database = pair.first;
         OlapTable table = pair.second;
         boolean isPartialUpdate = sink.isPartialUpdate() && table.getKeysType() == KeysType.UNIQUE_KEYS;
+        boolean isDeletePartialUpdate = isPartialUpdate && sink.getDMLCommandType() == DMLCommandType.DELETE;
         TPartialUpdateNewRowPolicy partialUpdateNewKeyPolicy = sink.getPartialUpdateNewRowPolicy();
 
         LogicalPlan child = ((LogicalPlan) sink.child());
@@ -170,7 +171,7 @@ public class BindSink implements AnalysisRuleFactory {
         // 1. bind target columns: from sink's column names to target tables' Columns
         Pair<List<Column>, Integer> bindColumnsResult =
                 bindTargetColumns(table, sink.getColNames(), childHasSeqCol, needExtraSeqCol,
-                        sink.getDMLCommandType() == DMLCommandType.GROUP_COMMIT);
+                        sink.getDMLCommandType() == DMLCommandType.GROUP_COMMIT, isDeletePartialUpdate);
         List<Column> bindColumns = bindColumnsResult.first;
         int extraColumnsNum = bindColumnsResult.second;
 
@@ -255,7 +256,7 @@ public class BindSink implements AnalysisRuleFactory {
         }
 
         Map<String, NamedExpression> columnToOutput = getColumnToOutput(
-                ctx, table, isPartialUpdate, boundSink, child);
+                ctx, table, isPartialUpdate, isDeletePartialUpdate, boundSink, child);
         LogicalProject<?> fullOutputProject = getOutputProjectByCoercion(
                 table.getFullSchema(), child, columnToOutput);
         List<Column> columns = new ArrayList<>(table.getFullSchema().size());
@@ -347,7 +348,8 @@ public class BindSink implements AnalysisRuleFactory {
 
     private static Map<String, NamedExpression> getColumnToOutput(
             MatchingContext<? extends UnboundLogicalSink<Plan>> ctx,
-            TableIf table, boolean isPartialUpdate, LogicalTableSink<?> boundSink, LogicalPlan child) {
+            TableIf table, boolean isPartialUpdate, boolean isDeletePartialUpdate,
+            LogicalTableSink<?> boundSink, LogicalPlan child) {
         // we need to insert all the columns of the target table
         // although some columns are not mentions.
         // so we add a projects to supply the default value.
@@ -470,6 +472,18 @@ public class BindSink implements AnalysisRuleFactory {
         // if processed in upper for loop, will lead to not found slot error
         // It's the same reason for moving the processing of materialized columns down.
         for (Column column : generatedColumns) {
+            if (isDeletePartialUpdate) {
+                NamedExpression childOutput = columnToChildOutput.get(column);
+                if (childOutput == null) {
+                    continue;
+                }
+                Alias output = new Alias(TypeCoercionUtils.castIfNotSameType(
+                        childOutput, DataType.fromCatalogType(column.getType())), column.getName());
+                columnToOutput.put(column.getName(), output);
+                columnToReplaced.put(column.getName(), output.toSlot());
+                replaceMap.put(output.toSlot(), output.child());
+                continue;
+            }
             Map<String, String> currentSessionVars =
                     ctx.connectContext.getSessionVariable().getAffectQueryResultInPlanVariables();
             try (AutoCloseSessionVariable autoClose = new AutoCloseSessionVariable(ctx.connectContext,
@@ -594,7 +608,7 @@ public class BindSink implements AnalysisRuleFactory {
         if (boundSink.getCols().size() != child.getOutput().size()) {
             throw new AnalysisException("insert into cols should be corresponding to the query output");
         }
-        Map<String, NamedExpression> columnToOutput = getColumnToOutput(ctx, table, false,
+        Map<String, NamedExpression> columnToOutput = getColumnToOutput(ctx, table, false, false,
                 boundSink, child);
         LogicalProject<?> fullOutputProject = getOutputProjectByCoercion(table.getFullSchema(), child, columnToOutput);
         return boundSink.withChildAndUpdateOutput(fullOutputProject);
@@ -635,7 +649,7 @@ public class BindSink implements AnalysisRuleFactory {
         if (boundSink.getCols().size() != child.getOutput().size()) {
             throw new AnalysisException("insert into cols should be corresponding to the query output");
         }
-        Map<String, NamedExpression> columnToOutput = getColumnToOutput(ctx, table, false,
+        Map<String, NamedExpression> columnToOutput = getColumnToOutput(ctx, table, false, false,
                 boundSink, child);
         LogicalProject<?> fullOutputProject = getOutputProjectByCoercion(table.getFullSchema(), child, columnToOutput);
         return boundSink.withChildAndUpdateOutput(fullOutputProject);
@@ -843,7 +857,7 @@ public class BindSink implements AnalysisRuleFactory {
 
     // bindTargetColumns means bind sink node's target columns' names to target table's columns
     private Pair<List<Column>, Integer> bindTargetColumns(OlapTable table, List<String> colsName,
-            boolean childHasSeqCol, boolean needExtraSeqCol, boolean isGroupCommit) {
+            boolean childHasSeqCol, boolean needExtraSeqCol, boolean isGroupCommit, boolean isDeletePartialUpdate) {
         // if the table set sequence column in stream load phase, the sequence map column is null, we query it.
         if (colsName.isEmpty()) {
             // ATTN: group commit without column list should return all base index column
@@ -861,7 +875,7 @@ public class BindSink implements AnalysisRuleFactory {
                         ++extraColumnsNum;
                         processedColsName.add(col.getName());
                     }
-                } else if (col.isGeneratedColumn()) {
+                } else if (col.isGeneratedColumn() && !isDeletePartialUpdate) {
                     ++extraColumnsNum;
                     processedColsName.add(col.getName());
                 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/DeleteFromUsingCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/DeleteFromUsingCommandTest.java
@@ -68,6 +68,60 @@ public class DeleteFromUsingCommandTest extends TestWithFeService implements Pla
                 + "properties(\n"
                 + "    \"replication_num\"=\"1\"\n"
                 + ")");
+        createTable("create table gen_value (\n"
+                + "    a int,\n"
+                + "    b int,\n"
+                + "    c int as (b + 1),\n"
+                + "    d int\n"
+                + ")\n"
+                + "unique key(a)\n"
+                + "distributed by hash(a) buckets 4\n"
+                + "properties(\n"
+                + "    \"replication_num\"=\"1\",\n"
+                + "    \"enable_unique_key_merge_on_write\" = \"true\",\n"
+                + "    \"enable_mow_light_delete\" = \"false\"\n"
+                + ")");
+        createTable("create table gen_key (\n"
+                + "    a int,\n"
+                + "    c int as (b + 1),\n"
+                + "    b int,\n"
+                + "    d int\n"
+                + ")\n"
+                + "unique key(a, c)\n"
+                + "distributed by hash(a) buckets 4\n"
+                + "properties(\n"
+                + "    \"replication_num\"=\"1\",\n"
+                + "    \"enable_unique_key_merge_on_write\" = \"true\",\n"
+                + "    \"enable_mow_light_delete\" = \"false\"\n"
+                + ")");
+        createTable("create table gen_value_required (\n"
+                + "    a int,\n"
+                + "    b int,\n"
+                + "    c int as (b + 1),\n"
+                + "    d int not null\n"
+                + ")\n"
+                + "unique key(a)\n"
+                + "distributed by hash(a) buckets 4\n"
+                + "properties(\n"
+                + "    \"replication_num\"=\"1\",\n"
+                + "    \"enable_unique_key_merge_on_write\" = \"true\",\n"
+                + "    \"enable_mow_light_delete\" = \"false\"\n"
+                + ")");
+        createTable("create table gen_variant (\n"
+                + "    id int not null,\n"
+                + "    create_time datetime not null,\n"
+                + "    order_no varchar(128) not null,\n"
+                + "    receive_address_detail varchar(1024) not null default \"{}\",\n"
+                + "    d int not null,\n"
+                + "    new_col variant as (receive_address_detail) null\n"
+                + ")\n"
+                + "unique key(id, create_time, order_no)\n"
+                + "distributed by hash(order_no) buckets 4\n"
+                + "properties(\n"
+                + "    \"replication_num\"=\"1\",\n"
+                + "    \"enable_unique_key_merge_on_write\" = \"true\",\n"
+                + "    \"enable_mow_light_delete\" = \"false\"\n"
+                + ")");
     }
 
     @Test
@@ -103,6 +157,41 @@ public class DeleteFromUsingCommandTest extends TestWithFeService implements Pla
                                                 )
                                         )
                                 )
+                        )
+                );
+    }
+
+    @Test
+    public void testDeletePartialUpdateWithGeneratedValueColumn() {
+        assertDeletePartialUpdateAnalyze("delete from gen_value t using src where t.a = src.k1");
+    }
+
+    @Test
+    public void testDeletePartialUpdateWithGeneratedKeyColumn() {
+        assertDeletePartialUpdateAnalyze("delete from gen_key t using src where t.a = src.k1");
+    }
+
+    @Test
+    public void testDeletePartialUpdateWithNotNullValueColumn() {
+        assertDeletePartialUpdateAnalyze("delete from gen_value_required t using src where t.a = src.k1");
+    }
+
+    @Test
+    public void testDeletePartialUpdateWithVariantGeneratedColumn() {
+        assertDeletePartialUpdateAnalyze("delete from gen_variant t using src where t.id = src.k1");
+    }
+
+    private void assertDeletePartialUpdateAnalyze(String sql) {
+        LogicalPlan parsed = new NereidsParser().parseSingle(sql);
+        Assertions.assertInstanceOf(DeleteFromUsingCommand.class, parsed);
+        DeleteFromUsingCommand command = ((DeleteFromUsingCommand) parsed);
+        LogicalPlan plan = command.completeQueryPlan(connectContext, command.getLogicalQuery());
+        PlanChecker.from(connectContext, plan)
+                .analyze(plan)
+                .rewrite()
+                .matches(
+                        logicalOlapTableSink(
+                                logicalProject()
                         )
                 );
     }

--- a/regression-test/data/ddl_p0/test_create_table_generated_column/test_delete_generated_column.out
+++ b/regression-test/data/ddl_p0/test_create_table_generated_column/test_delete_generated_column.out
@@ -27,3 +27,15 @@
 1	2	3
 10	2	12
 
+-- !delete_mow_without_light_delete_generated_column --
+2	20	21	200
+
+-- !delete_mow_without_light_delete_generated_key_column --
+2	21	20	200
+
+-- !delete_mow_without_light_delete_generated_column_with_not_null_value --
+2	20	21	200
+
+-- !delete_mow_without_light_delete_variant_generated_column --
+2	2026-06-08T11:00	order-2	{"city":"bj"}	200
+

--- a/regression-test/suites/ddl_p0/test_create_table_generated_column/test_delete_generated_column.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_generated_column/test_delete_generated_column.groovy
@@ -70,5 +70,101 @@ suite("test_generated_column_delete") {
     ) delete from test_par_gen_col_unique t1 using cte where t1.c=cte.c and t1.b=cte.b"""
     qt_delete_query_cte_select "select * from test_par_gen_col_unique order by a,b,c"
 
+    multi_sql """
+        drop table if exists test_gen_col_mow_delete_partial_update;
+        create table test_gen_col_mow_delete_partial_update (
+            a int,
+            b int,
+            c int as (b + 1),
+            d int
+        )
+        unique key(a)
+        distributed by hash(a) buckets 1
+        properties (
+            "enable_unique_key_merge_on_write" = "true",
+            "enable_mow_light_delete" = "false",
+            "replication_num" = "1"
+        );
+        insert into test_gen_col_mow_delete_partial_update(a, b, d) values (1, 10, 100), (2, 20, 200);
+    """
+    sql "delete from test_gen_col_mow_delete_partial_update where a = 1;"
+    qt_delete_mow_without_light_delete_generated_column """
+        select * from test_gen_col_mow_delete_partial_update order by a;
+    """
+
+    multi_sql """
+        drop table if exists test_gen_key_mow_delete_partial_update;
+        create table test_gen_key_mow_delete_partial_update (
+            a int,
+            c int as (b + 1),
+            b int,
+            d int
+        )
+        unique key(a, c)
+        distributed by hash(a) buckets 1
+        properties (
+            "enable_unique_key_merge_on_write" = "true",
+            "enable_mow_light_delete" = "false",
+            "replication_num" = "1"
+        );
+        insert into test_gen_key_mow_delete_partial_update(a, b, d) values (1, 10, 100), (2, 20, 200);
+    """
+    sql "delete from test_gen_key_mow_delete_partial_update where a = 1;"
+    qt_delete_mow_without_light_delete_generated_key_column """
+        select * from test_gen_key_mow_delete_partial_update order by a;
+    """
+
+    multi_sql """
+        drop table if exists test_gen_col_mow_delete_partial_update_not_null_value;
+        create table test_gen_col_mow_delete_partial_update_not_null_value (
+            a int,
+            b int,
+            c int as (b + 1),
+            d int not null
+        )
+        unique key(a)
+        distributed by hash(a) buckets 1
+        properties (
+            "enable_unique_key_merge_on_write" = "true",
+            "enable_mow_light_delete" = "false",
+            "replication_num" = "1"
+        );
+        insert into test_gen_col_mow_delete_partial_update_not_null_value(a, b, d)
+            values (1, 10, 100), (2, 20, 200);
+    """
+    sql "delete from test_gen_col_mow_delete_partial_update_not_null_value where a = 1;"
+    qt_delete_mow_without_light_delete_generated_column_with_not_null_value """
+        select * from test_gen_col_mow_delete_partial_update_not_null_value order by a;
+    """
+
+    multi_sql """
+        drop table if exists test_gen_variant_mow_delete_partial_update;
+        create table test_gen_variant_mow_delete_partial_update (
+            id int not null,
+            create_time datetime not null,
+            order_no varchar(128) not null,
+            receive_address_detail varchar(1024) not null default "{}",
+            d int not null,
+            new_col variant as (receive_address_detail) null
+        )
+        unique key(id, create_time, order_no)
+        distributed by hash(order_no) buckets 1
+        properties (
+            "enable_unique_key_merge_on_write" = "true",
+            "enable_mow_light_delete" = "false",
+            "replication_num" = "1"
+        );
+        insert into test_gen_variant_mow_delete_partial_update(
+            id, create_time, order_no, receive_address_detail, d
+        ) values
+            (1, '2026-06-08 10:00:00', 'order-1', '{"city":"sh"}', 100),
+            (2, '2026-06-08 11:00:00', 'order-2', '{"city":"bj"}', 200);
+    """
+    sql "delete from test_gen_variant_mow_delete_partial_update where id = 1;"
+    qt_delete_mow_without_light_delete_variant_generated_column """
+        select id, create_time, order_no, receive_address_detail, d
+        from test_gen_variant_mow_delete_partial_update order by id;
+    """
+
 
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #64884

Problem Summary:

This PR backports #64884 to branch-4.0.

For DELETE on unique merge-on-write tables with generated columns and
`enable_mow_light_delete=false`, Doris rewrites DELETE into a partial update.
Before the fix, `BindSink` still treated generated columns as target columns to
bind and recompute. If the generated-column expression referenced ordinary
columns that were not part of the DELETE partial-update output, analysis could
fail before the DELETE was planned.

This change detects the DELETE partial-update path in `BindSink`, avoids
auto-adding omitted generated columns for that path, and keeps existing
generated-column handling for normal INSERT/UPDATE partial updates.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Regression test:

```
./run-regression-test.sh --run -d regression-test/suites/ddl_p0/test_create_table_generated_column -s test_generated_column_delete
./run-regression-test.sh --run -d regression-test/suites/ddl_p0/test_create_table_generated_column -s test_partial_update_generated_column
```

Unit test:

```
./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.DeleteFromUsingCommandTest
```

Manual test:

```
git diff --check HEAD~1 HEAD
./build.sh --fe -j100
./build.sh --be -j100
```

The local regression cluster was restarted after rebuilding BE. FE and BE both
reported version `doris-4.0.6-rc02-a9d12207ae5` before running regression.

- Behavior changed:
    - [ ] No.
    - [x] Yes. DELETE partial updates on unique MOW tables no longer try to recompute omitted generated columns.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
