### PR TITLE
[regression-test](auth) Scope export cancel by label

### DIFF
--- a/regression-test/suites/auth_call/test_dml_export_table_auth.groovy
+++ b/regression-test/suites/auth_call/test_dml_export_table_auth.groovy
@@ -69,6 +69,7 @@ suite("test_dml_export_table_auth","p0,auth_call") {
         test {
             sql """EXPORT TABLE ${dbName}.${tableName} TO "s3://${bucket}/test_outfile/exp_${exportLabel}"
                 PROPERTIES(
+                    "label" = "${exportLabel}",
                     "format" = "csv",
                     "max_file_size" = "2048MB"
                 )
@@ -83,7 +84,7 @@ suite("test_dml_export_table_auth","p0,auth_call") {
         try {
             sql """CANCEL EXPORT
                 FROM ${dbName}
-                WHERE STATE = "EXPORTING";"""
+                WHERE LABEL = "${exportLabel}";"""
         } catch (Exception e) {
             log.info(e.getMessage())
             assertTrue(e.getMessage().indexOf("denied") == -1)
@@ -93,6 +94,7 @@ suite("test_dml_export_table_auth","p0,auth_call") {
     connect(user, "${pwd}", context.config.jdbcUrl) {
         sql """EXPORT TABLE ${dbName}.${tableName} TO "s3://${bucket}/test_outfile/exp_${exportLabel}"
                 PROPERTIES(
+                    "label" = "${exportLabel}",
                     "format" = "csv",
                     "max_file_size" = "2048MB"
                 )
@@ -118,7 +120,7 @@ suite("test_dml_export_table_auth","p0,auth_call") {
         try {
             sql """CANCEL EXPORT
             FROM ${dbName}
-            WHERE STATE = "EXPORTING";"""
+            WHERE LABEL = "${exportLabel}";"""
         } catch (Exception e) {
             log.info(e.getMessage())
             // should not cause by not have auth


### PR DESCRIPTION
## Summary

Fix `auth_call/test_dml_export_table_auth` by scoping `CANCEL EXPORT` to the case-local export label.

The case previously cancelled by `WHERE STATE = "EXPORTING"`. In concurrent Cloud P0 runs this can match an unrelated export job from another suite, such as `test_export_variant_10k`, and then fail with an unrelated permission denied error.

This patch adds an explicit export label and uses `WHERE LABEL = "${exportLabel}"` for both cancel statements, preserving the auth test intent while avoiding cross-suite export job interference.

## Testing

- [x] `git diff --check -- regression-test/suites/auth_call/test_dml_export_table_auth.groovy`
- [ ] Not run locally: requires a configured Cloud/S3 regression environment
