### PR TITLE
branch-4.0: [test](regression) drop unsupported use_path_style=true in test_s3_tvf

### DIFF
--- a/regression-test/suites/load_p2/tvf/test_s3_tvf.groovy
+++ b/regression-test/suites/load_p2/tvf/test_s3_tvf.groovy
@@ -64,7 +64,6 @@ suite("test_s3_tvf", "p2") {
                  .addProperty("uri", "s3://${s3BucketName}.${s3Endpoint}/regression/load/data/kd16=abcdefg/basic_data.csv")
                  .addProperty("format", "csv")
                  .addProperty("column_separator", "|")
-                 .addProperty("use_path_style", "true")
                  .addProperty("force_parsing_by_standard_uri", "true")
                  .addProperty("path_partition_keys", "kd16"))
    }
@@ -74,7 +73,6 @@ suite("test_s3_tvf", "p2") {
             .addProperty("uri", "s3://${s3BucketName}.${s3Endpoint}/regression/load/data/kd16=abcdefg/basic_data.csv")
             .addProperty("format", "csv")
             .addProperty("column_separator", "|")
-            .addProperty("use_path_style", "true")
             .addProperty("force_parsing_by_standard_uri", "true")
             .addProperty("path_partition_keys", "kd16"))
     // path partition key maybe don't support array type ? 
@@ -92,7 +90,6 @@ suite("test_s3_tvf", "p2") {
                  .addProperty("uri", "s3://${s3BucketName}.${s3Endpoint}/regression/load/data/kd16=abcdefg/kd17=hello/basic_data.csv")
                  .addProperty("format", "csv")
                  .addProperty("column_separator", "|")
-                 .addProperty("use_path_style", "true")
                  .addProperty("force_parsing_by_standard_uri", "true")
                  .addProperty("path_partition_keys", "kd16,kd17"))
    }
@@ -102,7 +99,6 @@ suite("test_s3_tvf", "p2") {
             .addProperty("uri", "s3://${s3BucketName}.${s3Endpoint}/regression/load/data/kd16=abcdefg/kd17=hello/basic_data.csv")
             .addProperty("format", "csv")
             .addProperty("column_separator", "|")
-            .addProperty("use_path_style", "true")
             .addProperty("force_parsing_by_standard_uri", "true")
             .addProperty("path_partition_keys", "kd16,kd17"))
     
@@ -284,7 +280,6 @@ suite("test_s3_tvf", "p2") {
                 .addProperty("read_json_by_line", "false")
                 .addProperty("strip_outer_array", "true")
                 .addProperty("column_separator", "|")
-                .addProperty("use_path_style", "true")
                 .addProperty("jsonpaths", '[\\"$.k00\\", \\"$.k01\\", \\"$.k12\\"]')
                 .addProperty("force_parsing_by_standard_uri", "true"))
     }
@@ -317,7 +312,6 @@ suite("test_s3_tvf", "p2") {
                 .addProperty("read_json_by_line", "true")
                 .addProperty("strip_outer_array", "true")
                 .addProperty("column_separator", "|")
-                .addProperty("use_path_style", "true")
                 .addProperty("strip_outer_array", "false")
                 .addProperty("jsonpaths", '[\\"$.k00\\", \\"$.k01\\", \\"$.k12\\"]')
                 .addProperty("num_as_string", "true")


### PR DESCRIPTION
## Proposed changes

Cherry-pick #64562 to branch-4.0.

`regression-test/suites/load_p2/tvf/test_s3_tvf.groovy` set both a
virtual-host style URI and `use_path_style=true` on six active S3 TVF
attributes. The two settings conflict: Aliyun OSS rejects path-style
access for this bucket with `HTTP 403 SecondLevelDomainForbidden`
(`Please use virtual hosted style to access`) after the P2 environment
switched to the Aliyun internal Beijing endpoint. This removes the six
active `use_path_style=true` settings whose URI is already virtual-host
style, so the SDK uses the addressing style OSS requires.

Test-only change.

### Backport note

The upstream commit also rewrote the `catch` block failure path to
`assertTrue(...)`. branch-4.0 already has functionally-equivalent
handling of that block from #64997
(`if (!attribute.expectFiled) { ...; throw ex }`, which rethrows the
original exception), so the one conflicting hunk was resolved by keeping
the existing branch-4.0 code. Pass/fail behavior is identical; only the
failure message differs. The six `use_path_style` removals — the actual
fix — apply unchanged.

Cherry-picked from #64562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
