### PR TITLE
[refine](pipeline) Add exchange source debug details

### DIFF
--- a/be/src/exec/operator/exchange_source_operator.cpp
+++ b/be/src/exec/operator/exchange_source_operator.cpp
@@ -18,6 +18,7 @@
 #include "exec/operator/exchange_source_operator.h"
 
 #include <fmt/core.h>
+#include <gen_cpp/Partitions_types.h>
 
 #include <cstdint>
 #include <memory>
@@ -32,6 +33,33 @@
 #include "util/defer_op.h"
 
 namespace doris {
+namespace {
+
+std::string partition_type_to_string(TPartitionType::type partition_type) {
+    auto it = _TPartitionType_VALUES_TO_NAMES.find(partition_type);
+    if (it == _TPartitionType_VALUES_TO_NAMES.end()) {
+        return fmt::format("UNKNOWN({})", partition_type);
+    }
+    return it->second;
+}
+
+void append_limited_instance_set(fmt::memory_buffer& buffer, const std::set<int>& instance_set) {
+    int count = 0;
+    for (int instance_idx : instance_set) {
+        if (count > 0) {
+            fmt::format_to(buffer, ",");
+        }
+        if (count >= 16) {
+            fmt::format_to(buffer, "...");
+            break;
+        }
+        fmt::format_to(buffer, "{}", instance_idx);
+        ++count;
+    }
+}
+
+} // namespace
+
 ExchangeLocalState::ExchangeLocalState(RuntimeState* state, OperatorXBase* parent)
         : Base(state, parent), num_rows_skipped(0), is_ready(false) {}
 
@@ -48,8 +76,14 @@ ExchangeLocalState::~ExchangeLocalState() {
 
 std::string ExchangeLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
-    fmt::format_to(debug_string_buffer, "{}, recvr: ({})", Base::debug_string(indentation_level),
-                   stream_recvr->debug_string());
+    auto& p = _parent->cast<ExchangeSourceOperatorX>();
+    const bool is_bucket_shuffle_orphan = p.is_bucket_shuffle_orphan_instance(local_task_idx);
+    const int effective_num_senders = is_bucket_shuffle_orphan ? 0 : p.num_senders();
+    fmt::format_to(debug_string_buffer,
+                   "{}, Source State: (local_task_idx = {}, effective_num_senders = {}, "
+                   "is_bucket_shuffle_orphan = {}), recvr: ({})",
+                   Base::debug_string(indentation_level), local_task_idx, effective_num_senders,
+                   is_bucket_shuffle_orphan, stream_recvr->debug_string());
     return fmt::to_string(debug_string_buffer);
 }
 
@@ -57,15 +91,22 @@ std::string ExchangeSourceOperatorX::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer, "{}",
                    OperatorX<ExchangeLocalState>::debug_string(indentation_level));
-    fmt::format_to(debug_string_buffer, ", Info: (_num_senders = {}, _is_merging = {})",
-                   _num_senders, _is_merging);
+    fmt::format_to(debug_string_buffer,
+                   ", Info: (_num_senders = {}, _is_merging = {}, _partition_type = {}, "
+                   "_has_bucket_dest_instances = {}, _bucket_dest_instances_count = {}, "
+                   "_bucket_dest_instances = [",
+                   _num_senders, _is_merging, partition_type_to_string(_partition_type),
+                   _has_bucket_dest_instances, _bucket_dest_instances.size());
+    append_limited_instance_set(debug_string_buffer, _bucket_dest_instances);
+    fmt::format_to(debug_string_buffer, "])");
     return fmt::to_string(debug_string_buffer);
 }
 
 void ExchangeLocalState::create_stream_recvr(RuntimeState* state) {
     auto& p = _parent->cast<ExchangeSourceOperatorX>();
     int num_senders = p.num_senders();
-    if (p.is_bucket_shuffle_orphan_instance(local_task_idx)) {
+    const bool is_bucket_shuffle_orphan = p.is_bucket_shuffle_orphan_instance(local_task_idx);
+    if (is_bucket_shuffle_orphan) {
         // Bucket-routed senders open one channel per destination entry (one per bucket),
         // so an instance owning no bucket never gets a channel — and never gets EOS.
         // Start its receiver with zero senders so it reports EOS immediately instead of


### PR DESCRIPTION
### What problem does this PR solve?


Intermittent query timeouts can leave an exchange receiver waiting with non-zero remaining senders, but the existing source-side debug string does not show enough information to tell why the receiver was initialized to wait for senders.

This PR extends the exchange source debug string with the local task index, effective sender count, bucket-shuffle orphan state, partition type, and bucket destination instances. These fields make timeout dumps more useful when only the stuck source operator is still alive, especially for checking whether the receiver should have been treated as a bucket-shuffle orphan or was initialized with the wrong sender count.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

