### PR TITLE
[fix](be) Use VExpr for file scanner v2 ZoneMap pruning

### DIFF
--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -177,7 +177,7 @@ Status read_integer_decoded_values(IColumn& column, const DecodedColumnView& vie
 }
 
 } // namespace
-// Type map的基本结构
+// Basic structure of the type map.
 template <typename Key, typename Value, typename... Rest>
 struct TypeMap {
     using KeyType = Key;
@@ -185,21 +185,21 @@ struct TypeMap {
     using Next = TypeMap<Rest...>;
 };
 
-// Type map的末端
+// End marker of the type map.
 template <>
 struct TypeMap<void, void> {};
 
-// TypeMapLookup 前向声明
+// Forward declaration of TypeMapLookup.
 template <typename Key, typename Map>
 struct TypeMapLookup;
 
-// Type map查找：找到匹配的键时的情况
+// Type map lookup when the key matches.
 template <typename Key, typename Value, typename... Rest>
 struct TypeMapLookup<Key, TypeMap<Key, Value, Rest...>> {
     using ValueType = Value;
 };
 
-// Type map查找：递归查找
+// Type map lookup by recursive search.
 template <typename Key, typename K, typename V, typename... Rest>
 struct TypeMapLookup<Key, TypeMap<K, V, Rest...>> {
     using ValueType = typename TypeMapLookup<Key, TypeMap<Rest...>>::ValueType;

--- a/be/src/core/data_type_serde/decoded_column_view.h
+++ b/be/src/core/data_type_serde/decoded_column_view.h
@@ -33,8 +33,9 @@ namespace doris {
 
 class IColumn;
 
-// 已解码 column batch 的物理值来源类型。
-// 该枚举只描述通用内存布局，不包含 Parquet/ORC/Arrow 等格式专有类型。
+// Physical value source type for a decoded column batch.
+// This enum describes only generic memory layouts, not format-specific types such as
+// Parquet/ORC/Arrow.
 enum class DecodedValueKind {
     BOOL,
     INT32,

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -359,13 +359,10 @@ Status FileScannerV2::_init_table_reader(const TFileRangeDesc& range) {
     RETURN_IF_ERROR(_to_file_format(format_type, &file_format));
     DORIS_CHECK(_table_reader != nullptr);
 
-    format::TableColumnPredicates table_column_predicates;
-    RETURN_IF_ERROR(_build_table_column_predicates(&table_column_predicates));
     VExprContextSPtrs table_conjuncts;
     RETURN_IF_ERROR(_build_table_conjuncts(&table_conjuncts));
     RETURN_IF_ERROR(_table_reader->init({
             .projected_columns = _projected_columns,
-            .column_predicates = std::move(table_column_predicates),
             .conjuncts = std::move(table_conjuncts),
             .format = file_format,
             .scan_params = const_cast<TFileScanRangeParams*>(_params),
@@ -586,25 +583,6 @@ format::ColumnDefinition FileScannerV2::_build_table_column(const SlotDescriptor
     column.name = slot_desc->col_name();
     column.type = slot_desc->get_data_type_ptr();
     return column;
-}
-
-Status FileScannerV2::_build_table_column_predicates(
-        format::TableColumnPredicates* predicates) const {
-    DORIS_CHECK(predicates != nullptr);
-    predicates->clear();
-    const auto& slot_predicates = _local_state->cast<FileScanLocalState>()._slot_id_to_predicates;
-    for (const auto& [slot_id, slot_predicate_list] : slot_predicates) {
-        const auto it = _slot_id_to_desc.find(slot_id);
-        if (it == _slot_id_to_desc.end()) {
-            continue;
-        }
-        const auto global_index_it = _slot_id_to_global_index.find(slot_id);
-        if (global_index_it == _slot_id_to_global_index.end()) {
-            continue;
-        }
-        (*predicates)[global_index_it->second] = slot_predicate_list;
-    }
-    return Status::OK();
 }
 
 Status FileScannerV2::_build_table_conjuncts(VExprContextSPtrs* conjuncts) const {

--- a/be/src/exec/scan/file_scanner_v2.h
+++ b/be/src/exec/scan/file_scanner_v2.h
@@ -104,7 +104,6 @@ private:
     Status _build_projected_columns(const format::TableReader& table_reader);
     Status _build_default_expr(const TFileScanSlotInfo& slot_info, VExprContextSPtr* ctx) const;
     static format::ColumnDefinition _build_table_column(const SlotDescriptor* slot_desc);
-    Status _build_table_column_predicates(format::TableColumnPredicates* predicates) const;
     Status _build_table_conjuncts(VExprContextSPtrs* conjuncts) const;
     static Status _to_file_format(TFileFormatType::type format_type,
                                   format::FileFormat* file_format);

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -32,6 +32,7 @@
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
 #include "runtime/runtime_state.h"
+#include "storage/index/bloom_filter/bloom_filter.h"
 
 namespace doris::expr_zonemap {
 namespace {
@@ -52,7 +53,85 @@ bool value_in_range(const Field& value, const Field& min_value, const Field& max
     return value >= min_value && value <= max_value;
 }
 
+bool dictionary_contains(const DictionaryEvalContext::SlotDictionary& dictionary,
+                         const Field& value) {
+    return std::ranges::any_of(dictionary.values, [&](const Field& dictionary_value) {
+        return dictionary_value == value;
+    });
+}
+
+bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slot_filter,
+                              const Field& value) {
+    DORIS_CHECK(slot_filter.data_type != nullptr);
+    DORIS_CHECK(slot_filter.bloom_filter != nullptr);
+    const auto data_type = remove_nullable(slot_filter.data_type);
+    DORIS_CHECK(data_type != nullptr);
+    switch (data_type->get_primitive_type()) {
+    case TYPE_BOOLEAN: {
+        const bool typed_value = value.get<TYPE_BOOLEAN>();
+        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
+                                                    sizeof(typed_value));
+    }
+    case TYPE_INT: {
+        const int32_t typed_value = value.get<TYPE_INT>();
+        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
+                                                    sizeof(typed_value));
+    }
+    case TYPE_BIGINT: {
+        const int64_t typed_value = value.get<TYPE_BIGINT>();
+        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
+                                                    sizeof(typed_value));
+    }
+    case TYPE_FLOAT: {
+        const float typed_value = value.get<TYPE_FLOAT>();
+        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
+                                                    sizeof(typed_value));
+    }
+    case TYPE_DOUBLE: {
+        const double typed_value = value.get<TYPE_DOUBLE>();
+        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
+                                                    sizeof(typed_value));
+    }
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+    case TYPE_STRING: {
+        const auto& typed_value = value.get<TYPE_STRING>();
+        return slot_filter.bloom_filter->test_bytes(typed_value.data(), typed_value.size());
+    }
+    default:
+        return true;
+    }
+}
+
+template <typename Capability>
+int single_slot_index(const VExprContextSPtr& ctx, Capability capability) {
+    DORIS_CHECK(ctx != nullptr);
+    const auto& root = ctx->root();
+    DORIS_CHECK(root != nullptr);
+    if (!capability(root)) {
+        return -1;
+    }
+
+    std::set<int> slot_indexes;
+    root->collect_slot_column_ids(slot_indexes);
+    if (slot_indexes.size() != 1) {
+        return -1;
+    }
+
+    return *slot_indexes.begin();
+}
+
 } // namespace
+
+const DictionaryEvalContext::SlotDictionary* DictionaryEvalContext::slot(int slot_index) const {
+    auto it = slots.find(slot_index);
+    return it == slots.end() ? nullptr : &it->second;
+}
+
+const BloomFilterEvalContext::SlotBloomFilter* BloomFilterEvalContext::slot(int slot_index) const {
+    auto it = slots.find(slot_index);
+    return it == slots.end() ? nullptr : &it->second;
+}
 
 TExprNode create_texpr_node_from_hybrid_set_value(const void* data, const PrimitiveType& type,
                                                   int precision, int scale) {
@@ -236,24 +315,100 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
     return ZoneMapFilterResult::kNoMatch;
 }
 
+ZoneMapFilterResult eval_eq_dictionary(const DictionaryEvalContext& ctx,
+                                       const SlotLiteral& slot_literal) {
+    auto dictionary = ctx.slot(slot_literal.slot_index);
+    if (dictionary == nullptr || dictionary->data_type == nullptr) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    DORIS_CHECK(data_types_compatible(dictionary->data_type, slot_literal.slot_type));
+    if (slot_literal.literal.is_null()) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    return dictionary_contains(*dictionary, slot_literal.literal) ? ZoneMapFilterResult::kMayMatch
+                                                                  : ZoneMapFilterResult::kNoMatch;
+}
+
+ZoneMapFilterResult eval_in_dictionary(const DictionaryEvalContext& ctx, const VExprSPtr& slot_expr,
+                                       bool is_not_in, const std::vector<Field>& values) {
+    if (is_not_in) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    auto slot = std::dynamic_pointer_cast<VSlotRef>(slot_expr);
+    DORIS_CHECK(slot != nullptr);
+    auto dictionary = ctx.slot(slot->column_id());
+    if (dictionary == nullptr || dictionary->data_type == nullptr) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    DORIS_CHECK(data_types_compatible(dictionary->data_type, slot->data_type()));
+    if (values.empty()) {
+        return ZoneMapFilterResult::kNoMatch;
+    }
+    for (const auto& value : values) {
+        if (!value.is_null() && dictionary_contains(*dictionary, value)) {
+            return ZoneMapFilterResult::kMayMatch;
+        }
+    }
+    return ZoneMapFilterResult::kNoMatch;
+}
+
+ZoneMapFilterResult eval_eq_bloom_filter(const BloomFilterEvalContext& ctx,
+                                         const SlotLiteral& slot_literal) {
+    auto slot_filter = ctx.slot(slot_literal.slot_index);
+    if (slot_filter == nullptr || slot_filter->data_type == nullptr ||
+        slot_filter->bloom_filter == nullptr) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    DORIS_CHECK(data_types_compatible(slot_filter->data_type, slot_literal.slot_type));
+    if (slot_literal.literal.is_null()) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    return bloom_filter_may_contain(*slot_filter, slot_literal.literal)
+                   ? ZoneMapFilterResult::kMayMatch
+                   : ZoneMapFilterResult::kNoMatch;
+}
+
+ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
+                                         const VExprSPtr& slot_expr, bool is_not_in,
+                                         const std::vector<Field>& values) {
+    if (is_not_in) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    auto slot = std::dynamic_pointer_cast<VSlotRef>(slot_expr);
+    DORIS_CHECK(slot != nullptr);
+    auto slot_filter = ctx.slot(slot->column_id());
+    if (slot_filter == nullptr || slot_filter->data_type == nullptr ||
+        slot_filter->bloom_filter == nullptr) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    DORIS_CHECK(data_types_compatible(slot_filter->data_type, slot->data_type()));
+    if (values.empty()) {
+        return ZoneMapFilterResult::kNoMatch;
+    }
+    for (const auto& value : values) {
+        if (!value.is_null() && bloom_filter_may_contain(*slot_filter, value)) {
+            return ZoneMapFilterResult::kMayMatch;
+        }
+    }
+    return ZoneMapFilterResult::kNoMatch;
+}
+
 // Return the only slot ordinal referenced by a zonemap-evaluable expression. A negative result is
 // the conservative fallback marker for unsupported expressions, multi-slot expressions, or invalid
 // slot ordinals, so callers can skip schema-indexed zonemap pruning safely.
 int single_slot_zonemap_index(const VExprContextSPtr& ctx) {
-    DORIS_CHECK(ctx != nullptr);
-    const auto& root = ctx->root();
-    DORIS_CHECK(root != nullptr);
-    if (!root->can_evaluate_zonemap_filter()) {
-        return -1;
-    }
+    return single_slot_index(
+            ctx, [](const VExprSPtr& expr) { return expr->can_evaluate_zonemap_filter(); });
+}
 
-    std::set<int> slot_indexes;
-    root->collect_slot_column_ids(slot_indexes);
-    if (slot_indexes.size() != 1) {
-        return -1;
-    }
+int single_slot_dictionary_index(const VExprContextSPtr& ctx) {
+    return single_slot_index(
+            ctx, [](const VExprSPtr& expr) { return expr->can_evaluate_dictionary_filter(); });
+}
 
-    return *slot_indexes.begin();
+int single_slot_bloom_filter_index(const VExprContextSPtr& ctx) {
+    return single_slot_index(
+            ctx, [](const VExprSPtr& expr) { return expr->can_evaluate_bloom_filter(); });
 }
 
 bool is_expr_zonemap_filter_enabled(const RuntimeState* state) {

--- a/be/src/exprs/expr_zonemap_filter.h
+++ b/be/src/exprs/expr_zonemap_filter.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <compare>
+#include <map>
 #include <optional>
 #include <vector>
 
@@ -35,6 +36,10 @@ namespace doris {
 class HybridSetBase;
 class RuntimeState;
 class TExprNode;
+
+namespace segment_v2 {
+class BloomFilter;
+} // namespace segment_v2
 } // namespace doris
 
 namespace doris::expr_zonemap {
@@ -44,6 +49,31 @@ struct InZonemapMaterializedSet {
     std::vector<Field> values;
     Field min_value;
     Field max_value;
+};
+
+// Dictionary pruning evaluates file-level dictionary values, not row-level data. A kNoMatch result
+// means no non-null dictionary entry can satisfy the expression, so the whole row group can be
+// skipped only for dictionary-encoded columns whose dictionary contains all non-null values.
+struct DictionaryEvalContext {
+    struct SlotDictionary {
+        DataTypePtr data_type;
+        std::vector<Field> values;
+    };
+
+    const SlotDictionary* slot(int slot_index) const;
+    std::map<int, SlotDictionary> slots;
+};
+
+// Bloom-filter pruning can only disprove equality-style predicates. A kNoMatch result means every
+// literal candidate required by the expression is definitely absent from the file bloom filter.
+struct BloomFilterEvalContext {
+    struct SlotBloomFilter {
+        DataTypePtr data_type;
+        const segment_v2::BloomFilter* bloom_filter = nullptr;
+    };
+
+    const SlotBloomFilter* slot(int slot_index) const;
+    std::map<int, SlotBloomFilter> slots;
 };
 
 struct SlotLiteral {
@@ -115,11 +145,33 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
                                     bool is_not_in, const std::vector<Field>& values,
                                     const Field& min_value, const Field& max_value);
 
+ZoneMapFilterResult eval_eq_dictionary(const DictionaryEvalContext& ctx,
+                                       const SlotLiteral& slot_literal);
+
+ZoneMapFilterResult eval_in_dictionary(const DictionaryEvalContext& ctx, const VExprSPtr& slot_expr,
+                                       bool is_not_in, const std::vector<Field>& values);
+
+ZoneMapFilterResult eval_eq_bloom_filter(const BloomFilterEvalContext& ctx,
+                                         const SlotLiteral& slot_literal);
+
+ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
+                                         const VExprSPtr& slot_expr, bool is_not_in,
+                                         const std::vector<Field>& values);
+
 // Return the only slot ordinal referenced by a zonemap-evaluable expression in its current
 // binding. Expressions that are unsupported by zonemap pruning, reference multiple slots, or use an
 // invalid negative slot ordinal return a negative value.
 int single_slot_zonemap_index(const VExprContextSPtr& ctx);
 
+int single_slot_dictionary_index(const VExprContextSPtr& ctx);
+
+int single_slot_bloom_filter_index(const VExprContextSPtr& ctx);
+
 bool is_expr_zonemap_filter_enabled(const RuntimeState* state);
 
 } // namespace doris::expr_zonemap
+
+namespace doris {
+using DictionaryEvalContext = expr_zonemap::DictionaryEvalContext;
+using BloomFilterEvalContext = expr_zonemap::BloomFilterEvalContext;
+} // namespace doris

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -411,4 +411,14 @@ ZoneMapFilterResult IFunctionBase::evaluate_zonemap_filter(
     return unsupported_zonemap_filter(ctx);
 }
 
+ZoneMapFilterResult IFunctionBase::evaluate_dictionary_filter(
+        const DictionaryEvalContext& ctx, const VExprSPtrs& function_arguments) const {
+    return ZoneMapFilterResult::kUnsupported;
+}
+
+ZoneMapFilterResult IFunctionBase::evaluate_bloom_filter(
+        const BloomFilterEvalContext& ctx, const VExprSPtrs& function_arguments) const {
+    return ZoneMapFilterResult::kUnsupported;
+}
+
 } // namespace doris

--- a/be/src/exprs/function/function.h
+++ b/be/src/exprs/function/function.h
@@ -42,6 +42,7 @@
 #include "core/data_type/data_type_struct.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/types.h"
+#include "exprs/expr_zonemap_filter.h"
 #include "exprs/function_context.h"
 #include "exprs/vexpr_fwd.h"
 #include "storage/index/inverted/inverted_index_iterator.h" // IWYU pragma: keep
@@ -234,6 +235,20 @@ public:
                                                         const VExprSPtrs& function_arguments) const;
 
     virtual bool can_evaluate_zonemap_filter(const VExprSPtrs& /*function_arguments*/) const {
+        return false;
+    }
+
+    virtual ZoneMapFilterResult evaluate_dictionary_filter(
+            const DictionaryEvalContext& ctx, const VExprSPtrs& function_arguments) const;
+
+    virtual bool can_evaluate_dictionary_filter(const VExprSPtrs& /*function_arguments*/) const {
+        return false;
+    }
+
+    virtual ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx,
+                                                      const VExprSPtrs& function_arguments) const;
+
+    virtual bool can_evaluate_bloom_filter(const VExprSPtrs& /*function_arguments*/) const {
         return false;
     }
 };

--- a/be/src/exprs/function/function.h
+++ b/be/src/exprs/function/function.h
@@ -526,6 +526,24 @@ public:
         return function->can_evaluate_zonemap_filter(function_arguments);
     }
 
+    ZoneMapFilterResult evaluate_dictionary_filter(
+            const DictionaryEvalContext& ctx, const VExprSPtrs& function_arguments) const override {
+        return function->evaluate_dictionary_filter(ctx, function_arguments);
+    }
+
+    bool can_evaluate_dictionary_filter(const VExprSPtrs& function_arguments) const override {
+        return function->can_evaluate_dictionary_filter(function_arguments);
+    }
+
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx,
+                                              const VExprSPtrs& function_arguments) const override {
+        return function->evaluate_bloom_filter(ctx, function_arguments);
+    }
+
+    bool can_evaluate_bloom_filter(const VExprSPtrs& function_arguments) const override {
+        return function->can_evaluate_bloom_filter(function_arguments);
+    }
+
 private:
     std::shared_ptr<IFunction> function;
     DataTypes arguments;

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -366,6 +366,26 @@ inline bool can_evaluate(const VExprSPtrs& arguments) {
     return true;
 }
 
+inline bool can_evaluate_equality(const VExprSPtrs& arguments, Op op) {
+    return op == Op::EQ && can_evaluate(arguments);
+}
+
+inline ZoneMapFilterResult evaluate_dictionary(const DictionaryEvalContext& ctx,
+                                               const VExprSPtrs& arguments, Op op) {
+    DORIS_CHECK(op == Op::EQ);
+    auto slot_literal = expr_zonemap::extract_slot_and_literal(arguments);
+    DORIS_CHECK(slot_literal.has_value());
+    return expr_zonemap::eval_eq_dictionary(ctx, *slot_literal);
+}
+
+inline ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx,
+                                                 const VExprSPtrs& arguments, Op op) {
+    DORIS_CHECK(op == Op::EQ);
+    auto slot_literal = expr_zonemap::extract_slot_and_literal(arguments);
+    DORIS_CHECK(slot_literal.has_value());
+    return expr_zonemap::eval_eq_bloom_filter(ctx, *slot_literal);
+}
+
 inline std::optional<Op> op_from_name(std::string_view name) {
     if (name == NameEquals::name) {
         return Op::EQ;
@@ -580,6 +600,30 @@ public:
     bool can_evaluate_zonemap_filter(const VExprSPtrs& arguments) const override {
         return comparison_zonemap_detail::op_from_name(name).has_value() &&
                comparison_zonemap_detail::can_evaluate(arguments);
+    }
+
+    ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx,
+                                                   const VExprSPtrs& arguments) const override {
+        auto op = comparison_zonemap_detail::op_from_name(name);
+        DORIS_CHECK(op.has_value());
+        return comparison_zonemap_detail::evaluate_dictionary(ctx, arguments, *op);
+    }
+
+    bool can_evaluate_dictionary_filter(const VExprSPtrs& arguments) const override {
+        auto op = comparison_zonemap_detail::op_from_name(name);
+        return op.has_value() && comparison_zonemap_detail::can_evaluate_equality(arguments, *op);
+    }
+
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx,
+                                              const VExprSPtrs& arguments) const override {
+        auto op = comparison_zonemap_detail::op_from_name(name);
+        DORIS_CHECK(op.has_value());
+        return comparison_zonemap_detail::evaluate_bloom_filter(ctx, arguments, *op);
+    }
+
+    bool can_evaluate_bloom_filter(const VExprSPtrs& arguments) const override {
+        auto op = comparison_zonemap_detail::op_from_name(name);
+        return op.has_value() && comparison_zonemap_detail::can_evaluate_equality(arguments, *op);
     }
 
     /// Get result types by argument types. If the function does not apply to these arguments, throw an exception.

--- a/be/src/exprs/function/match.cpp
+++ b/be/src/exprs/function/match.cpp
@@ -186,10 +186,10 @@ inline doris::segment_v2::InvertedIndexQueryType FunctionMatchBase::get_query_ty
     return doris::segment_v2::InvertedIndexQueryType::UNKNOWN_QUERY;
 }
 
-std::vector<TermInfo> FunctionMatchBase::analyse_query_str_token(
+std::vector<segment_v2::TermInfo> FunctionMatchBase::analyse_query_str_token(
         const InvertedIndexAnalyzerCtx* analyzer_ctx, const std::string& match_query_str,
         const std::string& column_name) const {
-    std::vector<TermInfo> query_tokens;
+    std::vector<segment_v2::TermInfo> query_tokens;
     if (analyzer_ctx == nullptr) {
         return query_tokens;
     }
@@ -224,11 +224,11 @@ std::vector<TermInfo> FunctionMatchBase::analyse_query_str_token(
     return query_tokens;
 }
 
-inline std::vector<TermInfo> FunctionMatchBase::analyse_data_token(
+inline std::vector<segment_v2::TermInfo> FunctionMatchBase::analyse_data_token(
         const std::string& column_name, const InvertedIndexAnalyzerCtx* analyzer_ctx,
         const ColumnString* string_col, int32_t current_block_row_idx,
         const ColumnArray::Offsets64* array_offsets, int32_t& current_src_array_offset) const {
-    std::vector<TermInfo> data_tokens;
+    std::vector<segment_v2::TermInfo> data_tokens;
     if (analyzer_ctx == nullptr) {
         return data_tokens;
     }
@@ -308,10 +308,10 @@ Status FunctionMatchAny::execute_match(FunctionContext* context, const std::stri
 
         // TODO: more efficient impl
         for (auto& term_info : query_tokens) {
-            auto it =
-                    std::find_if(data_tokens.begin(), data_tokens.end(), [&](const TermInfo& info) {
-                        return info.get_single_term() == term_info.get_single_term();
-                    });
+            auto it = std::find_if(data_tokens.begin(), data_tokens.end(),
+                                   [&](const segment_v2::TermInfo& info) {
+                                       return info.get_single_term() == term_info.get_single_term();
+                                   });
             if (it != data_tokens.end()) {
                 result[i] = true;
                 break;
@@ -349,10 +349,10 @@ Status FunctionMatchAll::execute_match(FunctionContext* context, const std::stri
         // TODO: more efficient impl
         auto find_count = 0;
         for (auto& term_info : query_tokens) {
-            auto it =
-                    std::find_if(data_tokens.begin(), data_tokens.end(), [&](const TermInfo& info) {
-                        return info.get_single_term() == term_info.get_single_term();
-                    });
+            auto it = std::find_if(data_tokens.begin(), data_tokens.end(),
+                                   [&](const segment_v2::TermInfo& info) {
+                                       return info.get_single_term() == term_info.get_single_term();
+                                   });
             if (it != data_tokens.end()) {
                 ++find_count;
             } else {
@@ -397,9 +397,10 @@ Status FunctionMatchPhrase::execute_match(FunctionContext* context, const std::s
         auto data_it = data_tokens.begin();
         while (data_it != data_tokens.end()) {
             // find position of first token
-            data_it = std::find_if(data_it, data_tokens.end(), [&](const TermInfo& info) {
-                return info.get_single_term() == query_tokens[0].get_single_term();
-            });
+            data_it =
+                    std::find_if(data_it, data_tokens.end(), [&](const segment_v2::TermInfo& info) {
+                        return info.get_single_term() == query_tokens[0].get_single_term();
+                    });
             if (data_it != data_tokens.end()) {
                 matched = true;
                 auto data_it_next = ++data_it;

--- a/be/src/exprs/function/match.h
+++ b/be/src/exprs/function/match.h
@@ -51,8 +51,6 @@ class FunctionContext;
 
 namespace doris {
 
-using namespace segment_v2;
-
 const std::string MATCH_ANY_FUNCTION = "match_any";
 const std::string MATCH_ALL_FUNCTION = "match_all";
 const std::string MATCH_PHRASE_FUNCTION = "match_phrase";
@@ -83,16 +81,14 @@ public:
 
     doris::segment_v2::InvertedIndexQueryType get_query_type_from_fn_name() const;
 
-    std::vector<TermInfo> analyse_query_str_token(const InvertedIndexAnalyzerCtx* analyzer_ctx,
-                                                  const std::string& match_query_str,
-                                                  const std::string& field_name) const;
+    std::vector<segment_v2::TermInfo> analyse_query_str_token(
+            const InvertedIndexAnalyzerCtx* analyzer_ctx, const std::string& match_query_str,
+            const std::string& field_name) const;
 
-    std::vector<TermInfo> analyse_data_token(const std::string& column_name,
-                                             const InvertedIndexAnalyzerCtx* analyzer_ctx,
-                                             const ColumnString* string_col,
-                                             int32_t current_block_row_idx,
-                                             const ColumnArray::Offsets64* array_offsets,
-                                             int32_t& current_src_array_offset) const;
+    std::vector<segment_v2::TermInfo> analyse_data_token(
+            const std::string& column_name, const InvertedIndexAnalyzerCtx* analyzer_ctx,
+            const ColumnString* string_col, int32_t current_block_row_idx,
+            const ColumnArray::Offsets64* array_offsets, int32_t& current_src_array_offset) const;
 
     Status check(FunctionContext* context, const std::string& function_name) const;
 

--- a/be/src/exprs/vcompound_pred.h
+++ b/be/src/exprs/vcompound_pred.h
@@ -112,6 +112,87 @@ public:
         }
     }
 
+    bool can_evaluate_dictionary_filter() const override {
+        switch (_op) {
+        case TExprOpcode::COMPOUND_AND:
+            return std::ranges::any_of(_children, [](const VExprSPtr& child) {
+                return child->can_evaluate_dictionary_filter();
+            });
+        case TExprOpcode::COMPOUND_OR:
+            return !_children.empty() && std::ranges::all_of(_children, [](const VExprSPtr& child) {
+                return child->can_evaluate_dictionary_filter();
+            });
+        default:
+            return false;
+        }
+    }
+
+    ZoneMapFilterResult evaluate_dictionary_filter(
+            const DictionaryEvalContext& ctx) const override {
+        switch (_op) {
+        case TExprOpcode::COMPOUND_AND:
+            for (const auto& child : _children) {
+                if (!child->can_evaluate_dictionary_filter()) {
+                    continue;
+                }
+                if (child->evaluate_dictionary_filter(ctx) == ZoneMapFilterResult::kNoMatch) {
+                    return ZoneMapFilterResult::kNoMatch;
+                }
+            }
+            return ZoneMapFilterResult::kMayMatch;
+        case TExprOpcode::COMPOUND_OR:
+            for (const auto& child : _children) {
+                DORIS_CHECK(child->can_evaluate_dictionary_filter());
+                if (child->evaluate_dictionary_filter(ctx) != ZoneMapFilterResult::kNoMatch) {
+                    return ZoneMapFilterResult::kMayMatch;
+                }
+            }
+            return ZoneMapFilterResult::kNoMatch;
+        default:
+            return ZoneMapFilterResult::kUnsupported;
+        }
+    }
+
+    bool can_evaluate_bloom_filter() const override {
+        switch (_op) {
+        case TExprOpcode::COMPOUND_AND:
+            return std::ranges::any_of(_children, [](const VExprSPtr& child) {
+                return child->can_evaluate_bloom_filter();
+            });
+        case TExprOpcode::COMPOUND_OR:
+            return !_children.empty() && std::ranges::all_of(_children, [](const VExprSPtr& child) {
+                return child->can_evaluate_bloom_filter();
+            });
+        default:
+            return false;
+        }
+    }
+
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
+        switch (_op) {
+        case TExprOpcode::COMPOUND_AND:
+            for (const auto& child : _children) {
+                if (!child->can_evaluate_bloom_filter()) {
+                    continue;
+                }
+                if (child->evaluate_bloom_filter(ctx) == ZoneMapFilterResult::kNoMatch) {
+                    return ZoneMapFilterResult::kNoMatch;
+                }
+            }
+            return ZoneMapFilterResult::kMayMatch;
+        case TExprOpcode::COMPOUND_OR:
+            for (const auto& child : _children) {
+                DORIS_CHECK(child->can_evaluate_bloom_filter());
+                if (child->evaluate_bloom_filter(ctx) != ZoneMapFilterResult::kNoMatch) {
+                    return ZoneMapFilterResult::kMayMatch;
+                }
+            }
+            return ZoneMapFilterResult::kNoMatch;
+        default:
+            return ZoneMapFilterResult::kUnsupported;
+        }
+    }
+
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override {
         segment_v2::InvertedIndexResultBitmap res;
         bool all_pass = true;

--- a/be/src/exprs/vectorized_fn_call.cpp
+++ b/be/src/exprs/vectorized_fn_call.cpp
@@ -220,6 +220,26 @@ bool VectorizedFnCall::can_evaluate_zonemap_filter() const {
            _function->can_evaluate_zonemap_filter(_children);
 }
 
+ZoneMapFilterResult VectorizedFnCall::evaluate_dictionary_filter(
+        const DictionaryEvalContext& ctx) const {
+    return _function->evaluate_dictionary_filter(ctx, _children);
+}
+
+bool VectorizedFnCall::can_evaluate_dictionary_filter() const {
+    return _function != nullptr && !_function->is_blockable() &&
+           _function->can_evaluate_dictionary_filter(_children);
+}
+
+ZoneMapFilterResult VectorizedFnCall::evaluate_bloom_filter(
+        const BloomFilterEvalContext& ctx) const {
+    return _function->evaluate_bloom_filter(ctx, _children);
+}
+
+bool VectorizedFnCall::can_evaluate_bloom_filter() const {
+    return _function != nullptr && !_function->is_blockable() &&
+           _function->can_evaluate_bloom_filter(_children);
+}
+
 Status VectorizedFnCall::_do_execute(VExprContext* context, const Block* block,
                                      const Selector* selector, size_t count,
                                      ColumnPtr& result_column, ColumnPtr* arg_column) const {

--- a/be/src/exprs/vectorized_fn_call.h
+++ b/be/src/exprs/vectorized_fn_call.h
@@ -60,6 +60,10 @@ public:
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
     ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override;
     bool can_evaluate_zonemap_filter() const override;
+    ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const override;
+    bool can_evaluate_dictionary_filter() const override;
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override;
+    bool can_evaluate_bloom_filter() const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -83,6 +83,14 @@ ZoneMapFilterResult VExpr::evaluate_zonemap_filter(const ZoneMapEvalContext& ctx
     return unsupported_zonemap_filter(ctx);
 }
 
+ZoneMapFilterResult VExpr::evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const {
+    return ZoneMapFilterResult::kUnsupported;
+}
+
+ZoneMapFilterResult VExpr::evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const {
+    return ZoneMapFilterResult::kUnsupported;
+}
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 // NOLINTBEGIN(readability-function-size)
 TExprNode create_texpr_node_from(const void* data, const PrimitiveType& type, int precision,

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -45,6 +45,7 @@
 #include "core/value/large_int_value.h"
 #include "core/value/timestamptz_value.h"
 #include "exprs/aggregate/aggregate_function.h"
+#include "exprs/expr_zonemap_filter.h"
 #include "exprs/function/cast/cast_to_string.h"
 #include "exprs/function/function.h"
 #include "exprs/function_context.h"
@@ -186,6 +187,10 @@ public:
 
     virtual ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const;
     virtual bool can_evaluate_zonemap_filter() const { return false; }
+    virtual ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const;
+    virtual bool can_evaluate_dictionary_filter() const { return false; }
+    virtual ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const;
+    virtual bool can_evaluate_bloom_filter() const { return false; }
 
     // Get analyzer key for inverted index queries (overridden by VMatchPredicate)
     [[nodiscard]] virtual const std::string& get_analyzer_key() const {

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -203,6 +203,38 @@ ZoneMapFilterResult VExprContext::evaluate_zonemap_filter(const VExprContextSPtr
     return ZoneMapFilterResult::kMayMatch;
 }
 
+ZoneMapFilterResult VExprContext::evaluate_dictionary_filter(const VExprContextSPtrs& conjuncts,
+                                                             const DictionaryEvalContext& ctx) {
+    for (const auto& conjunct : conjuncts) {
+        DORIS_CHECK(conjunct != nullptr);
+        const auto& root = conjunct->root();
+        DORIS_CHECK(root != nullptr);
+        if (!root->can_evaluate_dictionary_filter()) {
+            continue;
+        }
+        if (root->evaluate_dictionary_filter(ctx) == ZoneMapFilterResult::kNoMatch) {
+            return ZoneMapFilterResult::kNoMatch;
+        }
+    }
+    return ZoneMapFilterResult::kMayMatch;
+}
+
+ZoneMapFilterResult VExprContext::evaluate_bloom_filter(const VExprContextSPtrs& conjuncts,
+                                                        const BloomFilterEvalContext& ctx) {
+    for (const auto& conjunct : conjuncts) {
+        DORIS_CHECK(conjunct != nullptr);
+        const auto& root = conjunct->root();
+        DORIS_CHECK(root != nullptr);
+        if (!root->can_evaluate_bloom_filter()) {
+            continue;
+        }
+        if (root->evaluate_bloom_filter(ctx) == ZoneMapFilterResult::kNoMatch) {
+            return ZoneMapFilterResult::kNoMatch;
+        }
+    }
+    return ZoneMapFilterResult::kMayMatch;
+}
+
 bool VExprContext::all_expr_inverted_index_evaluated() {
     return _index_context->has_index_result_for_expr(_root.get());
 }

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -32,6 +32,7 @@
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
 #include "exec/runtime_filter/runtime_filter_selectivity.h"
+#include "exprs/expr_zonemap_filter.h"
 #include "exprs/function_context.h"
 #include "exprs/vexpr_fwd.h"
 #include "runtime/runtime_state.h"
@@ -290,6 +291,10 @@ public:
 
     [[nodiscard]] static ZoneMapFilterResult evaluate_zonemap_filter(
             const VExprContextSPtrs& conjuncts, const ZoneMapEvalContext& ctx);
+    [[nodiscard]] static ZoneMapFilterResult evaluate_dictionary_filter(
+            const VExprContextSPtrs& conjuncts, const DictionaryEvalContext& ctx);
+    [[nodiscard]] static ZoneMapFilterResult evaluate_bloom_filter(
+            const VExprContextSPtrs& conjuncts, const BloomFilterEvalContext& ctx);
 
     bool all_expr_inverted_index_evaluated();
 

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -163,6 +163,25 @@ bool VInPredicate::can_evaluate_zonemap_filter() const {
     return _zonemap_materialized && std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
 }
 
+ZoneMapFilterResult VInPredicate::evaluate_dictionary_filter(
+        const DictionaryEvalContext& ctx) const {
+    return expr_zonemap::eval_in_dictionary(ctx, get_child(0), _is_not_in, _seg_filter_values);
+}
+
+bool VInPredicate::can_evaluate_dictionary_filter() const {
+    return _zonemap_materialized && !_is_not_in &&
+           std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
+}
+
+ZoneMapFilterResult VInPredicate::evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const {
+    return expr_zonemap::eval_in_bloom_filter(ctx, get_child(0), _is_not_in, _seg_filter_values);
+}
+
+bool VInPredicate::can_evaluate_bloom_filter() const {
+    return _zonemap_materialized && !_is_not_in &&
+           std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
+}
+
 Status VInPredicate::execute_column_impl(VExprContext* context, const Block* block,
                                          const Selector* selector, size_t count,
                                          ColumnPtr& result_column) const {

--- a/be/src/exprs/vin_predicate.h
+++ b/be/src/exprs/vin_predicate.h
@@ -62,6 +62,10 @@ public:
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
     ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override;
     bool can_evaluate_zonemap_filter() const override;
+    ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const override;
+    bool can_evaluate_dictionary_filter() const override;
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override;
+    bool can_evaluate_bloom_filter() const override;
 
     uint64_t get_digest(uint64_t seed) const override { return 0; }
     Status clone_node(VExprSPtr* cloned_expr) const override {

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -429,19 +429,6 @@ static bool filter_conversion_has_local_source(FilterConversionType conversion) 
     return false;
 }
 
-static bool column_predicate_can_use_local_source(FilterConversionType conversion) {
-    switch (conversion) {
-    case FilterConversionType::COPY_DIRECTLY:
-        return true;
-    case FilterConversionType::CAST_FILTER:
-    case FilterConversionType::READER_EXPRESSION:
-    case FilterConversionType::FINALIZE_ONLY:
-    case FilterConversionType::CONSTANT:
-        return false;
-    }
-    return false;
-}
-
 static bool table_filter_has_only_local_entries(
         const TableFilter& table_filter, const std::map<GlobalIndex, FilterEntry>& filter_entries) {
     for (const auto global_index : table_filter.global_indices) {
@@ -1629,9 +1616,6 @@ Status TableColumnMapper::_build_hidden_filter_mappings(
         }
     }
 
-    // TableColumnPredicates only carry GlobalIndex and predicate objects. They do not provide the
-    // top-level column name/type needed to build a hidden mapping, so a predicate-only column can
-    // be hidden-mapped only when the same root slot also appears in a conjunct.
     for (const auto& [global_index, table_column] : filter_columns) {
         if (_find_mapping(global_index) != nullptr) {
             // Ignore columns that are already mapped by the projected columns
@@ -1692,7 +1676,6 @@ Status TableColumnMapper::_build_filter_entries(const FileScanRequest& file_requ
 
 Status TableColumnMapper::create_scan_request(
         const std::vector<TableFilter>& table_filters,
-        const TableColumnPredicates& table_column_predicates,
         const std::vector<ColumnDefinition>& projected_columns, FileScanRequest* file_request,
         RuntimeState* runtime_state) {
     // FileReader evaluates expressions against a file-local block. This mapper owns the
@@ -1702,7 +1685,6 @@ Status TableColumnMapper::create_scan_request(
     file_request->local_positions.clear();
     file_request->conjuncts.clear();
     file_request->delete_conjuncts.clear();
-    file_request->column_predicate_filters.clear();
     _filter_entries.clear();
     // 1. Build referenced non-predicate columns
     for (size_t column_idx = 0; column_idx < projected_columns.size(); ++column_idx) {
@@ -1710,8 +1692,7 @@ Status TableColumnMapper::create_scan_request(
         auto* mapping = _find_mapping(global_index);
         if (mapping != nullptr && mapping->file_local_id.has_value()) {
             // A file column can be read lazily as a non-predicate column only when it is not used
-            // by row-level expression filters. Single-column ColumnPredicate filters are pruning
-            // hints only and must not force row-level predicate materialization.
+            // by row-level expression filters.
             bool used_by_filter = false;
             for (const auto& table_filter : table_filters) {
                 const auto& global_indices = table_filter.global_indices;
@@ -1731,8 +1712,7 @@ Status TableColumnMapper::create_scan_request(
     // 2. Build referenced predicate columns
     // Hidden filter mappings must be built before localizing filters, so that they can be localized together with visible mappings and referenced by localized filter expressions.
     RETURN_IF_ERROR(_build_hidden_filter_mappings(table_filters));
-    RETURN_IF_ERROR(
-            localize_filters(table_filters, table_column_predicates, file_request, runtime_state));
+    RETURN_IF_ERROR(localize_filters(table_filters, file_request, runtime_state));
     // 3. Rebuild output projection expressions for projected columns. localize_filters() has
     // already applied the final scan projection to mapping.file_type/projected_file_children before
     // rewriting filter expressions.
@@ -1772,7 +1752,6 @@ ColumnMapping* TableColumnMapper::_find_filter_mapping(GlobalIndex global_index)
 }
 
 Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table_filters,
-                                           const TableColumnPredicates& table_column_predicates,
                                            FileScanRequest* file_request,
                                            RuntimeState* runtime_state) {
     FilterProjectionMap filter_projections;
@@ -1861,32 +1840,6 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
             auto localized_conjunct = VExprContext::create_shared(std::move(localized_root));
             RETURN_IF_ERROR(rewrite_context.prepare_created_exprs(localized_conjunct.get()));
             file_request->conjuncts.push_back(std::move(localized_conjunct));
-        }
-    }
-    if (enable_column_predicate_filters()) {
-        for (const auto& [global_index, predicates] : table_column_predicates) {
-            const auto* mapping = _find_filter_mapping(global_index);
-            const auto entry_it = _filter_entries.find(global_index);
-            if (mapping == nullptr || !mapping->file_local_id.has_value() || predicates.empty() ||
-                entry_it == _filter_entries.end() || !entry_it->second.is_local() ||
-                !column_predicate_can_use_local_source(mapping->filter_conversion) ||
-                mapping->file_type == nullptr) {
-                continue;
-            }
-            FileColumnPredicateFilter column_predicate_filter;
-            column_predicate_filter.file_column_id = LocalColumnId(*mapping->file_local_id);
-            const auto file_primitive_type =
-                    remove_nullable(mapping->file_type)->get_primitive_type();
-            for (const auto& predicate : predicates) {
-                DORIS_CHECK(predicate != nullptr);
-                if (predicate->primitive_type() == file_primitive_type) {
-                    column_predicate_filter.predicates.push_back(predicate);
-                }
-            }
-            if (column_predicate_filter.predicates.empty()) {
-                continue;
-            }
-            file_request->column_predicate_filters.push_back(std::move(column_predicate_filter));
         }
     }
     return Status::OK();

--- a/be/src/format_v2/column_mapper.h
+++ b/be/src/format_v2/column_mapper.h
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -33,7 +32,6 @@
 #include "format_v2/file_reader.h"
 
 namespace doris {
-class ColumnPredicate;
 class RuntimeState;
 } // namespace doris
 
@@ -41,11 +39,6 @@ namespace doris::format {
 
 struct ColumnDefinition;
 struct TableFilter;
-
-// Table-level simple predicates grouped by table/global output position. The key is not
-// LocalColumnId: TableColumnMapper resolves it through ColumnMapping before creating file pruning
-// hints.
-using TableColumnPredicates = std::map<GlobalIndex, std::vector<std::shared_ptr<ColumnPredicate>>>;
 
 enum class TableColumnMappingMode {
     // Match by ColumnDefinition::identifier TYPE_INT as field id.
@@ -189,11 +182,9 @@ public:
                                   const std::vector<ColumnDefinition>& file_schema);
 
     // Convert a table-level scan request into a file-local scan request. table_filters preserve
-    // row-level filtering semantics and are rewritten as file-local conjuncts. table_column_predicates
-    // are converted only into file-layer pruning hints and do not participate in batch row
-    // filtering.
+    // row-level filtering semantics and are rewritten as file-local conjuncts. File-layer pruning
+    // such as ZoneMap, dictionary, and bloom filter derives from those localized VExpr conjuncts.
     virtual Status create_scan_request(const std::vector<TableFilter>& table_filters,
-                                       const TableColumnPredicates& table_column_predicates,
                                        const std::vector<ColumnDefinition>& projected_columns,
                                        FileScanRequest* file_request,
                                        RuntimeState* runtime_state = nullptr);
@@ -203,7 +194,6 @@ public:
     // a safe cast. Expressions that cannot be pushed down safely should be handled through
     // reader_expression_map or table-level finalize/filter fallback.
     virtual Status localize_filters(const std::vector<TableFilter>& table_filters,
-                                    const TableColumnPredicates& table_column_predicates,
                                     FileScanRequest* file_request,
                                     RuntimeState* runtime_state = nullptr);
     void clear() {
@@ -224,9 +214,6 @@ protected:
     // lazily read the rest. Row-oriented readers such as CSV/Text materialize one row at a time and
     // should keep all required columns in one scan list.
     virtual bool enable_lazy_materialization() const { return true; }
-    // File-layer column predicate filters are reader-specific pruning hints. Parquet consumes them
-    // for row-group/page-index/statistics pruning; simple delimited readers do not.
-    virtual bool enable_column_predicate_filters() const { return true; }
     // Row-oriented readers such as CSV/Text cannot physically read only a nested child from one
     // delimited text field. They must scan the whole complex top-level field and let TableReader
     // rematerialize the requested table child after row-level filters have run.
@@ -272,7 +259,7 @@ protected:
 };
 
 // Parquet consumes the full FileScanRequest shape: predicate columns for lazy materialization and
-// top-level column_predicate_filters for statistics/page-index pruning.
+// file-local conjuncts for ZoneMap, dictionary, and bloom-filter pruning.
 class ParquetColumnMapper final : public TableColumnMapper {
 public:
     using TableColumnMapper::TableColumnMapper;
@@ -280,14 +267,13 @@ public:
 
 // Mapper for readers that always materialize every required file column before filtering. The
 // table-to-file schema mapping is still generic, but the FileScanRequest layout is simpler:
-// predicate_columns and column_predicate_filters are not populated.
+// predicate_columns are not populated.
 class MaterializedColumnMapper final : public TableColumnMapper {
 public:
     using TableColumnMapper::TableColumnMapper;
 
 protected:
     bool enable_lazy_materialization() const override { return false; }
-    bool enable_column_predicate_filters() const override { return false; }
     bool force_full_complex_scan_projection() const override { return true; }
 };
 

--- a/be/src/format_v2/file_reader.cpp
+++ b/be/src/format_v2/file_reader.cpp
@@ -43,13 +43,6 @@ std::string join_debug_strings(const std::vector<T>& values, Formatter formatter
 
 } // namespace
 
-std::string FileColumnPredicateFilter::debug_string() const {
-    std::ostringstream out;
-    out << "FileColumnPredicateFilter{file_column_id=" << file_column_id
-        << ", predicate_count=" << predicates.size() << "}";
-    return out.str();
-}
-
 std::string FileScanRequest::debug_string() const {
     std::ostringstream out;
     out << "FileScanRequest{predicate_columns="
@@ -69,11 +62,7 @@ std::string FileScanRequest::debug_string() const {
         out << column_id << ":" << block_position;
     }
     out << "}, conjunct_count=" << conjuncts.size()
-        << ", delete_conjunct_count=" << delete_conjuncts.size() << ", column_predicate_filters="
-        << join_debug_strings(
-                   column_predicate_filters,
-                   [](const FileColumnPredicateFilter& filter) { return filter.debug_string(); })
-        << "}";
+        << ", delete_conjunct_count=" << delete_conjuncts.size() << "}";
     return out.str();
 }
 

--- a/be/src/format_v2/file_reader.h
+++ b/be/src/format_v2/file_reader.h
@@ -35,7 +35,6 @@
 
 namespace doris {
 class Block;
-class ColumnPredicate;
 struct ConditionCacheContext;
 
 namespace io {
@@ -47,16 +46,6 @@ namespace doris::format {
 
 class TableColumnMapper;
 struct TableColumnMapperOptions;
-
-// File-local single-column predicates for file-layer pruning, such as min/max, page index,
-// dictionary and bloom filter. Predicates must all belong to file_column_id.
-// These predicates are pruning hints only and are not row-level conjuncts.
-struct FileColumnPredicateFilter {
-    LocalColumnId file_column_id = LocalColumnId::invalid();
-    std::vector<std::shared_ptr<ColumnPredicate>> predicates;
-
-    std::string debug_string() const;
-};
 
 enum class FileFormat {
     PARQUET,
@@ -86,9 +75,6 @@ struct FileScanRequest {
     VExprContextSPtrs conjuncts;
     // Delete predicates converted to file-local expressions.
     VExprContextSPtrs delete_conjuncts;
-    // Single-column predicates used only for file-layer pruning, such as statistics, page index,
-    // dictionary and bloom filter. They must not be used for batch row-level filtering.
-    std::vector<FileColumnPredicateFilter> column_predicate_filters;
 };
 
 // Helper for constructing the scan-column layout in FileScanRequest.

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -37,6 +37,8 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             profile, "RowGroupsFilteredByDictionary", TUnit::UNIT, parquet_profile, 1);
     filtered_row_groups_by_bloom_filter = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "RowGroupsFilteredByBloomFilter", TUnit::UNIT, parquet_profile, 1);
+    filtered_row_groups_by_page_index = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "RowGroupsFilteredByPageIndex", TUnit::UNIT, parquet_profile, 1);
     to_read_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "RowGroupsReadNum", TUnit::UNIT,
                                                       parquet_profile, 1);
     total_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "RowGroupsTotalNum", TUnit::UNIT,
@@ -91,6 +93,12 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             ADD_CHILD_TIMER_WITH_LEVEL(profile, "PageIndexReadTime", parquet_profile, 1);
     parse_page_index_time =
             ADD_CHILD_TIMER_WITH_LEVEL(profile, "PageIndexParseTime", parquet_profile, 1);
+    expr_zonemap_unusable = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "ExprZoneMapUnusableEvals",
+                                                         TUnit::UNIT, parquet_profile, 1);
+    in_zonemap_point_check = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "InZoneMapPointCheckCount",
+                                                          TUnit::UNIT, parquet_profile, 1);
+    in_zonemap_range_only = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "InZoneMapRangeOnlyCount",
+                                                         TUnit::UNIT, parquet_profile, 1);
     row_group_filter_time =
             ADD_CHILD_TIMER_WITH_LEVEL(profile, "RowGroupFilterTime", parquet_profile, 1);
     file_footer_read_calls = ADD_COUNTER_WITH_LEVEL(profile, "FileFooterReadCalls", TUnit::UNIT, 1);
@@ -144,6 +152,8 @@ void ParquetProfile::update_pruning_stats(const ParquetPruningStats& pruning_sta
                    pruning_stats.filtered_row_groups_by_dictionary);
     COUNTER_UPDATE(filtered_row_groups_by_bloom_filter,
                    pruning_stats.filtered_row_groups_by_bloom_filter);
+    COUNTER_UPDATE(filtered_row_groups_by_page_index,
+                   pruning_stats.filtered_row_groups_by_page_index);
     COUNTER_UPDATE(to_read_row_groups, pruning_stats.selected_row_groups);
     COUNTER_UPDATE(total_row_groups, pruning_stats.total_row_groups);
     COUNTER_UPDATE(selected_row_ranges, pruning_stats.selected_row_ranges);
@@ -154,6 +164,9 @@ void ParquetProfile::update_pruning_stats(const ParquetPruningStats& pruning_sta
     COUNTER_UPDATE(row_group_filter_time, pruning_stats.row_group_filter_time);
     COUNTER_UPDATE(page_index_filter_time, pruning_stats.page_index_filter_time);
     COUNTER_UPDATE(read_page_index_time, pruning_stats.read_page_index_time);
+    COUNTER_UPDATE(expr_zonemap_unusable, pruning_stats.expr_zonemap_unusable_evals);
+    COUNTER_UPDATE(in_zonemap_point_check, pruning_stats.in_zonemap_point_check_count);
+    COUNTER_UPDATE(in_zonemap_range_only, pruning_stats.in_zonemap_range_only_count);
 }
 
 ParquetPageSkipProfile ParquetProfile::page_skip_profile() const {

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -70,6 +70,7 @@ struct ParquetProfile {
     RuntimeProfile::Counter* filtered_row_groups_by_min_max = nullptr;
     RuntimeProfile::Counter* filtered_row_groups_by_dictionary = nullptr;
     RuntimeProfile::Counter* filtered_row_groups_by_bloom_filter = nullptr;
+    RuntimeProfile::Counter* filtered_row_groups_by_page_index = nullptr;
     RuntimeProfile::Counter* to_read_row_groups = nullptr;
     RuntimeProfile::Counter* total_row_groups = nullptr;
     RuntimeProfile::Counter* selected_row_ranges = nullptr;
@@ -110,6 +111,9 @@ struct ParquetProfile {
     RuntimeProfile::Counter* page_index_filter_time = nullptr;
     RuntimeProfile::Counter* read_page_index_time = nullptr;
     RuntimeProfile::Counter* parse_page_index_time = nullptr;
+    RuntimeProfile::Counter* expr_zonemap_unusable = nullptr;
+    RuntimeProfile::Counter* in_zonemap_point_check = nullptr;
+    RuntimeProfile::Counter* in_zonemap_range_only = nullptr;
 
     RuntimeProfile::Counter* decompress_time = nullptr;
     RuntimeProfile::Counter* decompress_cnt = nullptr;

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -413,6 +413,7 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
         }
     }
 
+    const auto num_fields = static_cast<int32_t>(_state->file_schema.size());
     for (const auto& col : request_snapshot->predicate_columns) {
         DORIS_CHECK(request_snapshot->local_positions.count(col.column_id()) > 0);
         const auto local_id = col.local_id();

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -48,6 +48,7 @@ struct ParquetReaderScanState {
     std::vector<std::unique_ptr<ParquetColumnSchema>> file_schema;
     RowGroupScanPlan scan_plan;
     ParquetScanScheduler scheduler;
+    const RuntimeState* runtime_state = nullptr;
     const cctz::time_zone* timezone = nullptr;
     bool enable_bloom_filter = false;
     bool enable_page_cache = false;
@@ -329,6 +330,7 @@ Status ParquetReader::init(RuntimeState* state) {
     _state->enable_page_cache =
             state != nullptr && state->query_options().enable_parquet_file_page_cache;
     if (state != nullptr) {
+        _state->runtime_state = state;
         _state->timezone = &state->timezone_obj();
         _state->enable_strict_mode = state->enable_strict_mode();
         _state->scheduler.set_timezone(&state->timezone_obj());
@@ -398,15 +400,6 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
     DORIS_CHECK(request_snapshot != nullptr);
     RETURN_IF_ERROR(format::FileReader::open(std::move(request)));
 
-    const int num_fields = static_cast<int>(_state->file_schema.size());
-    for (const auto& column_filter : request_snapshot->column_predicate_filters) {
-        const auto file_column_id = column_filter.file_column_id;
-        if (!file_column_id.is_valid() || file_column_id.value() >= num_fields) {
-            return Status::InvalidArgument("Invalid parquet filter top-level local id {}",
-                                           file_column_id.value());
-        }
-    }
-
     // `local_positions.empty()` means all columns are needed by table reader
     // TODO(gabriel): It will happen only for TVF `select *` query.
     if (request_snapshot->local_positions.empty()) {
@@ -448,7 +441,7 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
     RETURN_IF_ERROR(plan_parquet_row_groups(
             *_state->file_context.metadata, _state->file_context.file_reader.get(),
             _state->file_schema, *request_snapshot, scan_range, _state->enable_bloom_filter,
-            &row_group_plan, _state->timezone));
+            &row_group_plan, _state->timezone, _state->runtime_state));
     if (_profile != nullptr) {
         _parquet_profile.update_pruning_stats(row_group_plan.pruning_stats);
     }

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -336,6 +336,11 @@ Status ParquetReader::init(RuntimeState* state) {
         _state->scheduler.set_timezone(&state->timezone_obj());
         _state->scheduler.set_enable_strict_mode(_state->enable_strict_mode);
     }
+    int64_t merge_read_slice_size = -1;
+    if (state != nullptr && state->query_options().__isset.merge_read_slice_size) {
+        merge_read_slice_size = state->query_options().merge_read_slice_size;
+    }
+    _state->scheduler.set_merge_read_options(_profile, merge_read_slice_size);
     _state->scheduler.set_batch_size(_batch_size);
     // Open parquet file and parse metadata to get file schema.
     RETURN_IF_ERROR(_state->file_context.open(_tracing_file_reader, _io_ctx.get(),

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -336,11 +336,6 @@ Status ParquetReader::init(RuntimeState* state) {
         _state->scheduler.set_timezone(&state->timezone_obj());
         _state->scheduler.set_enable_strict_mode(_state->enable_strict_mode);
     }
-    int64_t merge_read_slice_size = -1;
-    if (state != nullptr && state->query_options().__isset.merge_read_slice_size) {
-        merge_read_slice_size = state->query_options().merge_read_slice_size;
-    }
-    _state->scheduler.set_merge_read_options(_profile, merge_read_slice_size);
     _state->scheduler.set_batch_size(_batch_size);
     // Open parquet file and parse metadata to get file schema.
     RETURN_IF_ERROR(_state->file_context.open(_tracing_file_reader, _io_ctx.get(),

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -154,24 +154,18 @@ std::vector<ParquetPageCacheRange> build_row_group_prefetch_ranges(
     return ranges;
 }
 
-} // namespace
-
-Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
-                               ::parquet::ParquetFileReader* file_reader,
-                               const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-                               const format::FileScanRequest& request,
-                               const ParquetScanRange& scan_range, bool enable_bloom_filter,
-                               RowGroupScanPlan* plan, const cctz::time_zone* timezone) {
-    DORIS_CHECK(plan != nullptr);
-    plan->row_groups.clear();
-    plan->pruning_stats = ParquetPruningStats {};
-
-    std::vector<int64_t> row_group_first_rows(metadata.num_row_groups());
-    std::vector<int> scan_range_selected_row_groups;
-    scan_range_selected_row_groups.reserve(metadata.num_row_groups());
+Status select_row_groups_by_scan_range(const ::parquet::FileMetaData& metadata,
+                                       const ParquetScanRange& scan_range,
+                                       std::vector<int64_t>* row_group_first_rows,
+                                       std::vector<int>* selected_row_groups) {
+    DORIS_CHECK(row_group_first_rows != nullptr);
+    DORIS_CHECK(selected_row_groups != nullptr);
+    row_group_first_rows->assign(metadata.num_row_groups(), 0);
+    selected_row_groups->clear();
+    selected_row_groups->reserve(metadata.num_row_groups());
     int64_t next_row_group_first_row = 0;
     for (int row_group_idx = 0; row_group_idx < metadata.num_row_groups(); ++row_group_idx) {
-        row_group_first_rows[row_group_idx] = next_row_group_first_row;
+        (*row_group_first_rows)[row_group_idx] = next_row_group_first_row;
         auto row_group_metadata = metadata.RowGroup(row_group_idx);
         DORIS_CHECK(row_group_metadata != nullptr);
         const int64_t row_group_rows = row_group_metadata->num_rows();
@@ -181,17 +175,23 @@ Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
         }
         next_row_group_first_row += row_group_rows;
         if (!is_row_group_outside_range(metadata, scan_range, row_group_idx)) {
-            scan_range_selected_row_groups.push_back(row_group_idx);
+            selected_row_groups->push_back(row_group_idx);
         }
     }
+    return Status::OK();
+}
 
-    std::vector<int> statistics_selected_row_groups;
-    RETURN_IF_ERROR(select_row_groups_by_statistics(
-            metadata, file_reader, file_schema, request, &scan_range_selected_row_groups,
-            &statistics_selected_row_groups, enable_bloom_filter, &plan->pruning_stats, timezone));
-
-    plan->row_groups.reserve(statistics_selected_row_groups.size());
-    for (const auto row_group_idx : statistics_selected_row_groups) {
+Status build_row_group_read_plans(
+        const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, const std::vector<int>& selected_row_groups,
+        const std::vector<int64_t>& row_group_first_rows, RowGroupScanPlan* plan,
+        const cctz::time_zone* timezone, const RuntimeState* runtime_state) {
+    DORIS_CHECK(plan != nullptr);
+    plan->row_groups.reserve(selected_row_groups.size());
+    for (const auto row_group_idx : selected_row_groups) {
+        DORIS_CHECK(row_group_idx >= 0);
+        DORIS_CHECK(static_cast<size_t>(row_group_idx) < row_group_first_rows.size());
         auto row_group_metadata = metadata.RowGroup(row_group_idx);
         DORIS_CHECK(row_group_metadata != nullptr);
         const int64_t row_group_rows = row_group_metadata->num_rows();
@@ -206,13 +206,64 @@ Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
         RETURN_IF_ERROR(select_row_group_ranges_by_page_index(
                 file_reader, file_schema, request, row_group_idx, row_group_rows,
                 &row_group_plan.selected_ranges, &row_group_plan.page_skip_plans,
-                &plan->pruning_stats, timezone));
+                &plan->pruning_stats, timezone, runtime_state));
         if (row_group_plan.selected_ranges.empty()) {
             continue;
         }
         plan->pruning_stats.selected_row_ranges += row_group_plan.selected_ranges.size();
         plan->row_groups.push_back(std::move(row_group_plan));
     }
+    return Status::OK();
+}
+
+} // namespace
+
+Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
+                               ::parquet::ParquetFileReader* file_reader,
+                               const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+                               const format::FileScanRequest& request,
+                               const ParquetScanRange& scan_range, bool enable_bloom_filter,
+                               RowGroupScanPlan* plan, const cctz::time_zone* timezone,
+                               const RuntimeState* runtime_state) {
+    DORIS_CHECK(plan != nullptr);
+    plan->row_groups.clear();
+    plan->pruning_stats = ParquetPruningStats {};
+
+    // Row-group planning flow:
+    //
+    //     parquet footer row groups
+    //              |
+    //              v
+    //     split byte-range candidates
+    //              |
+    //              v
+    //     row-group metadata pruning
+    //     statistics/ZoneMap -> dictionary -> bloom filter
+    //              |
+    //              v
+    //     page-index pruning per selected row group
+    //              |
+    //              v
+    //     RowGroupReadPlan with selected row ranges
+    //
+    // Metadata pruning removes whole row groups before readers are opened. Page index pruning runs
+    // only for remaining row groups and produces selected row ranges; the scan scheduler later skips
+    // gaps between those ranges, while row-level VExpr conjuncts still run on loaded batches for
+    // correctness.
+    std::vector<int64_t> row_group_first_rows;
+    std::vector<int> scan_range_selected_row_groups;
+    RETURN_IF_ERROR(select_row_groups_by_scan_range(metadata, scan_range, &row_group_first_rows,
+                                                    &scan_range_selected_row_groups));
+
+    std::vector<int> metadata_selected_row_groups;
+    RETURN_IF_ERROR(select_row_groups_by_metadata(
+            metadata, file_reader, file_schema, request, &scan_range_selected_row_groups,
+            &metadata_selected_row_groups, enable_bloom_filter, &plan->pruning_stats, timezone,
+            runtime_state));
+
+    RETURN_IF_ERROR(build_row_group_read_plans(metadata, file_reader, file_schema, request,
+                                               metadata_selected_row_groups, row_group_first_rows,
+                                               plan, timezone, runtime_state));
     plan->pruning_stats.selected_row_groups = plan->row_groups.size();
     return Status::OK();
 }

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -44,6 +44,7 @@ class time_zone;
 
 namespace doris {
 class Block;
+class RuntimeState;
 
 namespace format {
 struct FileScanRequest;
@@ -86,7 +87,8 @@ Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
                                const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
                                const format::FileScanRequest& request,
                                const ParquetScanRange& scan_range, bool enable_bloom_filter,
-                               RowGroupScanPlan* plan, const cctz::time_zone* timezone = nullptr);
+                               RowGroupScanPlan* plan, const cctz::time_zone* timezone = nullptr,
+                               const RuntimeState* runtime_state = nullptr);
 
 IColumn::Filter selection_to_filter(const SelectionVector& selection, uint16_t selected_rows,
                                     int64_t batch_rows);

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -28,8 +28,10 @@
 #include <cstddef>
 #include <cstring>
 #include <exception>
+#include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -40,11 +42,12 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type_serde/data_type_serde.h"
 #include "core/field.h"
+#include "exprs/expr_zonemap_filter.h"
+#include "exprs/vexpr_context.h"
 #include "format_v2/parquet/parquet_column_schema.h"
 #include "runtime/runtime_profile.h"
 #include "storage/index/zone_map/zone_map_index.h"
-#include "storage/predicate/accept_null_predicate.h"
-#include "storage/predicate/column_predicate.h"
+#include "storage/index/zone_map/zonemap_eval_context.h"
 
 namespace doris::format::parquet {
 
@@ -52,14 +55,14 @@ namespace {
 
 enum class ParquetRowGroupPruneReason {
     NONE,         // cannot prune; must read
-    STATISTICS,   // excluded by min/max statistics
+    STATISTICS,   // excluded by ZoneMap statistics
     DICTIONARY,   // excluded by dictionary
     BLOOM_FILTER, // excluded by bloom filter
 };
 
-PrimitiveType physical_filter_type(const ParquetColumnSchema& column_schema) {
+bool bloom_logical_type_supported(const ParquetColumnSchema& column_schema) {
     if (column_schema.type == nullptr) {
-        return INVALID_TYPE;
+        return false;
     }
     switch (remove_nullable(column_schema.type)->get_primitive_type()) {
     case TYPE_BOOLEAN:
@@ -68,9 +71,9 @@ PrimitiveType physical_filter_type(const ParquetColumnSchema& column_schema) {
     case TYPE_FLOAT:
     case TYPE_DOUBLE:
     case TYPE_STRING:
-        return remove_nullable(column_schema.type)->get_primitive_type();
+        return true;
     default:
-        return INVALID_TYPE;
+        return false;
     }
 }
 
@@ -189,34 +192,56 @@ bool set_string_min_max(const std::shared_ptr<::parquet::Statistics>& statistics
     }
 }
 
-bool is_null_only_predicate(const ColumnPredicate& predicate) {
-    return predicate.type() == PredicateType::IS_NULL ||
-           predicate.type() == PredicateType::IS_NOT_NULL;
-}
-
-bool is_supported_dictionary_predicate(const ColumnPredicate& predicate) {
-    switch (predicate.type()) {
-    case PredicateType::EQ:
-    case PredicateType::IN_LIST:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool is_bloom_filter_prunable_predicate(const ColumnPredicate& predicate) {
-    if (dynamic_cast<const AcceptNullPredicate*>(&predicate) != nullptr ||
-        is_null_only_predicate(predicate)) {
-        return false;
-    }
-    return predicate.can_do_bloom_filter(false);
-}
-
 template <typename T>
 T load_predicate_value(const char* data) {
     T value;
     memcpy(&value, data, sizeof(T));
     return value;
+}
+
+std::optional<int64_t> load_predicate_integral_value(const char* buf, size_t size) {
+    switch (size) {
+    case sizeof(int8_t):
+        return static_cast<int64_t>(load_predicate_value<int8_t>(buf));
+    case sizeof(int16_t):
+        return static_cast<int64_t>(load_predicate_value<int16_t>(buf));
+    case sizeof(int32_t):
+        return static_cast<int64_t>(load_predicate_value<int32_t>(buf));
+    case sizeof(int64_t):
+        return load_predicate_value<int64_t>(buf);
+    default:
+        return std::nullopt;
+    }
+}
+
+bool logical_integer_fits_physical_int32(const ParquetTypeDescriptor& type_descriptor,
+                                         int64_t value) {
+    const int bit_width =
+            type_descriptor.integer_bit_width > 0 ? type_descriptor.integer_bit_width : 32;
+    if (type_descriptor.is_unsigned_integer) {
+        const uint64_t max_value = bit_width >= 32 ? std::numeric_limits<uint32_t>::max()
+                                                   : ((uint64_t {1} << bit_width) - 1);
+        return value >= 0 && static_cast<uint64_t>(value) <= max_value;
+    }
+    const int64_t min_value = bit_width >= 32 ? std::numeric_limits<int32_t>::min()
+                                              : -(int64_t {1} << (bit_width - 1));
+    const int64_t max_value = bit_width >= 32 ? std::numeric_limits<int32_t>::max()
+                                              : ((int64_t {1} << (bit_width - 1)) - 1);
+    return value >= min_value && value <= max_value;
+}
+
+std::optional<int32_t> convert_logical_integer_to_physical_int32(
+        const ParquetTypeDescriptor& type_descriptor, int64_t value) {
+    if (!logical_integer_fits_physical_int32(type_descriptor, value)) {
+        return std::nullopt;
+    }
+    if (!type_descriptor.is_unsigned_integer) {
+        return static_cast<int32_t>(value);
+    }
+    const auto unsigned_value = static_cast<uint32_t>(value);
+    int32_t physical_value;
+    memcpy(&physical_value, &unsigned_value, sizeof(physical_value));
+    return physical_value;
 }
 
 class ArrowParquetBloomFilterAdapter final : public segment_v2::BloomFilter {
@@ -231,19 +256,25 @@ public:
         if (buf == nullptr) {
             return true;
         }
-        switch (physical_filter_type(_column_schema)) {
-        case TYPE_BOOLEAN:
+        // Parquet bloom filters are populated from the physical column carrier, while VExpr
+        // literals are materialized as Doris logical values. Keep the logical type in
+        // BloomFilterEvalContext for expression compatibility, and normalize to the Parquet
+        // physical representation only at this adapter boundary.
+        switch (_column_schema.type_descriptor.physical_type) {
+        case ::parquet::Type::BOOLEAN:
             return test_boolean(buf, size);
-        case TYPE_INT:
-            return test_int32(buf, size);
-        case TYPE_BIGINT:
+        case ::parquet::Type::INT32:
+            return test_physical_int32(buf, size);
+        case ::parquet::Type::INT64:
             return test_int64(buf, size);
-        case TYPE_FLOAT:
+        case ::parquet::Type::FLOAT:
             return test_float(buf, size);
-        case TYPE_DOUBLE:
+        case ::parquet::Type::DOUBLE:
             return test_double(buf, size);
-        case TYPE_STRING:
-            return test_string(buf, size);
+        case ::parquet::Type::BYTE_ARRAY:
+            return test_byte_array(buf, size);
+        case ::parquet::Type::FIXED_LEN_BYTE_ARRAY:
+            return test_fixed_len_byte_array(buf, size);
         default:
             return true;
         }
@@ -267,17 +298,17 @@ private:
         return true;
     }
 
-    bool test_int32(const char* buf, size_t size) const {
-        if (size == sizeof(int8_t)) {
-            return find_int32(static_cast<int32_t>(load_predicate_value<int8_t>(buf)));
+    bool test_physical_int32(const char* buf, size_t size) const {
+        const auto logical_value = load_predicate_integral_value(buf, size);
+        if (!logical_value.has_value()) {
+            return true;
         }
-        if (size == sizeof(int16_t)) {
-            return find_int32(static_cast<int32_t>(load_predicate_value<int16_t>(buf)));
+        const auto physical_value = convert_logical_integer_to_physical_int32(
+                _column_schema.type_descriptor, *logical_value);
+        if (!physical_value.has_value()) {
+            return false;
         }
-        if (size == sizeof(int32_t)) {
-            return find_int32(load_predicate_value<int32_t>(buf));
-        }
-        return true;
+        return find_int32(*physical_value);
     }
 
     bool test_int64(const char* buf, size_t size) const {
@@ -304,10 +335,22 @@ private:
         return _bloom_filter.FindHash(_bloom_filter.Hash(value));
     }
 
-    bool test_string(const char* buf, size_t size) const {
+    bool test_byte_array(const char* buf, size_t size) const {
         ::parquet::ByteArray value(static_cast<uint32_t>(size),
                                    reinterpret_cast<const uint8_t*>(buf));
         return _bloom_filter.FindHash(_bloom_filter.Hash(&value));
+    }
+
+    bool test_fixed_len_byte_array(const char* buf, size_t size) const {
+        if (_column_schema.type_descriptor.fixed_length <= 0) {
+            return true;
+        }
+        if (size != static_cast<size_t>(_column_schema.type_descriptor.fixed_length)) {
+            return false;
+        }
+        ::parquet::FLBA value(reinterpret_cast<const uint8_t*>(buf));
+        return _bloom_filter.FindHash(
+                _bloom_filter.Hash(&value, _column_schema.type_descriptor.fixed_length));
     }
 
     bool find_int32(int32_t value) const {
@@ -318,40 +361,39 @@ private:
     const ::parquet::BloomFilter& _bloom_filter;
 };
 
-const ParquetColumnSchema* resolve_predicate_leaf_schema(
-        const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
-        const format::FileColumnPredicateFilter& column_filter);
-
 bool bloom_filter_supported(const ParquetColumnSchema& column_schema) {
-    switch (physical_filter_type(column_schema)) {
-    case TYPE_BOOLEAN:
-    case TYPE_INT:
-    case TYPE_BIGINT:
-    case TYPE_FLOAT:
-    case TYPE_DOUBLE:
-    case TYPE_STRING:
+    if (!bloom_logical_type_supported(column_schema)) {
+        return false;
+    }
+    switch (column_schema.type_descriptor.physical_type) {
+    case ::parquet::Type::BOOLEAN:
+    case ::parquet::Type::INT32:
+    case ::parquet::Type::INT64:
+    case ::parquet::Type::FLOAT:
+    case ::parquet::Type::DOUBLE:
+    case ::parquet::Type::BYTE_ARRAY:
         return true;
+    case ::parquet::Type::FIXED_LEN_BYTE_ARRAY:
+        return column_schema.type_descriptor.is_string_like &&
+               column_schema.type_descriptor.fixed_length > 0;
     default:
         return false;
     }
 }
 
-bool bloom_filter_excludes(const ParquetColumnSchema& column_schema,
-                           const format::FileColumnPredicateFilter& column_filter,
+bool bloom_filter_excludes(const ParquetColumnSchema& column_schema, int slot_index,
+                           const VExprContextSPtrs& conjuncts,
                            const ::parquet::BloomFilter& bloom_filter) {
     if (!bloom_filter_supported(column_schema)) {
         return false;
     }
     ArrowParquetBloomFilterAdapter adapter(column_schema, bloom_filter);
-    for (const auto& column_predicate : column_filter.predicates) {
-        if (column_predicate == nullptr || !is_bloom_filter_prunable_predicate(*column_predicate)) {
-            return false;
-        }
-        if (!column_predicate->evaluate_and(&adapter)) {
-            return true;
-        }
-    }
-    return false;
+    BloomFilterEvalContext ctx;
+    ctx.slots.emplace(slot_index, BloomFilterEvalContext::SlotBloomFilter {
+                                          .data_type = column_schema.type,
+                                          .bloom_filter = &adapter,
+                                  });
+    return VExprContext::evaluate_bloom_filter(conjuncts, ctx) == ZoneMapFilterResult::kNoMatch;
 }
 
 struct RowGroupBloomFilterCache {
@@ -392,32 +434,6 @@ struct RowGroupBloomFilterCache {
         return it == column_bloom_filters.end() ? nullptr : it->second.get();
     }
 };
-
-ParquetRowGroupPruneReason bloom_filter_prune_reason(
-        int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
-        const format::FileColumnPredicateFilter& column_filter,
-        RowGroupBloomFilterCache* bloom_filter_cache, ParquetPruningStats* pruning_stats) {
-    if (bloom_filter_cache == nullptr || column_filter.predicates.empty()) {
-        return ParquetRowGroupPruneReason::NONE;
-    }
-    const auto* column_schema = resolve_predicate_leaf_schema(schema, column_filter);
-    if (column_schema == nullptr || !bloom_filter_supported(*column_schema)) {
-        return ParquetRowGroupPruneReason::NONE;
-    }
-    for (const auto& column_predicate : column_filter.predicates) {
-        if (column_predicate == nullptr || !is_bloom_filter_prunable_predicate(*column_predicate)) {
-            return ParquetRowGroupPruneReason::NONE;
-        }
-    }
-    auto* bloom_filter =
-            bloom_filter_cache->get(row_group_idx, column_schema->leaf_column_id, pruning_stats);
-    if (bloom_filter == nullptr) {
-        return ParquetRowGroupPruneReason::NONE;
-    }
-    return bloom_filter_excludes(*column_schema, column_filter, *bloom_filter)
-                   ? ParquetRowGroupPruneReason::BLOOM_FILTER
-                   : ParquetRowGroupPruneReason::NONE;
-}
 
 bool is_dictionary_data_encoding(::parquet::Encoding::type encoding) {
     return encoding == ::parquet::Encoding::PLAIN_DICTIONARY ||
@@ -467,8 +483,7 @@ bool is_dictionary_encoded_chunk(const ::parquet::ColumnChunkMetaData& column_me
 }
 
 bool supports_dictionary_pruning(const ParquetColumnSchema& column_schema,
-                                 const ::parquet::ColumnChunkMetaData& column_metadata,
-                                 const format::FileColumnPredicateFilter& column_filter) {
+                                 const ::parquet::ColumnChunkMetaData& column_metadata) {
     if (column_schema.kind != ParquetColumnSchemaKind::PRIMITIVE ||
         column_schema.descriptor == nullptr || column_schema.type == nullptr) {
         return false;
@@ -479,11 +494,6 @@ bool supports_dictionary_pruning(const ParquetColumnSchema& column_schema,
     if (column_metadata.type() != ::parquet::Type::BYTE_ARRAY &&
         column_metadata.type() != ::parquet::Type::FIXED_LEN_BYTE_ARRAY) {
         return false;
-    }
-    for (const auto& column_predicate : column_filter.predicates) {
-        if (column_predicate == nullptr || !is_supported_dictionary_predicate(*column_predicate)) {
-            return false;
-        }
     }
     return true;
 }
@@ -586,52 +596,112 @@ bool read_dictionary_words(::parquet::ParquetFileReader* file_reader, int row_gr
     return false;
 }
 
-segment_v2::ZoneMap to_column_predicate_statistics(const ParquetColumnStatistics& statistics) {
-    segment_v2::ZoneMap predicate_statistics;
-    predicate_statistics.min_value = statistics.min_value;
-    predicate_statistics.max_value = statistics.max_value;
-    predicate_statistics.has_null = statistics.has_null;
-    predicate_statistics.has_not_null = statistics.has_not_null;
-    return predicate_statistics;
-}
-
-const ParquetColumnSchema* resolve_predicate_leaf_schema(
+const ParquetColumnSchema* resolve_local_leaf_schema(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
-        const format::FileColumnPredicateFilter& column_filter) {
-    const auto file_column_id = column_filter.file_column_id;
+        const format::LocalColumnId file_column_id) {
     if (!file_column_id.is_valid() || file_column_id.value() >= static_cast<int>(schema.size())) {
         return nullptr;
     }
     const ParquetColumnSchema* column_schema = schema[file_column_id.value()].get();
-    if (column_schema == nullptr) {
-        return nullptr;
-    }
-    if (column_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
+    if (column_schema == nullptr || column_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
         column_schema->leaf_column_id < 0 || column_schema->max_repetition_level > 0) {
         return nullptr;
     }
     return column_schema;
 }
 
-bool check_statistics(const format::FileColumnPredicateFilter& column_filter,
-                      const ParquetColumnStatistics& statistics) {
-    if (!statistics.has_any_statistics()) {
+std::optional<format::LocalColumnId> file_column_id_by_block_position(
+        const format::FileScanRequest& request, int block_position) {
+    for (const auto& [file_column_id, local_index] : request.local_positions) {
+        if (local_index.value() == block_position) {
+            return file_column_id;
+        }
+    }
+    return std::nullopt;
+}
+
+bool has_expr_zonemap_filter(const format::FileScanRequest& request,
+                             const RuntimeState* runtime_state) {
+    if (!expr_zonemap::is_expr_zonemap_filter_enabled(runtime_state)) {
         return false;
     }
-
-    for (const auto& column_predicate : column_filter.predicates) {
-        if (is_null_only_predicate(*column_predicate)) {
-            if (!statistics.has_null_count) {
-                continue;
-            }
-        } else if (!statistics.has_any_statistics()) {
-            continue;
-        }
-        if (!column_predicate->evaluate_and(to_column_predicate_statistics(statistics))) {
+    for (const auto& conjunct : request.conjuncts) {
+        if (conjunct != nullptr && conjunct->root() != nullptr &&
+            conjunct->root()->can_evaluate_zonemap_filter()) {
             return true;
         }
     }
     return false;
+}
+
+std::set<int> collect_expr_zonemap_slot_indexes(const VExprContextSPtrs& conjuncts) {
+    std::set<int> slot_indexes;
+    for (const auto& conjunct : conjuncts) {
+        if (conjunct != nullptr && conjunct->root() != nullptr &&
+            conjunct->root()->can_evaluate_zonemap_filter()) {
+            conjunct->root()->collect_slot_column_ids(slot_indexes);
+        }
+    }
+    return slot_indexes;
+}
+
+template <typename SlotIndexSelector>
+std::map<int, VExprContextSPtrs> collect_conjuncts_by_single_slot(
+        const VExprContextSPtrs& conjuncts, SlotIndexSelector slot_index_selector) {
+    std::map<int, VExprContextSPtrs> conjuncts_by_slot;
+    for (const auto& conjunct : conjuncts) {
+        const auto slot_index = slot_index_selector(conjunct);
+        if (slot_index >= 0) {
+            conjuncts_by_slot[slot_index].push_back(conjunct);
+        }
+    }
+    return conjuncts_by_slot;
+}
+
+std::vector<Field> dictionary_fields_from_words(const OwnedDictionaryWords& dict_words) {
+    std::vector<Field> fields;
+    fields.reserve(dict_words.refs.size());
+    for (const auto& ref : dict_words.refs) {
+        fields.push_back(Field::create_field<TYPE_STRING>(String(ref.data, ref.size)));
+    }
+    return fields;
+}
+
+std::shared_ptr<segment_v2::ZoneMap> make_zonemap_from_statistics(
+        const ParquetColumnStatistics& statistics) {
+    if (!statistics.has_null_count && !statistics.has_min_max) {
+        return nullptr;
+    }
+    segment_v2::ZoneMap zone_map;
+    zone_map.has_null = statistics.has_null;
+    zone_map.has_not_null = statistics.has_not_null;
+    if (!statistics.has_not_null) {
+        return std::make_shared<segment_v2::ZoneMap>(std::move(zone_map));
+    }
+    if (!statistics.has_min_max) {
+        return nullptr;
+    }
+    zone_map.min_value = statistics.min_value;
+    zone_map.max_value = statistics.max_value;
+    return std::make_shared<segment_v2::ZoneMap>(std::move(zone_map));
+}
+
+void add_slot_zonemap(ZoneMapEvalContext* ctx, int slot_index, const DataTypePtr& data_type,
+                      std::shared_ptr<segment_v2::ZoneMap> zone_map) {
+    DORIS_CHECK(ctx != nullptr);
+    ZoneMapEvalContext::SlotZoneMap slot_zone_map;
+    slot_zone_map.data_type = data_type;
+    slot_zone_map.zone_map = std::move(zone_map);
+    ctx->slots.emplace(slot_index, std::move(slot_zone_map));
+}
+
+void accumulate_zonemap_stats(const ZoneMapEvalContext& ctx, ParquetPruningStats* pruning_stats) {
+    if (pruning_stats == nullptr) {
+        return;
+    }
+    pruning_stats->expr_zonemap_unusable_evals += ctx.stats.unusable_zonemap_eval_count;
+    pruning_stats->in_zonemap_point_check_count += ctx.stats.in_zonemap_point_check_count;
+    pruning_stats->in_zonemap_range_only_count += ctx.stats.in_zonemap_range_only_count;
 }
 
 } // namespace
@@ -684,49 +754,85 @@ ParquetColumnStatistics ParquetStatisticsUtils::TransformColumnStatistics(
     }
 }
 
+bool ParquetStatisticsUtils::BloomFilterExcludes(const ParquetColumnSchema& column_schema,
+                                                 int slot_index, const VExprContextSPtrs& conjuncts,
+                                                 const ::parquet::BloomFilter& bloom_filter) {
+    return bloom_filter_excludes(column_schema, slot_index, conjuncts, bloom_filter);
+}
+
 namespace {
 
-ParquetRowGroupPruneReason row_group_prune_reason(
+ParquetRowGroupPruneReason dictionary_prune_reason(
         const ::parquet::RowGroupMetaData& row_group, ::parquet::ParquetFileReader* file_reader,
-        int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
-        const format::FileColumnPredicateFilter& column_filter,
-        RowGroupBloomFilterCache* bloom_filter_cache, ParquetPruningStats* pruning_stats,
-        const cctz::time_zone* timezone) {
-    if (column_filter.predicates.empty()) {
-        return ParquetRowGroupPruneReason::NONE;
-    }
-    const auto* column_schema = resolve_predicate_leaf_schema(schema, column_filter);
-    if (column_schema == nullptr) {
-        return ParquetRowGroupPruneReason::NONE;
-    }
-    DCHECK_LT(column_schema->leaf_column_id, row_group.num_columns());
-    auto column_chunk = row_group.ColumnChunk(column_schema->leaf_column_id);
-    if (column_chunk == nullptr) {
-        return ParquetRowGroupPruneReason::NONE;
-    }
-    if (check_statistics(column_filter,
-                         ParquetStatisticsUtils::TransformColumnStatistics(
-                                 *column_schema, column_chunk->statistics(), timezone))) {
-        return ParquetRowGroupPruneReason::STATISTICS;
-    }
-    if (!supports_dictionary_pruning(*column_schema, *column_chunk, column_filter) ||
-        !is_dictionary_encoded_chunk(*column_chunk)) {
-        return bloom_filter_prune_reason(row_group_idx, schema, column_filter, bloom_filter_cache,
-                                         pruning_stats);
-    }
-    OwnedDictionaryWords dict_words;
-    if (!read_dictionary_words(file_reader, row_group_idx, column_schema->leaf_column_id,
-                               *column_schema, &dict_words)) {
-        return bloom_filter_prune_reason(row_group_idx, schema, column_filter, bloom_filter_cache,
-                                         pruning_stats);
-    }
-    for (const auto& column_predicate : column_filter.predicates) {
-        if (!column_predicate->evaluate_and(dict_words.refs.data(), dict_words.refs.size())) {
+        int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request) {
+    const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
+            request.conjuncts, expr_zonemap::single_slot_dictionary_index);
+    for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
+        const auto file_column_id = file_column_id_by_block_position(request, slot_index);
+        if (!file_column_id.has_value()) {
+            continue;
+        }
+        const auto* column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
+        if (column_schema == nullptr || column_schema->type == nullptr) {
+            continue;
+        }
+        DCHECK_LT(column_schema->leaf_column_id, row_group.num_columns());
+        auto column_chunk = row_group.ColumnChunk(column_schema->leaf_column_id);
+        if (column_chunk == nullptr ||
+            !supports_dictionary_pruning(*column_schema, *column_chunk) ||
+            !is_dictionary_encoded_chunk(*column_chunk)) {
+            continue;
+        }
+
+        OwnedDictionaryWords dict_words;
+        if (!read_dictionary_words(file_reader, row_group_idx, column_schema->leaf_column_id,
+                                   *column_schema, &dict_words)) {
+            continue;
+        }
+        DictionaryEvalContext ctx;
+        ctx.slots.emplace(slot_index, DictionaryEvalContext::SlotDictionary {
+                                              .data_type = column_schema->type,
+                                              .values = dictionary_fields_from_words(dict_words),
+                                      });
+        if (VExprContext::evaluate_dictionary_filter(conjuncts, ctx) ==
+            ZoneMapFilterResult::kNoMatch) {
             return ParquetRowGroupPruneReason::DICTIONARY;
         }
     }
-    return bloom_filter_prune_reason(row_group_idx, schema, column_filter, bloom_filter_cache,
-                                     pruning_stats);
+    return ParquetRowGroupPruneReason::NONE;
+}
+
+ParquetRowGroupPruneReason bloom_filter_prune_reason(
+        int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, RowGroupBloomFilterCache* bloom_filter_cache,
+        ParquetPruningStats* pruning_stats) {
+    if (bloom_filter_cache == nullptr) {
+        return ParquetRowGroupPruneReason::NONE;
+    }
+    const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
+            request.conjuncts, expr_zonemap::single_slot_bloom_filter_index);
+    for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
+        const auto file_column_id = file_column_id_by_block_position(request, slot_index);
+        if (!file_column_id.has_value()) {
+            continue;
+        }
+        const auto* column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
+        if (column_schema == nullptr || column_schema->type == nullptr ||
+            !bloom_filter_supported(*column_schema)) {
+            continue;
+        }
+        auto* bloom_filter = bloom_filter_cache->get(row_group_idx, column_schema->leaf_column_id,
+                                                     pruning_stats);
+        if (bloom_filter == nullptr) {
+            continue;
+        }
+        if (ParquetStatisticsUtils::BloomFilterExcludes(*column_schema, slot_index, conjuncts,
+                                                        *bloom_filter)) {
+            return ParquetRowGroupPruneReason::BLOOM_FILTER;
+        }
+    }
+    return ParquetRowGroupPruneReason::NONE;
 }
 
 void init_bloom_filter_cache(::parquet::ParquetFileReader* file_reader, bool enable_bloom_filter,
@@ -744,13 +850,49 @@ void init_bloom_filter_cache(::parquet::ParquetFileReader* file_reader, bool ena
     }
 }
 
-Status select_row_groups(const ::parquet::FileMetaData& metadata,
-                         ::parquet::ParquetFileReader* file_reader,
-                         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-                         const format::FileScanRequest& request,
-                         const std::vector<int>* candidate_row_groups,
-                         std::vector<int>* selected_row_groups, bool enable_bloom_filter,
-                         ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone) {
+bool check_statistics(const ::parquet::RowGroupMetaData& row_group,
+                      const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+                      const format::FileScanRequest& request, ParquetPruningStats* pruning_stats,
+                      const cctz::time_zone* timezone) {
+    const auto slot_indexes = collect_expr_zonemap_slot_indexes(request.conjuncts);
+    if (slot_indexes.empty()) {
+        return false;
+    }
+
+    ZoneMapEvalContext ctx;
+    for (const int slot_index : slot_indexes) {
+        const auto file_column_id = file_column_id_by_block_position(request, slot_index);
+        if (!file_column_id.has_value()) {
+            continue;
+        }
+        const auto* column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
+        if (column_schema == nullptr || column_schema->type == nullptr) {
+            continue;
+        }
+
+        std::shared_ptr<segment_v2::ZoneMap> zone_map;
+        DCHECK_LT(column_schema->leaf_column_id, row_group.num_columns());
+        auto column_chunk = row_group.ColumnChunk(column_schema->leaf_column_id);
+        if (column_chunk != nullptr) {
+            zone_map =
+                    make_zonemap_from_statistics(ParquetStatisticsUtils::TransformColumnStatistics(
+                            *column_schema, column_chunk->statistics(), timezone));
+        }
+        add_slot_zonemap(&ctx, slot_index, column_schema->type, std::move(zone_map));
+    }
+
+    const auto result = VExprContext::evaluate_zonemap_filter(request.conjuncts, ctx);
+    accumulate_zonemap_stats(ctx, pruning_stats);
+    return result == ZoneMapFilterResult::kNoMatch;
+}
+
+Status select_row_groups_by_metadata_impl(
+        const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, const std::vector<int>* candidate_row_groups,
+        std::vector<int>* selected_row_groups, bool enable_bloom_filter,
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
+        const RuntimeState* runtime_state) {
     int64_t row_group_filter_time_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &row_group_filter_time_sink
                                               : &pruning_stats->row_group_filter_time);
@@ -767,6 +909,8 @@ Status select_row_groups(const ::parquet::FileMetaData& metadata,
                                         ? static_cast<size_t>(num_row_groups)
                                         : candidate_row_groups->size();
     selected_row_groups->reserve(candidate_size);
+    RowGroupBloomFilterCache bloom_filter_cache;
+    init_bloom_filter_cache(file_reader, enable_bloom_filter, &bloom_filter_cache);
     for (size_t candidate_idx = 0; candidate_idx < candidate_size; ++candidate_idx) {
         const int row_group_idx = candidate_row_groups == nullptr
                                           ? static_cast<int>(candidate_idx)
@@ -778,17 +922,22 @@ Status select_row_groups(const ::parquet::FileMetaData& metadata,
             selected_row_groups->push_back(row_group_idx);
             continue;
         }
-        bool drop = false;
-        RowGroupBloomFilterCache bloom_filter_cache;
-        init_bloom_filter_cache(file_reader, enable_bloom_filter, &bloom_filter_cache);
-        for (const auto& column_filter : request.column_predicate_filters) {
-            const auto prune_reason = row_group_prune_reason(
-                    *row_group, file_reader, row_group_idx, file_schema, column_filter,
-                    &bloom_filter_cache, pruning_stats, timezone);
+        ParquetRowGroupPruneReason prune_reason = ParquetRowGroupPruneReason::NONE;
+        if (has_expr_zonemap_filter(request, runtime_state) &&
+            check_statistics(*row_group, file_schema, request, pruning_stats, timezone)) {
+            prune_reason = ParquetRowGroupPruneReason::STATISTICS;
+        }
+
+        if (prune_reason == ParquetRowGroupPruneReason::NONE) {
+            prune_reason = dictionary_prune_reason(*row_group, file_reader, row_group_idx,
+                                                   file_schema, request);
             if (prune_reason == ParquetRowGroupPruneReason::NONE) {
-                continue;
+                prune_reason = bloom_filter_prune_reason(row_group_idx, file_schema, request,
+                                                         &bloom_filter_cache, pruning_stats);
             }
-            drop = true;
+        }
+
+        if (prune_reason != ParquetRowGroupPruneReason::NONE) {
             if (pruning_stats != nullptr) {
                 pruning_stats->filtered_group_rows += row_group->num_rows();
                 if (prune_reason == ParquetRowGroupPruneReason::STATISTICS) {
@@ -798,11 +947,7 @@ Status select_row_groups(const ::parquet::FileMetaData& metadata,
                 } else if (prune_reason == ParquetRowGroupPruneReason::BLOOM_FILTER) {
                     ++pruning_stats->filtered_row_groups_by_bloom_filter;
                 }
-                break;
             }
-            break;
-        }
-        if (drop) {
             continue;
         }
         selected_row_groups->push_back(row_group_idx);
@@ -812,21 +957,16 @@ Status select_row_groups(const ::parquet::FileMetaData& metadata,
 
 } // namespace
 
-bool ParquetStatisticsUtils::BloomFilterExcludes(
-        const ParquetColumnSchema& column_schema,
-        const format::FileColumnPredicateFilter& column_filter,
-        const ::parquet::BloomFilter& bloom_filter) {
-    return bloom_filter_excludes(column_schema, column_filter, bloom_filter);
-}
-
-Status select_row_groups_by_statistics(
+Status select_row_groups_by_metadata(
         const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, const std::vector<int>* candidate_row_groups,
         std::vector<int>* selected_row_groups, bool enable_bloom_filter,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone) {
-    return select_row_groups(metadata, file_reader, file_schema, request, candidate_row_groups,
-                             selected_row_groups, enable_bloom_filter, pruning_stats, timezone);
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
+        const RuntimeState* runtime_state) {
+    return select_row_groups_by_metadata_impl(
+            metadata, file_reader, file_schema, request, candidate_row_groups, selected_row_groups,
+            enable_bloom_filter, pruning_stats, timezone, runtime_state);
 }
 
 namespace {
@@ -1024,35 +1164,58 @@ void append_row_range(const RowRange& range, std::vector<RowRange>* ranges) {
     ranges->push_back(range);
 }
 
-bool select_ranges_for_filter(const std::shared_ptr<::parquet::RowGroupPageIndexReader>& row_group,
-                              const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-                              const format::FileColumnPredicateFilter& column_filter,
-                              int64_t row_group_rows, std::vector<RowRange>* ranges,
-                              const cctz::time_zone* timezone) {
-    if (column_filter.predicates.empty()) {
-        return false;
+std::optional<
+        std::pair<std::shared_ptr<::parquet::ColumnIndex>, std::shared_ptr<::parquet::OffsetIndex>>>
+load_page_indexes_for_slot(const std::shared_ptr<::parquet::RowGroupPageIndexReader>& row_group,
+                           const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+                           const format::FileScanRequest& request, int slot_index,
+                           const ParquetColumnSchema** column_schema) {
+    DORIS_CHECK(column_schema != nullptr);
+    *column_schema = nullptr;
+    const auto file_column_id = file_column_id_by_block_position(request, slot_index);
+    if (!file_column_id.has_value()) {
+        return std::nullopt;
     }
-    const auto* column_schema = resolve_predicate_leaf_schema(file_schema, column_filter);
-    if (column_schema == nullptr || column_schema->descriptor == nullptr) {
-        return false;
+    *column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
+    if (*column_schema == nullptr || (*column_schema)->descriptor == nullptr) {
+        return std::nullopt;
     }
 
-    std::shared_ptr<::parquet::ColumnIndex> column_index;
-    std::shared_ptr<::parquet::OffsetIndex> offset_index;
     try {
-        column_index = row_group->GetColumnIndex(column_schema->leaf_column_id);
-        offset_index = row_group->GetOffsetIndex(column_schema->leaf_column_id);
+        auto column_index = row_group->GetColumnIndex((*column_schema)->leaf_column_id);
+        auto offset_index = row_group->GetOffsetIndex((*column_schema)->leaf_column_id);
+        if (column_index == nullptr || offset_index == nullptr ||
+            column_index->null_pages().size() != offset_index->page_locations().size()) {
+            return std::nullopt;
+        }
+        return std::make_pair(std::move(column_index), std::move(offset_index));
     } catch (const ::parquet::ParquetException&) {
-        return false;
+        return std::nullopt;
     } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+bool select_ranges_for_expr_zonemap(
+        const std::shared_ptr<::parquet::RowGroupPageIndexReader>& row_group,
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, int slot_index, const VExprContextSPtrs& conjuncts,
+        int64_t row_group_rows, std::vector<RowRange>* ranges, ParquetPruningStats* pruning_stats,
+        const cctz::time_zone* timezone) {
+    DORIS_CHECK(ranges != nullptr);
+    if (conjuncts.empty()) {
         return false;
     }
-    if (column_index == nullptr || offset_index == nullptr ||
-        column_index->null_pages().size() != offset_index->page_locations().size()) {
+    const ParquetColumnSchema* column_schema = nullptr;
+    const auto page_indexes =
+            load_page_indexes_for_slot(row_group, file_schema, request, slot_index, &column_schema);
+    if (!page_indexes.has_value()) {
         return false;
     }
+    const auto& [column_index, offset_index] = *page_indexes;
 
     ranges->clear();
+    ZoneMapEvalStats page_stats;
     const auto page_count = offset_index->page_locations().size();
     for (size_t page_idx = 0; page_idx < page_count; ++page_idx) {
         ParquetColumnStatistics page_statistics;
@@ -1061,11 +1224,21 @@ bool select_ranges_for_filter(const std::shared_ptr<::parquet::RowGroupPageIndex
             ranges->clear();
             return false;
         }
-        const RowRange row_range = page_row_range(*offset_index, page_idx, row_group_rows);
-        if (check_statistics(column_filter, page_statistics)) {
+
+        ZoneMapEvalContext ctx;
+        add_slot_zonemap(&ctx, slot_index, column_schema->type,
+                         make_zonemap_from_statistics(page_statistics));
+        const auto result = VExprContext::evaluate_zonemap_filter(conjuncts, ctx);
+        page_stats.merge_page_eval_stats(ctx.stats);
+        if (result == ZoneMapFilterResult::kNoMatch) {
             continue;
         }
-        append_row_range(row_range, ranges);
+        append_row_range(page_row_range(*offset_index, page_idx, row_group_rows), ranges);
+    }
+    if (pruning_stats != nullptr) {
+        pruning_stats->expr_zonemap_unusable_evals += page_stats.unusable_zonemap_eval_count;
+        pruning_stats->in_zonemap_point_check_count += page_stats.in_zonemap_point_check_count;
+        pruning_stats->in_zonemap_range_only_count += page_stats.in_zonemap_range_only_count;
     }
     return true;
 }
@@ -1127,15 +1300,6 @@ void collect_request_leaf_schemas(
     for (const auto& projection : request.non_predicate_columns) {
         collect_projection(projection);
     }
-    for (const auto& column_filter : request.column_predicate_filters) {
-        const auto* leaf_schema = resolve_predicate_leaf_schema(file_schema, column_filter);
-        if (leaf_schema == nullptr) {
-            continue;
-        }
-        if (seen_leaf_ids.insert(leaf_schema->leaf_column_id).second) {
-            leaf_schemas->push_back(leaf_schema);
-        }
-    }
 }
 
 bool build_page_skip_plan_for_leaf(
@@ -1144,8 +1308,6 @@ bool build_page_skip_plan_for_leaf(
         int64_t row_group_rows, ParquetPageSkipPlan* page_skip_plan) {
     DORIS_CHECK(page_skip_plan != nullptr);
     *page_skip_plan = ParquetPageSkipPlan {};
-    // OffsetIndex first_row_index is row-based only for non-repeated leaves. LIST/MAP/repeated
-    // leaves need repetition-level-aware range mapping and are intentionally left out for now.
     if (column_schema.kind != ParquetColumnSchemaKind::PRIMITIVE ||
         column_schema.descriptor == nullptr || column_schema.leaf_column_id < 0 ||
         column_schema.descriptor->max_repetition_level() != 0) {
@@ -1212,7 +1374,8 @@ Status select_row_group_ranges_by_page_index(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, int row_group_idx, int64_t row_group_rows,
         std::vector<RowRange>* selected_ranges, std::map<int, ParquetPageSkipPlan>* page_skip_plans,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone) {
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
+        const RuntimeState* runtime_state) {
     int64_t page_index_filter_time_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &page_index_filter_time_sink
                                               : &pruning_stats->page_index_filter_time);
@@ -1225,7 +1388,7 @@ Status select_row_group_ranges_by_page_index(
         return Status::OK();
     }
     selected_ranges->push_back(RowRange {0, row_group_rows});
-    if (!config::enable_parquet_page_index || request.column_predicate_filters.empty() ||
+    if (!config::enable_parquet_page_index || !has_expr_zonemap_filter(request, runtime_state) ||
         file_reader == nullptr) {
         return Status::OK();
     }
@@ -1255,10 +1418,19 @@ Status select_row_group_ranges_by_page_index(
         return Status::OK();
     }
 
-    for (const auto& column_filter : request.column_predicate_filters) {
+    std::map<int, VExprContextSPtrs> conjuncts_by_slot;
+    for (const auto& conjunct : request.conjuncts) {
+        const auto slot_index = expr_zonemap::single_slot_zonemap_index(conjunct);
+        if (slot_index >= 0) {
+            conjuncts_by_slot[slot_index].push_back(conjunct);
+        }
+    }
+
+    for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
         std::vector<RowRange> filter_ranges;
-        if (!select_ranges_for_filter(row_group_index_reader, file_schema, column_filter,
-                                      row_group_rows, &filter_ranges, timezone)) {
+        if (!select_ranges_for_expr_zonemap(row_group_index_reader, file_schema, request,
+                                            slot_index, conjuncts, row_group_rows, &filter_ranges,
+                                            pruning_stats, timezone)) {
             continue;
         }
         *selected_ranges = intersect_ranges(*selected_ranges, filter_ranges);

--- a/be/src/format_v2/parquet/parquet_statistics.h
+++ b/be/src/format_v2/parquet/parquet_statistics.h
@@ -22,6 +22,7 @@
 
 #include "common/status.h"
 #include "core/field.h"
+#include "exprs/vexpr_fwd.h"
 #include "format_v2/file_reader.h"
 #include "format_v2/parquet/selection_vector.h"
 
@@ -37,7 +38,7 @@ class time_zone;
 } // namespace cctz
 
 namespace doris {
-class ColumnPredicate;
+class RuntimeState;
 } // namespace doris
 
 namespace doris::format::parquet {
@@ -50,7 +51,7 @@ struct ParquetColumnSchema;
 struct ParquetPruningStats {
     int64_t total_row_groups = 0;                    // total row groups in the file
     int64_t selected_row_groups = 0;                 // row groups selected after pruning
-    int64_t filtered_row_groups_by_statistics = 0;   // row groups pruned by min/max statistics
+    int64_t filtered_row_groups_by_statistics = 0;   // row groups pruned by ZoneMap statistics
     int64_t filtered_row_groups_by_dictionary = 0;   // row groups pruned by dictionary
     int64_t filtered_row_groups_by_bloom_filter = 0; // row groups pruned by bloom filter
     int64_t filtered_row_groups_by_page_index = 0;   // row groups fully pruned by page index
@@ -62,6 +63,9 @@ struct ParquetPruningStats {
     int64_t row_group_filter_time = 0;               // row-group pruning time (ns)
     int64_t page_index_filter_time = 0;              // page-index pruning time (ns)
     int64_t read_page_index_time = 0;                // page-index read time (ns)
+    int64_t expr_zonemap_unusable_evals = 0;         // VExpr ZoneMap unusable evaluations
+    int64_t in_zonemap_point_check_count = 0;        // VExpr IN ZoneMap point checks
+    int64_t in_zonemap_range_only_count = 0;         // VExpr IN ZoneMap range-only checks
 };
 
 struct ParquetColumnStatistics {
@@ -77,9 +81,10 @@ struct ParquetColumnStatistics {
 
 // ============================================================================
 // ============================================================================
-//     statistics(TransformColumnStatistics + check_statistics)
-//     -> dictionary(read_dictionary_words + predicate::evaluate_and)
-//     -> bloom filter(bloom_filter_prune_reason)
+//     VExpr ZoneMap(TransformColumnStatistics + evaluate_zonemap_filter)
+//     -> page-index ZoneMap(evaluate_zonemap_filter)
+//     dictionary(read_dictionary_words + evaluate_dictionary_filter)
+//     -> bloom filter(evaluate_bloom_filter)
 // ============================================================================
 struct ParquetStatisticsUtils {
     static ParquetColumnStatistics TransformColumnStatistics(
@@ -87,23 +92,25 @@ struct ParquetStatisticsUtils {
             const std::shared_ptr<::parquet::Statistics>& statistics,
             const cctz::time_zone* timezone = nullptr);
 
-    static bool BloomFilterExcludes(const ParquetColumnSchema& column_schema,
-                                    const format::FileColumnPredicateFilter& column_filter,
+    static bool BloomFilterExcludes(const ParquetColumnSchema& column_schema, int slot_index,
+                                    const VExprContextSPtrs& conjuncts,
                                     const ::parquet::BloomFilter& bloom_filter);
 };
 
-Status select_row_groups_by_statistics(
+Status select_row_groups_by_metadata(
         const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, const std::vector<int>* candidate_row_groups,
         std::vector<int>* selected_row_groups, bool enable_bloom_filter,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone = nullptr);
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone = nullptr,
+        const RuntimeState* runtime_state = nullptr);
 
 Status select_row_group_ranges_by_page_index(
         ::parquet::ParquetFileReader* file_reader,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, int row_group_idx, int64_t row_group_rows,
         std::vector<RowRange>* selected_ranges, std::map<int, ParquetPageSkipPlan>* page_skip_plans,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone = nullptr);
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone = nullptr,
+        const RuntimeState* runtime_state = nullptr);
 
 } // namespace doris::format::parquet

--- a/be/src/format_v2/table/hudi_reader.cpp
+++ b/be/src/format_v2/table/hudi_reader.cpp
@@ -108,7 +108,6 @@ Status HudiHybridReader::_init_child_reader(format::TableReader* reader,
     RETURN_IF_ERROR(_clone_conjuncts(&conjuncts));
     return reader->init({
             .projected_columns = _projected_columns,
-            .column_predicates = _table_column_predicates,
             .conjuncts = std::move(conjuncts),
             .format = file_format,
             .scan_params = _scan_params,

--- a/be/src/format_v2/table/paimon_reader.cpp
+++ b/be/src/format_v2/table/paimon_reader.cpp
@@ -143,7 +143,6 @@ Status PaimonHybridReader::_init_child_reader(format::TableReader* reader,
     RETURN_IF_ERROR(_clone_conjuncts(&conjuncts));
     return reader->init({
             .projected_columns = _projected_columns,
-            .column_predicates = _table_column_predicates,
             .conjuncts = std::move(conjuncts),
             .format = file_format,
             .scan_params = _scan_params,

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -307,20 +307,6 @@ std::string table_filter_debug_string(const TableFilter& filter) {
     return out.str();
 }
 
-std::string table_column_predicates_debug_string(const TableColumnPredicates& predicates) {
-    std::ostringstream out;
-    out << "{";
-    size_t idx = 0;
-    for (const auto& [global_index, column_predicates] : predicates) {
-        if (idx++ > 0) {
-            out << ", ";
-        }
-        out << global_index.value() << ":{predicate_count=" << column_predicates.size() << "}";
-    }
-    out << "}";
-    return out.str();
-}
-
 bool contains_runtime_filter(const VExprContextSPtrs& conjuncts) {
     return std::ranges::any_of(conjuncts, [](const auto& conjunct) {
         return conjunct != nullptr && conjunct->root() != nullptr &&
@@ -481,8 +467,6 @@ std::string TableReader::debug_string() const {
         << join_table_reader_debug_strings(
                    _table_filters,
                    [](const TableFilter& filter) { return table_filter_debug_string(filter); })
-        << ", table_column_predicates="
-        << table_column_predicates_debug_string(_table_column_predicates)
         << ", conjunct_count=" << _conjuncts.size() << ", conjuncts="
         << join_table_reader_debug_strings(_conjuncts,
                                            [](const VExprContextSPtr& conjunct) {
@@ -541,7 +525,6 @@ Status TableReader::init(TableReadOptions&& options) {
     _system_properties = create_system_properties(_scan_params);
     _mapper_options.mode = TableColumnMappingMode::BY_NAME;
     _conjuncts = std::move(options.conjuncts);
-    _table_column_predicates = std::move(options.column_predicates);
 
     if (_scanner_profile != nullptr) {
         static const char* table_profile = "TableReader";
@@ -596,8 +579,8 @@ bool TableReader::_should_enable_condition_cache(const FileScanRequest& file_req
         return false;
     }
     // Condition cache is populated by file readers after evaluating file-local row-level
-    // conjuncts. ColumnPredicate-only scans can prune row groups/pages, but they do not produce a
-    // per-row survivor bitmap that can safely populate the cache.
+    // conjuncts. Metadata pruning can skip row groups/pages, but it does not produce a per-row
+    // survivor bitmap that can safely populate the cache.
     if (file_request.conjuncts.empty()) {
         return false;
     }

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -67,7 +67,6 @@
 
 namespace doris {
 class Block;
-class ColumnPredicate;
 struct DeleteFileDesc;
 class RuntimeState;
 } // namespace doris
@@ -113,8 +112,6 @@ struct TableReadOptions {
     // Columns need to be read from file and output by table reader. They are all in table/global
     // schema semantics.
     const std::vector<ColumnDefinition> projected_columns;
-    // Simple predicates for a single column, which is parsed on scan operator.
-    const TableColumnPredicates column_predicates;
     // All complex conjuncts from scan operator
     const VExprContextSPtrs conjuncts;
     // File format of the underlying data files, needed for reader initialization and reader-level
@@ -305,12 +302,10 @@ protected:
 
         // 3. Create file scan request based on column mapping and table filters, then open file
         // reader with the request. File scan request carries row-level expression filters and
-        // file-level pruning hints. Only expression filters decide returned rows; column predicates
-        // are pruning hints.
+        // file-level pruning hints. Only expression filters decide returned rows.
         auto file_request = std::make_shared<FileScanRequest>();
         RETURN_IF_ERROR(_data_reader.column_mapper->create_scan_request(
-                _table_filters, _table_column_predicates, _projected_columns, file_request.get(),
-                _runtime_state));
+                _table_filters, _projected_columns, file_request.get(), _runtime_state));
         bool constant_filter_pruned_split = false;
         RETURN_IF_ERROR(_evaluate_constant_filters(&constant_filter_pruned_split));
         if (constant_filter_pruned_split) {
@@ -846,13 +841,13 @@ protected:
         if (agg_type != TPushAggOp::type::COUNT && agg_type != TPushAggOp::type::MINMAX) {
             return false;
         }
-        // Only support aggregate pushdown when there is no delete, filter and column predicate, so
+        // Only support aggregate pushdown when there is no delete or filter, so
         // the reduced rows consumed by the upper aggregate remain semantically equivalent to a
         // normal scan.
         if (_delete_rows != nullptr && !_delete_rows->empty()) {
             return false;
         }
-        if (!_table_filters.empty() || !_table_column_predicates.empty()) {
+        if (!_table_filters.empty()) {
             return false;
         }
         if (agg_type == TPushAggOp::type::COUNT) {
@@ -1457,7 +1452,6 @@ protected:
     std::map<std::string, Field> _partition_values;
     // Predicates built from scan conjuncts before file-level localization.
     std::vector<TableFilter> _table_filters;
-    TableColumnPredicates _table_column_predicates;
     VExprContextSPtrs _conjuncts;
     ReadProfile _profile;
     // Parsed from row-position based delete files, including position delete and deletion vector.

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -190,21 +190,21 @@ public:
         _rowset_meta_pb.set_index_disk_size(index_disk_size);
     }
 
-    void zone_maps(std::vector<ZoneMap>* zone_maps) {
-        for (const ZoneMap& zone_map : _rowset_meta_pb.zone_maps()) {
+    void zone_maps(std::vector<::doris::ZoneMap>* zone_maps) {
+        for (const ::doris::ZoneMap& zone_map : _rowset_meta_pb.zone_maps()) {
             zone_maps->push_back(zone_map);
         }
     }
 
-    void set_zone_maps(const std::vector<ZoneMap>& zone_maps) {
-        for (const ZoneMap& zone_map : zone_maps) {
-            ZoneMap* new_zone_map = _rowset_meta_pb.add_zone_maps();
+    void set_zone_maps(const std::vector<::doris::ZoneMap>& zone_maps) {
+        for (const ::doris::ZoneMap& zone_map : zone_maps) {
+            ::doris::ZoneMap* new_zone_map = _rowset_meta_pb.add_zone_maps();
             *new_zone_map = zone_map;
         }
     }
 
-    void add_zone_map(const ZoneMap& zone_map) {
-        ZoneMap* new_zone_map = _rowset_meta_pb.add_zone_maps();
+    void add_zone_map(const ::doris::ZoneMap& zone_map) {
+        ::doris::ZoneMap* new_zone_map = _rowset_meta_pb.add_zone_maps();
         *new_zone_map = zone_map;
     }
 

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -47,6 +47,7 @@
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
+#include "storage/index/bloom_filter/block_split_bloom_filter.h"
 #include "storage/index/zone_map/zone_map_index.h"
 #include "storage/index/zone_map/zonemap_eval_context.h"
 #include "storage/segment/segment_iterator.h"
@@ -125,6 +126,36 @@ ZoneMapEvalContext make_context(segment_v2::ZoneMap zone_map, const DataTypePtr&
     slot_zone_map.data_type = data_type;
     slot_zone_map.zone_map = std::make_shared<segment_v2::ZoneMap>(std::move(zone_map));
     ctx.slots.emplace(0, std::move(slot_zone_map));
+    return ctx;
+}
+
+DictionaryEvalContext make_dictionary_context(std::vector<Field> values,
+                                              const DataTypePtr& data_type) {
+    DictionaryEvalContext ctx;
+    ctx.slots.emplace(0, DictionaryEvalContext::SlotDictionary {
+                                 .data_type = data_type,
+                                 .values = std::move(values),
+                         });
+    return ctx;
+}
+
+std::unique_ptr<segment_v2::BlockSplitBloomFilter> make_int_bloom_filter(
+        const std::vector<int32_t>& values) {
+    auto bloom_filter = std::make_unique<segment_v2::BlockSplitBloomFilter>();
+    EXPECT_TRUE(bloom_filter->init(segment_v2::BloomFilter::MINIMUM_BYTES).ok());
+    for (const auto value : values) {
+        bloom_filter->add_bytes(reinterpret_cast<const char*>(&value), sizeof(value));
+    }
+    return bloom_filter;
+}
+
+BloomFilterEvalContext make_bloom_filter_context(const segment_v2::BloomFilter* bloom_filter,
+                                                 const DataTypePtr& data_type) {
+    BloomFilterEvalContext ctx;
+    ctx.slots.emplace(0, BloomFilterEvalContext::SlotBloomFilter {
+                                 .data_type = data_type,
+                                 .bloom_filter = bloom_filter,
+                         });
     return ctx;
 }
 
@@ -335,6 +366,31 @@ TEST(ExprZonemapFilterTest, ComparisonZonemapHandlesNullAndUnsupportedInputs) {
     EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
               equals.evaluate_zonemap_filter(pass_all_ctx, {slot, make_int_literal(10)}));
     EXPECT_EQ(1, pass_all_ctx.stats.unusable_zonemap_eval_count);
+}
+
+TEST(ExprZonemapFilterTest, ComparisonDictionaryAndBloomUseEqualityLiterals) {
+    auto type = int_type();
+    auto slot = make_slot(0, type);
+    FunctionComparison<EqualsOp, NameEquals> equals;
+
+    EXPECT_TRUE(equals.can_evaluate_dictionary_filter({slot, make_int_literal(2)}));
+    auto dictionary_ctx = make_dictionary_context({int_field(1), int_field(3)}, type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals.evaluate_dictionary_filter(dictionary_ctx, {slot, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              equals.evaluate_dictionary_filter(dictionary_ctx, {slot, make_int_literal(3)}));
+
+    EXPECT_TRUE(equals.can_evaluate_bloom_filter({slot, make_int_literal(2)}));
+    auto bloom_filter = make_int_bloom_filter({1, 3});
+    auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals.evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              equals.evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(3)}));
+
+    FunctionComparison<NotEqualsOp, NameNotEquals> not_equals;
+    EXPECT_FALSE(not_equals.can_evaluate_dictionary_filter({slot, make_int_literal(3)}));
+    EXPECT_FALSE(not_equals.can_evaluate_bloom_filter({slot, make_int_literal(3)}));
 }
 
 TEST(ExprZonemapFilterTest, MissingSlotTypeCountsUnsupportedZonemapEvalOnce) {
@@ -640,6 +696,46 @@ TEST(ExprZonemapFilterTest, VInPredicateMaterializesZonemapValues) {
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
               not_in_with_null->evaluate_zonemap_filter(may_match_ctx));
     EXPECT_TRUE(not_in_with_null->_seg_filter_contains_null);
+}
+
+TEST(ExprZonemapFilterTest, VInPredicateDictionaryAndBloomUseMaterializedValues) {
+    auto type = int_type();
+    ObjectPool obj_pool;
+    DescriptorTbl* desc_tbl = nullptr;
+    auto thrift_desc_tbl = make_k2_scan_desc_tbl();
+    ASSERT_TRUE(DescriptorTbl::create(&obj_pool, thrift_desc_tbl, &desc_tbl).ok());
+
+    RuntimeState runtime_state;
+    runtime_state.set_desc_tbl(desc_tbl);
+    RowDescriptor row_desc(runtime_state.desc_tbl(), {0});
+
+    auto in_predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 3));
+    auto in_slot = make_slot(0, type);
+    std::static_pointer_cast<VSlotRef>(in_slot)->set_slot_id(0);
+    in_predicate->add_child(in_slot);
+    in_predicate->add_child(make_int_literal(2));
+    in_predicate->add_child(make_int_literal(4));
+    VExprContext in_context(in_predicate);
+    ASSERT_TRUE(in_context.prepare(&runtime_state, row_desc).ok());
+    ASSERT_TRUE(in_context.open(&runtime_state).ok());
+
+    EXPECT_TRUE(in_predicate->can_evaluate_dictionary_filter());
+    auto missing_dictionary_ctx = make_dictionary_context({int_field(1), int_field(3)}, type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              in_predicate->evaluate_dictionary_filter(missing_dictionary_ctx));
+    auto matching_dictionary_ctx = make_dictionary_context({int_field(4), int_field(5)}, type);
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              in_predicate->evaluate_dictionary_filter(matching_dictionary_ctx));
+
+    EXPECT_TRUE(in_predicate->can_evaluate_bloom_filter());
+    auto missing_bloom_filter = make_int_bloom_filter({1, 3});
+    auto missing_bloom_ctx = make_bloom_filter_context(missing_bloom_filter.get(), type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              in_predicate->evaluate_bloom_filter(missing_bloom_ctx));
+    auto matching_bloom_filter = make_int_bloom_filter({4});
+    auto matching_bloom_ctx = make_bloom_filter_context(matching_bloom_filter.get(), type);
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              in_predicate->evaluate_bloom_filter(matching_bloom_ctx));
 }
 
 TEST(ExprZonemapFilterTest, DirectInPredicateMaterializesStringSetForZonemap) {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -393,6 +393,30 @@ TEST(ExprZonemapFilterTest, ComparisonDictionaryAndBloomUseEqualityLiterals) {
     EXPECT_FALSE(not_equals.can_evaluate_bloom_filter({slot, make_int_literal(3)}));
 }
 
+TEST(ExprZonemapFilterTest, DefaultFunctionForwardsDictionaryAndBloomEvaluation) {
+    auto type = int_type();
+    auto slot = make_slot(0, type);
+    auto equals = SimpleFunctionFactory::instance().get_function(
+            "eq", ColumnsWithTypeAndName {{nullptr, type, "slot"}, {nullptr, type, "literal"}},
+            std::make_shared<DataTypeUInt8>());
+    ASSERT_NE(equals, nullptr);
+
+    EXPECT_TRUE(equals->can_evaluate_dictionary_filter({slot, make_int_literal(2)}));
+    auto dictionary_ctx = make_dictionary_context({int_field(1), int_field(3)}, type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals->evaluate_dictionary_filter(dictionary_ctx, {slot, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              equals->evaluate_dictionary_filter(dictionary_ctx, {slot, make_int_literal(3)}));
+
+    EXPECT_TRUE(equals->can_evaluate_bloom_filter({slot, make_int_literal(2)}));
+    auto bloom_filter = make_int_bloom_filter({1, 3});
+    auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals->evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              equals->evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(3)}));
+}
+
 TEST(ExprZonemapFilterTest, MissingSlotTypeCountsUnsupportedZonemapEvalOnce) {
     auto type = int_type();
     auto slot = make_slot(0, type);

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -48,7 +48,6 @@
 #include "format_v2/table_reader.h"
 #include "gen_cpp/Exprs_types.h"
 #include "runtime/descriptors.h"
-#include "storage/predicate/predicate_creator.h"
 #include "testutil/column_helper.h"
 #include "testutil/mock/mock_runtime_state.h"
 
@@ -953,14 +952,13 @@ TEST(ColumnMapperCollectNestedStructPathsTest, ProjectionMergeKeepsFilterOnlyPat
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_output}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_output}, &request).ok());
 
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].column_id(), LocalColumnId(5));
     ASSERT_FALSE(request.predicate_columns[0].project_all_children);
     EXPECT_EQ(projection_ids(request.predicate_columns[0].children), std::vector<int32_t>({0, 1}));
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: row-oriented readers such as CSV/Text cannot lazy-read predicate columns separately.
@@ -989,14 +987,13 @@ TEST(ColumnMapperScanRequestTest, MaterializedMapperUsesSingleScanColumnList) {
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_output}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_output}, &request).ok());
 
     EXPECT_TRUE(request.predicate_columns.empty());
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(5));
     EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
     EXPECT_TRUE(request.non_predicate_columns[0].children.empty());
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: a FileReader must expose semantic children for complex file columns. If it returns a
@@ -1044,14 +1041,13 @@ TEST(ColumnMapperScanRequestTest, MaterializedMapperLocalizesMappedStructChildCo
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 
     EXPECT_TRUE(request.predicate_columns.empty());
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(5));
     EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
     EXPECT_TRUE(request.non_predicate_columns[0].children.empty());
-    EXPECT_TRUE(request.column_predicate_filters.empty());
     ASSERT_EQ(request.conjuncts.size(), 1);
 }
 
@@ -1072,14 +1068,13 @@ TEST(ColumnMapperScanRequestTest, MaterializedMapperScansFullComplexRootForOutpu
     ASSERT_TRUE(mapper.create_mapping({table_output}, {}, {file_struct}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_output}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_output}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(5));
     EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
     EXPECT_TRUE(request.non_predicate_columns[0].children.empty());
     EXPECT_TRUE(request.predicate_columns.empty());
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: array/map nested projections also scan the full top-level complex root for
@@ -1121,7 +1116,7 @@ TEST(ColumnMapperScanRequestTest, MaterializedMapperScansFullArrayAndMapRoots) {
     ASSERT_TRUE(mapper.create_mapping({table_array, table_map}, {}, {file_array, file_map}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_array, table_map}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_array, table_map}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 2);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(4));
@@ -1131,7 +1126,6 @@ TEST(ColumnMapperScanRequestTest, MaterializedMapperScansFullArrayAndMapRoots) {
     EXPECT_TRUE(request.non_predicate_columns[1].project_all_children);
     EXPECT_TRUE(request.non_predicate_columns[1].children.empty());
     EXPECT_TRUE(request.predicate_columns.empty());
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // ----------------------------------------------------------------------
@@ -1963,7 +1957,7 @@ TEST(ColumnMapperConstantTest, PhysicalRowLineageFiltersStayFinalizeOnly) {
                                        .global_indices = {GlobalIndex(1)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({row_id_table_filter, sequence_table_filter}, {},
+    ASSERT_TRUE(mapper.create_scan_request({row_id_table_filter, sequence_table_filter},
                                            table_schema, &request)
                         .ok());
 
@@ -2056,7 +2050,7 @@ TEST(ColumnMapperConstantTest, PartitionConstantFilterEntryDoesNotReadFileColumn
             .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {partition_column}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {partition_column}, &request).ok());
 
     ASSERT_EQ(mapper.filter_entries().size(), 1);
     ASSERT_TRUE(mapper.filter_entries().at(GlobalIndex(0)).is_constant());
@@ -2066,7 +2060,6 @@ TEST(ColumnMapperConstantTest, PartitionConstantFilterEntryDoesNotReadFileColumn
     EXPECT_TRUE(request.predicate_columns.empty());
     EXPECT_TRUE(request.non_predicate_columns.empty());
     EXPECT_TRUE(request.conjuncts.empty());
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 TEST(ColumnMapperConstantTest, DefaultConstantFilterEntryUsesDefaultExpression) {
@@ -2082,7 +2075,7 @@ TEST(ColumnMapperConstantTest, DefaultConstantFilterEntryUsesDefaultExpression) 
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {default_column}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {default_column}, &request).ok());
 
     ASSERT_EQ(mapper.filter_entries().size(), 1);
     ASSERT_TRUE(mapper.filter_entries().at(GlobalIndex(0)).is_constant());
@@ -2115,9 +2108,8 @@ TEST(ColumnMapperConstantTest, MixedConstantAndFileFilterKeepsOnlyFileScanColumn
             .global_indices = {GlobalIndex(1)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({constant_filter, file_filter}, {}, table_schema, &request)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({constant_filter, file_filter}, table_schema, &request)
+                        .ok());
 
     ASSERT_EQ(mapper.filter_entries().size(), 2);
     ASSERT_TRUE(mapper.filter_entries().at(GlobalIndex(0)).is_constant());
@@ -2146,7 +2138,7 @@ TEST(ColumnMapperLocalizeFiltersTest, VisibleLocalFilterAddsPredicateColumnAndCo
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.localize_filters({filter}, {}, &request).ok());
+    ASSERT_TRUE(mapper.localize_filters({filter}, &request).ok());
 
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
@@ -2178,7 +2170,7 @@ TEST(ColumnMapperLocalizeFiltersTest, ConstantFilterBuildsEntryWithoutFileScanCo
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.localize_filters({filter}, {}, &request).ok());
+    ASSERT_TRUE(mapper.localize_filters({filter}, &request).ok());
 
     EXPECT_TRUE(request.predicate_columns.empty());
     EXPECT_TRUE(request.non_predicate_columns.empty());
@@ -2188,43 +2180,6 @@ TEST(ColumnMapperLocalizeFiltersTest, ConstantFilterBuildsEntryWithoutFileScanCo
     ASSERT_TRUE(mapper.filter_entries().at(GlobalIndex(0)).is_constant());
     EXPECT_EQ(mapper.filter_entries().at(GlobalIndex(0)).constant_index(),
               mapper.mappings()[0].constant_index);
-}
-
-TEST(ColumnMapperLocalizeFiltersTest, ColumnPredicatesUseOnlyExistingLocalPositions) {
-    const auto int_type = i32();
-    const std::vector<ColumnDefinition> table_schema = {name_col("id", int_type)};
-    const std::vector<ColumnDefinition> file_schema = {name_col("id", int_type, 3)};
-
-    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
-    ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
-
-    TableColumnPredicates predicates;
-    predicates[GlobalIndex(0)] = {create_comparison_predicate<PredicateType::GT>(
-            0, "id", int_type, Field::create_field<TYPE_INT>(10), false)};
-
-    FileScanRequest request_without_local_position;
-    ASSERT_TRUE(mapper.localize_filters({}, predicates, &request_without_local_position).ok());
-    EXPECT_TRUE(request_without_local_position.column_predicate_filters.empty());
-    ASSERT_EQ(mapper.filter_entries().size(), 1);
-    EXPECT_FALSE(mapper.filter_entries().at(GlobalIndex(0)).is_local());
-
-    FileScanRequest request_with_local_position;
-    request_with_local_position.non_predicate_columns.push_back(
-            LocalColumnIndex::top_level(LocalColumnId(3)));
-    request_with_local_position.local_positions.emplace(LocalColumnId(3), LocalIndex(0));
-    ASSERT_TRUE(mapper.localize_filters({}, predicates, &request_with_local_position).ok());
-
-    ASSERT_EQ(request_with_local_position.non_predicate_columns.size(), 1);
-    EXPECT_EQ(request_with_local_position.non_predicate_columns[0].column_id(), LocalColumnId(3));
-    EXPECT_TRUE(request_with_local_position.predicate_columns.empty());
-    ASSERT_EQ(request_with_local_position.column_predicate_filters.size(), 1);
-    EXPECT_EQ(request_with_local_position.column_predicate_filters[0].file_column_id,
-              LocalColumnId(3));
-    ASSERT_EQ(request_with_local_position.column_predicate_filters[0].predicates.size(), 1);
-    EXPECT_EQ(request_with_local_position.column_predicate_filters[0].predicates[0]->type(),
-              PredicateType::GT);
-    ASSERT_TRUE(mapper.filter_entries().at(GlobalIndex(0)).is_local());
-    EXPECT_EQ(mapper.filter_entries().at(GlobalIndex(0)).local_index(), LocalIndex(0));
 }
 
 TEST(ColumnMapperLocalizeFiltersTest, NestedFilterOnlyChildMergesIntoPredicateProjection) {
@@ -2249,7 +2204,7 @@ TEST(ColumnMapperLocalizeFiltersTest, NestedFilterOnlyChildMergesIntoPredicatePr
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.localize_filters({filter}, {}, &request).ok());
+    ASSERT_TRUE(mapper.localize_filters({filter}, &request).ok());
 
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
@@ -2260,7 +2215,6 @@ TEST(ColumnMapperLocalizeFiltersTest, NestedFilterOnlyChildMergesIntoPredicatePr
     EXPECT_EQ(request.local_positions.at(LocalColumnId(5)), LocalIndex(0));
     ASSERT_TRUE(mapper.filter_entries().at(GlobalIndex(0)).is_local());
     EXPECT_EQ(mapper.filter_entries().at(GlobalIndex(0)).local_index(), LocalIndex(0));
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 TEST(ColumnMapperLocalizeFiltersTest, PreservesExistingScanStateWhenAddingPredicateColumn) {
@@ -2283,7 +2237,7 @@ TEST(ColumnMapperLocalizeFiltersTest, PreservesExistingScanStateWhenAddingPredic
     FileScanRequest request;
     request.non_predicate_columns.push_back(LocalColumnIndex::top_level(LocalColumnId(4)));
     request.local_positions.emplace(LocalColumnId(4), LocalIndex(0));
-    ASSERT_TRUE(mapper.localize_filters({filter}, {}, &request).ok());
+    ASSERT_TRUE(mapper.localize_filters({filter}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(4));
@@ -2301,37 +2255,6 @@ TEST(ColumnMapperLocalizeFiltersTest, PreservesExistingScanStateWhenAddingPredic
 // These tests assert predicate/non-predicate split, local positions, hidden
 // filter mappings, and nested predicate targets.
 // ----------------------------------------------------------------------
-
-TEST(ColumnMapperScanRequestTest, ColumnPredicatesDoNotForceRowPredicateMaterialization) {
-    const auto int_type = i32();
-    const auto string_type = str();
-    const std::vector<ColumnDefinition> table_schema = {
-            name_col("id", int_type),
-            name_col("name", string_type),
-    };
-    const std::vector<ColumnDefinition> file_schema = {
-            name_col("id", int_type, 0),
-            name_col("name", string_type, 1),
-    };
-
-    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
-    ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
-
-    TableColumnPredicates predicates;
-    predicates[GlobalIndex(0)] = {create_comparison_predicate<PredicateType::GT>(
-            0, "id", int_type, Field::create_field<TYPE_INT>(10), false)};
-
-    FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, predicates, table_schema, &request).ok());
-
-    EXPECT_TRUE(request.predicate_columns.empty());
-    EXPECT_EQ(projection_ids(request.non_predicate_columns), std::vector<int32_t>({0, 1}));
-    ASSERT_EQ(request.local_positions.size(), 2);
-    EXPECT_EQ(request.local_positions.at(LocalColumnId(0)), LocalIndex(0));
-    EXPECT_EQ(request.local_positions.at(LocalColumnId(1)), LocalIndex(1));
-    ASSERT_EQ(request.column_predicate_filters.size(), 1);
-    EXPECT_EQ(request.column_predicate_filters[0].file_column_id, LocalColumnId(0));
-}
 
 TEST(ColumnMapperScanRequestTest, HiddenTopLevelFilterMappingUsesNameFallback) {
     const auto int_type = i32();
@@ -2351,7 +2274,7 @@ TEST(ColumnMapperScanRequestTest, HiddenTopLevelFilterMappingUsesNameFallback) {
     ASSERT_TRUE(mapper.create_mapping(table_schema, {}, file_schema).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, table_schema, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, table_schema, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(0));
@@ -2383,14 +2306,13 @@ TEST(ColumnMapperScanRequestTest, StructOutputAndFilterOnlyChildAreMerged) {
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].column_id(), LocalColumnId(5));
     ASSERT_FALSE(request.predicate_columns[0].project_all_children);
     EXPECT_EQ(projection_ids(request.predicate_columns[0].children), std::vector<int32_t>({0, 1}));
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 TEST(ColumnMapperScanRequestTest, RenamedNestedPredicateTargetsMappedFileChild) {
@@ -2412,9 +2334,7 @@ TEST(ColumnMapperScanRequestTest, RenamedNestedPredicateTargetsMappedFileChild) 
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
-
-    EXPECT_TRUE(request.column_predicate_filters.empty());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 }
 
 TEST(ColumnMapperScanRequestTest, NestedInNullAndReverseComparisonFiltersAreMerged) {
@@ -2450,9 +2370,7 @@ TEST(ColumnMapperScanRequestTest, NestedInNullAndReverseComparisonFiltersAreMerg
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
-
-    EXPECT_TRUE(request.column_predicate_filters.empty());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 }
 
 TEST(ColumnMapperScanRequestTest, NestedPredicateFilterThroughSafeCast) {
@@ -2481,9 +2399,7 @@ TEST(ColumnMapperScanRequestTest, NestedPredicateFilterThroughSafeCast) {
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
-
-    EXPECT_TRUE(request.column_predicate_filters.empty());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 }
 
 TEST(ColumnMapperScanRequestTest, UnsafeCastDoesNotBuildNestedPredicateFilter) {
@@ -2511,9 +2427,7 @@ TEST(ColumnMapperScanRequestTest, UnsafeCastDoesNotBuildNestedPredicateFilter) {
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
-
-    EXPECT_TRUE(request.column_predicate_filters.empty());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].column_id(), LocalColumnId(5));
     EXPECT_EQ(projection_ids(request.predicate_columns[0].children), std::vector<int32_t>({0, 1}));
@@ -2551,9 +2465,7 @@ TEST(ColumnMapperScanRequestTest, DeepNestedPredicateTargetsLeafPath) {
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
-
-    EXPECT_TRUE(request.column_predicate_filters.empty());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 }
 
 TEST(ColumnMapperScanRequestTest, ArrayStructProjectionPrunesElementChildren) {
@@ -2576,7 +2488,7 @@ TEST(ColumnMapperScanRequestTest, ArrayStructProjectionPrunesElementChildren) {
     ASSERT_TRUE(mapper.create_mapping({table_array}, {}, {file_array}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_array}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_array}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& projection = request.non_predicate_columns[0];
@@ -2618,7 +2530,7 @@ TEST(ColumnMapperScanRequestTest, MapValueStructProjectionPrunesValueChildren) {
     ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_map}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_map}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& projection = request.non_predicate_columns[0];
@@ -2657,7 +2569,7 @@ TEST(ColumnMapperScanRequestTest, StructProjectionPrunesChildrenByName) {
     ASSERT_TRUE(mapper.create_mapping({table_struct}, {}, {file_struct}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_struct}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& projection = request.non_predicate_columns[0];
@@ -2698,14 +2610,13 @@ TEST(ColumnMapperScanRequestTest, ArrayWrapperDoesNotBuildNestedPredicateFilter)
     ASSERT_TRUE(mapper.create_mapping({table_array}, {}, {file_array}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_array}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_array}, &request).ok());
 
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].column_id(), LocalColumnId(0));
     EXPECT_TRUE(request.predicate_columns[0].project_all_children);
     EXPECT_TRUE(request.predicate_columns[0].children.empty());
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: a map value struct projects child `b`, while a row filter reads value child `a`.
@@ -2741,7 +2652,7 @@ TEST(ColumnMapperScanRequestTest, MapFilterOnlyValueChildMergesWithOutputProject
     ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_map}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_map}, &request).ok());
 
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
@@ -2751,7 +2662,6 @@ TEST(ColumnMapperScanRequestTest, MapFilterOnlyValueChildMergesWithOutputProject
     ASSERT_EQ(projection.children.size(), 1);
     EXPECT_EQ(projection.children[0].local_id(), 1);
     EXPECT_EQ(projection_ids(projection.children[0].children), std::vector<int32_t>({0, 1}));
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: when projected struct children are an in-order prefix of the file struct, the mapper can
@@ -2776,7 +2686,7 @@ TEST(ColumnMapperScanRequestTest, MatchingProjectedStructDoesNotNeedComplexRemat
     EXPECT_TRUE(mapper.mappings()[0].is_trivial);
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_struct}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& projection = request.non_predicate_columns[0];
@@ -2810,7 +2720,7 @@ TEST(ColumnMapperScanRequestTest, RenameOnlyProjectedStructDoesNotRebuildFilePro
     EXPECT_EQ(mapper.mappings()[0].child_mappings[1].file_column_name, "b");
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_struct}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
@@ -2844,7 +2754,7 @@ TEST(ColumnMapperScanRequestTest, PredicateProjectionRebuildsProjectedStructFile
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_TRUE(request.non_predicate_columns.empty());
@@ -2885,7 +2795,7 @@ TEST(ColumnMapperScanRequestTest, PredicateOnlyTopLevelColumnUsesHiddenMapping) 
                         .global_indices = {GlobalIndex(1)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_id}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_id}, &request).ok());
 
     ASSERT_EQ(mapper.mappings().size(), 1);
     EXPECT_EQ(mapper.mappings()[0].table_column_name, "id");
@@ -2898,7 +2808,6 @@ TEST(ColumnMapperScanRequestTest, PredicateOnlyTopLevelColumnUsesHiddenMapping) 
     EXPECT_TRUE(request.predicate_columns[0].children.empty());
 
     ASSERT_EQ(request.conjuncts.size(), 1);
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: a nested predicate targets a table-side renamed struct field; scan projection must
@@ -2923,9 +2832,7 @@ TEST(ColumnMapperScanRequestTest, NestedPredicateProjectionUsesMappedRenamedChil
                         .global_indices = {GlobalIndex(0)}};
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
-
-    EXPECT_TRUE(request.column_predicate_filters.empty());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_TRUE(request.predicate_columns[0].project_all_children);
     EXPECT_TRUE(request.predicate_columns[0].children.empty());
@@ -2955,7 +2862,7 @@ TEST(ColumnMapperScanRequestTest,
     ASSERT_TRUE(mapper.create_mapping({table_struct}, {}, {file_struct}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
 
     ASSERT_EQ(request.conjuncts.size(), 1);
     const auto& localized_child = request.conjuncts[0]->root()->children()[0];
@@ -3001,7 +2908,7 @@ TEST(ColumnMapperScanRequestTest, NestedElementAtConjunctUsesFileChildTypeForRen
     ASSERT_TRUE(mapper.create_mapping({table_struct}, {}, {file_struct}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_struct}, &request).ok());
     ASSERT_EQ(request.conjuncts.size(), 1);
 
     const auto& localized_leaf = request.conjuncts[0]->root()->children()[0];
@@ -3056,7 +2963,7 @@ TEST(ColumnMapperScanRequestTest, NestedElementAtConjunctUsesMergedScanProjectio
     ASSERT_TRUE(mapper.create_mapping({projected_table_struct}, {}, {file_struct}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {projected_table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {projected_table_struct}, &request).ok());
     ASSERT_EQ(request.conjuncts.size(), 1);
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].column_id(), LocalColumnId(10));
@@ -3112,7 +3019,7 @@ TEST(ColumnMapperScanRequestTest, MapValuesStructChildConjunctStaysTableLevel) {
     ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_map}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_map}, &request).ok());
 
     EXPECT_TRUE(request.conjuncts.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
@@ -3120,7 +3027,6 @@ TEST(ColumnMapperScanRequestTest, MapValuesStructChildConjunctStaysTableLevel) {
     ASSERT_FALSE(request.predicate_columns[0].project_all_children);
     ASSERT_EQ(request.predicate_columns[0].children.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].children[0].local_id(), 1);
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: MAP_KEYS only reads map keys, but localizing it by wrapping the evolved file map slot
@@ -3156,13 +3062,12 @@ TEST(ColumnMapperScanRequestTest, MapKeysConjunctWithEvolvedValueStructStaysTabl
     ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, {table_map}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_map}, &request).ok());
 
     EXPECT_TRUE(request.conjuncts.empty());
     EXPECT_TRUE(request.non_predicate_columns.empty());
     ASSERT_EQ(request.predicate_columns.size(), 1);
     EXPECT_EQ(request.predicate_columns[0].column_id(), LocalColumnId(1));
-    EXPECT_TRUE(request.column_predicate_filters.empty());
 }
 
 // Scenario: an array element struct projection only contains missing/default children; the mapper
@@ -3184,7 +3089,7 @@ TEST(ColumnMapperScanRequestTest, ArrayStructOnlyMissingElementChildUsesFullFile
     ASSERT_TRUE(mapper.create_mapping({table_array}, {}, {file_array}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_array}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_array}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(10));
@@ -3215,7 +3120,7 @@ TEST(ColumnMapperScanRequestTest, MapValueStructOnlyMissingChildUsesFullValuePro
     ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_map}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_map}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& projection = request.non_predicate_columns[0];
@@ -3255,7 +3160,7 @@ TEST(ColumnMapperSchemaEvolutionTest, StructChildrenHandleMissingRenameReorderAn
     TableColumnMapper v1_mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(v1_mapper.create_mapping({table_struct}, {}, {file_v1}).ok());
     FileScanRequest v1_request;
-    ASSERT_TRUE(v1_mapper.create_scan_request({}, {}, {table_struct}, &v1_request).ok());
+    ASSERT_TRUE(v1_mapper.create_scan_request({}, {table_struct}, &v1_request).ok());
 
     const auto& v1_mapping = v1_mapper.mappings()[0];
     ASSERT_EQ(v1_mapping.child_mappings.size(), 3);
@@ -3269,7 +3174,7 @@ TEST(ColumnMapperSchemaEvolutionTest, StructChildrenHandleMissingRenameReorderAn
     TableColumnMapper v2_mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(v2_mapper.create_mapping({table_struct}, {}, {file_v2}).ok());
     FileScanRequest v2_request;
-    ASSERT_TRUE(v2_mapper.create_scan_request({}, {}, {table_struct}, &v2_request).ok());
+    ASSERT_TRUE(v2_mapper.create_scan_request({}, {table_struct}, &v2_request).ok());
 
     const auto& v2_mapping = v2_mapper.mappings()[0];
     ASSERT_EQ(v2_mapping.child_mappings.size(), 3);
@@ -3296,7 +3201,7 @@ TEST(ColumnMapperSchemaEvolutionTest, DroppedStructChildrenAreNotRead) {
     ASSERT_TRUE(mapper.create_mapping({table_struct}, {}, {file_struct}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({}, {}, {table_struct}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_struct}, &request).ok());
 
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& projection = request.non_predicate_columns[0];
@@ -3348,7 +3253,7 @@ TEST_F(ColumnMapperCastTest, ColumnMapperBuildsCastProjectionForTypeMismatch) {
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_EQ(mapper.mappings().size(), 1);
     FileScanRequest file_request;
-    status = mapper.create_scan_request({}, {}, projected_columns, &file_request);
+    status = mapper.create_scan_request({}, projected_columns, &file_request);
     ASSERT_TRUE(status.ok()) << status;
     const auto& mapping = mapper.mappings()[0];
     EXPECT_FALSE(mapping.is_trivial);
@@ -3402,9 +3307,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperBuildsCastFilterForTypeMismatch) {
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     ASSERT_EQ(projection_ids(file_request.predicate_columns), std::vector<int32_t>({0}));
     const auto& localized_expr = file_request.conjuncts[0]->root();
@@ -3459,9 +3363,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperRepreparesRewrittenPreparedFilter) {
     ASSERT_TRUE(status.ok()) << status;
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     const auto& localized_expr = file_request.conjuncts[0]->root();
     ASSERT_NE(dynamic_cast<const Cast*>(localized_expr.get()), nullptr);
@@ -3499,9 +3402,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperCastsLiteralForSlotLiteralPredicateType
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     ASSERT_EQ(projection_ids(file_request.predicate_columns), std::vector<int32_t>({0}));
     const auto& localized_expr = file_request.conjuncts[0]->root();
@@ -3553,9 +3455,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperCastsLiteralForLiteralSlotPredicateType
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     const auto& localized_expr = file_request.conjuncts[0]->root();
     ASSERT_EQ(localized_expr->get_num_children(), 2);
@@ -3608,9 +3509,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperCastsInPredicateLiteralsForTypeMismatch
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     ASSERT_EQ(projection_ids(file_request.predicate_columns), std::vector<int32_t>({0}));
     const auto& localized_expr = file_request.conjuncts[0]->root();
@@ -3647,9 +3547,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperFallsBackToSlotCastWhenInPredicateLiter
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     const auto& localized_expr = file_request.conjuncts[0]->root();
     ASSERT_EQ(localized_expr->get_num_children(), 3);
@@ -3685,10 +3584,9 @@ TEST_F(ColumnMapperCastTest, ColumnMapperDoesNotLeakRewrittenInPredicateLiteralA
     TableColumnMapper int_mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(int_mapper.create_mapping(projected_columns, {}, {int_file_field}).ok());
     FileScanRequest int_request;
-    ASSERT_TRUE(int_mapper
-                        .create_scan_request({table_filter}, {}, projected_columns, &int_request,
-                                             &state)
-                        .ok());
+    ASSERT_TRUE(
+            int_mapper.create_scan_request({table_filter}, projected_columns, &int_request, &state)
+                    .ok());
     ASSERT_EQ(int_request.conjuncts.size(), 1);
     const auto& int_localized_expr = int_request.conjuncts[0]->root();
     ASSERT_EQ(int_localized_expr->get_num_children(), 3);
@@ -3701,10 +3599,10 @@ TEST_F(ColumnMapperCastTest, ColumnMapperDoesNotLeakRewrittenInPredicateLiteralA
     TableColumnMapper bigint_mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(bigint_mapper.create_mapping(projected_columns, {}, {bigint_file_field}).ok());
     FileScanRequest bigint_request;
-    ASSERT_TRUE(bigint_mapper
-                        .create_scan_request({table_filter}, {}, projected_columns, &bigint_request,
-                                             &state)
-                        .ok());
+    ASSERT_TRUE(
+            bigint_mapper
+                    .create_scan_request({table_filter}, projected_columns, &bigint_request, &state)
+                    .ok());
     ASSERT_EQ(bigint_request.conjuncts.size(), 1);
     const auto& bigint_localized_expr = bigint_request.conjuncts[0]->root();
     ASSERT_EQ(bigint_localized_expr->get_num_children(), 3);
@@ -3739,9 +3637,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperFallsBackToSlotCastWhenLiteralRewriteFa
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     const auto& localized_expr = file_request.conjuncts[0]->root();
     ASSERT_EQ(localized_expr->get_num_children(), 2);
@@ -3773,10 +3670,9 @@ TEST_F(ColumnMapperCastTest, ColumnMapperDoesNotLeakRewrittenLiteralAcrossSplits
     TableColumnMapper int_mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(int_mapper.create_mapping(projected_columns, {}, {int_file_field}).ok());
     FileScanRequest int_request;
-    ASSERT_TRUE(int_mapper
-                        .create_scan_request({table_filter}, {}, projected_columns, &int_request,
-                                             &state)
-                        .ok());
+    ASSERT_TRUE(
+            int_mapper.create_scan_request({table_filter}, projected_columns, &int_request, &state)
+                    .ok());
     ASSERT_EQ(int_request.conjuncts.size(), 1);
     const auto& int_localized_expr = int_request.conjuncts[0]->root();
     ASSERT_EQ(int_localized_expr->get_num_children(), 2);
@@ -3787,10 +3683,10 @@ TEST_F(ColumnMapperCastTest, ColumnMapperDoesNotLeakRewrittenLiteralAcrossSplits
     TableColumnMapper bigint_mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(bigint_mapper.create_mapping(projected_columns, {}, {bigint_file_field}).ok());
     FileScanRequest bigint_request;
-    ASSERT_TRUE(bigint_mapper
-                        .create_scan_request({table_filter}, {}, projected_columns, &bigint_request,
-                                             &state)
-                        .ok());
+    ASSERT_TRUE(
+            bigint_mapper
+                    .create_scan_request({table_filter}, projected_columns, &bigint_request, &state)
+                    .ok());
     ASSERT_EQ(bigint_request.conjuncts.size(), 1);
     const auto& bigint_localized_expr = bigint_request.conjuncts[0]->root();
     ASSERT_EQ(bigint_localized_expr->get_num_children(), 2);
@@ -3825,9 +3721,8 @@ TEST_F(ColumnMapperCastTest, ColumnMapperKeepsExplicitSlotCastInSlotLiteralPredi
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request, &state)
-                    .ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request, &state)
+                        .ok());
     ASSERT_EQ(file_request.conjuncts.size(), 1);
     const auto& localized_expr = file_request.conjuncts[0]->root();
     ASSERT_EQ(localized_expr->get_num_children(), 2);
@@ -3861,13 +3756,13 @@ TEST_F(ColumnMapperCastTest, ColumnMapperDoesNotNestCastFilterAcrossScanRequests
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest first_request;
-    ASSERT_TRUE(mapper.create_scan_request({table_filter}, {}, projected_columns, &first_request,
-                                           &state)
-                        .ok());
+    ASSERT_TRUE(
+            mapper.create_scan_request({table_filter}, projected_columns, &first_request, &state)
+                    .ok());
     FileScanRequest second_request;
-    ASSERT_TRUE(mapper.create_scan_request({table_filter}, {}, projected_columns, &second_request,
-                                           &state)
-                        .ok());
+    ASSERT_TRUE(
+            mapper.create_scan_request({table_filter}, projected_columns, &second_request, &state)
+                    .ok());
 
     ASSERT_EQ(second_request.conjuncts.size(), 1);
     const auto& localized_expr = second_request.conjuncts[0]->root();
@@ -3895,10 +3790,9 @@ TEST_F(ColumnMapperCastTest, ColumnMapperRewritesPreviousCastFilterToMatchingSpl
     TableColumnMapper int_mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(int_mapper.create_mapping(projected_columns, {}, {int_file_field}).ok());
     FileScanRequest int_request;
-    ASSERT_TRUE(int_mapper
-                        .create_scan_request({table_filter}, {}, projected_columns, &int_request,
-                                             &state)
-                        .ok());
+    ASSERT_TRUE(
+            int_mapper.create_scan_request({table_filter}, projected_columns, &int_request, &state)
+                    .ok());
 
     const auto& int_localized_expr = int_request.conjuncts[0]->root();
     ASSERT_EQ(int_localized_expr->get_num_children(), 1);
@@ -3909,10 +3803,10 @@ TEST_F(ColumnMapperCastTest, ColumnMapperRewritesPreviousCastFilterToMatchingSpl
     TableColumnMapper bigint_mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(bigint_mapper.create_mapping(projected_columns, {}, {bigint_file_field}).ok());
     FileScanRequest bigint_request;
-    ASSERT_TRUE(bigint_mapper
-                        .create_scan_request({table_filter}, {}, projected_columns, &bigint_request,
-                                             &state)
-                        .ok());
+    ASSERT_TRUE(
+            bigint_mapper
+                    .create_scan_request({table_filter}, projected_columns, &bigint_request, &state)
+                    .ok());
 
     const auto& bigint_localized_expr = bigint_request.conjuncts[0]->root();
     ASSERT_EQ(bigint_localized_expr->get_num_children(), 1);
@@ -3956,7 +3850,7 @@ TEST_F(ColumnMapperCastTest, ColumnMapperKeepsTableSlotIdWhenFileBlockPositionCh
     table_filter.global_indices = {GlobalIndex(0)};
 
     FileScanRequest first_request;
-    ASSERT_TRUE(mapper.localize_filters({table_filter}, {}, &first_request, &state).ok());
+    ASSERT_TRUE(mapper.localize_filters({table_filter}, &first_request, &state).ok());
     ASSERT_EQ(first_request.conjuncts.size(), 1);
     const auto* first_slot =
             assert_cast<const VSlotRef*>(first_request.conjuncts[0]->root()->children()[0].get());
@@ -3967,7 +3861,7 @@ TEST_F(ColumnMapperCastTest, ColumnMapperKeepsTableSlotIdWhenFileBlockPositionCh
     second_request.local_positions.emplace(LocalColumnId(9), LocalIndex(0));
     second_request.local_positions.emplace(LocalColumnId(10), LocalIndex(1));
     second_request.non_predicate_columns.push_back(LocalColumnIndex::top_level(LocalColumnId(9)));
-    ASSERT_TRUE(mapper.localize_filters({table_filter}, {}, &second_request, &state).ok());
+    ASSERT_TRUE(mapper.localize_filters({table_filter}, &second_request, &state).ok());
     ASSERT_EQ(second_request.conjuncts.size(), 1);
     const auto* second_slot =
             assert_cast<const VSlotRef*>(second_request.conjuncts[0]->root()->children()[0].get());

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1405,7 +1405,7 @@ TEST_F(NewParquetReaderTest, EmptySelectionUpdatesProfileCounters) {
     auto request = std::make_shared<format::FileScanRequest>();
     request->predicate_columns = {field_projection(0)};
     request->non_predicate_columns = {field_projection(1)};
-    request->conjuncts.push_back(create_int32_greater_than_conjunct(0, 10));
+    request->conjuncts.push_back(create_int32_sum_greater_than_conjunct(0, 0, 10));
     use_schema_order_positions(request.get(), schema);
     ASSERT_TRUE(reader->open(request).ok());
 

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1757,6 +1757,7 @@ TEST_F(NewParquetReaderTest, PlannerNarrowsRowRangesByPageIndex) {
     ASSERT_EQ(file_schema.size(), 1);
 
     format::FileScanRequest request;
+    request.predicate_columns = {field_projection(0)};
     request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
     request.conjuncts.push_back(create_int32_greater_than_conjunct(0, 63));
 

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -60,7 +61,8 @@
 #include "gen_cpp/Types_types.h"
 #include "io/io_common.h"
 #include "runtime/runtime_state.h"
-#include "storage/predicate/predicate_creator.h"
+#include "storage/index/zone_map/zonemap_eval_context.h"
+#include "storage/index/zone_map/zonemap_filter_result.h"
 #include "storage/segment/condition_cache.h"
 #include "storage/utils.h"
 
@@ -114,6 +116,25 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
+    bool can_evaluate_zonemap_filter() const override { return true; }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_column_id);
+    }
+
+    ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
+        auto zone_map = ctx.zone_map(_column_id);
+        if (zone_map == nullptr) {
+            return unsupported_zonemap_filter(ctx);
+        }
+        if (!zone_map->has_not_null) {
+            return ZoneMapFilterResult::kNoMatch;
+        }
+        const auto literal = Field::create_field<TYPE_INT>(_value);
+        return zone_map->max_value <= literal ? ZoneMapFilterResult::kNoMatch
+                                              : ZoneMapFilterResult::kMayMatch;
+    }
+
 private:
     const int _column_id;
     const int32_t _value;
@@ -146,6 +167,11 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_left_column_id);
+        column_ids.insert(_right_column_id);
+    }
+
 private:
     const int _left_column_id;
     const int _right_column_id;
@@ -176,6 +202,29 @@ public:
     }
 
     const std::string& expr_name() const override { return _expr_name; }
+
+    bool can_evaluate_dictionary_filter() const override { return true; }
+
+    ZoneMapFilterResult evaluate_dictionary_filter(
+            const DictionaryEvalContext& ctx) const override {
+        const auto* dictionary = ctx.slot(_column_id);
+        if (dictionary == nullptr) {
+            return ZoneMapFilterResult::kUnsupported;
+        }
+        for (const auto& value : _values) {
+            const auto field = Field::create_field<TYPE_STRING>(value);
+            for (const auto& dictionary_value : dictionary->values) {
+                if (dictionary_value == field) {
+                    return ZoneMapFilterResult::kMayMatch;
+                }
+            }
+        }
+        return ZoneMapFilterResult::kNoMatch;
+    }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_column_id);
+    }
 
 private:
     const int _column_id;
@@ -1213,11 +1262,6 @@ TEST_F(NewParquetReaderTest, ReadPredicateAndNonPredicateColumnsWithSelection) {
     request->predicate_columns = {field_projection(0)};
     request->non_predicate_columns = {field_projection(1)};
     request->conjuncts.push_back(create_int32_greater_than_conjunct(0, 2));
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(2), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     size_t rows = 0;
@@ -1318,7 +1362,7 @@ TEST_F(NewParquetReaderTest, GlobalRowIdSchemaAndSelectionUseFileRowPosition) {
     }
 }
 
-TEST_F(NewParquetReaderTest, ColumnPredicateOnlyPrunesAndDoesNotFilterRowsInsideRowGroup) {
+TEST_F(NewParquetReaderTest, ScanWithoutConjunctDoesNotFilterRowsInsideRowGroup) {
     auto reader = create_reader();
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     ASSERT_TRUE(reader->init(&state).ok());
@@ -1330,11 +1374,6 @@ TEST_F(NewParquetReaderTest, ColumnPredicateOnlyPrunesAndDoesNotFilterRowsInside
     auto request = std::make_shared<format::FileScanRequest>();
     request->predicate_columns = {field_projection(0)};
     request->non_predicate_columns = {field_projection(1)};
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(2), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     size_t rows = 0;
@@ -1502,11 +1541,6 @@ TEST_F(NewParquetReaderTest, PredicateFiltersRowGroupsByStatistics) {
     request->predicate_columns = {field_projection(0)};
     request->non_predicate_columns = {field_projection(1)};
     request->conjuncts.push_back(create_int32_greater_than_conjunct(0, 2));
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(2), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     std::vector<int32_t> ids;
@@ -1553,12 +1587,8 @@ TEST_F(NewParquetReaderTest, PredicateFiltersRowGroupsByDictionary) {
     ASSERT_EQ(file_schema.size(), 2);
 
     format::FileScanRequest plan_request;
-    format::FileColumnPredicateFilter plan_column_filter;
-    plan_column_filter.file_column_id = format::LocalColumnId(1);
-    auto value_type = std::make_shared<DataTypeString>();
-    plan_column_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            1, "value", value_type, Field::create_field<TYPE_STRING>("lm"), false));
-    plan_request.column_predicate_filters.push_back(std::move(plan_column_filter));
+    plan_request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    plan_request.conjuncts.push_back(create_string_in_conjunct(1, {"lm"}));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -1583,11 +1613,6 @@ TEST_F(NewParquetReaderTest, PredicateFiltersRowGroupsByDictionary) {
     request->non_predicate_columns = {field_projection(0)};
     request->conjuncts.push_back(create_string_in_conjunct(1, {"lm"}));
     use_schema_order_positions(request.get(), schema);
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(1);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            1, "value", schema[1].type, Field::create_field<TYPE_STRING>("lm"), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     std::vector<int32_t> ids;
@@ -1624,12 +1649,8 @@ TEST_F(NewParquetReaderTest, ScanRangeFiltersRowGroupsBeforeDictionaryPruning) {
             format::parquet::build_parquet_column_schema(*schema_descriptor, &file_schema).ok());
 
     format::FileScanRequest request;
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(1);
-    auto value_type = std::make_shared<DataTypeString>();
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            1, "value", value_type, Field::create_field<TYPE_STRING>("lm"), false));
-    request.column_predicate_filters.push_back(std::move(column_filter));
+    request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    request.conjuncts.push_back(create_string_in_conjunct(1, {"lm"}));
 
     const auto [range_start_offset, range_size] = row_group_mid_range(_file_path, 2);
     format::parquet::ParquetScanRange scan_range;
@@ -1665,12 +1686,6 @@ TEST_F(NewParquetReaderTest, NestedStructPredicateDoesNotFilterRowGroupsByStatis
     ASSERT_EQ(file_schema[0]->children[0]->name, "id");
 
     format::FileScanRequest request;
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    auto id_type = std::make_shared<DataTypeInt32>();
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", id_type, Field::create_field<TYPE_INT>(5), false));
-    request.column_predicate_filters.push_back(std::move(column_filter));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -1708,12 +1723,6 @@ TEST_F(NewParquetReaderTest, NestedStructPredicateDoesNotFilterRowGroupsByDictio
     ASSERT_EQ(file_schema[0]->children[1]->name, "name");
 
     format::FileScanRequest request;
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    auto name_type = std::make_shared<DataTypeString>();
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            0, "name", name_type, Field::create_field<TYPE_STRING>("lm"), false));
-    request.column_predicate_filters.push_back(std::move(column_filter));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -1748,12 +1757,8 @@ TEST_F(NewParquetReaderTest, PlannerNarrowsRowRangesByPageIndex) {
     ASSERT_EQ(file_schema.size(), 1);
 
     format::FileScanRequest request;
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    auto id_type = std::make_shared<DataTypeInt32>();
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", id_type, Field::create_field<TYPE_INT>(63), false));
-    request.column_predicate_filters.push_back(std::move(column_filter));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(create_int32_greater_than_conjunct(0, 63));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -1808,12 +1813,8 @@ TEST_F(NewParquetReaderTest, NestedStructPredicateDoesNotNarrowRowRangesByPageIn
     ASSERT_EQ(file_schema[0]->children[0]->name, "id");
 
     format::FileScanRequest request;
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    auto id_type = std::make_shared<DataTypeInt32>();
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", id_type, Field::create_field<TYPE_INT>(63), false));
-    request.column_predicate_filters.push_back(std::move(column_filter));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(create_int32_greater_than_conjunct(0, 63));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -1850,11 +1851,6 @@ TEST_F(NewParquetReaderTest, PageIndexFilteredPagesDoNotDoubleSkipOutputColumns)
     request->predicate_columns = {field_projection(0)};
     request->non_predicate_columns = {field_projection(1)};
     request->conjuncts.push_back(create_int32_greater_than_conjunct(0, 63));
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(63), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     std::vector<int32_t> ids;
@@ -1914,14 +1910,6 @@ TEST_F(NewParquetReaderTest, InPredicateFiltersRowGroupsByDictionary) {
     request->non_predicate_columns = {field_projection(0)};
     request->conjuncts.push_back(create_string_in_conjunct(1, {"az", "za"}));
     use_schema_order_positions(request.get(), schema);
-    auto set = build_set<TYPE_STRING>();
-    set->insert(const_cast<char*>("az"), 2);
-    set->insert(const_cast<char*>("za"), 2);
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(1);
-    column_filter.predicates.push_back(create_in_list_predicate<PredicateType::IN_LIST>(
-            1, "value", schema[1].type, set, false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     std::vector<int32_t> ids;
@@ -1967,14 +1955,6 @@ TEST_F(NewParquetReaderTest, DictionaryPageV2StringEdgesSurviveSelection) {
     request->non_predicate_columns = {field_projection(0)};
     request->conjuncts.push_back(create_string_in_conjunct(1, {"", "same"}));
     use_schema_order_positions(request.get(), schema);
-    auto set = build_set<TYPE_STRING>();
-    set->insert(const_cast<char*>(""), 0);
-    set->insert(const_cast<char*>("same"), 4);
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(1);
-    column_filter.predicates.push_back(create_in_list_predicate<PredicateType::IN_LIST>(
-            1, "value", schema[1].type, set, false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     std::vector<int32_t> ids;
@@ -2014,11 +1994,6 @@ TEST_F(NewParquetReaderTest, StatisticsPruningSkipsPrefixRowGroupsAndReadsLaterG
     request->predicate_columns = {field_projection(0)};
     request->non_predicate_columns = {field_projection(1)};
     request->conjuncts.push_back(create_int32_greater_than_conjunct(0, 3));
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GE>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(4), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
     ASSERT_TRUE(reader->open(request).ok());
 
     std::vector<int32_t> ids;

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -88,9 +88,28 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
-    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
-                               ColumnPtr&) const override {
-        return Status::InternalError("Int32ZoneMapExpr is only used by parquet scan tests");
+    Status execute_column_impl(VExprContext*, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
+        DORIS_CHECK(block != nullptr);
+        DORIS_CHECK(selector == nullptr);
+        DORIS_CHECK(_column_id >= 0 && _column_id < static_cast<int>(block->columns()));
+        const auto& data_column = int32_data_column(*block->get_by_position(_column_id).column);
+        DORIS_CHECK(data_column.size() >= count);
+
+        auto result = ColumnUInt8::create(count, 0);
+        auto& result_data = result->get_data();
+        for (size_t row = 0; row < count; ++row) {
+            const auto value = data_column.get_element(row);
+            if (_op == Op::GE) {
+                result_data[row] = value >= _value;
+            } else if (_op == Op::GT) {
+                result_data[row] = value > _value;
+            } else {
+                result_data[row] = value < _value;
+            }
+        }
+        result_column = std::move(result);
+        return Status::OK();
     }
 
     bool can_evaluate_zonemap_filter() const override { return true; }
@@ -449,7 +468,8 @@ TEST_F(ParquetScanTest, PageIndexIntersectsMultipleFiltersAndBuildsSkipPlan) {
     auto file_schema = build_file_schema(*parquet_file_reader);
 
     format::FileScanRequest single_filter_request;
-    single_filter_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    format::FileScanRequestBuilder single_filter_builder(&single_filter_request);
+    ASSERT_TRUE(single_filter_builder.add_predicate_column(format::LocalColumnId(0)).ok());
     single_filter_request.conjuncts.push_back(
             create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 32));
     format::parquet::RowGroupScanPlan single_filter_plan;
@@ -463,8 +483,9 @@ TEST_F(ParquetScanTest, PageIndexIntersectsMultipleFiltersAndBuildsSkipPlan) {
             count_range_rows(single_filter_plan.row_groups[0].selected_ranges);
 
     format::FileScanRequest intersect_request;
-    intersect_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
-    intersect_request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    format::FileScanRequestBuilder intersect_builder(&intersect_request);
+    ASSERT_TRUE(intersect_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(intersect_builder.add_predicate_column(format::LocalColumnId(1)).ok());
     intersect_request.conjuncts.push_back(
             create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 32));
     intersect_request.conjuncts.push_back(
@@ -791,8 +812,8 @@ TEST_F(ParquetScanTest, ProfileCountersReflectPageIndexAndRangeGapPruning) {
     std::vector<format::ColumnDefinition> schema;
     ASSERT_TRUE(reader->get_schema(&schema).ok());
     auto request = std::make_shared<format::FileScanRequest>();
-    request->non_predicate_columns = {field_projection(0)};
-    use_schema_order_positions(request.get(), schema);
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
     request->conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GT, 63));
     ASSERT_TRUE(reader->open(request).ok());
 

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -41,6 +42,8 @@
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/field.h"
+#include "exprs/vexpr.h"
+#include "exprs/vexpr_context.h"
 #include "format_v2/file_reader.h"
 #include "format_v2/parquet/parquet_column_schema.h"
 #include "format_v2/parquet/parquet_reader.h"
@@ -48,7 +51,8 @@
 #include "gen_cpp/Types_types.h"
 #include "io/io_common.h"
 #include "runtime/runtime_state.h"
-#include "storage/predicate/predicate_creator.h"
+#include "storage/index/zone_map/zonemap_eval_context.h"
+#include "storage/index/zone_map/zonemap_filter_result.h"
 #include "storage/utils.h"
 
 namespace doris {
@@ -70,6 +74,57 @@ const ColumnString& string_data_column(const IColumn& column) {
         return assert_cast<const ColumnString&>(nullable_column->get_nested_column());
     }
     return assert_cast<const ColumnString&>(column);
+}
+
+class Int32ZoneMapExpr final : public VExpr {
+public:
+    enum class Op { GE, GT, LT };
+
+    Int32ZoneMapExpr(int column_id, Op op, int32_t value)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _column_id(column_id),
+              _op(op),
+              _value(value) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+
+    bool can_evaluate_zonemap_filter() const override { return true; }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_column_id);
+    }
+
+    ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
+        auto zone_map = ctx.zone_map(_column_id);
+        if (zone_map == nullptr) {
+            return unsupported_zonemap_filter(ctx);
+        }
+        if (!zone_map->has_not_null) {
+            return ZoneMapFilterResult::kNoMatch;
+        }
+        const auto literal = Field::create_field<TYPE_INT>(_value);
+        if (_op == Op::GE) {
+            return zone_map->max_value < literal ? ZoneMapFilterResult::kNoMatch
+                                                 : ZoneMapFilterResult::kMayMatch;
+        }
+        if (_op == Op::GT) {
+            return zone_map->max_value <= literal ? ZoneMapFilterResult::kNoMatch
+                                                  : ZoneMapFilterResult::kMayMatch;
+        }
+        return zone_map->min_value >= literal ? ZoneMapFilterResult::kNoMatch
+                                              : ZoneMapFilterResult::kMayMatch;
+    }
+
+private:
+    int _column_id;
+    Op _op;
+    int32_t _value;
+    const std::string _expr_name = "Int32ZoneMapExpr";
+};
+
+VExprContextSPtr create_int32_zonemap_conjunct(int column_id, Int32ZoneMapExpr::Op op,
+                                               int32_t value) {
+    return VExprContext::create_shared(std::make_shared<Int32ZoneMapExpr>(column_id, op, value));
 }
 
 std::shared_ptr<arrow::Array> finish_array(arrow::ArrayBuilder* builder) {
@@ -254,30 +309,6 @@ std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> build_file_sc
     return file_schema;
 }
 
-format::FileColumnPredicateFilter int32_filter(int32_t column_id, std::string column_name,
-                                               const DataTypePtr& type,
-                                               PredicateType predicate_type, int32_t value) {
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(column_id);
-    switch (predicate_type) {
-    case PredicateType::GE:
-        column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GE>(
-                column_id, column_name, type, Field::create_field<TYPE_INT>(value), false));
-        break;
-    case PredicateType::GT:
-        column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-                column_id, column_name, type, Field::create_field<TYPE_INT>(value), false));
-        break;
-    case PredicateType::LT:
-        column_filter.predicates.push_back(create_comparison_predicate<PredicateType::LT>(
-                column_id, column_name, type, Field::create_field<TYPE_INT>(value), false));
-        break;
-    default:
-        DORIS_CHECK(false);
-    }
-    return column_filter;
-}
-
 int64_t count_range_rows(const std::vector<format::parquet::RowRange>& ranges) {
     int64_t rows = 0;
     for (const auto& range : ranges) {
@@ -330,8 +361,8 @@ TEST_F(ParquetScanTest, PlanRowGroupsAppliesScanRangeBeforeStatistics) {
     auto file_schema = build_file_schema(*parquet_file_reader);
 
     format::FileScanRequest request;
-    request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::GE, 5));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 5));
 
     const auto [range_start_offset, range_size] = row_group_mid_range(_file_path, 1);
     format::parquet::ParquetScanRange scan_range;
@@ -358,8 +389,8 @@ TEST_F(ParquetScanTest, PlanRowGroupsPreservesFirstFileRowAcrossPrunedRowGroups)
     auto file_schema = build_file_schema(*parquet_file_reader);
 
     format::FileScanRequest request;
-    request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::GE, 5));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 5));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -413,8 +444,9 @@ TEST_F(ParquetScanTest, PageIndexIntersectsMultipleFiltersAndBuildsSkipPlan) {
     auto file_schema = build_file_schema(*parquet_file_reader);
 
     format::FileScanRequest single_filter_request;
-    single_filter_request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::GE, 32));
+    single_filter_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    single_filter_request.conjuncts.push_back(
+            create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 32));
     format::parquet::RowGroupScanPlan single_filter_plan;
     format::parquet::ParquetScanRange scan_range;
     ASSERT_TRUE(format::parquet::plan_parquet_row_groups(
@@ -426,10 +458,12 @@ TEST_F(ParquetScanTest, PageIndexIntersectsMultipleFiltersAndBuildsSkipPlan) {
             count_range_rows(single_filter_plan.row_groups[0].selected_ranges);
 
     format::FileScanRequest intersect_request;
-    intersect_request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::GE, 32));
-    intersect_request.column_predicate_filters.push_back(
-            int32_filter(1, "score", file_schema[1]->type, PredicateType::LT, 96));
+    intersect_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    intersect_request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    intersect_request.conjuncts.push_back(
+            create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 32));
+    intersect_request.conjuncts.push_back(
+            create_int32_zonemap_conjunct(1, Int32ZoneMapExpr::Op::LT, 96));
     format::parquet::RowGroupScanPlan intersect_plan;
     ASSERT_TRUE(format::parquet::plan_parquet_row_groups(
                         *parquet_file_reader->metadata(), parquet_file_reader.get(), file_schema,
@@ -463,10 +497,9 @@ TEST_F(ParquetScanTest, PageIndexCanFullyFilterRowGroupAfterRangeIntersection) {
     auto file_schema = build_file_schema(*parquet_file_reader);
 
     format::FileScanRequest request;
-    request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::GE, 32));
-    request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::LT, 32));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 32));
+    request.conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::LT, 32));
 
     format::parquet::RowGroupScanPlan plan;
     format::parquet::ParquetScanRange scan_range;
@@ -488,8 +521,8 @@ TEST_F(ParquetScanTest, PageIndexFullRangeWhenDisabledOrUnavailable) {
     auto file_schema = build_file_schema(*parquet_file_reader);
 
     format::FileScanRequest request;
-    request.column_predicate_filters.push_back(
-            int32_filter(0, "id", file_schema[0]->type, PredicateType::GT, 63));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GT, 63));
 
     const bool old_enable_page_index = config::enable_parquet_page_index;
     config::enable_parquet_page_index = false;
@@ -511,8 +544,9 @@ TEST_F(ParquetScanTest, PageIndexFullRangeWhenDisabledOrUnavailable) {
     auto no_index_reader = ::parquet::ParquetFileReader::OpenFile(_file_path, false);
     auto no_index_schema = build_file_schema(*no_index_reader);
     format::FileScanRequest no_index_request;
-    no_index_request.column_predicate_filters.push_back(
-            int32_filter(0, "id", no_index_schema[0]->type, PredicateType::GT, 3));
+    no_index_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    no_index_request.conjuncts.push_back(
+            create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GT, 3));
     selected_ranges.clear();
     page_skip_plans.clear();
     pruning_stats = {};
@@ -562,14 +596,9 @@ TEST_F(ParquetScanTest, AggregateRespectsStatisticsPrunedRowGroups) {
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     ASSERT_TRUE(reader->init(&state).ok());
 
-    std::vector<format::ColumnDefinition> schema;
-    ASSERT_TRUE(reader->get_schema(&schema).ok());
     auto request = std::make_shared<format::FileScanRequest>();
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GE>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(5), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
+    request->local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request->conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 5));
     ASSERT_TRUE(reader->open(request).ok());
 
     format::FileAggregateRequest aggregate_request;
@@ -589,14 +618,9 @@ TEST_F(ParquetScanTest, AggregateCountKeepsRowGroupRowsAfterPageIndexPruning) {
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     ASSERT_TRUE(reader->init(&state).ok());
 
-    std::vector<format::ColumnDefinition> schema;
-    ASSERT_TRUE(reader->get_schema(&schema).ok());
     auto request = std::make_shared<format::FileScanRequest>();
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(63), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
+    request->local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request->conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GT, 63));
     ASSERT_TRUE(reader->open(request).ok());
 
     format::FileAggregateRequest aggregate_request;
@@ -719,11 +743,8 @@ TEST_F(ParquetScanTest, EmptyScanPlanReturnsEofWithoutReadingColumns) {
     std::vector<format::ColumnDefinition> schema;
     ASSERT_TRUE(reader->get_schema(&schema).ok());
     auto request = std::make_shared<format::FileScanRequest>();
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GE>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(100), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
+    request->local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request->conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GE, 100));
     ASSERT_TRUE(reader->open(request).ok());
 
     Block block = build_file_block(schema);
@@ -767,11 +788,7 @@ TEST_F(ParquetScanTest, ProfileCountersReflectPageIndexAndRangeGapPruning) {
     auto request = std::make_shared<format::FileScanRequest>();
     request->non_predicate_columns = {field_projection(0)};
     use_schema_order_positions(request.get(), schema);
-    format::FileColumnPredicateFilter column_filter;
-    column_filter.file_column_id = format::LocalColumnId(0);
-    column_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "id", schema[0].type, Field::create_field<TYPE_INT>(63), false));
-    request->column_predicate_filters.push_back(std::move(column_filter));
+    request->conjuncts.push_back(create_int32_zonemap_conjunct(0, Int32ZoneMapExpr::Op::GT, 63));
     ASSERT_TRUE(reader->open(request).ok());
 
     size_t total_rows = 0;

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -88,6 +88,11 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("Int32ZoneMapExpr is only used by parquet scan tests");
+    }
+
     bool can_evaluate_zonemap_filter() const override { return true; }
 
     void collect_slot_column_ids(std::set<int>& column_ids) const override {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -25,41 +25,29 @@
 #include <parquet/arrow/writer.h>
 #include <parquet/bloom_filter.h>
 
+#include <cstdint>
+#include <cstring>
+#include <limits>
 #include <memory>
-#include <numeric>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/field.h"
+#include "exprs/vexpr.h"
+#include "exprs/vexpr_context.h"
+#include "exprs/vslot_ref.h"
 #include "format_v2/file_reader.h"
 #include "format_v2/parquet/parquet_column_schema.h"
-#include "storage/predicate/accept_null_predicate.h"
-#include "storage/predicate/null_predicate.h"
-#include "storage/predicate/predicate_creator.h"
+#include "storage/index/bloom_filter/block_split_bloom_filter.h"
+#include "storage/index/zone_map/zonemap_eval_context.h"
+#include "storage/index/zone_map/zonemap_filter_result.h"
 
 namespace doris {
 namespace {
-
-format::parquet::ParquetColumnSchema primitive_bloom_schema(const DataTypePtr& type) {
-    format::parquet::ParquetColumnSchema schema;
-    schema.local_id = 0;
-    schema.name = "c0";
-    schema.type = type;
-    schema.leaf_column_id = 0;
-    schema.kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
-    return schema;
-}
-
-format::FileColumnPredicateFilter bloom_filter_with_predicate(
-        const std::shared_ptr<ColumnPredicate>& predicate) {
-    format::FileColumnPredicateFilter filter;
-    filter.file_column_id = format::LocalColumnId(0);
-    filter.predicates.push_back(predicate);
-    return filter;
-}
 
 std::shared_ptr<arrow::Array> finish_array(arrow::ArrayBuilder* builder) {
     std::shared_ptr<arrow::Array> array;
@@ -140,19 +128,206 @@ std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> build_file_sc
     return file_schema;
 }
 
-format::FileScanRequest request_with_filter(format::FileColumnPredicateFilter filter) {
+class Int32ZoneMapExpr final : public VExpr {
+public:
+    enum class Op { GE, GT, IS_NULL, IS_NOT_NULL };
+
+    Int32ZoneMapExpr(int column_id, Op op, int32_t value = 0)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _column_id(column_id),
+              _op(op),
+              _value(value) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+
+    bool can_evaluate_zonemap_filter() const override { return true; }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_column_id);
+    }
+
+    ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
+        auto zone_map = ctx.zone_map(_column_id);
+        if (zone_map == nullptr) {
+            return unsupported_zonemap_filter(ctx);
+        }
+        if (_op == Op::IS_NULL) {
+            return zone_map->has_null ? ZoneMapFilterResult::kMayMatch
+                                      : ZoneMapFilterResult::kNoMatch;
+        }
+        if (_op == Op::IS_NOT_NULL) {
+            return zone_map->has_not_null ? ZoneMapFilterResult::kMayMatch
+                                          : ZoneMapFilterResult::kNoMatch;
+        }
+        if (!zone_map->has_not_null) {
+            return ZoneMapFilterResult::kNoMatch;
+        }
+        const auto literal = Field::create_field<TYPE_INT>(_value);
+        if (_op == Op::GE) {
+            return zone_map->max_value < literal ? ZoneMapFilterResult::kNoMatch
+                                                 : ZoneMapFilterResult::kMayMatch;
+        }
+        return zone_map->max_value <= literal ? ZoneMapFilterResult::kNoMatch
+                                              : ZoneMapFilterResult::kMayMatch;
+    }
+
+private:
+    int _column_id;
+    Op _op;
+    int32_t _value;
+    const std::string _expr_name = "Int32ZoneMapExpr";
+};
+
+class StringDictionaryInExpr final : public VExpr {
+public:
+    StringDictionaryInExpr(int column_id, std::vector<std::string> values)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _slot(VSlotRef::create_shared(0, column_id, -1, std::make_shared<DataTypeString>(),
+                                            "c0")) {
+        _values.reserve(values.size());
+        for (auto& value : values) {
+            _values.emplace_back(Field::create_field<TYPE_STRING>(std::move(value)));
+        }
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+    bool can_evaluate_dictionary_filter() const override { return true; }
+
+    ZoneMapFilterResult evaluate_dictionary_filter(
+            const DictionaryEvalContext& ctx) const override {
+        return expr_zonemap::eval_in_dictionary(ctx, _slot, false, _values);
+    }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        _slot->collect_slot_column_ids(column_ids);
+    }
+
+private:
+    VExprSPtr _slot;
+    std::vector<Field> _values;
+    const std::string _expr_name = "StringDictionaryInExpr";
+};
+
+class BloomInExpr final : public VExpr {
+public:
+    BloomInExpr(int column_id, DataTypePtr data_type, std::vector<Field> values)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _slot(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0")),
+              _values(std::move(values)) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+    bool can_evaluate_bloom_filter() const override { return true; }
+
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
+        return expr_zonemap::eval_in_bloom_filter(ctx, _slot, false, _values);
+    }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        _slot->collect_slot_column_ids(column_ids);
+    }
+
+private:
+    VExprSPtr _slot;
+    std::vector<Field> _values;
+    const std::string _expr_name = "BloomInExpr";
+};
+
+format::FileScanRequest request_with_zonemap_conjunct(std::shared_ptr<VExpr> expr) {
     format::FileScanRequest request;
-    request.column_predicate_filters.push_back(std::move(filter));
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(VExprContext::create_shared(std::move(expr)));
     return request;
 }
 
-::parquet::BlockSplitBloomFilter bloom_filter_for_int32_values(const std::vector<int32_t>& values) {
-    ::parquet::BlockSplitBloomFilter bloom_filter;
-    bloom_filter.Init(::parquet::BlockSplitBloomFilter::kMinimumBloomFilterBytes);
-    for (const auto value : values) {
-        bloom_filter.InsertHash(bloom_filter.Hash(value));
+format::FileScanRequest request_with_dictionary_conjunct(std::vector<std::string> values) {
+    format::FileScanRequest request;
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.conjuncts.push_back(VExprContext::create_shared(
+            std::make_shared<StringDictionaryInExpr>(0, std::move(values))));
+    return request;
+}
+
+VExprContextSPtrs bloom_conjuncts(DataTypePtr data_type, std::vector<Field> values) {
+    return {VExprContext::create_shared(
+            std::make_shared<BloomInExpr>(0, std::move(data_type), std::move(values)))};
+}
+
+void add_bloom_field(segment_v2::BlockSplitBloomFilter* bloom_filter, const Field& value,
+                     PrimitiveType type) {
+    DORIS_CHECK(bloom_filter != nullptr);
+    switch (type) {
+    case TYPE_BOOLEAN: {
+        const bool typed_value = value.get<TYPE_BOOLEAN>();
+        bloom_filter->add_bytes(reinterpret_cast<const char*>(&typed_value), sizeof(typed_value));
+        break;
+    }
+    case TYPE_INT: {
+        const int32_t typed_value = value.get<TYPE_INT>();
+        bloom_filter->add_bytes(reinterpret_cast<const char*>(&typed_value), sizeof(typed_value));
+        break;
+    }
+    case TYPE_STRING: {
+        const auto& typed_value = value.get<TYPE_STRING>();
+        bloom_filter->add_bytes(typed_value.data(), typed_value.size());
+        break;
+    }
+    default:
+        DORIS_CHECK(false);
+    }
+}
+
+std::unique_ptr<segment_v2::BlockSplitBloomFilter> bloom_filter_for_fields(
+        const std::vector<Field>& values, PrimitiveType type) {
+    auto bloom_filter = std::make_unique<segment_v2::BlockSplitBloomFilter>();
+    EXPECT_TRUE(bloom_filter->init(segment_v2::BloomFilter::MINIMUM_BYTES).ok());
+    for (const auto& value : values) {
+        add_bloom_field(bloom_filter.get(), value, type);
     }
     return bloom_filter;
+}
+
+BloomFilterEvalContext bloom_context(const DataTypePtr& data_type,
+                                     const segment_v2::BloomFilter* bloom_filter) {
+    BloomFilterEvalContext ctx;
+    ctx.slots.emplace(0, BloomFilterEvalContext::SlotBloomFilter {.data_type = data_type,
+                                                                  .bloom_filter = bloom_filter});
+    return ctx;
+}
+
+std::unique_ptr<::parquet::BlockSplitBloomFilter> parquet_bloom_filter() {
+    auto bloom_filter = std::make_unique<::parquet::BlockSplitBloomFilter>();
+    bloom_filter->Init(::parquet::BlockSplitBloomFilter::kMinimumBloomFilterBytes);
+    return bloom_filter;
+}
+
+format::parquet::ParquetColumnSchema uint32_parquet_bloom_schema() {
+    format::parquet::ParquetColumnSchema column_schema;
+    column_schema.type = std::make_shared<DataTypeInt64>();
+    column_schema.type_descriptor.doris_type = column_schema.type;
+    column_schema.type_descriptor.physical_type = ::parquet::Type::INT32;
+    column_schema.type_descriptor.integer_bit_width = 32;
+    column_schema.type_descriptor.is_unsigned_integer = true;
+    return column_schema;
+}
+
+format::parquet::ParquetColumnSchema fixed_len_string_parquet_bloom_schema(int fixed_length) {
+    format::parquet::ParquetColumnSchema column_schema;
+    column_schema.type = std::make_shared<DataTypeString>();
+    column_schema.type_descriptor.doris_type = column_schema.type;
+    column_schema.type_descriptor.physical_type = ::parquet::Type::FIXED_LEN_BYTE_ARRAY;
+    column_schema.type_descriptor.fixed_length = fixed_length;
+    column_schema.type_descriptor.is_string_like = true;
+    return column_schema;
+}
+
+format::parquet::ParquetColumnSchema float16_parquet_bloom_schema() {
+    format::parquet::ParquetColumnSchema column_schema;
+    column_schema.type = std::make_shared<DataTypeFloat32>();
+    column_schema.type_descriptor.doris_type = column_schema.type;
+    column_schema.type_descriptor.physical_type = ::parquet::Type::FIXED_LEN_BYTE_ARRAY;
+    column_schema.type_descriptor.fixed_length = 2;
+    column_schema.type_descriptor.extra_type_info = format::parquet::ParquetExtraTypeInfo::FLOAT16;
+    return column_schema;
 }
 
 TEST(ParquetStatisticsTransformTest, ConvertsMinMaxNullCountUnsignedStringAndTimestamp) {
@@ -223,45 +398,38 @@ TEST(ParquetStatisticsTransformTest, HandlesMissingStatisticsAndAllNullChunks) {
     EXPECT_FALSE(all_null_stats.has_min_max);
 }
 
-TEST(ParquetStatisticsPruningTest, StatisticsPredicatesAndNullPredicatesPruneRowGroups) {
+TEST(ParquetStatisticsPruningTest, ExprZonemapPredicatesAndNullPredicatesPruneRowGroups) {
     auto table = arrow::Table::Make(arrow::schema({arrow::field("i", arrow::int32(), true)}),
                                     {int32_array({std::nullopt, std::nullopt, 3, 4, 5, 6})});
     auto reader = make_reader(table, 2, false, true);
     auto schema = build_file_schema(*reader);
 
-    format::FileColumnPredicateFilter ge_filter;
-    ge_filter.file_column_id = format::LocalColumnId(0);
-    ge_filter.predicates.push_back(create_comparison_predicate<PredicateType::GE>(
-            0, "i", schema[0]->type, Field::create_field<TYPE_INT>(5), false));
     std::vector<int> selected;
     format::parquet::ParquetPruningStats pruning_stats;
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
-                        *reader->metadata(), reader.get(), schema, request_with_filter(ge_filter),
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                        *reader->metadata(), reader.get(), schema,
+                        request_with_zonemap_conjunct(
+                                std::make_shared<Int32ZoneMapExpr>(0, Int32ZoneMapExpr::Op::GE, 5)),
                         nullptr, &selected, false, &pruning_stats)
                         .ok());
     EXPECT_EQ(selected, std::vector<int>({2}));
     EXPECT_EQ(pruning_stats.filtered_row_groups_by_statistics, 2);
 
-    format::FileColumnPredicateFilter is_not_null_filter;
-    is_not_null_filter.file_column_id = format::LocalColumnId(0);
-    is_not_null_filter.predicates.push_back(
-            std::make_shared<NullPredicate>(0, "i", false, TYPE_INT));
     selected.clear();
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *reader->metadata(), reader.get(), schema,
-                        request_with_filter(is_not_null_filter), nullptr, &selected, false,
-                        &pruning_stats)
+                        request_with_zonemap_conjunct(std::make_shared<Int32ZoneMapExpr>(
+                                0, Int32ZoneMapExpr::Op::IS_NOT_NULL)),
+                        nullptr, &selected, false, &pruning_stats)
                         .ok());
     EXPECT_EQ(selected, std::vector<int>({1, 2}));
 
-    format::FileColumnPredicateFilter is_null_filter;
-    is_null_filter.file_column_id = format::LocalColumnId(0);
-    is_null_filter.predicates.push_back(std::make_shared<NullPredicate>(0, "i", true, TYPE_INT));
     selected.clear();
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *reader->metadata(), reader.get(), schema,
-                        request_with_filter(is_null_filter), nullptr, &selected, false,
-                        &pruning_stats)
+                        request_with_zonemap_conjunct(std::make_shared<Int32ZoneMapExpr>(
+                                0, Int32ZoneMapExpr::Op::IS_NULL)),
+                        nullptr, &selected, false, &pruning_stats)
                         .ok());
     EXPECT_EQ(selected, std::vector<int>({0}));
 }
@@ -272,29 +440,21 @@ TEST(ParquetStatisticsPruningTest, DictionaryPruningHandlesExcludeIncludeAndUnsu
     auto reader = make_reader(table, 2, true, false);
     auto schema = build_file_schema(*reader);
 
-    format::FileColumnPredicateFilter absent_filter;
-    absent_filter.file_column_id = format::LocalColumnId(0);
-    absent_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            0, "s", schema[0]->type, Field::create_field<TYPE_STRING>("missing"), false));
     std::vector<int> selected;
     format::parquet::ParquetPruningStats pruning_stats;
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *reader->metadata(), reader.get(), schema,
-                        request_with_filter(absent_filter), nullptr, &selected, false,
+                        request_with_dictionary_conjunct({"missing"}), nullptr, &selected, false,
                         &pruning_stats)
                         .ok());
     EXPECT_TRUE(selected.empty());
     EXPECT_EQ(pruning_stats.filtered_row_groups_by_dictionary, 2);
 
-    format::FileColumnPredicateFilter present_filter;
-    present_filter.file_column_id = format::LocalColumnId(0);
-    present_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            0, "s", schema[0]->type, Field::create_field<TYPE_STRING>("gamma"), false));
     selected.clear();
     pruning_stats = {};
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *reader->metadata(), reader.get(), schema,
-                        request_with_filter(present_filter), nullptr, &selected, false,
+                        request_with_dictionary_conjunct({"gamma"}), nullptr, &selected, false,
                         &pruning_stats)
                         .ok());
     EXPECT_EQ(selected, std::vector<int>({1}));
@@ -304,155 +464,181 @@ TEST(ParquetStatisticsPruningTest, DictionaryPruningHandlesExcludeIncludeAndUnsu
     auto plain_schema = build_file_schema(*plain_reader);
     selected.clear();
     pruning_stats = {};
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *plain_reader->metadata(), plain_reader.get(), plain_schema,
-                        request_with_filter(absent_filter), nullptr, &selected, false,
+                        request_with_dictionary_conjunct({"missing"}), nullptr, &selected, false,
                         &pruning_stats)
                         .ok());
     EXPECT_EQ(selected, std::vector<int>({0, 1}));
     EXPECT_EQ(pruning_stats.filtered_row_groups_by_dictionary, 0);
 }
 
-TEST(ParquetStatisticsPruningTest, StatisticsRunsBeforeDictionaryAndMissingBloomKeepsRows) {
+TEST(ParquetStatisticsPruningTest, VExprUsesDictionaryAndMissingBloomKeepsRows) {
     auto table = arrow::Table::Make(arrow::schema({arrow::field("s", arrow::utf8(), false)}),
                                     {string_array({"alpha", "beta", "gamma", "omega"})});
     auto reader = make_reader(table, 2, true, true);
     auto schema = build_file_schema(*reader);
 
-    format::FileColumnPredicateFilter beyond_max_filter;
-    beyond_max_filter.file_column_id = format::LocalColumnId(0);
-    beyond_max_filter.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
-            0, "s", schema[0]->type, Field::create_field<TYPE_STRING>("zzzz"), false));
     std::vector<int> selected;
     format::parquet::ParquetPruningStats pruning_stats;
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *reader->metadata(), reader.get(), schema,
-                        request_with_filter(beyond_max_filter), nullptr, &selected, true,
+                        request_with_dictionary_conjunct({"absent"}), nullptr, &selected, true,
                         &pruning_stats)
                         .ok());
     EXPECT_TRUE(selected.empty());
-    EXPECT_EQ(pruning_stats.filtered_row_groups_by_statistics, 2);
-    EXPECT_EQ(pruning_stats.filtered_row_groups_by_dictionary, 0);
+    EXPECT_EQ(pruning_stats.filtered_row_groups_by_statistics, 0);
+    EXPECT_EQ(pruning_stats.filtered_row_groups_by_dictionary, 2);
     EXPECT_EQ(pruning_stats.filtered_row_groups_by_bloom_filter, 0);
 
     auto no_stats_reader = make_reader(table, 2, false, false);
     auto no_stats_schema = build_file_schema(*no_stats_reader);
-    format::FileColumnPredicateFilter missing_bloom_filter;
-    missing_bloom_filter.file_column_id = format::LocalColumnId(0);
-    missing_bloom_filter.predicates.push_back(create_comparison_predicate<PredicateType::EQ>(
-            0, "s", no_stats_schema[0]->type, Field::create_field<TYPE_STRING>("absent"), false));
     selected.clear();
     pruning_stats = {};
-    ASSERT_TRUE(format::parquet::select_row_groups_by_statistics(
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
                         *no_stats_reader->metadata(), no_stats_reader.get(), no_stats_schema,
-                        request_with_filter(missing_bloom_filter), nullptr, &selected, true,
+                        request_with_dictionary_conjunct({"absent"}), nullptr, &selected, true,
                         &pruning_stats)
                         .ok());
     EXPECT_EQ(selected, std::vector<int>({0, 1}));
     EXPECT_EQ(pruning_stats.filtered_row_groups_by_bloom_filter, 0);
 }
 
-::parquet::BlockSplitBloomFilter bloom_filter_for_string_values(
-        const std::vector<std::string>& values) {
-    ::parquet::BlockSplitBloomFilter bloom_filter;
-    bloom_filter.Init(::parquet::BlockSplitBloomFilter::kMinimumBloomFilterBytes);
-    for (const auto& value : values) {
-        ::parquet::ByteArray byte_array(static_cast<uint32_t>(value.size()),
-                                        reinterpret_cast<const uint8_t*>(value.data()));
-        bloom_filter.InsertHash(bloom_filter.Hash(&byte_array));
-    }
-    return bloom_filter;
+TEST(ParquetBloomFilterPruningTest, VExprEqPrunesAbsentIntValue) {
+    auto data_type = std::make_shared<DataTypeInt32>();
+    auto bloom_filter = bloom_filter_for_fields(
+            {Field::create_field<TYPE_INT>(1), Field::create_field<TYPE_INT>(3)}, TYPE_INT);
+    auto ctx = bloom_context(data_type, bloom_filter.get());
+
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(data_type, {Field::create_field<TYPE_INT>(2)}), ctx),
+              ZoneMapFilterResult::kNoMatch);
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(data_type, {Field::create_field<TYPE_INT>(3)}), ctx),
+              ZoneMapFilterResult::kMayMatch);
 }
 
-TEST(ParquetBloomFilterPruningTest, EqPredicateUsesArrowHashAndPrunesAbsentIntValue) {
-    auto schema = primitive_bloom_schema(std::make_shared<DataTypeInt32>());
-    auto bloom_filter = bloom_filter_for_int32_values({1, 3});
-    auto absent_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-            0, "c0", schema.type, Field::create_field<TYPE_INT>(2), false));
-    auto present_filter =
-            bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-                    0, "c0", schema.type, Field::create_field<TYPE_INT>(3), false));
+TEST(ParquetBloomFilterPruningTest, VExprInPrunesOnlyWhenAllValuesAreAbsent) {
+    auto data_type = std::make_shared<DataTypeInt32>();
+    auto bloom_filter = bloom_filter_for_fields(
+            {Field::create_field<TYPE_INT>(1), Field::create_field<TYPE_INT>(3)}, TYPE_INT);
+    auto ctx = bloom_context(data_type, bloom_filter.get());
 
-    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, absent_filter,
-                                                                             bloom_filter));
-    EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
-            schema, present_filter, bloom_filter));
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(data_type, {Field::create_field<TYPE_INT>(2),
+                                                  Field::create_field<TYPE_INT>(4)}),
+                      ctx),
+              ZoneMapFilterResult::kNoMatch);
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(data_type, {Field::create_field<TYPE_INT>(2),
+                                                  Field::create_field<TYPE_INT>(3)}),
+                      ctx),
+              ZoneMapFilterResult::kMayMatch);
 }
 
-TEST(ParquetBloomFilterPruningTest, InPredicatePrunesOnlyWhenAllValuesAreAbsent) {
-    auto schema = primitive_bloom_schema(std::make_shared<DataTypeInt32>());
-    auto bloom_filter = bloom_filter_for_int32_values({1, 3});
+TEST(ParquetBloomFilterPruningTest, VExprBoolAndStringUseSlotBloomFilter) {
+    auto bool_type = std::make_shared<DataTypeBool>();
+    auto bool_filter =
+            bloom_filter_for_fields({Field::create_field<TYPE_BOOLEAN>(true)}, TYPE_BOOLEAN);
+    auto bool_ctx = bloom_context(bool_type, bool_filter.get());
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(bool_type, {Field::create_field<TYPE_BOOLEAN>(false)}),
+                      bool_ctx),
+              ZoneMapFilterResult::kNoMatch);
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(bool_type, {Field::create_field<TYPE_BOOLEAN>(true)}),
+                      bool_ctx),
+              ZoneMapFilterResult::kMayMatch);
 
-    auto absent_set = build_set<TYPE_INT>();
-    int32_t absent_first = 2;
-    int32_t absent_second = 4;
-    absent_set->insert(&absent_first);
-    absent_set->insert(&absent_second);
-    auto absent_filter =
-            bloom_filter_with_predicate(create_in_list_predicate<PredicateType::IN_LIST>(
-                    0, "c0", schema.type, absent_set, false));
-
-    auto present_set = build_set<TYPE_INT>();
-    int32_t present_first = 2;
-    int32_t present_second = 3;
-    present_set->insert(&present_first);
-    present_set->insert(&present_second);
-    auto present_filter =
-            bloom_filter_with_predicate(create_in_list_predicate<PredicateType::IN_LIST>(
-                    0, "c0", schema.type, present_set, false));
-
-    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, absent_filter,
-                                                                             bloom_filter));
-    EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
-            schema, present_filter, bloom_filter));
+    auto string_type = std::make_shared<DataTypeString>();
+    auto string_filter = bloom_filter_for_fields(
+            {Field::create_field<TYPE_STRING>("alpha"), Field::create_field<TYPE_STRING>("omega")},
+            TYPE_STRING);
+    auto string_ctx = bloom_context(string_type, string_filter.get());
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(string_type, {Field::create_field<TYPE_STRING>("beta")}),
+                      string_ctx),
+              ZoneMapFilterResult::kNoMatch);
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(string_type, {Field::create_field<TYPE_STRING>("alpha")}),
+                      string_ctx),
+              ZoneMapFilterResult::kMayMatch);
 }
 
-TEST(ParquetBloomFilterPruningTest, BooleanPredicateHashesAsParquetInt32) {
-    auto schema = primitive_bloom_schema(std::make_shared<DataTypeBool>());
-    auto bloom_filter = bloom_filter_for_int32_values({1});
-    auto false_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-            0, "c0", schema.type, Field::create_field<TYPE_BOOLEAN>(false), false));
-    auto true_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-            0, "c0", schema.type, Field::create_field<TYPE_BOOLEAN>(true), false));
+TEST(ParquetBloomFilterPruningTest, MissingOrUnsupportedBloomContextKeepsRowGroup) {
+    auto int_type = std::make_shared<DataTypeInt32>();
+    BloomFilterEvalContext missing_ctx;
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(int_type, {Field::create_field<TYPE_INT>(2)}), missing_ctx),
+              ZoneMapFilterResult::kMayMatch);
 
-    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, false_filter,
-                                                                             bloom_filter));
-    EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, true_filter,
-                                                                              bloom_filter));
+    auto smallint_type = std::make_shared<DataTypeInt16>();
+    auto bloom_filter = bloom_filter_for_fields({Field::create_field<TYPE_INT>(1)}, TYPE_INT);
+    auto unsupported_ctx = bloom_context(smallint_type, bloom_filter.get());
+    EXPECT_EQ(VExprContext::evaluate_bloom_filter(
+                      bloom_conjuncts(smallint_type, {Field::create_field<TYPE_SMALLINT>(2)}),
+                      unsupported_ctx),
+              ZoneMapFilterResult::kMayMatch);
 }
 
-TEST(ParquetBloomFilterPruningTest, StringPredicateUsesArrowByteArrayHash) {
-    auto schema = primitive_bloom_schema(std::make_shared<DataTypeString>());
-    auto bloom_filter = bloom_filter_for_string_values({"alpha", "omega"});
-    auto absent_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-            0, "c0", schema.type, Field::create_field<TYPE_STRING>("beta"), false));
-    auto present_filter =
-            bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-                    0, "c0", schema.type, Field::create_field<TYPE_STRING>("alpha"), false));
+TEST(ParquetBloomFilterPruningTest, ParquetUint32BloomUsesPhysicalInt32Hash) {
+    const auto column_schema = uint32_parquet_bloom_schema();
+    auto bloom_filter = parquet_bloom_filter();
 
-    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, absent_filter,
-                                                                             bloom_filter));
+    const uint32_t present_value = 4000000000U;
+    int32_t physical_value;
+    memcpy(&physical_value, &present_value, sizeof(physical_value));
+    bloom_filter->InsertHash(bloom_filter->Hash(physical_value));
+
+    // UINT32 is exposed to VExpr as Doris BIGINT, but Parquet stores and hashes it as a physical
+    // INT32 carrier. A present value above INT32_MAX must therefore be narrowed to the physical
+    // bit pattern before probing the file bloom filter.
     EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
-            schema, present_filter, bloom_filter));
+            column_schema, 0,
+            bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_BIGINT>(
+                                                        static_cast<int64_t>(present_value))}),
+            *bloom_filter));
+
+    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
+            column_schema, 0,
+            bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_BIGINT>(-1)}),
+            *bloom_filter));
+    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
+            column_schema, 0,
+            bloom_conjuncts(
+                    column_schema.type,
+                    {Field::create_field<TYPE_BIGINT>(
+                            static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) + 1)}),
+            *bloom_filter));
 }
 
-TEST(ParquetBloomFilterPruningTest, NullableAcceptingAndUnsupportedPredicatesKeepRowGroup) {
-    auto schema = primitive_bloom_schema(std::make_shared<DataTypeInt32>());
-    auto bloom_filter = bloom_filter_for_int32_values({1});
-    auto nested_predicate = create_comparison_predicate<PredicateType::EQ>(
-            0, "c0", schema.type, Field::create_field<TYPE_INT>(2), false);
-    auto accept_null_filter =
-            bloom_filter_with_predicate(std::make_shared<AcceptNullPredicate>(nested_predicate));
-    EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
-            schema, accept_null_filter, bloom_filter));
+TEST(ParquetBloomFilterPruningTest, ParquetFixedLenByteArrayBloomUsesFlbaHash) {
+    const auto column_schema = fixed_len_string_parquet_bloom_schema(4);
+    auto bloom_filter = parquet_bloom_filter();
 
-    auto unsupported_schema = primitive_bloom_schema(std::make_shared<DataTypeInt16>());
-    auto unsupported_filter =
-            bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
-                    0, "c0", unsupported_schema.type, Field::create_field<TYPE_SMALLINT>(2),
-                    false));
+    const std::string present_value = "abcd";
+    ::parquet::FLBA physical_value(reinterpret_cast<const uint8_t*>(present_value.data()));
+    bloom_filter->InsertHash(
+            bloom_filter->Hash(&physical_value, column_schema.type_descriptor.fixed_length));
+
     EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
-            unsupported_schema, unsupported_filter, bloom_filter));
+            column_schema, 0,
+            bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_STRING>(present_value)}),
+            *bloom_filter));
+    EXPECT_TRUE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
+            column_schema, 0,
+            bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_STRING>("abc")}),
+            *bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, ParquetFloat16BloomDoesNotUseFloatHash) {
+    const auto column_schema = float16_parquet_bloom_schema();
+    auto bloom_filter = parquet_bloom_filter();
+
+    EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::BloomFilterExcludes(
+            column_schema, 0,
+            bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_FLOAT>(1.0F)}),
+            *bloom_filter));
 }
 
 } // namespace

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -140,6 +140,11 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("Int32ZoneMapExpr is only used by parquet statistics tests");
+    }
+
     bool can_evaluate_zonemap_filter() const override { return true; }
 
     void collect_slot_column_ids(std::set<int>& column_ids) const override {
@@ -191,6 +196,13 @@ public:
     }
 
     const std::string& expr_name() const override { return _expr_name; }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError(
+                "StringDictionaryInExpr is only used by parquet statistics tests");
+    }
+
     bool can_evaluate_dictionary_filter() const override { return true; }
 
     ZoneMapFilterResult evaluate_dictionary_filter(
@@ -216,6 +228,12 @@ public:
               _values(std::move(values)) {}
 
     const std::string& expr_name() const override { return _expr_name; }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("BloomInExpr is only used by parquet statistics tests");
+    }
+
     bool can_evaluate_bloom_filter() const override { return true; }
 
     ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {

--- a/be/test/format_v2/table/hive_reader_test.cpp
+++ b/be/test/format_v2/table/hive_reader_test.cpp
@@ -46,7 +46,6 @@ Status init_hive_reader(FileFormat format, TFileScanRangeParams* params, Runtime
     return reader->init({
             .projected_columns = {table_column("id", std::make_shared<DataTypeInt32>()),
                                   table_column("name", std::make_shared<DataTypeString>())},
-            .column_predicates = {},
             .conjuncts = {},
             .format = format,
             .scan_params = params,

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -64,7 +64,6 @@
 #include "roaring/roaring64map.hh"
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
-#include "storage/predicate/predicate_creator.h"
 #include "storage/segment/condition_cache.h"
 
 namespace doris::format {
@@ -181,7 +180,6 @@ public:
         _state = std::make_unique<RuntimeState>(*_query_options, *_query_globals);
         RETURN_IF_ERROR(init({
                 .projected_columns = std::move(projected_columns),
-                .column_predicates = {},
                 .conjuncts = {},
                 .format = FileFormat::PARQUET,
                 .scan_params = nullptr,
@@ -712,12 +710,6 @@ void set_name_identifiers(std::vector<ColumnDefinition>* columns) {
     }
 }
 
-void add_column_predicate(TableColumnPredicates* column_predicates, GlobalIndex global_index,
-                          std::shared_ptr<ColumnPredicate> predicate) {
-    auto& entry = (*column_predicates)[global_index];
-    entry.push_back(std::move(predicate));
-}
-
 VExprContextSPtr prepared_conjunct(RuntimeState* state, const VExprSPtr& expr) {
     auto ctx = VExprContext::create_shared(expr);
     auto status = ctx->prepare(state, RowDescriptor());
@@ -750,7 +742,6 @@ TEST(IcebergV2ReaderTest, IcebergVirtualColumnsUseRowLineageMetadata) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(2, 2, 1))},
                                     .format = FileFormat::PARQUET,
@@ -804,7 +795,6 @@ TEST(IcebergV2ReaderTest, IcebergRowLineageUsesPhysicalRowIdAndFillsNulls) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -854,7 +844,6 @@ TEST(IcebergV2ReaderTest, IcebergPhysicalRowIdKeepsNullsWithoutFirstRowId) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -902,7 +891,6 @@ TEST(IcebergV2ReaderTest, IcebergMissingRowIdStaysNullWithoutFirstRowId) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -957,7 +945,6 @@ TEST(IcebergV2ReaderTest, IcebergRowIdPredicateFiltersAfterRowLineageMaterializa
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = conjuncts,
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1012,7 +999,6 @@ TEST(IcebergV2ReaderTest, IcebergLastUpdatedSequencePredicateFiltersAfterMateria
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = conjuncts,
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1060,7 +1046,6 @@ TEST(IcebergV2ReaderTest, IcebergRowidVirtualColumnUsesDataFilePosition) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(1, 1, 1))},
                                     .format = FileFormat::PARQUET,
@@ -1109,7 +1094,6 @@ TEST(IcebergV2ReaderTest, IcebergVirtualColumnsKeepRowLineageAfterConjunctFilter
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(2, 2, 1))},
                                     .format = FileFormat::PARQUET,
@@ -1148,8 +1132,8 @@ TEST(IcebergV2ReaderTest, IcebergVirtualColumnsKeepRowLineageAfterRowGroupPredic
     std::filesystem::create_directories(test_dir);
 
     const auto file_path = (test_dir / "split.parquet").string();
-    // ColumnPredicate is used for row-group/statistics pruning. Keep one row per row group so
-    // id > 2 prunes the first two row groups and leaves only the third file-local row.
+    // Keep one row per row group so the VExpr ZoneMap path can prune the first two row groups and
+    // leave only the third file-local row.
     write_int_pair_parquet_file(file_path, {1, 2, 3}, {10, 20, 30}, {"one", "two", "three"}, 1);
 
     std::vector<ColumnDefinition> projected_columns;
@@ -1157,18 +1141,12 @@ TEST(IcebergV2ReaderTest, IcebergVirtualColumnsKeepRowLineageAfterRowGroupPredic
     projected_columns.push_back(make_iceberg_last_updated_sequence_number_column());
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
 
-    TableColumnPredicates column_predicates;
-    add_column_predicate(&column_predicates, GlobalIndex(2),
-                         create_comparison_predicate<PredicateType::GT>(
-                                 0, "id", make_nullable(std::make_shared<DataTypeInt32>()),
-                                 Field::create_field<TYPE_INT>(2), false));
-
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = std::move(column_predicates),
-                                    .conjuncts = {},
+                                    .conjuncts = {prepared_conjunct(
+                                            &state, table_int32_greater_than_expr(2, 2, 2))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1258,7 +1236,6 @@ TEST(IcebergV2ReaderTest, IcebergTableReaderAppliesDeletionVectorFile) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1305,7 +1282,6 @@ TEST(IcebergV2ReaderTest, IcebergTableReaderDoesNotPushDownAggregateWithDeletes)
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1390,7 +1366,6 @@ TEST(IcebergV2ReaderTest, IcebergTableReaderDoesNotPushDownAggregateWithPosition
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1440,7 +1415,6 @@ TEST(IcebergV2ReaderTest, IcebergTableLevelCountUsesAssignedRowCountWithPosition
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1496,7 +1470,6 @@ TEST(IcebergV2ReaderTest, IcebergPositionDeleteFallsBackToSplitPath) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1546,7 +1519,6 @@ TEST(IcebergV2ReaderTest, IcebergTableReaderDoesNotPushDownAggregateWithEquality
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1600,7 +1572,6 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteCastsDataColumnToDeleteKeyType) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1647,7 +1618,6 @@ TEST(IcebergV2ReaderTest, IcebergPositionDeleteOnlyMatchesOriginalDataFilePath) 
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1694,7 +1664,6 @@ TEST(IcebergV2ReaderTest, IcebergRowLineageRemainsFileLocalAfterDeleteFiltering)
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1751,7 +1720,6 @@ TEST(IcebergV2ReaderTest, IcebergTableReaderAppliesPositionDeleteFile) {
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -1800,7 +1768,6 @@ TEST(IcebergV2ReaderTest, IcebergTableReaderMergesDeletionVectorAndPositionDelet
     doris::format::iceberg::IcebergTableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,

--- a/be/test/format_v2/table/paimon_reader_test.cpp
+++ b/be/test/format_v2/table/paimon_reader_test.cpp
@@ -437,7 +437,6 @@ TEST(PaimonReaderTest, AppliesBitmapDeletionVectorFile) {
     paimon::PaimonReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
@@ -510,7 +509,6 @@ TEST(PaimonHybridReaderTest, DispatchesNativeThenJniSplitToMatchingReader) {
     paimon::PaimonHybridReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = {},
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -59,7 +59,6 @@
 #include "io/io_common.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
-#include "storage/predicate/predicate_creator.h"
 #include "storage/segment/condition_cache.h"
 
 namespace doris::format {
@@ -956,12 +955,6 @@ void set_name_identifiers(std::vector<ColumnDefinition>* columns) {
     }
 }
 
-void add_column_predicate(TableColumnPredicates* column_predicates, GlobalIndex global_index,
-                          std::shared_ptr<ColumnPredicate> predicate) {
-    auto& entry = (*column_predicates)[global_index];
-    entry.push_back(std::move(predicate));
-}
-
 VExprContextSPtr prepared_conjunct(RuntimeState* state, const VExprSPtr& expr) {
     auto ctx = VExprContext::create_shared(expr);
     auto status = ctx->prepare(state, RowDescriptor());
@@ -1164,7 +1157,6 @@ TEST(TableReaderTest, CanUseInjectedFileReaderForStandaloneUnitTest) {
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1219,19 +1211,12 @@ TEST(TableReaderTest, DebugStringCoversReaderStateAndEnumNames) {
     projected_columns[0].name_mapping = {"legacy_id"};
     set_name_identifiers(&projected_columns);
 
-    TableColumnPredicates column_predicates;
-    add_column_predicate(&column_predicates, GlobalIndex(0),
-                         create_comparison_predicate<PredicateType::GT>(
-                                 0, "id", make_nullable(std::make_shared<DataTypeInt32>()),
-                                 Field::create_field<TYPE_INT>(0), false));
-
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     auto fake_state = std::make_shared<FakeFileReaderState>();
     fake_state->eof_with_first_batch = false;
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = std::move(column_predicates),
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 0))},
                                     .format = FileFormat::PARQUET,
@@ -1265,7 +1250,6 @@ TEST(TableReaderTest, DebugStringCoversReaderStateAndEnumNames) {
               std::string::npos);
     EXPECT_NE(debug.find("partition_values={dt}"), std::string::npos);
     EXPECT_NE(debug.find("table_filters=[TableFilter{conjunct=VExprContext"), std::string::npos);
-    EXPECT_NE(debug.find("table_column_predicates={0:{predicate_count=1}}"), std::string::npos);
     EXPECT_NE(debug.find("ColumnDefinition{name=id"), std::string::npos);
     EXPECT_NE(debug.find("name_mapping=[legacy_id]"), std::string::npos);
     EXPECT_NE(debug.find("ColumnMapping{global_index=0"), std::string::npos);
@@ -1282,7 +1266,6 @@ TEST(TableReaderTest, DebugStringCoversReaderStateAndEnumNames) {
         ASSERT_TRUE(enum_reader
                             .init({
                                     .projected_columns = {},
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = formats[idx],
                                     .scan_params = nullptr,
@@ -1304,7 +1287,6 @@ TEST(TableReaderTest, DebugStringCoversReaderStateAndEnumNames) {
         ASSERT_TRUE(enum_reader
                             .init({
                                     .projected_columns = {},
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1389,7 +1371,6 @@ TEST(TableReaderTest, ComplexRematerializeCastsScalarChildToTableType) {
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1452,7 +1433,6 @@ TEST(TableReaderTest, ReopenSplitAfterClose) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(1, 1, 0))},
                                     .format = FileFormat::PARQUET,
@@ -1499,9 +1479,9 @@ TEST(TableReaderTest, ReopenSplitAfterClose) {
     std::filesystem::remove_all(test_dir);
 }
 
-// Scenario: column predicates are pruning hints only. They do not produce a row-level survivor
-// bitmap, so TableReader must not enable condition cache when the scan request has no conjuncts.
-TEST(TableReaderTest, ConditionCacheSkipsColumnPredicateOnlyRequest) {
+// Scenario: requests without file-local row conjuncts do not produce a row-level survivor bitmap,
+// so TableReader must not enable condition cache.
+TEST(TableReaderTest, ConditionCacheSkipsRequestWithoutFileLocalConjuncts) {
     std::vector<ColumnDefinition> file_schema;
     file_schema.push_back(make_file_column(0, "id", std::make_shared<DataTypeInt32>()));
 
@@ -1509,18 +1489,11 @@ TEST(TableReaderTest, ConditionCacheSkipsColumnPredicateOnlyRequest) {
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
     set_name_identifiers(&projected_columns);
 
-    TableColumnPredicates column_predicates;
-    add_column_predicate(&column_predicates, GlobalIndex(0),
-                         create_comparison_predicate<PredicateType::GT>(
-                                 0, "id", make_nullable(std::make_shared<DataTypeInt32>()),
-                                 Field::create_field<TYPE_INT>(0), false));
-
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     auto fake_state = std::make_shared<FakeFileReaderState>();
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = std::move(column_predicates),
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1559,7 +1532,6 @@ TEST(TableReaderTest, ConditionCacheSkipsRuntimeFilterConjunct) {
     ASSERT_TRUE(
             reader.init({
                                 .projected_columns = projected_columns,
-                                .column_predicates = {},
                                 .conjuncts = {prepared_conjunct(
                                         &state, runtime_filter_wrapper_expr(
                                                         table_int32_greater_than_expr(0, 0, 0)))},
@@ -1601,7 +1573,6 @@ TEST(TableReaderTest, ConditionCacheSkipsRequestWithDeleteConjuncts) {
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 0))},
                                     .format = FileFormat::PARQUET,
@@ -1643,7 +1614,6 @@ TEST(TableReaderTest, ConditionCacheMissPublishesBitmapAfterReaderEof) {
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 0))},
                                     .format = FileFormat::PARQUET,
@@ -1695,7 +1665,6 @@ TEST(TableReaderTest, ConditionCacheMissIsDroppedWhenReaderClosesBeforeEof) {
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 0))},
                                     .format = FileFormat::PARQUET,
@@ -1740,7 +1709,6 @@ TEST(TableReaderTest, PushDownCountFromNewParquetReader) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1782,7 +1750,6 @@ TEST(TableReaderTest, TableLevelCountUsesAssignedRowCount) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1839,7 +1806,6 @@ TEST(TableReaderTest, PushDownMinMaxFromNewParquetReader) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1886,7 +1852,6 @@ TEST(TableReaderTest, PushDownMinMaxCastsFileValueToTableType) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1933,7 +1898,6 @@ TEST(TableReaderTest, PushDownMinMaxFromProjectedStructLeaf) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -1986,7 +1950,6 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackForProjectedListStructLeaf) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2058,7 +2021,6 @@ TEST(TableReaderTest, ProjectedListStructReadsSelectedElementChild) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2127,7 +2089,6 @@ TEST(TableReaderTest, ProjectedListStructReordersRenamedAndMissingElementChildre
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2199,7 +2160,6 @@ TEST(TableReaderTest, ProjectedListStructOnlyMissingElementChildFallsBackToFullE
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2258,7 +2218,6 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackForProjectedMapValueStructLeaf) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2336,7 +2295,6 @@ TEST(TableReaderTest, ProjectedMapValueStructReordersRenamedAndMissingChildren) 
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2589,7 +2547,6 @@ TEST(TableReaderTest, PushDownMinMaxOnlyUsesSelectedRowGroupInFileRange) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2631,7 +2588,6 @@ TEST(TableReaderTest, PushDownCountOnlyUsesSelectedRowGroupInFileRange) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2670,7 +2626,6 @@ TEST(TableReaderTest, PushDownCountFallsBackWithTableConjunct) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 2))},
                                     .format = FileFormat::PARQUET,
@@ -2695,7 +2650,7 @@ TEST(TableReaderTest, PushDownCountFallsBackWithTableConjunct) {
     std::filesystem::remove_all(test_dir);
 }
 
-TEST(TableReaderTest, PushDownCountFallsBackWithColumnPredicate) {
+TEST(TableReaderTest, PushDownCountFallsBackWithFilter) {
     const auto test_dir =
             std::filesystem::temp_directory_path() / "doris_table_reader_count_predicate_test";
     std::filesystem::remove_all(test_dir);
@@ -2707,19 +2662,13 @@ TEST(TableReaderTest, PushDownCountFallsBackWithColumnPredicate) {
     std::vector<ColumnDefinition> projected_columns;
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
 
-    TableColumnPredicates column_predicates;
-    add_column_predicate(&column_predicates, GlobalIndex(0),
-                         create_comparison_predicate<PredicateType::GT>(
-                                 0, "id", make_nullable(std::make_shared<DataTypeInt32>()),
-                                 Field::create_field<TYPE_INT>(2), false));
-
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     set_name_identifiers(&projected_columns);
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = std::move(column_predicates),
-                                    .conjuncts = {},
+                                    .conjuncts = {prepared_conjunct(
+                                            &state, table_int32_greater_than_expr(0, 0, 2))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -2760,7 +2709,6 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackWithoutDirectFileMapping) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -2801,7 +2749,6 @@ TEST(TableReaderTest, OpenReaderBuildsTableFiltersFromConjuncts) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(1, 1, 2))},
                                     .format = FileFormat::PARQUET,
@@ -2833,7 +2780,6 @@ TEST(TableReaderTest, OpenReaderBuildsTableFiltersFromConjuncts) {
     ASSERT_TRUE(filtered_reader
                         .init({
                                 .projected_columns = projected_columns,
-                                .column_predicates = {},
                                 .conjuncts = {prepared_conjunct(
                                         &state, table_int32_greater_than_expr(1, 1, 4))},
                                 .format = FileFormat::PARQUET,
@@ -2855,34 +2801,28 @@ TEST(TableReaderTest, OpenReaderBuildsTableFiltersFromConjuncts) {
     std::filesystem::remove_all(test_dir);
 }
 
-TEST(TableReaderTest, OpenReaderBuildsColumnPredicateFilters) {
+TEST(TableReaderTest, OpenReaderPushesVExprPredicateToParquetReader) {
     const auto test_dir =
             std::filesystem::temp_directory_path() / "doris_table_reader_column_predicate_test";
     std::filesystem::remove_all(test_dir);
     std::filesystem::create_directories(test_dir);
 
     const auto file_path = (test_dir / "split.parquet").string();
-    // ColumnPredicate is only used for row-group/statistics pruning. Keep one row per row
-    // group so the predicate can prune the first two row groups and leave only id = 3.
+    // Keep one row per row group so the VExpr ZoneMap path can prune the first two row groups and
+    // leave only id = 3.
     write_int_pair_parquet_file(file_path, {1, 2, 3}, {1, 5, 8}, {"one", "two", "three"}, 1);
 
     std::vector<ColumnDefinition> projected_columns;
     projected_columns.push_back(make_table_column(2, "value", std::make_shared<DataTypeString>()));
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
 
-    TableColumnPredicates column_predicates;
-    add_column_predicate(&column_predicates, GlobalIndex(1),
-                         create_comparison_predicate<PredicateType::GT>(
-                                 0, "id", make_nullable(std::make_shared<DataTypeInt32>()),
-                                 Field::create_field<TYPE_INT>(2), false));
-
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     set_name_identifiers(&projected_columns);
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = std::move(column_predicates),
-                                    .conjuncts = {},
+                                    .conjuncts = {prepared_conjunct(
+                                            &state, table_int32_greater_than_expr(1, 1, 2))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -2910,7 +2850,7 @@ TEST(TableReaderTest, OpenReaderBuildsColumnPredicateFilters) {
     std::filesystem::remove_all(test_dir);
 }
 
-TEST(TableReaderTest, ColumnPredicateSurvivesReopenSplit) {
+TEST(TableReaderTest, VExprPredicateSurvivesReopenSplit) {
     const auto test_dir =
             std::filesystem::temp_directory_path() / "doris_table_reader_predicate_reopen_test";
     std::filesystem::remove_all(test_dir);
@@ -2926,19 +2866,13 @@ TEST(TableReaderTest, ColumnPredicateSurvivesReopenSplit) {
     std::vector<ColumnDefinition> projected_columns;
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
 
-    TableColumnPredicates column_predicates;
-    add_column_predicate(&column_predicates, GlobalIndex(0),
-                         create_comparison_predicate<PredicateType::GT>(
-                                 0, "id", make_nullable(std::make_shared<DataTypeInt32>()),
-                                 Field::create_field<TYPE_INT>(2), false));
-
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     set_name_identifiers(&projected_columns);
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = std::move(column_predicates),
-                                    .conjuncts = {},
+                                    .conjuncts = {prepared_conjunct(
+                                            &state, table_int32_greater_than_expr(0, 0, 2))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -2999,8 +2933,7 @@ TEST(TableReaderTest, CreateScanRequestDeduplicatesSharedPredicateColumns) {
     });
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request(table_filters, {}, projected_columns, &file_request).ok());
+    ASSERT_TRUE(mapper.create_scan_request(table_filters, projected_columns, &file_request).ok());
 
     // Both filters reference column a. It must still be read once as a predicate column, and a
     // predicate column must not be repeated as a non-predicate column.
@@ -3039,8 +2972,7 @@ TEST(TableReaderTest, CreateScanRequestPromotesProjectedColumnToPredicateColumn)
     };
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request).ok());
 
     EXPECT_EQ(projection_ids(file_request.predicate_columns), std::vector<int32_t>({0}));
     EXPECT_EQ(projection_ids(file_request.non_predicate_columns), std::vector<int32_t>({1}));
@@ -3070,8 +3002,7 @@ TEST(TableReaderTest, CreateScanRequestUsesColumnNameForByNamePredicateMapping) 
     };
 
     FileScanRequest file_request;
-    ASSERT_TRUE(
-            mapper.create_scan_request({table_filter}, {}, projected_columns, &file_request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({table_filter}, projected_columns, &file_request).ok());
 
     EXPECT_EQ(projection_ids(file_request.predicate_columns), std::vector<int32_t>({0}));
     EXPECT_EQ(projection_ids(file_request.non_predicate_columns), std::vector<int32_t>({1}));
@@ -3080,37 +3011,6 @@ TEST(TableReaderTest, CreateScanRequestUsesColumnNameForByNamePredicateMapping) 
             assert_cast<const VSlotRef*>(file_request.conjuncts[0]->root()->children()[0].get());
     EXPECT_EQ(localized_slot->slot_id(), 0);
     EXPECT_EQ(localized_slot->column_id(), 1);
-}
-
-TEST(TableReaderTest, ColumnPredicateFilterUsesColumnNameForByNameMapping) {
-    const auto int_type = std::make_shared<DataTypeInt32>();
-    std::vector<ColumnDefinition> projected_columns = {
-            make_table_column(10, "id", int_type),
-            make_table_column(11, "score", int_type),
-    };
-    const std::vector<ColumnDefinition> file_schema = {
-            make_file_column(0, "ID", int_type),
-            make_file_column(1, "score", int_type),
-    };
-
-    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
-    set_name_identifiers(&projected_columns);
-    ASSERT_TRUE(mapper.create_mapping(projected_columns, {}, file_schema).ok());
-
-    TableColumnPredicates column_predicates;
-    add_column_predicate(
-            &column_predicates, GlobalIndex(0),
-            create_comparison_predicate<PredicateType::GT>(
-                    10, "id", make_nullable(int_type), Field::create_field<TYPE_INT>(2), false));
-
-    FileScanRequest file_request;
-    ASSERT_TRUE(mapper.create_scan_request({}, column_predicates, projected_columns, &file_request)
-                        .ok());
-
-    ASSERT_EQ(file_request.column_predicate_filters.size(), 1);
-    EXPECT_EQ(file_request.column_predicate_filters[0].file_column_id.value(), 0);
-    EXPECT_EQ(projection_ids(file_request.non_predicate_columns), std::vector<int32_t>({0, 1}));
-    EXPECT_TRUE(file_request.predicate_columns.empty());
 }
 
 TEST(TableReaderTest, OpenReaderPushesMultiColumnConjunctToParquetReader) {
@@ -3133,7 +3033,6 @@ TEST(TableReaderTest, OpenReaderPushesMultiColumnConjunctToParquetReader) {
     ASSERT_TRUE(
             reader.init({
                                 .projected_columns = projected_columns,
-                                .column_predicates = {},
                                 .conjuncts = {prepared_conjunct(
                                         &state, table_int32_sum_greater_than_expr(1, 1, 2, 2, 8))},
                                 .format = FileFormat::PARQUET,
@@ -3188,7 +3087,6 @@ TEST(TableReaderTest, ProjectedColumnsFillDefaultForParquetSchemaMismatch) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3234,7 +3132,6 @@ TEST(TableReaderTest, DefaultExprResultMatchesNullableTableType) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3289,7 +3186,6 @@ TEST(TableReaderTest, DefaultExprAlignsNestedNullableArrayTableType) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3346,7 +3242,6 @@ TEST(TableReaderTest, ProjectedColumnsFillMissingParquetColumnWithDefault) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3400,7 +3295,6 @@ TEST(TableReaderTest, ProjectedStructFillsMissingChildWithDefault) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3457,7 +3351,6 @@ TEST(TableReaderTest, ReusedBlockClearsProjectedStructWithNullableChild) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3507,7 +3400,6 @@ TEST(TableReaderTest, ProjectedPartitionColumnUsesSplitPartitionValue) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3557,7 +3449,6 @@ TEST(TableReaderTest, ConstantPartitionFilterSkipsSplitWhenFalse) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 10))},
                                     .format = FileFormat::PARQUET,
@@ -3601,7 +3492,6 @@ TEST(TableReaderTest, ConstantPartitionFilterKeepsSplitWhenTrue) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {prepared_conjunct(
                                             &state, table_int32_greater_than_expr(0, 0, 1))},
                                     .format = FileFormat::PARQUET,
@@ -3647,7 +3537,6 @@ TEST(TableReaderTest, RuntimeFilterOnConstantPartitionIsNotPreExecuted) {
     ASSERT_TRUE(
             reader.init({
                                 .projected_columns = projected_columns,
-                                .column_predicates = {},
                                 .conjuncts = {prepared_conjunct(
                                         &state, runtime_filter_wrapper_expr(
                                                         table_int32_greater_than_expr(0, 0, 1)))},
@@ -3693,7 +3582,6 @@ TEST(TableReaderTest, ParquetReaderReadsOnlyRowGroupsInFileRange) {
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3742,7 +3630,6 @@ TEST(TableReaderTest, ProjectedColumnsUseMapperExpressionForSameNameDifferentIdP
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
@@ -3788,7 +3675,6 @@ TEST(TableReaderTest, ProjectedColumnsUseMapperExpressionsForParquetSchemaMismat
     TableReader reader;
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .column_predicates = {},
                                     .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: File scanner v2 still carried ColumnPredicate metadata pruning through FileScanRequest for Parquet row-group dictionary and bloom filters after ZoneMap pruning had moved to VExpr. This kept two pruning APIs in the same scanner path and made statistics/profile accounting harder to keep consistent.

This change adds VExpr dictionary and bloom-filter evaluation interfaces, wires comparison/IN/compound predicates through those interfaces, and makes the Parquet v2 row-group/page pruning path evaluate localized VExpr conjuncts for ZoneMap, dictionary, and bloom filters. FileScanRequest no longer carries ColumnPredicate filters, and the remaining TableColumnPredicates plumbing has been removed from FileScannerV2 and table reader v2 tests. The existing STATISTICS/DICTIONARY/BLOOM_FILTER prune reasons and profile counters remain.

Parquet bloom pruning now probes the file bloom filter with the Parquet physical carrier instead of the widened Doris logical type. This keeps UINT32 predicates from hashing as INT64, handles fixed-length byte-array string blooms with FLBA hashing, and avoids unsupported logical encodings such as FLOAT16. The change also removes a header-level segment_v2 namespace import from match.h that made ZoneMap ambiguous after expr zonemap headers were included broadly. This also keeps the earlier cleanup that translates Chinese comments under be/src/core/data_type_serde to English.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran build-support/clang-format.sh
    - Ran git diff --check and git diff --cached --check
    - Verified no FileScannerV2 ColumnPredicate request/pruning symbols remain with rg
    - Added ExprZonemapFilterTest coverage for comparison and IN predicate dictionary/bloom VExpr interfaces
    - Added ParquetBloomFilterPruningTest coverage for UINT32 physical INT32 bloom hashing, fixed-length byte-array FLBA hashing, and unsupported FLOAT16 bloom pruning
    - BE UT was not completed in this turn per request; the remote UT run was stopped before completion
- Behavior changed: No
- Does this need documentation: No