### PR TITLE
[fix](iceberg) Execute empty static overwrite and stabilize info_schema timezone test

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -276,6 +276,39 @@ public abstract class AbstractInsertExecutor {
         afterExec(executor);
     }
 
+    /**
+     * Execute an insert that has no source rows but still needs side effects.
+     * For example, Iceberg static partition overwrite with an empty source still
+     * needs to commit a partition delete.
+     */
+    public void executeEmptyInsert(StmtExecutor executor) throws Exception {
+        beforeExec();
+        try {
+            for (InsertExecutorListener listener : listeners) {
+                listener.beforeComplete(this, executor, jobId);
+            }
+            onComplete();
+            for (InsertExecutorListener listener : listeners) {
+                listener.afterComplete(this, executor, jobId);
+            }
+        } catch (Throwable t) {
+            onFail(t);
+            return;
+        } finally {
+            coordinator.close();
+            executor.updateProfile(true);
+        }
+        afterExec(executor);
+    }
+
+    /**
+     * Whether an empty source insert should still execute instead of using the
+     * normal fast-return path.
+     */
+    public boolean shouldExecuteEmptyInsert() {
+        return false;
+    }
+
     public boolean isEmptyInsert() {
         return emptyInsert;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/IcebergInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/IcebergInsertExecutor.java
@@ -68,4 +68,13 @@ public class IcebergInsertExecutor extends BaseExternalTableInsertExecutor {
         return TransactionType.ICEBERG;
     }
 
+    @Override
+    public boolean shouldExecuteEmptyInsert() {
+        return emptyInsert
+                && insertCtx.filter(IcebergInsertCommandContext.class::isInstance)
+                        .map(IcebergInsertCommandContext.class::cast)
+                        .map(IcebergInsertCommandContext::isStaticPartitionOverwrite)
+                        .orElse(false);
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/IcebergInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/IcebergInsertExecutor.java
@@ -70,11 +70,22 @@ public class IcebergInsertExecutor extends BaseExternalTableInsertExecutor {
 
     @Override
     public boolean shouldExecuteEmptyInsert() {
-        return emptyInsert
-                && insertCtx.filter(IcebergInsertCommandContext.class::isInstance)
-                        .map(IcebergInsertCommandContext.class::cast)
-                        .map(IcebergInsertCommandContext::isStaticPartitionOverwrite)
-                        .orElse(false);
+        return shouldExecuteEmptyInsert(emptyInsert, insertCtx,
+                ((IcebergExternalTable) table).isPartitionedTable());
+    }
+
+    static boolean shouldExecuteEmptyInsert(boolean emptyInsert, Optional<InsertCommandContext> insertCtx,
+            boolean partitionedTable) {
+        if (!emptyInsert) {
+            return false;
+        }
+        Optional<IcebergInsertCommandContext> icebergInsertCtx = insertCtx
+                .filter(IcebergInsertCommandContext.class::isInstance)
+                .map(IcebergInsertCommandContext.class::cast);
+        return icebergInsertCtx
+                .filter(IcebergInsertCommandContext::isOverwrite)
+                .map(ctx -> ctx.isStaticPartitionOverwrite() || !partitionedTable)
+                .orElse(false);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -375,6 +375,8 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
                             buildResult.planner.getFragments().get(0), buildResult.dataSink,
                             buildResult.physicalSink
                     );
+                } else if (insertExecutor.shouldExecuteEmptyInsert()) {
+                    insertExecutor.beginTransaction();
                 }
                 newestTargetTableIf.readUnlock();
             } catch (Throwable e) {
@@ -721,6 +723,13 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
         AbstractInsertExecutor insertExecutor = initPlan(ctx, executor);
         // if the insert stmt data source is empty, directly return, no need to be executed.
         if (insertExecutor.isEmptyInsert()) {
+            if (!insertExecutor.shouldExecuteEmptyInsert()) {
+                return;
+            }
+            if (insertExecutorListener != null) {
+                insertExecutor.registerListener(insertExecutorListener);
+            }
+            insertExecutor.executeEmptyInsert(executor);
             return;
         }
         if (insertExecutorListener != null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergTransactionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergTransactionTest.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,10 +136,14 @@ public class IcebergTransactionTest {
     }
 
     private List<String> createPartitionValues() {
+        return createPartitionValues(Instant.parse("2024-12-11T12:34:56.123456Z"),
+                "2024-12-11", "2024-12-11", 1);
+    }
 
-        Instant instant = Instant.parse("2024-12-11T12:34:56.123456Z");
+    private List<String> createPartitionValues(Instant instant, String str1, String str2, Integer int1) {
         long ts = DateTimeUtil.microsFromInstant(instant);
         int dt = DateTimeUtil.daysFromInstant(instant);
+        String dateString = numToDay(dt);
 
         List<String> partitionValues = new ArrayList<>();
 
@@ -151,16 +156,16 @@ public class IcebergTransactionTest {
         // reference: org.apache.iceberg.transforms.Dates
         partitionValues.add(Integer.valueOf(DateTimeUtil.daysToYears(dt)).toString());
         partitionValues.add(Integer.valueOf(DateTimeUtil.daysToMonths(dt)).toString());
-        partitionValues.add("2024-12-11");
+        partitionValues.add(dateString);
 
         // identity dt4
-        partitionValues.add("2024-12-11");
+        partitionValues.add(dateString);
         // identity str1
-        partitionValues.add("2024-12-11");
+        partitionValues.add(str1);
         // truncate str2
-        partitionValues.add("2024-12-11");
+        partitionValues.add(str2);
         // bucket int1
-        partitionValues.add("1");
+        partitionValues.add(int1.toString());
 
         return partitionValues;
     }
@@ -460,6 +465,77 @@ public class IcebergTransactionTest {
         }
 
         checkSnapshotTotalProperties(table.currentSnapshot().summary(), "0", "0", "0");
+    }
+
+    @Test
+    public void testStaticPartitionOverwriteWithoutDataDeletesMatchingPartition() throws UserException {
+        List<TIcebergCommitData> ctdList = new ArrayList<>();
+        TIcebergCommitData ctd1 = new TIcebergCommitData();
+        ctd1.setFilePath("partition-a.parquet");
+        ctd1.setPartitionValues(createPartitionValues(
+                Instant.parse("2024-12-11T12:34:56.123456Z"),
+                "partition-a", "truncate-a", 11));
+        ctd1.setFileContent(TFileContent.DATA);
+        ctd1.setRowCount(2);
+        ctd1.setFileSize(2);
+
+        TIcebergCommitData ctd2 = new TIcebergCommitData();
+        ctd2.setFilePath("partition-b.parquet");
+        ctd2.setPartitionValues(createPartitionValues(
+                Instant.parse("2024-12-12T12:34:56.123456Z"),
+                "partition-b", "truncate-b", 25));
+        ctd2.setFileContent(TFileContent.DATA);
+        ctd2.setRowCount(4);
+        ctd2.setFileSize(4);
+
+        ctdList.add(ctd1);
+        ctdList.add(ctd2);
+
+        Table table = ops.getCatalog().loadTable(TableIdentifier.of(dbName, tbWithPartition));
+        IcebergExternalTable icebergExternalTable = Mockito.mock(IcebergExternalTable.class);
+        Mockito.when(icebergExternalTable.getCatalog()).thenReturn(spyExternalCatalog);
+        Mockito.when(icebergExternalTable.getDbName()).thenReturn(dbName);
+        Mockito.when(icebergExternalTable.getName()).thenReturn(tbWithPartition);
+
+        try (MockedStatic<IcebergUtils> mockedStatic = Mockito.mockStatic(IcebergUtils.class)) {
+            mockedStatic.when(() -> IcebergUtils.getIcebergTable(ArgumentMatchers.any(ExternalTable.class)))
+                    .thenReturn(table);
+            mockedStatic.when(() -> IcebergUtils.parsePartitionValueFromString(
+                    ArgumentMatchers.any(), ArgumentMatchers.any()))
+                    .thenCallRealMethod();
+
+            IcebergTransaction txn = getTxn();
+            txn.updateIcebergCommitData(ctdList);
+            txn.beginInsert(icebergExternalTable, Optional.empty());
+            txn.finishInsert(NameMapping.createForTest(dbName, tbWithPartition));
+            txn.commit();
+        }
+
+        checkPushDownByPartition(table, Expressions.equal("str1", "partition-a"), 1);
+        checkPushDownByPartition(table, Expressions.equal("str1", "partition-b"), 1);
+
+        try (MockedStatic<IcebergUtils> mockedStatic = Mockito.mockStatic(IcebergUtils.class)) {
+            mockedStatic.when(() -> IcebergUtils.getIcebergTable(ArgumentMatchers.any(ExternalTable.class)))
+                    .thenReturn(table);
+            mockedStatic.when(() -> IcebergUtils.parsePartitionValueFromString(
+                    ArgumentMatchers.any(), ArgumentMatchers.any()))
+                    .thenCallRealMethod();
+
+            IcebergTransaction txn = getTxn();
+            IcebergInsertCommandContext ctx = new IcebergInsertCommandContext();
+            ctx.setOverwrite(true);
+            Map<String, String> staticPartitions = new LinkedHashMap<>();
+            staticPartitions.put("dt4", "2024-12-11");
+            staticPartitions.put("str1", "partition-a");
+            ctx.setStaticPartitionValues(staticPartitions);
+            txn.beginInsert(icebergExternalTable, Optional.of(ctx));
+            txn.finishInsert(NameMapping.createForTest(dbName, tbWithPartition));
+            txn.commit();
+        }
+
+        checkPushDownByPartition(table, Expressions.equal("str1", "partition-a"), 0);
+        checkPushDownByPartition(table, Expressions.equal("str1", "partition-b"), 1);
+        checkSnapshotTotalProperties(table.currentSnapshot().summary(), "4", "1", "4");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/IcebergInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/IcebergInsertExecutorTest.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+class IcebergInsertExecutorTest {
+
+    @Test
+    void testShouldExecuteEmptyInsertForIcebergOverwrite() {
+        IcebergInsertCommandContext appendCtx = new IcebergInsertCommandContext();
+        IcebergInsertCommandContext overwriteCtx = new IcebergInsertCommandContext();
+        overwriteCtx.setOverwrite(true);
+        IcebergInsertCommandContext staticOverwriteCtx = new IcebergInsertCommandContext();
+        staticOverwriteCtx.setOverwrite(true);
+        staticOverwriteCtx.setStaticPartitionValues(Collections.singletonMap("dt", "2026-07-07"));
+
+        Assertions.assertFalse(IcebergInsertExecutor.shouldExecuteEmptyInsert(
+                false, Optional.of(staticOverwriteCtx), true));
+        Assertions.assertFalse(IcebergInsertExecutor.shouldExecuteEmptyInsert(
+                true, Optional.empty(), false));
+        Assertions.assertFalse(IcebergInsertExecutor.shouldExecuteEmptyInsert(
+                true, Optional.of(appendCtx), false));
+        Assertions.assertFalse(IcebergInsertExecutor.shouldExecuteEmptyInsert(
+                true, Optional.of(overwriteCtx), true));
+        Assertions.assertTrue(IcebergInsertExecutor.shouldExecuteEmptyInsert(
+                true, Optional.of(overwriteCtx), false));
+        Assertions.assertTrue(IcebergInsertExecutor.shouldExecuteEmptyInsert(
+                true, Optional.of(staticOverwriteCtx), true));
+    }
+}

--- a/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
@@ -79,7 +79,7 @@ suite("test_information_schema_timezone", "p0,external") {
 
     def getStableRowsetsTime = { tabletId ->
         List<List<Object>> result = null
-        waitUntil(30) {
+        awaitUntil(30) {
             result = sql """
                 select CREATION_TIME, NEWEST_WRITE_TIMESTAMP
                 from information_schema.rowsets

--- a/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
@@ -77,6 +77,22 @@ suite("test_information_schema_timezone", "p0,external") {
         }
     }
 
+    def getStableRowsetsTime = { tabletId ->
+        List<List<Object>> result = null
+        waitUntil(30) {
+            result = sql """
+                select CREATION_TIME, NEWEST_WRITE_TIMESTAMP
+                from information_schema.rowsets
+                where TABLET_ID = ${tabletId}
+                order by CREATION_TIME, NEWEST_WRITE_TIMESTAMP
+                limit 1
+            """
+            logger.info("stable rowsets result = " + result)
+            return result != null && !result.isEmpty()
+        }
+        return result
+    }
+
     // 0. Assert the timezone
     qt_session_time_zone_UTC """ show variables like "time_zone" """
 
@@ -97,9 +113,7 @@ suite("test_information_schema_timezone", "p0,external") {
     // 5. rowsets
     def rowsets_table_name_tablets = sql_return_maparray """ show tablets from ${table_name}; """
     def tablet_id = rowsets_table_name_tablets[0].TabletId
-    List<List<Object>> rowsets_res_1 = sql """ 
-            select CREATION_TIME, NEWEST_WRITE_TIMESTAMP from information_schema.rowsets where TABLET_ID = ${tablet_id}
-            """
+    List<List<Object>> rowsets_res_1 = getStableRowsetsTime(tablet_id)
     logger.info("rowsets_res_1 = " + rowsets_res_1);
     
     // 6. backend_kerberos_ticket_cache
@@ -166,13 +180,15 @@ suite("test_information_schema_timezone", "p0,external") {
     logger.info("processlist_res_2 = " + processlist_res_2);
     assertEquals(true, isEightHoursDiff(processlist_res_1[0][0], processlist_res_2[0][0]))
 
-    // 4. rowsets
-    List<List<Object>> rowsets_res_2 = sql """ 
-            select CREATION_TIME, NEWEST_WRITE_TIMESTAMP from information_schema.rowsets where TABLET_ID = ${tablet_id}
-            """
+    // 5. rowsets
+    List<List<Object>> rowsets_res_2 = getStableRowsetsTime(tablet_id)
     logger.info("rowsets_res_2 = " + rowsets_res_2);
     assertEquals(true, isEightHoursDiff(rowsets_res_1[0][0], rowsets_res_2[0][0]))
-    assertEquals(true, isEightHoursDiff(rowsets_res_1[0][1], rowsets_res_2[0][1]))
+    if (rowsets_res_1[0][1] == null || rowsets_res_2[0][1] == null) {
+        assertEquals(rowsets_res_1[0][1], rowsets_res_2[0][1])
+    } else {
+        assertEquals(true, isEightHoursDiff(rowsets_res_1[0][1], rowsets_res_2[0][1]))
+    }
 
     // 5. backend_kerberos_ticket_cache
     if (enabled != null && enabled.equalsIgnoreCase("true")) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: apache/doris#62344

Problem Summary: Pick apache/doris#62344 from branch-4.1 to master. The source PR fixes Iceberg static partition overwrite when the source query is optimized to an empty relation, and stabilizes the information_schema.rowsets timezone regression case. `git cherry` showed the three source commits were not present on origin/master, so this PR applies them to master. The only pick conflict was in test_information_schema_timezone.groovy; the resolution keeps the current master offset timezone coverage and applies the stable rowsets query helper from the source PR.

### Release note

Fix Iceberg static partition overwrite when the source query is empty.

### Check List (For Author)

- Test: Manual test
    - git diff --check origin/master..HEAD
- Behavior changed: Yes. Empty-source Iceberg static partition overwrite can execute the overwrite path instead of being skipped as empty.
- Does this need documentation: No
