### PR TITLE
[fix](test) pin variant defaults in check_before_quit

### DIFF
--- a/regression-test/suites/check_before_quit/check_before_quit.groovy
+++ b/regression-test/suites/check_before_quit/check_before_quit.groovy
@@ -247,6 +247,14 @@ suite("check_before_quit", "nonConcurrent,p0") {
 
     sql "set enable_decimal256 = true;"
     sql "set enable_variant_flatten_nested = true;"
+    // Pin the fuzzed variant session defaults so the CREATE -> recreate round-trip below
+    // is idempotent. The recreate parser bakes the current session default into variant
+    // columns when a property is omitted. The per-connection session-variable fuzzer
+    // randomizes these, which would otherwise make a sparse variant column re-render as
+    // doc mode, or make a bare-variant origin re-render with PROPERTIES.
+    sql "set default_variant_enable_doc_mode = false;"
+    sql "set default_variant_max_subcolumns_count = 0;"
+    sql "set default_variant_sparse_hash_shard_count = 0;"
     sql """
         ADMIN SET ALL FRONTENDS CONFIG ('enable_inverted_index_v1_for_variant' = 'true');
     """

--- a/regression-test/suites/variant_p0/doc_mode/predefine/load.groovy
+++ b/regression-test/suites/variant_p0/doc_mode/predefine/load.groovy
@@ -203,9 +203,9 @@ suite("test_variant_predefine_doc_value", "nonConcurrent"){
 
     // // schema change
     // // 1. add column
-    sql "alter table test_predefine1 add column v2 variant<'dcm':double,'dt':string> default null"
+    sql "alter table test_predefine1 add column v2 variant<'dcm':double,'dt':string, properties(\"variant_enable_doc_mode\" = \"false\")> default null"
     sql """insert into test_predefine1 values(101, '{"a" :1}', '{"dcm": 1111111}')""" 
-    sql "alter table test_predefine1 add column v3 variant<'dcm':double,'dt':string,'ip':string> default null"
+    sql "alter table test_predefine1 add column v3 variant<'dcm':double,'dt':string,'ip':string, properties(\"variant_enable_doc_mode\" = \"false\")> default null"
     sql """insert into test_predefine1 values(102, '{"a" :1}', '{"dcm": 1111111}', '{"dcm": 1111111}');"""
     // 2. todo support alter column type
     // sql "alter table test_predefine1 modify column v3 variant<dcm:decimal,dt:datetime,ip:ipv6>"


### PR DESCRIPTION
## Summary

- Pin variant session defaults before `check_before_quit` recreates tables from `SHOW CREATE TABLE`.
- Prevent the per-connection session-variable fuzzer from changing omitted variant properties during the create/drop/recreate round trip.
- This forward-ports the same case-level strategy from #64613 and additionally pins doc mode for the master failure seen in NonConcurrent build 982802.
- Keep schema-change columns on the legacy `test_predefine1` flatten-nested table in non-doc mode, so the table left by `variant_p0/doc_mode/predefine/load.groovy` remains recreate-able by `SHOW CREATE TABLE`.

Failure example:

- Build: http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_NonConcurrentRegression/982802
- Symptom: `Found 22 failures during database recreation checks`
- Drift: sparse variant properties from the original `SHOW CREATE TABLE` were recreated as doc-mode properties when the check connection inherited fuzzed variant defaults.

Follow-up failure:

- Build: http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_NonConcurrentRegression/983657
- Symptom: `Found 1 failures during database recreation checks`
- Cause: `test_predefine1` had `deprecated_variant_enable_flatten_nested=true` and a later `ALTER ADD COLUMN` inherited doc mode, producing a `SHOW CREATE TABLE` statement rejected by the create path with `variant flatten nested is not enabled, because doc snapshot mode is enabled`.

## Testing

- [x] `git diff --check`
- [ ] Not run locally; `check_before_quit` depends on the state left by a full regression pipeline.
