### PR TITLE
[fix](docker) Fix doris-compose up without env argument

### DIFF
--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -674,14 +674,15 @@ class UpCommand(Command):
 
             instance_id = getattr(args, 'instance_id', None)
             cluster_snapshot = getattr(args, 'cluster_snapshot', '')
+            env = getattr(args, 'env', None)
             enable_storage_vault = CLUSTER.is_true(
-                CLUSTER.get_env_value(args.env, "ENABLE_STORAGE_VAULT"))
+                CLUSTER.get_env_value(env, "ENABLE_STORAGE_VAULT"))
 
             cluster = CLUSTER.Cluster.new(
                 args.NAME, args.IMAGE, args.cloud, args.root, args.fe_config,
                 args.be_config, args.ms_config, args.recycle_config,
                 args.remote_master_fe, args.local_network_ip, args.fe_follower,
-                args.be_disks if args.be_disks is not None else ["HDD=1"], args.be_cluster, args.reg_be, args.extra_hosts, args.env,
+                args.be_disks if args.be_disks is not None else ["HDD=1"], args.be_cluster, args.reg_be, args.extra_hosts, env,
                 args.coverage_dir, cloud_store_config, args.sql_mode_node_mgr,
                 args.be_metaservice_endpoint, args.be_cluster_id, args.tde_ak, args.tde_sk,
                 external_ms_cluster, instance_id, cluster_snapshot,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: In 4.1.2-tmp-rc03 release regression, Docker Case and S3 Docker Case failed broadly during docker-compose cluster startup. The storage vault snapshot change reads `args.env` in `doris-compose.py up` to check `ENABLE_STORAGE_VAULT`, but the affected release branch can run with an argparse `Namespace` that does not define `env`. This causes `AttributeError: 'Namespace' object has no attribute 'env'` before the test cluster is created, blocking docker-based regression suites.

This change reads the optional `env` argument with `getattr(args, 'env', None)` once and reuses that value for both `ENABLE_STORAGE_VAULT` parsing and `Cluster.new()`. When the argument is absent, the default behavior is unchanged: no extra environment variables are passed and storage vault remains disabled.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

