### PR TITLE
[refactor](fe) Refactor SetPreAggStatus traversal to use per-scan context map instead of shared stack

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SetPreAggStatus.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SetPreAggStatus.java
@@ -66,7 +66,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**
@@ -74,7 +73,7 @@ import java.util.stream.Collectors;
  * bottom-up tranverse the plan tree and collect required info into PreAggInfoContext
  * when get to the bottom LogicalOlapScan node, we set the preagg status using info in PreAggInfoContext
  */
-public class SetPreAggStatus extends DefaultPlanRewriter<Stack<SetPreAggStatus.PreAggInfoContext>>
+public class SetPreAggStatus extends DefaultPlanRewriter<Map<RelationId, SetPreAggStatus.PreAggInfoContext>>
         implements CustomRewriter {
     private Map<RelationId, PreAggInfoContext> olapScanPreAggContexts = new HashMap<>();
 
@@ -136,19 +135,24 @@ public class SetPreAggStatus extends DefaultPlanRewriter<Stack<SetPreAggStatus.P
 
     @Override
     public Plan rewriteRoot(Plan plan, JobContext jobContext) {
-        Plan newPlan = plan.accept(this, new Stack<>());
+        Plan newPlan = plan.accept(this, new HashMap<>());
         return newPlan.accept(SetOlapScanPreAgg.INSTANCE, olapScanPreAggContexts);
     }
 
     @Override
-    public Plan visit(Plan plan, Stack<PreAggInfoContext> context) {
+    public Plan visit(Plan plan, Map<RelationId, PreAggInfoContext> context) {
+        Set<RelationId> beforeKeys = new HashSet<>(context.keySet());
         Plan newPlan = super.visit(plan, context);
-        context.clear();
+        Set<RelationId> childKeys = new HashSet<>(context.keySet());
+        childKeys.removeAll(beforeKeys);
+        for (RelationId id : childKeys) {
+            context.remove(id);
+        }
         return newPlan;
     }
 
     @Override
-    public Plan visitLogicalOlapScan(LogicalOlapScan logicalOlapScan, Stack<PreAggInfoContext> context) {
+    public Plan visitLogicalOlapScan(LogicalOlapScan logicalOlapScan, Map<RelationId, PreAggInfoContext> context) {
         if (logicalOlapScan instanceof LogicalOlapTableStreamScan) {
             // no pre-agg for LogicalOlapTableStreamScan
             return logicalOlapScan;
@@ -166,10 +170,9 @@ public class SetPreAggStatus extends DefaultPlanRewriter<Stack<SetPreAggStatus.P
                             logicalOlapScan.getTable().getName()))) {
                 return logicalOlapScan.withPreAggStatus(PreAggStatus.on());
             } else {
-                if (context.empty()) {
-                    context.push(new PreAggInfoContext());
-                }
-                context.peek().addRelationId(logicalOlapScan.getRelationId());
+                PreAggInfoContext preAggInfoContext = new PreAggInfoContext();
+                preAggInfoContext.addRelationId(logicalOlapScan.getRelationId());
+                context.put(logicalOlapScan.getRelationId(), preAggInfoContext);
                 return logicalOlapScan;
             }
         } else {
@@ -178,56 +181,70 @@ public class SetPreAggStatus extends DefaultPlanRewriter<Stack<SetPreAggStatus.P
     }
 
     @Override
-    public Plan visitLogicalFilter(LogicalFilter<? extends Plan> logicalFilter, Stack<PreAggInfoContext> context) {
+    public Plan visitLogicalFilter(LogicalFilter<? extends Plan> logicalFilter,
+            Map<RelationId, PreAggInfoContext> context) {
+        Set<RelationId> beforeKeys = new HashSet<>(context.keySet());
         LogicalFilter plan = (LogicalFilter) super.visit(logicalFilter, context);
-        if (!context.empty()) {
-            context.peek().addFilterConjuncts(plan.getExpressions());
+        Set<RelationId> childKeys = new HashSet<>(context.keySet());
+        childKeys.removeAll(beforeKeys);
+        for (RelationId id : childKeys) {
+            context.get(id).addFilterConjuncts(plan.getExpressions());
         }
         return plan;
     }
 
     @Override
     public Plan visitLogicalJoin(LogicalJoin<? extends Plan, ? extends Plan> logicalJoin,
-            Stack<PreAggInfoContext> context) {
+            Map<RelationId, PreAggInfoContext> context) {
+        Set<RelationId> beforeKeys = new HashSet<>(context.keySet());
         LogicalJoin plan = (LogicalJoin) super.visit(logicalJoin, context);
-        if (!context.empty()) {
-            context.peek().addJoinInfo(plan);
+        Set<RelationId> childKeys = new HashSet<>(context.keySet());
+        childKeys.removeAll(beforeKeys);
+        for (RelationId id : childKeys) {
+            context.get(id).addJoinInfo(plan);
         }
         return plan;
     }
 
     @Override
     public Plan visitLogicalProject(LogicalProject<? extends Plan> logicalProject,
-            Stack<PreAggInfoContext> context) {
+            Map<RelationId, PreAggInfoContext> context) {
+        Set<RelationId> beforeKeys = new HashSet<>(context.keySet());
         LogicalProject plan = (LogicalProject) super.visit(logicalProject, context);
-        if (!context.empty()) {
-            context.peek().setReplaceMap(plan.getAliasToProducer());
+        Set<RelationId> childKeys = new HashSet<>(context.keySet());
+        childKeys.removeAll(beforeKeys);
+        for (RelationId id : childKeys) {
+            context.get(id).setReplaceMap(plan.getAliasToProducer());
         }
         return plan;
     }
 
     @Override
     public Plan visitLogicalAggregate(LogicalAggregate<? extends Plan> logicalAggregate,
-            Stack<PreAggInfoContext> context) {
+            Map<RelationId, PreAggInfoContext> context) {
+        Set<RelationId> beforeKeys = new HashSet<>(context.keySet());
         Plan plan = super.visit(logicalAggregate, context);
-        if (!context.isEmpty()) {
-            PreAggInfoContext preAggInfoContext = context.pop();
-            preAggInfoContext.olapScanIds.retainAll(logicalAggregate.child().getInputRelations());
+        Set<RelationId> childKeys = new HashSet<>(context.keySet());
+        childKeys.removeAll(beforeKeys);
+        for (RelationId id : childKeys) {
+            PreAggInfoContext preAggInfoContext = context.remove(id);
             preAggInfoContext.addAggregateFunctions(logicalAggregate.getAggregateFunctions());
             preAggInfoContext.addGroupByExpresssions(logicalAggregate.getGroupByExpressions());
-            for (RelationId id : preAggInfoContext.olapScanIds) {
-                olapScanPreAggContexts.put(id, preAggInfoContext);
-            }
+            olapScanPreAggContexts.put(id, preAggInfoContext);
         }
         return plan;
     }
 
     @Override
-    public Plan visitLogicalRepeat(LogicalRepeat<? extends Plan> repeat, Stack<PreAggInfoContext> context) {
+    public Plan visitLogicalRepeat(LogicalRepeat<? extends Plan> repeat, Map<RelationId, PreAggInfoContext> context) {
+        Set<RelationId> beforeKeys = new HashSet<>(context.keySet());
         repeat = (LogicalRepeat<? extends Plan>) super.visit(repeat, context);
-        if (!context.isEmpty()) {
-            context.peek().addGroupingScalarFunctionExpresssion(repeat.getGroupingId().get());
-            context.peek().addGroupingScalarFunctionExpresssions(
+        Set<RelationId> childKeys = new HashSet<>(context.keySet());
+        childKeys.removeAll(beforeKeys);
+        for (RelationId id : childKeys) {
+            PreAggInfoContext ctx = context.get(id);
+            ctx.addGroupingScalarFunctionExpresssion(repeat.getGroupingId().get());
+            ctx.addGroupingScalarFunctionExpresssions(
                     repeat.getOutputExpressions().stream()
                             .filter(e -> e.containsType(GroupingScalarFunction.class))
                             .map(e -> e.toSlot())

--- a/regression-test/suites/nereids_rules_p0/set_preagg/set_preagg.groovy
+++ b/regression-test/suites/nereids_rules_p0/set_preagg/set_preagg.groovy
@@ -271,7 +271,7 @@ suite("set_preagg") {
         """)
         contains "(preagg_t1), PREAGGREGATION: ON"
         contains "(preagg_t2), PREAGGREGATION: ON"
-        contains "(preagg_t3), PREAGGREGATION: OFF"
+        contains "(preagg_t3), PREAGGREGATION: ON"
     }
 
     explain {
@@ -291,7 +291,7 @@ suite("set_preagg") {
         """)
         contains "(preagg_t1), PREAGGREGATION: ON"
         contains "(preagg_t2), PREAGGREGATION: ON"
-        contains "(preagg_t3), PREAGGREGATION: OFF"
+        contains "(preagg_t3), PREAGGREGATION: ON"
     }
 
     explain {


### PR DESCRIPTION
Related PR: https://github.com/apache/doris/pull/48502

Problem Summary:

The SetPreAggStatus rule uses a bottom-up traversal to determine whether
pre-aggregation can be enabled for OlapScan nodes. The original implementation
used a `Stack<PreAggInfoContext>` as the traversal context, which had a
fundamental flaw: multiple scan nodes under sibling subtrees (e.g., both sides
of a Join) incorrectly shared the same stack-level context.

This caused two problems:
1. A scan could inherit filter/join/project information from unrelated branches
   of the plan tree.
2. To work around this, `visitLogicalAggregate` used `retainAll()` to filter out
   scan nodes that were not actually children of the current aggregate — an
   inelegant patch that partially masked the underlying issue.

Root cause: The stack-based context could not guarantee a one-to-one
correspondence between a scan node and its nearest aggregate ancestor.

Fix: Replace the `Stack<PreAggInfoContext>` with a `Map<RelationId,
PreAggInfoContext>`, where each scan node gets its own dedicated context entry.
Each visitor method uses a snapshot-diff pattern:

  1. Snapshot the current map keys before visiting children
  2. Visit children (they add scan contexts to the map)
  3. Diff to identify which scans were added by this subtree
  4. Apply node-specific info only to those scans

At `LogicalAggregate`, child scan contexts are consumed (removed from the map)
and their results are stored — no more `retainAll()` filtering needed.


None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

