### PR TITLE
[refine](join) add cross join block size debug info

### DIFF
--- a/be/src/exec/operator/nested_loop_join_probe_operator.cpp
+++ b/be/src/exec/operator/nested_loop_join_probe_operator.cpp
@@ -17,6 +17,7 @@
 
 #include "exec/operator/nested_loop_join_probe_operator.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "common/cast_set.h"
@@ -171,6 +172,43 @@ Status NestedLoopJoinProbeLocalState::close(RuntimeState* state) {
 
     return JoinProbeLocalState<NestedLoopJoinSharedState, NestedLoopJoinProbeLocalState>::close(
             state);
+}
+
+std::string NestedLoopJoinProbeLocalState::debug_string(int indentation_level) const {
+    const auto batch_size = _state ? _state->batch_size() : 0;
+    const auto child_block_rows = _child_block ? _child_block->rows() : 0;
+    const auto join_block_rows = _join_block.rows();
+    size_t build_blocks = 0;
+    size_t current_build_block_rows = 0;
+    size_t max_build_block_rows = 0;
+    if (_shared_state) {
+        build_blocks = _shared_state->build_blocks.size();
+        for (const auto& build_block : _shared_state->build_blocks) {
+            max_build_block_rows = std::max(max_build_block_rows, build_block.rows());
+        }
+        if (_current_build_pos < build_blocks) {
+            current_build_block_rows = _shared_state->build_blocks[_current_build_pos].rows();
+        }
+    }
+
+    fmt::memory_buffer debug_string_buffer;
+    fmt::format_to(
+            debug_string_buffer,
+            "{}, batch_size: {}, child_block_rows: {}, child_eos: {}, join_block_rows: {}, "
+            "build_blocks: {}, current_build_pos: {}, current_build_block_rows: {}, "
+            "max_build_block_rows: {}, probe_block_start_pos: {}, probe_block_pos: {}, "
+            "current_build_row_pos: {}, need_more_input_data: {}, matched_rows_done: {}, "
+            "oversized_child_block: {}, oversized_join_block: {}, oversized_build_block: {}",
+            JoinProbeLocalState<NestedLoopJoinSharedState,
+                                NestedLoopJoinProbeLocalState>::debug_string(indentation_level),
+            batch_size, child_block_rows, _child_eos, join_block_rows, build_blocks,
+            _current_build_pos, current_build_block_rows, max_build_block_rows,
+            _probe_block_start_pos, _probe_block_pos, _current_build_row_pos, _need_more_input_data,
+            _matched_rows_done,
+            batch_size > 0 && child_block_rows > static_cast<size_t>(batch_size),
+            batch_size > 0 && join_block_rows > static_cast<size_t>(batch_size),
+            batch_size > 0 && max_build_block_rows > static_cast<size_t>(batch_size));
+    return fmt::to_string(debug_string_buffer);
 }
 
 void NestedLoopJoinProbeLocalState::_update_additional_flags(Block* block) {

--- a/be/src/exec/operator/nested_loop_join_probe_operator.h
+++ b/be/src/exec/operator/nested_loop_join_probe_operator.h
@@ -58,6 +58,7 @@ public:
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
+    std::string debug_string(int indentation_level) const override;
 
     // For some complex join types, after generating data on the build/probe side,
     // we need to update visited flags.


### PR DESCRIPTION
### What problem does this PR solve?

Cross Join timeout investigation needs to confirm whether the operator receives or keeps blocks whose rows are larger than the session `batch_size`. The previous `CROSS_JOIN_OPERATOR` debug string only exposed the generic operator metadata, so `/api/running_pipeline_tasks` could not show the probe input block size, temporary join block size, or build-side block size.

This change adds `NestedLoopJoinProbeLocalState::debug_string()` and reports `batch_size`, probe child block rows, join temporary block rows, build block counts and row sizes, current probe/build positions, and explicit `oversized_*_block` flags. This is diagnostic-only and does not change Cross Join execution behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

