### PR TITLE
[improvement](stream-load) Rename Stream Load display field LoadBytes to receivedBytes

### DIFF
--- a/be/src/load/stream_load/stream_load_context.cpp
+++ b/be/src/load/stream_load/stream_load_context.cpp
@@ -97,7 +97,7 @@ std::string StreamLoadContext::to_json() const {
     writer.Int64(number_filtered_rows);
     writer.Key("NumberUnselectedRows");
     writer.Int64(number_unselected_rows);
-    writer.Key("LoadBytes");
+    writer.Key("receivedBytes");
     writer.Int64(receive_bytes);
     writer.Key("LoadTimeMs");
     writer.Int64(load_cost_millis);
@@ -271,10 +271,10 @@ void StreamLoadContext::parse_stream_load_record(const std::string& stream_load_
         ss << ", NumberUnselectedRows: " << unselected_rows.GetInt64();
     }
 
-    if (document.HasMember("LoadBytes")) {
-        const rapidjson::Value& load_bytes = document["LoadBytes"];
-        stream_load_item.__set_load_bytes(load_bytes.GetInt64());
-        ss << ", LoadBytes: " << load_bytes.GetInt64();
+    if (document.HasMember("receivedBytes")) {
+        const rapidjson::Value& received_bytes = document["receivedBytes"];
+        stream_load_item.__set_load_bytes(received_bytes.GetInt64());
+        ss << ", receivedBytes: " << received_bytes.GetInt64();
     }
 
     if (document.HasMember("StartTime")) {

--- a/be/src/load/stream_load/stream_load_recorder_manager.cpp
+++ b/be/src/load/stream_load/stream_load_recorder_manager.cpp
@@ -195,7 +195,7 @@ std::string StreamLoadRecorderManager::_parse_and_format_record(const std::strin
     int64_t loaded_rows = get_int64("NumberLoadedRows");
     int64_t filtered_rows = get_int64("NumberFilteredRows");
     int64_t unselected_rows = get_int64("NumberUnselectedRows");
-    int64_t load_bytes = get_int64("LoadBytes");
+    int64_t load_bytes = get_int64("receivedBytes");
     int64_t start_time = get_int64("StartTime");
     int64_t finish_time = get_int64("FinishTime");
     std::string comment = get_string("Comment");

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/LoadSubmitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/LoadSubmitter.java
@@ -165,7 +165,7 @@ public class LoadSubmitter {
         public String NumberLoadedRows;
         public String NumberFilteredRows;
         public String NumberUnselectedRows;
-        public String LoadBytes;
+        public String receivedBytes;
         public String LoadTimeMs;
         public String BeginTxnTimeMs;
         public String StreamLoadPutTimeMs;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommand.java
@@ -81,7 +81,7 @@ public class ShowLoadCommand extends ShowCommand {
     public static final ImmutableList<String> STREAM_LOAD_TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("Label").add("Db").add("Table")
             .add("ClientIp").add("Status").add("Message").add("Url").add("TotalRows")
-            .add("LoadedRows").add("FilteredRows").add("UnselectedRows").add("LoadBytes")
+            .add("LoadedRows").add("FilteredRows").add("UnselectedRows").add("receivedBytes")
             .add("StartTime").add("FinishTime").add("User").add("Comment")
             .add("FirstErrorMsg")
             .build();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommandTest.java
@@ -50,7 +50,7 @@ public class ShowLoadCommandTest extends TestWithFeService {
     public static final ImmutableList<String> STREAM_LOAD_TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("Label").add("Db").add("Table")
             .add("ClientIp").add("Status").add("Message").add("Url").add("TotalRows")
-            .add("LoadedRows").add("FilteredRows").add("UnselectedRows").add("LoadBytes")
+            .add("LoadedRows").add("FilteredRows").add("UnselectedRows").add("receivedBytes")
             .add("StartTime").add("FinishTime").add("User").add("Comment")
             .build();
 

--- a/regression-test/plugins/cloud_show_data_plugin.groovy
+++ b/regression-test/plugins/cloud_show_data_plugin.groovy
@@ -34,7 +34,7 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }
@@ -62,7 +62,7 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/bloom_filter_p0/test_bloom_filter_hit.groovy
+++ b/regression-test/suites/bloom_filter_p0/test_bloom_filter_hit.groovy
@@ -94,7 +94,7 @@ suite("test_bloom_filter_hit") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/bloom_filter_p0/test_bloom_filter_hit_with_renamed_column.groovy
+++ b/regression-test/suites/bloom_filter_p0/test_bloom_filter_hit_with_renamed_column.groovy
@@ -78,7 +78,7 @@ suite("test_bloom_filter_hit_with_renamed_column") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/brown_p2/load.groovy
+++ b/regression-test/suites/brown_p2/load.groovy
@@ -69,7 +69,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
+++ b/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
@@ -162,7 +162,7 @@ suite('test_read_from_peer', 'docker') {
                 def json = parseJson(res)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_inverted_index.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_inverted_index.groovy
@@ -99,7 +99,7 @@ suite("test_recycler_inverted_index") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         logger.info("index:${index}")

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_db.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_db.groovy
@@ -98,7 +98,7 @@ suite("test_recycler_with_drop_db") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         logger.info("index:${index}")

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_index.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_index.groovy
@@ -137,7 +137,7 @@ suite("test_recycler_with_drop_index") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         logger.info("index:${index}")

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_multi_db.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_multi_db.groovy
@@ -70,7 +70,7 @@ suite("test_recycler_with_drop_multi_db") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         qt_sql """ select count(*) from ${tableName} """

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_partition.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_partition.groovy
@@ -93,7 +93,7 @@ suite("test_recycler_with_drop_partition") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         logger.info("index:${index}")

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_schema_change.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_schema_change.groovy
@@ -98,7 +98,7 @@ suite("test_recycler_with_schema_change") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         logger.info("index:${index}")

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_truncate_table.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_truncate_table.groovy
@@ -93,7 +93,7 @@ suite("test_recycler_with_truncate_table") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -157,7 +157,7 @@ suite("test_recycler_with_truncate_table") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         logger.info("index:${index}")

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_txn_label.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_txn_label.groovy
@@ -65,7 +65,7 @@ suite("test_recycler_with_txn_label") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 
@@ -137,7 +137,7 @@ suite("test_recycler_with_txn_label") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
@@ -83,7 +83,7 @@ suite("create_table_use_partition_policy") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy_by_hdfs.groovy
@@ -86,7 +86,7 @@ suite("create_table_use_partition_policy_by_hdfs") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_policy.groovy
@@ -83,7 +83,7 @@ suite("create_table_use_policy") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_policy_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_policy_by_hdfs.groovy
@@ -86,7 +86,7 @@ suite("create_table_use_policy_by_hdfs") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/load_colddata_to_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/load_colddata_to_hdfs.groovy
@@ -86,7 +86,7 @@ suite("load_colddata_to_hdfs") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition.groovy
@@ -101,7 +101,7 @@ try {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition_by_hdfs.groovy
@@ -105,7 +105,7 @@ try {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
@@ -83,7 +83,7 @@ suite("table_modify_resouce") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy_by_hdfs.groovy
@@ -86,7 +86,7 @@ suite("table_modify_resouce_by_hdfs") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/compaction/test_base_compaction.groovy
+++ b/regression-test/suites/compaction/test_base_compaction.groovy
@@ -94,7 +94,7 @@ suite("test_base_compaction", "p2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 
@@ -129,7 +129,7 @@ suite("test_base_compaction", "p2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 
@@ -169,7 +169,7 @@ suite("test_base_compaction", "p2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/compaction/test_base_compaction_no_value.groovy
+++ b/regression-test/suites/compaction/test_base_compaction_no_value.groovy
@@ -94,7 +94,7 @@ suite("test_base_compaction_no_value", "p2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 
@@ -129,7 +129,7 @@ suite("test_base_compaction_no_value", "p2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 
@@ -169,7 +169,7 @@ suite("test_base_compaction_no_value", "p2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/compaction/test_filecache_with_base_compaction_thresthold.groovy
+++ b/regression-test/suites/compaction/test_filecache_with_base_compaction_thresthold.groovy
@@ -203,7 +203,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
                 def json = parseJson(res)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 
@@ -364,7 +364,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
                 def json = parseJson(res)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 
@@ -527,7 +527,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
                 def json = parseJson(res)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 
@@ -689,7 +689,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
                 def json = parseJson(res)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/correctness_p0/test_select_stddev_variance_window.groovy
+++ b/regression-test/suites/correctness_p0/test_select_stddev_variance_window.groovy
@@ -69,7 +69,7 @@ suite("test_select_stddev_variance_window") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/csv_header_p0/test_csv_with_header.groovy
+++ b/regression-test/suites/csv_header_p0/test_csv_with_header.groovy
@@ -51,7 +51,7 @@ suite("test_csv_with_header", "p0,external") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, exect_rows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/datatype_p0/decimalv3/test_decimal256_index.groovy
+++ b/regression-test/suites/datatype_p0/decimalv3/test_decimal256_index.groovy
@@ -105,7 +105,7 @@ suite("test_decimal256_index") {
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(4096, json.NumberTotalRows)
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
     // RowsStatsFiltered in profile

--- a/regression-test/suites/datatype_p0/decimalv3/test_decimal256_load.groovy
+++ b/regression-test/suites/datatype_p0/decimalv3/test_decimal256_load.groovy
@@ -104,7 +104,7 @@ suite("test_decimal256_load") {
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(19, json.NumberTotalRows)
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
     qt_select "select * from test_decimal256_load order by 1,2,3;"

--- a/regression-test/suites/datatype_p0/decimalv3/test_decimal256_outfile_csv.groovy
+++ b/regression-test/suites/datatype_p0/decimalv3/test_decimal256_outfile_csv.groovy
@@ -76,7 +76,7 @@ suite("test_decimal256_outfile_csv") {
            assertEquals("success", json.Status.toLowerCase())
            assertEquals(19, json.NumberTotalRows)
            assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-           assertTrue(json.LoadBytes > 0)
+           assertTrue(json.receivedBytes > 0)
        }
    }
     sql "sync"

--- a/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
@@ -207,7 +207,7 @@ suite("test_ip_basic") {
                  def json = parseJson(res)
                  assertEquals("success", json.Status.toLowerCase())
                  assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                 assertTrue(json.LoadBytes > 0)
+                 assertTrue(json.receivedBytes > 0)
              }
     }
     qt_sql_ipv6 """ select * from table_ipv6_uint128 order by col0 """
@@ -230,7 +230,7 @@ suite("test_ip_basic") {
                      def json = parseJson(res)
                      assertEquals("success", json.Status.toLowerCase())
                      assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                     assertTrue(json.LoadBytes > 0)
+                     assertTrue(json.receivedBytes > 0)
                  }
         }
 

--- a/regression-test/suites/datatype_p0/string/test_string_basic.groovy
+++ b/regression-test/suites/datatype_p0/string/test_string_basic.groovy
@@ -66,7 +66,7 @@ suite("test_string_basic") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/delete_p0/test_delete_where_in.groovy
+++ b/regression-test/suites/delete_p0/test_delete_where_in.groovy
@@ -66,7 +66,7 @@ suite("test_delete_where_in", "delete_p0") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/demo_p0/streamLoad_action.groovy
+++ b/regression-test/suites/demo_p0/streamLoad_action.groovy
@@ -94,7 +94,7 @@ suite("streamLoad_action") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     sql """ sync; """

--- a/regression-test/suites/fault_injection_p0/test_build_index_fault.groovy
+++ b/regression-test/suites/fault_injection_p0/test_build_index_fault.groovy
@@ -156,7 +156,7 @@ suite("test_build_index_fault", "inverted_index, nonConcurrent,p2"){
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/fault_injection_p0/test_variant_bloom_filter.groovy
+++ b/regression-test/suites/fault_injection_p0/test_variant_bloom_filter.groovy
@@ -46,7 +46,7 @@ suite("test_variant_bloom_filter", "nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/fault_injection_p2/test_partial_update_rowset_not_found_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p2/test_partial_update_rowset_not_found_fault_injection.groovy
@@ -60,7 +60,7 @@ suite("test_partial_update_rowset_not_found_fault_injection", "p2,nonConcurrent"
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/github_events_p2/load.groovy
+++ b/regression-test/suites/github_events_p2/load.groovy
@@ -135,7 +135,7 @@ suite("load") {
 //                 def json = parseJson(result)
 //                 assertEquals("success", json.Status.toLowerCase())
 //                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-//                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+//                 assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
 //             }
 //         }
 //     }

--- a/regression-test/suites/hdfs_vault_p2/default_vault_p2/load.groovy
+++ b/regression-test/suites/hdfs_vault_p2/default_vault_p2/load.groovy
@@ -104,7 +104,7 @@ suite("load", "p2, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/hdfs_vault_p2/multi_vault_p2/load.groovy
+++ b/regression-test/suites/hdfs_vault_p2/multi_vault_p2/load.groovy
@@ -98,7 +98,7 @@ suite("load", "p2, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/hdfs_vault_p2/ssb_sf1_p2/load.groovy
+++ b/regression-test/suites/hdfs_vault_p2/ssb_sf1_p2/load.groovy
@@ -89,7 +89,7 @@ suite("load", "p2, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/insert_p0/insert.groovy
+++ b/regression-test/suites/insert_p0/insert.groovy
@@ -60,7 +60,7 @@ suite("insert") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/insert_p0/transaction/txn_insert_concurrent_insert.groovy
+++ b/regression-test/suites/insert_p0/transaction/txn_insert_concurrent_insert.groovy
@@ -73,7 +73,7 @@ suite("txn_insert_concurrent_insert") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/insert_p0/transaction/txn_insert_concurrent_insert_mow.groovy
+++ b/regression-test/suites/insert_p0/transaction/txn_insert_concurrent_insert_mow.groovy
@@ -74,7 +74,7 @@ suite("txn_insert_concurrent_insert_mow") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_aggregate.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_aggregate.groovy
@@ -74,7 +74,7 @@ suite("txn_insert_concurrent_insert_aggregate") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_duplicate.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_duplicate.groovy
@@ -74,7 +74,7 @@ suite("txn_insert_concurrent_insert_duplicate") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mor.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mor.groovy
@@ -75,7 +75,7 @@ suite("txn_insert_concurrent_insert_mor") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mow.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mow.groovy
@@ -74,7 +74,7 @@ suite("txn_insert_concurrent_insert_mow") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_ud.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_ud.groovy
@@ -76,7 +76,7 @@ suite("txn_insert_concurrent_insert_ud") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_update.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_update.groovy
@@ -77,7 +77,7 @@ suite("txn_insert_concurrent_insert_update") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/insert_p2/transaction/txn_insert_with_schema_change.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_with_schema_change.groovy
@@ -77,7 +77,7 @@ suite("txn_insert_with_schema_change") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/array_contains/test_add_index_for_arr.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_add_index_for_arr.groovy
@@ -100,7 +100,7 @@ suite("test_add_index_for_arr") {
                  def json = parseJson(result)
                  assertEquals(200, json.NumberTotalRows)
                  assertEquals(200, json.NumberLoadedRows)
-                 assertTrue(json.LoadBytes > 0)
+                 assertTrue(json.receivedBytes > 0)
              }
      }
 

--- a/regression-test/suites/inverted_index_p0/array_contains/test_array_contains_estimate.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_array_contains_estimate.groovy
@@ -64,7 +64,7 @@ suite("test_array_contains_estimate", "nonConcurrent"){
             def json = parseJson(result)
             assertEquals(149, json.NumberTotalRows)
             assertEquals(149, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/inverted_index_p0/array_contains/test_count_on_index_httplogs_arr.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_count_on_index_httplogs_arr.groovy
@@ -130,7 +130,7 @@ suite("test_count_on_index_httplogs_arr", "array_contains_inverted_index") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/array_contains/test_index_match_regexp_arr.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_index_match_regexp_arr.groovy
@@ -75,7 +75,7 @@ suite("test_index_match_regexp_arr", "array_contains_inverted_index"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/index_change/test_build_index.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_build_index.groovy
@@ -166,7 +166,7 @@ suite("test_build_index", "inverted_index"){
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_p0.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_p0.groovy
@@ -46,7 +46,7 @@ suite("test_index_compaction_p0", "p0, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p0/load/test_stream_load.groovy
+++ b/regression-test/suites/inverted_index_p0/load/test_stream_load.groovy
@@ -58,7 +58,7 @@ suite("test_stream_load_with_inverted_index_p0", "p0, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p0/ssb_unique_sql_zstd/load.groovy
+++ b/regression-test/suites/inverted_index_p0/ssb_unique_sql_zstd/load.groovy
@@ -72,7 +72,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/inverted_index_p0/storage_format/test_schema_change_storage_format.groovy
+++ b/regression-test/suites/inverted_index_p0/storage_format/test_schema_change_storage_format.groovy
@@ -53,7 +53,7 @@ suite("test_local_schema_change_storge_format", "p0") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p0/storage_format/test_storage_format_default.groovy
+++ b/regression-test/suites/inverted_index_p0/storage_format/test_storage_format_default.groovy
@@ -67,7 +67,7 @@ suite("test_storage_format_default", "p0") {
                     assertEquals(json.NumberLoadedRows, expectedSuccRows)
                 } else {
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/storage_format/test_storage_format_v1.groovy
+++ b/regression-test/suites/inverted_index_p0/storage_format/test_storage_format_v1.groovy
@@ -87,7 +87,7 @@ suite("test_storage_format_v1", "p0") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/storage_format/test_storage_format_v2.groovy
+++ b/regression-test/suites/inverted_index_p0/storage_format/test_storage_format_v2.groovy
@@ -75,7 +75,7 @@ suite("test_storage_format_v2", "p0, nonConcurrent") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_bm25_score.groovy
+++ b/regression-test/suites/inverted_index_p0/test_bm25_score.groovy
@@ -66,7 +66,7 @@ suite("test_bm25_score", "p0") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_compound_1.groovy
+++ b/regression-test/suites/inverted_index_p0/test_compound_1.groovy
@@ -70,7 +70,7 @@ suite("test_compound_1", "p0"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_compound_inlist.groovy
+++ b/regression-test/suites/inverted_index_p0/test_compound_inlist.groovy
@@ -92,7 +92,7 @@ suite("test_compound_inlist", "nonConcurrent"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_count_on_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_count_on_index.groovy
@@ -124,7 +124,7 @@ suite("test_count_on_index_httplogs", "p0") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_count_on_index_2.groovy
+++ b/regression-test/suites/inverted_index_p0/test_count_on_index_2.groovy
@@ -142,7 +142,7 @@ suite("test_count_on_index_2", "p0"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_ignore_above_in_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_ignore_above_in_index.groovy
@@ -81,7 +81,7 @@ suite("test_ignore_above_in_index", "p0") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     sql """ set enable_segment_limit_pushdown = true; """

--- a/regression-test/suites/inverted_index_p0/test_index_complex_match.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_complex_match.groovy
@@ -90,7 +90,7 @@ suite("test_index_complex_match", "p0"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_index_match_phrase_edge.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_match_phrase_edge.groovy
@@ -150,7 +150,7 @@ suite("test_index_match_phrase_edge", "nonConcurrent"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_index_match_phrase_ordered.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_match_phrase_ordered.groovy
@@ -86,7 +86,7 @@ suite("test_index_match_phrase_ordered", "nonConcurrent"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_index_match_phrase_prefix.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_match_phrase_prefix.groovy
@@ -87,7 +87,7 @@ suite("test_index_match_phrase_prefix", "nonConcurrent"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_index_match_phrase_slop.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_match_phrase_slop.groovy
@@ -70,7 +70,7 @@ suite("test_index_match_phrase_slop", "nonConcurrent"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_index_match_regexp.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_match_regexp.groovy
@@ -69,7 +69,7 @@ suite("test_index_match_regexp", "nonConcurrent"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_index_multi_match.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_multi_match.groovy
@@ -82,7 +82,7 @@ suite("test_index_multi_match", "p0"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_inverted_index_file_size.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_file_size.groovy
@@ -50,7 +50,7 @@ suite("test_inverted_index_file_size", "nonConcurrent"){
                 log.info("Stream load result: ${result}".toString())
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p0/test_inverted_index_io_timer.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_io_timer.groovy
@@ -79,7 +79,7 @@ suite('test_inverted_index_io_timer', 'p0') {
                     assertEquals(json.NumberLoadedRows, expected_succ_rows)
                 } else {
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_inverted_index_v3.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_v3.groovy
@@ -110,7 +110,7 @@ suite("test_inverted_index_v3", "p0"){
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_no_index_match.groovy
+++ b/regression-test/suites/inverted_index_p0/test_no_index_match.groovy
@@ -70,7 +70,7 @@ suite("test_no_index_match", "p0") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_or_not_match.groovy
+++ b/regression-test/suites/inverted_index_p0/test_or_not_match.groovy
@@ -55,7 +55,7 @@ suite("test_or_not_match", "p0") {
             log.info("Stream load result: ${result}".toString())
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     for (int i = 0; i < 10; i++) {

--- a/regression-test/suites/inverted_index_p0/test_show_nested_index_file_http_action_with_variant.groovy
+++ b/regression-test/suites/inverted_index_p0/test_show_nested_index_file_http_action_with_variant.groovy
@@ -53,7 +53,7 @@ suite("test_show_nested_index_file_http_action_with_variant", "nonConcurrent,p0"
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p0/test_single_column_multi_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_single_column_multi_index.groovy
@@ -79,7 +79,7 @@ suite("test_single_column_multi_index", "nonConcurrent") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/test_single_column_multi_index1.groovy
+++ b/regression-test/suites/inverted_index_p0/test_single_column_multi_index1.groovy
@@ -70,7 +70,7 @@ suite("test_single_column_multi_index1", "p0") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p0/topn_clear_block.groovy
+++ b/regression-test/suites/inverted_index_p0/topn_clear_block.groovy
@@ -34,7 +34,7 @@ suite("test_clear_block") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p0/unique_with_mow/test_unique_mow_sequence.groovy
+++ b/regression-test/suites/inverted_index_p0/unique_with_mow/test_unique_mow_sequence.groovy
@@ -71,7 +71,7 @@ suite("test_unique_mow_sequence", "inverted_index") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/inverted_index_p1/index_compaction/test_index_compaction_p1.groovy
+++ b/regression-test/suites/inverted_index_p1/index_compaction/test_index_compaction_p1.groovy
@@ -46,7 +46,7 @@ suite("test_index_compaction_p1", "p1, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p1/need_read_data/test_dup_table_inverted_index.groovy
+++ b/regression-test/suites/inverted_index_p1/need_read_data/test_dup_table_inverted_index.groovy
@@ -34,7 +34,7 @@ suite("test_dup_table_inverted_index", "p1") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p1/show_data/test_show_index_data.groovy
+++ b/regression-test/suites/inverted_index_p1/show_data/test_show_index_data.groovy
@@ -52,7 +52,7 @@ suite("test_show_index_data", "p1") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
+++ b/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
@@ -95,7 +95,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p2/load_with_inverted_index_p2/test_stream_load_with_inverted_index.groovy
+++ b/regression-test/suites/inverted_index_p2/load_with_inverted_index_p2/test_stream_load_with_inverted_index.groovy
@@ -58,7 +58,7 @@ suite("test_stream_load_with_inverted_index", "p2") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p2/show_data/test_show_index_data_p2.groovy
+++ b/regression-test/suites/inverted_index_p2/show_data/test_show_index_data_p2.groovy
@@ -52,7 +52,7 @@ suite("test_show_index_data_p2", "p2") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p2/test_array_with_large_dataset.groovy
+++ b/regression-test/suites/inverted_index_p2/test_array_with_large_dataset.groovy
@@ -49,7 +49,7 @@ suite("test_array_with_large_dataset", "p2"){
                 log.info("Stream load result: ${result}".toString())
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p2/test_insert_into_index.groovy
+++ b/regression-test/suites/inverted_index_p2/test_insert_into_index.groovy
@@ -63,7 +63,7 @@ suite("test_insert_into_with_inverted_index", "p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/inverted_index_p2/test_show_data.groovy
+++ b/regression-test/suites/inverted_index_p2/test_show_data.groovy
@@ -94,7 +94,7 @@ suite("test_show_data", "p2") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }
@@ -291,7 +291,7 @@ suite("test_show_data_for_bkd", "p2") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }
@@ -489,7 +489,7 @@ suite("test_show_data_multi_add", "p2") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }
@@ -701,7 +701,7 @@ suite("test_show_data_with_compaction", "p2") {
                         assertEquals(json.NumberLoadedRows, expected_succ_rows)
                     } else {
                         assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                        assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                        assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }

--- a/regression-test/suites/inverted_index_p2/test_variant_index_format_v1.groovy
+++ b/regression-test/suites/inverted_index_p2/test_variant_index_format_v1.groovy
@@ -56,7 +56,7 @@ suite("test_variant_index_format_v1", "p2, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/json_p0/test_json_load_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_and_function.groovy
@@ -59,7 +59,7 @@ suite("test_json_load_and_function", "p0") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(0, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
             log.info("url: " + json.ErrorURL)
         }
     }
@@ -91,7 +91,7 @@ suite("test_json_load_and_function", "p0") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(18, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/json_p0/test_json_load_double.groovy
+++ b/regression-test/suites/json_p0/test_json_load_double.groovy
@@ -76,7 +76,7 @@ suite("test_json_load_double", "p0") {
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(2, json.NumberTotalRows)
             assertEquals(2, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
             log.info("url: " + json.ErrorURL)
         }
     }

--- a/regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
@@ -54,7 +54,7 @@ suite("test_json_unique_load_and_function", "p0") {
             assertEquals(75, json.NumberTotalRows)
             assertEquals(0, json.NumberLoadedRows)
             assertEquals(21, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -81,7 +81,7 @@ suite("test_json_unique_load_and_function", "p0") {
             assertEquals(75, json.NumberTotalRows)
             assertEquals(54, json.NumberLoadedRows)
             assertEquals(21, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/json_p0/test_json_predict_is_null.groovy
+++ b/regression-test/suites/json_p0/test_json_predict_is_null.groovy
@@ -66,7 +66,7 @@ suite("test_json_predict_is_null", "p0") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(18, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/jsonb_p0/test_jsonb_cast.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_cast.groovy
@@ -53,7 +53,7 @@ suite("test_jsonb_cast", "p0") {
             def json = parseJson(result)
             assertEquals(4, json.NumberTotalRows)
             assertEquals(4, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
@@ -59,7 +59,7 @@ suite("test_jsonb_load_and_function", "p0") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(0, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
             log.info("url: " + json.ErrorURL)
         }
     }
@@ -90,7 +90,7 @@ suite("test_jsonb_load_and_function", "p0") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(18, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy
@@ -55,7 +55,7 @@ suite("test_jsonb_unique_load_and_function", "p0") {
             assertEquals(75, json.NumberTotalRows)
             assertEquals(0, json.NumberLoadedRows)
             assertEquals(21, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -82,7 +82,7 @@ suite("test_jsonb_unique_load_and_function", "p0") {
             assertEquals(75, json.NumberTotalRows)
             assertEquals(54, json.NumberLoadedRows)
             assertEquals(21, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/jsonb_p0/test_jsonb_predict_is_null.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_predict_is_null.groovy
@@ -65,7 +65,7 @@ suite("test_jsonb_predict_is_null", "p0") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(18, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/jsonb_p0/test_jsonb_with_unescaped_string.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_with_unescaped_string.groovy
@@ -54,7 +54,7 @@ suite("test_jsonb_with_unescaped_string", "p0") {
             def json = parseJson(result)
             assertEquals(5, json.NumberTotalRows)
             assertEquals(5, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -84,7 +84,7 @@ suite("test_jsonb_with_unescaped_string", "p0") {
             def json = parseJson(result)
             assertEquals(5, json.NumberTotalRows)
             assertEquals(5, json.NumberLoadedRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/load/insert/test_move_memtable_multi_segment_index.groovy
+++ b/regression-test/suites/load/insert/test_move_memtable_multi_segment_index.groovy
@@ -49,7 +49,7 @@ suite("test_move_memtable_multi_segment_index", "nonConcurrent"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/load_p0/broker_load/test_array_load.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_array_load.groovy
@@ -126,7 +126,7 @@ suite("test_array_load", "load_p0,external") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows + json.NumberFilteredRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/load_p0/insert/test_insert_statistic.groovy
+++ b/regression-test/suites/load_p0/insert/test_insert_statistic.groovy
@@ -85,7 +85,7 @@ suite("test_insert_statistic", "p0") {
     assertEquals(json.ScannedRows, 3)
     assertEquals(json.FileNumber, 0)
     assertEquals(json.FileSize, 0)
-    assertTrue(json.LoadBytes > 0)
+    assertTrue(json.receivedBytes > 0)
 
     // failed insert into select → job should be CANCELLED
     sql """ DROP TABLE IF EXISTS ${insert_tbl}_fail"""
@@ -149,5 +149,5 @@ suite("test_insert_statistic", "p0") {
     assertEquals(json.ScannedRows, 2)
     assertEquals(json.FileNumber, 1)
     assertEquals(json.FileSize, 86)
-    assertTrue(json.LoadBytes > 0)
+    assertTrue(json.receivedBytes > 0)
 }

--- a/regression-test/suites/load_p0/stream_load/load_json_null_to_nullable.groovy
+++ b/regression-test/suites/load_p0/stream_load/load_json_null_to_nullable.groovy
@@ -65,7 +65,7 @@ suite("test_load_json_null_to_nullable", "p0") {
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows
                              + json.NumberFilteredRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/load_p0/stream_load/load_json_with_jsonpath.groovy
+++ b/regression-test/suites/load_p0/stream_load/load_json_with_jsonpath.groovy
@@ -65,7 +65,7 @@ suite("test_load_json_with_jsonpath", "p0") {
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows
                              + json.NumberFilteredRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/load_p0/stream_load/load_object_array_json.groovy
+++ b/regression-test/suites/load_p0/stream_load/load_object_array_json.groovy
@@ -73,7 +73,7 @@ suite("load_object_array_json", "p0") {
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows
                              + json.NumberFilteredRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/load_p0/stream_load/test_compress_type.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_compress_type.groovy
@@ -42,7 +42,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -64,7 +64,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -86,7 +86,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -107,7 +107,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -128,7 +128,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -149,7 +149,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }       
     }
 
@@ -171,7 +171,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -192,7 +192,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -214,7 +214,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -235,7 +235,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(20, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
                 assertEquals(0, json.NumberUnselectedRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -257,7 +257,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(13, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(13, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -279,7 +279,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(9, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(9, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -301,7 +301,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(31, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(31, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -322,7 +322,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(13, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(13, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -343,7 +343,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(9, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(9, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -364,7 +364,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(31, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(31, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -385,7 +385,7 @@ suite("test_stream_load_compress_type", "load_p0") {
                 assertEquals(23, json.NumberTotalRows)
                 assertEquals(0, json.NumberLoadedRows)
                 assertEquals(23, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/load_p0/stream_load/test_csv_with_none_utf8_data.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_csv_with_none_utf8_data.groovy
@@ -62,7 +62,7 @@ suite("test_csv_with_none_utf8_data", "p0") {
             assertEquals(4, json.NumberTotalRows)
             assertEquals(0, json.NumberLoadedRows)
             assertEquals(2, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
             log.info("url: " + json.ErrorURL)
         }
     }

--- a/regression-test/suites/load_p0/stream_load/test_json_load.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_json_load.groovy
@@ -177,7 +177,7 @@ suite("test_json_load", "p0,nonConcurrent") {
                     assertEquals(json.NumberLoadedRows, expected_succ_rows)
                 } else {
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
         }
@@ -449,7 +449,7 @@ suite("test_json_load", "p0,nonConcurrent") {
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows + json.NumberFilteredRows)
                 assertEquals(json.NumberFilteredRows, 4)
                 assertEquals(json.NumberLoadedRows, 6)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql "sync"

--- a/regression-test/suites/load_p0/stream_load/test_load_with_map_nested_array.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_load_with_map_nested_array.groovy
@@ -51,7 +51,7 @@ suite("test_load_with_map_nested_array", "p0") {
             assertEquals("success", json.Status.toLowerCase())
             assertEquals("OK", json.Message)
             assertEquals(1000, json.NumberTotalRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
 
         }
     }

--- a/regression-test/suites/load_p0/stream_load/test_map_load_and_compaction.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_map_load_and_compaction.groovy
@@ -62,7 +62,7 @@ suite("test_map_load_and_compaction", "p0") {
                 log.info("expect ", assertLoadNum)
                 log.info("now: ",  json.NumberTotalRows)
                 assertTrue(assertLoadNum==json.NumberTotalRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/load_p0/stream_load/test_map_load_and_function.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_map_load_and_function.groovy
@@ -56,7 +56,7 @@ suite("test_map_load_and_function", "p0") {
             assertEquals("success", json.Status.toLowerCase())
             assertEquals("OK", json.Message)
             assertEquals(15, json.NumberTotalRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
 
         }
     }

--- a/regression-test/suites/load_p2/test_single_replica_load.groovy
+++ b/regression-test/suites/load_p2/test_single_replica_load.groovy
@@ -46,7 +46,7 @@ suite("test_single_replica_load", "p2, nonConcurrent") {
                 logger.info("Stream load ${file_name} result: ${result}".toString())
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/mysql_fulltext/load.groovy
+++ b/regression-test/suites/mysql_fulltext/load.groovy
@@ -142,7 +142,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -178,7 +178,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -214,7 +214,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -250,7 +250,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/mysql_fulltext_array_contains/load.groovy
+++ b/regression-test/suites/mysql_fulltext_array_contains/load.groovy
@@ -143,7 +143,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -180,7 +180,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -217,7 +217,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -254,7 +254,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/nereids_function_p0/scalar_function/J.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/J.groovy
@@ -59,7 +59,7 @@ suite("nereids_scalar_fn_J") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(0, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
             log.info("url: " + json.ErrorURL)
         }
     }
@@ -90,7 +90,7 @@ suite("nereids_scalar_fn_J") {
             assertEquals(25, json.NumberTotalRows)
             assertEquals(18, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/create_commit_mtmv_many_task.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/create_commit_mtmv_many_task.groovy
@@ -88,7 +88,7 @@ suite("create_commit_mtmv_many_tasks", "p2") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
 
         }

--- a/regression-test/suites/nereids_rules_p0/mv/nested/nested_materialized_view.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/nested/nested_materialized_view.groovy
@@ -89,7 +89,7 @@ suite("nested_materialized_view") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/nereids_rules_p0/mv/ssb/mv_ssb_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/ssb/mv_ssb_test.groovy
@@ -77,7 +77,7 @@ suite("mv_ssb_test") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/nereids_rules_p0/mv/tpch/mv_tpch_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/tpch/mv_tpch_test.groovy
@@ -71,7 +71,7 @@ suite("mv_tpch_test") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/nereids_syntax_p0/set_operation.groovy
+++ b/regression-test/suites/nereids_syntax_p0/set_operation.groovy
@@ -337,7 +337,7 @@ suite("set_operation") {
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows
                         + json.NumberFilteredRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
             def loadRowCount = sql "select count(*) from ${table_name};"
             logger.info("select count(*) from ${loadRowCount};")

--- a/regression-test/suites/nereids_tpch_p0/load.groovy
+++ b/regression-test/suites/nereids_tpch_p0/load.groovy
@@ -76,7 +76,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/opensky_p2/load.groovy
+++ b/regression-test/suites/opensky_p2/load.groovy
@@ -59,7 +59,7 @@ suite("load"){
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/query_p0/aggregate/aggregate.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate.groovy
@@ -100,7 +100,7 @@ suite("aggregate") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/query_p0/intersect/test_intersect2.groovy
+++ b/regression-test/suites/query_p0/intersect/test_intersect2.groovy
@@ -44,7 +44,7 @@ suite("test_intersect2") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     sql "sync"

--- a/regression-test/suites/query_p0/join/test_partitioned_hash_join.groovy
+++ b/regression-test/suites/query_p0/join/test_partitioned_hash_join.groovy
@@ -55,7 +55,7 @@ suite("test_partitioned_hash_join", "query,p0,arrow_flight_sql") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     sql """ set enable_profile = 1; """

--- a/regression-test/suites/query_p0/limit/load.groovy
+++ b/regression-test/suites/query_p0/limit/load.groovy
@@ -56,7 +56,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals('success', json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/query_p0/set_operations/load.groovy
+++ b/regression-test/suites/query_p0/set_operations/load.groovy
@@ -55,7 +55,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals('success', json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/query_p0/show/test_complex_type_unique_key.groovy
+++ b/regression-test/suites/query_p0/show/test_complex_type_unique_key.groovy
@@ -65,7 +65,7 @@ suite("test_complex_type_unique_key", "p0") {
             assertEquals(2, json.NumberTotalRows)
             assertEquals(2, json.NumberLoadedRows)
             assertEquals(0, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 
@@ -93,7 +93,7 @@ suite("test_complex_type_unique_key", "p0") {
             assertEquals(2, json.NumberTotalRows)
             assertEquals(2, json.NumberLoadedRows)
             assertEquals(0, json.NumberFilteredRows)
-            assertTrue(json.LoadBytes > 0)
+            assertTrue(json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_nullif.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_nullif.groovy
@@ -74,7 +74,7 @@ suite("test_nullif") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/query_p0/sql_functions/string_functions/load.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/load.groovy
@@ -55,7 +55,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals('success', json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }
@@ -105,7 +105,7 @@ suite("load") {
             def json = parseJson(result)
             assertEquals('success', json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 }

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode.groovy
@@ -114,7 +114,7 @@ suite("explode") {
                 assertEquals(25, json.NumberTotalRows)
                 assertEquals(25, json.NumberLoadedRows)
                 assertEquals(0, json.NumberFilteredRows)
-                assertTrue(json.LoadBytes > 0)
+                assertTrue(json.receivedBytes > 0)
             }
      }
 

--- a/regression-test/suites/query_p0/sql_functions/window_functions/load.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/load.groovy
@@ -56,7 +56,7 @@ suite("load") {
       def json = parseJson(result)
       assertEquals('success', json.Status.toLowerCase())
       assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-      assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+      assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
       }
     }
   }

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_ntile_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_ntile_function.groovy
@@ -61,7 +61,7 @@ suite("test_ntile_function") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     sql "sync"

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_select_stddev_variance_window.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_select_stddev_variance_window.groovy
@@ -73,7 +73,7 @@ suite("test_select_stddev_variance_window") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
     sql "sync"

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
@@ -113,7 +113,7 @@ suite("test_window_fn") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/query_p0/topn_lazy/load.groovy
+++ b/regression-test/suites/query_p0/topn_lazy/load.groovy
@@ -76,7 +76,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/s3_vault/default_vault_p2/load.groovy
+++ b/regression-test/suites/s3_vault/default_vault_p2/load.groovy
@@ -107,7 +107,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/s3_vault/multi_vault_p2/load.groovy
+++ b/regression-test/suites/s3_vault/multi_vault_p2/load.groovy
@@ -118,7 +118,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/s3_vault/ssb_sf1_p2/load.groovy
+++ b/regression-test/suites/s3_vault/ssb_sf1_p2/load.groovy
@@ -95,7 +95,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/schema_change/test_double_write_when_schema_change.groovy
+++ b/regression-test/suites/schema_change/test_double_write_when_schema_change.groovy
@@ -68,7 +68,7 @@ suite("double_write_schema_change", "p1") {
             def json = parseJson(result)
             assertEquals("success", json.Status.toLowerCase())
             assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-            assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+            assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
         }
     }
 

--- a/regression-test/suites/ssb_sf0.1_p1/load.groovy
+++ b/regression-test/suites/ssb_sf0.1_p1/load.groovy
@@ -75,7 +75,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/ssb_sf1_p2/load.groovy
+++ b/regression-test/suites/ssb_sf1_p2/load.groovy
@@ -85,7 +85,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/temp_table_p0/test_temp_table.groovy
+++ b/regression-test/suites/temp_table_p0/test_temp_table.groovy
@@ -580,7 +580,7 @@ suite('test_temp_table', 'p0') {
             log.info("Stream load result: ${result}".toString())
             def json = parseJson(result)
             assertEquals("fail", json.Status.toLowerCase())
-            assertTrue(json.NumberLoadedRows == 0 && json.LoadBytes == 0)
+            assertTrue(json.NumberLoadedRows == 0 && json.receivedBytes == 0)
         }
     }
     sql "sync"

--- a/regression-test/suites/tpcds_sf1_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_p1/load.groovy
@@ -95,7 +95,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpcds_sf1_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf1_p2/load.groovy
@@ -64,7 +64,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpcds_sf1_unique_ck_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_unique_ck_p1/load.groovy
@@ -135,7 +135,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpcds_sf1_unique_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_unique_p1/load.groovy
@@ -135,7 +135,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpch_sf0.1_constraints_p1/load.groovy
+++ b/regression-test/suites/tpch_sf0.1_constraints_p1/load.groovy
@@ -70,7 +70,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpch_sf0.1_p1/load.groovy
+++ b/regression-test/suites/tpch_sf0.1_p1/load.groovy
@@ -70,7 +70,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpch_sf0.1_unique_ck_p1/load.groovy
+++ b/regression-test/suites/tpch_sf0.1_unique_ck_p1/load.groovy
@@ -70,7 +70,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/tpch_sf0.1_unique_p1/load.groovy
+++ b/regression-test/suites/tpch_sf0.1_unique_p1/load.groovy
@@ -70,7 +70,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/tpch_sf1_p2/load.groovy
+++ b/regression-test/suites/tpch_sf1_p2/load.groovy
@@ -70,7 +70,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         streamLoad {
@@ -105,7 +105,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpch_sf1_unique_p2/load.groovy
+++ b/regression-test/suites/tpch_sf1_unique_p2/load.groovy
@@ -60,7 +60,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         streamLoad {
@@ -94,7 +94,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/tpch_unique_sql_zstd_bucket1_p1/load.groovy
+++ b/regression-test/suites/tpch_unique_sql_zstd_bucket1_p1/load.groovy
@@ -70,7 +70,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/trino_p0/load.groovy
+++ b/regression-test/suites/trino_p0/load.groovy
@@ -63,7 +63,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/four/load_four_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/four/load_four_step.groovy
@@ -56,7 +56,7 @@ suite("load_four_step") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             sql 'sync'
@@ -98,7 +98,7 @@ suite("load_four_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/one/load_one_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/one/load_one_step.groovy
@@ -50,7 +50,7 @@ suite("load_one_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/three/load_three_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/three/load_three_step.groovy
@@ -52,7 +52,7 @@ suite("load_three_step") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/two/load_two_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/ssb_unique_load_zstd/two/load_two_step.groovy
@@ -51,7 +51,7 @@ suite("load_two_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p0/ssb_unique_sql_zstd/load.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/ssb_unique_sql_zstd/load.groovy
@@ -72,7 +72,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/unique_with_mow_c_p0/test_unique_mow_sequence.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/test_unique_mow_sequence.groovy
@@ -64,7 +64,7 @@ suite("test_unique_mow_sequence") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/four/load_four_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/four/load_four_step.groovy
@@ -60,7 +60,7 @@ suite("load_four_step") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             sql 'sync'
@@ -103,7 +103,7 @@ suite("load_four_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/one/load_one_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/one/load_one_step.groovy
@@ -54,7 +54,7 @@ suite("load_one_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/three/load_three_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/three/load_three_step.groovy
@@ -56,7 +56,7 @@ suite("load_three_step") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/two/load_two_step.groovy
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_load_zstd/two/load_two_step.groovy
@@ -55,7 +55,7 @@ suite("load_two_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/load.groovy
+++ b/regression-test/suites/unique_with_mow_c_p2/ssb_unique_sql_zstd/load.groovy
@@ -73,7 +73,7 @@ suite("load") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             i++

--- a/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/four/load_four_step.groovy
+++ b/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/four/load_four_step.groovy
@@ -56,7 +56,7 @@ suite("load_four_step") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             sql 'sync'
@@ -98,7 +98,7 @@ suite("load_four_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/one/load_one_step.groovy
+++ b/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/one/load_one_step.groovy
@@ -50,7 +50,7 @@ suite("load_one_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/three/load_three_step.groovy
+++ b/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/three/load_three_step.groovy
@@ -52,7 +52,7 @@ suite("load_three_step") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             sql 'sync'

--- a/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/two/load_two_step.groovy
+++ b/regression-test/suites/unique_with_mow_p0/ssb_unique_load_zstd/two/load_two_step.groovy
@@ -51,7 +51,7 @@ suite("load_two_step") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         sql 'sync'

--- a/regression-test/suites/unique_with_mow_p0/ssb_unique_sql_zstd/load.groovy
+++ b/regression-test/suites/unique_with_mow_p0/ssb_unique_sql_zstd/load.groovy
@@ -72,7 +72,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
         i++

--- a/regression-test/suites/unique_with_mow_p0/test_unique_mow_sequence.groovy
+++ b/regression-test/suites/unique_with_mow_p0/test_unique_mow_sequence.groovy
@@ -63,7 +63,7 @@ suite("test_unique_mow_sequence") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
 

--- a/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/load.groovy
+++ b/regression-test/suites/unique_with_mow_p2/ssb_unique_sql_zstd/load.groovy
@@ -73,7 +73,7 @@ suite("load") {
                     def json = parseJson(result)
                     assertEquals("success", json.Status.toLowerCase())
                     assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                    assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                    assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
                 }
             }
             i++

--- a/regression-test/suites/variant_doc_mode_p2/load.groovy
+++ b/regression-test/suites/variant_doc_mode_p2/load.groovy
@@ -69,7 +69,7 @@ suite("test_doc_value_p2", "nonConcurrent,p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_github_events_new_p2/load.groovy
+++ b/regression-test/suites/variant_github_events_new_p2/load.groovy
@@ -40,7 +40,7 @@ suite("regression_test_variant_github_events_p2", "p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_github_events_nonConcurrent_p2/load.groovy
+++ b/regression-test/suites/variant_github_events_nonConcurrent_p2/load.groovy
@@ -62,7 +62,7 @@ suite("regression_test_variant_github_events_p2", "nonConcurrent,p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_github_events_nonConcurrent_upgrade_p2/load.groovy
+++ b/regression-test/suites/variant_github_events_nonConcurrent_upgrade_p2/load.groovy
@@ -67,7 +67,7 @@ suite("regression_test_variant_github_events_upgrade_p2", "nonConcurrent,p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_log_data_p2/load.groovy
+++ b/regression-test/suites/variant_log_data_p2/load.groovy
@@ -40,7 +40,7 @@ suite("regression_test_variant_logdata", "p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/desc.groovy
+++ b/regression-test/suites/variant_p0/desc.groovy
@@ -39,7 +39,7 @@ suite("regression_test_variant_desc", "p0"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/doc_mode/load.groovy
+++ b/regression-test/suites/variant_p0/doc_mode/load.groovy
@@ -43,7 +43,7 @@ suite("regression_test_variant_doc_value", "p0"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/doc_mode/schema_change/test_double_write_when_schema_change.groovy
+++ b/regression-test/suites/variant_p0/doc_mode/schema_change/test_double_write_when_schema_change.groovy
@@ -51,7 +51,7 @@ suite("double_write_schema_change_doc_value", "nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/load.groovy
+++ b/regression-test/suites/variant_p0/load.groovy
@@ -41,7 +41,7 @@ suite("regression_test_variant", "p0"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/mtmv.groovy
+++ b/regression-test/suites/variant_p0/mtmv.groovy
@@ -46,7 +46,7 @@ suite("regression_test_variant_mtmv"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/predefine/predefined_typed_to_sparse.groovy
+++ b/regression-test/suites/variant_p0/predefine/predefined_typed_to_sparse.groovy
@@ -44,7 +44,7 @@ suite("predefined_typed_to_sparse", "p0"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/predefine/predefined_typed_to_sparse_1shard.groovy
+++ b/regression-test/suites/variant_p0/predefine/predefined_typed_to_sparse_1shard.groovy
@@ -43,7 +43,7 @@ suite("test_predefine_typed_to_sparse_1shard", "p0"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/predefine/test_multi_index_nonCurrent.groovy
+++ b/regression-test/suites/variant_p0/predefine/test_multi_index_nonCurrent.groovy
@@ -207,7 +207,7 @@ suite("test_variant_multi_index_nonCurrent", "p0, nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/predefine/test_types_with_indexes_profile.groovy
+++ b/regression-test/suites/variant_p0/predefine/test_types_with_indexes_profile.groovy
@@ -45,7 +45,7 @@ suite("test_variant_predefine_types_with_indexes_profile", "p0,nonConcurrent"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/schema_change/test_double_write_when_schema_change.groovy
+++ b/regression-test/suites/variant_p0/schema_change/test_double_write_when_schema_change.groovy
@@ -50,7 +50,7 @@ suite("double_write_schema_change_with_variant", "nonConcurrent") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/tpch/load.groovy
+++ b/regression-test/suites/variant_p0/tpch/load.groovy
@@ -78,7 +78,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p0/view.groovy
+++ b/regression-test/suites/variant_p0/view.groovy
@@ -39,7 +39,7 @@ suite("regression_test_variant_view", "var_view") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p1/doc_snapshot/load.groovy
+++ b/regression-test/suites/variant_p1/doc_snapshot/load.groovy
@@ -46,7 +46,7 @@ suite("predefine_type_multi_index_doc_value", "p1"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p1/predefine/load.groovy
+++ b/regression-test/suites/variant_p1/predefine/load.groovy
@@ -46,7 +46,7 @@ suite("test_predefine_type_multi_index", "p1"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p2/load.groovy
+++ b/regression-test/suites/variant_p2/load.groovy
@@ -42,7 +42,7 @@ suite("load_p2", "variant_type,p2"){
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 // assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberUnselectedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/variant_p2/tpch_upgrade/load.groovy
+++ b/regression-test/suites/variant_p2/tpch_upgrade/load.groovy
@@ -74,7 +74,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/with_clause_p0/load.groovy
+++ b/regression-test/suites/with_clause_p0/load.groovy
@@ -56,7 +56,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals('success', json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }

--- a/regression-test/suites/yandex_metrica_p2/load.groovy
+++ b/regression-test/suites/yandex_metrica_p2/load.groovy
@@ -67,7 +67,7 @@ suite("load") {
                 def json = parseJson(result)
                 assertEquals("success", json.Status.toLowerCase())
                 assertEquals(json.NumberTotalRows, json.NumberLoadedRows)
-                assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
+                assertTrue(json.NumberLoadedRows > 0 && json.receivedBytes > 0)
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

The Stream Load HTTP response JSON field `LoadBytes` and the `SHOW STREAM LOAD` result column were named `LoadBytes`, but the value actually represents the bytes **received** from the HTTP request body (`receive_bytes`), not the bytes loaded into storage. The name is misleading. This PR renames the outward-facing display field to `receivedBytes` for clarity.

### Release note

Rename Stream Load display field `LoadBytes` to `receivedBytes` in HTTP response JSON and `SHOW STREAM LOAD` result column. Field value and semantics are unchanged.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes. Stream Load HTTP response JSON key renamed from `LoadBytes` to `receivedBytes`; `SHOW STREAM LOAD` column renamed accordingly.

- Does this need documentation?
    - [ ] No.
    - [x] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label