### PR TITLE
[fix](be) Release workload group schedulers on shutdown

### DIFF
--- a/be/src/exec/pipeline/task_queue.cpp
+++ b/be/src/exec/pipeline/task_queue.cpp
@@ -21,6 +21,7 @@
 #include <chrono> // IWYU pragma: keep
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "common/logging.h"
 #include "exec/pipeline/pipeline_task.h"
@@ -37,6 +38,12 @@ PipelineTaskSPtr SubTaskQueue::try_take(bool is_steal) {
     return task;
 }
 
+std::queue<PipelineTaskSPtr> SubTaskQueue::take_all() {
+    std::queue<PipelineTaskSPtr> tasks;
+    tasks.swap(_queue);
+    return tasks;
+}
+
 ////////////////////  PriorityTaskQueue ////////////////////
 
 PriorityTaskQueue::PriorityTaskQueue() : _closed(false) {
@@ -48,10 +55,24 @@ PriorityTaskQueue::PriorityTaskQueue() : _closed(false) {
 }
 
 void PriorityTaskQueue::close() {
-    std::unique_lock<std::mutex> lock(_work_size_mutex);
-    _closed = true;
-    _wait_task.notify_all();
-    DorisMetrics::instance()->pipeline_task_queue_size->increment(-_total_task_size);
+    std::vector<std::queue<PipelineTaskSPtr>> tasks_to_release;
+    {
+        std::unique_lock<std::mutex> lock(_work_size_mutex);
+        _closed = true;
+        const auto total_task_size = _total_task_size.exchange(0);
+        _wait_task.notify_all();
+        DorisMetrics::instance()->pipeline_task_queue_size->increment(
+                -static_cast<int64_t>(total_task_size));
+        for (auto& sub_queue : _sub_queues) {
+            tasks_to_release.emplace_back(sub_queue.take_all());
+        }
+    }
+    for (auto& tasks : tasks_to_release) {
+        while (!tasks.empty()) {
+            tasks.front()->pop_out_runnable_queue();
+            tasks.pop();
+        }
+    }
 }
 
 PipelineTaskSPtr PriorityTaskQueue::_try_take_unprotected(bool is_steal) {
@@ -113,11 +134,11 @@ PipelineTaskSPtr PriorityTaskQueue::take(uint32_t timeout_ms) {
 }
 
 Status PriorityTaskQueue::push(PipelineTaskSPtr task) {
+    auto level = _compute_level(task->get_runtime_ns());
+    std::unique_lock<std::mutex> lock(_work_size_mutex);
     if (_closed) {
         return Status::InternalError("WorkTaskQueue closed");
     }
-    auto level = _compute_level(task->get_runtime_ns());
-    std::unique_lock<std::mutex> lock(_work_size_mutex);
 
     // update empty queue's  runtime, to avoid too high priority
     if (_sub_queues[level].empty() &&
@@ -125,6 +146,7 @@ Status PriorityTaskQueue::push(PipelineTaskSPtr task) {
         _sub_queues[level].adjust_runtime(_queue_level_min_vruntime);
     }
 
+    task->put_in_runnable_queue();
     _sub_queues[level].push_back(task);
     _total_task_size++;
     DorisMetrics::instance()->pipeline_task_queue_size->increment(1);
@@ -199,7 +221,6 @@ Status MultiCoreTaskQueue::push_back(PipelineTaskSPtr task) {
 
 Status MultiCoreTaskQueue::push_back(PipelineTaskSPtr task, int core_id) {
     DCHECK(core_id < _core_size);
-    task->put_in_runnable_queue();
     return _prio_task_queues[core_id].push(task);
 }
 

--- a/be/src/exec/pipeline/task_queue.h
+++ b/be/src/exec/pipeline/task_queue.h
@@ -56,6 +56,8 @@ public:
 
     bool empty() { return _queue.empty(); }
 
+    std::queue<PipelineTaskSPtr> take_all();
+
 private:
     std::queue<PipelineTaskSPtr> _queue;
     // depends on LEVEL_QUEUE_TIME_FACTOR

--- a/be/src/exec/scan/scanner_scheduler.h
+++ b/be/src/exec/scan/scanner_scheduler.h
@@ -164,7 +164,9 @@ public:
     }
 
     void stop() override {
-        _is_stop.store(true);
+        if (_is_stop.exchange(true)) {
+            return;
+        }
         _scan_thread_pool->shutdown();
         _scan_thread_pool->wait();
     }
@@ -264,7 +266,9 @@ public:
     }
 
     void stop() override {
-        _is_stop.store(true);
+        if (_is_stop.exchange(true)) {
+            return;
+        }
         _task_executor->stop();
         _task_executor->wait();
     }

--- a/be/src/exec/scan/task_executor/time_sharing/time_sharing_task_executor.cpp
+++ b/be/src/exec/scan/task_executor/time_sharing/time_sharing_task_executor.cpp
@@ -255,9 +255,7 @@ Status TimeSharingTaskExecutor::init() {
 }
 
 TimeSharingTaskExecutor::~TimeSharingTaskExecutor() {
-    if (!_stopped.exchange(true)) {
-        stop();
-    }
+    stop();
 
     std::vector<std::shared_ptr<PrioritizedSplitRunner>> splits_to_destroy;
     {
@@ -294,6 +292,9 @@ Status TimeSharingTaskExecutor::start() {
 }
 
 void TimeSharingTaskExecutor::stop() {
+    if (_stopped.exchange(true)) {
+        return;
+    }
     // Why access to doris_metrics is safe here?
     // Since DorisMetrics is a singleton, it will be destroyed only after doris_main is exited.
     // The shutdown/destroy of SplitThreadPool is guaranteed to take place before doris_main exits by

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -884,7 +884,9 @@ void ExecEnv::destroy() {
     _load_stream_map_pool.reset();
     // Workload group schedulers own the query pipeline, scan, and memtable flush queues.
     // Release them after fragment/load resources have stopped submitting cleanup work.
-    _workload_group_manager->destroy_schedulers();
+    if (_workload_group_manager) {
+        _workload_group_manager->destroy_schedulers();
+    }
     SAFE_STOP(_write_cooldown_meta_executors);
 
     // _id_manager must be destoried before tablet schema cache

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -868,7 +868,8 @@ void ExecEnv::destroy() {
     SAFE_STOP(_stream_load_recorder_manager);
     // stop workload scheduler
     SAFE_STOP(_workload_sched_mgr);
-    // stop pipline step 2, cgroup execution
+    // Stop workload group execution threads before FragmentMgr. Running pipeline tasks can still
+    // report status through FragmentMgr's async thread pool.
     SAFE_STOP(_workload_group_manager);
 
     SAFE_STOP(_external_scan_context_mgr);
@@ -881,6 +882,9 @@ void ExecEnv::destroy() {
     _memtable_memory_limiter.reset();
     _delta_writer_v2_pool.reset();
     _load_stream_map_pool.reset();
+    // Workload group schedulers own the query pipeline, scan, and memtable flush queues.
+    // Release them after fragment/load resources have stopped submitting cleanup work.
+    _workload_group_manager->destroy_schedulers();
     SAFE_STOP(_write_cooldown_meta_executors);
 
     // _id_manager must be destoried before tablet schema cache

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -743,6 +743,10 @@ int64_t WorkloadGroup::get_mem_used() {
 
 void WorkloadGroup::try_stop_schedulers() {
     std::lock_guard<std::shared_mutex> wlock(_task_sched_lock);
+    stop_schedulers_no_lock();
+}
+
+void WorkloadGroup::stop_schedulers_no_lock() {
     if (_task_sched) {
         _task_sched->stop();
     }
@@ -764,6 +768,15 @@ void WorkloadGroup::try_stop_schedulers() {
         _memtable_flush_pool->shutdown();
         _memtable_flush_pool->wait();
     }
+}
+
+void WorkloadGroup::destroy_schedulers() {
+    std::lock_guard<std::shared_mutex> wlock(_task_sched_lock);
+    _task_sched.reset();
+    _scan_task_sched.reset();
+    _remote_scan_task_sched.reset();
+    _memtable_flush_pool.reset();
+    _cgroup_cpu_ctl.reset();
 }
 
 void WorkloadGroup::update_memtable_flush_threads() {

--- a/be/src/runtime/workload_group/workload_group.h
+++ b/be/src/runtime/workload_group/workload_group.h
@@ -219,6 +219,8 @@ private:
     void upsert_cgroup_cpu_ctl_no_lock(WorkloadGroupInfo* wg_info);
     Status upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
                                       std::shared_ptr<CgroupCpuCtl> cg_cpu_ctl_ptr);
+    void stop_schedulers_no_lock();
+    void destroy_schedulers();
 
     std::string _memory_debug_string() const;
 

--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -971,6 +971,13 @@ void WorkloadGroupMgr::stop() {
     }
 }
 
+void WorkloadGroupMgr::destroy_schedulers() {
+    std::shared_lock<std::shared_mutex> r_lock(_group_mutex);
+    for (auto iter = _workload_groups.begin(); iter != _workload_groups.end(); iter++) {
+        iter->second->destroy_schedulers();
+    }
+}
+
 Status WorkloadGroupMgr::create_internal_wg() {
     TWorkloadGroupInfo twg_info;
     twg_info.__set_id(INTERNAL_NORMAL_WG_ID);

--- a/be/src/runtime/workload_group/workload_group_manager.h
+++ b/be/src/runtime/workload_group/workload_group_manager.h
@@ -81,6 +81,8 @@ public:
 
     void stop();
 
+    void destroy_schedulers();
+
     void refresh_workload_group_memory_state();
 
     void get_wg_resource_usage(Block* block);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

There are smart pointer cycle references:
```
  ResourceContext
    -> shared_ptr<WorkloadGroup>
    -> WorkloadGroup::_task_sched
    -> HybridTaskScheduler
    -> TaskScheduler::_task_queue
    -> MultiCoreTaskQueue
    -> PriorityTaskQueue
    -> SubTaskQueue::_queue
    -> shared_ptr<PipelineTask>
    -> ScanLocalState / ScannerContext / ScanTask / operator local state
    -> shared_ptr<ResourceContext>
```
and 
```
ResourceContext
    -> WorkloadGroup
    -> _scan_task_sched / _remote_scan_task_sched
    -> TaskExecutorSimplifiedScanScheduler
    -> queued scan task / split runner
    -> ScannerContext / ScanTask
    -> shared_ptr<ResourceContext>
```
Graceful shutdown with enable_graceful_exit_check could report ASAN/LSan leaks after exec env destroy. The leak stacks showed pending pipeline tasks in MultiCoreTaskQueue, scanner splits in TimeSharingTaskExecutor, memtable flush tasks in workload group ThreadPool, and QueryContext/ResourceContext retaining WorkloadGroup.

ExecEnv stopped workload group schedulers before fragment and load resources were released, and WorkloadGroupMgr::stop only stopped scheduler threads without destroying scheduler objects or their queued resources. Pending queues and executor task maps could therefore retain query/load resources until process exit. This change clears pending pipeline task queues on close, makes queue close and submit mutually exclusive, only marks tasks runnable after a successful enqueue, releases scheduler-owned queues after fragment/load resources have stopped.

Leak callstacks:
```
==1794738==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 40960 byte(s) in 80 object(s) allocated from:
    #0 0x55dc4a0a52ad in operator new(unsigned long) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x23c0d2ad)
    #1 0x55dc625cc299 in std::__new_allocator<std::shared_ptr<doris::PipelineTask> >::allocate(unsigned long, void const*) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/new_allocator.h:151:27
    #2 0x55dc625cc299 in std::allocator<std::shared_ptr<doris::PipelineTask> >::allocate(unsigned long) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/allocator.h:203:32
    #3 0x55dc625cc299 in std::allocator_traits<std::allocator<std::shared_ptr<doris::PipelineTask> > >::allocate(std::allocator<std::shared_ptr<doris::PipelineTask> >&, unsigned long) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/alloc_traits.h:614:20
    #4 0x55dc625cc299 in std::_Deque_base<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > >::_M_allocate_node() /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_deque.h:586:9
    #5 0x55dc625cc299 in std::_Deque_base<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > >::_M_create_nodes(std::shared_ptr<doris::PipelineTask>**, std::shared_ptr<doris::PipelineTask>**) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_deque.h:687:21
    #6 0x55dc625cbe8a in std::_Deque_base<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > >::_M_initialize_map(unsigned long) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_deque.h:661:4
    #7 0x55dc625badab in std::_Deque_base<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > >::_Deque_base() /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_deque.h:463:9
    #8 0x55dc625badab in std::deque<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > >::deque() /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_deque.h:858:7
    #9 0x55dc625badab in std::queue<std::shared_ptr<doris::PipelineTask>, std::deque<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > > >::queue<std::deque<std::shared_ptr<doris::PipelineTask>, std::allocator<std::shared_ptr<doris::PipelineTask> > >, void>() /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_queue.h:171:4
    #10 0x55dc625badab in doris::SubTaskQueue::SubTaskQueue() be/build_ASAN/../src/exec/pipeline/task_queue.h:36:7
    #11 0x55dc625badab in doris::PriorityTaskQueue::PriorityTaskQueue() be/build_ASAN/./be/build_ASAN/../src/exec/pipeline/task_queue.cpp:42:20
    #12 0x55dc625ce544 in void std::_Construct<doris::PriorityTaskQueue>(doris::PriorityTaskQueue*) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_construct.h:133:38
    #13 0x55dc625ce544 in doris::PriorityTaskQueue* std::__uninitialized_default_n_1<false>::__uninit_default_n<doris::PriorityTaskQueue*, unsigned long>(doris::PriorityTaskQueue*, unsigned long) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_uninitialized.h:876:6
    #14 0x55dc625cb811 in doris::PriorityTaskQueue* std::__uninitialized_default_n<doris::PriorityTaskQueue*, unsigned long>(doris::PriorityTaskQueue*, unsigned long) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_uninitialized.h:939:14
    #15 0x55dc625cb811 in doris::PriorityTaskQueue* std::__uninitialized_default_n_a<doris::PriorityTaskQueue*, unsigned long, doris::PriorityTaskQueue>(doris::PriorityTaskQueue*, unsigned long, std::allocator<doris::PriorityTaskQueue>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_uninitialized.h:996:14
    #16 0x55dc625cb811 in std::vector<doris::PriorityTaskQueue, std::allocator<doris::PriorityTaskQueue> >::_M_default_initialize(unsigned long) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_vector.h:2010:4
    #17 0x55dc625cb811 in std::vector<doris::PriorityTaskQueue, std::allocator<doris::PriorityTaskQueue> >::vector(unsigned long, std::allocator<doris::PriorityTaskQueue> const&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_vector.h:588:9
    #18 0x55dc625bca03 in doris::MultiCoreTaskQueue::MultiCoreTaskQueue(int) be/build_ASAN/./be/build_ASAN/../src/exec/pipeline/task_queue.cpp:138:11
    #19 0x55dc629de212 in doris::TaskScheduler::TaskScheduler(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<doris::CgroupCpuCtl>) be/build_ASAN/../src/exec/pipeline/task_scheduler.h:72:15
    #20 0x55dc629ddbd8 in doris::HybridTaskScheduler::HybridTaskScheduler(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<doris::CgroupCpuCtl>) be/build_ASAN/../src/exec/pipeline/task_scheduler.h:89:15
    #21 0x55dc629d8430 in std::__detail::_MakeUniq<doris::HybridTaskScheduler>::__single_object std::make_unique<doris::HybridTaskScheduler, int&, int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<doris::CgroupCpuCtl>&>(int&, int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::shared_ptr<doris::CgroupCpuCtl>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/unique_ptr.h:1085:34
    #22 0x55dc629c207f in doris::WorkloadGroup::upsert_thread_pool_no_lock(doris::WorkloadGroupInfo*, std::shared_ptr<doris::CgroupCpuCtl>) be/build_ASAN/./be/build_ASAN/../src/runtime/workload_group/workload_group.cpp:547:17
    #23 0x55dc629c62c7 in doris::WorkloadGroup::upsert_task_scheduler(doris::WorkloadGroupInfo*) be/build_ASAN/./be/build_ASAN/../src/runtime/workload_group/workload_group.cpp:665:12
    #24 0x55dc629f5ad6 in doris::WorkloadGroupMgr::create_internal_wg() be/build_ASAN/./be/build_ASAN/../src/runtime/workload_group/workload_group_manager.cpp:987:5
    #25 0x55dc625e56e4 in doris::ExecEnv::_create_internal_workload_group() be/build_ASAN/./be/build_ASAN/../src/runtime/exec_env_init.cpp:487:5
    #26 0x55dc625dafb2 in doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) be/build_ASAN/./be/build_ASAN/../src/runtime/exec_env_init.cpp:425:5
    #27 0x55dc625d5e53 in doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) be/build_ASAN/./be/build_ASAN/../src/runtime/exec_env_init.cpp:201:17
    #28 0x55dc4a0ae1fc in main be/build_ASAN/./be/build_ASAN/../src/service/doris_main.cpp:613:14
```
[be.out.tgz](https://github.com/user-attachments/files/29685220/be.out.tgz)


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

