### PR TITLE
[regression-test](variant) Fix schema change wait timeout

### DIFF
--- a/regression-test/suites/variant_p0/schema_change/schema_change.groovy
+++ b/regression-test/suites/variant_p0/schema_change/schema_change.groovy
@@ -28,22 +28,23 @@ suite("regression_test_variant_schema_change", "variant_type"){
         DISTRIBUTED BY HASH(k) BUCKETS 4
         properties("replication_num" = "1");
     """
-    def timeout = 60000
+    def timeout = 120000
     def delta_time = 1000
-    def useTime = 0
     def wait_for_latest_op_on_table_finish = { tableName, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            def alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${tableName}" ORDER BY CreateTime DESC LIMIT 1;"""
+        boolean finished = false
+        def alter_res = null
+        for (int t = delta_time; t <= OpTimeout; t += delta_time) {
+            alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${tableName}" ORDER BY CreateTime DESC LIMIT 1;"""
             alter_res = alter_res.toString()
             if(alter_res.contains("FINISHED")) {
                 sleep(3000) // wait change table state to normal
                 logger.info(tableName + " latest alter job finished, detail: " + alter_res)
+                finished = true
                 break
             }
-            useTime = t
             sleep(delta_time)
         }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_op_on_table_finish timeout")
+        assertTrue(finished, "wait_for_latest_op_on_table_finish timeout, last alter result: " + alter_res)
     }
 
     // sql "set experimental_enable_nereids_planner = true"


### PR DESCRIPTION
### What problem does this PR solve?

Fixes a flaky Cloud P0 failure in `variant_p0/schema_change/schema_change.groovy`.

The case waits for the latest schema-change job before issuing the next ALTER. The old helper could return after timeout without observing `FINISHED`, because `useTime == OpTimeout` still passed `assertTrue(useTime <= OpTimeout)`. Then the case could run `DROP INDEX` while the table was still in `SCHEMA_CHANGE`.

Remote logs from a failing run showed:

- the case polled `SHOW ALTER TABLE COLUMN` for about 60s without logging `latest alter job finished`
- `DROP INDEX` failed about 9s before the schema-change job actually finished
- the schema-change RUNNING phase took about 69s in that run

### How is this fixed?

- Increase the schema-change wait timeout from 60s to 120s.
- Make the helper require an explicit `FINISHED` observation.
- Include the last `SHOW ALTER TABLE COLUMN` result in the timeout failure message.

### Check

- `git diff --check`

No local regression rerun was performed.
