### PR TITLE
[fix](regression) avoid physical row count wait in partition stats case

### DIFF
--- a/regression-test/suites/query_p0/stats/partition_key_minmax.groovy
+++ b/regression-test/suites/query_p0/stats/partition_key_minmax.groovy
@@ -16,19 +16,6 @@
 // under the License.
 
 suite("partition_key_minmax") {
-    def waitIndexRowCountReported = { tableName, expectedRowCount ->
-        def lastResult = null
-        for (int i = 0; i < 60; i++) {
-            lastResult = sql """show index stats ${tableName} ${tableName};"""
-            logger.info("${tableName} index stats: " + lastResult)
-            if (lastResult[0][4].toString() == expectedRowCount.toString()) {
-                return
-            }
-            sleep(1000)
-        }
-        throw new Exception("${tableName} row count report timeout, last index stats: ${lastResult}")
-    }
-
     sql """
         drop table if exists rangetable;
         create table rangetable (a int,
@@ -45,7 +32,6 @@ suite("partition_key_minmax") {
 
         analyze table rangetable with sync;
     """
-    waitIndexRowCountReported("rangetable", 4)
     def columnStats = sql """show column cached stats rangetable"""
     logger.info("rangetable cached stats: " + columnStats)
     explain {
@@ -77,7 +63,6 @@ suite("partition_key_minmax") {
 
     analyze table listtable with sync;
     """
-    waitIndexRowCountReported("listtable", 3)
 
     columnStats = sql """show column cached stats listtable"""
     logger.info("listtable cached stats: " + columnStats)


### PR DESCRIPTION
## Summary
- Remove the `show index stats` physical row count polling from `partition_key_minmax`.
- Rely on `analyze table ... with sync` and keep cached stats/explain assertions for the planner stats under test.

## Testing
- `git diff --check -- regression-test/suites/query_p0/stats/partition_key_minmax.groovy`
- Not run: no confirmed regression test environment for this case.