### PR TITLE
[fix](regression) wait row count for partition_key_minmax

### DIFF
--- a/regression-test/suites/query_p0/stats/partition_key_minmax.groovy
+++ b/regression-test/suites/query_p0/stats/partition_key_minmax.groovy
@@ -16,6 +16,19 @@
 // under the License.
 
 suite("partition_key_minmax") {
+    def waitIndexRowCountReported = { tableName, expectedRowCount ->
+        def lastResult = null
+        for (int i = 0; i < 60; i++) {
+            lastResult = sql """show index stats ${tableName} ${tableName};"""
+            logger.info("${tableName} index stats: " + lastResult)
+            if (lastResult[0][4].toString() == expectedRowCount.toString()) {
+                return
+            }
+            sleep(1000)
+        }
+        throw new Exception("${tableName} row count report timeout, last index stats: ${lastResult}")
+    }
+
     sql """
         drop table if exists rangetable;
         create table rangetable (a int,
@@ -32,6 +45,7 @@ suite("partition_key_minmax") {
 
         analyze table rangetable with sync;
     """
+    waitIndexRowCountReported("rangetable", 4)
     def columnStats = sql """show column cached stats rangetable"""
     logger.info("rangetable cached stats: " + columnStats)
     explain {
@@ -63,6 +77,7 @@ suite("partition_key_minmax") {
 
     analyze table listtable with sync;
     """
+    waitIndexRowCountReported("listtable", 3)
 
     columnStats = sql """show column cached stats listtable"""
     logger.info("listtable cached stats: " + columnStats)
@@ -74,4 +89,3 @@ suite("partition_key_minmax") {
         contains("id#0 -> ndv=1.0000, min=3.000000(3), max=3.000000(3), count=1.0000")
     }
 }
-


### PR DESCRIPTION
## Proposed changes

`partition_key_minmax` checks partition-pruned memo-plan statistics. In Cloud P0, this case can run the `EXPLAIN` before the physical index row count has finished reporting after insert/analyze. When that happens, the planner's selected-partition row count can be `0`, so the existing `ndv/count` assertions fail even though the partition-key `min/max` is already correct.

This patch keeps the existing `EXPLAIN` assertions and adds a bounded wait for the base index strict row count via `show index stats <table> <index>` before running each memo-plan check.

## Testing

- `git diff --check`

No local regression environment was allocated in this session, so the targeted regression case was not run locally.
