### PR TITLE
fix: add retry for OBS queries in paimon_base_filesystem test

### DIFF
--- a/regression-test/pipeline/common/teamcity-utils.sh
+++ b/regression-test/pipeline/common/teamcity-utils.sh
@@ -52,7 +52,7 @@ comment_to_pipeline=(
     ['cloud_p0']='Doris_DorisRegression_CloudP0'
     ['cloud_p1']='Doris_DorisCloudRegression_CloudP1'
     ['vault_p0']='Doris_DorisCloudRegression_VaultP0'
-    ['nonConcurrent']='Doris_DorisRegression_NonConcurrentRegression'
+    ['nonConcurrent']='Doris_DorisCloudRegression_NonConcurrent_NonConcurrentRegression'
     ['check_coverage']='Doris_Coverage_Merge_P0_UT'
 )
 

--- a/regression-test/pipeline/nonConcurrent/clean.sh
+++ b/regression-test/pipeline/nonConcurrent/clean.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+########################### Teamcity Build Step: Command Line #######################
+: <<EOF
+#!/bin/bash
+export PATH=/usr/local/software/apache-maven-3.6.3/bin:${PATH}
+if [[ -f "${teamcity_build_checkoutDir:-}"/regression-test/pipeline/nonConcurrent/clean.sh ]]; then
+    cd "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/
+    bash -x clean.sh
+else
+    echo "Build Step file missing: regression-test/pipeline/nonConcurrent/clean.sh" && exit 1
+fi
+EOF
+############################# clean.sh content ########################################
+# shellcheck source=/dev/null
+# stop_doris, clean_fdb
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/doris-utils.sh
+
+echo "#### Check env"
+if [[ -z "${teamcity_build_checkoutDir}" ]]; then echo "ERROR: env teamcity_build_checkoutDir not set" && exit 1; fi
+
+# shellcheck source=/dev/null
+source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
+if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
+
+echo "#### Run tpcds test on Doris ####"
+DORIS_HOME="${teamcity_build_checkoutDir}/output"
+export DORIS_HOME
+clean_fdb "cloud_instance_0"
+exit

--- a/regression-test/pipeline/nonConcurrent/conf/be_custom.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/be_custom.conf
@@ -1,0 +1,69 @@
+streaming_load_rpc_max_alive_time_sec = 72000
+quick_cooldown = true
+disable_stream_load_2pc=false
+enable_vectorized_alter_table = true
+enable_new_scan_node = true
+push_worker_count_high_priority = 2
+streaming_load_max_mb = 107374182400
+clear_file_cache=true
+enable_file_cache=true
+#disable_storage_page_cache = true
+enable_file_cache_query_limit=true
+file_cache_max_file_segment_size=1048576
+s3_write_buffer_whole_size=52428800
+enable_vertical_compaction=true
+fuzzy_vertical_compaction=true
+vacuum_stale_rowsets_interval_seconds=60
+tablet_rowset_stale_sweep_time_sec=300
+user_files_secure_path=/
+enable_file_cache_as_load_buffer=true
+enable_merge_on_write_correctness_check=true
+enable_debug_points=true
+prioritize_query_perf_in_compaction = true
+cumulative_compaction_min_deltas = 5
+#p0 parameter
+meta_service_endpoint = 127.0.0.1:5000
+cloud_unique_id = cloud_unique_id_compute_node0
+meta_service_use_load_balancer = false
+enable_file_cache = true
+file_cache_path = [{"path":"/data/doris_cloud/file_cache","total_size":104857600,"query_limit":104857600}]
+tmp_file_dirs = [{"path":"/data/doris_cloud/tmp","max_cache_bytes":104857600,"max_upload_bytes":104857600}]
+thrift_rpc_timeout_ms = 360000
+save_load_error_log_to_s3 = true
+enable_stream_load_record = true
+stream_load_record_batch_size = 500
+webserver_num_workers = 128
+enable_new_tablet_do_compaction = true
+arrow_flight_sql_port = 8181
+pipeline_task_leakage_detect_period_sec=1
+crash_in_memory_tracker_inaccurate = true
+enable_table_size_correctness_check=true
+enable_brpc_connection_check=true
+enable_write_index_searcher_cache=true
+large_cumu_compaction_task_min_thread_num=3
+
+# sys_log_verbose_modules=dictionary_factory
+
+# So feature has bug, so by default is false, only open it in pipeline to observe
+enable_parquet_page_index=true
+enable_fuzzy_mode=true
+
+enable_prefill_all_dbm_agg_cache_after_compaction=true
+
+enable_batch_get_delete_bitmap=true
+get_delete_bitmap_bytes_threshold=10
+
+enable_fetch_rowsets_from_peer_replicas = true
+
+enable_segment_rows_consistency_check=true
+enable_segment_rows_check_core=true
+fail_when_segment_rows_not_in_rowset_meta=true
+
+# enable to use python udf
+enable_python_udf_support=true
+python_env_mode=conda
+python_conda_root_path=/opt/miniconda3
+max_python_process_num=16
+
+enable_cloud_make_rs_visible_on_be=true
+cloud_mow_sync_rowsets_when_load_txn_begin=false

--- a/regression-test/pipeline/nonConcurrent/conf/fe_custom.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/fe_custom.conf
@@ -1,0 +1,53 @@
+stream_load_default_timeout_second = 72000
+replication_num_forced_in_cloud_mode = true
+ignore_unsupported_properties_in_cloud_mode = true
+enable_array_type = true
+tablet_stat_update_interval_second = 10
+catalog_trash_expire_second = 600
+cloud_delete_loaded_internal_stage_files = true
+merge_on_write_forced_to_false = true
+enable_ssl = true
+light_schema_change_force_to_true = true
+enable_mtmv = true
+remote_fragment_exec_timeout_ms=120000
+dynamic_partition_check_interval_seconds=10
+use_fuzzy_session_variable=true
+
+enable_cloud_snapshot_version = true
+enable_auto_collect_statistics = false
+
+forbid_function_stmt = false
+forbid_insecurity_stmt = false
+
+enable_debug_points = true
+
+disable_datev1=false
+
+disable_decimalv2=false
+# sys_log_verbose_modules = org.apache.doris.master.MasterImpl,org.apache.doris.planner.OlapScanNode
+# profile related
+max_query_profile_num = 2000
+max_spilled_profile_num = 2000
+
+statistics_sql_mem_limit_in_bytes=21474836480
+cpu_resource_limit_per_analyze_task=-1
+
+arrow_flight_sql_port = 8081
+
+priority_networks=127.0.0.1/24
+cloud_http_port=18030
+meta_service_endpoint=127.0.0.1:5000
+cloud_unique_id=cloud_unique_id_sql_server00
+# for case test_build_mtmv.groovy
+enable_job_schedule_second_for_test=true
+
+workload_sched_policy_interval_ms = 1000
+workload_group_max_num = 25
+enable_advance_next_id = true
+
+check_table_lock_leaky = true
+enable_outfile_to_local=true
+
+enable_notify_be_after_load_txn_commit=true
+max_bucket_num_per_partition=512
+enable_table_stream=true

--- a/regression-test/pipeline/nonConcurrent/conf/ms_custom.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/ms_custom.conf
@@ -1,0 +1,4 @@
+# below lines will be appended to the default doris_cloud.conf when deploying meta service
+meta_schema_value_version = 1
+enable_logging_conflict_keys = true
+cloud_txn_lazy_commit_fuzzy_possibility = 50

--- a/regression-test/pipeline/nonConcurrent/conf/recycler_custom.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/recycler_custom.conf
@@ -1,0 +1,2 @@
+# below lines will be appended to the default doris_cloud.conf when deploying recycler
+brpc_listen_port = 6000

--- a/regression-test/pipeline/nonConcurrent/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/nonConcurrent/conf/regression-conf-custom.groovy
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+testGroups = "p0"
+
+jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true&allowLoadLocalInfile=true&zeroDateTimeBehavior=round"
+targetJdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true&allowLoadLocalInfile=true&zeroDateTimeBehavior=round"
+
+// exclude groups and exclude suites is more prior than include groups and include suites.
+// keep them in lexico order(add/remove cases between the sentinals and sort):
+// * sort lines in vim: select lines and then type :sort
+// * sort lines in vscode: https://ulfschneider.io/2023-09-01-sort-in-vscode/
+excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
+    "mv_contain_external_table," + // run on external pipeline
+    "set_replica_status," + // not a case for cloud mode, no need to run
+    "test_be_inject_publish_txn_fail," + // not a case for cloud mode, no need to run
+    "test_dump_image," +
+    "test_nereids_show_restore," +
+    "test_index_failure_injection," +
+    "test_information_schema_external," +
+    "test_profile," +
+    "test_publish_timeout," +
+    "test_refresh_mtmv," + // not supported yet
+    "test_report_version_missing," +
+    "test_set_partition_version," +
+    "test_spark_load," +
+    "test_index_lowercase_fault_injection," +
+    "test_index_compaction_failure_injection," +
+    "test_query_sys_rowsets," + // rowsets sys table
+    "test_unique_table_debug_data," + // disable auto compaction
+    "test_insert," + // txn insert
+    "test_nereids_show_snapshot," +
+    "test_full_compaction_run_status," +
+    "test_topn_fault_injection," +
+    "auto_partition_in_partition_prune," + // inserted data in too many tablets, txn to large. not suitable for cloud.
+    "one_col_range_partition," + // inserted data in too many tablets, txn to large. not suitable for cloud.
+    "test_nereids_show_backup," +
+    "check_meta,"+
+    "test_checker,"+
+    "test_recycler_expired_stage_objects," +
+    "test_recycler_inverted_index," +
+    "test_recycler_with_drop_column," +
+    "test_recycler_with_drop_db," +
+    "test_recycler_with_drop_index," +
+    "test_recycler_with_drop_multi_db," +
+    "test_recycler_with_drop_mv," +
+    "test_recycler_with_drop_partition," +
+    "test_recycler_with_drop_rollup," +
+    "test_recycler_with_dynamic_partition," +
+    "test_recycler_with_internal_copy," +
+    "test_recycler_with_many_partitions," +
+    "test_recycler_with_schema_change," +
+    "test_recycler_with_truncate_table," +
+    "test_recycler_with_txn_label," +
+    "test_recycler," +
+    "rec_cte_with_delete_test," +
+    "test_recycler_cleanup_snapshot," +
+    "test_recycler_clone_instance," +
+    "test_stream_consumption_schema," +
+    "test_stream_info_schema," + // table stream is not supported for cloud mode now
+    "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
+
+excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
+    "external_table_p0," + // run on external pipeline
+    "cloud/multi_cluster," + // run in specific regression pipeline
+    "cloud_p0/multi_cluster," + // run in specific regression pipeline
+    "cloud_p0/cache," +
+    "shape_check," + // run only in p0 is enough
+    "query_p0/cache," + // run only in p0 is enough
+    "nereids_rules_p0/mv/increment_create," + // run only in p0 is enough
+    "nereids_rules_p0/mv/genera_constant_sql," + // run only in p0 is enough
+    "workload_manager_p1," +
+    "nereids_rules_p0/subquery," +
+    "backup_restore," + // not a case for cloud mode, no need to run
+    "cold_heat_separation," +
+    "storage_medium_p0," +
+    "ccr_syncer_p0," +
+    "ccr_mow_syncer_p0," +
+    "hdfs_vault_p2," +
+    "inject_hdfs_vault_p0," +
+    "variant_p0/nested," +
+    "variant_p0/nested/sql," +
+    "plsql_p0," + // plsql is not developped any more, add by sk.
+    "restore_p0," + // 
+    "table_stream_p0," + // table stream is not supported for cloud mode now
+    "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
+
+max_failure_num = 50
+
+// test_routine_load
+enableKafkaTest=true
+
+// vim: tw=10086 et ts=4 sw=4:
+
+// trino-connector catalog test config
+enableTrinoConnectorTest = false
+
+s3Source = "aliyun"
+s3Endpoint = "oss-cn-hongkong-internal.aliyuncs.com"
+recycleServiceHttpAddress = "127.0.0.1:6000"

--- a/regression-test/pipeline/nonConcurrent/conf/session_variables.sql
+++ b/regression-test/pipeline/nonConcurrent/conf/session_variables.sql
@@ -1,0 +1,1 @@
+-- set those session variables before run cloud p0 regression

--- a/regression-test/pipeline/nonConcurrent/deploy.sh
+++ b/regression-test/pipeline/nonConcurrent/deploy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+########################### Teamcity Build Step: Command Line #######################
+: <<EOF
+#!/bin/bash
+
+if [[ -f "${teamcity_build_checkoutDir:-}"/regression-test/pipeline/nonConcurrent/deploy.sh ]]; then
+    cd "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent
+    bash -x deploy.sh
+else
+    echo "Build Step file missing: regression-test/pipeline/nonConcurrent/deploy.sh" && exit 1
+fi
+EOF
+#####################################################################################
+
+########################## deploy.sh content ########################################
+# shellcheck source=/dev/null
+source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
+if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
+
+# shellcheck source=/dev/null
+# upload_doris_log_to_oss, download_oss_file
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/oss-utils.sh
+# shellcheck source=/dev/null
+# stop_doris, install_fdb, clean_fdb, print_doris_conf,
+# start_doris_fe, get_doris_conf_value, start_doris_be,
+# print_doris_fe_log, print_doris_be_log, archive_doris_logs
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/doris-utils.sh
+
+if ${DEBUG:-false}; then
+    pr_num_from_trigger=${pr_num_from_debug:-"30772"}
+    commit_id_from_trigger=${commit_id_from_debug:-"8a0077c2cfc492894d9ff68916e7e131f9a99b65"}
+fi
+echo "#### Check env"
+if [[ -z "${teamcity_build_checkoutDir}" ]]; then echo "ERROR: env teamcity_build_checkoutDir not set" && exit 1; fi
+if [[ -z "${pr_num_from_trigger}" ]]; then echo "ERROR: env pr_num_from_trigger not set" && exit 1; fi
+if [[ -z "${commit_id_from_trigger}" ]]; then echo "ERROR: env commit_id_from_trigger not set" && exit 1; fi
+if [[ -z "${oss_ak}" || -z "${oss_sk}" ]]; then echo "ERROR: env oss_ak or oss_sk not set." && exit 1; fi
+
+echo "#### Deploy Doris ####"
+DORIS_HOME="${teamcity_build_checkoutDir}/output"
+export DORIS_HOME
+exit_flag=0
+(
+    echo "#### 1. download doris binary"
+    cd "${teamcity_build_checkoutDir}"
+    export OSS_DIR="${OSS_DIR:-"oss://opensource-pipeline/compile_result"}"
+    if download_oss_file "${pr_num_from_trigger}_${commit_id_from_trigger}.tar.gz"; then
+        rm -rf "${teamcity_build_checkoutDir}"/output
+        tar -I pigz -xf "${pr_num_from_trigger}_${commit_id_from_trigger}.tar.gz"
+    else exit 1; fi
+
+    echo "#### 2. try to kill old doris process and clean foundationdb"
+    stop_doris
+    install_fdb && clean_fdb "cloud_instance_0"
+
+    set -e
+    echo "#### 3. copy conf from regression-test/pipeline/nonConcurrent/conf/ and modify"
+    cp -rf "${DORIS_HOME}"/ms/ "${DORIS_HOME}"/recycler/
+    cp -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/conf/fe_custom.conf "${DORIS_HOME}"/fe/conf/
+    cp -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/conf/be_custom.conf "${DORIS_HOME}"/be/conf/
+    fdb_cluster="$(cat /etc/foundationdb/fdb.cluster)"
+    sed -i "s/^fdb_cluster = .*/fdb_cluster = ${fdb_cluster}/" "${DORIS_HOME}"/ms/conf/doris_cloud.conf
+    sed -i "s/^fdb_cluster = .*/fdb_cluster = ${fdb_cluster}/" "${DORIS_HOME}"/recycler/conf/doris_cloud.conf
+    cat "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/conf/ms_custom.conf >>"${DORIS_HOME}"/ms/conf/doris_cloud.conf
+    echo >>"${DORIS_HOME}"/ms/conf/doris_cloud.conf
+    cat "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/conf/recycler_custom.conf >>"${DORIS_HOME}"/recycler/conf/doris_cloud.conf
+    echo >>"${DORIS_HOME}"/recycler/conf/doris_cloud.conf
+    print_doris_conf
+
+    echo "#### 4. start Doris"
+    JAVA_HOME="$(find /usr/lib/jvm -maxdepth 1 -type d -name 'java-17-*' | sed -n '1p')"
+    export JAVA_HOME
+    if ! start_doris_ms; then exit 1; fi
+    if ! start_doris_recycler; then exit 1; fi
+    if ! create_warehouse; then exit 1; fi
+    if ! warehouse_add_fe; then exit 1; fi
+    if ! warehouse_add_be; then exit 1; fi
+    if ! prepare_java_udf; then exit 1; fi
+    if ! start_doris_fe; then exit 1; fi
+    if ! start_doris_be; then exit 1; fi
+    if ! deploy_doris_sql_converter; then exit 1; else
+        set_session_variable sql_converter_service_url "http://127.0.0.1:${doris_sql_converter_port:-5001}/api/v1/convert"
+    fi
+    if ! check_doris_ready; then exit 1; fi
+
+    echo "#### 5. set session variables"
+    if ! reset_doris_session_variables; then exit 1; fi
+    session_variables_file="${teamcity_build_checkoutDir}/regression-test/pipeline/nonConcurrent/conf/session_variables.sql"
+    echo -e "\n\ntuned session variables:\n$(cat "${session_variables_file}")\n\n"
+    set_doris_session_variables_from_file "${session_variables_file}"
+    # record session variables
+    set +x
+    show_session_variables &>"${DORIS_HOME}"/session_variables
+)
+exit_flag="$?"
+
+echo "#### 5. check if need backup doris logs"
+if [[ ${exit_flag} != "0" ]]; then
+    stop_doris
+    print_doris_fe_log
+    print_doris_be_log
+    if file_name=$(archive_doris_logs "${pr_num_from_trigger}_${commit_id_from_trigger}_$(date +%Y%m%d%H%M%S)_doris_logs.tar.gz"); then
+        upload_doris_log_to_oss "${file_name}"
+    fi
+fi
+
+exit "${exit_flag}"
+#####################################################################################

--- a/regression-test/pipeline/nonConcurrent/prepare.sh
+++ b/regression-test/pipeline/nonConcurrent/prepare.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+########################### Teamcity Build Step: Command Line #######################
+: <<EOF
+#!/bin/bash
+
+set -x
+pwd
+rm -rf ../.old/*
+
+export teamcity_build_checkoutDir="%teamcity.build.checkoutDir%"
+export commit_id_from_checkout="%build.vcs.number%"
+export target_branch='%teamcity.pullRequest.target.branch%'
+export teamcity_buildType_id='%system.teamcity.buildType.id%'
+export skip_pipeline='%skip_pipline%'
+export PATH=/usr/local/software/apache-maven-3.6.3/bin:${PATH}
+if [[ -f "${teamcity_build_checkoutDir:-}"/regression-test/pipeline/nonConcurrent/prepare.sh ]]; then
+    cd "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/
+    if [[ "${skip_pipeline}" == "true" ]]; then
+    	bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'set' "export skip_pipeline=true"
+    fi
+    bash prepare.sh
+else
+    echo "Build Step file missing: regression-test/pipeline/nonConcurrent/prepare.sh" && exit 1
+fi
+EOF
+#####################################################################################
+## prepare.sh content ##
+
+if ${DEBUG:-false}; then
+    pr_num_from_trigger=${pr_num_from_debug:-"30772"}
+    commit_id_from_trigger=${commit_id_from_debug:-"8a0077c2cfc492894d9ff68916e7e131f9a99b65"}
+    commit_id_from_checkout=${commit_id_from_debug:-"8a0077c2cfc492894d9ff68916e7e131f9a99b65"} # teamcity checkout commit id
+    target_branch="master"
+fi
+
+# shellcheck source=/dev/null
+# stop_doris, clean_fdb, install_fdb, install_java, clear_coredump
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/doris-utils.sh
+# shellcheck source=/dev/null
+# check_oss_file_exist, download_oss_file
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/oss-utils.sh
+
+echo "#### Check env"
+if [[ -z "${teamcity_build_checkoutDir}" ]]; then echo "ERROR: env teamcity_build_checkoutDir not set" && exit 1; fi
+if [[ -z "${pr_num_from_trigger}" ]]; then echo "ERROR: env pr_num_from_trigger not set" && exit 1; fi
+if [[ -z "${commit_id_from_trigger}" ]]; then echo "ERROR: env commit_id_from_trigger not set" && exit 1; fi
+if [[ -z "${commit_id_from_checkout}" ]]; then echo "ERROR: env commit_id_from_checkout not set" && exit 1; fi
+if [[ -z "${target_branch}" ]]; then echo "ERROR: env target_branch not set" && exit 1; fi
+if [[ -z "${s3SourceAk}" || -z "${s3SourceSk}" ]]; then echo "ERROR: env s3SourceAk or s3SourceSk not set" && exit 1; fi
+if [[ -z "${oss_ak}" || -z "${oss_sk}" ]]; then echo "ERROR: env oss_ak or oss_sk not set." && exit 1; fi
+
+echo "#### 1. check if need run"
+if [[ "${commit_id_from_trigger}" != "${commit_id_from_checkout}" ]]; then
+    echo -e "从触发流水线 -> 流水线开始跑，这个时间段中如果有新commit，
+这时候流水线 checkout 出来的 commit 就不是触发时的传过来的 commit 了，
+这种情况不需要跑，预期 pr owner 会重新触发。"
+    echo -e "ERROR: PR(${pr_num_from_trigger}),
+    the commit_id_from_checkout
+    ${commit_id_from_checkout}
+    not equail to the commit_id_from_trigger
+    ${commit_id_from_trigger}
+    commit_id_from_trigger is outdate"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
+if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
+echo "INFO: PR target branch ${target_branch}"
+install_java
+
+# shellcheck source=/dev/null
+# _get_pr_changed_files file_changed_performance
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/github-utils.sh
+if _get_pr_changed_files "${pr_num_from_trigger}"; then
+    if ! file_changed_cloud_p0; then
+        bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'set' "export skip_pipeline=true"
+        exit 0
+    fi
+fi
+
+echo "#### 2. check if tpch depending files exist"
+set -x
+if ! [[ -d "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/ &&
+    -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/oss-utils.sh &&
+    -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/doris-utils.sh &&
+    -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/github-utils.sh &&
+    -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh ]]; then
+    echo "ERROR: depending files missing" && exit 1
+fi
+
+echo "#### 3. try to kill old doris process"
+DORIS_HOME="${teamcity_build_checkoutDir}/output"
+export DORIS_HOME
+stop_doris
+clear_coredump
+
+echo "#### 4. prepare fundationdb"
+install_fdb
+clean_fdb "cloud_instance_0"
+
+echo "#### 5. check if binary package ready"
+merge_pr_to_master_commit() {
+    local pr_num_from_trigger="$1"
+    local target_branch="$2"
+    local master_commit="$3"
+    echo "INFO: merge pull request into ${target_branch} ${master_commit}"
+    if [[ -z "${teamcity_build_checkoutDir}" ]]; then
+        echo "ERROR: env teamcity_build_checkoutDir not set" && return 1
+    fi
+    cd "${teamcity_build_checkoutDir}" || return 1
+    git reset --hard
+    git fetch origin "${target_branch}"
+    git checkout "${target_branch}"
+    git reset --hard origin/"${target_branch}"
+    git checkout "${master_commit}"
+    returnValue=$?
+    if [[ ${returnValue} -ne 0 ]]; then
+        echo "ERROR: checkout ${target_branch} ${master_commit} failed. please rebase to the newest version."
+        return 1
+    fi
+    git rev-parse HEAD
+    git config user.email "ci@selectdb.com"
+    git config user.name "ci"
+    echo "git fetch origin refs/pull/${pr_num_from_trigger}/head"
+    git fetch origin "refs/pull/${pr_num_from_trigger}/head"
+    git merge --no-edit --allow-unrelated-histories FETCH_HEAD
+    echo "INFO: merge refs/pull/${pr_num_from_trigger}/head into ${target_branch} ${master_commit}"
+    # CONFLICTS=$(git ls-files -u | wc -l)
+    if [[ $(git ls-files -u | wc -l) -gt 0 ]]; then
+        echo "ERROR: merge refs/pull/${pr_num_from_trigger}/head into  failed. Aborting"
+        git merge --abort
+        return 1
+    fi
+}
+export OSS_DIR="${OSS_DIR:-"oss://opensource-pipeline/compile_result"}"
+if ! check_oss_file_exist "${pr_num_from_trigger}_${commit_id_from_trigger}.tar.gz"; then return 1; fi
+if download_oss_file "${pr_num_from_trigger}_${commit_id_from_trigger}.tar.gz"; then
+    rm -rf "${teamcity_build_checkoutDir}"/output
+    tar -I pigz -xf "${pr_num_from_trigger}_${commit_id_from_trigger}.tar.gz"
+    master_commit_file="master.commit"
+    if [[ -e output/${master_commit_file} ]]; then
+        # checkout to master commit and merge this pr, to ensure binary and case are same version
+        master_commit=$(cat output/"${master_commit_file}")
+        if merge_pr_to_master_commit "${pr_num_from_trigger}" "${target_branch}" "${master_commit}"; then
+            echo "INFO: merged done"
+        else
+            exit 1
+        fi
+    fi
+else
+    exit 1
+fi

--- a/regression-test/pipeline/nonConcurrent/run.sh
+++ b/regression-test/pipeline/nonConcurrent/run.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+########################### Teamcity Build Step: Command Line #######################
+: <<EOF
+#!/bin/bash
+export PATH=/usr/local/software/jdk1.8.0_131/bin:/usr/local/software/apache-maven-3.6.3/bin:${PATH}
+if [[ -f "${teamcity_build_checkoutDir:-}"/regression-test/pipeline/nonConcurrent/run.sh ]]; then
+    cd "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/
+    bash -x run.sh
+else
+    echo "Build Step file missing: regression-test/pipeline/nonConcurrent/run.sh" && exit 1
+fi
+EOF
+############################# run.sh content ########################################
+# shellcheck source=/dev/null
+# _monitor_regression_log, print_running_pipeline_tasks
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/doris-utils.sh
+# shellcheck source=/dev/null
+# create_an_issue_comment
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/github-utils.sh
+# shellcheck source=/dev/null
+# upload_doris_log_to_oss
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/oss-utils.sh
+# shellcheck source=/dev/null
+# reporting_build_problem, reporting_messages_error
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/teamcity-utils.sh
+
+if ${DEBUG:-false}; then
+    pr_num_from_trigger=${pr_num_from_debug:-"30772"}
+    commit_id_from_trigger=${commit_id_from_debug:-"8a0077c2cfc492894d9ff68916e7e131f9a99b65"}
+fi
+echo "#### Check env"
+if [[ -z "${teamcity_build_checkoutDir}" ]]; then echo "ERROR: env teamcity_build_checkoutDir not set" && exit 1; fi
+if [[ -z "${pr_num_from_trigger}" ]]; then echo "ERROR: env pr_num_from_trigger not set" && exit 1; fi
+if [[ -z "${commit_id_from_trigger}" ]]; then echo "ERROR: env commit_id_from_trigger not set" && exit 1; fi
+if [[ -z "${s3SourceAk}" || -z "${s3SourceSk}" ]]; then echo "ERROR: env s3SourceAk or s3SourceSk not set" && exit 1; fi
+if [[ -z "${hwYunAk}" || -z "${hwYunSk}" ]]; then echo "WARNING: env hwYunAk or hwYunSk not set"; fi
+if [[ -z "${txYunAk}" || -z "${txYunSk}" ]]; then echo "WARNING: env txYunAk or txYunSk not set"; fi
+
+# shellcheck source=/dev/null
+source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
+if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
+
+echo "#### Run nonConcurrent test on Doris ####"
+DORIS_HOME="${teamcity_build_checkoutDir}/output"
+export DORIS_HOME
+exit_flag=0
+need_collect_log=false
+
+# monitoring the log files in "${DORIS_HOME}"/regression-test/log/ for keyword 'Reach limit of connections'
+_monitor_regression_log &
+
+# shellcheck disable=SC2329
+run() {
+    set -e
+    shopt -s inherit_errexit
+
+    cd "${teamcity_build_checkoutDir}" || return 1
+    {
+        echo # add a new line to prevent two config items from being combined, which will cause the error "No signature of method"
+        echo "ak='${s3SourceAk}'"
+        echo "sk='${s3SourceSk}'"
+        echo "hwYunAk='${hwYunAk:-}'"
+        echo "hwYunSk='${hwYunSk:-}'"
+        echo "txYunAk='${txYunAk:-}'"
+        echo "txYunSk='${txYunSk:-}'"
+        echo "regressionAliyunStsRegion='${regressionAliyunStsRegion:-cn-hongkong}'"
+        echo "regressionAliyunStsRoleArn='${regressionAliyunStsRoleArn:-}'"
+    } >>"${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/conf/regression-conf-custom.groovy
+    cp -f "${teamcity_build_checkoutDir}"/regression-test/pipeline/nonConcurrent/conf/regression-conf-custom.groovy \
+        "${teamcity_build_checkoutDir}"/regression-test/conf/
+    # start kafka docker to run case test_rountine_load
+    sed -i "s/^CONTAINER_UID=\"doris--\"/CONTAINER_UID=\"doris-external--\"/" "${teamcity_build_checkoutDir}"/docker/thirdparties/custom_settings.env
+    sed -i "s/oss-cn-hongkong.aliyuncs.com/oss-cn-hongkong-internal.aliyuncs.com/" "${teamcity_build_checkoutDir}"/docker/thirdparties/custom_settings.env
+    if bash "${teamcity_build_checkoutDir}"/docker/thirdparties/run-thirdparties-docker.sh --stop; then echo; fi
+    if bash "${teamcity_build_checkoutDir}"/docker/thirdparties/run-thirdparties-docker.sh -c kafka; then echo; else echo "ERROR: start kafka docker failed"; fi
+    # Run the regression suite under JDK 17: the Arrow Flight SQL JDBC driver (arrow 19)
+    # is Java 11+ bytecode and cannot be loaded by a JDK 8 runtime.
+    JAVA_HOME="$(find /usr/lib/jvm -maxdepth 1 -type d -name 'java-17-*' | sed -n '1p')"
+    export JAVA_HOME
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+    if "${teamcity_build_checkoutDir}"/run-regression-test.sh \
+        --teamcity \
+        --run \
+        --times "${repeat_times_from_trigger:-1}" \
+        -g nonConcurrent; then
+        echo
+    else
+        bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'set' "export need_collect_log=true"
+        # regression 测试跑完后输出的汇总信息，Test 1961 suites, failed 1 suites, fatal 0 scripts, skipped 0 scripts
+        # 如果 test_suites>0 && failed_suites<=3  && fatal_scripts=0，就把返回状态码改为正常的0，让teamcity根据跑case的情况去判断成功还是失败
+        # 这样预期能够快速 mute 不稳定的 case
+        summary=$(
+            grep -aoE 'Test ([0-9]+) suites, failed ([0-9]+) suites, fatal ([0-9]+) scripts, skipped ([0-9]+) scripts' \
+                "${DORIS_HOME}"/regression-test/log/doris-regression-test.*.log
+        )
+        set -x
+        test_suites=$(echo "${summary}" | cut -d ' ' -f 2)
+        failed_suites=$(echo "${summary}" | cut -d ' ' -f 5)
+        fatal_scripts=$(echo "${summary}" | cut -d ' ' -f 8)
+        if [[ ${test_suites} -gt 0 && ${failed_suites} -le ${failed_suites_threshold:=100} && ${fatal_scripts} -eq 0 ]]; then
+            echo "INFO: regression test result meet (test_suites>0 && failed_suites<=${failed_suites_threshold} && fatal_scripts=0)"
+        else
+            return 1
+        fi
+    fi
+}
+export -f run
+# 设置超时时间（以分为单位）
+timeout_minutes=$((${repeat_times_from_trigger:-1} * ${BUILD_TIMEOUT_MINUTES:-180}))m
+timeout "${timeout_minutes}" bash -cx run
+exit_flag="$?"
+if print_running_pipeline_tasks; then :; fi
+# shellcheck source=/dev/null
+source "$(cd "${teamcity_build_checkoutDir}" && bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
+if get_jstack_and_jmap_of_fe; then echo "INFO: get_jstack_and_jmap_of_fe done."; fi
+check_if_need_gcore "${exit_flag}"
+if stop_doris_grace; then
+    echo "INFO: stop doris grace success."
+else
+    echo "ERROR: stop grace failed." && exit_flag=2
+fi
+if core_file_name=$(archive_doris_coredump "${pr_num_from_trigger}_${commit_id_from_trigger}_$(date +%Y%m%d%H%M%S)_doris_coredump.tar.gz"); then
+    reporting_build_problem "coredump"
+    print_doris_fe_log
+    print_doris_be_log
+fi
+echo "#### check if need backup doris logs ####"
+if [[ ${exit_flag} != "0" ]] || ${need_collect_log}; then
+    if log_file_name=$(archive_doris_logs "${pr_num_from_trigger}_${commit_id_from_trigger}_$(date +%Y%m%d%H%M%S)_doris_logs.tar.gz"); then
+        if log_info="$(upload_doris_log_to_oss "${log_file_name}")"; then
+            reporting_messages_error "${log_info##*logs.tar.gz to }"
+        fi
+    fi
+    if core_info="$(upload_doris_log_to_oss "${core_file_name}")"; then reporting_messages_error "${core_info##*coredump.tar.gz to }"; fi
+fi
+
+exit "${exit_flag}"

--- a/regression-test/suites/external_table_p0/paimon/paimon_base_filesystem.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_base_filesystem.groovy
@@ -106,17 +106,20 @@ suite("paimon_base_filesystem", "p0,external") {
         sql """SELECT * FROM all_table\$snapshots;"""
 
         sql """ switch ${catalog_obs} """
-        sql """ show databases """
-        sql """ use ${catalog_obs}.db1 """
-        // sql """ show tables """
-        // batch incremental
-        sql """SELECT * FROM all_table @incr('startTimestamp'='876488912')"""
-        // time travel
-        sql """SELECT * FROM all_table FOR VERSION AS OF 1;"""
-        // branch/tag
-        // TODO(zgx): add branch/tag
-        // system table
-        sql """SELECT * FROM all_table\$snapshots;"""
+        // OBS cross-region (HK -> Beijing cn-north-4) network may be unstable, retry data access
+        retry(5, 3000) {
+            sql """ show databases """
+            sql """ use ${catalog_obs}.db1 """
+            // sql """ show tables """
+            // batch incremental
+            sql """SELECT * FROM all_table @incr('startTimestamp'='876488912')"""
+            // time travel
+            sql """SELECT * FROM all_table FOR VERSION AS OF 1;"""
+            // branch/tag
+            // TODO(zgx): add branch/tag
+            // system table
+            sql """SELECT * FROM all_table\$snapshots;"""
+        }
 
         sql """ switch ${catalog_cos} """
         sql """ show databases """
@@ -147,13 +150,13 @@ suite("paimon_base_filesystem", "p0,external") {
 
         sql """set force_jni_scanner=false"""
         qt_oss oss
-        qt_obs obs
+        retry(5, 3000) { qt_obs obs }
         qt_cos cos
         qt_cosn cosn
 
         sql """set force_jni_scanner=true"""
         qt_oss oss
-        qt_obs obs
+        retry(5, 3000) { qt_obs obs }
         qt_cos cos
         qt_cosn cosn
 


### PR DESCRIPTION
## Problem

Paimon filesystem catalog OBS queries intermittently fail with `Connect timed out` / `RequestTimeOut (408)` errors.

Root cause: test machines are in Alibaba Cloud Hong Kong, while the OBS endpoint is `obs.cn-north-4.myhuaweicloud.com` (Beijing). Cross-region network instability causes transient TCP connection failures.

Related: [DORIS-26713](http://39.106.86.136:8090/browse/DORIS-26713)

## Solution

Add `retry(5, 3000)` (5 attempts, 3s interval) around OBS data access queries in `paimon_base_filesystem.groovy`:
- OBS `show databases`, `use`, SELECT queries block
- Both `qt_obs obs` comparison calls (force_jni_scanner=false and true)

The retry uses the existing framework `Suite.retry()` method which catches any Throwable and re-executes the closure. Network errors from OBS will be retried transparently.

OSS/COS/COSN operations are unaffected as they use different endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)