### PR TITLE
[fix](regression) Wait for cloud tablet meta sync in compaction test

### DIFF
--- a/regression-test/suites/cloud_p0/compaction/test_cloud_alter_disable_auto_compaction.groovy
+++ b/regression-test/suites/cloud_p0/compaction/test_cloud_alter_disable_auto_compaction.groovy
@@ -28,8 +28,9 @@ suite("test_cloud_alter_disable_auto_compaction", "p0,docker") {
         'cloud_cluster_check_interval_second=1',
     ]
     options.beConfigs += [
-        // Short sync interval for faster property propagation
-        'tablet_sync_interval_s=5',
+        // Short sync intervals for faster tablet meta property propagation
+        'schedule_sync_tablets_interval_s=1',
+        'tablet_sync_interval_s=1',
         // Trigger cumulative compaction after 5 rowsets
         'cumulative_compaction_min_deltas=5',
         // Enable file cache (required for sync_meta to work)
@@ -116,7 +117,8 @@ suite("test_cloud_alter_disable_auto_compaction", "p0,docker") {
         assertTrue(result[0][1].contains('"disable_auto_compaction" = "true"'))
 
         // Wait for sync_meta to propagate the change to BE
-        // tablet_sync_interval_s is set to 5 seconds, so wait a bit longer
+        // schedule_sync_tablets_interval_s and tablet_sync_interval_s are set to 1 second,
+        // so wait a bit longer.
         logger.info("Waiting for sync_meta to propagate disable_auto_compaction=true to BE...")
         sleep(10000)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The cloud regression case changes disable_auto_compaction and then waits for BE to observe the updated tablet schema before inserting more rowsets. The test only shortened tablet_sync_interval_s, but BE wakes the sync_tablets_thread according to schedule_sync_tablets_interval_s. With the default wake interval, the test can insert rowsets before BE refreshes tablet meta from Meta Service, so automatic compaction may still be scheduled from stale local tablet schema. This change sets both sync intervals to one second in the docker case so the existing wait covers the actual BE tablet meta refresh path.


