### PR TITLE
[fix](test) filter joined FEs in sql cache case

### DIFF
--- a/regression-test/suites/query_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/parse_sql_from_sql_cache.groovy
@@ -702,19 +702,22 @@ suite("parse_sql_from_sql_cache") {
                 }),
                 extraThread("testMultiFrontends", {
                     retryTestSqlCache(3, 1000) {
-                        def aliveFrontends = sql_return_maparray("show frontends")
+                        def aliveJoinedFrontends = sql_return_maparray("show frontends")
                                 .stream()
-                                .filter { it["Alive"].toString().equalsIgnoreCase("true") }
+                                .filter {
+                                    it["Alive"].toString().equalsIgnoreCase("true")
+                                            && it["Join"].toString().equalsIgnoreCase("true")
+                                }
                                 .collect(Collectors.toList())
 
-                        if (aliveFrontends.size() <= 1) {
+                        if (aliveJoinedFrontends.size() <= 1) {
                             return
                         }
 
-                        def fe1 = aliveFrontends[0]["Host"] + ":" + aliveFrontends[0]["QueryPort"]
+                        def fe1 = aliveJoinedFrontends[0]["Host"] + ":" + aliveJoinedFrontends[0]["QueryPort"]
                         def fe2 = fe1
-                        if (aliveFrontends.size() > 1) {
-                            fe2 = aliveFrontends[1]["Host"] + ":" + aliveFrontends[1]["QueryPort"]
+                        if (aliveJoinedFrontends.size() > 1) {
+                            fe2 = aliveJoinedFrontends[1]["Host"] + ":" + aliveJoinedFrontends[1]["QueryPort"]
                         }
 
                         log.info("fe1: ${fe1}")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

`parse_sql_from_sql_cache.groovy` has a `testMultiFrontends` block that should only run when at least two usable FEs are present.

In fixed-1FE P0 regression environments, `SHOW FRONTENDS` can still contain another FE row where `Alive=true` but `Join=false`. The previous guard only filtered by `Alive`, so the case could treat that non-joined row as a second FE and run the multi-FE assertions in a single joined FE topology.

This PR filters candidates with both `Alive=true` and `Join=true`, so the multi-FE block is skipped unless there are at least two joined FEs.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
      - `git diff --check`
      - Manual diff review: only the FE candidate filtering in `parse_sql_from_sql_cache.groovy` changed.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
