### PR TITLE
[fix](be) Fix release build warning in column mapper

### DIFF
--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1819,7 +1819,7 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
             Status clone_status;
             try {
                 clone_status = clone_table_expr_tree(table_filter.conjunct->root(), &rewrite_root);
-            } catch (const Exception& e) {
+            } catch ([[maybe_unused]] const Exception& e) {
                 // Some table filters contain complex intermediate values, for example
                 // `element_at(MAP_VALUES(m)[1], 'age') > 30`. The current file-local rewrite only
                 // understands top-level slots and struct-element paths rooted at top-level slots;
@@ -1833,7 +1833,7 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
 #else
                 continue;
 #endif
-            } catch (const std::exception& e) {
+            } catch ([[maybe_unused]] const std::exception& e) {
 #ifndef NDEBUG
                 return Status::InternalError(
                         "Failed to clone table filter for file-local rewrite: {}, expr={}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: https://github.com/apache/doris/pull/65046

Problem Summary:

Release builds compile out the non-NDEBUG diagnostic path in the table-filter clone exception handlers. The caught exceptions are still named, but no longer referenced, so clang fails the release build with `-Werror,-Wunused-exception-parameter`.

This patch marks both catch parameters as `[[maybe_unused]]`, matching the existing BE style for intentionally unused catch parameters. The debug diagnostics and release fallback behavior are unchanged.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `build-support/check-format.sh`
        - `clang++ -x c++ -std=c++17 -DNDEBUG -Werror -Wunused-exception-parameter -fsyntax-only -`
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
