### PR TITLE
[fix](fe) Fix duplicate join nodes in PushDownAggThroughJoinOnPkFk tree reconstruction

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFk.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFk.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -100,7 +101,7 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
             LogicalAggregate<?> newAgg =
                     eliminatePrimaryOutput(agg, subJoin, primaryAndForeign.first, primaryAndForeign.second);
             if (newAgg == null) {
-                return null;
+                continue;
             }
             LogicalJoin<?, ?> newJoin = innerJoinCluster
                     .constructJoinWithPrimary(e.getKey(), subJoin, primaryAndForeign.first);
@@ -279,7 +280,8 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
      *        a       b
      */
     static class InnerJoinCluster {
-        private final Map<BitSet, LogicalJoin<?, ?>> innerJoins = new HashMap<>();
+        private final Map<BitSet, LogicalJoin<?, ?>> innerJoins = new LinkedHashMap<>();
+        private final Map<BitSet, int[]> joinChildLeaves = new HashMap<>();
         private final List<Plan> leaf = new ArrayList<>();
 
         void collectContiguousInnerJoins(Plan plan) {
@@ -295,14 +297,21 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
                 Set<Slot> inputSlots = join.getInputSlots();
                 BitSet childrenIndices = new BitSet();
                 List<Plan> children = new ArrayList<>();
+                int[] childLeaves = new int[2];
+                int childIdx = 0;
                 for (int i = 0; i < leaf.size(); i++) {
                     if (!Sets.intersection(leaf.get(i).getOutputSet(), inputSlots).isEmpty()) {
                         childrenIndices.set(i);
                         children.add(leaf.get(i));
+                        if (childIdx < 2) {
+                            childLeaves[childIdx] = i;
+                        }
+                        childIdx++;
                     }
                 }
                 if (childrenIndices.cardinality() == 2) {
                     join = join.withChildren(children);
+                    joinChildLeaves.put(childrenIndices, childLeaves);
                 }
                 innerJoins.put(childrenIndices, join);
             }
@@ -340,14 +349,73 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
                         continue;
                     }
                     if (currentBitset.isEmpty()) {
+                        // Start with the first available join that is a subset of target
+                        BitSet entryBitset = entry.getKey();
+                        // The join should cover at most what's in the target
+                        BitSet outsideTarget = (BitSet) entryBitset.clone();
+                        outsideTarget.andNot(bitSet);
+                        if (!outsideTarget.isEmpty()) {
+                            continue;
+                        }
                         addJoin = true;
-                        currentBitset.or(entry.getKey());
+                        currentBitset.or(entryBitset);
                         currentPlan = entry.getValue();
                         forbiddenJoin.add(entry.getKey());
                     } else if (currentBitset.intersects(entry.getKey())) {
+                        // The new join shares leaves with the current accumulated plan.
+                        // We need to replace the shared child with currentPlan.
+                        BitSet entryBitset = entry.getKey();
+
+                        // Ensure the new join doesn't introduce leaves outside the target
+                        BitSet outsideTarget = (BitSet) entryBitset.clone();
+                        outsideTarget.andNot(bitSet);
+                        if (!outsideTarget.isEmpty()) {
+                            continue;
+                        }
+
+                        // Find which leaf is shared and which is new
+                        BitSet sharedBits = (BitSet) entryBitset.clone();
+                        sharedBits.and(currentBitset);
+
+                        BitSet newBits = (BitSet) entryBitset.clone();
+                        newBits.andNot(currentBitset);
+
+                        if (sharedBits.isEmpty()) {
+                            continue;
+                        }
+
+                        LogicalJoin<?, ?> entryJoin = entry.getValue();
+                        int sharedLeaf = sharedBits.nextSetBit(0);
+
+                        // Determine the new child: it could be a single leaf or a sub-plan
+                        Plan newChild;
+                        if (newBits.cardinality() == 1) {
+                            newChild = leaf.get(newBits.nextSetBit(0));
+                        } else if (newBits.cardinality() == 0) {
+                            // Both leaves already covered, skip
+                            continue;
+                        } else {
+                            // Multiple new leaves, recursively construct
+                            newChild = constructPlan(newBits, new HashSet<>(forbiddenJoin));
+                            if (newChild == null) {
+                                continue;
+                            }
+                        }
+
+                        // Determine which child of entryJoin covers the shared leaf
+                        int[] childLeaves = joinChildLeaves.get(entryBitset);
+                        if (childLeaves != null && childLeaves[1] == sharedLeaf) {
+                            // Right child covers the shared leaf,
+                            // replace right child with currentPlan
+                            currentPlan = entryJoin.withChildren(newChild, currentPlan);
+                        } else {
+                            // Left child covers the shared leaf,
+                            // replace left child with currentPlan
+                            currentPlan = entryJoin.withChildren(currentPlan, newChild);
+                        }
+
                         addJoin = true;
-                        currentBitset.or(entry.getKey());
-                        currentPlan = currentPlan.withChildren(currentPlan, entry.getValue());
+                        currentBitset.or(entryBitset);
                         forbiddenJoin.add(entry.getKey());
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFk.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFk.java
@@ -61,6 +61,15 @@ import java.util.Set;
  *  |  Agg(group by fk)
  *  |      |
  *  pk    fk
+ *
+ * Constraints applied on the pattern:
+ *   - Join is Inner Join (no semi/anti/outer join, no mark join).
+ *   - otherJoinConjuncts is empty: only equi-join conditions are allowed,
+ *     and each condition must reference exactly one slot from each side.
+ *   - All GROUP BY expressions are Slot (complex grouping expressions
+ *     are not supported).
+ *   - If an intermediate LogicalProject exists, it must be isAllSlots
+ *     (projections that introduce computations are not supported).
  */
 public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
     @Override
@@ -281,7 +290,6 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
      */
     static class InnerJoinCluster {
         private final Map<BitSet, LogicalJoin<?, ?>> innerJoins = new LinkedHashMap<>();
-        private final Map<BitSet, int[]> joinChildLeaves = new HashMap<>();
         private final List<Plan> leaf = new ArrayList<>();
 
         void collectContiguousInnerJoins(Plan plan) {
@@ -297,21 +305,14 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
                 Set<Slot> inputSlots = join.getInputSlots();
                 BitSet childrenIndices = new BitSet();
                 List<Plan> children = new ArrayList<>();
-                int[] childLeaves = new int[2];
-                int childIdx = 0;
                 for (int i = 0; i < leaf.size(); i++) {
                     if (!Sets.intersection(leaf.get(i).getOutputSet(), inputSlots).isEmpty()) {
                         childrenIndices.set(i);
                         children.add(leaf.get(i));
-                        if (childIdx < 2) {
-                            childLeaves[childIdx] = i;
-                        }
-                        childIdx++;
                     }
                 }
                 if (childrenIndices.cardinality() == 2) {
                     join = join.withChildren(children);
-                    joinChildLeaves.put(childrenIndices, childLeaves);
                 }
                 innerJoins.put(childrenIndices, join);
             }
@@ -349,71 +350,28 @@ public class PushDownAggThroughJoinOnPkFk implements RewriteRuleFactory {
                         continue;
                     }
                     if (currentBitset.isEmpty()) {
-                        // Start with the first available join that is a subset of target
-                        BitSet entryBitset = entry.getKey();
-                        // The join should cover at most what's in the target
-                        BitSet outsideTarget = (BitSet) entryBitset.clone();
-                        outsideTarget.andNot(bitSet);
-                        if (!outsideTarget.isEmpty()) {
-                            continue;
-                        }
                         addJoin = true;
-                        currentBitset.or(entryBitset);
+                        currentBitset.or(entry.getKey());
                         currentPlan = entry.getValue();
                         forbiddenJoin.add(entry.getKey());
                     } else if (currentBitset.intersects(entry.getKey())) {
                         // The new join shares leaves with the current accumulated plan.
-                        // We need to replace the shared child with currentPlan.
+                        // We need to connect the newChild with current plan
                         BitSet entryBitset = entry.getKey();
-
-                        // Ensure the new join doesn't introduce leaves outside the target
-                        BitSet outsideTarget = (BitSet) entryBitset.clone();
-                        outsideTarget.andNot(bitSet);
-                        if (!outsideTarget.isEmpty()) {
-                            continue;
-                        }
-
-                        // Find which leaf is shared and which is new
-                        BitSet sharedBits = (BitSet) entryBitset.clone();
-                        sharedBits.and(currentBitset);
 
                         BitSet newBits = (BitSet) entryBitset.clone();
                         newBits.andNot(currentBitset);
-
-                        if (sharedBits.isEmpty()) {
-                            continue;
-                        }
-
                         LogicalJoin<?, ?> entryJoin = entry.getValue();
-                        int sharedLeaf = sharedBits.nextSetBit(0);
 
-                        // Determine the new child: it could be a single leaf or a sub-plan
+                        // Determine the new child: it must be a single leaf
                         Plan newChild;
                         if (newBits.cardinality() == 1) {
                             newChild = leaf.get(newBits.nextSetBit(0));
-                        } else if (newBits.cardinality() == 0) {
-                            // Both leaves already covered, skip
-                            continue;
                         } else {
-                            // Multiple new leaves, recursively construct
-                            newChild = constructPlan(newBits, new HashSet<>(forbiddenJoin));
-                            if (newChild == null) {
-                                continue;
-                            }
+                            return null;
                         }
 
-                        // Determine which child of entryJoin covers the shared leaf
-                        int[] childLeaves = joinChildLeaves.get(entryBitset);
-                        if (childLeaves != null && childLeaves[1] == sharedLeaf) {
-                            // Right child covers the shared leaf,
-                            // replace right child with currentPlan
-                            currentPlan = entryJoin.withChildren(newChild, currentPlan);
-                        } else {
-                            // Left child covers the shared leaf,
-                            // replace left child with currentPlan
-                            currentPlan = entryJoin.withChildren(currentPlan, newChild);
-                        }
-
+                        currentPlan = entryJoin.withChildren(newChild, currentPlan);
                         addJoin = true;
                         currentBitset.or(entryBitset);
                         forbiddenJoin.add(entry.getKey());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOnPkFkTest.java
@@ -49,6 +49,46 @@ class PushDownAggThroughJoinOnPkFkTest extends TestWithFeService implements Memo
                         + ")\n"
                         + "DUPLICATE KEY(id3)\n"
                         + "DISTRIBUTED BY HASH(id3) BUCKETS 10\n"
+                        + "PROPERTIES (\"replication_num\" = \"1\")\n",
+                // Tables for tree-structured multi-join test (like TPC-H Q10):
+                // t_primary acts as the "bridge" table (like customer):
+                //   - pk(pk_id)
+                //   - fk(fk_to_other) references t_other_primary(other_pk_id)
+                // t_foreign1 acts like orders:
+                //   - fk(fk_to_primary) references t_primary(pk_id)
+                // t_foreign2 acts like lineitem (no pk/fk constraints, just for tree structure)
+                // t_other_primary acts like nation:
+                //   - pk(other_pk_id)
+                "CREATE TABLE IF NOT EXISTS t_primary (\n"
+                        + "    pk_id int not null,\n"
+                        + "    name char,\n"
+                        + "    fk_to_other int not null\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(pk_id)\n"
+                        + "DISTRIBUTED BY HASH(pk_id) BUCKETS 10\n"
+                        + "PROPERTIES (\"replication_num\" = \"1\")\n",
+                "CREATE TABLE IF NOT EXISTS t_foreign1 (\n"
+                        + "    fk1_id int not null,\n"
+                        + "    name char,\n"
+                        + "    fk_to_primary int not null\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(fk1_id)\n"
+                        + "DISTRIBUTED BY HASH(fk1_id) BUCKETS 10\n"
+                        + "PROPERTIES (\"replication_num\" = \"1\")\n",
+                "CREATE TABLE IF NOT EXISTS t_foreign2 (\n"
+                        + "    fk2_id int not null,\n"
+                        + "    name char,\n"
+                        + "    fk_to_foreign1 int not null\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(fk2_id)\n"
+                        + "DISTRIBUTED BY HASH(fk2_id) BUCKETS 10\n"
+                        + "PROPERTIES (\"replication_num\" = \"1\")\n",
+                "CREATE TABLE IF NOT EXISTS t_other_primary (\n"
+                        + "    other_pk_id int not null,\n"
+                        + "    name char\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(other_pk_id)\n"
+                        + "DISTRIBUTED BY HASH(other_pk_id) BUCKETS 10\n"
                         + "PROPERTIES (\"replication_num\" = \"1\")\n"
         );
         addConstraint("Alter table pri add constraint pk primary key (id1)");
@@ -56,7 +96,15 @@ class PushDownAggThroughJoinOnPkFkTest extends TestWithFeService implements Memo
                 + "references pri(id1)");
         addConstraint("Alter table foreign_null add constraint f_not_null foreign key (id3)\n"
                 + "references pri(id1)");
-        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        // Constraints for tree-structured multi-join test
+        addConstraint("Alter table t_primary add constraint pk_t_primary primary key (pk_id)");
+        addConstraint("Alter table t_foreign1 add constraint fk1_to_primary foreign key (fk_to_primary)\n"
+                + "references t_primary(pk_id)");
+        addConstraint("Alter table t_other_primary add constraint pk_other primary key (other_pk_id)");
+        addConstraint("Alter table t_primary add constraint fk_primary_to_other foreign key (fk_to_other)\n"
+                + "references t_other_primary(other_pk_id)");
+        connectContext.getSessionVariable().setDisableNereidsRules(
+                "PRUNE_EMPTY_PARTITION,ELIMINATE_JOIN_BY_FK");
     }
 
     @Test
@@ -177,6 +225,82 @@ class PushDownAggThroughJoinOnPkFkTest extends TestWithFeService implements Memo
                 .analyze(sql)
                 .rewrite()
                 .matches(logicalAggregate(logicalProject(logicalJoin())))
+                .printlnTree();
+    }
+
+    @Test
+    void testPushDownAggThroughTreeJoin() {
+        // Test pushing agg through a tree-structured join (like TPC-H Q10):
+        // Join(t_primary.fk_to_other = t_other_primary.other_pk_id)  ← root (pk-fk: other is pk)
+        //   /  \
+        // Join(t_foreign1.fk1_id = t_foreign2.fk_to_foreign1)        t_other_primary
+        //   /  \
+        // Join(t_primary.pk_id = t_foreign1.fk_to_primary)           t_foreign2
+        //   /  \
+        // t_primary  t_foreign1
+        // The pk-fk join with t_other_primary as pk is recognized,
+        // and agg should be pushed down through it.
+        String sql = "select t_primary.pk_id, t_primary.fk_to_other, sum(t_foreign2.fk2_id) "
+                + "from t_primary "
+                + "inner join t_foreign1 on t_primary.pk_id = t_foreign1.fk_to_primary "
+                + "inner join t_foreign2 on t_foreign1.fk1_id = t_foreign2.fk_to_foreign1 "
+                + "inner join t_other_primary on t_primary.fk_to_other = t_other_primary.other_pk_id "
+                + "group by t_primary.pk_id, t_primary.fk_to_other";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin(logicalAggregate(), any()))
+                .printlnTree();
+    }
+
+    @Test
+    void testPushDownAggThroughTreeJoinOtherSide() {
+        // When the pk-fk join's primary is t_primary (the connector table that
+        // also joins to other tables), the remaining leaves can still form a
+        // connected chain t_foreign1 ↔ t_foreign2 ↔ t_other_primary via joins
+        // {1,2} and {2,3}, allowing constructPlan to assemble them into a
+        // single plan. The agg should be pushed down through the pk-fk join.
+        // Note: the join to t_other_primary uses t_foreign2.name = t_other_primary.name
+        // (a non-PK-FK join) so the remaining leaves form a connected chain.
+        String sql = "select t_primary.pk_id, t_foreign1.fk_to_primary, sum(t_foreign2.fk2_id) "
+                + "from t_primary "
+                + "inner join t_foreign1 on t_primary.pk_id = t_foreign1.fk_to_primary "
+                + "inner join t_foreign2 on t_foreign1.fk1_id = t_foreign2.fk_to_foreign1 "
+                + "inner join t_other_primary on t_foreign2.name = t_other_primary.name "
+                + "group by t_primary.pk_id, t_foreign1.fk_to_primary";
+        // In this case, pk-fk is t_primary(pk)↔t_foreign1(fk). t_primary is the
+        // connector table but the remaining leaves {t_foreign1, t_foreign2, t_other_primary}
+        // are connected (t_foreign1↔t_foreign2, t_foreign2↔t_other_primary).
+        // constructPlan successfully assembles them, and the agg is pushed down
+        // below the pk-fk join.
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin(logicalAggregate(), any()))
+                .printlnTree();
+    }
+
+    @Test
+    void testSkipIneligibleEdgeAndSucceedOnLaterEdge() {
+        // Regression: pushAgg iterates all PK/FK edges but used to return null
+        // on the first ineligible candidate instead of continuing to later edges.
+        // The lower edge {t_primary, t_foreign1} (t_primary is pk) is visited
+        // first on Java 17 HashMap<BitSet> iteration, and sum(t_primary.pk_id)
+        // makes eliminatePrimaryOutput return null because the Sum aggregate
+        // function references a primary-side column that cannot be rewritten.
+        // With the fix, the rule skips that edge and succeeds on the root edge
+        // {t_other_primary, t_primary} (t_other_primary is pk), which pushes
+        // the aggregate through because the query outputs no t_other_primary cols.
+        String sql = "select t_primary.pk_id, t_primary.fk_to_other, sum(t_primary.pk_id) "
+                + "from t_primary "
+                + "inner join t_foreign1 on t_primary.pk_id = t_foreign1.fk_to_primary "
+                + "inner join t_foreign2 on t_foreign1.fk1_id = t_foreign2.fk_to_foreign1 "
+                + "inner join t_other_primary on t_primary.fk_to_other = t_other_primary.other_pk_id "
+                + "group by t_primary.pk_id, t_primary.fk_to_other";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin(logicalAggregate(), any()))
                 .printlnTree();
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/36035
Problem Summary:

This PR fixes two bugs in the PushDownAggThroughJoinOnPkFk rule that handles
pushing aggregates through joins using PK-FK constraints on multi-table joins.

**Bug 1: Duplicate join nodes in tree reconstruction**

When `constructPlan` rebuilt a subtree from flattened inner joins, the merge
path did `currentPlan.withChildren(currentPlan, entryJoin)`, which inserted
`currentPlan` as a child of itself and also kept `entryJoin` with its original
two children. This produced duplicate join nodes and duplicate leaf references
in the resulting plan tree. The fix computes the new leaf set (`newBits =
entryBitset - currentBitset`) and only attaches the genuinely new child, using
`entryJoin.withChildren(newChild, currentPlan)` instead.

**Bug 2: First ineligible PK-FK edge aborts the entire rule**

`pushAgg` iterates all flattened PK-FK edges, but when `eliminatePrimaryOutput`
returned null for an earlier edge, the code did `return null` — aborting the
whole rule instead of continuing to try later edges. Since `HashMap<BitSet>`
iteration order on Java 17 visits the lower `{t_primary, t_foreign1}` edge
before the root `{t_other_primary, t_primary}` edge, a query aggregating a
primary-side column (e.g., `SUM(t_primary.pk_id)`) would fail on the first
edge and never reach the valid root edge. Fixed by changing `return null` to
`continue`.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

