### PR TITLE
[fix](regression) check partition minmax only

### DIFF
--- a/regression-test/suites/query_p0/stats/partition_key_minmax.groovy
+++ b/regression-test/suites/query_p0/stats/partition_key_minmax.groovy
@@ -16,19 +16,6 @@
 // under the License.
 
 suite("partition_key_minmax") {
-    def waitIndexRowCountReported = { tableName, expectedRowCount ->
-        def lastResult = null
-        for (int i = 0; i < 60; i++) {
-            lastResult = sql """show index stats ${tableName} ${tableName};"""
-            logger.info("${tableName} index stats: " + lastResult)
-            if (lastResult[0][4].toString() == expectedRowCount.toString()) {
-                return
-            }
-            sleep(1000)
-        }
-        throw new Exception("${tableName} row count report timeout, last index stats: ${lastResult}")
-    }
-
     sql """
         drop table if exists rangetable;
         create table rangetable (a int,
@@ -45,21 +32,20 @@ suite("partition_key_minmax") {
 
         analyze table rangetable with sync;
     """
-    waitIndexRowCountReported("rangetable", 4)
     def columnStats = sql """show column cached stats rangetable"""
     logger.info("rangetable cached stats: " + columnStats)
     explain {
         sql """memo plan
             select * from rangetable where a < 250;
             """
-        // case 1: partition col stats not available, partition row count not available
-        containsAny("a#0 -> ndv=2.6667, min=5.000000(5), max=30.000000(30)")
-        // case 2: partition col stats not available, partition row count available
-        containsAny("a#0 -> ndv=3.0000, min=5.000000(5), max=30.000000(30)")
-        // case 3: partition col stats available, partition row count not available
-        containsAny("a#0 -> ndv=2.6667, min=5.000000(5), max=22.000000(22)")
-        // case 4: partition col stats available, partition row count available
-        containsAny("a#0 -> ndv=3.0000, min=5.000000(5), max=22.000000(22)")
+        // Check partition-key min/max only. ndv/count depends on async physical row-count reporting.
+        check { explainString ->
+            explainString.readLines().any { line ->
+                line.contains("a#0 ->")
+                        && (line.contains("min=5.000000(5), max=30.000000(30)")
+                            || line.contains("min=5.000000(5), max=22.000000(22)"))
+            }
+        }
     }
 
     sql """
@@ -77,7 +63,6 @@ suite("partition_key_minmax") {
 
     analyze table listtable with sync;
     """
-    waitIndexRowCountReported("listtable", 3)
 
     columnStats = sql """show column cached stats listtable"""
     logger.info("listtable cached stats: " + columnStats)
@@ -86,6 +71,12 @@ suite("partition_key_minmax") {
         sql """
          memo plan select * from listtable where id >=3;
         """
-        contains("id#0 -> ndv=1.0000, min=3.000000(3), max=3.000000(3), count=1.0000")
+        // Check partition-key min/max only. ndv/count depends on async physical row-count reporting.
+        check { explainString ->
+            explainString.readLines().any { line ->
+                line.contains("id#0 ->")
+                        && line.contains("min=3.000000(3), max=3.000000(3)")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

`partition_key_minmax` is intended to validate that partition-pruned memo-plan statistics tighten partition-key min/max for RANGE and LIST partitions.

The previous exact checks also depended on `ndv/count`, which are derived from selected partition row count and can vary with async physical row-count reporting (`0`, `-1` unknown, or positive). Waiting for physical row count via `show index stats` was too strict and caused P0 timeout when strict row count stayed `-1`.

This patch removes the physical row-count wait and uses `check {}` to assert only the partition-key min/max invariants:

- RANGE `a#0` has `min=5` and an accepted max of `30` or `22`
- LIST `id#0` has `min=max=3`

## Testing

- `git diff --check`

Targeted regression was not run locally; CI will cover it.
