### PR TITLE
[fix](regression) Isolate S3 TVF insert paths

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_s3_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_s3_tvf.groovy
@@ -28,7 +28,8 @@ suite("test_insert_into_s3_tvf", "p0,external") {
         return
     }
 
-    def s3BasePath = "${bucket}/regression/insert_tvf_test"
+    def s3BasePrefix = "regression/insert_tvf_test/${UUID.randomUUID().toString()}"
+    def s3BasePath = "${bucket}/${s3BasePrefix}"
 
     // file_path is now a prefix; BE generates: {prefix}{query_id}_{idx}.{ext}
     def s3WriteProps = { String path, String format ->
@@ -45,7 +46,7 @@ suite("test_insert_into_s3_tvf", "p0,external") {
     // Read uses wildcard to match generated file names
     def s3ReadProps = { String path, String format ->
         return """
-            "uri" = "https://${bucket}.${s3_endpoint}/regression/insert_tvf_test/${path}",
+            "uri" = "https://${bucket}.${s3_endpoint}/${s3BasePrefix}/${path}",
             "s3.access_key" = "${ak}",
             "s3.secret_key" = "${sk}",
             "format" = "${format}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The S3 TVF insert regression case wrote all runs under a fixed regression/insert_tvf_test prefix while also using delete_existing_files=true and wildcard reads. Concurrent regression jobs could delete each other directories or infer schema from another run files, causing flaky mismatches or missing columns. This change gives each suite run a UUID-scoped S3 prefix and uses that same prefix for both writes and reads, so deletes and wildcard reads are isolated to the current run.

### Release note

None

### Check List (For Author)

- Test: Regression test attempted: ./run-regression-test.sh --run -d external_table_p0/tvf/insert -s test_insert_into_s3_tvf. It could not complete because local FE at 127.0.0.1:9030 refused the MySQL connection before the first SQL statement.
- Behavior changed: No, test-only path isolation.
- Does this need documentation: No