### PR TITLE
[fix](shuffle)Fix incorrect shuffle-key pruning when column statistics are unknown.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtils.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.PlanContext;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.stats.ExpressionEstimation;
 import org.apache.doris.nereids.stats.StatsCalculator;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -40,6 +41,7 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -188,7 +190,7 @@ public class ShuffleKeyPruneUtils {
                 .filter(s -> s.getDataType().isNumericType() || s.getDataType().isDateLikeType())
                 .collect(Collectors.toList());
         if (!numericAndDateExprs.isEmpty()) {
-            double combinedNdv = StatsCalculator.estimateGroupByRowCount(numericAndDateExprs, childStats);
+            double combinedNdv = estimateCombinedNDV(numericAndDateExprs, childStats);
             long ndvThreshold = (long) instanceNum * AggregateUtils.NDV_INSTANCE_BALANCE_MULTIPLIER;
             if (combinedNdv > ndvThreshold) {
                 return Optional.of(ImmutableList.copyOf(numericAndDateExprs));
@@ -231,151 +233,6 @@ public class ShuffleKeyPruneUtils {
             return ((CharacterType) dataType).getLen();
         }
         return 0;
-    }
-
-    /**
-     * Get Global AGG plan and its input statistics from a Group (if the group's best plan is Global AGG).
-     */
-    private static Optional<Pair<PhysicalHashAggregate<? extends Plan>, Statistics>> getGlobalAggInputStatsFromGroup(
-            Group group) {
-        for (GroupExpression ge : group.getPhysicalExpressions()) {
-            Plan p = ge.getPlan();
-            if (p instanceof PhysicalHashAggregate && ((PhysicalHashAggregate<?>) p).getAggPhase().isGlobal()) {
-                Optional<Statistics> inputStats = getGlobalAggChildStats((PhysicalHashAggregate<? extends Plan>) p);
-                return inputStats.map(statistics -> Pair.of((PhysicalHashAggregate<? extends Plan>) p, statistics));
-            }
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Scenario 3.3: when both join children are Global AGG, find optimal shuffle keys from
-     * join key ∩ left_agg.gby ∩ right_agg.gby. Same three-step strategy as agg:
-     * 1) Try single key (isBalanced); 2) Try numeric+date keys (remove strings);
-     * 3) Fall back. Returns (leftKeys, rightKeys) or empty.
-     */
-    public static Optional<Pair<List<ExprId>, List<ExprId>>> tryFindOptimalShuffleKeyForBothAggChildren(
-            PhysicalHashJoin<? extends Plan, ? extends Plan> hashJoin, PlanContext context) {
-        Optional<GroupExpression> joinGroupExpr = hashJoin.getGroupExpression();
-        if (!joinGroupExpr.isPresent()) {
-            return Optional.empty();
-        }
-        Group leftGroup = joinGroupExpr.get().child(0);
-        Group rightGroup = joinGroupExpr.get().child(1);
-        Optional<Pair<PhysicalHashAggregate<? extends Plan>, Statistics>> leftOpt =
-                getGlobalAggInputStatsFromGroup(leftGroup);
-        Optional<Pair<PhysicalHashAggregate<? extends Plan>, Statistics>> rightOpt =
-                getGlobalAggInputStatsFromGroup(rightGroup);
-        if (!leftOpt.isPresent() || !rightOpt.isPresent()) {
-            return Optional.empty();
-        }
-
-        PhysicalHashAggregate<? extends Plan> leftAgg = leftOpt.get().first;
-        PhysicalHashAggregate<? extends Plan> rightAgg = rightOpt.get().first;
-        if (leftAgg.hasSourceRepeat() || rightAgg.hasSourceRepeat()) {
-            return Optional.empty();
-        }
-        Statistics leftStats = leftOpt.get().second;
-        Statistics rightStats = rightOpt.get().second;
-
-        Pair<List<ExprId>, List<ExprId>> joinKeys = hashJoin.getHashConjunctsExprIds();
-        if (joinKeys.first.isEmpty() || joinKeys.second.size() != joinKeys.first.size()) {
-            return Optional.empty();
-        }
-
-        Set<ExprId> leftGbyIds = leftAgg.getGroupByExpressions().stream()
-                .filter(SlotReference.class::isInstance)
-                .map(SlotReference.class::cast)
-                .map(SlotReference::getExprId)
-                .collect(Collectors.toSet());
-        Set<ExprId> rightGbyIds = rightAgg.getGroupByExpressions().stream()
-                .filter(SlotReference.class::isInstance)
-                .map(SlotReference.class::cast)
-                .map(SlotReference::getExprId)
-                .collect(Collectors.toSet());
-
-        double leftRows = leftStats.getRowCount();
-        double rightRows = rightStats.getRowCount();
-        int instanceNum = context.getConnectContext().getTotalInstanceNum();
-
-        // Build (leftSlotRef, rightSlotRef) pairs for join keys in both gby sets
-        List<Pair<SlotReference, SlotReference>> validPairs = new ArrayList<>();
-        for (int i = 0; i < joinKeys.first.size(); i++) {
-            ExprId leftId = joinKeys.first.get(i);
-            ExprId rightId = joinKeys.second.get(i);
-            if (!leftGbyIds.contains(leftId) || !rightGbyIds.contains(rightId)) {
-                continue;
-            }
-            SlotReference leftSlotRef = leftAgg.getGroupByExpressions().stream()
-                    .filter(e -> e instanceof SlotReference && ((SlotReference) e).getExprId().equals(leftId))
-                    .map(SlotReference.class::cast)
-                    .findFirst()
-                    .orElse(null);
-            SlotReference rightSlotRef = rightAgg.getGroupByExpressions().stream()
-                    .filter(e -> e instanceof SlotReference && ((SlotReference) e).getExprId().equals(rightId))
-                    .map(SlotReference.class::cast)
-                    .findFirst()
-                    .orElse(null);
-            if (leftSlotRef != null && rightSlotRef != null) {
-                validPairs.add(Pair.of(leftSlotRef, rightSlotRef));
-            }
-        }
-        if (validPairs.isEmpty()) {
-            return Optional.empty();
-        }
-        // If any join key pair lacks column stats on either side, skip optimization.
-        for (Pair<SlotReference, SlotReference> pair : validPairs) {
-            if (leftStats.findColumnStatistics(pair.first) == null
-                    || rightStats.findColumnStatistics(pair.second) == null) {
-                return Optional.empty();
-            }
-        }
-
-        // Step 1: Try single key - sort by type, pick first where both isBalanced
-        List<Pair<SlotReference, SlotReference>> sortedPairs =
-                sortJoinKeyPairsByTypePriority(validPairs, leftStats, rightStats);
-        for (Pair<SlotReference, SlotReference> pair : sortedPairs) {
-            SlotReference leftSlotRef = pair.first;
-            SlotReference rightSlotRef = pair.second;
-            ColumnStatistic leftColStats = leftStats.findColumnStatistics(leftSlotRef);
-            ColumnStatistic rightColStats = rightStats.findColumnStatistics(rightSlotRef);
-            if (StatisticsUtil.isBalanced(leftColStats, leftRows, instanceNum)
-                    && StatisticsUtil.isBalanced(rightColStats, rightRows, instanceNum)) {
-                return Optional.of(Pair.of(
-                        ImmutableList.of(leftSlotRef.getExprId()),
-                        ImmutableList.of(rightSlotRef.getExprId())));
-            }
-        }
-
-        // Step 2: Try remove string types - filter numeric+date pairs, check combined NDV
-        List<SlotReference> numericDateLeftSlots = new ArrayList<>();
-        List<SlotReference> numericDateRightSlots = new ArrayList<>();
-        for (Pair<SlotReference, SlotReference> pair : validPairs) {
-            if ((pair.first.getDataType().isNumericType() || pair.first.getDataType().isDateLikeType())
-                    && (pair.second.getDataType().isNumericType() || pair.second.getDataType().isDateLikeType())) {
-                numericDateLeftSlots.add(pair.first);
-                numericDateRightSlots.add(pair.second);
-            }
-        }
-        if (!numericDateLeftSlots.isEmpty()) {
-            double leftCombinedNdv = StatsCalculator.estimateGroupByRowCount(
-                    new ArrayList<>(numericDateLeftSlots), leftStats);
-            double rightCombinedNdv = StatsCalculator.estimateGroupByRowCount(
-                    new ArrayList<>(numericDateRightSlots), rightStats);
-            long ndvThreshold = (long) instanceNum * AggregateUtils.NDV_INSTANCE_BALANCE_MULTIPLIER;
-            if (leftCombinedNdv > ndvThreshold && rightCombinedNdv > ndvThreshold) {
-                List<ExprId> leftIds = numericDateLeftSlots.stream()
-                        .map(SlotReference::getExprId)
-                        .collect(Collectors.toList());
-                List<ExprId> rightIds = numericDateRightSlots.stream()
-                        .map(SlotReference::getExprId)
-                        .collect(Collectors.toList());
-                return Optional.of(Pair.of(leftIds, rightIds));
-            }
-        }
-
-        // Step 3: Fall back
-        return Optional.empty();
     }
 
     /**
@@ -472,9 +329,9 @@ public class ShuffleKeyPruneUtils {
             }
         }
         if (!numericDateLeftSlots.isEmpty()) {
-            double leftCombinedNdv = StatsCalculator.estimateGroupByRowCount(
+            double leftCombinedNdv = estimateCombinedNDV(
                     new ArrayList<>(numericDateLeftSlots), leftStats);
-            double rightCombinedNdv = StatsCalculator.estimateGroupByRowCount(
+            double rightCombinedNdv = estimateCombinedNDV(
                     new ArrayList<>(numericDateRightSlots), rightStats);
             long ndvThreshold = (long) instanceNum * AggregateUtils.NDV_INSTANCE_BALANCE_MULTIPLIER;
             if (leftCombinedNdv > ndvThreshold && rightCombinedNdv > ndvThreshold) {
@@ -511,5 +368,44 @@ public class ShuffleKeyPruneUtils {
             return (getStringAvgSizeForSort(pair.first, leftStats) + getStringAvgSizeForSort(pair.second, rightStats));
         }
         return 0;
+    }
+
+    /**
+     * computeAggregate
+     */
+    public static double estimateCombinedNDV(List<Expression> groupByExpressions, Statistics childStats) {
+        double combinedNDV = 1;
+        // if there is group-bys, output row count is childStats.getRowCount() * DEFAULT_AGGREGATE_RATIO,
+        // o.w. output row count is 1
+        // example: select sum(A) from T;
+        if (groupByExpressions.isEmpty()) {
+            return 1;
+        }
+        List<Double> groupByNdvs = new ArrayList<>();
+        for (Expression groupByExpr : groupByExpressions) {
+            ColumnStatistic colStats = childStats.findColumnStatistics(groupByExpr);
+            if (colStats == null) {
+                colStats = ExpressionEstimation.estimate(groupByExpr, childStats);
+            }
+            if (colStats.isUnKnown()) {
+                return -1;
+            }
+            double ndv = colStats.ndv;
+            groupByNdvs.add(ndv);
+        }
+        groupByNdvs.sort(Collections.reverseOrder());
+
+        combinedNDV = groupByNdvs.get(0);
+        for (int groupByIndex = 1; groupByIndex < groupByExpressions.size(); ++groupByIndex) {
+            combinedNDV *= Math.max(1, groupByNdvs.get(groupByIndex) * Math.pow(
+                    StatsCalculator.AGGREGATE_COLUMN_CORRELATION_COEFFICIENT, groupByIndex + 1D));
+            if (combinedNDV > childStats.getRowCount()) {
+                combinedNDV = childStats.getRowCount();
+                break;
+            }
+        }
+        combinedNDV = Math.max(1, combinedNDV);
+        combinedNDV = Math.min(combinedNDV, childStats.getRowCount());
+        return combinedNDV;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtils.java
@@ -47,7 +47,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**AggShuffleKeyOptimize*/

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtilsTest.java
@@ -34,7 +34,6 @@ import org.apache.doris.nereids.trees.plans.AggPhase;
 import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
-import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
@@ -44,6 +43,8 @@ import org.apache.doris.nereids.types.VarcharType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.statistics.ColumnStatistic;
+import org.apache.doris.statistics.Statistics;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
@@ -342,5 +343,27 @@ class ShuffleKeyPruneUtilsTest extends TestWithFeService {
         Assertions.assertEquals(2, result.get().size());
         Assertions.assertEquals(numericSlot, result.get().get(0));
         Assertions.assertEquals(dateSlot, result.get().get(1));
+    }
+
+    @Test
+    void testSelectBestShuffleKeyForAgg_unknownStatsDoNotPruneStringKey() {
+        SlotReference numericSlot = new SlotReference(new ExprId(17), "num_col", IntegerType.INSTANCE, true,
+                ImmutableList.of());
+        SlotReference stringSlot = new SlotReference(new ExprId(18), "str_col", new VarcharType(64), true,
+                ImmutableList.of());
+
+        Map<Expression, ColumnStatistic> columnStats = new HashMap<>();
+        columnStats.put(numericSlot, ColumnStatistic.UNKNOWN);
+        columnStats.put(stringSlot, statsWithNdv(ImmutableMap.of(stringSlot, 1.0), ROW_COUNT)
+                .findColumnStatistics(stringSlot));
+        Group childGroup = new Group(GroupId.createGenerator().getNextId(), emptyExpression, null);
+        childGroup.setStatistics(new Statistics(ROW_COUNT, columnStats));
+        Pair<PhysicalHashAggregate<GroupPlan>, GroupExpression> aggSetup = createAggAndRegister(childGroup,
+                ImmutableList.of(numericSlot, stringSlot), false);
+
+        Optional<List<Expression>> result = ShuffleKeyPruneUtils.selectBestShuffleKeyForAgg(aggSetup.first,
+                ImmutableList.of(numericSlot, stringSlot), connectContext);
+
+        Assertions.assertFalse(result.isPresent());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ShuffleKeyPruneUtilsTest.java
@@ -319,23 +319,6 @@ class ShuffleKeyPruneUtilsTest extends TestWithFeService {
     }
 
     @Test
-    void testTryFindOptimalShuffleKeyForBothAggChildren_selectBestKey() {
-        Pair<Group, Group> groups = createJoinAggGroups();
-        PhysicalHashJoin<GroupPlan, GroupPlan> hashJoin = createHashJoinWithConjuncts(groups.first, groups.second, 7);
-
-        GroupExpression joinGroupExpr = new GroupExpression(hashJoin, Lists.newArrayList(groups.first, groups.second));
-        new Group(GroupId.createGenerator().getNextId(), joinGroupExpr, null);
-        PlanContext planContext = new PlanContext(connectContext, joinGroupExpr);
-
-        Optional<Pair<List<ExprId>, List<ExprId>>> result = ShuffleKeyPruneUtils.tryFindOptimalShuffleKeyForBothAggChildren(
-                (PhysicalHashJoin) joinGroupExpr.getPlan(), planContext);
-
-        Assertions.assertTrue(result.isPresent());
-        Assertions.assertFalse(result.get().first.isEmpty());
-        Assertions.assertFalse(result.get().second.isEmpty());
-    }
-
-    @Test
     void testSelectBestShuffleKeyForAgg_pruneStringKeysWithCombinedNdv() {
         SlotReference numericSlot = new SlotReference(new ExprId(14), "num_col", IntegerType.INSTANCE, true,
                 ImmutableList.of());
@@ -359,35 +342,5 @@ class ShuffleKeyPruneUtilsTest extends TestWithFeService {
         Assertions.assertEquals(2, result.get().size());
         Assertions.assertEquals(numericSlot, result.get().get(0));
         Assertions.assertEquals(dateSlot, result.get().get(1));
-    }
-
-    @Test
-    void testTryFindOptimalShuffleKeyForBothAggChildren_leftHasSourceRepeat() {
-        Pair<Group, Group> groups = createJoinAggGroups(true, false);
-        PhysicalHashJoin<GroupPlan, GroupPlan> hashJoin = createHashJoinWithConjuncts(groups.first, groups.second, 7);
-
-        GroupExpression joinGroupExpr = new GroupExpression(hashJoin, Lists.newArrayList(groups.first, groups.second));
-        new Group(GroupId.createGenerator().getNextId(), joinGroupExpr, null);
-        PlanContext planContext = new PlanContext(connectContext, joinGroupExpr);
-
-        Optional<Pair<List<ExprId>, List<ExprId>>> result = ShuffleKeyPruneUtils.tryFindOptimalShuffleKeyForBothAggChildren(
-                (PhysicalHashJoin<? extends Plan, ? extends Plan>) joinGroupExpr.getPlan(), planContext);
-
-        Assertions.assertFalse(result.isPresent());
-    }
-
-    @Test
-    void testTryFindOptimalShuffleKeyForBothAggChildren_rightHasSourceRepeat() {
-        Pair<Group, Group> groups = createJoinAggGroups(false, true);
-        PhysicalHashJoin<GroupPlan, GroupPlan> hashJoin = createHashJoinWithConjuncts(groups.first, groups.second, 7);
-
-        GroupExpression joinGroupExpr = new GroupExpression(hashJoin, Lists.newArrayList(groups.first, groups.second));
-        new Group(GroupId.createGenerator().getNextId(), joinGroupExpr, null);
-        PlanContext planContext = new PlanContext(connectContext, joinGroupExpr);
-
-        Optional<Pair<List<ExprId>, List<ExprId>>> result = ShuffleKeyPruneUtils.tryFindOptimalShuffleKeyForBothAggChildren(
-                (PhysicalHashJoin<? extends Plan, ? extends Plan>) joinGroupExpr.getPlan(), planContext);
-
-        Assertions.assertFalse(result.isPresent());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #61298

Problem Summary:
When column statistics are unknown, the combined NDV was estimated using the default aggregate ratio. This could overestimate the NDV and incorrectly prune string shuffle keys.
This PR treats the combined NDV as invalid when any shuffle-key statistic is unknown, causing the optimizer to fall back to the complete shuffle keys.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

