### PR TITLE
[Enhancement](FE) Centralize internal FE HTTPS handling

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1468,7 +1468,7 @@ public class Env {
                 try {
                     String url = "http://" + NetUtils
                             .getHostPortInAccessibleFormat(rightHelperNode.getHost(), Config.http_port) + "/check";
-                    HttpURLConnection conn = HttpURLUtil.getConnectionWithNodeIdent(url);
+                    HttpURLConnection conn = HttpURLUtil.getInternalConnectionWithNodeIdent(url);
                     conn.setConnectTimeout(2 * 1000);
                     conn.setReadTimeout(2 * 1000);
                     String clusterIdString = conn.getHeaderField(MetaBaseAction.CLUSTER_ID);
@@ -1566,7 +1566,7 @@ public class Env {
                 String url = "http://" + NetUtils.getHostPortInAccessibleFormat(helperNode.getHost(), Config.http_port)
                         + "/role?host=" + selfNode.getHost()
                         + "&port=" + selfNode.getPort();
-                HttpURLConnection conn = HttpURLUtil.getConnectionWithNodeIdent(url);
+                HttpURLConnection conn = HttpURLUtil.getInternalConnectionWithNodeIdent(url);
                 if (conn.getResponseCode() != 200) {
                     LOG.warn("failed to get fe node type from helper node: {}. response code: {}", helperNode,
                             conn.getResponseCode());

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -19,27 +19,59 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.security.SecurityChecker;
+import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.collect.Maps;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
 
 public class HttpURLUtil {
 
     public static HttpURLConnection getConnectionWithNodeIdent(String request) throws IOException {
+        return getConnectionWithNodeIdent(request, false);
+    }
+
+    public static HttpURLConnection getInternalConnectionWithNodeIdent(String request) throws IOException {
+        return getConnectionWithNodeIdent(request, true);
+    }
+
+    private static HttpURLConnection getConnectionWithNodeIdent(String request, boolean internal) throws IOException {
+        HttpURLConnection conn = getConnection(request, internal);
+        // Must use Env.getServingEnv() instead of getCurrentEnv(),
+        // because here we need to obtain selfNode through the official service catalog.
+        HostInfo selfNode = Env.getServingEnv().getSelfNode();
+        conn.setRequestProperty(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
+        conn.setRequestProperty(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
+        return conn;
+    }
+
+    public static HttpURLConnection getConnection(String request) throws IOException {
+        return getConnection(request, false);
+    }
+
+    public static HttpURLConnection getInternalConnection(String request) throws IOException {
+        return getConnection(request, true);
+    }
+
+    private static HttpURLConnection getConnection(String request, boolean internal) throws IOException {
+        if (internal && Config.enable_https && request.startsWith("http://")) {
+            request = "https://" + request.substring(7);
+        }
         try {
             SecurityChecker.getInstance().startSSRFChecking(request);
             URL url = new URL(request);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            // Must use Env.getServingEnv() instead of getCurrentEnv(),
-            // because here we need to obtain selfNode through the official service catalog.
-            HostInfo selfNode = Env.getServingEnv().getSelfNode();
-            conn.setRequestProperty(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
-            conn.setRequestProperty(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
+            if (internal && conn instanceof HttpsURLConnection && Config.enable_https) {
+                HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+                httpsConn.setSSLSocketFactory(InternalHttpsUtils.getSslContext().getSocketFactory());
+                httpsConn.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+            }
             return conn;
         } catch (Exception e) {
             throw new IOException(e);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.common.Config;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+public class InternalHttpsUtils {
+    private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
+    private static volatile SSLContext cachedSslContext = null;
+
+    public static SSLContext getSslContext() {
+        if (cachedSslContext == null) {
+            synchronized (InternalHttpsUtils.class) {
+                if (cachedSslContext == null) {
+                    cachedSslContext = buildSslContext();
+                }
+            }
+        }
+        return cachedSslContext;
+    }
+
+    private static SSLContext buildSslContext() {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
+            try (InputStream stream = Files.newInputStream(Paths.get(Config.mysql_ssl_default_ca_certificate))) {
+                trustStore.load(stream, Config.mysql_ssl_default_ca_certificate_password.toCharArray());
+            }
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(trustStore);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, tmf.getTrustManagers(), null);
+            return sslContext;
+        } catch (Exception e) {
+            LOG.error("Failed to build SSLContext from truststore: {}",
+                    Config.mysql_ssl_default_ca_certificate, e);
+            throw new RuntimeException("Failed to build SSLContext from truststore: "
+                    + Config.mysql_ssl_default_ca_certificate, e);
+        }
+    }
+
+    public static CloseableHttpClient createValidatedHttpClient() {
+        SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(
+                getSslContext(), NoopHostnameVerifier.INSTANCE);
+        return HttpClients.custom().setSSLSocketFactory(sslFactory).build();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
@@ -118,7 +118,7 @@ public class SessionController extends RestBaseController {
                                                           Frontend frontend) throws IOException {
         Map<String, String> header = Maps.newHashMap();
         header.put(NodeAction.AUTHORIZATION, request.getHeader(NodeAction.AUTHORIZATION));
-        String res = HttpUtils.doGet(String.format("http://%s:%s/rest/v1/session",
+        String res = HttpUtils.doInternalGet(String.format("http://%s:%s/rest/v1/session",
                 frontend.getHost(), Env.getCurrentEnv().getMasterHttpPort()), header);
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> jsonMap = objectMapper.readValue(res,

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.httpv2.controller.BaseController;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
@@ -43,6 +44,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -52,8 +54,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -292,7 +297,7 @@ public class RestBaseController extends BaseController {
 
             HttpEntity<Object> entity = new HttpEntity<>(body, headers);
 
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate = new RestTemplate(new InternalHttpRequestFactory());
 
             ResponseEntity<Object> responseEntity;
             switch (method) {
@@ -316,6 +321,13 @@ public class RestBaseController extends BaseController {
         } catch (Exception e) {
             LOG.warn(e);
             return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        }
+    }
+
+    private static class InternalHttpRequestFactory extends SimpleClientHttpRequestFactory {
+        @Override
+        protected HttpURLConnection openConnection(URL url, Proxy proxy) throws IOException {
+            return HttpURLUtil.getInternalConnection(url.toString());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -20,6 +20,7 @@ package org.apache.doris.httpv2.rest.manager;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.InternalHttpsUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -89,9 +90,25 @@ public class HttpUtils {
     }
 
     public static String doGet(String url, Map<String, String> headers, int timeoutMs) throws IOException {
+        return doGet(url, headers, timeoutMs, false);
+    }
+
+    public static String doInternalGet(String url, Map<String, String> headers, int timeoutMs) throws IOException {
+        return doGet(url, headers, timeoutMs, true);
+    }
+
+    public static String doInternalGet(String url, Map<String, String> headers) throws IOException {
+        return doInternalGet(url, headers, DEFAULT_TIME_OUT_MS);
+    }
+
+    private static String doGet(String url, Map<String, String> headers, int timeoutMs, boolean internal)
+            throws IOException {
+        if (internal && Config.enable_https && isFeHttpUrl(url)) {
+            url = "https://" + url.substring(7);
+        }
         HttpGet httpGet = new HttpGet(url);
         setRequestConfig(httpGet, headers, timeoutMs);
-        return executeRequest(httpGet);
+        return executeRequest(httpGet, internal);
     }
 
     public static String doGet(String url, Map<String, String> headers) throws IOException {
@@ -99,6 +116,18 @@ public class HttpUtils {
     }
 
     public static String doPost(String url, Map<String, String> headers, Object body) throws IOException {
+        return doPost(url, headers, body, false);
+    }
+
+    public static String doInternalPost(String url, Map<String, String> headers, Object body) throws IOException {
+        return doPost(url, headers, body, true);
+    }
+
+    private static String doPost(String url, Map<String, String> headers, Object body, boolean internal)
+            throws IOException {
+        if (internal && Config.enable_https && isFeHttpUrl(url)) {
+            url = "https://" + url.substring(7);
+        }
         HttpPost httpPost = new HttpPost(url);
         if (Objects.nonNull(body)) {
             String jsonString = GsonUtils.GSON.toJson(body);
@@ -107,7 +136,7 @@ public class HttpUtils {
         }
 
         setRequestConfig(httpPost, headers, DEFAULT_TIME_OUT_MS);
-        return executeRequest(httpPost);
+        return executeRequest(httpPost, internal);
     }
 
     private static void setRequestConfig(HttpRequestBase request, Map<String, String> headers, int timeoutMs) {
@@ -126,12 +155,39 @@ public class HttpUtils {
     }
 
     public static CloseableHttpClient getHttpClient() {
+        return getHttpClient(false);
+    }
+
+    public static CloseableHttpClient getInternalHttpClient() {
+        return getHttpClient(true);
+    }
+
+    private static CloseableHttpClient getHttpClient(boolean internal) {
+        if (internal && Config.enable_https) {
+            return InternalHttpsUtils.createValidatedHttpClient();
+        }
         return HttpClientBuilder.create().build();
     }
 
     private static String executeRequest(HttpRequestBase request) throws IOException {
-        CloseableHttpClient client = getHttpClient();
+        return executeRequest(request, false);
+    }
+
+    private static String executeRequest(HttpRequestBase request, boolean internal) throws IOException {
+        boolean useInternalHttpsClient = internal && "https".equalsIgnoreCase(request.getURI().getScheme());
+        CloseableHttpClient client = getHttpClient(useInternalHttpsClient);
         return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
+    }
+
+    private static boolean isFeHttpUrl(String url) {
+        try {
+            URL parsedUrl = new URL(url);
+            int port = parsedUrl.getPort();
+            return url.startsWith("http://")
+                    && (port == Config.http_port || (port == -1 && Config.http_port == 80));
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     static String parseResponse(String response) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -204,7 +204,7 @@ public class NodeAction extends RestBaseController {
                 Backend be = Env.getCurrentSystemInfo().getBackend(beIds.get(0));
                 String url = "http://" + NetUtils.getHostPortInAccessibleFormat(be.getHost(), be.getHttpPort())
                         + "/api/show_config";
-                String questResult = HttpUtils.doGet(url, null);
+                String questResult = HttpUtils.doInternalGet(url, null);
                 List<List<String>> configs = GsonUtils.GSON.fromJson(questResult, new TypeToken<List<List<String>>>() {
                 }.getType());
                 for (List<String> config : configs) {
@@ -439,7 +439,7 @@ public class NodeAction extends RestBaseController {
         public void run() {
             String configInfo;
             try {
-                configInfo = HttpUtils.doGet(url,
+                configInfo = HttpUtils.doInternalGet(url,
                         ImmutableMap.<String, String>builder().put(AUTHORIZATION, authorization).build());
                 List<List<String>> configs = GsonUtils.GSON.fromJson(configInfo, new TypeToken<List<List<String>>>() {
                 }.getType());
@@ -507,7 +507,7 @@ public class NodeAction extends RestBaseController {
             if (!nodeConfigs.getConfigs(true).isEmpty()) {
                 String url = concatFeSetConfigUrl(nodeConfigs, true);
                 try {
-                    String responsePersist = HttpUtils.doGet(url, header);
+                    String responsePersist = HttpUtils.doInternalGet(url, header);
                     parseFeSetConfigResponse(responsePersist, nodeConfigs.getHostPort(), failedTotal);
                 } catch (Exception e) {
                     addSetConfigErrNode(nodeConfigs.getConfigs(true), nodeConfigs.getHostPort(), e.getMessage(),
@@ -517,7 +517,7 @@ public class NodeAction extends RestBaseController {
             if (!nodeConfigs.getConfigs(false).isEmpty()) {
                 String url = concatFeSetConfigUrl(nodeConfigs, false);
                 try {
-                    String responseTemp = HttpUtils.doGet(url, header);
+                    String responseTemp = HttpUtils.doInternalGet(url, header);
                     parseFeSetConfigResponse(responseTemp, nodeConfigs.getHostPort(), failedTotal);
                 } catch (Exception e) {
                     addSetConfigErrNode(nodeConfigs.getConfigs(false), nodeConfigs.getHostPort(), e.getMessage(),
@@ -913,7 +913,7 @@ public class NodeAction extends RestBaseController {
         @Override
         public void run() {
             try {
-                String response = HttpUtils.doPost(url,
+                String response = HttpUtils.doInternalPost(url,
                         ImmutableMap.<String, String>builder().put(AUTHORIZATION, authorization).build(), null);
                 JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
                 String status = jsonObject.get("status").getAsString();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -134,9 +134,9 @@ public class QueryProfileAction extends RestBaseController {
             try {
                 String data = null;
                 if (method == HttpMethod.GET) {
-                    data = HttpUtils.parseResponse(HttpUtils.doGet(url, header));
+                    data = HttpUtils.parseResponse(HttpUtils.doInternalGet(url, header));
                 } else if (method == HttpMethod.POST) {
-                    data = HttpUtils.parseResponse(HttpUtils.doPost(url, header, null));
+                    data = HttpUtils.parseResponse(HttpUtils.doInternalPost(url, header, null));
                 }
                 if (!Strings.isNullOrEmpty(data) && !data.equals("{}")) {
                     dataList.add(data);
@@ -349,7 +349,7 @@ public class QueryProfileAction extends RestBaseController {
                     continue;
                 }
                 String url = HttpUtils.concatUrl(ipPort, httpPath, arguments);
-                String responseJson = HttpUtils.doGet(url, header);
+                String responseJson = HttpUtils.doInternalGet(url, header);
                 JsonObject jObj = JsonParser.parseString(responseJson).getAsJsonObject();
                 int code = jObj.get("code").getAsInt();
                 if (code == HttpUtils.REQUEST_SUCCESS_CODE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/ClusterGuardAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/ClusterGuardAction.java
@@ -124,7 +124,7 @@ public class ClusterGuardAction extends RestBaseController {
             String nodeKey = ipPort.first + ":" + ipPort.second;
             String url = HttpUtils.concatUrl(ipPort, httpPath, arguments);
             try {
-                String resp = HttpUtils.doPost(url, header, null);
+                String resp = HttpUtils.doInternalPost(url, header, null);
                 JsonObject jsonObj = JsonParser.parseString(resp).getAsJsonObject();
                 int code = jsonObj.get("code").getAsInt();
                 if (code == HttpUtils.REQUEST_SUCCESS_CODE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -297,7 +297,7 @@ public class Checkpoint extends MasterDaemon {
                              * this lagging node can never get the deleted journal.
                              */
                             idURL = "http://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/journal_id";
-                            conn = HttpURLUtil.getConnectionWithNodeIdent(idURL);
+                            conn = HttpURLUtil.getInternalConnectionWithNodeIdent(idURL);
                             conn.setConnectTimeout(CONNECT_TIMEOUT_SECOND * 1000);
                             conn.setReadTimeout(READ_TIMEOUT_SECOND * 1000);
                             String idString = conn.getHeaderField("id");

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -150,7 +150,7 @@ public class MetaHelper {
     public static <T> ResponseBody doGet(String url, int timeout, Class<T> clazz) throws IOException {
         Map<String, String> headers = HttpURLUtil.getNodeIdentHeaders();
         LOG.info("meta helper, url: {}, timeout{}, headers: {}", url, timeout, headers);
-        String response = HttpUtils.doGet(url, headers, timeout);
+        String response = HttpUtils.doInternalGet(url, headers, timeout);
         return parseResponse(response, clazz);
     }
 
@@ -161,7 +161,7 @@ public class MetaHelper {
         checkFile(file);
         OutputStream out = new FileOutputStream(file);
         try {
-            conn = HttpURLUtil.getConnectionWithNodeIdent(urlStr);
+            conn = HttpURLUtil.getInternalConnectionWithNodeIdent(urlStr);
             conn.setConnectTimeout(timeout);
             conn.setReadTimeout(timeout);
 


### PR DESCRIPTION
## Proposed changes

This is an alternative implementation for apache/doris#60921.

The goal is to keep the HTTPS decision in the common internal HTTP helper layer, while making FE internal call sites explicit through `getInternalConnectionWithNodeIdent`, `doInternalGet`, and `doInternalPost`.

Key points:
- FE internal call sites use explicit internal helper names, but keep their existing URL construction style
- `HttpURLUtil` handles `HttpURLConnection` based internal FE connections
- `HttpUtils` handles Apache `HttpClient` based internal requests and only upgrades FE `http_port` URLs to HTTPS
- FE-to-BE manager requests are not forced through the internal HTTPS client unless the request URL has actually been converted to HTTPS
- `RestBaseController` routes master-forwarding through `HttpURLUtil.getInternalConnection()` because `RestTemplate` does not use `HttpURLUtil.getConnectionWithNodeIdent()` or `HttpUtils`
- the Doris community condition remains `Config.enable_https`; downstream forks can map the same helper boundary to their own TLS switch without changing FE business URL construction

## Validation

- `git diff --check`
- merge-tree simulation against SelectDB 4.0/current internal branches for pick-shape review
- no compile/UT run; this draft is for code review and pick-shape review first