### PR TITLE
[regression-test](variant) Avoid unstable bool numeric output

### DIFF
--- a/regression-test/data/variant_p0/test_types_in_variant.out
+++ b/regression-test/data/variant_p0/test_types_in_variant.out
@@ -102,7 +102,7 @@ var.a.b	array<largeint>	Yes	false	\N	NONE
 
 -- !sql --
 1	{"a":[{"b":18446744073709551615}]}
-2	{"a":[{"b":1}]}
+2	{"a":[{"b":2}]}
 
 -- !sql_array_largeint --
 id	int	Yes	true	\N	
@@ -111,11 +111,10 @@ var.a.b	array<largeint>	Yes	false	\N	NONE
 
 -- !sql --
 1	{"a":[{"b":18446744073709551615}]}
-2	{"a":[{"b":1}]}
+2	{"a":[{"b":2}]}
 3	{"a":[{"b":1.1}]}
 
 -- !sql_array_json --
 id	int	Yes	true	\N	
 var	variant<PROPERTIES ("variant_max_subcolumns_count" = "0","variant_enable_typed_paths_to_sparse" = "false","variant_max_sparse_column_statistics_size" = "10","variant_sparse_hash_shard_count" = "10")>	Yes	false	\N	NONE
 var.a.b	array<json>	Yes	false	\N	NONE
-

--- a/regression-test/suites/variant_p0/test_types_in_variant.groovy
+++ b/regression-test/suites/variant_p0/test_types_in_variant.groovy
@@ -92,7 +92,8 @@ suite("regression_test_variant_types", "var_view") {
 
     qt_sql_array_largeint "desc ${table_name}"
     
-    sql """ insert into ${table_name} (id, var) values (2, '{"a": [{"b" : true}]}'); """
+    // Avoid relying on bool-to-number rendering when this path evolves to array<json>.
+    sql """ insert into ${table_name} (id, var) values (2, '{"a": [{"b" : 2}]}'); """
 
     qt_sql "select * from ${table_name} order by id"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

This PR updates `variant_p0/test_types_in_variant.groovy` to avoid depending on whether a boolean value is rendered as `true` or numerically coerced to `1` after the nested Variant path evolves to `array<json>`. The case still covers the largeint-to-json type evolution, but uses a numeric value for the second row to avoid unstable JSON comparison.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason

Regression test:

```bash
env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u all_proxy -u ALL_PROXY \
  NO_PROXY="127.0.0.1,localhost" no_proxy="127.0.0.1,localhost" \
  ./run-regression-test.sh --run --conf tmp/regression-conf.9753.groovy \
    -d variant_p0 -s regression_test_variant_types
```

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
