### PR TITLE
[refine](pipeline) Add diagnostics for oversized pipeline blocks

### DIFF
--- a/be/src/exec/operator/nested_loop_join_probe_operator.cpp
+++ b/be/src/exec/operator/nested_loop_join_probe_operator.cpp
@@ -173,6 +173,38 @@ Status NestedLoopJoinProbeLocalState::close(RuntimeState* state) {
             state);
 }
 
+std::string NestedLoopJoinProbeLocalState::debug_string(int indentation_level) const {
+    fmt::memory_buffer debug_string_buffer;
+    fmt::format_to(
+            debug_string_buffer, "{}",
+            JoinProbeLocalState<NestedLoopJoinSharedState,
+                                NestedLoopJoinProbeLocalState>::debug_string(indentation_level));
+
+    const auto child_block_rows = _child_block == nullptr ? 0 : _child_block->rows();
+    const auto build_blocks = _shared_state == nullptr ? 0 : _shared_state->build_blocks.size();
+    const auto first_build_block_rows =
+            build_blocks == 0 ? 0 : _shared_state->build_blocks[0].rows();
+    const auto current_build_block_rows =
+            _shared_state != nullptr && _current_build_pos < build_blocks
+                    ? _shared_state->build_blocks[_current_build_pos].rows()
+                    : 0;
+    const auto use_build_base = build_blocks == 1;
+    const auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
+    fmt::format_to(debug_string_buffer,
+                   ", join_state: _child_block_rows={}, _child_eos={}, _join_block_rows={}, "
+                   "_need_more_input_data={}, _matched_rows_done={}, _probe_block_start_pos={}, "
+                   "_probe_block_pos={}, _probe_side_process_count={}, _current_build_pos={}, "
+                   "_current_build_row_pos={}, build_blocks={}, first_build_block_rows={}, "
+                   "current_build_block_rows={}, use_generate_block_base_build={}, "
+                   "_enable_lazy_materialize={}",
+                   child_block_rows, _child_eos, _join_block.rows(), _need_more_input_data,
+                   _matched_rows_done, _probe_block_start_pos, _probe_block_pos,
+                   _probe_side_process_count, _current_build_pos, _current_build_row_pos,
+                   build_blocks, first_build_block_rows, current_build_block_rows, use_build_base,
+                   p._enable_lazy_materialize);
+    return fmt::to_string(debug_string_buffer);
+}
+
 void NestedLoopJoinProbeLocalState::_update_additional_flags(Block* block) {
     auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
     if (p._is_mark_join) {

--- a/be/src/exec/operator/nested_loop_join_probe_operator.h
+++ b/be/src/exec/operator/nested_loop_join_probe_operator.h
@@ -58,6 +58,7 @@ public:
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
+    std::string debug_string(int indentation_level = 0) const override;
 
     // For some complex join types, after generating data on the build/probe side,
     // we need to update visited flags.

--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "common/be_mock_util.h"
+#include "common/check.h"
 #include "common/exception.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -617,6 +618,10 @@ public:
     [[nodiscard]] Status sink(RuntimeState* state, Block* block, bool eos) {
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_type_and_column());
+        DORIS_CHECK_LE(block->rows(), static_cast<size_t>(state->batch_size()))
+                << "sink=" << get_name() << ", node_id=" << _node_id
+                << ", operator_id=" << _operator_id << ", block_rows=" << block->rows()
+                << ", batch_size=" << state->batch_size() << ", eos=" << eos;
         return sink_impl(state, block, eos);
     }
 
@@ -879,6 +884,10 @@ public:
         RETURN_IF_ERROR(get_block_impl(state, block, eos));
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_type_and_column());
+        DORIS_CHECK_LE(block->rows(), static_cast<size_t>(state->batch_size()))
+                << "operator=" << _op_name << ", node_id=" << _node_id
+                << ", operator_id=" << _operator_id << ", block_rows=" << block->rows()
+                << ", batch_size=" << state->batch_size() << ", eos=" << *eos;
         return Status::OK();
     }
 

--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -30,7 +30,6 @@
 #include <vector>
 
 #include "common/be_mock_util.h"
-#include "common/check.h"
 #include "common/exception.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -618,10 +617,12 @@ public:
     [[nodiscard]] Status sink(RuntimeState* state, Block* block, bool eos) {
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_type_and_column());
-        DORIS_CHECK_LE(block->rows(), static_cast<size_t>(state->batch_size()))
-                << "sink=" << get_name() << ", node_id=" << _node_id
-                << ", operator_id=" << _operator_id << ", block_rows=" << block->rows()
-                << ", batch_size=" << state->batch_size() << ", eos=" << eos;
+        if (UNLIKELY(block->rows() > static_cast<size_t>(state->batch_size()))) {
+            return Status::InternalError(
+                    "sink={} node_id={} operator_id={} oversized block rows={}, batch_size={}, "
+                    "eos={}",
+                    get_name(), _node_id, _operator_id, block->rows(), state->batch_size(), eos);
+        }
         return sink_impl(state, block, eos);
     }
 
@@ -884,10 +885,12 @@ public:
         RETURN_IF_ERROR(get_block_impl(state, block, eos));
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_type_and_column());
-        DORIS_CHECK_LE(block->rows(), static_cast<size_t>(state->batch_size()))
-                << "operator=" << _op_name << ", node_id=" << _node_id
-                << ", operator_id=" << _operator_id << ", block_rows=" << block->rows()
-                << ", batch_size=" << state->batch_size() << ", eos=" << *eos;
+        if (UNLIKELY(block->rows() > static_cast<size_t>(state->batch_size()))) {
+            return Status::InternalError(
+                    "operator={} node_id={} operator_id={} oversized block rows={}, "
+                    "batch_size={}, eos={}",
+                    _op_name, _node_id, _operator_id, block->rows(), state->batch_size(), *eos);
+        }
         return Status::OK();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

We are investigating an occasional query timeout where a pipeline task stayed runnable for almost 900s around a local exchange, cross join, and sort sink pipeline. The current evidence suggests the task is not blocked waiting for LocalExchange input: all local exchange sink operators have finished, the source queue still has data, and all dependencies of the runnable task are ready. We suspect the cross join may be stuck or making no progress when it receives an oversized block from an adaptive passthrough local exchange.

Relevant debug info from the timeout log:

```text
PipelineFragmentContext Info: _closed_tasks=22, _total_tasks=24, need_notify_close=false, fragment_id=10, _rec_cte_stage=0
Task 0: QueryId: 160c012c0d7e49b0-bb5252d26339a281
InstanceId: 160c012c0d7e49b0-bb5252d26339a2af
PipelineTask[id = 0, open = true, eos = false, state = BLOCKED, dry run = false, _wake_up_early = false, _wake_up_by = -1, time elapsed since last state changing = 899s, spilling = false, is running = false] elapse time = 899s, block dependency = [LOCAL_MERGE_SORT_SOURCE_OPERATOR_DEPENDENCY: id=16, block task = 1, ready=false, _always_ready=false]
LOCAL_MERGE_SORT_SOURCE_OPERATOR: id=16, parallel_tasks=3, _is_serial_operator=false

Task 1: QueryId: 160c012c0d7e49b0-bb5252d26339a281
InstanceId: 160c012c0d7e49b0-bb5252d26339a2af
PipelineTask[id = 1, open = true, eos = false, state = RUNNABLE, dry run = false, _wake_up_early = false, _wake_up_by = -1, time elapsed since last state changing = 895s, spilling = false, is running = true] elapse time = 899s, block dependency = [NULL]
LOCAL_EXCHANGE_OPERATOR(ADAPTIVE_PASSTHROUGH): id=20, parallel_tasks=3, _is_serial_operator=false, _channel_id: 0, _num_partitions: 3, _num_senders: 3, _num_sources: 3, _running_sink_operators: 0, _running_source_operators: 1, mem_usage: 1205248, data queue info: Data Queue 0: [size approx = 7, eos = false], MemTrackers: 0: 1205248, 1: 1203200, 2: 1205248,
  CROSS_JOIN_OPERATOR: id=15, parallel_tasks=3, _is_serial_operator=false
    SORT_SINK_OPERATOR: id=16, _is_serial_operator=false

Read Dependency Information:
0.   LOCAL_EXCHANGE_OPERATOR_DEPENDENCY: id=-3, block task = 0, ready=true, _always_ready=true
1.     CROSS_JOIN_OPERATOR_DEPENDENCY: id=15, block task = 0, ready=true, _always_ready=false
3.     MemorySufficientDependency: id=-1, block task = 0, ready=true, _always_ready=true

Write Dependency Information:
3.   SORT_SINK_OPERATOR_DEPENDENCY: id=16, block task = 0, ready=true, _always_ready=false
```

This change adds defensive diagnostics to the common operator output and sink input paths to assert that block rows do not exceed `batch_size`. It also extends nested loop join probe debug output with the current child block rows, join block rows, probe/build cursor positions, build block row counts, and whether the operator is using the build-base generation path. These details should make the next timeout dump show whether the cross join is holding an oversized probe/build block and whether it is in a no-progress state.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

