### PR TITLE
[feature](cloud) Support segment id list

### DIFF
--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -38,12 +38,14 @@
 #include "cloud/cloud_warm_up_manager.h"
 #include "cloud/cloud_warmup_metrics.h"
 #include "cloud/config.h"
+#include "common/cast_set.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/block_file_cache_downloader.h"
 #include "io/cache/block_file_cache_factory.h"
 #include "io/fs/path.h"
 #include "runtime/thread_context.h"
 #include "runtime/workload_management/io_throttle.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/storage_policy.h"
 #include "util/async_io.h"
 #include "util/bvar_windowed_adder.h"
@@ -242,22 +244,21 @@ static std::optional<int64_t> warm_up_rowset_cross_host_latency_us(int64_t start
 
 static void add_file_cache_block_meta_to_response(
         PGetFileCacheMetaResponse* resp, int64_t tablet_id, const std::string& rowset_id,
-        int32_t segment_id, const std::string& file_name,
-        const std::tuple<int64_t, int64_t, io::FileCacheType, int64_t>& tuple,
-        const RowsetSharedPtr& rowset, bool is_index) {
+        RowsetSegmentView seg, const std::string& file_name,
+        const std::tuple<int64_t, int64_t, io::FileCacheType, int64_t>& tuple, bool is_index) {
     FileCacheBlockMeta* meta = resp->add_file_cache_block_metas();
     meta->set_tablet_id(tablet_id);
     meta->set_rowset_id(rowset_id);
-    meta->set_segment_id(segment_id);
+    meta->set_segment_id(cast_set<int32_t>(seg.id()));
     meta->set_file_name(file_name);
 
     if (!is_index) {
         // .dat
-        meta->set_file_size(rowset->rowset_meta()->segment_file_size(segment_id));
+        meta->set_file_size(seg.file_size());
         meta->set_file_type(doris::FileType::SEGMENT_FILE);
     } else {
         // .idx
-        const auto& idx_file_info = rowset->rowset_meta()->inverted_index_file_info(segment_id);
+        auto idx_file_info = seg.inverted_index_file_info();
         meta->set_file_size(idx_file_info.has_index_size() ? idx_file_info.index_size() : -1);
         meta->set_file_type(doris::FileType::INVERTED_INDEX_FILE);
     }
@@ -268,19 +269,18 @@ static void add_file_cache_block_meta_to_response(
     meta->set_expiration_time(std::get<3>(tuple));
 }
 
-static void process_segment_file_cache_meta(PGetFileCacheMetaResponse* resp,
-                                            const RowsetSharedPtr& rowset, int64_t tablet_id,
-                                            const std::string& rowset_id, int32_t segment_id,
+static void process_segment_file_cache_meta(PGetFileCacheMetaResponse* resp, int64_t tablet_id,
+                                            const std::string& rowset_id, RowsetSegmentView seg,
                                             bool is_index) {
     const char* extension = is_index ? ".idx" : ".dat";
-    std::string file_name = fmt::format("{}_{}{}", rowset_id, segment_id, extension);
+    std::string file_name = fmt::format("{}_{}{}", rowset_id, seg.id(), extension);
     auto cache_key = io::BlockFileCache::hash(file_name);
     auto* cache = io::FileCacheFactory::instance()->get_by_path(cache_key);
     if (!cache) return;
     auto segments_meta = cache->get_hot_blocks_meta(cache_key);
     for (const auto& tuple : segments_meta) {
-        add_file_cache_block_meta_to_response(resp, tablet_id, rowset_id, segment_id, file_name,
-                                              tuple, rowset, is_index);
+        add_file_cache_block_meta_to_response(resp, tablet_id, rowset_id, seg, file_name, tuple,
+                                              is_index);
     }
 }
 
@@ -325,11 +325,9 @@ void CloudInternalServiceImpl::get_file_cache_meta_by_tablet_id(
 
         for (const RowsetSharedPtr& rowset : rowsets) {
             std::string rowset_id = rowset->rowset_id().to_string();
-            for (int32_t segment_id = 0; segment_id < rowset->num_segments(); ++segment_id) {
-                process_segment_file_cache_meta(response, rowset, tablet_id, rowset_id, segment_id,
-                                                false);
-                process_segment_file_cache_meta(response, rowset, tablet_id, rowset_id, segment_id,
-                                                true);
+            for (auto seg : rowset->segments()) {
+                process_segment_file_cache_meta(response, tablet_id, rowset_id, seg, false);
+                process_segment_file_cache_meta(response, tablet_id, rowset_id, seg, true);
             }
         }
     }
@@ -1057,20 +1055,20 @@ void record_warmup_ed_skipped_rowset_as_finished(RowsetMeta& rs_meta,
     auto schema_ptr = rs_meta.tablet_schema();
     bool has_inverted_index = schema_ptr->has_inverted_or_ann_index();
     auto idx_version = schema_ptr->get_inverted_index_storage_format();
-    for (int64_t segment_id = 0; segment_id < rs_meta.num_segments(); segment_id++) {
-        record_warmup_ed_finish_segment(job_id_str, rs_meta.segment_file_size(segment_id));
+    for (auto seg : rs_meta.segments()) {
+        record_warmup_ed_finish_segment(job_id_str, seg.file_size());
 
         if (!has_inverted_index) {
             continue;
         }
-        auto&& inverted_index_info = rs_meta.inverted_index_file_info(segment_id);
+        auto inverted_index_info = seg.inverted_index_file_info();
         if (idx_version == InvertedIndexStorageFormatPB::V1) {
             std::unordered_map<int64_t, int64_t> index_size_map;
             for (const auto& info : inverted_index_info.index_info()) {
                 if (info.index_file_size() != -1) {
                     index_size_map[info.index_id()] = info.index_file_size();
                 } else {
-                    VLOG_DEBUG << "Invalid index_file_size for segment_id " << segment_id
+                    VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg.id()
                                << ", index_id " << info.index_id();
                 }
             }
@@ -1082,7 +1080,7 @@ void record_warmup_ed_skipped_rowset_as_finished(RowsetMeta& rs_meta,
             if (inverted_index_info.has_index_size()) {
                 idx_size = inverted_index_info.index_size();
             } else {
-                VLOG_DEBUG << "index_size is not set for segment " << segment_id;
+                VLOG_DEBUG << "index_size is not set for segment " << seg.id();
             }
             record_warmup_ed_finish_index(job_id_str, idx_size);
         }
@@ -1286,9 +1284,10 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                                                                      upstream_trigger_ts_ms);
         }
 
-        for (int64_t segment_id = 0; segment_id < rs_meta.num_segments(); segment_id++) {
+        for (auto seg : rs_meta.segments()) {
+            auto segment_id = seg.id();
             if (!config::file_cache_enable_only_warm_up_idx) {
-                auto segment_size = rs_meta.segment_file_size(segment_id);
+                auto segment_size = seg.file_size();
 
                 // Use rs_meta.fs() instead of storage_resource.value()->fs to support packed files.
                 // PackedFileSystem wrapper in rs_meta.fs() handles the index_map lookup and
@@ -1361,7 +1360,7 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
 
             if (schema_ptr->has_inverted_or_ann_index()) {
                 if (idx_version == InvertedIndexStorageFormatPB::V1) {
-                    auto&& inverted_index_info = rs_meta.inverted_index_file_info(segment_id);
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     std::unordered_map<int64_t, int64_t> index_size_map;
                     for (const auto& info : inverted_index_info.index_info()) {
                         if (info.index_file_size() != -1) {
@@ -1377,7 +1376,7 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                         download_inverted_index(idx_path, index_size_map[index->index_id()]);
                     }
                 } else { // InvertedIndexStorageFormatPB::V2
-                    auto&& inverted_index_info = rs_meta.inverted_index_file_info(segment_id);
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     int64_t idx_size = 0;
                     if (inverted_index_info.has_index_size()) {
                         idx_size = inverted_index_info.index_size();
@@ -1414,8 +1413,10 @@ void CloudInternalServiceImpl::recycle_cache(google::protobuf::RpcController* co
         return;
     }
     for (const auto& meta : request->cache_metas()) {
-        for (int64_t segment_id = 0; segment_id < meta.num_segments(); segment_id++) {
-            auto file_key = Segment::file_cache_key(meta.rowset_id(), segment_id);
+        for (int64_t pos = 0; pos < meta.num_segments(); pos++) {
+            auto segment_id = rowset_segment_id(meta, pos);
+            auto file_key =
+                    Segment::file_cache_key(meta.rowset_id(), cast_set<uint32_t>(segment_id));
             auto* file_cache = io::FileCacheFactory::instance()->get_by_path(file_key);
             file_cache->remove_if_cached_async(file_key);
             g_file_cache_recycle_cache_finished_segment_num << 1;

--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -38,12 +38,14 @@
 #include "cloud/cloud_warm_up_manager.h"
 #include "cloud/cloud_warmup_metrics.h"
 #include "cloud/config.h"
+#include "common/cast_set.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/block_file_cache_downloader.h"
 #include "io/cache/block_file_cache_factory.h"
 #include "io/fs/path.h"
 #include "runtime/thread_context.h"
 #include "runtime/workload_management/io_throttle.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/storage_policy.h"
 #include "util/async_io.h"
 #include "util/bvar_windowed_adder.h"
@@ -165,22 +167,21 @@ static std::optional<int64_t> warm_up_rowset_cross_host_latency_us(int64_t start
 
 static void add_file_cache_block_meta_to_response(
         PGetFileCacheMetaResponse* resp, int64_t tablet_id, const std::string& rowset_id,
-        int32_t segment_id, const std::string& file_name,
-        const std::tuple<int64_t, int64_t, io::FileCacheType, int64_t>& tuple,
-        const RowsetSharedPtr& rowset, bool is_index) {
+        RowsetSegmentView seg, const std::string& file_name,
+        const std::tuple<int64_t, int64_t, io::FileCacheType, int64_t>& tuple, bool is_index) {
     FileCacheBlockMeta* meta = resp->add_file_cache_block_metas();
     meta->set_tablet_id(tablet_id);
     meta->set_rowset_id(rowset_id);
-    meta->set_segment_id(segment_id);
+    meta->set_segment_id(cast_set<int32_t>(seg.id()));
     meta->set_file_name(file_name);
 
     if (!is_index) {
         // .dat
-        meta->set_file_size(rowset->rowset_meta()->segment_file_size(segment_id));
+        meta->set_file_size(seg.file_size());
         meta->set_file_type(doris::FileType::SEGMENT_FILE);
     } else {
         // .idx
-        const auto& idx_file_info = rowset->rowset_meta()->inverted_index_file_info(segment_id);
+        auto idx_file_info = seg.inverted_index_file_info();
         meta->set_file_size(idx_file_info.has_index_size() ? idx_file_info.index_size() : -1);
         meta->set_file_type(doris::FileType::INVERTED_INDEX_FILE);
     }
@@ -191,19 +192,18 @@ static void add_file_cache_block_meta_to_response(
     meta->set_expiration_time(std::get<3>(tuple));
 }
 
-static void process_segment_file_cache_meta(PGetFileCacheMetaResponse* resp,
-                                            const RowsetSharedPtr& rowset, int64_t tablet_id,
-                                            const std::string& rowset_id, int32_t segment_id,
+static void process_segment_file_cache_meta(PGetFileCacheMetaResponse* resp, int64_t tablet_id,
+                                            const std::string& rowset_id, RowsetSegmentView seg,
                                             bool is_index) {
     const char* extension = is_index ? ".idx" : ".dat";
-    std::string file_name = fmt::format("{}_{}{}", rowset_id, segment_id, extension);
+    std::string file_name = fmt::format("{}_{}{}", rowset_id, seg.id(), extension);
     auto cache_key = io::BlockFileCache::hash(file_name);
     auto* cache = io::FileCacheFactory::instance()->get_by_path(cache_key);
     if (!cache) return;
     auto segments_meta = cache->get_hot_blocks_meta(cache_key);
     for (const auto& tuple : segments_meta) {
-        add_file_cache_block_meta_to_response(resp, tablet_id, rowset_id, segment_id, file_name,
-                                              tuple, rowset, is_index);
+        add_file_cache_block_meta_to_response(resp, tablet_id, rowset_id, seg, file_name, tuple,
+                                              is_index);
     }
 }
 
@@ -248,11 +248,9 @@ void CloudInternalServiceImpl::get_file_cache_meta_by_tablet_id(
 
         for (const RowsetSharedPtr& rowset : rowsets) {
             std::string rowset_id = rowset->rowset_id().to_string();
-            for (int32_t segment_id = 0; segment_id < rowset->num_segments(); ++segment_id) {
-                process_segment_file_cache_meta(response, rowset, tablet_id, rowset_id, segment_id,
-                                                false);
-                process_segment_file_cache_meta(response, rowset, tablet_id, rowset_id, segment_id,
-                                                true);
+            for (auto seg : rowset->segments()) {
+                process_segment_file_cache_meta(response, tablet_id, rowset_id, seg, false);
+                process_segment_file_cache_meta(response, tablet_id, rowset_id, seg, true);
             }
         }
     }
@@ -985,20 +983,20 @@ void record_warmup_ed_skipped_rowset_as_finished(RowsetMeta& rs_meta,
     auto schema_ptr = rs_meta.tablet_schema();
     bool has_inverted_index = schema_ptr->has_inverted_index() || schema_ptr->has_ann_index();
     auto idx_version = schema_ptr->get_inverted_index_storage_format();
-    for (int64_t segment_id = 0; segment_id < rs_meta.num_segments(); segment_id++) {
-        record_warmup_ed_finish_segment(job_id_str, rs_meta.segment_file_size(segment_id));
+    for (auto seg : rs_meta.segments()) {
+        record_warmup_ed_finish_segment(job_id_str, seg.file_size());
 
         if (!has_inverted_index) {
             continue;
         }
-        auto&& inverted_index_info = rs_meta.inverted_index_file_info(segment_id);
+        auto inverted_index_info = seg.inverted_index_file_info();
         if (idx_version == InvertedIndexStorageFormatPB::V1) {
             std::unordered_map<int64_t, int64_t> index_size_map;
             for (const auto& info : inverted_index_info.index_info()) {
                 if (info.index_file_size() != -1) {
                     index_size_map[info.index_id()] = info.index_file_size();
                 } else {
-                    VLOG_DEBUG << "Invalid index_file_size for segment_id " << segment_id
+                    VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg.id()
                                << ", index_id " << info.index_id();
                 }
             }
@@ -1010,7 +1008,7 @@ void record_warmup_ed_skipped_rowset_as_finished(RowsetMeta& rs_meta,
             if (inverted_index_info.has_index_size()) {
                 idx_size = inverted_index_info.index_size();
             } else {
-                VLOG_DEBUG << "index_size is not set for segment " << segment_id;
+                VLOG_DEBUG << "index_size is not set for segment " << seg.id();
             }
             record_warmup_ed_finish_index(job_id_str, idx_size);
         }
@@ -1214,9 +1212,10 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                                                                      upstream_trigger_ts_ms);
         }
 
-        for (int64_t segment_id = 0; segment_id < rs_meta.num_segments(); segment_id++) {
+        for (auto seg : rs_meta.segments()) {
+            auto segment_id = seg.id();
             if (!config::file_cache_enable_only_warm_up_idx) {
-                auto segment_size = rs_meta.segment_file_size(segment_id);
+                auto segment_size = seg.file_size();
 
                 // Use rs_meta.fs() instead of storage_resource.value()->fs to support packed files.
                 // PackedFileSystem wrapper in rs_meta.fs() handles the index_map lookup and
@@ -1289,7 +1288,7 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
 
             if (schema_ptr->has_inverted_index() || schema_ptr->has_ann_index()) {
                 if (idx_version == InvertedIndexStorageFormatPB::V1) {
-                    auto&& inverted_index_info = rs_meta.inverted_index_file_info(segment_id);
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     std::unordered_map<int64_t, int64_t> index_size_map;
                     for (const auto& info : inverted_index_info.index_info()) {
                         if (info.index_file_size() != -1) {
@@ -1305,7 +1304,7 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                         download_inverted_index(idx_path, index_size_map[index->index_id()]);
                     }
                 } else { // InvertedIndexStorageFormatPB::V2
-                    auto&& inverted_index_info = rs_meta.inverted_index_file_info(segment_id);
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     int64_t idx_size = 0;
                     if (inverted_index_info.has_index_size()) {
                         idx_size = inverted_index_info.index_size();
@@ -1342,8 +1341,10 @@ void CloudInternalServiceImpl::recycle_cache(google::protobuf::RpcController* co
         return;
     }
     for (const auto& meta : request->cache_metas()) {
-        for (int64_t segment_id = 0; segment_id < meta.num_segments(); segment_id++) {
-            auto file_key = Segment::file_cache_key(meta.rowset_id(), segment_id);
+        for (int64_t pos = 0; pos < meta.num_segments(); pos++) {
+            auto segment_id = rowset_segment_id(meta, pos);
+            auto file_key =
+                    Segment::file_cache_key(meta.rowset_id(), cast_set<uint32_t>(segment_id));
             auto* file_cache = io::FileCacheFactory::instance()->get_by_path(file_key);
             file_cache->remove_if_cached_async(file_key);
             g_file_cache_recycle_cache_finished_segment_num << 1;

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -65,6 +65,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_fwd.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet_meta.h"
 #include "util/client_cache.h"
@@ -1309,20 +1310,25 @@ Status CloudMetaMgr::_check_delete_bitmap_v2_correctness(CloudTablet* tablet, Ge
     }
     int64_t tablet_id = tablet->tablet_id();
     int64_t new_max_version = std::max(old_max_version, resp.rowset_meta().rbegin()->end_version());
-    // rowset_id, num_segments
-    std::vector<std::pair<RowsetId, int64_t>> all_rowsets;
+    // rowset_id, segment_ids
+    std::vector<std::pair<RowsetId, std::vector<int64_t>>> all_rowsets;
     std::map<std::string, std::string> rowset_to_resource;
     for (const auto& rs_meta : resp.rowset_meta()) {
         RowsetId rowset_id;
         rowset_id.init(rs_meta.rowset_id_v2());
-        all_rowsets.emplace_back(std::make_pair(rowset_id, rs_meta.num_segments()));
+        all_rowsets.emplace_back(rowset_id, rowset_segment_ids(rs_meta));
         rowset_to_resource[rs_meta.rowset_id_v2()] = rs_meta.resource_id();
     }
     if (old_max_version > 0) {
         RowsetIdUnorderedSet all_rs_ids;
         RETURN_IF_ERROR(tablet->get_all_rs_id(old_max_version, &all_rs_ids));
         for (auto& rowset : tablet->get_rowset_by_ids(&all_rs_ids)) {
-            all_rowsets.emplace_back(std::make_pair(rowset->rowset_id(), rowset->num_segments()));
+            std::vector<int64_t> segment_ids;
+            segment_ids.reserve(rowset->num_segments());
+            for (auto seg : rowset->segments()) {
+                segment_ids.push_back(seg.id());
+            }
+            all_rowsets.emplace_back(std::make_pair(rowset->rowset_id(), std::move(segment_ids)));
             rowset_to_resource[rowset->rowset_id().to_string()] =
                     rowset->rowset_meta()->resource_id();
         }
@@ -1330,8 +1336,8 @@ Status CloudMetaMgr::_check_delete_bitmap_v2_correctness(CloudTablet* tablet, Ge
 
     auto compare_delete_bitmap = [&](DeleteBitmap* delete_bitmap, int version) {
         bool success = true;
-        for (auto& [rs_id, num_segments] : all_rowsets) {
-            for (int seg_id = 0; seg_id < num_segments; ++seg_id) {
+        for (auto& [rs_id, segment_ids] : all_rowsets) {
+            for (auto seg_id : segment_ids) {
                 DeleteBitmap::BitmapKey key = {rs_id, seg_id, new_max_version};
                 auto dm1 = tablet->tablet_meta()->delete_bitmap().get_agg(key);
                 auto dm2 = delete_bitmap->get_agg_without_cache(key);
@@ -2387,9 +2393,9 @@ int64_t CloudMetaMgr::get_segment_file_size(RowsetMeta& rs_meta) {
     if (!fs) {
         LOG(WARNING) << "get fs failed, resource_id={}" << rs_meta.resource_id();
     }
-    for (int64_t seg_id = 0; seg_id < rs_meta.num_segments(); seg_id++) {
+    for (auto seg : rs_meta.segments()) {
         std::string segment_path = StorageResource().remote_segment_path(
-                rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg_id);
+                rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg.id());
         int64_t segment_file_size = 0;
         auto st = fs->file_size(segment_path, &segment_file_size);
         if (!st.ok()) {
@@ -2418,9 +2424,9 @@ int64_t CloudMetaMgr::get_inverted_index_file_size(RowsetMeta& rs_meta) {
         InvertedIndexStorageFormatPB::V1) {
         const auto& indices = rs_meta.tablet_schema()->inverted_indexes();
         for (auto& index : indices) {
-            for (int seg_id = 0; seg_id < rs_meta.num_segments(); ++seg_id) {
+            for (auto seg : rs_meta.segments()) {
                 std::string segment_path = StorageResource().remote_segment_path(
-                        rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg_id);
+                        rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg.id());
                 int64_t file_size = 0;
 
                 std::string inverted_index_file_path =
@@ -2446,10 +2452,10 @@ int64_t CloudMetaMgr::get_inverted_index_file_size(RowsetMeta& rs_meta) {
             }
         }
     } else {
-        for (int seg_id = 0; seg_id < rs_meta.num_segments(); ++seg_id) {
+        for (auto seg : rs_meta.segments()) {
             int64_t file_size = 0;
             std::string segment_path = StorageResource().remote_segment_path(
-                    rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg_id);
+                    rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg.id());
 
             std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_path_v2(
                     InvertedIndexDescriptor::get_index_file_path_prefix(segment_path));

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -62,6 +62,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_fwd.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet_meta.h"
 #include "util/client_cache.h"
@@ -1263,20 +1264,25 @@ Status CloudMetaMgr::_check_delete_bitmap_v2_correctness(CloudTablet* tablet, Ge
     }
     int64_t tablet_id = tablet->tablet_id();
     int64_t new_max_version = std::max(old_max_version, resp.rowset_meta().rbegin()->end_version());
-    // rowset_id, num_segments
-    std::vector<std::pair<RowsetId, int64_t>> all_rowsets;
+    // rowset_id, segment_ids
+    std::vector<std::pair<RowsetId, std::vector<int64_t>>> all_rowsets;
     std::map<std::string, std::string> rowset_to_resource;
     for (const auto& rs_meta : resp.rowset_meta()) {
         RowsetId rowset_id;
         rowset_id.init(rs_meta.rowset_id_v2());
-        all_rowsets.emplace_back(std::make_pair(rowset_id, rs_meta.num_segments()));
+        all_rowsets.emplace_back(rowset_id, rowset_segment_ids(rs_meta));
         rowset_to_resource[rs_meta.rowset_id_v2()] = rs_meta.resource_id();
     }
     if (old_max_version > 0) {
         RowsetIdUnorderedSet all_rs_ids;
         RETURN_IF_ERROR(tablet->get_all_rs_id(old_max_version, &all_rs_ids));
         for (auto& rowset : tablet->get_rowset_by_ids(&all_rs_ids)) {
-            all_rowsets.emplace_back(std::make_pair(rowset->rowset_id(), rowset->num_segments()));
+            std::vector<int64_t> segment_ids;
+            segment_ids.reserve(rowset->num_segments());
+            for (auto seg : rowset->segments()) {
+                segment_ids.push_back(seg.id());
+            }
+            all_rowsets.emplace_back(std::make_pair(rowset->rowset_id(), std::move(segment_ids)));
             rowset_to_resource[rowset->rowset_id().to_string()] =
                     rowset->rowset_meta()->resource_id();
         }
@@ -1284,8 +1290,8 @@ Status CloudMetaMgr::_check_delete_bitmap_v2_correctness(CloudTablet* tablet, Ge
 
     auto compare_delete_bitmap = [&](DeleteBitmap* delete_bitmap, int version) {
         bool success = true;
-        for (auto& [rs_id, num_segments] : all_rowsets) {
-            for (int seg_id = 0; seg_id < num_segments; ++seg_id) {
+        for (auto& [rs_id, segment_ids] : all_rowsets) {
+            for (auto seg_id : segment_ids) {
                 DeleteBitmap::BitmapKey key = {rs_id, seg_id, new_max_version};
                 auto dm1 = tablet->tablet_meta()->delete_bitmap().get_agg(key);
                 auto dm2 = delete_bitmap->get_agg_without_cache(key);
@@ -2305,9 +2311,9 @@ int64_t CloudMetaMgr::get_segment_file_size(RowsetMeta& rs_meta) {
     if (!fs) {
         LOG(WARNING) << "get fs failed, resource_id={}" << rs_meta.resource_id();
     }
-    for (int64_t seg_id = 0; seg_id < rs_meta.num_segments(); seg_id++) {
+    for (auto seg : rs_meta.segments()) {
         std::string segment_path = StorageResource().remote_segment_path(
-                rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg_id);
+                rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg.id());
         int64_t segment_file_size = 0;
         auto st = fs->file_size(segment_path, &segment_file_size);
         if (!st.ok()) {
@@ -2336,9 +2342,9 @@ int64_t CloudMetaMgr::get_inverted_index_file_size(RowsetMeta& rs_meta) {
         InvertedIndexStorageFormatPB::V1) {
         const auto& indices = rs_meta.tablet_schema()->inverted_indexes();
         for (auto& index : indices) {
-            for (int seg_id = 0; seg_id < rs_meta.num_segments(); ++seg_id) {
+            for (auto seg : rs_meta.segments()) {
                 std::string segment_path = StorageResource().remote_segment_path(
-                        rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg_id);
+                        rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg.id());
                 int64_t file_size = 0;
 
                 std::string inverted_index_file_path =
@@ -2364,10 +2370,10 @@ int64_t CloudMetaMgr::get_inverted_index_file_size(RowsetMeta& rs_meta) {
             }
         }
     } else {
-        for (int seg_id = 0; seg_id < rs_meta.num_segments(); ++seg_id) {
+        for (auto seg : rs_meta.segments()) {
             int64_t file_size = 0;
             std::string segment_path = StorageResource().remote_segment_path(
-                    rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg_id);
+                    rs_meta.tablet_id(), rs_meta.rowset_id().to_string(), seg.id());
 
             std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_path_v2(
                     InvertedIndexDescriptor::get_index_file_path_prefix(segment_path));

--- a/be/src/cloud/cloud_rowset_writer.cpp
+++ b/be/src/cloud/cloud_rowset_writer.cpp
@@ -86,12 +86,14 @@ Status CloudRowsetWriter::init(const RowsetWriterContext& rowset_writer_context)
     return Status::OK();
 }
 
-Status CloudRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num) {
+Status CloudRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num,
+                                             std::vector<int64_t>* completed_segment_ids) {
     VLOG_NOTICE << "start to build rowset meta. tablet_id=" << rowset_meta->tablet_id()
                 << ", rowset_id=" << rowset_meta->rowset_id()
                 << ", check_segment_num=" << check_segment_num;
     // Call base class implementation
-    RETURN_IF_ERROR(BaseBetaRowsetWriter::_build_rowset_meta(rowset_meta, check_segment_num));
+    RETURN_IF_ERROR(BaseBetaRowsetWriter::_build_rowset_meta(rowset_meta, check_segment_num,
+                                                             completed_segment_ids));
 
     // Collect packed file segment index information for interim rowsets as well.
     return _collect_all_packed_slice_locations(rowset_meta);

--- a/be/src/cloud/cloud_rowset_writer.cpp
+++ b/be/src/cloud/cloud_rowset_writer.cpp
@@ -83,12 +83,14 @@ Status CloudRowsetWriter::init(const RowsetWriterContext& rowset_writer_context)
     return Status::OK();
 }
 
-Status CloudRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num) {
+Status CloudRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num,
+                                             std::vector<int64_t>* completed_segment_ids) {
     VLOG_NOTICE << "start to build rowset meta. tablet_id=" << rowset_meta->tablet_id()
                 << ", rowset_id=" << rowset_meta->rowset_id()
                 << ", check_segment_num=" << check_segment_num;
     // Call base class implementation
-    RETURN_IF_ERROR(BaseBetaRowsetWriter::_build_rowset_meta(rowset_meta, check_segment_num));
+    RETURN_IF_ERROR(BaseBetaRowsetWriter::_build_rowset_meta(rowset_meta, check_segment_num,
+                                                             completed_segment_ids));
 
     // Collect packed file segment index information for interim rowsets as well.
     return _collect_all_packed_slice_locations(rowset_meta);

--- a/be/src/cloud/cloud_rowset_writer.h
+++ b/be/src/cloud/cloud_rowset_writer.h
@@ -33,7 +33,8 @@ public:
     Status build(RowsetSharedPtr& rowset) override;
 
 private:
-    Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false) override;
+    Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false,
+                              std::vector<int64_t>* completed_segment_ids = nullptr) override;
 
     Status _collect_all_packed_slice_locations(RowsetMeta* rowset_meta);
 

--- a/be/src/cloud/cloud_snapshot_mgr.cpp
+++ b/be/src/cloud/cloud_snapshot_mgr.cpp
@@ -40,6 +40,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_meta.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_policy.h"
@@ -234,8 +235,9 @@ Status CloudSnapshotMgr::_create_rowset_meta(
     rowset_id_mapping[src_rs_id] = dst_rs_id;
 
     for (int i = 0; i < source_meta_pb.num_segments(); ++i) {
-        std::string src_segment_file = fmt::format("{}_{}.dat", src_rs_id.to_string(), i);
-        std::string dst_segment_file = fmt::format("{}_{}.dat", dst_rs_id.to_string(), i);
+        auto segment_id = rowset_segment_id(source_meta_pb, i);
+        std::string src_segment_file = fmt::format("{}_{}.dat", src_rs_id.to_string(), segment_id);
+        std::string dst_segment_file = fmt::format("{}_{}.dat", dst_rs_id.to_string(), segment_id);
         file_mapping[src_segment_file] = dst_segment_file;
         if (context.tablet_schema->get_inverted_index_storage_format() ==
             InvertedIndexStorageFormatPB::V1) {
@@ -268,6 +270,7 @@ Status CloudSnapshotMgr::_create_rowset_meta(
     new_rowset_meta_pb->set_empty(source_meta_pb.num_rows() == 0);
     new_rowset_meta_pb->set_creation_time(time(nullptr));
     new_rowset_meta_pb->set_num_segments(source_meta_pb.num_segments());
+    new_rowset_meta_pb->mutable_segment_ids()->CopyFrom(source_meta_pb.segment_ids());
     new_rowset_meta_pb->set_rowset_state(source_meta_pb.rowset_state());
 
     new_rowset_meta_pb->clear_segments_key_bounds();

--- a/be/src/cloud/cloud_snapshot_mgr.cpp
+++ b/be/src/cloud/cloud_snapshot_mgr.cpp
@@ -40,6 +40,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_meta.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_policy.h"
@@ -234,8 +235,9 @@ Status CloudSnapshotMgr::_create_rowset_meta(
     rowset_id_mapping[src_rs_id] = dst_rs_id;
 
     for (int i = 0; i < source_meta_pb.num_segments(); ++i) {
-        std::string src_segment_file = fmt::format("{}_{}.dat", src_rs_id.to_string(), i);
-        std::string dst_segment_file = fmt::format("{}_{}.dat", dst_rs_id.to_string(), i);
+        auto segment_id = rowset_segment_id(source_meta_pb, i);
+        std::string src_segment_file = fmt::format("{}_{}.dat", src_rs_id.to_string(), segment_id);
+        std::string dst_segment_file = fmt::format("{}_{}.dat", dst_rs_id.to_string(), segment_id);
         file_mapping[src_segment_file] = dst_segment_file;
         if (context.tablet_schema->get_inverted_index_storage_format() ==
             InvertedIndexStorageFormatPB::V1) {
@@ -269,6 +271,7 @@ Status CloudSnapshotMgr::_create_rowset_meta(
     new_rowset_meta_pb->set_empty(source_meta_pb.num_rows() == 0);
     new_rowset_meta_pb->set_creation_time(time(nullptr));
     new_rowset_meta_pb->set_num_segments(source_meta_pb.num_segments());
+    new_rowset_meta_pb->mutable_segment_ids()->CopyFrom(source_meta_pb.segment_ids());
     new_rowset_meta_pb->set_rowset_state(source_meta_pb.rowset_state());
 
     new_rowset_meta_pb->clear_segments_key_bounds();

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -713,10 +713,13 @@ void CloudTablet::remove_unused_rowsets() {
 
         for (auto& rs : removed_rowsets) {
             auto index_names = rs->get_index_file_names();
-            recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(), index_names);
+            std::vector<int64_t> segment_ids(rs->rowset_meta()->segment_ids().begin(),
+                                             rs->rowset_meta()->segment_ids().end());
+            recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(),
+                                          std::move(segment_ids), index_names);
             int64_t segment_size_sum = 0;
-            for (int32_t i = 0; i < rs->num_segments(); i++) {
-                segment_size_sum += rs->rowset_meta()->segment_file_size(i);
+            for (auto seg : rs->segments()) {
+                segment_size_sum += seg.file_size();
             }
             g_file_cache_recycle_cached_data_segment_num << rs->num_segments();
             g_file_cache_recycle_cached_data_segment_size << segment_size_sum;
@@ -791,11 +794,14 @@ std::vector<RecycledRowsets> CloudTablet::recycle_cached_data(
         }
         rs->clear_cache();
         auto index_names = rs->get_index_file_names();
-        recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(), index_names);
+        std::vector<int64_t> segment_ids(rs->rowset_meta()->segment_ids().begin(),
+                                         rs->rowset_meta()->segment_ids().end());
+        recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(), std::move(segment_ids),
+                                      index_names);
 
         int64_t segment_size_sum = 0;
-        for (int32_t i = 0; i < rs->num_segments(); i++) {
-            segment_size_sum += rs->rowset_meta()->segment_file_size(i);
+        for (auto seg : rs->segments()) {
+            segment_size_sum += seg.file_size();
         }
         g_file_cache_recycle_cached_data_segment_num << rs->num_segments();
         g_file_cache_recycle_cached_data_segment_size << segment_size_sum;
@@ -1380,9 +1386,10 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     RETURN_IF_ERROR(_engine.meta_mgr().sync_tablet_rowsets(this));
     Version version = max_version();
     std::size_t missed_rows_size = 0;
-    calc_compaction_output_rowset_delete_bitmap(
-            input_rowsets, rowid_conversion, 0, version.second + 1, missed_rows.get(),
-            location_map.get(), tablet_meta()->delete_bitmap(), output_rowset_delete_bitmap.get());
+    calc_compaction_output_rowset_delete_bitmap(input_rowsets, output_rowset, rowid_conversion, 0,
+                                                version.second + 1, missed_rows.get(),
+                                                location_map.get(), tablet_meta()->delete_bitmap(),
+                                                output_rowset_delete_bitmap.get());
     if (missed_rows) {
         missed_rows_size = missed_rows->size();
         if (!allow_delete_in_cumu_compaction) {
@@ -1427,9 +1434,10 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     RETURN_IF_ERROR(_engine.meta_mgr().sync_tablet_rowsets(this));
     int64_t t3 = MonotonicMicros();
 
-    calc_compaction_output_rowset_delete_bitmap(
-            input_rowsets, rowid_conversion, version.second, UINT64_MAX, missed_rows.get(),
-            location_map.get(), tablet_meta()->delete_bitmap(), output_rowset_delete_bitmap.get());
+    calc_compaction_output_rowset_delete_bitmap(input_rowsets, output_rowset, rowid_conversion,
+                                                version.second, UINT64_MAX, missed_rows.get(),
+                                                location_map.get(), tablet_meta()->delete_bitmap(),
+                                                output_rowset_delete_bitmap.get());
     int64_t t4 = MonotonicMicros();
     if (location_map) {
         RETURN_IF_ERROR(check_rowid_conversion(output_rowset, *location_map));
@@ -1442,24 +1450,28 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     auto store_version = config::delete_bitmap_store_write_version;
     if (store_version == 2 || store_version == 3) {
         delete_bitmap_v2 = std::make_shared<DeleteBitmap>(*output_rowset_delete_bitmap);
-        std::vector<std::pair<RowsetId, int64_t>> retained_rowsets_to_seg_num;
+        std::vector<DeleteBitmap::RowsetIdWithSegmentIds> retained_rowsets;
         {
             std::shared_lock rlock(get_header_lock());
             for (const auto& [rowset_version, rowset_ptr] : rowset_map()) {
                 if (rowset_version.second < output_rowset->start_version()) {
-                    retained_rowsets_to_seg_num.emplace_back(
-                            std::make_pair(rowset_ptr->rowset_id(), rowset_ptr->num_segments()));
+                    std::vector<DeleteBitmap::SegmentId> segment_ids;
+                    segment_ids.reserve(rowset_ptr->num_segments());
+                    for (auto segment : rowset_ptr->segments()) {
+                        segment_ids.push_back(cast_set<DeleteBitmap::SegmentId>(segment.id()));
+                    }
+                    retained_rowsets.emplace_back(rowset_ptr->rowset_id(), std::move(segment_ids));
                 }
             }
         }
         if (config::enable_agg_delta_delete_bitmap_for_store_v2) {
             tablet_meta()->delete_bitmap().subset_and_agg(
-                    retained_rowsets_to_seg_num, output_rowset->start_version(),
-                    output_rowset->end_version(), delete_bitmap_v2.get());
+                    retained_rowsets, output_rowset->start_version(), output_rowset->end_version(),
+                    delete_bitmap_v2.get());
         } else {
-            tablet_meta()->delete_bitmap().subset(
-                    retained_rowsets_to_seg_num, output_rowset->start_version(),
-                    output_rowset->end_version(), delete_bitmap_v2.get());
+            tablet_meta()->delete_bitmap().subset(retained_rowsets, output_rowset->start_version(),
+                                                  output_rowset->end_version(),
+                                                  delete_bitmap_v2.get());
         }
     }
     std::optional<StorageResource> storage_resource;
@@ -1487,7 +1499,8 @@ void CloudTablet::agg_delete_bitmap_for_compaction(
         DeleteBitmapPtr& new_delete_bitmap,
         std::map<std::string, int64_t>& pre_rowset_to_versions) {
     for (auto& rowset : pre_rowsets) {
-        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+        for (auto seg : rowset->segments()) {
+            auto seg_id = cast_set<uint32_t>(seg.id());
             auto d = tablet_meta()->delete_bitmap().get_agg_without_cache(
                     {rowset->rowset_id(), seg_id, end_version}, start_version);
             if (d->isEmpty()) {
@@ -1812,9 +1825,8 @@ bool CloudTablet::_check_rowset_should_be_visible_but_not_warmed_up(
     return ret;
 }
 
-void CloudTablet::_submit_segment_download_task(const RowsetSharedPtr& rs,
-                                                const StorageResource* storage_resource, int seg_id,
-
+void CloudTablet::_submit_segment_download_task(const RowsetSharedPtr& rs, io::Path segment_path,
+                                                int64_t segment_file_size,
                                                 int64_t expiration_time) {
     // clang-format off
     const auto& rowset_meta = rs->rowset_meta();
@@ -1830,8 +1842,8 @@ void CloudTablet::_submit_segment_download_task(const RowsetSharedPtr& rs,
         return;
     }
     _engine.file_cache_block_downloader().submit_download_task(io::DownloadFileMeta {
-            .path = storage_resource->remote_segment_path(*rowset_meta, seg_id),
-            .file_size = rs->rowset_meta()->segment_file_size(seg_id),
+            .path = std::move(segment_path),
+            .file_size = segment_file_size,
             .file_system = file_system,
             .ctx = {
                     .expiration_time = expiration_time,
@@ -1921,7 +1933,7 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
             rs->rowset_meta()->set_encryption_algorithm(_tablet_meta->encryption_algorithm());
             bool warm_up_state_updated = false;
             // Warmup rowset data in background
-            for (int seg_id = 0; seg_id < rs->num_segments(); ++seg_id) {
+            for (auto seg : rs->segments()) {
                 const auto& rowset_meta = rs->rowset_meta();
                 constexpr int64_t interval = 600; // 10 mins
                 // When BE restart and receive the `load_sync` rpc, it will sync all historical rowsets first time.
@@ -1939,9 +1951,8 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
 
                 int64_t expiration_time = _tablet_meta->ttl_seconds();
                 g_file_cache_cloud_tablet_submitted_segment_num << 1;
-                if (rs->rowset_meta()->segment_file_size(seg_id) > 0) {
-                    g_file_cache_cloud_tablet_submitted_segment_size
-                            << rs->rowset_meta()->segment_file_size(seg_id);
+                if (seg.file_size() > 0) {
+                    g_file_cache_cloud_tablet_submitted_segment_size << seg.file_size();
                 }
                 if (!warm_up_state_updated) {
                     VLOG_DEBUG << "warm up rowset " << rs->version() << "(" << rs->rowset_id()
@@ -1956,7 +1967,10 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
                 }
 
                 if (!config::file_cache_enable_only_warm_up_idx) {
-                    _submit_segment_download_task(rs, storage_resource.value(), seg_id,
+                    io::Path segment_path(
+                            storage_resource.value()->remote_segment_path(*rowset_meta, seg.id()));
+                    auto segment_file_size = seg.file_size();
+                    _submit_segment_download_task(rs, std::move(segment_path), segment_file_size,
                                                   expiration_time);
                 }
 
@@ -1964,33 +1978,34 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
                 auto idx_version = schema_ptr->get_inverted_index_storage_format();
                 if (idx_version == InvertedIndexStorageFormatPB::V1) {
                     std::unordered_map<int64_t, int64_t> index_size_map;
-                    auto&& inverted_index_info = rowset_meta->inverted_index_file_info(seg_id);
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     for (const auto& info : inverted_index_info.index_info()) {
                         if (info.index_file_size() != -1) {
                             index_size_map[info.index_id()] = info.index_file_size();
                         } else {
-                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg_id
+                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg.id()
                                        << ", index_id " << info.index_id();
                         }
                     }
                     for (const auto& index : schema_ptr->inverted_indexes()) {
                         auto idx_path = storage_resource.value()->remote_idx_v1_path(
-                                *rowset_meta, seg_id, index->index_id(), index->get_index_suffix());
+                                *rowset_meta, seg.id(), index->index_id(),
+                                index->get_index_suffix());
                         _submit_inverted_index_download_task(rs, storage_resource.value(), idx_path,
                                                              index_size_map[index->index_id()],
                                                              expiration_time);
                     }
                 } else {
                     if (schema_ptr->has_inverted_or_ann_index()) {
-                        auto&& inverted_index_info = rowset_meta->inverted_index_file_info(seg_id);
+                        auto inverted_index_info = seg.inverted_index_file_info();
                         int64_t idx_size = 0;
                         if (inverted_index_info.has_index_size()) {
                             idx_size = inverted_index_info.index_size();
                         } else {
-                            VLOG_DEBUG << "index_size is not set for segment " << seg_id;
+                            VLOG_DEBUG << "index_size is not set for segment " << seg.id();
                         }
-                        auto idx_path =
-                                storage_resource.value()->remote_idx_v2_path(*rowset_meta, seg_id);
+                        auto idx_path = storage_resource.value()->remote_idx_v2_path(*rowset_meta,
+                                                                                     seg.id());
                         _submit_inverted_index_download_task(rs, storage_resource.value(), idx_path,
                                                              idx_size, expiration_time);
                     }

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -713,10 +713,13 @@ void CloudTablet::remove_unused_rowsets() {
 
         for (auto& rs : removed_rowsets) {
             auto index_names = rs->get_index_file_names();
-            recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(), index_names);
+            std::vector<int64_t> segment_ids(rs->rowset_meta()->segment_ids().begin(),
+                                             rs->rowset_meta()->segment_ids().end());
+            recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(),
+                                          std::move(segment_ids), index_names);
             int64_t segment_size_sum = 0;
-            for (int32_t i = 0; i < rs->num_segments(); i++) {
-                segment_size_sum += rs->rowset_meta()->segment_file_size(i);
+            for (auto seg : rs->segments()) {
+                segment_size_sum += seg.file_size();
             }
             g_file_cache_recycle_cached_data_segment_num << rs->num_segments();
             g_file_cache_recycle_cached_data_segment_size << segment_size_sum;
@@ -791,11 +794,14 @@ std::vector<RecycledRowsets> CloudTablet::recycle_cached_data(
         }
         rs->clear_cache();
         auto index_names = rs->get_index_file_names();
-        recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(), index_names);
+        std::vector<int64_t> segment_ids(rs->rowset_meta()->segment_ids().begin(),
+                                         rs->rowset_meta()->segment_ids().end());
+        recycled_rowsets.emplace_back(rs->rowset_id(), rs->num_segments(), std::move(segment_ids),
+                                      index_names);
 
         int64_t segment_size_sum = 0;
-        for (int32_t i = 0; i < rs->num_segments(); i++) {
-            segment_size_sum += rs->rowset_meta()->segment_file_size(i);
+        for (auto seg : rs->segments()) {
+            segment_size_sum += seg.file_size();
         }
         g_file_cache_recycle_cached_data_segment_num << rs->num_segments();
         g_file_cache_recycle_cached_data_segment_size << segment_size_sum;
@@ -1328,9 +1334,10 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     RETURN_IF_ERROR(_engine.meta_mgr().sync_tablet_rowsets(this));
     Version version = max_version();
     std::size_t missed_rows_size = 0;
-    calc_compaction_output_rowset_delete_bitmap(
-            input_rowsets, rowid_conversion, 0, version.second + 1, missed_rows.get(),
-            location_map.get(), tablet_meta()->delete_bitmap(), output_rowset_delete_bitmap.get());
+    calc_compaction_output_rowset_delete_bitmap(input_rowsets, output_rowset, rowid_conversion, 0,
+                                                version.second + 1, missed_rows.get(),
+                                                location_map.get(), tablet_meta()->delete_bitmap(),
+                                                output_rowset_delete_bitmap.get());
     if (missed_rows) {
         missed_rows_size = missed_rows->size();
         if (!allow_delete_in_cumu_compaction) {
@@ -1375,9 +1382,10 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     RETURN_IF_ERROR(_engine.meta_mgr().sync_tablet_rowsets(this));
     int64_t t3 = MonotonicMicros();
 
-    calc_compaction_output_rowset_delete_bitmap(
-            input_rowsets, rowid_conversion, version.second, UINT64_MAX, missed_rows.get(),
-            location_map.get(), tablet_meta()->delete_bitmap(), output_rowset_delete_bitmap.get());
+    calc_compaction_output_rowset_delete_bitmap(input_rowsets, output_rowset, rowid_conversion,
+                                                version.second, UINT64_MAX, missed_rows.get(),
+                                                location_map.get(), tablet_meta()->delete_bitmap(),
+                                                output_rowset_delete_bitmap.get());
     int64_t t4 = MonotonicMicros();
     if (location_map) {
         RETURN_IF_ERROR(check_rowid_conversion(output_rowset, *location_map));
@@ -1390,24 +1398,28 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     auto store_version = config::delete_bitmap_store_write_version;
     if (store_version == 2 || store_version == 3) {
         delete_bitmap_v2 = std::make_shared<DeleteBitmap>(*output_rowset_delete_bitmap);
-        std::vector<std::pair<RowsetId, int64_t>> retained_rowsets_to_seg_num;
+        std::vector<DeleteBitmap::RowsetIdWithSegmentIds> retained_rowsets;
         {
             std::shared_lock rlock(get_header_lock());
             for (const auto& [rowset_version, rowset_ptr] : rowset_map()) {
                 if (rowset_version.second < output_rowset->start_version()) {
-                    retained_rowsets_to_seg_num.emplace_back(
-                            std::make_pair(rowset_ptr->rowset_id(), rowset_ptr->num_segments()));
+                    std::vector<DeleteBitmap::SegmentId> segment_ids;
+                    segment_ids.reserve(rowset_ptr->num_segments());
+                    for (auto segment : rowset_ptr->segments()) {
+                        segment_ids.push_back(cast_set<DeleteBitmap::SegmentId>(segment.id()));
+                    }
+                    retained_rowsets.emplace_back(rowset_ptr->rowset_id(), std::move(segment_ids));
                 }
             }
         }
         if (config::enable_agg_delta_delete_bitmap_for_store_v2) {
             tablet_meta()->delete_bitmap().subset_and_agg(
-                    retained_rowsets_to_seg_num, output_rowset->start_version(),
-                    output_rowset->end_version(), delete_bitmap_v2.get());
+                    retained_rowsets, output_rowset->start_version(), output_rowset->end_version(),
+                    delete_bitmap_v2.get());
         } else {
-            tablet_meta()->delete_bitmap().subset(
-                    retained_rowsets_to_seg_num, output_rowset->start_version(),
-                    output_rowset->end_version(), delete_bitmap_v2.get());
+            tablet_meta()->delete_bitmap().subset(retained_rowsets, output_rowset->start_version(),
+                                                  output_rowset->end_version(),
+                                                  delete_bitmap_v2.get());
         }
     }
     std::optional<StorageResource> storage_resource;
@@ -1435,7 +1447,8 @@ void CloudTablet::agg_delete_bitmap_for_compaction(
         DeleteBitmapPtr& new_delete_bitmap,
         std::map<std::string, int64_t>& pre_rowset_to_versions) {
     for (auto& rowset : pre_rowsets) {
-        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+        for (auto seg : rowset->segments()) {
+            auto seg_id = cast_set<uint32_t>(seg.id());
             auto d = tablet_meta()->delete_bitmap().get_agg_without_cache(
                     {rowset->rowset_id(), seg_id, end_version}, start_version);
             if (d->isEmpty()) {
@@ -1753,9 +1766,8 @@ bool CloudTablet::_check_rowset_should_be_visible_but_not_warmed_up(
     return ret;
 }
 
-void CloudTablet::_submit_segment_download_task(const RowsetSharedPtr& rs,
-                                                const StorageResource* storage_resource, int seg_id,
-
+void CloudTablet::_submit_segment_download_task(const RowsetSharedPtr& rs, io::Path segment_path,
+                                                int64_t segment_file_size,
                                                 int64_t expiration_time) {
     // clang-format off
     const auto& rowset_meta = rs->rowset_meta();
@@ -1771,8 +1783,8 @@ void CloudTablet::_submit_segment_download_task(const RowsetSharedPtr& rs,
         return;
     }
     _engine.file_cache_block_downloader().submit_download_task(io::DownloadFileMeta {
-            .path = storage_resource->remote_segment_path(*rowset_meta, seg_id),
-            .file_size = rs->rowset_meta()->segment_file_size(seg_id),
+            .path = std::move(segment_path),
+            .file_size = segment_file_size,
             .file_system = file_system,
             .ctx = {
                     .expiration_time = expiration_time,
@@ -1862,7 +1874,7 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
             rs->rowset_meta()->set_encryption_algorithm(_tablet_meta->encryption_algorithm());
             bool warm_up_state_updated = false;
             // Warmup rowset data in background
-            for (int seg_id = 0; seg_id < rs->num_segments(); ++seg_id) {
+            for (auto seg : rs->segments()) {
                 const auto& rowset_meta = rs->rowset_meta();
                 constexpr int64_t interval = 600; // 10 mins
                 // When BE restart and receive the `load_sync` rpc, it will sync all historical rowsets first time.
@@ -1880,9 +1892,8 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
 
                 int64_t expiration_time = _tablet_meta->ttl_seconds();
                 g_file_cache_cloud_tablet_submitted_segment_num << 1;
-                if (rs->rowset_meta()->segment_file_size(seg_id) > 0) {
-                    g_file_cache_cloud_tablet_submitted_segment_size
-                            << rs->rowset_meta()->segment_file_size(seg_id);
+                if (seg.file_size() > 0) {
+                    g_file_cache_cloud_tablet_submitted_segment_size << seg.file_size();
                 }
                 if (!warm_up_state_updated) {
                     VLOG_DEBUG << "warm up rowset " << rs->version() << "(" << rs->rowset_id()
@@ -1897,7 +1908,10 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
                 }
 
                 if (!config::file_cache_enable_only_warm_up_idx) {
-                    _submit_segment_download_task(rs, storage_resource.value(), seg_id,
+                    io::Path segment_path(
+                            storage_resource.value()->remote_segment_path(*rowset_meta, seg.id()));
+                    auto segment_file_size = seg.file_size();
+                    _submit_segment_download_task(rs, std::move(segment_path), segment_file_size,
                                                   expiration_time);
                 }
 
@@ -1905,33 +1919,34 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
                 auto idx_version = schema_ptr->get_inverted_index_storage_format();
                 if (idx_version == InvertedIndexStorageFormatPB::V1) {
                     std::unordered_map<int64_t, int64_t> index_size_map;
-                    auto&& inverted_index_info = rowset_meta->inverted_index_file_info(seg_id);
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     for (const auto& info : inverted_index_info.index_info()) {
                         if (info.index_file_size() != -1) {
                             index_size_map[info.index_id()] = info.index_file_size();
                         } else {
-                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg_id
+                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg.id()
                                        << ", index_id " << info.index_id();
                         }
                     }
                     for (const auto& index : schema_ptr->inverted_indexes()) {
                         auto idx_path = storage_resource.value()->remote_idx_v1_path(
-                                *rowset_meta, seg_id, index->index_id(), index->get_index_suffix());
+                                *rowset_meta, seg.id(), index->index_id(),
+                                index->get_index_suffix());
                         _submit_inverted_index_download_task(rs, storage_resource.value(), idx_path,
                                                              index_size_map[index->index_id()],
                                                              expiration_time);
                     }
                 } else {
                     if (schema_ptr->has_inverted_index() || schema_ptr->has_ann_index()) {
-                        auto&& inverted_index_info = rowset_meta->inverted_index_file_info(seg_id);
+                        auto inverted_index_info = seg.inverted_index_file_info();
                         int64_t idx_size = 0;
                         if (inverted_index_info.has_index_size()) {
                             idx_size = inverted_index_info.index_size();
                         } else {
-                            VLOG_DEBUG << "index_size is not set for segment " << seg_id;
+                            VLOG_DEBUG << "index_size is not set for segment " << seg.id();
                         }
-                        auto idx_path =
-                                storage_resource.value()->remote_idx_v2_path(*rowset_meta, seg_id);
+                        auto idx_path = storage_resource.value()->remote_idx_v2_path(*rowset_meta,
+                                                                                     seg.id());
                         _submit_inverted_index_download_task(rs, storage_resource.value(), idx_path,
                                                              idx_size, expiration_time);
                     }

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -71,6 +71,7 @@ struct SyncOptions {
 struct RecycledRowsets {
     RowsetId rowset_id;
     int64_t num_segments;
+    std::vector<int64_t> segment_ids;
     std::vector<std::string> index_file_names;
 };
 
@@ -442,9 +443,8 @@ private:
             std::chrono::system_clock::time_point freshness_limit_tp) const;
 
     // Submit a segment download task for warming up
-    void _submit_segment_download_task(const RowsetSharedPtr& rs,
-                                       const StorageResource* storage_resource, int seg_id,
-                                       int64_t expiration_time);
+    void _submit_segment_download_task(const RowsetSharedPtr& rs, io::Path segment_path,
+                                       int64_t segment_file_size, int64_t expiration_time);
 
     // Submit an inverted index download task for warming up
     void _submit_inverted_index_download_task(const RowsetSharedPtr& rs,

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -303,19 +303,19 @@ void CloudWarmUpManager::handle_jobs() {
                               << ", skip it";
                     continue;
                 }
-                for (int64_t seg_id = 0; seg_id < rs->num_segments(); seg_id++) {
+                for (auto seg : rs->segments()) {
+                    auto segment_id = seg.id();
                     // 1st. download segment files
                     // Use rs->fs() instead of storage_resource.value()->fs to support packed
                     // files. PackedFileSystem wrapper in RowsetMeta::fs() handles the index_map
                     // lookup and reads from the correct packed file.
                     if (!config::file_cache_enable_only_warm_up_idx) {
                         submit_download_tasks(
-                                storage_resource.value()->remote_segment_path(*rs, seg_id),
-                                rs->segment_file_size(cast_set<int>(seg_id)), rs->fs(),
-                                expiration_time, wait, false,
-                                [tablet, rs, seg_id](Status st) {
+                                storage_resource.value()->remote_segment_path(*rs, segment_id),
+                                seg.file_size(), rs->fs(), expiration_time, wait, false,
+                                [tablet, rs, segment_id](Status st) {
                                     VLOG_DEBUG << "warmup rowset " << rs->version() << " segment "
-                                               << seg_id << " completed";
+                                               << segment_id << " completed";
                                     if (tablet->complete_rowset_segment_warmup(
                                                       WarmUpTriggerSource::JOB, rs->rowset_id(), st,
                                                       1, 0)
@@ -331,22 +331,21 @@ void CloudWarmUpManager::handle_jobs() {
                     int64_t file_size = -1;
                     auto schema_ptr = rs->tablet_schema();
                     auto idx_version = schema_ptr->get_inverted_index_storage_format();
-                    const auto& idx_file_info = rs->inverted_index_file_info(cast_set<int>(seg_id));
+                    auto idx_file_info = seg.inverted_index_file_info();
                     if (idx_version == InvertedIndexStorageFormatPB::V1) {
-                        auto&& inverted_index_info =
-                                rs->inverted_index_file_info(cast_set<int>(seg_id));
+                        auto inverted_index_info = seg.inverted_index_file_info();
                         std::unordered_map<int64_t, int64_t> index_size_map;
                         for (const auto& info : inverted_index_info.index_info()) {
                             if (info.index_file_size() != -1) {
                                 index_size_map[info.index_id()] = info.index_file_size();
                             } else {
-                                VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg_id
-                                           << ", index_id " << info.index_id();
+                                VLOG_DEBUG << "Invalid index_file_size for segment_id "
+                                           << segment_id << ", index_id " << info.index_id();
                             }
                         }
                         for (const auto& index : schema_ptr->inverted_indexes()) {
                             auto idx_path = storage_resource.value()->remote_idx_v1_path(
-                                    *rs, seg_id, index->index_id(), index->get_index_suffix());
+                                    *rs, segment_id, index->index_id(), index->get_index_suffix());
                             if (idx_file_info.index_info_size() > 0) {
                                 for (const auto& idx_info : idx_file_info.index_info()) {
                                     if (index->index_id() == idx_info.index_id() &&
@@ -362,7 +361,7 @@ void CloudWarmUpManager::handle_jobs() {
                                     idx_path, file_size, rs->fs(), expiration_time, wait, true,
                                     [=](Status st) {
                                         VLOG_DEBUG << "warmup rowset " << rs->version()
-                                                   << " segment " << seg_id
+                                                   << " segment " << segment_id
                                                    << "inverted idx:" << idx_path << " completed";
                                         if (tablet->complete_rowset_segment_warmup(
                                                           WarmUpTriggerSource::JOB, rs->rowset_id(),
@@ -377,7 +376,7 @@ void CloudWarmUpManager::handle_jobs() {
                     } else {
                         if (schema_ptr->has_inverted_or_ann_index()) {
                             auto idx_path =
-                                    storage_resource.value()->remote_idx_v2_path(*rs, seg_id);
+                                    storage_resource.value()->remote_idx_v2_path(*rs, segment_id);
                             file_size = idx_file_info.has_index_size() ? idx_file_info.index_size()
                                                                        : -1;
                             tablet->update_rowset_warmup_state_inverted_idx_num(
@@ -386,7 +385,7 @@ void CloudWarmUpManager::handle_jobs() {
                                     idx_path, file_size, rs->fs(), expiration_time, wait, true,
                                     [=](Status st) {
                                         VLOG_DEBUG << "warmup rowset " << rs->version()
-                                                   << " segment " << seg_id
+                                                   << " segment " << segment_id
                                                    << "inverted idx:" << idx_path << " completed";
                                         if (tablet->complete_rowset_segment_warmup(
                                                           WarmUpTriggerSource::JOB, rs->rowset_id(),
@@ -839,8 +838,8 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
         // update metrics
         auto schema_ptr = rs_meta.tablet_schema();
         auto idx_version = schema_ptr->get_inverted_index_storage_format();
-        for (int64_t segment_id = 0; segment_id < rs_meta.num_segments(); segment_id++) {
-            auto seg_size = rs_meta.segment_file_size(cast_set<int>(segment_id));
+        for (auto seg : rs_meta.segments()) {
+            auto seg_size = seg.file_size();
 
             g_file_cache_event_driven_warm_up_requested_segment_num << 1;
             g_warmup_ed_requested_segment_num.put({job_id_str}, 1);
@@ -850,10 +849,9 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
 
             if (schema_ptr->has_inverted_or_ann_index()) {
                 if (idx_version == InvertedIndexStorageFormatPB::V1) {
-                    auto&& inverted_index_info =
-                            rs_meta.inverted_index_file_info(cast_set<int>(segment_id));
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     if (inverted_index_info.index_info().empty()) {
-                        VLOG_DEBUG << "No index info available for segment " << segment_id;
+                        VLOG_DEBUG << "No index info available for segment " << seg.id();
                         continue;
                     }
                     for (const auto& idx_info : inverted_index_info.index_info()) {
@@ -866,13 +864,12 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
                             g_warmup_ed_requested_index_size.put({job_id_str},
                                                                  idx_info.index_file_size());
                         } else {
-                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << segment_id
+                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg.id()
                                        << ", index_id " << idx_info.index_id();
                         }
                     }
                 } else { // InvertedIndexStorageFormatPB::V2
-                    auto&& inverted_index_info =
-                            rs_meta.inverted_index_file_info(cast_set<int>(segment_id));
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     g_file_cache_event_driven_warm_up_requested_index_num << 1;
                     g_warmup_ed_requested_index_num.put({job_id_str}, 1);
 
@@ -882,7 +879,7 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
                         g_warmup_ed_requested_index_size.put({job_id_str},
                                                              inverted_index_info.index_size());
                     } else {
-                        VLOG_DEBUG << "index_size is not set for segment " << segment_id;
+                        VLOG_DEBUG << "index_size is not set for segment " << seg.id();
                     }
                 }
             }
@@ -965,6 +962,7 @@ void CloudWarmUpManager::_recycle_cache(int64_t tablet_id,
         meta->set_tablet_id(tablet_id);
         meta->set_rowset_id(rowset.rowset_id.to_string());
         meta->set_num_segments(rowset.num_segments);
+        meta->mutable_segment_ids()->Add(rowset.segment_ids.begin(), rowset.segment_ids.end());
         for (const auto& name : rowset.index_file_names) {
             meta->add_index_file_names(name);
         }

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -307,19 +307,19 @@ void CloudWarmUpManager::handle_jobs() {
                               << ", skip it";
                     continue;
                 }
-                for (int64_t seg_id = 0; seg_id < rs->num_segments(); seg_id++) {
+                for (auto seg : rs->segments()) {
+                    auto segment_id = seg.id();
                     // 1st. download segment files
                     // Use rs->fs() instead of storage_resource.value()->fs to support packed
                     // files. PackedFileSystem wrapper in RowsetMeta::fs() handles the index_map
                     // lookup and reads from the correct packed file.
                     if (!config::file_cache_enable_only_warm_up_idx) {
                         submit_download_tasks(
-                                storage_resource.value()->remote_segment_path(*rs, seg_id),
-                                rs->segment_file_size(cast_set<int>(seg_id)), rs->fs(),
-                                expiration_time, wait, false,
-                                [tablet, rs, seg_id](Status st) {
+                                storage_resource.value()->remote_segment_path(*rs, segment_id),
+                                seg.file_size(), rs->fs(), expiration_time, wait, false,
+                                [tablet, rs, segment_id](Status st) {
                                     VLOG_DEBUG << "warmup rowset " << rs->version() << " segment "
-                                               << seg_id << " completed";
+                                               << segment_id << " completed";
                                     if (tablet->complete_rowset_segment_warmup(
                                                       WarmUpTriggerSource::JOB, rs->rowset_id(), st,
                                                       1, 0)
@@ -335,22 +335,21 @@ void CloudWarmUpManager::handle_jobs() {
                     int64_t file_size = -1;
                     auto schema_ptr = rs->tablet_schema();
                     auto idx_version = schema_ptr->get_inverted_index_storage_format();
-                    const auto& idx_file_info = rs->inverted_index_file_info(cast_set<int>(seg_id));
+                    auto idx_file_info = seg.inverted_index_file_info();
                     if (idx_version == InvertedIndexStorageFormatPB::V1) {
-                        auto&& inverted_index_info =
-                                rs->inverted_index_file_info(cast_set<int>(seg_id));
+                        auto inverted_index_info = seg.inverted_index_file_info();
                         std::unordered_map<int64_t, int64_t> index_size_map;
                         for (const auto& info : inverted_index_info.index_info()) {
                             if (info.index_file_size() != -1) {
                                 index_size_map[info.index_id()] = info.index_file_size();
                             } else {
-                                VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg_id
-                                           << ", index_id " << info.index_id();
+                                VLOG_DEBUG << "Invalid index_file_size for segment_id "
+                                           << segment_id << ", index_id " << info.index_id();
                             }
                         }
                         for (const auto& index : schema_ptr->inverted_indexes()) {
                             auto idx_path = storage_resource.value()->remote_idx_v1_path(
-                                    *rs, seg_id, index->index_id(), index->get_index_suffix());
+                                    *rs, segment_id, index->index_id(), index->get_index_suffix());
                             if (idx_file_info.index_info_size() > 0) {
                                 for (const auto& idx_info : idx_file_info.index_info()) {
                                     if (index->index_id() == idx_info.index_id() &&
@@ -366,7 +365,7 @@ void CloudWarmUpManager::handle_jobs() {
                                     idx_path, file_size, rs->fs(), expiration_time, wait, true,
                                     [=](Status st) {
                                         VLOG_DEBUG << "warmup rowset " << rs->version()
-                                                   << " segment " << seg_id
+                                                   << " segment " << segment_id
                                                    << "inverted idx:" << idx_path << " completed";
                                         if (tablet->complete_rowset_segment_warmup(
                                                           WarmUpTriggerSource::JOB, rs->rowset_id(),
@@ -381,7 +380,7 @@ void CloudWarmUpManager::handle_jobs() {
                     } else {
                         if (schema_ptr->has_inverted_index() || schema_ptr->has_ann_index()) {
                             auto idx_path =
-                                    storage_resource.value()->remote_idx_v2_path(*rs, seg_id);
+                                    storage_resource.value()->remote_idx_v2_path(*rs, segment_id);
                             file_size = idx_file_info.has_index_size() ? idx_file_info.index_size()
                                                                        : -1;
                             tablet->update_rowset_warmup_state_inverted_idx_num(
@@ -390,7 +389,7 @@ void CloudWarmUpManager::handle_jobs() {
                                     idx_path, file_size, rs->fs(), expiration_time, wait, true,
                                     [=](Status st) {
                                         VLOG_DEBUG << "warmup rowset " << rs->version()
-                                                   << " segment " << seg_id
+                                                   << " segment " << segment_id
                                                    << "inverted idx:" << idx_path << " completed";
                                         if (tablet->complete_rowset_segment_warmup(
                                                           WarmUpTriggerSource::JOB, rs->rowset_id(),
@@ -843,8 +842,8 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
         // update metrics
         auto schema_ptr = rs_meta.tablet_schema();
         auto idx_version = schema_ptr->get_inverted_index_storage_format();
-        for (int64_t segment_id = 0; segment_id < rs_meta.num_segments(); segment_id++) {
-            auto seg_size = rs_meta.segment_file_size(cast_set<int>(segment_id));
+        for (auto seg : rs_meta.segments()) {
+            auto seg_size = seg.file_size();
 
             g_file_cache_event_driven_warm_up_requested_segment_num << 1;
             g_warmup_ed_requested_segment_num.put({job_id_str}, 1);
@@ -854,10 +853,9 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
 
             if (schema_ptr->has_inverted_index() || schema_ptr->has_ann_index()) {
                 if (idx_version == InvertedIndexStorageFormatPB::V1) {
-                    auto&& inverted_index_info =
-                            rs_meta.inverted_index_file_info(cast_set<int>(segment_id));
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     if (inverted_index_info.index_info().empty()) {
-                        VLOG_DEBUG << "No index info available for segment " << segment_id;
+                        VLOG_DEBUG << "No index info available for segment " << seg.id();
                         continue;
                     }
                     for (const auto& idx_info : inverted_index_info.index_info()) {
@@ -870,13 +868,12 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
                             g_warmup_ed_requested_index_size.put({job_id_str},
                                                                  idx_info.index_file_size());
                         } else {
-                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << segment_id
+                            VLOG_DEBUG << "Invalid index_file_size for segment_id " << seg.id()
                                        << ", index_id " << idx_info.index_id();
                         }
                     }
                 } else { // InvertedIndexStorageFormatPB::V2
-                    auto&& inverted_index_info =
-                            rs_meta.inverted_index_file_info(cast_set<int>(segment_id));
+                    auto inverted_index_info = seg.inverted_index_file_info();
                     g_file_cache_event_driven_warm_up_requested_index_num << 1;
                     g_warmup_ed_requested_index_num.put({job_id_str}, 1);
 
@@ -886,7 +883,7 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
                         g_warmup_ed_requested_index_size.put({job_id_str},
                                                              inverted_index_info.index_size());
                     } else {
-                        VLOG_DEBUG << "index_size is not set for segment " << segment_id;
+                        VLOG_DEBUG << "index_size is not set for segment " << seg.id();
                     }
                 }
             }
@@ -969,6 +966,7 @@ void CloudWarmUpManager::_recycle_cache(int64_t tablet_id,
         meta->set_tablet_id(tablet_id);
         meta->set_rowset_id(rowset.rowset_id.to_string());
         meta->set_num_segments(rowset.num_segments);
+        meta->mutable_segment_ids()->Add(rowset.segment_ids.begin(), rowset.segment_ids.end());
         for (const auto& name : rowset.index_file_names) {
             meta->add_index_file_names(name);
         }

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -67,6 +67,7 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->CopyFrom(in.segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
@@ -164,6 +165,7 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->Swap(in.mutable_segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
@@ -275,6 +277,7 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->CopyFrom(in.segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
@@ -372,6 +375,7 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->Swap(in.mutable_segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -67,6 +67,7 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->CopyFrom(in.segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
@@ -161,6 +162,7 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->Swap(in.mutable_segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
@@ -269,6 +271,7 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->CopyFrom(in.segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
@@ -363,6 +366,7 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
         out->mutable_tablet_uid()->CopyFrom(in.tablet_uid());
     }
     out->set_num_segments(in.num_segments());
+    out->mutable_segment_ids()->Swap(in.mutable_segment_ids());
     out->set_rowset_id_v2(in.rowset_id_v2());
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1961,6 +1961,7 @@ DEFINE_Validator(concurrency_stats_dump_interval_ms,
 DEFINE_mBool(cloud_mow_sync_rowsets_when_load_txn_begin, "true");
 
 DEFINE_mBool(enable_cloud_make_rs_visible_on_be, "false");
+DEFINE_mBool(enable_cloud_random_segment_id, "false");
 DEFINE_mInt32(file_handles_deplenish_frequency_times, "3");
 
 // clang-format off

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1858,6 +1858,7 @@ DEFINE_Validator(concurrency_stats_dump_interval_ms,
 DEFINE_mBool(cloud_mow_sync_rowsets_when_load_txn_begin, "true");
 
 DEFINE_mBool(enable_cloud_make_rs_visible_on_be, "false");
+DEFINE_mBool(enable_cloud_random_segment_id, "true");
 DEFINE_mInt32(file_handles_deplenish_frequency_times, "3");
 
 // clang-format off

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1982,6 +1982,7 @@ DECLARE_mInt32(concurrency_stats_dump_interval_ms);
 DECLARE_mBool(cloud_mow_sync_rowsets_when_load_txn_begin);
 
 DECLARE_mBool(enable_cloud_make_rs_visible_on_be);
+DECLARE_mBool(enable_cloud_random_segment_id);
 DECLARE_mInt32(file_handles_deplenish_frequency_times);
 
 #ifdef BE_TEST

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1904,6 +1904,7 @@ DECLARE_mInt32(concurrency_stats_dump_interval_ms);
 DECLARE_mBool(cloud_mow_sync_rowsets_when_load_txn_begin);
 
 DECLARE_mBool(enable_cloud_make_rs_visible_on_be);
+DECLARE_mBool(enable_cloud_random_segment_id);
 DECLARE_mInt32(file_handles_deplenish_frequency_times);
 
 #ifdef BE_TEST

--- a/be/src/io/fs/packed_file_manager.h
+++ b/be/src/io/fs/packed_file_manager.h
@@ -57,6 +57,7 @@ struct PackedAppendContext {
     std::string resource_id;
     int64_t tablet_id = 0;
     std::string rowset_id;
+    int64_t first_segment_id = 0;
     int64_t txn_id = 0;
     uint64_t expiration_time = 0; // TTL expiration time in seconds since epoch, 0 means no TTL
     bool write_file_cache = true; // Whether to write data to file cache

--- a/be/src/io/fs/packed_file_system.cpp
+++ b/be/src/io/fs/packed_file_system.cpp
@@ -17,6 +17,7 @@
 
 #include "io/fs/packed_file_system.h"
 
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -40,7 +41,8 @@ namespace {
 // Multi-segment rowsets usually come from large loads or memory-pressure flushes,
 // and continuing to buffer later segments in packed files can amplify memory usage.
 // Non-rowset file names keep the legacy behavior to avoid changing unrelated callers.
-bool should_use_packed_writer(std::string_view file_name) {
+bool should_use_packed_writer(std::string_view file_name, int64_t first_segment_id) {
+    DORIS_CHECK_GE(first_segment_id, 0);
     constexpr std::string_view kSegmentSuffix = ".dat";
     constexpr std::string_view kIndexSuffix = ".idx";
 
@@ -59,7 +61,7 @@ bool should_use_packed_writer(std::string_view file_name) {
         return true;
     }
 
-    return file_name.substr(pos + 1) == "0";
+    return file_name.substr(pos + 1) == std::to_string(first_segment_id);
 }
 
 } // namespace
@@ -92,7 +94,7 @@ Status PackedFileSystem::create_file_impl(const Path& file, FileWriterPtr* write
     FileWriterPtr inner_writer;
     RETURN_IF_ERROR(_inner_fs->create_file(file, &inner_writer, opts));
 
-    if (!should_use_packed_writer(file.filename().native())) {
+    if (!should_use_packed_writer(file.filename().native(), _append_info.first_segment_id)) {
         *writer = std::move(inner_writer);
         return Status::OK();
     }

--- a/be/src/load/delta_writer/delta_writer.cpp
+++ b/be/src/load/delta_writer/delta_writer.cpp
@@ -340,7 +340,8 @@ void DeltaWriter::_request_slave_tablet_pull_rowset(const PNodeInfo& node_info) 
     request->set_token(ExecEnv::GetInstance()->token());
     request->set_brpc_port(config::brpc_port);
     request->set_node_id(static_cast<int32_t>(node_info.id()));
-    for (int segment_id = 0; segment_id < cur_rowset->rowset_meta()->num_segments(); segment_id++) {
+    for (auto seg : cur_rowset->segments()) {
+        auto segment_id = seg.id();
         auto seg_path =
                 local_segment_path(tablet_path, cur_rowset->rowset_id().to_string(), segment_id);
         int64_t segment_size = std::filesystem::file_size(seg_path);

--- a/be/src/load/memtable/memtable_flush_executor.cpp
+++ b/be/src/load/memtable/memtable_flush_executor.cpp
@@ -184,8 +184,8 @@ Status FlushToken::submit(std::shared_ptr<MemTable> mem_table) {
         shared_memtable = std::make_shared<SharedMemtable>();
         shared_memtable->memtable = mem_table;
         // Keep data/binlog segment_id allocators in sync.
-        auto segment_id = data_writer->allocate_segment_id();
-        auto binlog_segment_id = binlog_writer->allocate_segment_id();
+        auto segment_id = DORIS_TRY(data_writer->allocate_segment_id());
+        auto binlog_segment_id = DORIS_TRY(binlog_writer->allocate_segment_id());
         DCHECK_EQ(segment_id, binlog_segment_id);
         shared_memtable->segment_id = segment_id;
 
@@ -195,9 +195,9 @@ Status FlushToken::submit(std::shared_ptr<MemTable> mem_table) {
                 shared_from_this(), shared_memtable, WriteRequestType::ROW_BINLOG,
                 submit_task_time));
     } else {
+        auto segment_id = DORIS_TRY(_rowset_writer->allocate_segment_id());
         tasks.emplace_back(MemtableFlushTask::create_shared(shared_from_this(), mem_table,
-                                                            _rowset_writer->allocate_segment_id(),
-                                                            submit_task_time));
+                                                            segment_id, submit_task_time));
     }
     // NOTE: we should guarantee WorkloadGroup is not deconstructed when submit memtable flush task.
     // because currently WorkloadGroup's can only be destroyed when all queries in the group is finished,

--- a/be/src/load/memtable/memtable_flush_executor.cpp
+++ b/be/src/load/memtable/memtable_flush_executor.cpp
@@ -182,8 +182,8 @@ Status FlushToken::submit(std::shared_ptr<MemTable> mem_table) {
         shared_memtable = std::make_shared<SharedMemtable>();
         shared_memtable->memtable = mem_table;
         // Keep data/binlog segment_id allocators in sync.
-        auto segment_id = data_writer->allocate_segment_id();
-        auto binlog_segment_id = binlog_writer->allocate_segment_id();
+        auto segment_id = DORIS_TRY(data_writer->allocate_segment_id());
+        auto binlog_segment_id = DORIS_TRY(binlog_writer->allocate_segment_id());
         DCHECK_EQ(segment_id, binlog_segment_id);
         shared_memtable->segment_id = segment_id;
 
@@ -193,9 +193,9 @@ Status FlushToken::submit(std::shared_ptr<MemTable> mem_table) {
                 shared_from_this(), shared_memtable, WriteRequestType::ROW_BINLOG,
                 submit_task_time));
     } else {
+        auto segment_id = DORIS_TRY(_rowset_writer->allocate_segment_id());
         tasks.emplace_back(MemtableFlushTask::create_shared(shared_from_this(), mem_table,
-                                                            _rowset_writer->allocate_segment_id(),
-                                                            submit_task_time));
+                                                            segment_id, submit_task_time));
     }
     // NOTE: we should guarantee WorkloadGroup is not deconstructed when submit memtable flush task.
     // because currently WorkloadGroup's can only be destroyed when all queries in the group is finished,

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -388,6 +388,8 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     rowset_meta->set_rowset_id(new_rowset_id);
     rowset_meta->set_tablet_uid(local_tablet->tablet_uid());
 
+    // Binlog is only supported in local mode. Segment-list rowsets are cloud-only, so binlog files
+    // are still named by contiguous segment indexes rather than persisted segment_ids.
     // Step 5: get all segment files
     // Step 5.1: get all segment files size
     std::vector<std::string> segment_file_urls;

--- a/be/src/service/http/action/check_encryption_action.cpp
+++ b/be/src/service/http/action/check_encryption_action.cpp
@@ -78,7 +78,7 @@ Result<bool> is_tablet_encrypted(const BaseTabletSPtr& tablet) {
         if (rs->num_segments() == 0) {
             return;
         }
-        auto maybe_seg_path = rs->segment_path(0);
+        auto maybe_seg_path = rs->segment(0).path();
         if (!maybe_seg_path) {
             st = std::move(maybe_seg_path.error());
             return;
@@ -129,7 +129,7 @@ Result<std::string> get_last_encrypt_footer(const BaseTabletSPtr& tablet) {
     if (rs->num_segments() == 0) {
         return "{}";
     }
-    auto maybe_seg_path = rs->segment_path(0);
+    auto maybe_seg_path = rs->segment(0).path();
     if (!maybe_seg_path) {
         return ResultError(maybe_seg_path.error());
     }

--- a/be/src/storage/AGENTS.md
+++ b/be/src/storage/AGENTS.md
@@ -33,3 +33,43 @@
 ## Segment Writing
 
 - [ ] MoW tables: `SegmentWriterOptions::enable_unique_key_merge_on_write` set to `true` on every path?
+
+## Rowset Segment Position and Physical ID
+
+A segment's position inside a rowset and its physical segment ID are different concepts.
+
+- Segment-list rowset layout is currently supported only in cloud mode. Cloud-mode code must
+  handle both explicit `segment_ids` and legacy rowsets whose empty `segment_ids` implies
+  contiguous physical IDs in `[0, num_segments())`.
+- Local-mode rowsets still use contiguous physical segment IDs. Local-only metadata and workflows,
+  such as `RemoteRowsetGcPB`, `BinlogMetaEntryPB`, local binlog files, and local storage migration,
+  intentionally do not persist `segment_ids`.
+- A local-only path may rely on position equaling physical ID only when that mode restriction is an
+  established invariant and is explicit in the surrounding code or comment. Do not carry that
+  assumption into shared or cloud-mode code.
+- `Rowset::num_segments()` and `RowsetMeta::num_segments()` return a segment count, not an upper
+  bound for physical segment IDs.
+- Physical segment IDs may be nonzero or non-contiguous when `segment_ids` is present.
+- Never assume that a position in `[0, num_segments())` is also the physical segment ID.
+- Prefer `for (auto segment : rowset->segments())` or
+  `for (auto segment : rowset_meta->segments())` when traversing rowset segments.
+- Use `segment.pos()` only for position-aligned metadata arrays, such as `num_segment_rows`,
+  `segments_key_bounds`, `segments_file_size`, and `inverted_index_file_info`.
+- Use `segment.id()` for physical identity, including segment and index file paths, cache keys,
+  delete bitmap keys, `RowLocation`, RPC fields, and persisted segment IDs.
+- When only a position is available, obtain the physical ID through `rowset->segment(pos).id()`,
+  `rowset_meta->segment(pos).id()`, or `rowset_segment_id(rowset_meta_pb, pos)` for raw protobuf
+  metadata.
+- A loop over `[0, num_segments())` is allowed only when the loop variable represents a position.
+  Name it `pos`, `segment_pos`, or `segment_index`, never `segment_id`.
+- Tests for code that consumes physical segment IDs should use nonzero IDs and, where applicable,
+  non-contiguous IDs.
+
+### Checkpoints
+
+- [ ] Does cloud-mode code support both explicit `segment_ids` and the legacy empty-list fallback?
+- [ ] If code relies on contiguous IDs, is it guaranteed and clearly documented to be local-only?
+- [ ] Does any code assume that segment position equals physical segment ID?
+- [ ] Are file paths, cache keys, delete bitmap keys, and row locations built from `segment.id()`?
+- [ ] Are position-aligned metadata arrays accessed with `segment.pos()`?
+- [ ] Does raw protobuf code use `rowset_segment_id()` instead of treating the position as an ID?

--- a/be/src/storage/compaction/collection_statistics.cpp
+++ b/be/src/storage/compaction/collection_statistics.cpp
@@ -52,10 +52,8 @@ Status CollectionStatistics::collect(RuntimeState* state,
     for (const auto& rs_split : rs_splits) {
         const auto& rs_reader = rs_split.rs_reader;
         auto rowset = rs_reader->rowset();
-        auto num_segments = rowset->num_segments();
-        for (int32_t seg_id = 0; seg_id < num_segments; ++seg_id) {
-            auto status =
-                    process_segment(rowset, seg_id, tablet_schema.get(), collect_infos, io_ctx);
+        for (auto seg : rowset->segments()) {
+            auto status = process_segment(rowset, seg, tablet_schema.get(), collect_infos, io_ctx);
             if (!status.ok()) {
                 if (status.code() == ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND ||
                     status.code() == ErrorCode::INVERTED_INDEX_BYPASS) {
@@ -153,18 +151,19 @@ Status CollectionStatistics::extract_collect_info(
     return Status::OK();
 }
 
-Status CollectionStatistics::process_segment(const RowsetSharedPtr& rowset, int32_t seg_id,
+Status CollectionStatistics::process_segment(const RowsetSharedPtr& rowset,
+                                             const RowsetSegmentView& seg,
                                              const TabletSchema* tablet_schema,
                                              const CollectInfoMap& collect_infos,
                                              io::IOContext* io_ctx) {
-    auto seg_path = DORIS_TRY(rowset->segment_path(seg_id));
+    auto seg_path = DORIS_TRY(seg.path());
     auto rowset_meta = rowset->rowset_meta();
 
     auto idx_file_reader = std::make_unique<IndexFileReader>(
             rowset_meta->fs(),
             std::string {InvertedIndexDescriptor::get_index_file_path_prefix(seg_path)},
-            tablet_schema->get_inverted_index_storage_format(),
-            rowset_meta->inverted_index_file_info(seg_id), rowset_meta->tablet_id());
+            tablet_schema->get_inverted_index_storage_format(), seg.inverted_index_file_info(),
+            rowset_meta->tablet_id());
     RETURN_IF_ERROR(idx_file_reader->init(config::inverted_index_read_buffer_size, io_ctx));
 
     int32_t total_seg_num_docs = 0;

--- a/be/src/storage/compaction/collection_statistics.h
+++ b/be/src/storage/compaction/collection_statistics.h
@@ -38,6 +38,7 @@ struct IOContext;
 struct RowSetSplits;
 
 class Rowset;
+class RowsetSegmentView;
 using RowsetSharedPtr = std::shared_ptr<Rowset>;
 
 class TabletIndex;
@@ -62,7 +63,7 @@ private:
                                 const VExprContextSPtrs& common_expr_ctxs_push_down,
                                 const TabletSchemaSPtr& tablet_schema,
                                 CollectInfoMap* collect_infos);
-    Status process_segment(const RowsetSharedPtr& rowset, int32_t seg_id,
+    Status process_segment(const RowsetSharedPtr& rowset, const RowsetSegmentView& seg,
                            const TabletSchema* tablet_schema, const CollectInfoMap& collect_infos,
                            io::IOContext* io_ctx);
 

--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -35,6 +35,7 @@
 #include <nlohmann/json.hpp>
 #include <numeric>
 #include <ostream>
+#include <random>
 #include <ranges>
 #include <set>
 #include <shared_mutex>
@@ -92,6 +93,7 @@
 #include "storage/task/engine_checksum_task.h"
 #include "storage/txn/txn_manager.h"
 #include "storage/utils.h"
+#include "util/debug_points.h"
 #include "util/pretty_printer.h"
 #include "util/stopwatch.hpp"
 #include "util/time.h"
@@ -903,6 +905,32 @@ Status Compaction::do_inverted_index_compaction() {
         return Status::OK();
     }
 
+    auto& inverted_index_file_writers =
+            dynamic_cast<BaseBetaRowsetWriter*>(_output_rs_writer.get())->index_file_writers();
+    DBUG_EXECUTE_IF(
+            "Compaction::do_inverted_index_compaction_inverted_index_file_writers_size_error",
+            { inverted_index_file_writers.clear(); })
+    if (inverted_index_file_writers.size() != dest_segment_num) {
+        LOG(WARNING) << "failed to do index compaction, dest segment num not match. tablet_id="
+                     << _tablet->tablet_id() << " dest_segment_num=" << dest_segment_num
+                     << " inverted_index_file_writers.size()="
+                     << inverted_index_file_writers.size();
+        mark_skip_index_compaction(ctx, error_handler);
+        return Status::Error<INVERTED_INDEX_COMPACTION_ERROR>(
+                "dest segment num not match. tablet_id={} dest_segment_num={} "
+                "inverted_index_file_writers.size()={}",
+                _tablet->tablet_id(), dest_segment_num, inverted_index_file_writers.size());
+    }
+
+    // RowIdConversion and dest_segment_num_rows use destination segment positions, while the
+    // output writer map is keyed by physical segment ids.
+    std::vector<int> dest_segment_ids;
+    dest_segment_ids.reserve(dest_segment_num);
+    for (const auto& [segment_id, _] : inverted_index_file_writers) {
+        dest_segment_ids.push_back(segment_id);
+    }
+    std::sort(dest_segment_ids.begin(), dest_segment_ids.end());
+
     // Only write info files when debug index compaction is enabled.
     // The files are used to debug index compaction and works with index_tool.
     if (config::debug_inverted_index_compaction) {
@@ -917,9 +945,10 @@ Status Compaction::do_inverted_index_compaction() {
         // dest index files
         // format: rowsetId_segmentId
         std::vector<std::string> dest_index_files(dest_segment_num);
-        for (int i = 0; i < dest_segment_num; ++i) {
-            auto prefix = dest_rowset_id.to_string() + "_" + std::to_string(i);
-            dest_index_files[i] = prefix;
+        for (size_t dest_segment_pos = 0; dest_segment_pos < dest_segment_num; ++dest_segment_pos) {
+            auto prefix = dest_rowset_id.to_string() + "_" +
+                          std::to_string(dest_segment_ids[dest_segment_pos]);
+            dest_index_files[dest_segment_pos] = prefix;
         }
 
         auto write_json_to_file = [&](const nlohmann::json& json_obj,
@@ -982,6 +1011,8 @@ Status Compaction::do_inverted_index_compaction() {
         }
 
         auto* rowset = find_it->second;
+        auto seg_pos = rowset->rowset_meta()->position_of(seg_id);
+        auto seg = rowset->segment(seg_pos);
         auto fs = rowset->rowset_meta()->fs();
         DBUG_EXECUTE_IF("Compaction::do_inverted_index_compaction_get_fs_error", { fs = nullptr; })
         if (!fs) {
@@ -992,7 +1023,7 @@ Status Compaction::do_inverted_index_compaction() {
                     "get fs failed, resource_id={}", rowset->rowset_meta()->resource_id());
         }
 
-        auto seg_path = rowset->segment_path(seg_id);
+        auto seg_path = seg.path();
         DBUG_EXECUTE_IF("Compaction::do_inverted_index_compaction_seg_path_nullptr", {
             seg_path = ResultError(Status::Error<ErrorCode::INTERNAL_ERROR>(
                     "do_inverted_index_compaction_seg_path_nullptr"));
@@ -1010,7 +1041,7 @@ Status Compaction::do_inverted_index_compaction() {
                 fs,
                 std::string {InvertedIndexDescriptor::get_index_file_path_prefix(seg_path.value())},
                 _cur_tablet_schema->get_inverted_index_storage_format(),
-                rowset->rowset_meta()->inverted_index_file_info(seg_id), _tablet->tablet_id());
+                seg.inverted_index_file_info(), _tablet->tablet_id());
         auto st = index_file_reader->init(config::inverted_index_read_buffer_size);
         DBUG_EXECUTE_IF("Compaction::do_inverted_index_compaction_init_inverted_index_file_reader",
                         {
@@ -1031,25 +1062,6 @@ Status Compaction::do_inverted_index_compaction() {
         }
         index_file_readers[m.second] = std::move(index_file_reader);
         source_rowsets[m.second] = rowset;
-    }
-
-    // dest index files
-    // format: rowsetId_segmentId
-    auto& inverted_index_file_writers =
-            dynamic_cast<BaseBetaRowsetWriter*>(_output_rs_writer.get())->index_file_writers();
-    DBUG_EXECUTE_IF(
-            "Compaction::do_inverted_index_compaction_inverted_index_file_writers_size_error",
-            { inverted_index_file_writers.clear(); })
-    if (inverted_index_file_writers.size() != dest_segment_num) {
-        LOG(WARNING) << "failed to do index compaction, dest segment num not match. tablet_id="
-                     << _tablet->tablet_id() << " dest_segment_num=" << dest_segment_num
-                     << " inverted_index_file_writers.size()="
-                     << inverted_index_file_writers.size();
-        mark_skip_index_compaction(ctx, error_handler);
-        return Status::Error<INVERTED_INDEX_COMPACTION_ERROR>(
-                "dest segment num not match. tablet_id={} dest_segment_num={} "
-                "inverted_index_file_writers.size()={}",
-                _tablet->tablet_id(), dest_segment_num, inverted_index_file_writers.size());
     }
 
     // use tmp file dir to store index files
@@ -1244,8 +1256,9 @@ Status Compaction::do_inverted_index_compaction() {
             try {
                 std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>> src_idx_dirs(
                         src_segment_num);
-                for (int src_segment_id = 0; src_segment_id < src_segment_num; src_segment_id++) {
-                    auto res = index_file_readers[src_segment_id]->open(index_meta);
+                for (int src_segment_pos = 0; src_segment_pos < src_segment_num;
+                     src_segment_pos++) {
+                    auto res = index_file_readers[src_segment_pos]->open(index_meta);
                     DBUG_EXECUTE_IF("Compaction::open_inverted_index_file_reader", {
                         res = ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                                 "debug point: Compaction::open_index_file_reader error"));
@@ -1255,15 +1268,16 @@ Status Compaction::do_inverted_index_compaction() {
                                         "reader failed"
                                      << ". tablet=" << _tablet->tablet_id()
                                      << ", column uniq id=" << column_uniq_id
-                                     << ", src_segment_id=" << src_segment_id;
+                                     << ", src_segment_pos=" << src_segment_pos;
                         throw Exception(ErrorCode::INVERTED_INDEX_COMPACTION_ERROR,
                                         res.error().msg());
                     }
-                    src_idx_dirs[src_segment_id] = std::move(res.value());
+                    src_idx_dirs[src_segment_pos] = std::move(res.value());
                 }
-                for (int dest_segment_id = 0; dest_segment_id < dest_segment_num;
-                     dest_segment_id++) {
-                    auto res = inverted_index_file_writers[dest_segment_id]->open(index_meta);
+                for (size_t dest_segment_pos = 0; dest_segment_pos < dest_segment_num;
+                     ++dest_segment_pos) {
+                    const auto dest_segment_id = dest_segment_ids[dest_segment_pos];
+                    auto res = inverted_index_file_writers.at(dest_segment_id)->open(index_meta);
                     DBUG_EXECUTE_IF("Compaction::open_inverted_index_file_writer", {
                         res = ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                                 "debug point: Compaction::open_inverted_index_file_writer error"));
@@ -1279,7 +1293,7 @@ Status Compaction::do_inverted_index_compaction() {
                     }
                     // Destination directories in dest_index_dirs do not need to be deconstructed,
                     // but their lifecycle must be managed by inverted_index_file_writers.
-                    dest_index_dirs[dest_segment_id] = res.value().get();
+                    dest_index_dirs[dest_segment_pos] = res.value().get();
                 }
                 auto st = compact_column(index_meta->index_id(), src_idx_dirs, dest_index_dirs,
                                          index_tmp_path.native(), trans_vec, dest_segment_num_rows);
@@ -1362,9 +1376,9 @@ static bool check_rowset_has_inverted_index(const RowsetSharedPtr& src_rs, int32
         return false;
     }
     for (const auto& index_meta : index_metas) {
-        for (auto i = 0; i < rowset->num_segments(); i++) {
+        for (auto seg : rowset->segments()) {
             // TODO: inverted_index_path
-            auto seg_path = rowset->segment_path(i);
+            auto seg_path = seg.path();
             DBUG_EXECUTE_IF("Compaction::construct_skip_inverted_index_seg_path_nullptr", {
                 seg_path = ResultError(Status::Error<ErrorCode::INTERNAL_ERROR>(
                         "construct_skip_inverted_index_seg_path_nullptr"));
@@ -1381,7 +1395,7 @@ static bool check_rowset_has_inverted_index(const RowsetSharedPtr& src_rs, int32
                         std::string {InvertedIndexDescriptor::get_index_file_path_prefix(
                                 seg_path.value())},
                         cur_tablet_schema->get_inverted_index_storage_format(),
-                        rowset->rowset_meta()->inverted_index_file_info(i), tablet->tablet_id());
+                        seg.inverted_index_file_info(), tablet->tablet_id());
                 auto st = index_file_reader->init(config::inverted_index_read_buffer_size);
                 index_file_path = index_file_reader->get_index_file_path(index_meta);
                 DBUG_EXECUTE_IF(
@@ -1508,8 +1522,8 @@ void Compaction::construct_index_compaction_columns(RowsetWriterContext& ctx) {
                     break;
                 }
 
-                for (uint32_t segment_id = 0; segment_id < rowset->num_segments(); ++segment_id) {
-                    auto segment_path = rowset->segment_path(segment_id);
+                for (auto segment : rowset->segments()) {
+                    auto segment_path = segment.path();
                     if (!segment_path.has_value()) {
                         eligible = false;
                         break;
@@ -1521,8 +1535,7 @@ void Compaction::construct_index_compaction_columns(RowsetWriterContext& ctx) {
                     if (source_file_reader_it == source_file_readers.end()) {
                         auto source_file_reader = std::make_unique<IndexFileReader>(
                                 fs, index_file_path_prefix, InvertedIndexStorageFormatPB::SNII,
-                                rowset->rowset_meta()->inverted_index_file_info(segment_id),
-                                _tablet->tablet_id());
+                                segment.inverted_index_file_info(), _tablet->tablet_id());
                         const Status init_status =
                                 source_file_reader->init(config::inverted_index_read_buffer_size);
                         if (!init_status.ok()) {
@@ -1799,8 +1812,8 @@ Status CompactionMixin::modify_rowsets() {
         // TODO(LiaoXin): check if there are duplicate keys
         std::size_t missed_rows_size = 0;
         tablet()->calc_compaction_output_rowset_delete_bitmap(
-                _input_rowsets, *_rowid_conversion, 0, version.second + 1, missed_rows.get(),
-                location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
+                _input_rowsets, _output_rowset, *_rowid_conversion, 0, version.second + 1,
+                missed_rows.get(), location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
                 &output_rowset_delete_bitmap);
         if (missed_rows) {
             missed_rows_size = missed_rows->size();
@@ -1899,8 +1912,9 @@ Status CompactionMixin::modify_rowsets() {
                 }
                 DeleteBitmap txn_output_delete_bitmap(_tablet->tablet_id());
                 tablet()->calc_compaction_output_rowset_delete_bitmap(
-                        _input_rowsets, *_rowid_conversion, 0, UINT64_MAX, missed_rows.get(),
-                        location_map.get(), *it.delete_bitmap.get(), &txn_output_delete_bitmap);
+                        _input_rowsets, _output_rowset, *_rowid_conversion, 0, UINT64_MAX,
+                        missed_rows.get(), location_map.get(), *it.delete_bitmap.get(),
+                        &txn_output_delete_bitmap);
                 if (config::enable_merge_on_write_correctness_check) {
                     RowsetIdUnorderedSet rowsetids;
                     rowsetids.insert(_output_rowset->rowset_id());
@@ -1919,7 +1933,7 @@ Status CompactionMixin::modify_rowsets() {
             // Convert the delete bitmap of the input rowsets to output rowset for
             // incremental data.
             tablet()->calc_compaction_output_rowset_delete_bitmap(
-                    _input_rowsets, *_rowid_conversion, version.second, UINT64_MAX,
+                    _input_rowsets, _output_rowset, *_rowid_conversion, version.second, UINT64_MAX,
                     missed_rows.get(), location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
                     &output_rowset_delete_bitmap);
 
@@ -2361,7 +2375,28 @@ Status CloudCompactionMixin::construct_output_rowset_writer(RowsetWriterContext&
     ctx.tablet = _tablet;
     ctx.job_id = _uuid;
 
+    if (!_is_vertical) {
+        DBUG_EXECUTE_IF(
+                "CloudCompactionMixin.construct_output_rowset_writer.max_rows_per_segment", {
+                    ctx.max_rows_per_segment =
+                            dp->param<uint32_t>("max_rows_per_segment", ctx.max_rows_per_segment);
+                    DORIS_CHECK_GT(ctx.max_rows_per_segment, 0);
+                });
+    }
     _output_rs_writer = DORIS_TRY(_tablet->create_rowset_writer(ctx, _is_vertical));
+    if (config::enable_cloud_random_segment_id) {
+        constexpr int32_t kDefaultMaxStartSegmentId = 1000;
+        int32_t max_start_segment_id = kDefaultMaxStartSegmentId;
+        DBUG_EXECUTE_IF(
+                "CloudCompactionMixin.construct_output_rowset_writer.random_start_segment_id", {
+                    max_start_segment_id =
+                            dp->param<int32_t>("max_start_segment_id", kDefaultMaxStartSegmentId);
+                });
+        DORIS_CHECK_GT(max_start_segment_id, 0);
+        static thread_local std::mt19937 generator(std::random_device {}());
+        std::uniform_int_distribution<int32_t> distribution(1, max_start_segment_id);
+        _output_rs_writer->set_segment_start_id(distribution(generator));
+    }
     RETURN_IF_ERROR(_engine.meta_mgr().prepare_rowset(*_output_rs_writer->rowset_meta().get(),
                                                       _uuid, _tablet->table_id()));
     return Status::OK();

--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -32,6 +32,7 @@
 #include <nlohmann/json.hpp>
 #include <numeric>
 #include <ostream>
+#include <random>
 #include <set>
 #include <shared_mutex>
 #include <utility>
@@ -83,6 +84,7 @@
 #include "storage/task/engine_checksum_task.h"
 #include "storage/txn/txn_manager.h"
 #include "storage/utils.h"
+#include "util/debug_points.h"
 #include "util/pretty_printer.h"
 #include "util/time.h"
 #include "util/trace.h"
@@ -851,6 +853,32 @@ Status Compaction::do_inverted_index_compaction() {
         return Status::OK();
     }
 
+    auto& inverted_index_file_writers =
+            dynamic_cast<BaseBetaRowsetWriter*>(_output_rs_writer.get())->index_file_writers();
+    DBUG_EXECUTE_IF(
+            "Compaction::do_inverted_index_compaction_inverted_index_file_writers_size_error",
+            { inverted_index_file_writers.clear(); })
+    if (inverted_index_file_writers.size() != dest_segment_num) {
+        LOG(WARNING) << "failed to do index compaction, dest segment num not match. tablet_id="
+                     << _tablet->tablet_id() << " dest_segment_num=" << dest_segment_num
+                     << " inverted_index_file_writers.size()="
+                     << inverted_index_file_writers.size();
+        mark_skip_index_compaction(ctx, error_handler);
+        return Status::Error<INVERTED_INDEX_COMPACTION_ERROR>(
+                "dest segment num not match. tablet_id={} dest_segment_num={} "
+                "inverted_index_file_writers.size()={}",
+                _tablet->tablet_id(), dest_segment_num, inverted_index_file_writers.size());
+    }
+
+    // RowIdConversion and dest_segment_num_rows use destination segment positions, while the
+    // output writer map is keyed by physical segment ids.
+    std::vector<int> dest_segment_ids;
+    dest_segment_ids.reserve(dest_segment_num);
+    for (const auto& [segment_id, _] : inverted_index_file_writers) {
+        dest_segment_ids.push_back(segment_id);
+    }
+    std::sort(dest_segment_ids.begin(), dest_segment_ids.end());
+
     // Only write info files when debug index compaction is enabled.
     // The files are used to debug index compaction and works with index_tool.
     if (config::debug_inverted_index_compaction) {
@@ -865,9 +893,10 @@ Status Compaction::do_inverted_index_compaction() {
         // dest index files
         // format: rowsetId_segmentId
         std::vector<std::string> dest_index_files(dest_segment_num);
-        for (int i = 0; i < dest_segment_num; ++i) {
-            auto prefix = dest_rowset_id.to_string() + "_" + std::to_string(i);
-            dest_index_files[i] = prefix;
+        for (size_t dest_segment_pos = 0; dest_segment_pos < dest_segment_num; ++dest_segment_pos) {
+            auto prefix = dest_rowset_id.to_string() + "_" +
+                          std::to_string(dest_segment_ids[dest_segment_pos]);
+            dest_index_files[dest_segment_pos] = prefix;
         }
 
         auto write_json_to_file = [&](const nlohmann::json& json_obj,
@@ -929,6 +958,8 @@ Status Compaction::do_inverted_index_compaction() {
         }
 
         auto* rowset = find_it->second;
+        auto seg_pos = rowset->rowset_meta()->position_of(seg_id);
+        auto seg = rowset->segment(seg_pos);
         auto fs = rowset->rowset_meta()->fs();
         DBUG_EXECUTE_IF("Compaction::do_inverted_index_compaction_get_fs_error", { fs = nullptr; })
         if (!fs) {
@@ -939,7 +970,7 @@ Status Compaction::do_inverted_index_compaction() {
                     "get fs failed, resource_id={}", rowset->rowset_meta()->resource_id());
         }
 
-        auto seg_path = rowset->segment_path(seg_id);
+        auto seg_path = seg.path();
         DBUG_EXECUTE_IF("Compaction::do_inverted_index_compaction_seg_path_nullptr", {
             seg_path = ResultError(Status::Error<ErrorCode::INTERNAL_ERROR>(
                     "do_inverted_index_compaction_seg_path_nullptr"));
@@ -957,7 +988,7 @@ Status Compaction::do_inverted_index_compaction() {
                 fs,
                 std::string {InvertedIndexDescriptor::get_index_file_path_prefix(seg_path.value())},
                 _cur_tablet_schema->get_inverted_index_storage_format(),
-                rowset->rowset_meta()->inverted_index_file_info(seg_id), _tablet->tablet_id());
+                seg.inverted_index_file_info(), _tablet->tablet_id());
         auto st = index_file_reader->init(config::inverted_index_read_buffer_size);
         DBUG_EXECUTE_IF("Compaction::do_inverted_index_compaction_init_inverted_index_file_reader",
                         {
@@ -977,25 +1008,6 @@ Status Compaction::do_inverted_index_compaction() {
                     _tablet->tablet_id(), rowset_id.to_string(), seg_id);
         }
         index_file_readers[m.second] = std::move(index_file_reader);
-    }
-
-    // dest index files
-    // format: rowsetId_segmentId
-    auto& inverted_index_file_writers =
-            dynamic_cast<BaseBetaRowsetWriter*>(_output_rs_writer.get())->index_file_writers();
-    DBUG_EXECUTE_IF(
-            "Compaction::do_inverted_index_compaction_inverted_index_file_writers_size_error",
-            { inverted_index_file_writers.clear(); })
-    if (inverted_index_file_writers.size() != dest_segment_num) {
-        LOG(WARNING) << "failed to do index compaction, dest segment num not match. tablet_id="
-                     << _tablet->tablet_id() << " dest_segment_num=" << dest_segment_num
-                     << " inverted_index_file_writers.size()="
-                     << inverted_index_file_writers.size();
-        mark_skip_index_compaction(ctx, error_handler);
-        return Status::Error<INVERTED_INDEX_COMPACTION_ERROR>(
-                "dest segment num not match. tablet_id={} dest_segment_num={} "
-                "inverted_index_file_writers.size()={}",
-                _tablet->tablet_id(), dest_segment_num, inverted_index_file_writers.size());
     }
 
     // use tmp file dir to store index files
@@ -1042,9 +1054,10 @@ Status Compaction::do_inverted_index_compaction() {
                     }
                     src_idx_dirs[src_segment_id] = std::move(res.value());
                 }
-                for (int dest_segment_id = 0; dest_segment_id < dest_segment_num;
-                     dest_segment_id++) {
-                    auto res = inverted_index_file_writers[dest_segment_id]->open(index_meta);
+                for (size_t dest_segment_pos = 0; dest_segment_pos < dest_segment_num;
+                     ++dest_segment_pos) {
+                    const auto dest_segment_id = dest_segment_ids[dest_segment_pos];
+                    auto res = inverted_index_file_writers.at(dest_segment_id)->open(index_meta);
                     DBUG_EXECUTE_IF("Compaction::open_inverted_index_file_writer", {
                         res = ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                                 "debug point: Compaction::open_inverted_index_file_writer error"));
@@ -1060,7 +1073,7 @@ Status Compaction::do_inverted_index_compaction() {
                     }
                     // Destination directories in dest_index_dirs do not need to be deconstructed,
                     // but their lifecycle must be managed by inverted_index_file_writers.
-                    dest_index_dirs[dest_segment_id] = res.value().get();
+                    dest_index_dirs[dest_segment_pos] = res.value().get();
                 }
                 auto st = compact_column(index_meta->index_id(), src_idx_dirs, dest_index_dirs,
                                          index_tmp_path.native(), trans_vec, dest_segment_num_rows);
@@ -1139,9 +1152,9 @@ static bool check_rowset_has_inverted_index(const RowsetSharedPtr& src_rs, int32
         return false;
     }
     for (const auto& index_meta : index_metas) {
-        for (auto i = 0; i < rowset->num_segments(); i++) {
+        for (auto seg : rowset->segments()) {
             // TODO: inverted_index_path
-            auto seg_path = rowset->segment_path(i);
+            auto seg_path = seg.path();
             DBUG_EXECUTE_IF("Compaction::construct_skip_inverted_index_seg_path_nullptr", {
                 seg_path = ResultError(Status::Error<ErrorCode::INTERNAL_ERROR>(
                         "construct_skip_inverted_index_seg_path_nullptr"));
@@ -1158,7 +1171,7 @@ static bool check_rowset_has_inverted_index(const RowsetSharedPtr& src_rs, int32
                         std::string {InvertedIndexDescriptor::get_index_file_path_prefix(
                                 seg_path.value())},
                         cur_tablet_schema->get_inverted_index_storage_format(),
-                        rowset->rowset_meta()->inverted_index_file_info(i), tablet->tablet_id());
+                        seg.inverted_index_file_info(), tablet->tablet_id());
                 auto st = index_file_reader->init(config::inverted_index_read_buffer_size);
                 index_file_path = index_file_reader->get_index_file_path(index_meta);
                 DBUG_EXECUTE_IF(
@@ -1428,8 +1441,8 @@ Status CompactionMixin::modify_rowsets() {
         // TODO(LiaoXin): check if there are duplicate keys
         std::size_t missed_rows_size = 0;
         tablet()->calc_compaction_output_rowset_delete_bitmap(
-                _input_rowsets, *_rowid_conversion, 0, version.second + 1, missed_rows.get(),
-                location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
+                _input_rowsets, _output_rowset, *_rowid_conversion, 0, version.second + 1,
+                missed_rows.get(), location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
                 &output_rowset_delete_bitmap);
         if (missed_rows) {
             missed_rows_size = missed_rows->size();
@@ -1528,8 +1541,9 @@ Status CompactionMixin::modify_rowsets() {
                 }
                 DeleteBitmap txn_output_delete_bitmap(_tablet->tablet_id());
                 tablet()->calc_compaction_output_rowset_delete_bitmap(
-                        _input_rowsets, *_rowid_conversion, 0, UINT64_MAX, missed_rows.get(),
-                        location_map.get(), *it.delete_bitmap.get(), &txn_output_delete_bitmap);
+                        _input_rowsets, _output_rowset, *_rowid_conversion, 0, UINT64_MAX,
+                        missed_rows.get(), location_map.get(), *it.delete_bitmap.get(),
+                        &txn_output_delete_bitmap);
                 if (config::enable_merge_on_write_correctness_check) {
                     RowsetIdUnorderedSet rowsetids;
                     rowsetids.insert(_output_rowset->rowset_id());
@@ -1548,7 +1562,7 @@ Status CompactionMixin::modify_rowsets() {
             // Convert the delete bitmap of the input rowsets to output rowset for
             // incremental data.
             tablet()->calc_compaction_output_rowset_delete_bitmap(
-                    _input_rowsets, *_rowid_conversion, version.second, UINT64_MAX,
+                    _input_rowsets, _output_rowset, *_rowid_conversion, version.second, UINT64_MAX,
                     missed_rows.get(), location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
                     &output_rowset_delete_bitmap);
 
@@ -1962,7 +1976,28 @@ Status CloudCompactionMixin::construct_output_rowset_writer(RowsetWriterContext&
     ctx.tablet = _tablet;
     ctx.job_id = _uuid;
 
+    if (!_is_vertical) {
+        DBUG_EXECUTE_IF(
+                "CloudCompactionMixin.construct_output_rowset_writer.max_rows_per_segment", {
+                    ctx.max_rows_per_segment =
+                            dp->param<uint32_t>("max_rows_per_segment", ctx.max_rows_per_segment);
+                    DORIS_CHECK_GT(ctx.max_rows_per_segment, 0);
+                });
+    }
     _output_rs_writer = DORIS_TRY(_tablet->create_rowset_writer(ctx, _is_vertical));
+    if (config::enable_cloud_random_segment_id) {
+        constexpr int32_t kDefaultMaxStartSegmentId = 1000;
+        int32_t max_start_segment_id = kDefaultMaxStartSegmentId;
+        DBUG_EXECUTE_IF(
+                "CloudCompactionMixin.construct_output_rowset_writer.random_start_segment_id", {
+                    max_start_segment_id =
+                            dp->param<int32_t>("max_start_segment_id", kDefaultMaxStartSegmentId);
+                });
+        DORIS_CHECK_GT(max_start_segment_id, 0);
+        static thread_local std::mt19937 generator(std::random_device {}());
+        std::uniform_int_distribution<int32_t> distribution(1, max_start_segment_id);
+        _output_rs_writer->set_segment_start_id(distribution(generator));
+    }
     RETURN_IF_ERROR(_engine.meta_mgr().prepare_rowset(*_output_rs_writer->rowset_meta().get(),
                                                       _uuid, _tablet->table_id()));
     return Status::OK();

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -1109,6 +1109,8 @@ void DataDir::perform_remote_rowset_gc() {
 
         std::vector<io::Path> seg_paths;
         seg_paths.reserve(gc_pb.num_segments());
+        // RemoteRowsetGcPB is local-mode only. Segment-list rowsets are cloud-only, so remote GC
+        // files are still named by contiguous segment indexes rather than persisted segment_ids.
         for (int i = 0; i < gc_pb.num_segments(); ++i) {
             seg_paths.emplace_back(
                     storage_resource->first.remote_segment_path(gc_pb.tablet_id(), rowset_id, i));

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -1151,6 +1151,8 @@ void DataDir::perform_remote_rowset_gc() {
 
         std::vector<io::Path> seg_paths;
         seg_paths.reserve(gc_pb.num_segments());
+        // RemoteRowsetGcPB is local-mode only. Segment-list rowsets are cloud-only, so remote GC
+        // files are still named by contiguous segment indexes rather than persisted segment_ids.
         for (int i = 0; i < gc_pb.num_segments(); ++i) {
             seg_paths.emplace_back(
                     storage_resource->first.remote_segment_path(gc_pb.tablet_id(), rowset_id, i));

--- a/be/src/storage/index/inverted/similarity/collection_statistics.cpp
+++ b/be/src/storage/index/inverted/similarity/collection_statistics.cpp
@@ -104,10 +104,8 @@ Status CollectionStatistics::collect_full_collection(
 
     for (const auto& rowset : rowsets) {
         DORIS_CHECK(rowset != nullptr);
-        const auto num_segments = rowset->num_segments();
-        for (int64_t seg_id = 0; seg_id < num_segments; ++seg_id) {
-            auto status =
-                    process_segment(rowset, seg_id, tablet_schema.get(), collect_infos, io_ctx);
+        for (auto seg : rowset->segments()) {
+            auto status = process_segment(rowset, seg, tablet_schema.get(), collect_infos, io_ctx);
             if (!status.ok()) {
                 if (tablet_schema->get_inverted_index_storage_format() !=
                             InvertedIndexStorageFormatPB::SNII &&
@@ -210,18 +208,18 @@ Status CollectionStatistics::extract_collect_info(
     return Status::OK();
 }
 
-Status CollectionStatistics::process_segment(const RowsetSharedPtr& rowset, int64_t seg_id,
+Status CollectionStatistics::process_segment(const RowsetSharedPtr& rowset,
+                                             const RowsetSegmentView& seg,
                                              const TabletSchema* tablet_schema,
                                              const CollectInfoMap& collect_infos,
                                              io::IOContext* io_ctx) {
-    auto seg_path = DORIS_TRY(rowset->segment_path(seg_id));
+    auto seg_path = DORIS_TRY(seg.path());
     auto rowset_meta = rowset->rowset_meta();
 
     auto idx_file_reader = std::make_unique<IndexFileReader>(
             rowset_meta->fs(),
             std::string {InvertedIndexDescriptor::get_index_file_path_prefix(seg_path)},
-            tablet_schema->get_inverted_index_storage_format(),
-            rowset_meta->inverted_index_file_info(static_cast<int>(seg_id)),
+            tablet_schema->get_inverted_index_storage_format(), seg.inverted_index_file_info(),
             rowset_meta->tablet_id());
     const bool is_snii =
             idx_file_reader->get_storage_format() == InvertedIndexStorageFormatPB::SNII;

--- a/be/src/storage/index/inverted/similarity/collection_statistics.h
+++ b/be/src/storage/index/inverted/similarity/collection_statistics.h
@@ -46,6 +46,7 @@ struct IOContext;
 struct RowSetSplits;
 
 class Rowset;
+class RowsetSegmentView;
 using RowsetSharedPtr = std::shared_ptr<Rowset>;
 
 class TabletIndex;
@@ -81,7 +82,7 @@ private:
                                 const VExprContextSPtrs& common_expr_ctxs_push_down,
                                 const TabletSchemaSPtr& tablet_schema,
                                 CollectInfoMap* collect_infos);
-    Status process_segment(const RowsetSharedPtr& rowset, int64_t seg_id,
+    Status process_segment(const RowsetSharedPtr& rowset, const RowsetSegmentView& seg,
                            const TabletSchema* tablet_schema, const CollectInfoMap& collect_infos,
                            io::IOContext* io_ctx);
     Status admit_snii_scoring_segment(

--- a/be/src/storage/rowid_conversion.h
+++ b/be/src/storage/rowid_conversion.h
@@ -20,7 +20,6 @@
 #include <map>
 #include <vector>
 
-#include "common/cast_set.h"
 #include "runtime/thread_context.h"
 #include "storage/olap_common.h"
 #include "storage/utils.h"
@@ -34,11 +33,17 @@ namespace doris {
 // destination rowset.
 class RowIdConversion {
 public:
+    struct DestinationRowId {
+        uint32_t segment_pos;
+        uint32_t row_id;
+    };
+
     RowIdConversion() = default;
     ~RowIdConversion() { RELEASE_THREAD_MEM_TRACKER(_seg_rowid_map_mem_used); }
 
-    // resize segment rowid map to its rows num
-    Status init_segment_map(const RowsetId& src_rowset_id, const std::vector<uint32_t>& num_rows) {
+    Status init_segment_map(const RowsetId& src_rowset_id, const std::vector<uint32_t>& segment_ids,
+                            const std::vector<uint32_t>& num_rows) {
+        DCHECK_EQ(segment_ids.size(), num_rows.size());
         for (size_t i = 0; i < num_rows.size(); i++) {
             constexpr size_t RESERVED_MEMORY = 10 * 1024 * 1024; // 10M
             if (doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(RESERVED_MEMORY)) {
@@ -60,8 +65,10 @@ public:
             }
 
             uint32_t id = static_cast<uint32_t>(_segments_rowid_map.size());
-            _segment_to_id_map.emplace(std::pair<RowsetId, uint32_t> {src_rowset_id, i}, id);
-            _id_to_segment_map.emplace_back(src_rowset_id, i);
+            auto segment_id = segment_ids[i];
+            _segment_to_id_map.emplace(std::pair<RowsetId, uint32_t> {src_rowset_id, segment_id},
+                                       id);
+            _id_to_segment_map.emplace_back(src_rowset_id, segment_id);
             std::vector<std::pair<uint32_t, uint32_t>> vec(
                     num_rows[i], std::pair<uint32_t, uint32_t>(UINT32_MAX, UINT32_MAX));
 
@@ -76,7 +83,7 @@ public:
 
     // set dst rowset id
     void set_dst_rowset_id(const RowsetId& dst_rowset_id) { _dst_rowst_id = dst_rowset_id; }
-    const RowsetId get_dst_rowset_id() { return _dst_rowst_id; }
+    const RowsetId& get_dst_rowset_id() const { return _dst_rowst_id; }
 
     // add row id to the map
     void add(const std::vector<RowLocation>& rss_row_ids,
@@ -87,19 +94,20 @@ public:
             }
             uint32_t id = _segment_to_id_map.at(
                     std::pair<RowsetId, uint32_t> {item.rowset_id, item.segment_id});
-            if (_cur_dst_segment_id < dst_segments_num_row.size() &&
-                _cur_dst_segment_rowid >= dst_segments_num_row[_cur_dst_segment_id]) {
-                _cur_dst_segment_id++;
+            if (_cur_dst_segment_pos < dst_segments_num_row.size() &&
+                _cur_dst_segment_rowid >= dst_segments_num_row[_cur_dst_segment_pos]) {
+                _cur_dst_segment_pos++;
                 _cur_dst_segment_rowid = 0;
             }
             _segments_rowid_map[id][item.row_id] =
-                    std::pair<uint32_t, uint32_t> {_cur_dst_segment_id, _cur_dst_segment_rowid++};
+                    std::pair<uint32_t, uint32_t> {_cur_dst_segment_pos, _cur_dst_segment_rowid++};
         }
     }
 
-    // get destination RowLocation
+    // Get the destination segment position and row id. The physical destination segment id is
+    // resolved only after the output rowset is built.
     // return non-zero if the src RowLocation does not exist
-    int get(const RowLocation& src, RowLocation* dst) const {
+    int get(const RowLocation& src, DestinationRowId* dst) const {
         auto iter = _segment_to_id_map.find({src.rowset_id, src.segment_id});
         if (iter == _segment_to_id_map.end()) {
             return -1;
@@ -108,13 +116,12 @@ public:
         if (src.row_id >= rowid_map.size()) {
             return -1;
         }
-        auto& [dst_segment_id, dst_rowid] = rowid_map[src.row_id];
-        if (dst_segment_id == UINT32_MAX && dst_rowid == UINT32_MAX) {
+        auto& [dst_segment_pos, dst_rowid] = rowid_map[src.row_id];
+        if (dst_segment_pos == UINT32_MAX && dst_rowid == UINT32_MAX) {
             return -1;
         }
 
-        dst->rowset_id = _dst_rowst_id;
-        dst->segment_id = dst_segment_id;
+        dst->segment_pos = dst_segment_pos;
         dst->row_id = dst_rowid;
         return 0;
     }
@@ -151,7 +158,7 @@ private:
 private:
     // the first level vector: index indicates src segment.
     // the second level vector: index indicates row id of source segment,
-    // value indicates row id of destination segment.
+    // value indicates destination segment position and row id.
     // <UINT32_MAX, UINT32_MAX> indicates current row not exist.
     std::vector<std::vector<std::pair<uint32_t, uint32_t>>> _segments_rowid_map;
     size_t _seg_rowid_map_mem_used {0};
@@ -166,8 +173,8 @@ private:
     // dst rowset id
     RowsetId _dst_rowst_id;
 
-    // current dst segment id
-    std::uint32_t _cur_dst_segment_id = 0;
+    // current dst segment position
+    std::uint32_t _cur_dst_segment_pos = 0;
 
     // current rowid of dst segment
     std::uint32_t _cur_dst_segment_rowid = 0;

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "cloud/config.h"
+#include "common/cast_set.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/metrics/doris_metrics.h"
@@ -178,8 +179,8 @@ Status BetaRowset::get_inverted_index_size(int64_t* index_size) {
 
     if (_schema->get_inverted_index_storage_format() == InvertedIndexStorageFormatPB::V1) {
         for (const auto& index : _schema->inverted_indexes()) {
-            for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-                auto seg_path = DORIS_TRY(segment_path(seg_id));
+            for (auto seg : segments()) {
+                auto seg_path = DORIS_TRY(seg.path());
                 int64_t file_size = 0;
 
                 std::string inverted_index_file_path =
@@ -191,8 +192,8 @@ Status BetaRowset::get_inverted_index_size(int64_t* index_size) {
             }
         }
     } else {
-        for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-            auto seg_path = DORIS_TRY(segment_path(seg_id));
+        for (auto seg : segments()) {
+            auto seg_path = DORIS_TRY(seg.path());
             int64_t file_size = 0;
 
             std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_path_v2(
@@ -205,8 +206,8 @@ Status BetaRowset::get_inverted_index_size(int64_t* index_size) {
 }
 
 void BetaRowset::clear_inverted_index_cache() {
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_path(i);
+    for (auto seg : segments()) {
+        auto seg_path = seg.path();
         if (!seg_path) {
             continue;
         }
@@ -233,8 +234,8 @@ Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
                                           _rowset_meta->resource_id());
     }
 
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
         int64_t file_size;
         RETURN_IF_ERROR(fs->file_size(seg_path, &file_size));
         segments_size->push_back(file_size);
@@ -243,17 +244,10 @@ Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
 }
 
 Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments) {
-    return load_segments(0, num_segments(), segments);
-}
-
-Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
-                                 std::vector<segment_v2::SegmentSharedPtr>* segments) {
-    int64_t seg_id = seg_id_begin;
-    while (seg_id < seg_id_end) {
+    for (auto seg : _rowset_meta->segments()) {
         std::shared_ptr<segment_v2::Segment> segment;
-        RETURN_IF_ERROR(load_segment(seg_id, nullptr, &segment));
+        RETURN_IF_ERROR(load_segment(seg.ref(), nullptr, &segment));
         segments->push_back(std::move(segment));
-        seg_id++;
     }
     return Status::OK();
 }
@@ -261,27 +255,34 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
 Status BetaRowset::load_segment(int64_t seg_id, OlapReaderStatistics* stats,
                                 segment_v2::SegmentSharedPtr* segment,
                                 const io::IOContext* io_ctx) {
+    return load_segment(_rowset_meta->segment_ref(_rowset_meta->position_of(seg_id)), stats,
+                        segment, io_ctx);
+}
+
+Status BetaRowset::load_segment(RowsetSegmentRef seg, OlapReaderStatistics* stats,
+                                segment_v2::SegmentSharedPtr* segment,
+                                const io::IOContext* io_ctx) {
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");
     }
 
-    DCHECK(seg_id >= 0);
-    auto seg_path = DORIS_TRY(segment_path(seg_id));
+    DCHECK(seg.id >= 0);
+    auto seg_path = DORIS_TRY(segment_path(seg.id));
     io::FileReaderOptions reader_options {
             .cache_type = config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
                                                     : io::FileCachePolicy::NO_CACHE,
             .is_doris_table = true,
             .cache_base_path = "",
-            .file_size = _rowset_meta->segment_file_size(static_cast<int>(seg_id)),
+            .file_size = _rowset_meta->segment_file_size_by_pos(seg.pos),
             .tablet_id = _rowset_meta->tablet_id(),
             .storage_resource_id = _rowset_meta->resource_id(),
     };
 
     auto s = segment_v2::Segment::open(
-            fs, seg_path, _rowset_meta->tablet_id(), static_cast<uint32_t>(seg_id), rowset_id(),
+            fs, seg_path, _rowset_meta->tablet_id(), cast_set<uint32_t>(seg.id), rowset_id(),
             _schema, reader_options, segment,
-            _rowset_meta->inverted_index_file_info(static_cast<int>(seg_id)), stats, io_ctx);
+            _rowset_meta->inverted_index_file_info_by_pos(seg.pos), stats, io_ctx);
     if (!s.ok()) {
         LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset " << rowset_id()
                      << " : " << s.to_string();
@@ -312,8 +313,8 @@ Status BetaRowset::remove() {
     bool success = true;
     Status st;
     const auto& fs = io::global_local_filesystem();
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = local_segment_path(_tablet_path, rowset_id().to_string(), i);
+    for (auto seg : segments()) {
+        auto seg_path = local_segment_path(_tablet_path, rowset_id().to_string(), seg.id());
         LOG(INFO) << "deleting " << seg_path;
         st = fs->delete_file(seg_path);
         if (!st.ok()) {
@@ -605,8 +606,8 @@ Status BetaRowset::check_file_exist() {
                                      _rowset_meta->resource_id());
     }
 
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = DORIS_TRY(segment_path(i));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
         bool seg_file_exist = false;
         RETURN_IF_ERROR(fs->exists(seg_path, &seg_file_exist));
         if (!seg_file_exist) {
@@ -625,8 +626,8 @@ Status BetaRowset::check_current_rowset_segment() {
                                      _rowset_meta->resource_id());
     }
 
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
 
         std::shared_ptr<segment_v2::Segment> segment;
         io::FileReaderOptions reader_options {
@@ -634,14 +635,14 @@ Status BetaRowset::check_current_rowset_segment() {
                                                         : io::FileCachePolicy::NO_CACHE,
                 .is_doris_table = true,
                 .cache_base_path {},
-                .file_size = _rowset_meta->segment_file_size(seg_id),
+                .file_size = seg.file_size(),
                 .tablet_id = _rowset_meta->tablet_id(),
                 .storage_resource_id = _rowset_meta->resource_id(),
         };
 
-        auto s = segment_v2::Segment::open(fs, seg_path, _rowset_meta->tablet_id(), seg_id,
-                                           rowset_id(), _schema, reader_options, &segment,
-                                           _rowset_meta->inverted_index_file_info(seg_id));
+        auto s = segment_v2::Segment::open(
+                fs, seg_path, _rowset_meta->tablet_id(), cast_set<uint32_t>(seg.id()), rowset_id(),
+                _schema, reader_options, &segment, seg.inverted_index_file_info());
         if (!s.ok()) {
             LOG(WARNING) << "segment can not be opened. file=" << seg_path;
             return s;
@@ -762,8 +763,8 @@ Status BetaRowset::calc_file_crc(uint32_t* crc_value, int64_t* file_count) {
 
     // 1. pick up all the files including dat file and idx file
     std::vector<io::Path> file_paths;
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
         file_paths.emplace_back(seg_path);
         if (_schema->get_inverted_index_storage_format() == InvertedIndexStorageFormatPB::V1) {
             for (const auto& column : _schema->columns()) {
@@ -856,11 +857,11 @@ Status BetaRowset::show_nested_index_file(rapidjson::Value* rowset_value,
         json_value.AddMember("idx_file_size", rapidjson::Value(idx_file_size).Move(), allocator);
         return Status::OK();
     };
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
+    for (auto seg : this->segments()) {
         rapidjson::Value segment(rapidjson::kObjectType);
-        segment.AddMember("segment_id", rapidjson::Value(seg_id).Move(), allocator);
+        segment.AddMember("segment_id", rapidjson::Value(seg.id()).Move(), allocator);
 
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+        auto seg_path = DORIS_TRY(seg.path());
         auto index_file_path_prefix = InvertedIndexDescriptor::get_index_file_path_prefix(seg_path);
         auto index_file_reader = std::make_unique<IndexFileReader>(
                 fs, std::string(index_file_path_prefix), storage_format, InvertedIndexFileInfo(),

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "cloud/config.h"
+#include "common/cast_set.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/metrics/doris_metrics.h"
@@ -178,8 +179,8 @@ Status BetaRowset::get_inverted_index_size(int64_t* index_size) {
 
     if (_schema->get_inverted_index_storage_format() == InvertedIndexStorageFormatPB::V1) {
         for (const auto& index : _schema->inverted_indexes()) {
-            for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-                auto seg_path = DORIS_TRY(segment_path(seg_id));
+            for (auto seg : segments()) {
+                auto seg_path = DORIS_TRY(seg.path());
                 int64_t file_size = 0;
 
                 std::string inverted_index_file_path =
@@ -191,8 +192,8 @@ Status BetaRowset::get_inverted_index_size(int64_t* index_size) {
             }
         }
     } else {
-        for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-            auto seg_path = DORIS_TRY(segment_path(seg_id));
+        for (auto seg : segments()) {
+            auto seg_path = DORIS_TRY(seg.path());
             int64_t file_size = 0;
 
             std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_path_v2(
@@ -205,8 +206,8 @@ Status BetaRowset::get_inverted_index_size(int64_t* index_size) {
 }
 
 void BetaRowset::clear_inverted_index_cache() {
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = segment_path(i);
+    for (auto seg : segments()) {
+        auto seg_path = seg.path();
         if (!seg_path) {
             continue;
         }
@@ -233,8 +234,8 @@ Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
                                           _rowset_meta->resource_id());
     }
 
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
         int64_t file_size;
         RETURN_IF_ERROR(fs->file_size(seg_path, &file_size));
         segments_size->push_back(file_size);
@@ -243,17 +244,10 @@ Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
 }
 
 Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments) {
-    return load_segments(0, num_segments(), segments);
-}
-
-Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
-                                 std::vector<segment_v2::SegmentSharedPtr>* segments) {
-    int64_t seg_id = seg_id_begin;
-    while (seg_id < seg_id_end) {
+    for (auto seg : _rowset_meta->segments()) {
         std::shared_ptr<segment_v2::Segment> segment;
-        RETURN_IF_ERROR(load_segment(seg_id, nullptr, &segment));
+        RETURN_IF_ERROR(load_segment(seg.ref(), nullptr, &segment));
         segments->push_back(std::move(segment));
-        seg_id++;
     }
     return Status::OK();
 }
@@ -261,27 +255,34 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
 Status BetaRowset::load_segment(int64_t seg_id, OlapReaderStatistics* stats,
                                 segment_v2::SegmentSharedPtr* segment,
                                 const io::IOContext* io_ctx) {
+    return load_segment(_rowset_meta->segment_ref(_rowset_meta->position_of(seg_id)), stats,
+                        segment, io_ctx);
+}
+
+Status BetaRowset::load_segment(RowsetSegmentRef seg, OlapReaderStatistics* stats,
+                                segment_v2::SegmentSharedPtr* segment,
+                                const io::IOContext* io_ctx) {
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");
     }
 
-    DCHECK(seg_id >= 0);
-    auto seg_path = DORIS_TRY(segment_path(seg_id));
+    DCHECK(seg.id >= 0);
+    auto seg_path = DORIS_TRY(segment_path(seg.id));
     io::FileReaderOptions reader_options {
             .cache_type = config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
                                                     : io::FileCachePolicy::NO_CACHE,
             .is_doris_table = true,
             .cache_base_path = "",
-            .file_size = _rowset_meta->segment_file_size(static_cast<int>(seg_id)),
+            .file_size = _rowset_meta->segment_file_size_by_pos(seg.pos),
             .tablet_id = _rowset_meta->tablet_id(),
             .storage_resource_id = _rowset_meta->resource_id(),
     };
 
     auto s = segment_v2::Segment::open(
-            fs, seg_path, _rowset_meta->tablet_id(), static_cast<uint32_t>(seg_id), rowset_id(),
+            fs, seg_path, _rowset_meta->tablet_id(), cast_set<uint32_t>(seg.id), rowset_id(),
             _schema, reader_options, segment,
-            _rowset_meta->inverted_index_file_info(static_cast<int>(seg_id)), stats, io_ctx);
+            _rowset_meta->inverted_index_file_info_by_pos(seg.pos), stats, io_ctx);
     if (!s.ok()) {
         LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset " << rowset_id()
                      << " : " << s.to_string();
@@ -312,8 +313,8 @@ Status BetaRowset::remove() {
     bool success = true;
     Status st;
     const auto& fs = io::global_local_filesystem();
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = local_segment_path(_tablet_path, rowset_id().to_string(), i);
+    for (auto seg : segments()) {
+        auto seg_path = local_segment_path(_tablet_path, rowset_id().to_string(), seg.id());
         LOG(INFO) << "deleting " << seg_path;
         st = fs->delete_file(seg_path);
         if (!st.ok()) {
@@ -605,8 +606,8 @@ Status BetaRowset::check_file_exist() {
                                      _rowset_meta->resource_id());
     }
 
-    for (int i = 0; i < num_segments(); ++i) {
-        auto seg_path = DORIS_TRY(segment_path(i));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
         bool seg_file_exist = false;
         RETURN_IF_ERROR(fs->exists(seg_path, &seg_file_exist));
         if (!seg_file_exist) {
@@ -625,8 +626,8 @@ Status BetaRowset::check_current_rowset_segment() {
                                      _rowset_meta->resource_id());
     }
 
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
 
         std::shared_ptr<segment_v2::Segment> segment;
         io::FileReaderOptions reader_options {
@@ -634,14 +635,14 @@ Status BetaRowset::check_current_rowset_segment() {
                                                         : io::FileCachePolicy::NO_CACHE,
                 .is_doris_table = true,
                 .cache_base_path {},
-                .file_size = _rowset_meta->segment_file_size(seg_id),
+                .file_size = seg.file_size(),
                 .tablet_id = _rowset_meta->tablet_id(),
                 .storage_resource_id = _rowset_meta->resource_id(),
         };
 
-        auto s = segment_v2::Segment::open(fs, seg_path, _rowset_meta->tablet_id(), seg_id,
-                                           rowset_id(), _schema, reader_options, &segment,
-                                           _rowset_meta->inverted_index_file_info(seg_id));
+        auto s = segment_v2::Segment::open(
+                fs, seg_path, _rowset_meta->tablet_id(), cast_set<uint32_t>(seg.id()), rowset_id(),
+                _schema, reader_options, &segment, seg.inverted_index_file_info());
         if (!s.ok()) {
             LOG(WARNING) << "segment can not be opened. file=" << seg_path;
             return s;
@@ -762,8 +763,8 @@ Status BetaRowset::calc_file_crc(uint32_t* crc_value, int64_t* file_count) {
 
     // 1. pick up all the files including dat file and idx file
     std::vector<io::Path> file_paths;
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+    for (auto seg : segments()) {
+        auto seg_path = DORIS_TRY(seg.path());
         file_paths.emplace_back(seg_path);
         if (_schema->get_inverted_index_storage_format() == InvertedIndexStorageFormatPB::V1) {
             for (const auto& column : _schema->columns()) {
@@ -840,11 +841,11 @@ Status BetaRowset::show_nested_index_file(rapidjson::Value* rowset_value,
     rowset_value->AddMember("index_storage_format", rapidjson::Value(format_str.c_str(), allocator),
                             allocator);
     rapidjson::Value segments(rapidjson::kArrayType);
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
+    for (auto seg : this->segments()) {
         rapidjson::Value segment(rapidjson::kObjectType);
-        segment.AddMember("segment_id", rapidjson::Value(seg_id).Move(), allocator);
+        segment.AddMember("segment_id", rapidjson::Value(seg.id()).Move(), allocator);
 
-        auto seg_path = DORIS_TRY(segment_path(seg_id));
+        auto seg_path = DORIS_TRY(seg.path());
         auto index_file_path_prefix = InvertedIndexDescriptor::get_index_file_path_prefix(seg_path);
         auto index_file_reader = std::make_unique<IndexFileReader>(
                 fs, std::string(index_file_path_prefix), storage_format, InvertedIndexFileInfo(),

--- a/be/src/storage/rowset/beta_rowset.h
+++ b/be/src/storage/rowset/beta_rowset.h
@@ -75,10 +75,11 @@ public:
 
     Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
 
-    Status load_segments(int64_t seg_id_begin, int64_t seg_id_end,
-                         std::vector<segment_v2::SegmentSharedPtr>* segments);
-
     Status load_segment(int64_t seg_id, OlapReaderStatistics* read_stats,
+                        segment_v2::SegmentSharedPtr* segment,
+                        const io::IOContext* io_ctx = nullptr);
+
+    Status load_segment(RowsetSegmentRef seg, OlapReaderStatistics* read_stats,
                         segment_v2::SegmentSharedPtr* segment,
                         const io::IOContext* io_ctx = nullptr);
 

--- a/be/src/storage/rowset/beta_rowset_reader.cpp
+++ b/be/src/storage/rowset/beta_rowset_reader.cpp
@@ -157,7 +157,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         {
             SCOPED_RAW_TIMER(&_stats->delete_bitmap_get_agg_ns);
             RowsetId rowset_id = rowset()->rowset_id();
-            for (uint32_t seg_id = 0; seg_id < rowset()->num_segments(); ++seg_id) {
+            for (auto seg : rowset()->segments()) {
+                uint32_t seg_id = cast_set<uint32_t>(seg.id());
                 auto d = _read_context->delete_bitmap->get_agg(
                         {rowset_id, seg_id, _read_context->version.second});
                 if (d->isEmpty()) {
@@ -258,11 +259,18 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         // init segment rowid map for rowid conversion
         std::vector<uint32_t> segment_rows;
         RETURN_IF_ERROR(_rowset->get_segment_num_rows(&segment_rows, should_use_cache, _stats));
-        RETURN_IF_ERROR(_read_context->rowid_conversion->init_segment_map(rowset()->rowset_id(),
-                                                                          segment_rows));
+        std::vector<uint32_t> segment_ids;
+        segment_ids.reserve(segment_rows.size());
+        for (auto seg : rowset()->segments()) {
+            segment_ids.push_back(cast_set<uint32_t>(seg.id()));
+        }
+        RETURN_IF_ERROR(_read_context->rowid_conversion->init_segment_map(
+                rowset()->rowset_id(), segment_ids, segment_rows));
     }
 
     for (int64_t i = seg_start; i < seg_end; i++) {
+        const auto pos = cast_set<size_t>(i);
+        const auto seg = _rowset->segment(pos).ref();
         SCOPED_RAW_TIMER(&_stats->rowset_reader_create_iterators_timer_ns);
         std::unique_ptr<RowwiseIterator> iter;
 
@@ -272,7 +280,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         /// and prevents excessive memory consumption, especially for wide tables.
         if (_segment_row_ranges.empty()) {
             _read_options.row_ranges.clear();
-            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, i, should_use_cache,
+            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, seg, should_use_cache,
                                                              read_schema, _read_options);
         } else {
             DCHECK_EQ(seg_end - seg_start, _segment_row_ranges.size());
@@ -282,7 +290,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
                 local_options.condition_cache_digest =
                         local_options.row_ranges.get_digest(local_options.condition_cache_digest);
             }
-            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, i, should_use_cache,
+            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, seg, should_use_cache,
                                                              read_schema, local_options);
         }
 

--- a/be/src/storage/rowset/beta_rowset_reader.cpp
+++ b/be/src/storage/rowset/beta_rowset_reader.cpp
@@ -217,7 +217,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         {
             SCOPED_RAW_TIMER(&_stats->delete_bitmap_get_agg_ns);
             RowsetId rowset_id = rowset()->rowset_id();
-            for (uint32_t seg_id = 0; seg_id < rowset()->num_segments(); ++seg_id) {
+            for (auto seg : rowset()->segments()) {
+                uint32_t seg_id = cast_set<uint32_t>(seg.id());
                 auto d = _read_context->delete_bitmap->get_agg(
                         {rowset_id, seg_id, _read_context->version.second});
                 if (d->isEmpty()) {
@@ -319,11 +320,18 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         // init segment rowid map for rowid conversion
         std::vector<uint32_t> segment_rows;
         RETURN_IF_ERROR(_rowset->get_segment_num_rows(&segment_rows, should_use_cache, _stats));
-        RETURN_IF_ERROR(_read_context->rowid_conversion->init_segment_map(rowset()->rowset_id(),
-                                                                          segment_rows));
+        std::vector<uint32_t> segment_ids;
+        segment_ids.reserve(segment_rows.size());
+        for (auto seg : rowset()->segments()) {
+            segment_ids.push_back(cast_set<uint32_t>(seg.id()));
+        }
+        RETURN_IF_ERROR(_read_context->rowid_conversion->init_segment_map(
+                rowset()->rowset_id(), segment_ids, segment_rows));
     }
 
     for (int64_t i = seg_start; i < seg_end; i++) {
+        const auto pos = cast_set<size_t>(i);
+        const auto seg = _rowset->segment(pos).ref();
         SCOPED_RAW_TIMER(&_stats->rowset_reader_create_iterators_timer_ns);
         std::unique_ptr<RowwiseIterator> iter;
 
@@ -333,7 +341,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         /// and prevents excessive memory consumption, especially for wide tables.
         if (_segment_row_ranges.empty()) {
             _read_options.row_ranges.clear();
-            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, i, should_use_cache,
+            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, seg, should_use_cache,
                                                              _input_schema, _read_options);
         } else {
             DCHECK_EQ(seg_end - seg_start, _segment_row_ranges.size());
@@ -343,7 +351,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
                 local_options.condition_cache_digest =
                         local_options.row_ranges.get_digest(local_options.condition_cache_digest);
             }
-            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, i, should_use_cache,
+            iter = std::make_unique<LazyInitSegmentIterator>(_rowset, seg, should_use_cache,
                                                              _input_schema, local_options);
         }
 

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -131,6 +131,10 @@ void build_rowset_meta_with_spec_field(RowsetMeta& rowset_meta,
     rowset_meta.set_empty(spec_rowset_meta.num_rows() == 0);
     rowset_meta.set_creation_time(time(nullptr));
     rowset_meta.set_num_segments(spec_rowset_meta.num_segments());
+    if (spec_rowset_meta.has_segment_ids()) {
+        rowset_meta.set_segment_ids(std::vector<int64_t>(spec_rowset_meta.segment_ids().begin(),
+                                                         spec_rowset_meta.segment_ids().end()));
+    }
     rowset_meta.set_segments_overlap(spec_rowset_meta.segments_overlap());
     rowset_meta.set_rowset_state(spec_rowset_meta.rowset_state());
     rowset_meta.set_segments_key_bounds_truncated(
@@ -455,10 +459,12 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
         // Step 3: Load segments (needs file_writer to be closed and rowset to be built)
         auto* beta_rowset = reinterpret_cast<BetaRowset*>(rowset_ptr.get());
         std::vector<segment_v2::SegmentSharedPtr> segments;
-        st = beta_rowset->load_segments(segment_id, segment_id + 1, &segments);
+        segment_v2::SegmentSharedPtr segment;
+        st = beta_rowset->load_segment(segment_id, nullptr, &segment);
         if (!st.ok()) {
             return st;
         }
+        segments.emplace_back(std::move(segment));
 
         // Step 4: Calculate delete bitmap
         st = BaseTablet::calc_delete_bitmap(_context.tablet, rowset_ptr, segments,
@@ -671,7 +677,7 @@ Status BetaRowsetWriter::_rename_compacted_segment_plain(uint32_t seg_id) {
     return Status::OK();
 }
 
-Status BetaRowsetWriter::_remove_segment_footer_cache(const uint32_t seg_id,
+Status BetaRowsetWriter::_remove_segment_footer_cache(uint32_t seg_pos,
                                                       const std::string& segment_path) {
     auto* footer_page_cache = ExecEnv::GetInstance()->get_storage_page_cache();
     if (!footer_page_cache) {
@@ -688,7 +694,7 @@ Status BetaRowsetWriter::_remove_segment_footer_cache(const uint32_t seg_id,
                                                         : io::FileCachePolicy::NO_CACHE,
                 .is_doris_table = true,
                 .cache_base_path = "",
-                .file_size = _rowset_meta->segment_file_size(static_cast<int>(seg_id)),
+                .file_size = _rowset_meta->segment_file_size_by_pos(seg_pos),
                 .tablet_id = _rowset_meta->tablet_id(),
                 .storage_resource_id = _rowset_meta->resource_id(),
         };
@@ -1034,16 +1040,33 @@ int64_t BetaRowsetWriter::_num_seg() const {
     return is_segcompacted() ? _num_segcompacted : _num_segment;
 }
 
-Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num) {
+Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num,
+                                                std::vector<int64_t>* completed_segment_ids) {
     int64_t num_rows_written = 0;
     int64_t total_data_size = 0;
     int64_t total_index_size = 0;
     std::vector<KeyBoundsPB> segments_encoded_key_bounds;
     std::vector<uint32_t> segment_rows;
+    std::vector<int64_t> segment_ids;
     std::optional<bool> segments_key_bounds_truncated;
+    const bool record_segment_ids =
+            _context.write_type == DataWriteType::TYPE_COMPACTION && _segment_start_id != 0;
     {
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
+        if (record_segment_ids) {
+            segment_ids.reserve(_segid_statistics_map.size());
+        }
+        if (completed_segment_ids != nullptr) {
+            completed_segment_ids->clear();
+            completed_segment_ids->reserve(_segid_statistics_map.size());
+        }
         for (const auto& itr : _segid_statistics_map) {
+            if (record_segment_ids) {
+                segment_ids.push_back(itr.first);
+            }
+            if (completed_segment_ids != nullptr) {
+                completed_segment_ids->push_back(itr.first);
+            }
             num_rows_written += itr.second.row_num;
             total_data_size += itr.second.data_size;
             total_index_size += itr.second.index_size;
@@ -1107,6 +1130,10 @@ Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool ch
     }
 
     rowset_meta->set_num_segments(segment_num);
+    if (!segment_ids.empty()) {
+        DORIS_CHECK_EQ(segment_ids.size(), segment_num);
+        rowset_meta->set_segment_ids(segment_ids);
+    }
     rowset_meta->set_num_rows(num_rows_written + _num_rows_written);
     rowset_meta->set_total_disk_size(total_data_size + _total_data_size + total_index_size +
                                      _total_index_size);
@@ -1127,11 +1154,13 @@ Status BaseBetaRowsetWriter::_build_tmp(RowsetSharedPtr& rowset_ptr) {
     std::shared_ptr<RowsetMeta> tmp_rs_meta = std::make_shared<RowsetMeta>();
     tmp_rs_meta->init(_rowset_meta.get());
 
-    status = _build_rowset_meta(tmp_rs_meta.get());
+    std::vector<int64_t> completed_segment_ids;
+    status = _build_rowset_meta(tmp_rs_meta.get(), false, &completed_segment_ids);
     if (!status.ok()) {
         LOG(WARNING) << "failed to build rowset meta, res=" << status;
         return status;
     }
+    tmp_rs_meta->set_segment_ids(completed_segment_ids);
 
     status = RowsetFactory::create_rowset(_context.tablet_schema, _context.tablet_path, tmp_rs_meta,
                                           &rowset_ptr);
@@ -1242,10 +1271,10 @@ Status BaseBetaRowsetWriter::_check_segment_number_limit(size_t segnum) {
     if (UNLIKELY(segnum > config::max_segment_num_per_rowset)) {
         return Status::Error<TOO_MANY_SEGMENTS>(
                 "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, "
-                "_num_segment:{}, rowset_num_rows:{}. Please check if the bucket number is too "
-                "small or if the data is skewed.",
+                "segment_num:{}, _num_segment:{}, rowset_num_rows:{}. Please check if the bucket "
+                "number is too small or if the data is skewed.",
                 _context.tablet_id, _context.rowset_id.to_string(),
-                config::max_segment_num_per_rowset, _num_segment, get_rowset_num_rows());
+                config::max_segment_num_per_rowset, segnum, _num_segment, get_rowset_num_rows());
     }
     return Status::OK();
 }
@@ -1255,11 +1284,11 @@ Status BetaRowsetWriter::_check_segment_number_limit(size_t segnum) {
                     { segnum = dp->param("segnum", 1024); });
     if (UNLIKELY(segnum > config::max_segment_num_per_rowset)) {
         return Status::Error<TOO_MANY_SEGMENTS>(
-                "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, _num_segment:{}, "
-                "_segcompacted_point:{}, _num_segcompacted:{}, rowset_num_rows:{}. Please check if "
-                "the bucket number is too small or if the data is skewed.",
+                "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, segment_num:{}, "
+                "_num_segment:{}, _segcompacted_point:{}, _num_segcompacted:{}, rowset_num_rows:{}."
+                " Please check if the bucket number is too small or if the data is skewed.",
                 _context.tablet_id, _context.rowset_id.to_string(),
-                config::max_segment_num_per_rowset, _num_segment, _segcompacted_point,
+                config::max_segment_num_per_rowset, segnum, _num_segment, _segcompacted_point,
                 _num_segcompacted, get_rowset_num_rows());
     }
     return Status::OK();
@@ -1274,8 +1303,8 @@ Status BaseBetaRowsetWriter::add_segment(uint32_t segment_id, const SegmentStati
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
         CHECK_EQ(_segid_statistics_map.find(segment_id) == _segid_statistics_map.end(), true);
         _segid_statistics_map.emplace(segment_id, std::move(stored_segstat));
-        if (segment_id >= _segment_num_rows.size()) {
-            _segment_num_rows.resize(segment_id + 1);
+        if (segid_offset >= _segment_num_rows.size()) {
+            _segment_num_rows.resize(segid_offset + 1);
         }
         _segment_num_rows[segid_offset] = cast_set<uint32_t>(segstat.row_num);
         if (key_bounds_truncated) {

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -131,6 +131,10 @@ void build_rowset_meta_with_spec_field(RowsetMeta& rowset_meta,
     rowset_meta.set_empty(spec_rowset_meta.num_rows() == 0);
     rowset_meta.set_creation_time(time(nullptr));
     rowset_meta.set_num_segments(spec_rowset_meta.num_segments());
+    if (spec_rowset_meta.has_segment_ids()) {
+        rowset_meta.set_segment_ids(std::vector<int64_t>(spec_rowset_meta.segment_ids().begin(),
+                                                         spec_rowset_meta.segment_ids().end()));
+    }
     rowset_meta.set_segments_overlap(spec_rowset_meta.segments_overlap());
     rowset_meta.set_rowset_state(spec_rowset_meta.rowset_state());
     rowset_meta.set_segments_key_bounds_truncated(
@@ -455,10 +459,12 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
         // Step 3: Load segments (needs file_writer to be closed and rowset to be built)
         auto* beta_rowset = reinterpret_cast<BetaRowset*>(rowset_ptr.get());
         std::vector<segment_v2::SegmentSharedPtr> segments;
-        st = beta_rowset->load_segments(segment_id, segment_id + 1, &segments);
+        segment_v2::SegmentSharedPtr segment;
+        st = beta_rowset->load_segment(segment_id, nullptr, &segment);
         if (!st.ok()) {
             return st;
         }
+        segments.emplace_back(std::move(segment));
 
         // Step 4: Calculate delete bitmap
         st = BaseTablet::calc_delete_bitmap(_context.tablet, rowset_ptr, segments,
@@ -671,7 +677,7 @@ Status BetaRowsetWriter::_rename_compacted_segment_plain(uint32_t seg_id) {
     return Status::OK();
 }
 
-Status BetaRowsetWriter::_remove_segment_footer_cache(const uint32_t seg_id,
+Status BetaRowsetWriter::_remove_segment_footer_cache(uint32_t seg_pos,
                                                       const std::string& segment_path) {
     auto* footer_page_cache = ExecEnv::GetInstance()->get_storage_page_cache();
     if (!footer_page_cache) {
@@ -688,7 +694,7 @@ Status BetaRowsetWriter::_remove_segment_footer_cache(const uint32_t seg_id,
                                                         : io::FileCachePolicy::NO_CACHE,
                 .is_doris_table = true,
                 .cache_base_path = "",
-                .file_size = _rowset_meta->segment_file_size(static_cast<int>(seg_id)),
+                .file_size = _rowset_meta->segment_file_size_by_pos(seg_pos),
                 .tablet_id = _rowset_meta->tablet_id(),
                 .storage_resource_id = _rowset_meta->resource_id(),
         };
@@ -1036,16 +1042,33 @@ int64_t BetaRowsetWriter::_num_seg() const {
     return is_segcompacted() ? _num_segcompacted : _num_segment;
 }
 
-Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num) {
+Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num,
+                                                std::vector<int64_t>* completed_segment_ids) {
     int64_t num_rows_written = 0;
     int64_t total_data_size = 0;
     int64_t total_index_size = 0;
     std::vector<KeyBoundsPB> segments_encoded_key_bounds;
     std::vector<uint32_t> segment_rows;
+    std::vector<int64_t> segment_ids;
     std::optional<bool> segments_key_bounds_truncated;
+    const bool record_segment_ids =
+            _context.write_type == DataWriteType::TYPE_COMPACTION && _segment_start_id != 0;
     {
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
+        if (record_segment_ids) {
+            segment_ids.reserve(_segid_statistics_map.size());
+        }
+        if (completed_segment_ids != nullptr) {
+            completed_segment_ids->clear();
+            completed_segment_ids->reserve(_segid_statistics_map.size());
+        }
         for (const auto& itr : _segid_statistics_map) {
+            if (record_segment_ids) {
+                segment_ids.push_back(itr.first);
+            }
+            if (completed_segment_ids != nullptr) {
+                completed_segment_ids->push_back(itr.first);
+            }
             num_rows_written += itr.second.row_num;
             total_data_size += itr.second.data_size;
             total_index_size += itr.second.index_size;
@@ -1098,6 +1121,10 @@ Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool ch
     }
 
     rowset_meta->set_num_segments(segment_num);
+    if (!segment_ids.empty()) {
+        DORIS_CHECK_EQ(segment_ids.size(), segment_num);
+        rowset_meta->set_segment_ids(segment_ids);
+    }
     rowset_meta->set_num_rows(num_rows_written + _num_rows_written);
     rowset_meta->set_total_disk_size(total_data_size + _total_data_size + total_index_size +
                                      _total_index_size);
@@ -1117,11 +1144,13 @@ Status BaseBetaRowsetWriter::_build_tmp(RowsetSharedPtr& rowset_ptr) {
     std::shared_ptr<RowsetMeta> tmp_rs_meta = std::make_shared<RowsetMeta>();
     tmp_rs_meta->init(_rowset_meta.get());
 
-    status = _build_rowset_meta(tmp_rs_meta.get());
+    std::vector<int64_t> completed_segment_ids;
+    status = _build_rowset_meta(tmp_rs_meta.get(), false, &completed_segment_ids);
     if (!status.ok()) {
         LOG(WARNING) << "failed to build rowset meta, res=" << status;
         return status;
     }
+    tmp_rs_meta->set_segment_ids(completed_segment_ids);
 
     status = RowsetFactory::create_rowset(_context.tablet_schema, _context.tablet_path, tmp_rs_meta,
                                           &rowset_ptr);
@@ -1233,10 +1262,10 @@ Status BaseBetaRowsetWriter::_check_segment_number_limit(size_t segnum) {
     if (UNLIKELY(segnum > config::max_segment_num_per_rowset)) {
         return Status::Error<TOO_MANY_SEGMENTS>(
                 "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, "
-                "_num_segment:{}, rowset_num_rows:{}. Please check if the bucket number is too "
-                "small or if the data is skewed.",
+                "segment_num:{}, _num_segment:{}, rowset_num_rows:{}. Please check if the bucket "
+                "number is too small or if the data is skewed.",
                 _context.tablet_id, _context.rowset_id.to_string(),
-                config::max_segment_num_per_rowset, _num_segment, get_rowset_num_rows());
+                config::max_segment_num_per_rowset, segnum, _num_segment, get_rowset_num_rows());
     }
     return Status::OK();
 }
@@ -1246,11 +1275,11 @@ Status BetaRowsetWriter::_check_segment_number_limit(size_t segnum) {
                     { segnum = dp->param("segnum", 1024); });
     if (UNLIKELY(segnum > config::max_segment_num_per_rowset)) {
         return Status::Error<TOO_MANY_SEGMENTS>(
-                "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, _num_segment:{}, "
-                "_segcompacted_point:{}, _num_segcompacted:{}, rowset_num_rows:{}. Please check if "
-                "the bucket number is too small or if the data is skewed.",
+                "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, segment_num:{}, "
+                "_num_segment:{}, _segcompacted_point:{}, _num_segcompacted:{}, rowset_num_rows:{}."
+                " Please check if the bucket number is too small or if the data is skewed.",
                 _context.tablet_id, _context.rowset_id.to_string(),
-                config::max_segment_num_per_rowset, _num_segment, _segcompacted_point,
+                config::max_segment_num_per_rowset, segnum, _num_segment, _segcompacted_point,
                 _num_segcompacted, get_rowset_num_rows());
     }
     return Status::OK();
@@ -1265,8 +1294,8 @@ Status BaseBetaRowsetWriter::add_segment(uint32_t segment_id, const SegmentStati
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
         CHECK_EQ(_segid_statistics_map.find(segment_id) == _segid_statistics_map.end(), true);
         _segid_statistics_map.emplace(segment_id, std::move(stored_segstat));
-        if (segment_id >= _segment_num_rows.size()) {
-            _segment_num_rows.resize(segment_id + 1);
+        if (segid_offset >= _segment_num_rows.size()) {
+            _segment_num_rows.resize(segid_offset + 1);
         }
         _segment_num_rows[segid_offset] = cast_set<uint32_t>(segstat.row_num);
         if (key_bounds_truncated) {

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -167,15 +167,19 @@ public:
         return Status::OK();
     }
 
-    int32_t allocate_segment_id() override { return _segment_creator.allocate_segment_id(); };
+    Result<int32_t> allocate_segment_id() override {
+        return _segment_creator.allocate_segment_id();
+    };
 
     int32_t get_allocated_segment_id() override {
         return _segment_creator.get_allocated_segment_id();
     };
 
-    void set_segment_start_id(int32_t start_id) override {
-        _segment_creator.set_segment_start_id(start_id);
-        _segment_start_id = start_id;
+    void set_segment_start_id(int32_t start_seg_id,
+                              int32_t max_seg_num = MAX_SEGMENT_NUM) override {
+        _context.set_first_segment_id(start_seg_id);
+        _segment_creator.set_segment_start_id(start_seg_id, max_seg_num);
+        _segment_start_id = start_seg_id;
     }
 
     Status force_rollback() override {
@@ -210,7 +214,10 @@ private:
     // for this segment
 protected:
     Status _generate_delete_bitmap(int32_t segment_id);
-    virtual Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false);
+    // `completed_segment_ids`, when requested, is populated from the same statistics snapshot
+    // used to build the rowset meta.
+    virtual Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false,
+                                      std::vector<int64_t>* completed_segment_ids = nullptr);
     Status _create_file_writer(const std::string& path, io::FileWriterPtr& file_writer,
                                FileType file_type = FileType::SEGMENT_FILE);
     virtual Status _close_file_writers();
@@ -311,7 +318,7 @@ private:
     Status _rename_compacted_segments(int64_t begin, int64_t end);
     Status _rename_compacted_segment_plain(uint32_t seg_id);
     Status _rename_compacted_indices(int64_t begin, int64_t end, uint64_t seg_id);
-    Status _remove_segment_footer_cache(const uint32_t seg_id, const std::string& segment_path);
+    Status _remove_segment_footer_cache(uint32_t seg_pos, const std::string& segment_path);
     void _clear_statistics_for_deleting_segments_unsafe(uint32_t begin, uint32_t end);
 
     StorageEngine& _engine;

--- a/be/src/storage/rowset/beta_rowset_writer_v2.h
+++ b/be/src/storage/rowset/beta_rowset_writer_v2.h
@@ -112,7 +112,9 @@ public:
 
     Status add_segment(uint32_t segment_id, const SegmentStatistics& segstat) override;
 
-    int32_t allocate_segment_id() override { return _segment_creator.allocate_segment_id(); };
+    Result<int32_t> allocate_segment_id() override {
+        return _segment_creator.allocate_segment_id();
+    };
 
     int32_t get_allocated_segment_id() override {
         return _segment_creator.get_allocated_segment_id();

--- a/be/src/storage/rowset/group_rowset_writer.cpp
+++ b/be/src/storage/rowset/group_rowset_writer.cpp
@@ -68,7 +68,8 @@ Status GroupRowsetWriter::flush_memtable(Block* block, int32_t segment_id, int64
 }
 
 Status GroupRowsetWriter::flush_single_block(const Block* block) {
-    return flush_single_block(block, allocate_segment_id());
+    auto segment_id = DORIS_TRY(allocate_segment_id());
+    return flush_single_block(block, segment_id);
 }
 
 Status GroupRowsetWriter::flush_single_block(const Block* block, int32_t segment_id) {
@@ -77,11 +78,11 @@ Status GroupRowsetWriter::flush_single_block(const Block* block, int32_t segment
     return Status::OK();
 }
 
-int32_t GroupRowsetWriter::allocate_segment_id() {
+Result<int32_t> GroupRowsetWriter::allocate_segment_id() {
     DCHECK(_txn_rowset_writer != nullptr);
     DCHECK(_row_binlog_rowset_writer != nullptr);
-    auto segment_id = _txn_rowset_writer->allocate_segment_id();
-    auto binlog_segment_id = _row_binlog_rowset_writer->allocate_segment_id();
+    auto segment_id = DORIS_TRY(_txn_rowset_writer->allocate_segment_id());
+    auto binlog_segment_id = DORIS_TRY(_row_binlog_rowset_writer->allocate_segment_id());
     DCHECK_EQ(segment_id, binlog_segment_id);
     return segment_id;
 }

--- a/be/src/storage/rowset/group_rowset_writer.h
+++ b/be/src/storage/rowset/group_rowset_writer.h
@@ -108,7 +108,7 @@ public:
         return Status::NotSupported("GroupRowsetWriter::get_segment_num_rows to be implemented");
     }
 
-    int32_t allocate_segment_id() override;
+    Result<int32_t> allocate_segment_id() override;
 
     int32_t get_allocated_segment_id() override {
         DCHECK(_txn_rowset_writer != nullptr);
@@ -118,7 +118,8 @@ public:
         return seg_id;
     }
 
-    void set_segment_start_id(int num_segment) override {
+    void set_segment_start_id(int32_t start_seg_id,
+                              int32_t max_seg_num = MAX_SEGMENT_NUM) override {
         LOG(FATAL) << "GroupRowsetWriter::set_segment_start_id not supported";
     }
 

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -17,6 +17,7 @@
 
 #include "storage/rowset/rowset.h"
 
+#include <fmt/ranges.h>
 #include <gen_cpp/olap_file.pb.h>
 
 #include "common/cast_set.h"
@@ -26,6 +27,7 @@
 #include "storage/olap_define.h"
 #include "storage/segment/segment_loader.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/utils.h"
 #include "util/time.h"
 #include "util/trace.h"
 
@@ -108,10 +110,15 @@ bool Rowset::check_rowset_segment() {
 std::string Rowset::get_rowset_info_str() {
     std::string disk_size = PrettyPrinter::print(
             static_cast<uint64_t>(_rowset_meta->total_disk_size()), TUnit::BYTES);
-    return fmt::format("[{}-{}] {} {} {} {} {} level={}", start_version(), end_version(),
-                       num_segments(), _rowset_meta->has_delete_predicate() ? "DELETE" : "DATA",
-                       SegmentsOverlapPB_Name(_rowset_meta->segments_overlap()),
-                       rowset_id().to_string(), disk_size, _rowset_meta->compaction_level());
+    std::string rowset_info =
+            fmt::format("[{}-{}] {} {} {} {} {} level={}", start_version(), end_version(),
+                        num_segments(), _rowset_meta->has_delete_predicate() ? "DELETE" : "DATA",
+                        SegmentsOverlapPB_Name(_rowset_meta->segments_overlap()),
+                        rowset_id().to_string(), disk_size, _rowset_meta->compaction_level());
+    if (_rowset_meta->has_segment_ids()) {
+        rowset_info += fmt::format(" [{}]", fmt::join(_rowset_meta->segment_ids(), ","));
+    }
+    return rowset_info;
 }
 
 const TabletSchemaSPtr& Rowset::tablet_schema() const {
@@ -125,15 +132,15 @@ const TabletSchemaSPtr& Rowset::tablet_schema() const {
 void Rowset::clear_cache() {
     {
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(std::chrono::seconds(1));
-        SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
+        SegmentLoader::instance()->erase_segments(*rowset_meta());
     }
     {
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(std::chrono::seconds(1));
         clear_inverted_index_cache();
     }
     if (config::enable_file_cache) {
-        for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-            auto file_key = segment_v2::Segment::file_cache_key(rowset_id().to_string(), seg_id);
+        for (auto seg : segments()) {
+            auto file_key = seg.file_cache_key();
             auto* file_cache = io::FileCacheFactory::instance()->get_by_path(file_key);
             file_cache->remove_if_cached_async(file_key);
         }
@@ -184,20 +191,9 @@ void Rowset::merge_rowset_meta(const RowsetMeta& other) {
 
 std::vector<std::string> Rowset::get_index_file_names() {
     std::vector<std::string> file_names;
-    auto idx_version = _schema->get_inverted_index_storage_format();
-    for (int64_t seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        if (idx_version == InvertedIndexStorageFormatPB::V1) {
-            for (const auto& index : _schema->inverted_indexes()) {
-                auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v1(
-                        rowset_id().to_string(), seg_id, index->index_id(),
-                        index->get_index_suffix());
-                file_names.emplace_back(std::move(file_name));
-            }
-        } else {
-            auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v2(
-                    rowset_id().to_string(), seg_id);
-            file_names.emplace_back(std::move(file_name));
-        }
+    for (auto seg : segments()) {
+        auto segment_file_names = seg.index_file_names();
+        file_names.insert(file_names.end(), segment_file_names.begin(), segment_file_names.end());
     }
     return file_names;
 }
@@ -208,8 +204,8 @@ int64_t Rowset::approximate_cached_data_size() {
     }
 
     int64_t total_cache_size = 0;
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto cache_key = segment_v2::Segment::file_cache_key(rowset_id().to_string(), seg_id);
+    for (auto seg : segments()) {
+        auto cache_key = seg.file_cache_key();
         int64_t cache_size =
                 io::FileCacheFactory::instance()->get_cache_file_size_by_path(cache_key);
         total_cache_size += cache_size;
@@ -235,6 +231,55 @@ int64_t Rowset::approximate_cache_index_size() {
 
 std::chrono::time_point<std::chrono::system_clock> Rowset::visible_timestamp() const {
     return _rowset_meta->visible_timestamp();
+}
+
+std::string RowsetSegmentView::file_name() const {
+    return fmt::format("{}_{}.dat", _rowset->rowset_id().to_string(), id());
+}
+
+Result<std::string> RowsetSegmentView::path() const {
+    return _rowset->segment_path(id());
+}
+
+io::UInt128Wrapper RowsetSegmentView::file_cache_key() const {
+    return segment_v2::Segment::file_cache_key(_rowset->rowset_id().to_string(),
+                                               cast_set<uint32_t>(id()));
+}
+
+RowsetSegmentView::DeleteBitmapKey RowsetSegmentView::delete_bitmap_key(int64_t version) const {
+    return {_rowset->rowset_id(), cast_set<uint32_t>(id()), version};
+}
+
+RowLocation RowsetSegmentView::row_location(uint32_t row_id) const {
+    return {_rowset->rowset_id(), cast_set<uint32_t>(id()), row_id};
+}
+
+std::vector<std::string> RowsetSegmentView::index_file_names() const {
+    std::vector<std::string> file_names;
+    auto idx_version = _rowset->tablet_schema()->get_inverted_index_storage_format();
+    if (idx_version == InvertedIndexStorageFormatPB::V1) {
+        for (const auto& index : _rowset->tablet_schema()->inverted_indexes()) {
+            auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v1(
+                    _rowset->rowset_id().to_string(), id(), index->index_id(),
+                    index->get_index_suffix());
+            file_names.emplace_back(std::move(file_name));
+        }
+    } else {
+        auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v2(
+                _rowset->rowset_id().to_string(), id());
+        file_names.emplace_back(std::move(file_name));
+    }
+    return file_names;
+}
+
+Result<std::string> RowsetSegmentView::index_file_cache_key(const TabletIndex& index) const {
+    auto segment_path = path();
+    if (!segment_path.has_value()) {
+        return ResultError(segment_path.error());
+    }
+    return segment_v2::InvertedIndexDescriptor::get_index_file_cache_key(
+            segment_v2::InvertedIndexDescriptor::get_index_file_path_prefix(segment_path.value()),
+            index.index_id(), index.get_index_suffix());
 }
 
 } // namespace doris

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -17,6 +17,7 @@
 
 #include "storage/rowset/rowset.h"
 
+#include <fmt/ranges.h>
 #include <gen_cpp/olap_file.pb.h>
 
 #include "common/cast_set.h"
@@ -26,6 +27,7 @@
 #include "storage/olap_define.h"
 #include "storage/segment/segment_loader.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/utils.h"
 #include "util/time.h"
 #include "util/trace.h"
 
@@ -108,10 +110,15 @@ bool Rowset::check_rowset_segment() {
 std::string Rowset::get_rowset_info_str() {
     std::string disk_size = PrettyPrinter::print(
             static_cast<uint64_t>(_rowset_meta->total_disk_size()), TUnit::BYTES);
-    return fmt::format("[{}-{}] {} {} {} {} {}", start_version(), end_version(), num_segments(),
-                       _rowset_meta->has_delete_predicate() ? "DELETE" : "DATA",
-                       SegmentsOverlapPB_Name(_rowset_meta->segments_overlap()),
-                       rowset_id().to_string(), disk_size);
+    std::string rowset_info =
+            fmt::format("[{}-{}] {} {} {} {} {}", start_version(), end_version(), num_segments(),
+                        _rowset_meta->has_delete_predicate() ? "DELETE" : "DATA",
+                        SegmentsOverlapPB_Name(_rowset_meta->segments_overlap()),
+                        rowset_id().to_string(), disk_size);
+    if (_rowset_meta->has_segment_ids()) {
+        rowset_info += fmt::format(" [{}]", fmt::join(_rowset_meta->segment_ids(), ","));
+    }
+    return rowset_info;
 }
 
 const TabletSchemaSPtr& Rowset::tablet_schema() const {
@@ -125,15 +132,15 @@ const TabletSchemaSPtr& Rowset::tablet_schema() const {
 void Rowset::clear_cache() {
     {
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(std::chrono::seconds(1));
-        SegmentLoader::instance()->erase_segments(rowset_id(), num_segments());
+        SegmentLoader::instance()->erase_segments(*rowset_meta());
     }
     {
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(std::chrono::seconds(1));
         clear_inverted_index_cache();
     }
     if (config::enable_file_cache) {
-        for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-            auto file_key = segment_v2::Segment::file_cache_key(rowset_id().to_string(), seg_id);
+        for (auto seg : segments()) {
+            auto file_key = seg.file_cache_key();
             auto* file_cache = io::FileCacheFactory::instance()->get_by_path(file_key);
             file_cache->remove_if_cached_async(file_key);
         }
@@ -184,20 +191,9 @@ void Rowset::merge_rowset_meta(const RowsetMeta& other) {
 
 std::vector<std::string> Rowset::get_index_file_names() {
     std::vector<std::string> file_names;
-    auto idx_version = _schema->get_inverted_index_storage_format();
-    for (int64_t seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        if (idx_version == InvertedIndexStorageFormatPB::V1) {
-            for (const auto& index : _schema->inverted_indexes()) {
-                auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v1(
-                        rowset_id().to_string(), seg_id, index->index_id(),
-                        index->get_index_suffix());
-                file_names.emplace_back(std::move(file_name));
-            }
-        } else {
-            auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v2(
-                    rowset_id().to_string(), seg_id);
-            file_names.emplace_back(std::move(file_name));
-        }
+    for (auto seg : segments()) {
+        auto segment_file_names = seg.index_file_names();
+        file_names.insert(file_names.end(), segment_file_names.begin(), segment_file_names.end());
     }
     return file_names;
 }
@@ -208,8 +204,8 @@ int64_t Rowset::approximate_cached_data_size() {
     }
 
     int64_t total_cache_size = 0;
-    for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
-        auto cache_key = segment_v2::Segment::file_cache_key(rowset_id().to_string(), seg_id);
+    for (auto seg : segments()) {
+        auto cache_key = seg.file_cache_key();
         int64_t cache_size =
                 io::FileCacheFactory::instance()->get_cache_file_size_by_path(cache_key);
         total_cache_size += cache_size;
@@ -235,6 +231,55 @@ int64_t Rowset::approximate_cache_index_size() {
 
 std::chrono::time_point<std::chrono::system_clock> Rowset::visible_timestamp() const {
     return _rowset_meta->visible_timestamp();
+}
+
+std::string RowsetSegmentView::file_name() const {
+    return fmt::format("{}_{}.dat", _rowset->rowset_id().to_string(), id());
+}
+
+Result<std::string> RowsetSegmentView::path() const {
+    return _rowset->segment_path(id());
+}
+
+io::UInt128Wrapper RowsetSegmentView::file_cache_key() const {
+    return segment_v2::Segment::file_cache_key(_rowset->rowset_id().to_string(),
+                                               cast_set<uint32_t>(id()));
+}
+
+RowsetSegmentView::DeleteBitmapKey RowsetSegmentView::delete_bitmap_key(int64_t version) const {
+    return {_rowset->rowset_id(), cast_set<uint32_t>(id()), version};
+}
+
+RowLocation RowsetSegmentView::row_location(uint32_t row_id) const {
+    return {_rowset->rowset_id(), cast_set<uint32_t>(id()), row_id};
+}
+
+std::vector<std::string> RowsetSegmentView::index_file_names() const {
+    std::vector<std::string> file_names;
+    auto idx_version = _rowset->tablet_schema()->get_inverted_index_storage_format();
+    if (idx_version == InvertedIndexStorageFormatPB::V1) {
+        for (const auto& index : _rowset->tablet_schema()->inverted_indexes()) {
+            auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v1(
+                    _rowset->rowset_id().to_string(), id(), index->index_id(),
+                    index->get_index_suffix());
+            file_names.emplace_back(std::move(file_name));
+        }
+    } else {
+        auto file_name = segment_v2::InvertedIndexDescriptor::get_index_file_name_v2(
+                _rowset->rowset_id().to_string(), id());
+        file_names.emplace_back(std::move(file_name));
+    }
+    return file_names;
+}
+
+Result<std::string> RowsetSegmentView::index_file_cache_key(const TabletIndex& index) const {
+    auto segment_path = path();
+    if (!segment_path.has_value()) {
+        return ResultError(segment_path.error());
+    }
+    return segment_v2::InvertedIndexDescriptor::get_index_file_cache_key(
+            segment_v2::InvertedIndexDescriptor::get_index_file_path_prefix(segment_path.value()),
+            index.index_id(), index.get_index_suffix());
 }
 
 } // namespace doris

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -25,14 +25,18 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <vector>
 
+#include "common/cast_set.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "io/cache/file_cache_common.h"
 #include "storage/metadata_adder.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_meta.h"
@@ -41,6 +45,9 @@
 namespace doris {
 
 class Rowset;
+class RowsetSegmentRange;
+class RowsetSegmentView;
+struct RowLocation;
 
 namespace io {
 class RemoteFileSystem;
@@ -326,6 +333,8 @@ public:
     void clear_cache();
 
     MOCK_FUNCTION Result<std::string> segment_path(int64_t seg_id);
+    RowsetSegmentView segment(size_t pos);
+    RowsetSegmentRange segments();
 
     std::vector<std::string> get_index_file_names();
 
@@ -386,6 +395,84 @@ protected:
     // it is used to ensure that the version sequence is continuous.
     bool _is_hole_rowset = false;
 };
+
+// Non-owning view over a segment in a Rowset. The referenced Rowset and RowsetMeta must outlive
+// this view. Do not store it or capture it into async callbacks; copy the needed values or keep a
+// RowsetSharedPtr instead.
+class RowsetSegmentView {
+public:
+    using DeleteBitmapKey = std::tuple<RowsetId, uint32_t, int64_t>;
+
+    RowsetSegmentView(Rowset* rowset, size_t pos)
+            : _rowset(rowset), _meta(rowset->rowset_meta()->segment(pos)) {}
+
+    size_t pos() const { return _meta.pos(); }
+    int64_t id() const { return _meta.id(); }
+    RowsetSegmentRef ref() const { return _meta.ref(); }
+    RowsetSegmentMetaView meta() const { return _meta; }
+    int64_t file_size() const { return _meta.file_size(); }
+    InvertedIndexFileInfo inverted_index_file_info() const {
+        return _meta.inverted_index_file_info();
+    }
+    bool has_num_rows() const { return _meta.has_num_rows(); }
+    int64_t num_rows() const { return _meta.num_rows(); }
+    bool has_position_key_bounds() const { return _meta.has_position_key_bounds(); }
+    const KeyBoundsPB& key_bounds() const { return _meta.key_bounds(); }
+
+    std::string file_name() const;
+    Result<std::string> path() const;
+    io::UInt128Wrapper file_cache_key() const;
+    DeleteBitmapKey delete_bitmap_key(int64_t version) const;
+    RowLocation row_location(uint32_t row_id) const;
+    std::vector<std::string> index_file_names() const;
+    Result<std::string> index_file_cache_key(const TabletIndex& index) const;
+
+private:
+    Rowset* _rowset;
+    RowsetSegmentMetaView _meta;
+};
+
+class RowsetSegmentRange {
+public:
+    class Iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = RowsetSegmentView;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator(Rowset* rowset, size_t pos) : _rowset(rowset), _pos(pos) {}
+
+        RowsetSegmentView operator*() const { return {_rowset, _pos}; }
+        Iterator& operator++() {
+            ++_pos;
+            return *this;
+        }
+        bool operator==(const Iterator& other) const {
+            return _rowset == other._rowset && _pos == other._pos;
+        }
+        bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+    private:
+        Rowset* _rowset;
+        size_t _pos;
+    };
+
+    explicit RowsetSegmentRange(Rowset* rowset) : _rowset(rowset) {}
+
+    Iterator begin() const { return {_rowset, 0}; }
+    Iterator end() const { return {_rowset, cast_set<size_t>(_rowset->num_segments())}; }
+
+private:
+    Rowset* _rowset;
+};
+
+inline RowsetSegmentView Rowset::segment(size_t pos) {
+    return RowsetSegmentView(this, pos);
+}
+
+inline RowsetSegmentRange Rowset::segments() {
+    return RowsetSegmentRange(this);
+}
 
 // `rs_metas` MUST already be sorted by `RowsetMeta::comparator`
 Status check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -25,14 +25,18 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <vector>
 
+#include "common/cast_set.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "io/cache/file_cache_common.h"
 #include "storage/metadata_adder.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_meta.h"
@@ -41,6 +45,9 @@
 namespace doris {
 
 class Rowset;
+class RowsetSegmentRange;
+class RowsetSegmentView;
+struct RowLocation;
 
 namespace io {
 class RemoteFileSystem;
@@ -318,6 +325,8 @@ public:
     void clear_cache();
 
     MOCK_FUNCTION Result<std::string> segment_path(int64_t seg_id);
+    RowsetSegmentView segment(size_t pos);
+    RowsetSegmentRange segments();
 
     std::vector<std::string> get_index_file_names();
 
@@ -376,6 +385,84 @@ protected:
     // it is used to ensure that the version sequence is continuous.
     bool _is_hole_rowset = false;
 };
+
+// Non-owning view over a segment in a Rowset. The referenced Rowset and RowsetMeta must outlive
+// this view. Do not store it or capture it into async callbacks; copy the needed values or keep a
+// RowsetSharedPtr instead.
+class RowsetSegmentView {
+public:
+    using DeleteBitmapKey = std::tuple<RowsetId, uint32_t, int64_t>;
+
+    RowsetSegmentView(Rowset* rowset, size_t pos)
+            : _rowset(rowset), _meta(rowset->rowset_meta()->segment(pos)) {}
+
+    size_t pos() const { return _meta.pos(); }
+    int64_t id() const { return _meta.id(); }
+    RowsetSegmentRef ref() const { return _meta.ref(); }
+    RowsetSegmentMetaView meta() const { return _meta; }
+    int64_t file_size() const { return _meta.file_size(); }
+    InvertedIndexFileInfo inverted_index_file_info() const {
+        return _meta.inverted_index_file_info();
+    }
+    bool has_num_rows() const { return _meta.has_num_rows(); }
+    int64_t num_rows() const { return _meta.num_rows(); }
+    bool has_position_key_bounds() const { return _meta.has_position_key_bounds(); }
+    const KeyBoundsPB& key_bounds() const { return _meta.key_bounds(); }
+
+    std::string file_name() const;
+    Result<std::string> path() const;
+    io::UInt128Wrapper file_cache_key() const;
+    DeleteBitmapKey delete_bitmap_key(int64_t version) const;
+    RowLocation row_location(uint32_t row_id) const;
+    std::vector<std::string> index_file_names() const;
+    Result<std::string> index_file_cache_key(const TabletIndex& index) const;
+
+private:
+    Rowset* _rowset;
+    RowsetSegmentMetaView _meta;
+};
+
+class RowsetSegmentRange {
+public:
+    class Iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = RowsetSegmentView;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator(Rowset* rowset, size_t pos) : _rowset(rowset), _pos(pos) {}
+
+        RowsetSegmentView operator*() const { return {_rowset, _pos}; }
+        Iterator& operator++() {
+            ++_pos;
+            return *this;
+        }
+        bool operator==(const Iterator& other) const {
+            return _rowset == other._rowset && _pos == other._pos;
+        }
+        bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+    private:
+        Rowset* _rowset;
+        size_t _pos;
+    };
+
+    explicit RowsetSegmentRange(Rowset* rowset) : _rowset(rowset) {}
+
+    Iterator begin() const { return {_rowset, 0}; }
+    Iterator end() const { return {_rowset, cast_set<size_t>(_rowset->num_segments())}; }
+
+private:
+    Rowset* _rowset;
+};
+
+inline RowsetSegmentView Rowset::segment(size_t pos) {
+    return RowsetSegmentView(this, pos);
+}
+
+inline RowsetSegmentRange Rowset::segments() {
+    return RowsetSegmentRange(this);
+}
 
 // `rs_metas` MUST already be sorted by `RowsetMeta::comparator`
 Status check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -20,6 +20,8 @@
 #include <gen_cpp/olap_file.pb.h>
 #include <glog/logging.h>
 
+#include <algorithm>
+#include <iterator>
 #include <memory>
 #include <random>
 
@@ -268,7 +270,40 @@ void RowsetMeta::_init() {
     } else {
         _rowset_id.init(_rowset_meta_pb.rowset_id_v2());
     }
+    _validate_segment_ids();
     update_metadata_size();
+}
+
+void RowsetMeta::_validate_segment_ids() const {
+    if (!has_segment_ids()) {
+        return;
+    }
+    DORIS_CHECK_EQ(_rowset_meta_pb.segment_ids_size(), _rowset_meta_pb.num_segments());
+    int64_t prev_segment_id = -1;
+    for (const auto segment_id : _rowset_meta_pb.segment_ids()) {
+        DORIS_CHECK_GE(segment_id, 0);
+        DORIS_CHECK_GT(segment_id, prev_segment_id);
+        prev_segment_id = segment_id;
+    }
+}
+
+void RowsetMeta::set_segment_ids(const std::vector<int64_t>& segment_ids) {
+    _rowset_meta_pb.mutable_segment_ids()->Assign(segment_ids.begin(), segment_ids.end());
+    set_num_segments(cast_set<int64_t>(segment_ids.size()));
+    _validate_segment_ids();
+}
+
+size_t RowsetMeta::position_of(int64_t seg_id) const {
+    DORIS_CHECK_GE(seg_id, 0);
+    if (!has_segment_ids()) {
+        DORIS_CHECK_LT(seg_id, num_segments());
+        return cast_set<size_t>(seg_id);
+    }
+    const auto& segment_ids = _rowset_meta_pb.segment_ids();
+    auto it = std::lower_bound(segment_ids.begin(), segment_ids.end(), seg_id);
+    DORIS_CHECK(it != segment_ids.end());
+    DORIS_CHECK_EQ(*it, seg_id);
+    return cast_set<size_t>(std::distance(segment_ids.begin(), it));
 }
 
 void RowsetMeta::add_segments_file_size(const std::vector<size_t>& seg_file_size) {
@@ -278,13 +313,13 @@ void RowsetMeta::add_segments_file_size(const std::vector<size_t>& seg_file_size
     }
 }
 
-int64_t RowsetMeta::segment_file_size(int seg_id) const {
+int64_t RowsetMeta::segment_file_size_by_pos(size_t pos) const {
     DCHECK(_rowset_meta_pb.segments_file_size().empty() ||
-           _rowset_meta_pb.segments_file_size_size() > seg_id)
-            << _rowset_meta_pb.segments_file_size_size() << ' ' << seg_id;
+           _rowset_meta_pb.segments_file_size_size() > cast_set<int>(pos))
+            << _rowset_meta_pb.segments_file_size_size() << ' ' << pos;
     return _rowset_meta_pb.enable_segments_file_size()
-                   ? (_rowset_meta_pb.segments_file_size_size() > seg_id
-                              ? _rowset_meta_pb.segments_file_size(seg_id)
+                   ? (_rowset_meta_pb.segments_file_size_size() > cast_set<int>(pos)
+                              ? _rowset_meta_pb.segments_file_size(cast_set<int>(pos))
                               : -1)
                    : -1;
 }
@@ -404,10 +439,10 @@ int64_t RowsetMeta::get_metadata_size() const {
     return sizeof(RowsetMeta) + _rowset_meta_pb.ByteSizeLong();
 }
 
-InvertedIndexFileInfo RowsetMeta::inverted_index_file_info(int seg_id) {
+InvertedIndexFileInfo RowsetMeta::inverted_index_file_info_by_pos(size_t pos) const {
     return _rowset_meta_pb.enable_inverted_index_file_info()
-                   ? (_rowset_meta_pb.inverted_index_file_info_size() > seg_id
-                              ? _rowset_meta_pb.inverted_index_file_info(seg_id)
+                   ? (_rowset_meta_pb.inverted_index_file_info_size() > cast_set<int>(pos)
+                              ? _rowset_meta_pb.inverted_index_file_info(cast_set<int>(pos))
                               : InvertedIndexFileInfo())
                    : InvertedIndexFileInfo();
 }

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -23,12 +23,15 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "common/cast_set.h"
+#include "common/check.h"
 #include "common/config.h"
 #include "common/status.h"
 #include "io/fs/encrypted_fs_factory.h"
@@ -37,11 +40,15 @@
 #include "storage/metadata_adder.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_fwd.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/storage_policy.h"
 #include "storage/tablet/tablet_fwd.h"
 #include "util/once.h"
 
 namespace doris {
+
+class RowsetSegmentMetaView;
+class RowsetSegmentMetaRange;
 
 class RowsetMeta : public MetadataAdder<RowsetMeta> {
 public:
@@ -259,9 +266,33 @@ public:
         return _rowset_meta_pb.set_partition_id(partition_id);
     }
 
-    int64_t num_segments() const { return _rowset_meta_pb.num_segments(); }
+    int64_t num_segments() const {
+        DCHECK(_rowset_meta_pb.segment_ids_size() == 0 ||
+               _rowset_meta_pb.segment_ids_size() == _rowset_meta_pb.num_segments());
+        return _rowset_meta_pb.num_segments();
+    }
 
     void set_num_segments(int64_t num_segments) { _rowset_meta_pb.set_num_segments(num_segments); }
+
+    bool has_segment_ids() const { return _rowset_meta_pb.segment_ids_size() > 0; }
+
+    const auto& segment_ids() const { return _rowset_meta_pb.segment_ids(); }
+
+    void set_segment_ids(const std::vector<int64_t>& segment_ids);
+
+    int64_t segment_id(size_t pos) const {
+        DORIS_CHECK_LT(pos, cast_set<size_t>(num_segments()));
+        return has_segment_ids() ? _rowset_meta_pb.segment_ids(cast_set<int>(pos))
+                                 : cast_set<int64_t>(pos);
+    }
+
+    RowsetSegmentRef segment_ref(size_t pos) const { return {pos, segment_id(pos)}; }
+
+    RowsetSegmentMetaView segment(size_t pos) const;
+
+    RowsetSegmentMetaRange segments() const;
+
+    size_t position_of(int64_t seg_id) const;
 
     // Convert to RowsetMetaPB, skip_schema is only used by cloud to separate schema from rowset meta.
     void to_rowset_pb(RowsetMetaPB* rs_meta_pb, bool skip_schema = false) const;
@@ -441,18 +472,18 @@ public:
 
     int64_t compaction_level() { return _rowset_meta_pb.compaction_level(); }
 
-    // `seg_file_size` MUST ordered by segment id
+    // `seg_file_size` MUST be ordered by rowset segment position.
     void add_segments_file_size(const std::vector<size_t>& seg_file_size);
 
     // Return -1 if segment file size is unknown
-    int64_t segment_file_size(int seg_id) const;
+    int64_t segment_file_size_by_pos(size_t pos) const;
 
     const auto& segments_file_size() const { return _rowset_meta_pb.segments_file_size(); }
 
     // Used for partial update, when publish, partial update may add a new rowset and we should update rowset meta
     void merge_rowset_meta(const RowsetMeta& other);
 
-    InvertedIndexFileInfo inverted_index_file_info(int seg_id);
+    InvertedIndexFileInfo inverted_index_file_info_by_pos(size_t pos) const;
 
     const auto& inverted_index_file_info() const {
         return _rowset_meta_pb.inverted_index_file_info();
@@ -521,6 +552,8 @@ private:
 
     void _init();
 
+    void _validate_segment_ids() const;
+
     friend bool operator==(const RowsetMeta& a, const RowsetMeta& b);
 
     friend bool operator!=(const RowsetMeta& a, const RowsetMeta& b) { return !(a == b); }
@@ -535,6 +568,90 @@ private:
     DorisCallOnce<Result<EncryptionAlgorithmPB>> _determine_encryption_once;
     std::atomic<int64_t> _stale_at_s {0};
 };
+
+class RowsetSegmentMetaView {
+public:
+    RowsetSegmentMetaView(const RowsetMeta* meta, size_t pos)
+            : _meta(meta), _ref(meta->segment_ref(pos)) {}
+
+    size_t pos() const { return _ref.pos; }
+    int64_t id() const { return _ref.id; }
+    RowsetSegmentRef ref() const { return _ref; }
+
+    int64_t file_size() const { return _meta->segment_file_size_by_pos(pos()); }
+
+    InvertedIndexFileInfo inverted_index_file_info() const {
+        return _meta->inverted_index_file_info_by_pos(pos());
+    }
+
+    bool has_num_rows() const {
+        return cast_set<size_t>(_meta->get_num_segment_rows().size()) > pos();
+    }
+
+    int64_t num_rows() const {
+        DORIS_CHECK(has_num_rows());
+        return _meta->get_num_segment_rows().Get(cast_set<int>(pos()));
+    }
+
+    bool has_position_key_bounds() const {
+        return !_meta->is_segments_key_bounds_aggregated() &&
+               cast_set<size_t>(_meta->get_segments_key_bounds().size()) > pos();
+    }
+
+    const KeyBoundsPB& key_bounds() const {
+        DORIS_CHECK(has_position_key_bounds());
+        return _meta->get_segments_key_bounds().Get(cast_set<int>(pos()));
+    }
+
+private:
+    const RowsetMeta* _meta;
+    RowsetSegmentRef _ref;
+};
+
+class RowsetSegmentMetaRange {
+public:
+    class Iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = RowsetSegmentMetaView;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator(const RowsetMeta* meta, size_t pos) : _meta(meta), _pos(pos) {}
+
+        RowsetSegmentMetaView operator*() const { return {_meta, _pos}; }
+
+        Iterator& operator++() {
+            ++_pos;
+            return *this;
+        }
+
+        bool operator==(const Iterator& other) const {
+            return _meta == other._meta && _pos == other._pos;
+        }
+
+        bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+    private:
+        const RowsetMeta* _meta;
+        size_t _pos;
+    };
+
+    explicit RowsetSegmentMetaRange(const RowsetMeta* meta) : _meta(meta) {}
+
+    Iterator begin() const { return {_meta, 0}; }
+    Iterator end() const { return {_meta, cast_set<size_t>(_meta->num_segments())}; }
+
+private:
+    const RowsetMeta* _meta;
+};
+
+inline RowsetSegmentMetaView RowsetMeta::segment(size_t pos) const {
+    return {this, pos};
+}
+
+inline RowsetSegmentMetaRange RowsetMeta::segments() const {
+    return RowsetSegmentMetaRange(this);
+}
 
 } // namespace doris
 

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -23,12 +23,16 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/cast_set.h"
+#include "common/check.h"
 #include "common/config.h"
 #include "common/status.h"
 #include "io/fs/encrypted_fs_factory.h"
@@ -38,11 +42,15 @@
 #include "storage/metadata_adder.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_fwd.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/storage_policy.h"
 #include "storage/tablet/tablet_fwd.h"
 #include "util/once.h"
 
 namespace doris {
+
+class RowsetSegmentMetaView;
+class RowsetSegmentMetaRange;
 
 class RowsetMeta : public MetadataAdder<RowsetMeta> {
 public:
@@ -260,9 +268,33 @@ public:
         return _rowset_meta_pb.set_partition_id(partition_id);
     }
 
-    int64_t num_segments() const { return _rowset_meta_pb.num_segments(); }
+    int64_t num_segments() const {
+        DCHECK(_rowset_meta_pb.segment_ids_size() == 0 ||
+               _rowset_meta_pb.segment_ids_size() == _rowset_meta_pb.num_segments());
+        return _rowset_meta_pb.num_segments();
+    }
 
     void set_num_segments(int64_t num_segments) { _rowset_meta_pb.set_num_segments(num_segments); }
+
+    bool has_segment_ids() const { return _rowset_meta_pb.segment_ids_size() > 0; }
+
+    const auto& segment_ids() const { return _rowset_meta_pb.segment_ids(); }
+
+    void set_segment_ids(const std::vector<int64_t>& segment_ids);
+
+    int64_t segment_id(size_t pos) const {
+        DORIS_CHECK_LT(pos, cast_set<size_t>(num_segments()));
+        return has_segment_ids() ? _rowset_meta_pb.segment_ids(cast_set<int>(pos))
+                                 : cast_set<int64_t>(pos);
+    }
+
+    RowsetSegmentRef segment_ref(size_t pos) const { return {pos, segment_id(pos)}; }
+
+    RowsetSegmentMetaView segment(size_t pos) const;
+
+    RowsetSegmentMetaRange segments() const;
+
+    size_t position_of(int64_t seg_id) const;
 
     // Convert to RowsetMetaPB, skip_schema is only used by cloud to separate schema from rowset meta.
     void to_rowset_pb(RowsetMetaPB* rs_meta_pb, bool skip_schema = false) const;
@@ -447,18 +479,18 @@ public:
 
     int64_t compaction_level() { return _rowset_meta_pb.compaction_level(); }
 
-    // `seg_file_size` MUST ordered by segment id
+    // `seg_file_size` MUST be ordered by rowset segment position.
     void add_segments_file_size(const std::vector<size_t>& seg_file_size);
 
     // Return -1 if segment file size is unknown
-    int64_t segment_file_size(int seg_id) const;
+    int64_t segment_file_size_by_pos(size_t pos) const;
 
     const auto& segments_file_size() const { return _rowset_meta_pb.segments_file_size(); }
 
     // Used for partial update, when publish, partial update may add a new rowset and we should update rowset meta
     void merge_rowset_meta(const RowsetMeta& other);
 
-    InvertedIndexFileInfo inverted_index_file_info(int seg_id);
+    InvertedIndexFileInfo inverted_index_file_info_by_pos(size_t pos) const;
 
     const auto& inverted_index_file_info() const {
         return _rowset_meta_pb.inverted_index_file_info();
@@ -527,6 +559,8 @@ private:
 
     void _init();
 
+    void _validate_segment_ids() const;
+
     friend bool operator==(const RowsetMeta& a, const RowsetMeta& b);
 
     friend bool operator!=(const RowsetMeta& a, const RowsetMeta& b) { return !(a == b); }
@@ -541,6 +575,90 @@ private:
     DorisCallOnce<Result<EncryptionAlgorithmPB>> _determine_encryption_once;
     std::atomic<int64_t> _stale_at_s {0};
 };
+
+class RowsetSegmentMetaView {
+public:
+    RowsetSegmentMetaView(const RowsetMeta* meta, size_t pos)
+            : _meta(meta), _ref(meta->segment_ref(pos)) {}
+
+    size_t pos() const { return _ref.pos; }
+    int64_t id() const { return _ref.id; }
+    RowsetSegmentRef ref() const { return _ref; }
+
+    int64_t file_size() const { return _meta->segment_file_size_by_pos(pos()); }
+
+    InvertedIndexFileInfo inverted_index_file_info() const {
+        return _meta->inverted_index_file_info_by_pos(pos());
+    }
+
+    bool has_num_rows() const {
+        return cast_set<size_t>(_meta->get_num_segment_rows().size()) > pos();
+    }
+
+    int64_t num_rows() const {
+        DORIS_CHECK(has_num_rows());
+        return _meta->get_num_segment_rows().Get(cast_set<int>(pos()));
+    }
+
+    bool has_position_key_bounds() const {
+        return !_meta->is_segments_key_bounds_aggregated() &&
+               cast_set<size_t>(_meta->get_segments_key_bounds().size()) > pos();
+    }
+
+    const KeyBoundsPB& key_bounds() const {
+        DORIS_CHECK(has_position_key_bounds());
+        return _meta->get_segments_key_bounds().Get(cast_set<int>(pos()));
+    }
+
+private:
+    const RowsetMeta* _meta;
+    RowsetSegmentRef _ref;
+};
+
+class RowsetSegmentMetaRange {
+public:
+    class Iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = RowsetSegmentMetaView;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator(const RowsetMeta* meta, size_t pos) : _meta(meta), _pos(pos) {}
+
+        RowsetSegmentMetaView operator*() const { return {_meta, _pos}; }
+
+        Iterator& operator++() {
+            ++_pos;
+            return *this;
+        }
+
+        bool operator==(const Iterator& other) const {
+            return _meta == other._meta && _pos == other._pos;
+        }
+
+        bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+    private:
+        const RowsetMeta* _meta;
+        size_t _pos;
+    };
+
+    explicit RowsetSegmentMetaRange(const RowsetMeta* meta) : _meta(meta) {}
+
+    Iterator begin() const { return {_meta, 0}; }
+    Iterator end() const { return {_meta, cast_set<size_t>(_meta->num_segments())}; }
+
+private:
+    const RowsetMeta* _meta;
+};
+
+inline RowsetSegmentMetaView RowsetMeta::segment(size_t pos) const {
+    return {this, pos};
+}
+
+inline RowsetSegmentMetaRange RowsetMeta::segments() const {
+    return RowsetSegmentMetaRange(this);
+}
 
 using RowsetMetaMapContainer = std::unordered_map<Version, RowsetMetaSharedPtr, HashOfVersion>;
 

--- a/be/src/storage/rowset/rowset_segment_id.h
+++ b/be/src/storage/rowset/rowset_segment_id.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace doris {
+
+struct RowsetSegmentRef {
+    // Position in rowset-level repeated metadata arrays.
+    size_t pos;
+    // Real segment id used in file names, cache keys, delete bitmap keys, and RowLocation.
+    int64_t id;
+};
+
+template <typename RowsetMetaPB>
+int64_t rowset_segment_id(const RowsetMetaPB& rowset_meta, int64_t pos) {
+    DCHECK_GE(pos, 0);
+    DCHECK_LT(pos, rowset_meta.num_segments());
+    if (rowset_meta.segment_ids_size() == 0) {
+        return pos;
+    }
+    DCHECK_EQ(rowset_meta.segment_ids_size(), rowset_meta.num_segments());
+    return rowset_meta.segment_ids(static_cast<int>(pos));
+}
+
+template <typename RowsetMetaPB>
+std::vector<int64_t> rowset_segment_ids(const RowsetMetaPB& rowset_meta) {
+    DCHECK_GE(rowset_meta.num_segments(), 0);
+    std::vector<int64_t> segment_ids;
+    segment_ids.reserve(static_cast<size_t>(rowset_meta.num_segments()));
+    for (int64_t pos = 0; pos < rowset_meta.num_segments(); ++pos) {
+        segment_ids.push_back(rowset_segment_id(rowset_meta, pos));
+    }
+    return segment_ids;
+}
+
+} // namespace doris

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -22,6 +22,7 @@
 #include <gen_cpp/types.pb.h>
 
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 
@@ -69,6 +70,8 @@ using SegmentStatisticsSharedPtr = std::shared_ptr<SegmentStatistics>;
 
 class RowsetWriter {
 public:
+    static constexpr int32_t MAX_SEGMENT_NUM = std::numeric_limits<int32_t>::max();
+
     RowsetWriter() = default;
     virtual ~RowsetWriter() = default;
 
@@ -175,14 +178,16 @@ public:
         return Status::NotSupported("to be implemented");
     }
 
-    virtual int32_t allocate_segment_id() = 0;
+    virtual Result<int32_t> allocate_segment_id() = 0;
 
     // Return the next segment id to be allocated without advancing internal state.
     // NOTE: This value equals the one that would be returned by the next
     // `allocate_segment_id()` call.
     virtual int32_t get_allocated_segment_id() = 0;
 
-    virtual void set_segment_start_id(int num_segment) {
+    // Set the first physical segment id and the maximum number of ids this writer may allocate.
+    // The default maximum preserves the original unbounded allocation behavior.
+    virtual void set_segment_start_id(int32_t start_seg_id, int32_t max_seg_num = MAX_SEGMENT_NUM) {
         throw Exception(Status::FatalError("not supported!"));
     }
 

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -139,6 +139,10 @@ struct RowsetWriterContext {
     // This describes whether we *want* to try small-file merging.
     bool allow_packed_file = true;
 
+    // Physical id of the first segment in this rowset. It can be nonzero for writers that
+    // allocate segment ids from a configured range.
+    int64_t first_segment_id = 0;
+
     // Effective flag: whether this context actually ends up using MergeFileSystem for writes.
     // This is decided inside fs() based on enable_merge_file plus other conditions
     // (cloud mode, S3 filesystem, V1 inverted index, global config, etc.), and once
@@ -149,6 +153,12 @@ struct RowsetWriterContext {
     // This prevents creating multiple MergeFileSystem instances and ensures
     // packed_file_active flag remains consistent.
     mutable io::FileSystemSPtr _cached_fs = nullptr;
+
+    void set_first_segment_id(int64_t segment_id) {
+        DORIS_CHECK_GE(segment_id, 0);
+        DORIS_CHECK(_cached_fs == nullptr);
+        first_segment_id = segment_id;
+    }
 
     // For collect segment statistics for compaction
     std::vector<RowsetReaderSharedPtr> input_rs_readers;
@@ -235,6 +245,7 @@ struct RowsetWriterContext {
             io::PackedAppendContext append_info;
             append_info.tablet_id = tablet_id;
             append_info.rowset_id = rowset_id.to_string();
+            append_info.first_segment_id = first_segment_id;
             append_info.txn_id = txn_id;
             append_info.expiration_time = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
                                                   ? newest_write_timestamp + file_cache_ttl_sec

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -132,6 +132,10 @@ struct RowsetWriterContext {
     // This describes whether we *want* to try small-file merging.
     bool allow_packed_file = true;
 
+    // Physical id of the first segment in this rowset. It can be nonzero for writers that
+    // allocate segment ids from a configured range.
+    int64_t first_segment_id = 0;
+
     // Effective flag: whether this context actually ends up using MergeFileSystem for writes.
     // This is decided inside fs() based on enable_merge_file plus other conditions
     // (cloud mode, S3 filesystem, V1 inverted index, global config, etc.), and once
@@ -142,6 +146,12 @@ struct RowsetWriterContext {
     // This prevents creating multiple MergeFileSystem instances and ensures
     // packed_file_active flag remains consistent.
     mutable io::FileSystemSPtr _cached_fs = nullptr;
+
+    void set_first_segment_id(int64_t segment_id) {
+        DORIS_CHECK_GE(segment_id, 0);
+        DORIS_CHECK(_cached_fs == nullptr);
+        first_segment_id = segment_id;
+    }
 
     // For collect segment statistics for compaction
     std::vector<RowsetReaderSharedPtr> input_rs_readers;
@@ -228,6 +238,7 @@ struct RowsetWriterContext {
             io::PackedAppendContext append_info;
             append_info.tablet_id = tablet_id;
             append_info.rowset_id = rowset_id.to_string();
+            append_info.first_segment_id = first_segment_id;
             append_info.txn_id = txn_id;
             append_info.expiration_time = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
                                                   ? newest_write_timestamp + file_cache_ttl_sec

--- a/be/src/storage/rowset/segment_creator.cpp
+++ b/be/src/storage/rowset/segment_creator.cpp
@@ -442,7 +442,8 @@ Status SegmentCreator::add_block(const Block* block) {
     };
 
     if (_flush_writer == nullptr) {
-        RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, allocate_segment_id()));
+        auto segment_id = DORIS_TRY(allocate_segment_id());
+        RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, segment_id));
     }
 
     do {
@@ -450,7 +451,8 @@ Status SegmentCreator::add_block(const Block* block) {
         if (UNLIKELY(max_row_add < 1)) {
             // no space for another single row, need flush now
             RETURN_IF_ERROR(flush());
-            RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, allocate_segment_id()));
+            auto segment_id = DORIS_TRY(allocate_segment_id());
+            RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, segment_id));
             max_row_add = _flush_writer->max_row_to_add(row_avg_size_in_bytes);
             DCHECK(max_row_add > 0);
         }

--- a/be/src/storage/rowset/segment_creator.cpp
+++ b/be/src/storage/rowset/segment_creator.cpp
@@ -408,7 +408,8 @@ Status SegmentCreator::add_block(const Block* block) {
     size_t row_offset = 0;
 
     if (_flush_writer == nullptr) {
-        RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, allocate_segment_id()));
+        auto segment_id = DORIS_TRY(allocate_segment_id());
+        RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, segment_id));
     }
 
     do {
@@ -416,7 +417,8 @@ Status SegmentCreator::add_block(const Block* block) {
         if (UNLIKELY(max_row_add < 1)) {
             // no space for another single row, need flush now
             RETURN_IF_ERROR(flush());
-            RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, allocate_segment_id()));
+            auto segment_id = DORIS_TRY(allocate_segment_id());
+            RETURN_IF_ERROR(_segment_flusher.create_writer(_flush_writer, segment_id));
             max_row_add = _flush_writer->max_row_to_add(row_avg_size_in_bytes);
             DCHECK(max_row_add > 0);
         }

--- a/be/src/storage/rowset/segment_creator.h
+++ b/be/src/storage/rowset/segment_creator.h
@@ -20,6 +20,7 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/olap_file.pb.h>
 
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <utility>
@@ -192,13 +193,44 @@ public:
 
     ~SegmentCreator() = default;
 
-    void set_segment_start_id(uint32_t start_id) { _next_segment_id = start_id; }
+    void set_segment_start_id(int32_t start_seg_id,
+                              int32_t max_seg_num = std::numeric_limits<int32_t>::max()) {
+        DORIS_CHECK_GE(start_seg_id, 0);
+        DORIS_CHECK_GE(max_seg_num, 0);
+        DORIS_CHECK_EQ(_next_segment_id.load(std::memory_order_relaxed), _segment_start_id);
+        if (max_seg_num != std::numeric_limits<int32_t>::max()) {
+            DORIS_CHECK_LE(static_cast<int64_t>(start_seg_id) + max_seg_num,
+                           std::numeric_limits<int32_t>::max());
+        }
+        _segment_start_id = start_seg_id;
+        _max_segment_num = max_seg_num;
+        _next_segment_id.store(start_seg_id, std::memory_order_relaxed);
+    }
 
     Status add_block(const Block* block);
 
     Status flush();
 
-    int32_t allocate_segment_id() { return _next_segment_id.fetch_add(1); }
+    Result<int32_t> allocate_segment_id() {
+        if (_max_segment_num == std::numeric_limits<int32_t>::max()) {
+            return _next_segment_id.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        int32_t next_seg_id = _next_segment_id.load(std::memory_order_relaxed);
+        while (true) {
+            const int64_t allocated_segment_num =
+                    static_cast<int64_t>(next_seg_id) - _segment_start_id;
+            if (allocated_segment_num >= _max_segment_num) {
+                return ResultError(Status::Error<ErrorCode::TOO_MANY_SEGMENTS>(
+                        "too many segments, start_seg_id:{}, max_seg_num:{}", _segment_start_id,
+                        _max_segment_num));
+            }
+            if (_next_segment_id.compare_exchange_weak(next_seg_id, next_seg_id + 1,
+                                                       std::memory_order_relaxed)) {
+                return next_seg_id;
+            }
+        }
+    }
 
     // Return the next segment id to be allocated without advancing internal state.
     int32_t get_allocated_segment_id() const { return _next_segment_id.load(); }
@@ -222,13 +254,16 @@ public:
     // Flush a block into a single segment, without pre-allocated segment_id.
     // This method is thread-safe.
     Status flush_single_block(const Block* block) {
-        return flush_single_block(block, allocate_segment_id());
+        auto segment_id = DORIS_TRY(allocate_segment_id());
+        return flush_single_block(block, segment_id);
     }
 
     Status close();
 
 private:
     std::atomic<int32_t> _next_segment_id = 0;
+    int32_t _segment_start_id = 0;
+    int32_t _max_segment_num = std::numeric_limits<int32_t>::max();
     SegmentFlusher _segment_flusher;
     std::unique_ptr<SegmentFlusher::Writer> _flush_writer;
 };

--- a/be/src/storage/rowset/segment_creator.h
+++ b/be/src/storage/rowset/segment_creator.h
@@ -20,6 +20,7 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/olap_file.pb.h>
 
+#include <limits>
 #include <mutex>
 #include <vector>
 
@@ -179,13 +180,44 @@ public:
 
     ~SegmentCreator() = default;
 
-    void set_segment_start_id(uint32_t start_id) { _next_segment_id = start_id; }
+    void set_segment_start_id(int32_t start_seg_id,
+                              int32_t max_seg_num = std::numeric_limits<int32_t>::max()) {
+        DORIS_CHECK_GE(start_seg_id, 0);
+        DORIS_CHECK_GE(max_seg_num, 0);
+        DORIS_CHECK_EQ(_next_segment_id.load(std::memory_order_relaxed), _segment_start_id);
+        if (max_seg_num != std::numeric_limits<int32_t>::max()) {
+            DORIS_CHECK_LE(static_cast<int64_t>(start_seg_id) + max_seg_num,
+                           std::numeric_limits<int32_t>::max());
+        }
+        _segment_start_id = start_seg_id;
+        _max_segment_num = max_seg_num;
+        _next_segment_id.store(start_seg_id, std::memory_order_relaxed);
+    }
 
     Status add_block(const Block* block);
 
     Status flush();
 
-    int32_t allocate_segment_id() { return _next_segment_id.fetch_add(1); }
+    Result<int32_t> allocate_segment_id() {
+        if (_max_segment_num == std::numeric_limits<int32_t>::max()) {
+            return _next_segment_id.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        int32_t next_seg_id = _next_segment_id.load(std::memory_order_relaxed);
+        while (true) {
+            const int64_t allocated_segment_num =
+                    static_cast<int64_t>(next_seg_id) - _segment_start_id;
+            if (allocated_segment_num >= _max_segment_num) {
+                return ResultError(Status::Error<ErrorCode::TOO_MANY_SEGMENTS>(
+                        "too many segments, start_seg_id:{}, max_seg_num:{}", _segment_start_id,
+                        _max_segment_num));
+            }
+            if (_next_segment_id.compare_exchange_weak(next_seg_id, next_seg_id + 1,
+                                                       std::memory_order_relaxed)) {
+                return next_seg_id;
+            }
+        }
+    }
 
     // Return the next segment id to be allocated without advancing internal state.
     int32_t get_allocated_segment_id() const { return _next_segment_id.load(); }
@@ -209,13 +241,16 @@ public:
     // Flush a block into a single segment, without pre-allocated segment_id.
     // This method is thread-safe.
     Status flush_single_block(const Block* block) {
-        return flush_single_block(block, allocate_segment_id());
+        auto segment_id = DORIS_TRY(allocate_segment_id());
+        return flush_single_block(block, segment_id);
     }
 
     Status close();
 
 private:
     std::atomic<int32_t> _next_segment_id = 0;
+    int32_t _segment_start_id = 0;
+    int32_t _max_segment_num = std::numeric_limits<int32_t>::max();
     SegmentFlusher _segment_flusher;
     std::unique_ptr<SegmentFlusher::Writer> _flush_writer;
 };

--- a/be/src/storage/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/vertical_beta_rowset_writer.cpp
@@ -159,14 +159,15 @@ Status VerticalBetaRowsetWriter<T>::flush_columns(bool is_key) {
     return Status::OK();
 }
 
-template <class T>
-    requires std::is_base_of_v<BaseBetaRowsetWriter, T>
-Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
+template <class WriterType>
+    requires std::is_base_of_v<BaseBetaRowsetWriter, WriterType>
+Status VerticalBetaRowsetWriter<WriterType>::_create_segment_writer(
         const std::vector<uint32_t>& column_ids, bool is_key,
         std::unique_ptr<segment_v2::SegmentWriter>* writer) {
     auto& context = this->_context;
 
-    int seg_id = this->_num_segment.fetch_add(1, std::memory_order_relaxed);
+    const int32_t seg_id = DORIS_TRY(WriterType::allocate_segment_id());
+    this->_num_segment.fetch_add(1, std::memory_order_relaxed);
 
     io::FileWriterPtr segment_file_writer;
     RETURN_IF_ERROR(BaseBetaRowsetWriter::create_file_writer(seg_id, segment_file_writer));
@@ -199,6 +200,24 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
         return s;
     }
     return Status::OK();
+}
+
+template <class T>
+    requires std::is_base_of_v<BaseBetaRowsetWriter, T>
+Status VerticalBetaRowsetWriter<T>::build(RowsetSharedPtr& rowset) {
+    const int32_t next_segment_id = T::get_allocated_segment_id();
+    const int32_t segment_num = this->_num_segment.load(std::memory_order_relaxed);
+    DORIS_CHECK_EQ(next_segment_id - this->_segment_start_id, segment_num);
+    if (this->_segment_start_id != 0) {
+        std::vector<int64_t> segment_ids;
+        segment_ids.reserve(segment_num);
+        for (int32_t segment_id = this->_segment_start_id; segment_id < next_segment_id;
+             ++segment_id) {
+            segment_ids.push_back(segment_id);
+        }
+        this->_rowset_meta->set_segment_ids(segment_ids);
+    }
+    return T::build(rowset);
 }
 
 template <class T>

--- a/be/src/storage/rowset/vertical_beta_rowset_writer.h
+++ b/be/src/storage/rowset/vertical_beta_rowset_writer.h
@@ -49,6 +49,8 @@ public:
     // flush when all column finished, flush column footer
     Status final_flush() override;
 
+    Status build(RowsetSharedPtr& rowset) override;
+
     int64_t num_rows() const override { return _total_key_group_rows; }
 
     Status _close_file_writers() override;

--- a/be/src/storage/segment/lazy_init_segment_iterator.cpp
+++ b/be/src/storage/segment/lazy_init_segment_iterator.cpp
@@ -21,11 +21,11 @@
 
 namespace doris::segment_v2 {
 
-LazyInitSegmentIterator::LazyInitSegmentIterator(BetaRowsetSharedPtr rowset, int64_t segment_id,
-                                                 bool should_use_cache, SchemaSPtr schema,
-                                                 const StorageReadOptions& opts)
+LazyInitSegmentIterator::LazyInitSegmentIterator(BetaRowsetSharedPtr rowset,
+                                                 RowsetSegmentRef segment, bool should_use_cache,
+                                                 SchemaSPtr schema, const StorageReadOptions& opts)
         : _rowset(std::move(rowset)),
-          _segment_id(segment_id),
+          _segment(segment),
           _should_use_cache(should_use_cache),
           _schema(std::move(schema)),
           _read_options(opts) {}
@@ -41,7 +41,7 @@ Status LazyInitSegmentIterator::init(const StorageReadOptions& opts) {
     {
         SegmentCacheHandle segment_cache_handle;
         RETURN_IF_ERROR(SegmentLoader::instance()->load_segment(
-                _rowset, _segment_id, &segment_cache_handle, _should_use_cache, false, opts.stats,
+                _rowset, _segment, &segment_cache_handle, _should_use_cache, false, opts.stats,
                 &opts.io_ctx));
         const auto& tmp_segments = segment_cache_handle.get_segments();
         segment = tmp_segments[0];

--- a/be/src/storage/segment/lazy_init_segment_iterator.cpp
+++ b/be/src/storage/segment/lazy_init_segment_iterator.cpp
@@ -21,11 +21,12 @@
 
 namespace doris::segment_v2 {
 
-LazyInitSegmentIterator::LazyInitSegmentIterator(BetaRowsetSharedPtr rowset, int64_t segment_id,
-                                                 bool should_use_cache, ReadSchemaSPtr schema,
+LazyInitSegmentIterator::LazyInitSegmentIterator(BetaRowsetSharedPtr rowset,
+                                                 RowsetSegmentRef segment, bool should_use_cache,
+                                                 ReadSchemaSPtr schema,
                                                  const StorageReadOptions& opts)
         : _rowset(std::move(rowset)),
-          _segment_id(segment_id),
+          _segment(segment),
           _should_use_cache(should_use_cache),
           _schema(std::move(schema)),
           _read_options(opts) {}
@@ -41,7 +42,7 @@ Status LazyInitSegmentIterator::init(const StorageReadOptions& opts) {
     {
         SegmentCacheHandle segment_cache_handle;
         RETURN_IF_ERROR(SegmentLoader::instance()->load_segment(
-                _rowset, _segment_id, &segment_cache_handle, _should_use_cache, false, opts.stats,
+                _rowset, _segment, &segment_cache_handle, _should_use_cache, false, opts.stats,
                 &opts.io_ctx));
         const auto& tmp_segments = segment_cache_handle.get_segments();
         segment = tmp_segments[0];

--- a/be/src/storage/segment/lazy_init_segment_iterator.h
+++ b/be/src/storage/segment/lazy_init_segment_iterator.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "core/block/block.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/segment/common.h"
 #include "storage/segment/segment.h"
 #include "storage/segment/segment_iterator.h"
@@ -30,8 +31,9 @@ namespace doris::segment_v2 {
 
 class LazyInitSegmentIterator : public RowwiseIterator {
 public:
-    LazyInitSegmentIterator(BetaRowsetSharedPtr rowset, int64_t segment_id, bool should_use_cache,
-                            ReadSchemaSPtr schema, const StorageReadOptions& opts);
+    LazyInitSegmentIterator(BetaRowsetSharedPtr rowset, RowsetSegmentRef segment,
+                            bool should_use_cache, ReadSchemaSPtr schema,
+                            const StorageReadOptions& opts);
 
     ~LazyInitSegmentIterator() override = default;
 
@@ -61,7 +63,7 @@ public:
 private:
     bool _need_lazy_init {true};
     BetaRowsetSharedPtr _rowset;
-    int64_t _segment_id {-1};
+    RowsetSegmentRef _segment {0, -1};
     bool _should_use_cache {false};
     ReadSchemaSPtr _schema = nullptr;
     StorageReadOptions _read_options;

--- a/be/src/storage/segment/lazy_init_segment_iterator.h
+++ b/be/src/storage/segment/lazy_init_segment_iterator.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "core/block/block.h"
+#include "storage/rowset/rowset_segment_id.h"
 #include "storage/segment/common.h"
 #include "storage/segment/segment.h"
 #include "storage/segment/segment_iterator.h"
@@ -30,8 +31,9 @@ namespace doris::segment_v2 {
 
 class LazyInitSegmentIterator : public RowwiseIterator {
 public:
-    LazyInitSegmentIterator(BetaRowsetSharedPtr rowset, int64_t segment_id, bool should_use_cache,
-                            SchemaSPtr schema, const StorageReadOptions& opts);
+    LazyInitSegmentIterator(BetaRowsetSharedPtr rowset, RowsetSegmentRef segment,
+                            bool should_use_cache, SchemaSPtr schema,
+                            const StorageReadOptions& opts);
 
     ~LazyInitSegmentIterator() override = default;
 
@@ -61,7 +63,7 @@ public:
 private:
     bool _need_lazy_init {true};
     BetaRowsetSharedPtr _rowset;
-    int64_t _segment_id {-1};
+    RowsetSegmentRef _segment {0, -1};
     bool _should_use_cache {false};
     SchemaSPtr _schema = nullptr;
     StorageReadOptions _read_options;

--- a/be/src/storage/segment/segment_loader.cpp
+++ b/be/src/storage/segment/segment_loader.cpp
@@ -23,6 +23,7 @@
 #include "common/status.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/beta_rowset.h"
+#include "storage/rowset/rowset_meta.h"
 #include "util/stopwatch.hpp"
 
 namespace doris {
@@ -52,13 +53,13 @@ void SegmentCache::erase(const SegmentCache::CacheKey& key) {
     LRUCachePolicy::erase(key.encode());
 }
 
-Status SegmentLoader::load_segment(const BetaRowsetSharedPtr& rowset, int64_t segment_id,
+Status SegmentLoader::load_segment(const BetaRowsetSharedPtr& rowset, RowsetSegmentRef seg,
                                    SegmentCacheHandle* cache_handle, bool use_cache,
                                    bool need_load_pk_index_and_bf,
                                    OlapReaderStatistics* index_load_stats,
                                    const io::IOContext* io_ctx) {
     auto start = MonotonicMicros();
-    SegmentCache::CacheKey cache_key(rowset->rowset_id(), segment_id);
+    SegmentCache::CacheKey cache_key(rowset->rowset_id(), seg.id);
     if (_segment_cache->lookup(cache_key, cache_handle)) {
         // Has to check the segment status here, because the segment in cache may has something wrong during
         // load index or create column reader.
@@ -73,7 +74,7 @@ Status SegmentLoader::load_segment(const BetaRowsetSharedPtr& rowset, int64_t se
     }
     // If the segment is not healthy, then will create a new segment and will replace the unhealthy one in SegmentCache.
     segment_v2::SegmentSharedPtr segment;
-    RETURN_IF_ERROR(rowset->load_segment(segment_id, index_load_stats, &segment, io_ctx));
+    RETURN_IF_ERROR(rowset->load_segment(seg, index_load_stats, &segment, io_ctx));
     if (need_load_pk_index_and_bf) {
         RETURN_IF_ERROR(segment->load_pk_index_and_bf(index_load_stats, io_ctx));
     }
@@ -101,9 +102,9 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     if (cache_handle->is_inited()) {
         return Status::OK();
     }
-    for (int64_t i = 0; i < rowset->num_segments(); i++) {
-        RETURN_IF_ERROR(load_segment(rowset, i, cache_handle, use_cache, need_load_pk_index_and_bf,
-                                     index_load_stats, io_ctx));
+    for (auto seg : rowset->segments()) {
+        RETURN_IF_ERROR(load_segment(rowset, seg.ref(), cache_handle, use_cache,
+                                     need_load_pk_index_and_bf, index_load_stats, io_ctx));
     }
     cache_handle->set_inited();
     return Status::OK();
@@ -113,9 +114,9 @@ void SegmentLoader::erase_segment(const SegmentCache::CacheKey& key) {
     _segment_cache->erase(key);
 }
 
-void SegmentLoader::erase_segments(const RowsetId& rowset_id, int64_t num_segments) {
-    for (int64_t i = 0; i < num_segments; i++) {
-        erase_segment(SegmentCache::CacheKey(rowset_id, i));
+void SegmentLoader::erase_segments(const RowsetMeta& rowset_meta) {
+    for (auto seg : rowset_meta.segments()) {
+        erase_segment(SegmentCache::CacheKey(rowset_meta.rowset_id(), seg.id()));
     }
 }
 

--- a/be/src/storage/segment/segment_loader.h
+++ b/be/src/storage/segment/segment_loader.h
@@ -41,6 +41,8 @@ namespace doris {
 
 class SegmentCacheHandle;
 class BetaRowset;
+class RowsetMeta;
+struct RowsetSegmentRef;
 
 // SegmentLoader is used to load the Segment of BetaRowset.
 // An LRUCache is encapsulated inside it, which is used to cache the opened segments.
@@ -126,7 +128,7 @@ public:
 
     // Load one segment of "rowset", return the "cache_handle" which contains segments.
     // If use_cache is true, it will be loaded from _cache.
-    Status load_segment(const BetaRowsetSharedPtr& rowset, int64_t segment_id,
+    Status load_segment(const BetaRowsetSharedPtr& rowset, RowsetSegmentRef seg,
                         SegmentCacheHandle* cache_handle, bool use_cache = false,
                         bool need_load_pk_index_and_bf = false,
                         OlapReaderStatistics* index_load_stats = nullptr,
@@ -134,7 +136,7 @@ public:
 
     void erase_segment(const SegmentCache::CacheKey& key);
 
-    void erase_segments(const RowsetId& rowset_id, int64_t num_segments);
+    void erase_segments(const RowsetMeta& rowset_meta);
 
     int64_t cache_mem_usage() const {
 #ifdef BE_TEST

--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -915,6 +915,8 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                 }
             }};
 
+            // Binlog is local-mode only. These files use contiguous segment indexes because
+            // segment-list rowsets are cloud-only.
             // link segment files and index files
             for (int64_t segment_index = 0; segment_index < num_segments; ++segment_index) {
                 segment_file_path = ref_tablet->get_segment_filepath(rowset_id, segment_index);

--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -778,6 +778,8 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                 }
             }};
 
+            // Binlog is local-mode only. These files use contiguous segment indexes because
+            // segment-list rowsets are cloud-only.
             // link segment files and index files
             for (int64_t segment_index = 0; segment_index < num_segments; ++segment_index) {
                 segment_file_path = ref_tablet->get_segment_filepath(rowset_id, segment_index);

--- a/be/src/storage/tablet/base_tablet.cpp
+++ b/be/src/storage/tablet/base_tablet.cpp
@@ -873,7 +873,7 @@ Status BaseTablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
 
         std::vector<uint32_t> sort_perm;
         RETURN_IF_ERROR(sort_block(block, ordered_block, &sort_perm));
-        auto segment_id = rowset_writer->allocate_segment_id();
+        auto segment_id = DORIS_TRY(rowset_writer->allocate_segment_id());
 
         // Publish-phase partial update may flush transient segments to a GroupRowsetWriter.
         // For row-binlog writing, the derive stage requires `seg_id -> lsn_ids` to be
@@ -1751,14 +1751,13 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
                << " flush binlog<row> (old segment num: " << old_segments
                << ", new segment num: " << new_segments << ")";
 
-            SegmentLoader::instance()->erase_segments(row_binlog_rowset->rowset_id(),
-                                                      row_binlog_rowset->num_segments());
+            SegmentLoader::instance()->erase_segments(*row_binlog_rowset->rowset_meta());
         }
 
         // update the shared_ptr to new bitmap, which is consistent with current rowset.
         txn_info->delete_bitmap = delete_bitmap;
         // erase segment cache cause we will add a segment to rowset
-        SegmentLoader::instance()->erase_segments(rowset->rowset_id(), rowset->num_segments());
+        SegmentLoader::instance()->erase_segments(*rowset->rowset_meta());
     }
 
     size_t total_rows = std::accumulate(
@@ -1784,15 +1783,18 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
 }
 
 void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
-        const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
-        uint64_t start_version, uint64_t end_version, std::set<RowLocation>* missed_rows,
+        const std::vector<RowsetSharedPtr>& input_rowsets, const RowsetSharedPtr& output_rowset,
+        const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
+        std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
         const DeleteBitmap& input_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap) {
+    DORIS_CHECK_EQ(output_rowset->rowset_id(), rowid_conversion.get_dst_rowset_id());
     RowLocation src;
-    RowLocation dst;
+    RowIdConversion::DestinationRowId converted_dst;
     for (auto& rowset : input_rowsets) {
         src.rowset_id = rowset->rowset_id();
-        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+        for (auto seg : rowset->segments()) {
+            auto seg_id = cast_set<uint32_t>(seg.id());
             src.segment_id = seg_id;
             DeleteBitmap subset_map(tablet_id());
             input_delete_bitmap.subset({rowset->rowset_id(), seg_id, start_version},
@@ -1803,7 +1805,7 @@ void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
                 auto cur_version = std::get<2>(iter->first);
                 for (auto index = iter->second.begin(); index != iter->second.end(); ++index) {
                     src.row_id = *index;
-                    if (rowid_conversion.get(src, &dst) != 0) {
+                    if (rowid_conversion.get(src, &converted_dst) != 0) {
                         VLOG_CRITICAL << "Can't find rowid, may be deleted by the delete_handler, "
                                       << " src loaction: |" << src.rowset_id << "|"
                                       << src.segment_id << "|" << src.row_id
@@ -1813,6 +1815,8 @@ void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
                         }
                         continue;
                     }
+                    RowLocation dst = output_rowset->segment(converted_dst.segment_pos)
+                                              .row_location(converted_dst.row_id);
                     VLOG_DEBUG << "calc_compaction_output_rowset_delete_bitmap dst location: |"
                                << dst.rowset_id << "|" << dst.segment_id << "|" << dst.row_id
                                << " src location: |" << src.rowset_id << "|" << src.segment_id
@@ -1854,7 +1858,8 @@ Status BaseTablet::check_rowid_conversion(
         for (auto& [src, dst] : locations) {
             std::string src_key;
             std::string dst_key;
-            Status s = segments[src.segment_id]->read_key_by_rowid(src.row_id, &src_key);
+            const size_t src_segment_pos = src_rowset->rowset_meta()->position_of(src.segment_id);
+            Status s = segments[src_segment_pos]->read_key_by_rowid(src.row_id, &src_key);
             if (UNLIKELY(s.is<NOT_IMPLEMENTED_ERROR>())) {
                 LOG(INFO) << "primary key index of old version does not "
                              "support reading key by rowid";
@@ -1867,7 +1872,8 @@ Status BaseTablet::check_rowid_conversion(
                 return s;
             }
 
-            s = dst_segments[dst.segment_id]->read_key_by_rowid(dst.row_id, &dst_key);
+            const size_t dst_segment_pos = dst_rowset->rowset_meta()->position_of(dst.segment_id);
+            s = dst_segments[dst_segment_pos]->read_key_by_rowid(dst.row_id, &dst_key);
             if (UNLIKELY(!s)) {
                 LOG(WARNING) << "failed to get dst key: |" << dst.rowset_id << "|" << dst.segment_id
                              << "|" << dst.row_id << " status: " << s;
@@ -1992,7 +1998,8 @@ void BaseTablet::agg_delete_bitmap_for_stale_rowsets(
     // do agg for pre rowsets
     DeleteBitmapPtr new_delete_bitmap = std::make_shared<DeleteBitmap>(tablet_id());
     for (auto& rowset : pre_rowsets) {
-        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+        for (auto seg : rowset->segments()) {
+            auto seg_id = cast_set<uint32_t>(seg.id());
             auto d = tablet_meta()->delete_bitmap().get_agg_without_cache(
                     {rowset->rowset_id(), seg_id, end_version}, start_version);
             if (d->isEmpty()) {
@@ -2305,8 +2312,9 @@ int32_t BaseTablet::max_version_config() {
 }
 
 void BaseTablet::prefill_dbm_agg_cache(const RowsetSharedPtr& rowset, int64_t version) {
-    for (std::size_t i = 0; i < rowset->num_segments(); i++) {
-        tablet_meta()->delete_bitmap().get_agg({rowset->rowset_id(), i, version});
+    for (auto seg : rowset->segments()) {
+        tablet_meta()->delete_bitmap().get_agg(
+                {rowset->rowset_id(), cast_set<uint32_t>(seg.id()), version});
     }
 }
 

--- a/be/src/storage/tablet/base_tablet.cpp
+++ b/be/src/storage/tablet/base_tablet.cpp
@@ -886,7 +886,7 @@ Status BaseTablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
 
         std::vector<uint32_t> sort_perm;
         RETURN_IF_ERROR(sort_block(block, ordered_block, &sort_perm));
-        auto segment_id = rowset_writer->allocate_segment_id();
+        auto segment_id = DORIS_TRY(rowset_writer->allocate_segment_id());
 
         // Publish-phase partial update may flush transient segments to a GroupRowsetWriter.
         // For row-binlog writing, RowBinlogSegmentWriter requires `seg_id -> lsn_ids` to be
@@ -1761,14 +1761,13 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
                << " flush binlog<row> (old segment num: " << old_segments
                << ", new segment num: " << new_segments << ")";
 
-            SegmentLoader::instance()->erase_segments(row_binlog_rowset->rowset_id(),
-                                                      row_binlog_rowset->num_segments());
+            SegmentLoader::instance()->erase_segments(*row_binlog_rowset->rowset_meta());
         }
 
         // update the shared_ptr to new bitmap, which is consistent with current rowset.
         txn_info->delete_bitmap = delete_bitmap;
         // erase segment cache cause we will add a segment to rowset
-        SegmentLoader::instance()->erase_segments(rowset->rowset_id(), rowset->num_segments());
+        SegmentLoader::instance()->erase_segments(*rowset->rowset_meta());
     }
 
     size_t total_rows = std::accumulate(
@@ -1794,15 +1793,18 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
 }
 
 void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
-        const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
-        uint64_t start_version, uint64_t end_version, std::set<RowLocation>* missed_rows,
+        const std::vector<RowsetSharedPtr>& input_rowsets, const RowsetSharedPtr& output_rowset,
+        const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
+        std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
         const DeleteBitmap& input_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap) {
+    DORIS_CHECK_EQ(output_rowset->rowset_id(), rowid_conversion.get_dst_rowset_id());
     RowLocation src;
-    RowLocation dst;
+    RowIdConversion::DestinationRowId converted_dst;
     for (auto& rowset : input_rowsets) {
         src.rowset_id = rowset->rowset_id();
-        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+        for (auto seg : rowset->segments()) {
+            auto seg_id = cast_set<uint32_t>(seg.id());
             src.segment_id = seg_id;
             DeleteBitmap subset_map(tablet_id());
             input_delete_bitmap.subset({rowset->rowset_id(), seg_id, start_version},
@@ -1813,7 +1815,7 @@ void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
                 auto cur_version = std::get<2>(iter->first);
                 for (auto index = iter->second.begin(); index != iter->second.end(); ++index) {
                     src.row_id = *index;
-                    if (rowid_conversion.get(src, &dst) != 0) {
+                    if (rowid_conversion.get(src, &converted_dst) != 0) {
                         VLOG_CRITICAL << "Can't find rowid, may be deleted by the delete_handler, "
                                       << " src loaction: |" << src.rowset_id << "|"
                                       << src.segment_id << "|" << src.row_id
@@ -1823,6 +1825,8 @@ void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
                         }
                         continue;
                     }
+                    RowLocation dst = output_rowset->segment(converted_dst.segment_pos)
+                                              .row_location(converted_dst.row_id);
                     VLOG_DEBUG << "calc_compaction_output_rowset_delete_bitmap dst location: |"
                                << dst.rowset_id << "|" << dst.segment_id << "|" << dst.row_id
                                << " src location: |" << src.rowset_id << "|" << src.segment_id
@@ -1864,7 +1868,8 @@ Status BaseTablet::check_rowid_conversion(
         for (auto& [src, dst] : locations) {
             std::string src_key;
             std::string dst_key;
-            Status s = segments[src.segment_id]->read_key_by_rowid(src.row_id, &src_key);
+            const size_t src_segment_pos = src_rowset->rowset_meta()->position_of(src.segment_id);
+            Status s = segments[src_segment_pos]->read_key_by_rowid(src.row_id, &src_key);
             if (UNLIKELY(s.is<NOT_IMPLEMENTED_ERROR>())) {
                 LOG(INFO) << "primary key index of old version does not "
                              "support reading key by rowid";
@@ -1877,7 +1882,8 @@ Status BaseTablet::check_rowid_conversion(
                 return s;
             }
 
-            s = dst_segments[dst.segment_id]->read_key_by_rowid(dst.row_id, &dst_key);
+            const size_t dst_segment_pos = dst_rowset->rowset_meta()->position_of(dst.segment_id);
+            s = dst_segments[dst_segment_pos]->read_key_by_rowid(dst.row_id, &dst_key);
             if (UNLIKELY(!s)) {
                 LOG(WARNING) << "failed to get dst key: |" << dst.rowset_id << "|" << dst.segment_id
                              << "|" << dst.row_id << " status: " << s;
@@ -2002,7 +2008,8 @@ void BaseTablet::agg_delete_bitmap_for_stale_rowsets(
     // do agg for pre rowsets
     DeleteBitmapPtr new_delete_bitmap = std::make_shared<DeleteBitmap>(tablet_id());
     for (auto& rowset : pre_rowsets) {
-        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+        for (auto seg : rowset->segments()) {
+            auto seg_id = cast_set<uint32_t>(seg.id());
             auto d = tablet_meta()->delete_bitmap().get_agg_without_cache(
                     {rowset->rowset_id(), seg_id, end_version}, start_version);
             if (d->isEmpty()) {
@@ -2315,8 +2322,9 @@ int32_t BaseTablet::max_version_config() {
 }
 
 void BaseTablet::prefill_dbm_agg_cache(const RowsetSharedPtr& rowset, int64_t version) {
-    for (std::size_t i = 0; i < rowset->num_segments(); i++) {
-        tablet_meta()->delete_bitmap().get_agg({rowset->rowset_id(), i, version});
+    for (auto seg : rowset->segments()) {
+        tablet_meta()->delete_bitmap().get_agg(
+                {rowset->rowset_id(), cast_set<uint32_t>(seg.id()), version});
     }
 }
 

--- a/be/src/storage/tablet/base_tablet.h
+++ b/be/src/storage/tablet/base_tablet.h
@@ -269,7 +269,7 @@ public:
     virtual CalcDeleteBitmapExecutor* calc_delete_bitmap_executor() = 0;
 
     void calc_compaction_output_rowset_delete_bitmap(
-            const std::vector<RowsetSharedPtr>& input_rowsets,
+            const std::vector<RowsetSharedPtr>& input_rowsets, const RowsetSharedPtr& output_rowset,
             const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -2159,7 +2159,7 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     Status st;
     Defer defer {[&] {
         if (!st.ok()) {
-            // reclaim the incomplete rowset data in remote storage
+            // Local-mode only remote rowset GC; segment files are named by contiguous indexes.
             record_unused_remote_rowset(new_rowset_id, storage_resource.fs->id(),
                                         old_rowset->num_segments());
         }
@@ -2737,6 +2737,8 @@ Status Tablet::get_rowset_binlog_metas(Version binlog_versions, RowsetBinlogMeta
                                                       binlog_versions, metas_pb);
 }
 
+// Binlog is local-mode only. The segment index is the real binlog file id because segment-list
+// rowsets are cloud-only.
 std::string Tablet::get_segment_filepath(std::string_view rowset_id,
                                          std::string_view segment_index) const {
     return fmt::format("{}/_binlog/{}_{}.dat", _tablet_path, rowset_id, segment_index);
@@ -2929,8 +2931,8 @@ int64_t Tablet::get_segment_file_size(const RowsetMetaSharedPtr& rs_meta) {
         LOG(WARNING) << "get fs failed, resource_id={}" << rs_meta->resource_id();
     }
     int64_t total_segment_size = 0;
-    for (int64_t seg_id = 0; seg_id < rs_meta->num_segments(); seg_id++) {
-        std::string segment_path = get_segment_path(rs_meta, seg_id);
+    for (auto seg : rs_meta->segments()) {
+        std::string segment_path = get_segment_path(rs_meta, seg.id());
         int64_t segment_file_size = 0;
         auto st = fs->file_size(segment_path, &segment_file_size);
         if (!st.ok()) {
@@ -2954,8 +2956,8 @@ int64_t Tablet::get_inverted_index_file_size(const RowsetMetaSharedPtr& rs_meta)
         InvertedIndexStorageFormatPB::V1) {
         const auto& indices = rs_meta->tablet_schema()->inverted_indexes();
         for (auto& index : indices) {
-            for (int seg_id = 0; seg_id < rs_meta->num_segments(); ++seg_id) {
-                std::string segment_path = get_segment_path(rs_meta, seg_id);
+            for (auto seg : rs_meta->segments()) {
+                std::string segment_path = get_segment_path(rs_meta, seg.id());
                 int64_t file_size = 0;
 
                 std::string inverted_index_file_path =
@@ -2976,9 +2978,9 @@ int64_t Tablet::get_inverted_index_file_size(const RowsetMetaSharedPtr& rs_meta)
             }
         }
     } else {
-        for (int seg_id = 0; seg_id < rs_meta->num_segments(); ++seg_id) {
+        for (auto seg : rs_meta->segments()) {
             int64_t file_size = 0;
-            std::string segment_path = get_segment_path(rs_meta, seg_id);
+            std::string segment_path = get_segment_path(rs_meta, seg.id());
             std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_path_v2(
                     InvertedIndexDescriptor::get_index_file_path_prefix(segment_path));
             auto st = fs->file_size(inverted_index_file_path, &file_size);

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -2405,7 +2405,7 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     Status st;
     Defer defer {[&] {
         if (!st.ok()) {
-            // reclaim the incomplete rowset data in remote storage
+            // Local-mode only remote rowset GC; segment files are named by contiguous indexes.
             record_unused_remote_rowset(new_rowset_id, storage_resource.fs->id(),
                                         old_rowset->num_segments());
         }
@@ -2984,6 +2984,8 @@ Status Tablet::get_rowset_binlog_metas(Version binlog_versions, RowsetBinlogMeta
                                                       binlog_versions, metas_pb);
 }
 
+// Binlog is local-mode only. The segment index is the real binlog file id because segment-list
+// rowsets are cloud-only.
 std::string Tablet::get_segment_filepath(std::string_view rowset_id,
                                          std::string_view segment_index) const {
     return fmt::format("{}/_binlog/{}_{}.dat", _tablet_path, rowset_id, segment_index);
@@ -3176,8 +3178,8 @@ int64_t Tablet::get_segment_file_size(const RowsetMetaSharedPtr& rs_meta) {
         LOG(WARNING) << "get fs failed, resource_id={}" << rs_meta->resource_id();
     }
     int64_t total_segment_size = 0;
-    for (int64_t seg_id = 0; seg_id < rs_meta->num_segments(); seg_id++) {
-        std::string segment_path = get_segment_path(rs_meta, seg_id);
+    for (auto seg : rs_meta->segments()) {
+        std::string segment_path = get_segment_path(rs_meta, seg.id());
         int64_t segment_file_size = 0;
         auto st = fs->file_size(segment_path, &segment_file_size);
         if (!st.ok()) {
@@ -3201,8 +3203,8 @@ int64_t Tablet::get_inverted_index_file_size(const RowsetMetaSharedPtr& rs_meta)
         InvertedIndexStorageFormatPB::V1) {
         const auto& indices = rs_meta->tablet_schema()->inverted_indexes();
         for (auto& index : indices) {
-            for (int seg_id = 0; seg_id < rs_meta->num_segments(); ++seg_id) {
-                std::string segment_path = get_segment_path(rs_meta, seg_id);
+            for (auto seg : rs_meta->segments()) {
+                std::string segment_path = get_segment_path(rs_meta, seg.id());
                 int64_t file_size = 0;
 
                 std::string inverted_index_file_path =
@@ -3223,9 +3225,9 @@ int64_t Tablet::get_inverted_index_file_size(const RowsetMetaSharedPtr& rs_meta)
             }
         }
     } else {
-        for (int seg_id = 0; seg_id < rs_meta->num_segments(); ++seg_id) {
+        for (auto seg : rs_meta->segments()) {
             int64_t file_size = 0;
-            std::string segment_path = get_segment_path(rs_meta, seg_id);
+            std::string segment_path = get_segment_path(rs_meta, seg.id());
             std::string inverted_index_file_path = InvertedIndexDescriptor::get_index_file_path_v2(
                     InvertedIndexDescriptor::get_index_file_path_prefix(segment_path));
             auto st = fs->file_size(inverted_index_file_path, &file_size);

--- a/be/src/storage/tablet/tablet.h
+++ b/be/src/storage/tablet/tablet.h
@@ -414,6 +414,8 @@ public:
 
     Status remove_all_remote_rowsets();
 
+    // Local-mode only remote rowset GC. Segment-list rowsets are cloud-only and do not use this
+    // path, so GC entries record only contiguous segment indexes [0, num_segments).
     void record_unused_remote_rowset(const RowsetId& rowset_id, const std::string& resource,
                                      int64_t num_segments);
 

--- a/be/src/storage/tablet/tablet.h
+++ b/be/src/storage/tablet/tablet.h
@@ -453,6 +453,8 @@ public:
 
     Status remove_all_remote_rowsets();
 
+    // Local-mode only remote rowset GC. Segment-list rowsets are cloud-only and do not use this
+    // path, so GC entries record only contiguous segment indexes [0, num_segments).
     void record_unused_remote_rowset(const RowsetId& rowset_id, const std::string& resource,
                                      int64_t num_segments);
 

--- a/be/src/storage/tablet/tablet_meta.cpp
+++ b/be/src/storage/tablet/tablet_meta.cpp
@@ -1585,11 +1585,10 @@ void DeleteBitmap::subset(const BitmapKey& start, const BitmapKey& end,
     }
 }
 
-void DeleteBitmap::subset(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
-                          int64_t start_version, int64_t end_version,
-                          DeleteBitmap* subset_delete_map) const {
+void DeleteBitmap::subset(const std::vector<RowsetIdWithSegmentIds>& rowsets, int64_t start_version,
+                          int64_t end_version, DeleteBitmap* subset_delete_map) const {
     DCHECK(start_version <= end_version);
-    for (auto& [rowset_id, _] : rowset_ids) {
+    for (const auto& [rowset_id, _] : rowsets) {
         BitmapKey start {rowset_id, 0, 0};
         BitmapKey end {rowset_id, UINT32_MAX, end_version + 1};
         std::shared_lock l(lock);
@@ -1611,16 +1610,16 @@ void DeleteBitmap::subset(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
     }
 }
 
-void DeleteBitmap::subset_and_agg(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
+void DeleteBitmap::subset_and_agg(const std::vector<RowsetIdWithSegmentIds>& rowsets,
                                   int64_t start_version, int64_t end_version,
                                   DeleteBitmap* subset_delete_map) const {
     DCHECK(start_version <= end_version);
-    for (auto& [rowset_id, segment_num] : rowset_ids) {
-        for (int64_t seg_id = 0; seg_id < segment_num; ++seg_id) {
-            BitmapKey end {rowset_id, seg_id, end_version};
+    for (const auto& [rowset_id, segment_ids] : rowsets) {
+        for (auto segment_id : segment_ids) {
+            BitmapKey end {rowset_id, segment_id, end_version};
             auto bm = get_agg_without_cache(end, start_version);
             VLOG_DEBUG << "subset delete bitmap, tablet=" << _tablet_id << ", rowset=" << rowset_id
-                       << ", segment=" << seg_id << ", version=[" << start_version << "-"
+                       << ", segment=" << segment_id << ", version=[" << start_version << "-"
                        << end_version << "], cardinality=" << bm->cardinality();
             if (bm->isEmpty()) {
                 continue;

--- a/be/src/storage/tablet/tablet_meta.cpp
+++ b/be/src/storage/tablet/tablet_meta.cpp
@@ -1721,11 +1721,10 @@ void DeleteBitmap::subset(const BitmapKey& start, const BitmapKey& end,
     }
 }
 
-void DeleteBitmap::subset(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
-                          int64_t start_version, int64_t end_version,
-                          DeleteBitmap* subset_delete_map) const {
+void DeleteBitmap::subset(const std::vector<RowsetIdWithSegmentIds>& rowsets, int64_t start_version,
+                          int64_t end_version, DeleteBitmap* subset_delete_map) const {
     DCHECK(start_version <= end_version);
-    for (auto& [rowset_id, _] : rowset_ids) {
+    for (const auto& [rowset_id, _] : rowsets) {
         BitmapKey start {rowset_id, 0, 0};
         BitmapKey end {rowset_id, UINT32_MAX, end_version + 1};
         std::shared_lock l(lock);
@@ -1747,16 +1746,16 @@ void DeleteBitmap::subset(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
     }
 }
 
-void DeleteBitmap::subset_and_agg(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
+void DeleteBitmap::subset_and_agg(const std::vector<RowsetIdWithSegmentIds>& rowsets,
                                   int64_t start_version, int64_t end_version,
                                   DeleteBitmap* subset_delete_map) const {
     DCHECK(start_version <= end_version);
-    for (auto& [rowset_id, segment_num] : rowset_ids) {
-        for (int64_t seg_id = 0; seg_id < segment_num; ++seg_id) {
-            BitmapKey end {rowset_id, seg_id, end_version};
+    for (const auto& [rowset_id, segment_ids] : rowsets) {
+        for (auto segment_id : segment_ids) {
+            BitmapKey end {rowset_id, segment_id, end_version};
             auto bm = get_agg_without_cache(end, start_version);
             VLOG_DEBUG << "subset delete bitmap, tablet=" << _tablet_id << ", rowset=" << rowset_id
-                       << ", segment=" << seg_id << ", version=[" << start_version << "-"
+                       << ", segment=" << segment_id << ", version=[" << start_version << "-"
                        << end_version << "], cardinality=" << bm->cardinality();
             if (bm->isEmpty()) {
                 continue;

--- a/be/src/storage/tablet/tablet_meta.h
+++ b/be/src/storage/tablet/tablet_meta.h
@@ -447,6 +447,7 @@ public:
     using SegmentId = uint32_t;
     using Version = uint64_t;
     using BitmapKey = std::tuple<RowsetId, SegmentId, Version>;
+    using RowsetIdWithSegmentIds = std::pair<RowsetId, std::vector<SegmentId>>;
     std::map<BitmapKey, roaring::Roaring> delete_bitmap; // Ordered map
     constexpr static inline uint32_t INVALID_SEGMENT_ID = std::numeric_limits<uint32_t>::max() - 1;
     constexpr static inline uint32_t ROWSET_SENTINEL_MARK =
@@ -566,7 +567,7 @@ public:
      */
     void subset(const BitmapKey& start, const BitmapKey& end,
                 DeleteBitmap* subset_delete_map) const;
-    void subset(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids, int64_t start_version,
+    void subset(const std::vector<RowsetIdWithSegmentIds>& rowsets, int64_t start_version,
                 int64_t end_version, DeleteBitmap* subset_delete_map) const;
 
     /**
@@ -574,9 +575,8 @@ public:
      * with given version range [start_version, end_version] and agg to end_version,
      * then merge to subset_delete_map
      */
-    void subset_and_agg(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
-                        int64_t start_version, int64_t end_version,
-                        DeleteBitmap* subset_delete_map) const;
+    void subset_and_agg(const std::vector<RowsetIdWithSegmentIds>& rowsets, int64_t start_version,
+                        int64_t end_version, DeleteBitmap* subset_delete_map) const;
 
     /**
      * Gets count of delete_bitmap with given range [start, end)

--- a/be/src/storage/tablet/tablet_meta.h
+++ b/be/src/storage/tablet/tablet_meta.h
@@ -463,6 +463,7 @@ public:
     using SegmentId = uint32_t;
     using Version = uint64_t;
     using BitmapKey = std::tuple<RowsetId, SegmentId, Version>;
+    using RowsetIdWithSegmentIds = std::pair<RowsetId, std::vector<SegmentId>>;
     std::map<BitmapKey, roaring::Roaring> delete_bitmap; // Ordered map
     constexpr static inline uint32_t INVALID_SEGMENT_ID = std::numeric_limits<uint32_t>::max() - 1;
     constexpr static inline uint32_t ROWSET_SENTINEL_MARK =
@@ -582,7 +583,7 @@ public:
      */
     void subset(const BitmapKey& start, const BitmapKey& end,
                 DeleteBitmap* subset_delete_map) const;
-    void subset(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids, int64_t start_version,
+    void subset(const std::vector<RowsetIdWithSegmentIds>& rowsets, int64_t start_version,
                 int64_t end_version, DeleteBitmap* subset_delete_map) const;
 
     /**
@@ -590,9 +591,8 @@ public:
      * with given version range [start_version, end_version] and agg to end_version,
      * then merge to subset_delete_map
      */
-    void subset_and_agg(std::vector<std::pair<RowsetId, int64_t>>& rowset_ids,
-                        int64_t start_version, int64_t end_version,
-                        DeleteBitmap* subset_delete_map) const;
+    void subset_and_agg(const std::vector<RowsetIdWithSegmentIds>& rowsets, int64_t start_version,
+                        int64_t end_version, DeleteBitmap* subset_delete_map) const;
 
     /**
      * Gets count of delete_bitmap with given range [start, end)

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -392,6 +392,8 @@ Status EngineStorageMigrationTask::_copy_index_and_data_files(
         TabletSchema tablet_schema;
         tablet_schema.init_from_pb(tablet_schema_pb);
 
+        // Binlog is local-mode only. These files use contiguous segment indexes because
+        // segment-list rowsets are cloud-only.
         // copy segment files and index files
         for (int64_t segment_index = 0; segment_index < num_segments; ++segment_index) {
             std::string segment_file_path = _tablet->get_segment_filepath(rowset_id, segment_index);

--- a/be/src/storage/task/index_builder.cpp
+++ b/be/src/storage/task/index_builder.cpp
@@ -168,7 +168,6 @@ Status IndexBuilder::update_inverted_index_info() {
                 return size_st;
             }
         }
-        auto num_segments = input_rowset->num_segments();
         size_t drop_index_size = 0;
 
         if (_is_drop_op) {
@@ -202,10 +201,10 @@ Status IndexBuilder::update_inverted_index_info() {
                         InvertedIndexStorageFormatPB::V1) {
                         const auto& fs = io::global_local_filesystem();
 
-                        for (int seg_id = 0; seg_id < num_segments; seg_id++) {
+                        for (auto seg : input_rowset->segments()) {
                             auto seg_path = local_segment_path(
                                     _tablet->tablet_path(), input_rowset->rowset_id().to_string(),
-                                    seg_id);
+                                    seg.id());
                             auto index_path = InvertedIndexDescriptor::get_index_file_path_v1(
                                     InvertedIndexDescriptor::get_index_file_path_prefix(seg_path),
                                     index_meta->index_id(), index_meta->get_index_suffix());
@@ -374,8 +373,8 @@ Status IndexBuilder::update_inverted_index_info() {
             rowset_meta->set_index_disk_size(
                     preserve_snii_container ? input_rowset_meta->index_disk_size() : 0);
         } else {
-            for (int seg_id = 0; seg_id < num_segments; seg_id++) {
-                auto seg_path = DORIS_TRY(input_rowset->segment_path(seg_id));
+            for (auto seg : input_rowset->segments()) {
+                auto seg_path = DORIS_TRY(seg.path());
                 auto idx_file_reader = std::make_unique<IndexFileReader>(
                         context.fs(),
                         std::string {InvertedIndexDescriptor::get_index_file_path_prefix(seg_path)},
@@ -391,7 +390,7 @@ Status IndexBuilder::update_inverted_index_info() {
                     return st;
                 }
                 _index_file_readers.emplace(
-                        std::make_pair(output_rs_writer->rowset_id().to_string(), seg_id),
+                        std::make_pair(output_rs_writer->rowset_id().to_string(), seg.id()),
                         std::move(idx_file_reader));
             }
             rowset_meta->set_total_disk_size(input_rowset_meta->total_disk_size() -

--- a/be/src/storage/task/index_builder.cpp
+++ b/be/src/storage/task/index_builder.cpp
@@ -93,7 +93,6 @@ Status IndexBuilder::update_inverted_index_info() {
             !size_st.is<ErrorCode::NOT_FOUND>()) {
             return size_st;
         }
-        auto num_segments = input_rowset->num_segments();
         size_t drop_index_size = 0;
 
         if (_is_drop_op) {
@@ -127,10 +126,10 @@ Status IndexBuilder::update_inverted_index_info() {
                         InvertedIndexStorageFormatPB::V1) {
                         const auto& fs = io::global_local_filesystem();
 
-                        for (int seg_id = 0; seg_id < num_segments; seg_id++) {
+                        for (auto seg : input_rowset->segments()) {
                             auto seg_path = local_segment_path(
                                     _tablet->tablet_path(), input_rowset->rowset_id().to_string(),
-                                    seg_id);
+                                    seg.id());
                             auto index_path = InvertedIndexDescriptor::get_index_file_path_v1(
                                     InvertedIndexDescriptor::get_index_file_path_prefix(seg_path),
                                     index_meta->index_id(), index_meta->get_index_suffix());
@@ -273,8 +272,8 @@ Status IndexBuilder::update_inverted_index_info() {
                 rowset_meta->set_index_disk_size(input_rowset_meta->index_disk_size());
             }
         } else {
-            for (int seg_id = 0; seg_id < num_segments; seg_id++) {
-                auto seg_path = DORIS_TRY(input_rowset->segment_path(seg_id));
+            for (auto seg : input_rowset->segments()) {
+                auto seg_path = DORIS_TRY(seg.path());
                 auto idx_file_reader = std::make_unique<IndexFileReader>(
                         context.fs(),
                         std::string {InvertedIndexDescriptor::get_index_file_path_prefix(seg_path)},
@@ -290,7 +289,7 @@ Status IndexBuilder::update_inverted_index_info() {
                     return st;
                 }
                 _index_file_readers.emplace(
-                        std::make_pair(output_rs_writer->rowset_id().to_string(), seg_id),
+                        std::make_pair(output_rs_writer->rowset_id().to_string(), seg.id()),
                         std::move(idx_file_reader));
             }
             rowset_meta->set_total_disk_size(input_rowset_meta->total_disk_size() -

--- a/be/test/exprs/function/function_is_null_test.cpp
+++ b/be/test/exprs/function/function_is_null_test.cpp
@@ -225,8 +225,8 @@ TEST_F(FunctionIsNullTest, gc_binlogs_test) {
         }
     };
 
-    for (int i = 0; i < rowset->num_segments(); i++) {
-        auto segment_path = rowset->segment_path(i);
+    for (auto seg : rowset->segments()) {
+        auto segment_path = seg.path();
         EXPECT_TRUE(segment_path.has_value());
         std::string index_prefix = std::string(
                 InvertedIndexDescriptor::get_index_file_path_prefix(segment_path.value()));
@@ -359,8 +359,8 @@ TEST_F(FunctionIsNullTest, evaluate_inverted_index_corner_cases) {
     // Test with data that has no nulls
     // This will exercise the code path where has_null() might return false
     // or null_bitmap might be nullptr
-    for (int i = 0; i < rowset->num_segments(); i++) {
-        auto segment_path = rowset->segment_path(i);
+    for (auto seg : rowset->segments()) {
+        auto segment_path = seg.path();
         EXPECT_TRUE(segment_path.has_value());
         std::string index_prefix = std::string(
                 InvertedIndexDescriptor::get_index_file_path_prefix(segment_path.value()));

--- a/be/test/exprs/function/function_is_null_test.cpp
+++ b/be/test/exprs/function/function_is_null_test.cpp
@@ -216,8 +216,8 @@ TEST_F(FunctionIsNullTest, gc_binlogs_test) {
         }
     };
 
-    for (int i = 0; i < rowset->num_segments(); i++) {
-        auto segment_path = rowset->segment_path(i);
+    for (auto seg : rowset->segments()) {
+        auto segment_path = seg.path();
         EXPECT_TRUE(segment_path.has_value());
         std::string index_prefix = std::string(
                 InvertedIndexDescriptor::get_index_file_path_prefix(segment_path.value()));
@@ -350,8 +350,8 @@ TEST_F(FunctionIsNullTest, evaluate_inverted_index_corner_cases) {
     // Test with data that has no nulls
     // This will exercise the code path where has_null() might return false
     // or null_bitmap might be nullptr
-    for (int i = 0; i < rowset->num_segments(); i++) {
-        auto segment_path = rowset->segment_path(i);
+    for (auto seg : rowset->segments()) {
+        auto segment_path = seg.path();
         EXPECT_TRUE(segment_path.has_value());
         std::string index_prefix = std::string(
                 InvertedIndexDescriptor::get_index_file_path_prefix(segment_path.value()));

--- a/be/test/io/fs/packed_file_system_test.cpp
+++ b/be/test/io/fs/packed_file_system_test.cpp
@@ -284,6 +284,45 @@ TEST_F(PackedFileSystemTest, LaterSegmentIndexFileUsesDirectWriter) {
     EXPECT_FALSE(writer->is_in_packed_file());
 }
 
+TEST_F(PackedFileSystemTest, NonzeroFirstSegmentUsesPackedWriter) {
+    _append_info.first_segment_id = 10;
+    PackedFileSystem merge_fs(_inner_fs, _append_info);
+
+    Path first_segment_path("rowset_1_10.dat");
+    FileWriterPtr first_segment_writer;
+    ASSERT_TRUE(merge_fs.create_file(first_segment_path, &first_segment_writer, nullptr).ok());
+    ASSERT_NE(first_segment_writer, nullptr);
+
+    std::string data = "test";
+    Slice data_slice(data);
+    ASSERT_TRUE(first_segment_writer->appendv(&data_slice, 1).ok());
+    ASSERT_NE(_inner_fs->last_writer(), nullptr);
+    EXPECT_EQ(_inner_fs->last_writer()->bytes_appended(), 0);
+    EXPECT_TRUE(first_segment_writer->is_in_packed_file());
+
+    Path segment_zero_path("rowset_1_0.dat");
+    FileWriterPtr segment_zero_writer;
+    ASSERT_TRUE(merge_fs.create_file(segment_zero_path, &segment_zero_writer, nullptr).ok());
+    ASSERT_NE(segment_zero_writer, nullptr);
+    ASSERT_TRUE(segment_zero_writer->appendv(&data_slice, 1).ok());
+    ASSERT_NE(_inner_fs->last_writer(), nullptr);
+    EXPECT_EQ(_inner_fs->last_writer()->bytes_appended(), data.size());
+    EXPECT_FALSE(segment_zero_writer->is_in_packed_file());
+
+    Path first_segment_index_path("rowset_1_10.idx");
+    FileWriterPtr first_segment_index_writer;
+    ASSERT_TRUE(merge_fs.create_file(first_segment_index_path, &first_segment_index_writer, nullptr)
+                        .ok());
+    ASSERT_NE(first_segment_index_writer, nullptr);
+
+    std::string index = "idx";
+    Slice index_slice(index);
+    ASSERT_TRUE(first_segment_index_writer->appendv(&index_slice, 1).ok());
+    ASSERT_NE(_inner_fs->last_writer(), nullptr);
+    EXPECT_EQ(_inner_fs->last_writer()->bytes_appended(), 0);
+    EXPECT_TRUE(first_segment_index_writer->is_in_packed_file());
+}
+
 TEST_F(PackedFileSystemTest, OpenFileNotInMergeFile) {
     PackedFileSystem merge_fs(_inner_fs, _append_info);
 

--- a/be/test/load/memtable/memtable_flush_executor_test.cpp
+++ b/be/test/load/memtable/memtable_flush_executor_test.cpp
@@ -106,7 +106,7 @@ public:
     int64_t num_rows_filtered() const override { return 0; }
     RowsetId rowset_id() override { return _context.rowset_id; }
     RowsetTypePB type() const override { return BETA_ROWSET; }
-    int32_t allocate_segment_id() override { return _next_segment_id++; }
+    Result<int32_t> allocate_segment_id() override { return _next_segment_id++; }
     int32_t get_allocated_segment_id() override { return _next_segment_id; }
     std::shared_ptr<PartialUpdateInfo> get_partial_update_info() override { return nullptr; }
     bool is_partial_update() override { return false; }

--- a/be/test/storage/compaction/collection_statistics_test.cpp
+++ b/be/test/storage/compaction/collection_statistics_test.cpp
@@ -127,9 +127,7 @@ private:
 class MockRowset : public Rowset {
 public:
     MockRowset(TabletSchemaSPtr schema, RowsetMetaSharedPtr rowset_meta)
-            : Rowset(schema, rowset_meta, "/mock/tablet/path") {
-        _num_segments = 0;
-    }
+            : Rowset(schema, rowset_meta, "/mock/tablet/path") {}
 
     Status create_reader(std::shared_ptr<RowsetReader>* result) override {
         return Status::NotSupported("MockRowset::create_reader not implemented");
@@ -169,8 +167,6 @@ public:
 
     Status check_current_rowset_segment() override { return Status::OK(); }
 
-    int64_t num_segments() const override { return _num_segments; }
-
     Result<std::string> segment_path(int64_t seg_id) override {
         if (_segment_paths.find(seg_id) != _segment_paths.end()) {
             return _segment_paths.at(seg_id);
@@ -182,10 +178,9 @@ public:
         _segment_paths[seg_id] = path;
     }
 
-    void set_num_segments(int64_t num) { _num_segments = num; }
+    void set_num_segments(int64_t num) { rowset_meta()->set_num_segments(num); }
 
 private:
-    int64_t _num_segments;
     std::map<int64_t, std::string> _segment_paths;
 };
 

--- a/be/test/storage/compaction/vertical_compaction_test.cpp
+++ b/be/test/storage/compaction/vertical_compaction_test.cpp
@@ -37,6 +37,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/block/block.h"
@@ -222,6 +223,19 @@ protected:
         return rowset_writer_context;
     }
 
+    Block create_column_block(const TabletSchemaSPtr& tablet_schema,
+                              const std::vector<uint32_t>& column_ids, int32_t row_count,
+                              int32_t start_value) {
+        auto block = tablet_schema->create_storage_block(column_ids);
+        auto columns = std::move(block).mutate_columns();
+        for (int32_t i = 0; i < row_count; ++i) {
+            int32_t value = start_value + i;
+            columns[0]->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+        }
+        block.set_columns(std::move(columns));
+        return block;
+    }
+
     void create_and_init_rowset_reader(Rowset* rowset, RowsetReaderContext& context,
                                        RowsetReaderSharedPtr* result) {
         auto s = rowset->create_reader(result);
@@ -376,6 +390,44 @@ private:
     std::string absolute_dir;
     DataDir* _data_dir = nullptr;
 };
+
+TEST_F(VerticalCompactionTest, TestNonZeroSegmentIdAllocation) {
+    auto tablet_schema = create_schema();
+    auto writer_context =
+            create_rowset_writer_context(tablet_schema, NONOVERLAPPING, UINT32_MAX, {0, 0});
+    auto writer_result = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, true);
+    ASSERT_TRUE(writer_result.has_value()) << writer_result.error();
+    auto rowset_writer = std::move(writer_result).value();
+
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 0);
+    rowset_writer->set_segment_start_id(10);
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 10);
+
+    std::vector<uint32_t> key_column_ids = {0};
+    auto first_key_block = create_column_block(tablet_schema, key_column_ids, 8, 1);
+    ASSERT_TRUE(rowset_writer->add_columns(&first_key_block, key_column_ids, true, 4, false).ok());
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 11);
+
+    auto second_key_block = create_column_block(tablet_schema, key_column_ids, 8, 100);
+    ASSERT_TRUE(rowset_writer->add_columns(&second_key_block, key_column_ids, true, 4, false).ok());
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 12);
+    ASSERT_TRUE(rowset_writer->flush_columns(true).ok());
+
+    std::vector<uint32_t> value_column_ids = {1};
+    auto value_block = create_column_block(tablet_schema, value_column_ids, 16, 1);
+    ASSERT_TRUE(rowset_writer->add_columns(&value_block, value_column_ids, false, UINT32_MAX, false)
+                        .ok());
+    ASSERT_TRUE(rowset_writer->flush_columns(false).ok());
+    ASSERT_TRUE(rowset_writer->final_flush().ok());
+
+    RowsetSharedPtr rowset;
+    ASSERT_TRUE(rowset_writer->build(rowset).ok());
+    ASSERT_NE(rowset, nullptr);
+    const auto& segment_ids = rowset->rowset_meta()->segment_ids();
+    ASSERT_EQ(segment_ids.size(), 2);
+    EXPECT_EQ(segment_ids[0], 10);
+    EXPECT_EQ(segment_ids[1], 11);
+}
 
 TEST_F(VerticalCompactionTest, TestRowSourcesBuffer) {
     RowSourcesBuffer buffer(100, absolute_dir, ReaderType::READER_CUMULATIVE_COMPACTION);

--- a/be/test/storage/compaction/vertical_compaction_test.cpp
+++ b/be/test/storage/compaction/vertical_compaction_test.cpp
@@ -36,6 +36,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
@@ -217,6 +218,19 @@ protected:
         return rowset_writer_context;
     }
 
+    Block create_column_block(const TabletSchemaSPtr& tablet_schema,
+                              const std::vector<uint32_t>& column_ids, int32_t row_count,
+                              int32_t start_value) {
+        auto block = tablet_schema->create_block(column_ids);
+        auto columns = std::move(block).mutate_columns();
+        for (int32_t i = 0; i < row_count; ++i) {
+            int32_t value = start_value + i;
+            columns[0]->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+        }
+        block.set_columns(std::move(columns));
+        return block;
+    }
+
     void create_and_init_rowset_reader(Rowset* rowset, RowsetReaderContext& context,
                                        RowsetReaderSharedPtr* result) {
         auto s = rowset->create_reader(result);
@@ -392,6 +406,44 @@ private:
     std::string absolute_dir;
     DataDir* _data_dir = nullptr;
 };
+
+TEST_F(VerticalCompactionTest, TestNonZeroSegmentIdAllocation) {
+    auto tablet_schema = create_schema();
+    auto writer_context =
+            create_rowset_writer_context(tablet_schema, NONOVERLAPPING, UINT32_MAX, {0, 0});
+    auto writer_result = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, true);
+    ASSERT_TRUE(writer_result.has_value()) << writer_result.error();
+    auto rowset_writer = std::move(writer_result).value();
+
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 0);
+    rowset_writer->set_segment_start_id(10);
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 10);
+
+    std::vector<uint32_t> key_column_ids = {0};
+    auto first_key_block = create_column_block(tablet_schema, key_column_ids, 8, 1);
+    ASSERT_TRUE(rowset_writer->add_columns(&first_key_block, key_column_ids, true, 4, false).ok());
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 11);
+
+    auto second_key_block = create_column_block(tablet_schema, key_column_ids, 8, 100);
+    ASSERT_TRUE(rowset_writer->add_columns(&second_key_block, key_column_ids, true, 4, false).ok());
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 12);
+    ASSERT_TRUE(rowset_writer->flush_columns(true).ok());
+
+    std::vector<uint32_t> value_column_ids = {1};
+    auto value_block = create_column_block(tablet_schema, value_column_ids, 16, 1);
+    ASSERT_TRUE(rowset_writer->add_columns(&value_block, value_column_ids, false, UINT32_MAX, false)
+                        .ok());
+    ASSERT_TRUE(rowset_writer->flush_columns(false).ok());
+    ASSERT_TRUE(rowset_writer->final_flush().ok());
+
+    RowsetSharedPtr rowset;
+    ASSERT_TRUE(rowset_writer->build(rowset).ok());
+    ASSERT_NE(rowset, nullptr);
+    const auto& segment_ids = rowset->rowset_meta()->segment_ids();
+    ASSERT_EQ(segment_ids.size(), 2);
+    EXPECT_EQ(segment_ids[0], 10);
+    EXPECT_EQ(segment_ids[1], 11);
+}
 
 TEST_F(VerticalCompactionTest, TestRowSourcesBuffer) {
     RowSourcesBuffer buffer(100, absolute_dir, ReaderType::READER_CUMULATIVE_COMPACTION);

--- a/be/test/storage/index/inverted/compaction/index_compaction_test.cpp
+++ b/be/test/storage/index/inverted/compaction/index_compaction_test.cpp
@@ -706,8 +706,9 @@ protected:
                 // check index file terms for multiple segments
                 std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>> dirs_idx(
                         num_segments_idx);
-                for (int i = 0; i < num_segments_idx; i++) {
-                    const auto& seg_path = output_rowset_index->segment_path(i);
+                size_t idx_pos = 0;
+                for (auto seg : output_rowset_index->segments()) {
+                    const auto& seg_path = seg.path();
                     EXPECT_TRUE(seg_path.has_value()) << seg_path.error();
                     auto inverted_index_file_reader_index =
                             IndexCompactionUtils::init_index_file_reader(
@@ -715,12 +716,13 @@ protected:
                                     _tablet_schema->get_inverted_index_storage_format());
                     auto dir_idx = inverted_index_file_reader_index->_open(idx, "");
                     EXPECT_TRUE(dir_idx.has_value()) << dir_idx.error();
-                    dirs_idx[i] = std::move(dir_idx.value());
+                    dirs_idx[idx_pos++] = std::move(dir_idx.value());
                 }
                 std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>> dirs_normal(
                         num_segments_normal);
-                for (int i = 0; i < num_segments_normal; i++) {
-                    const auto& seg_path = output_rowset_normal->segment_path(i);
+                size_t normal_pos = 0;
+                for (auto seg : output_rowset_normal->segments()) {
+                    const auto& seg_path = seg.path();
                     EXPECT_TRUE(seg_path.has_value()) << seg_path.error();
                     auto inverted_index_file_reader_normal =
                             IndexCompactionUtils::init_index_file_reader(
@@ -728,7 +730,7 @@ protected:
                                     _tablet_schema->get_inverted_index_storage_format());
                     auto dir_normal = inverted_index_file_reader_normal->_open(idx, "");
                     EXPECT_TRUE(dir_normal.has_value()) << dir_normal.error();
-                    dirs_normal[i] = std::move(dir_normal.value());
+                    dirs_normal[normal_pos++] = std::move(dir_normal.value());
                 }
                 st = IndexCompactionUtils::check_idx_file_correctness(dirs_idx, dirs_normal);
                 EXPECT_TRUE(st.ok()) << st.to_string();
@@ -818,20 +820,26 @@ TEST_F(IndexCompactionTest, tes_write_index_normally) {
             _data_dir, _tablet_schema, _tablet, _engine_ref, rowsets, data_files, _inc_id,
             custom_check_build_rowsets);
 
-    auto custom_check_index = [](const BaseCompaction& compaction, const RowsetWriterContext& ctx) {
+    constexpr int32_t output_segment_start_id = 10;
+    auto custom_check_index = [output_segment_start_id](const BaseCompaction& compaction,
+                                                        const RowsetWriterContext& ctx) {
         EXPECT_EQ(compaction._cur_tablet_schema->inverted_indexes().size(), 4);
         EXPECT_TRUE(ctx.columns_to_do_index_compaction.size() == 2);
         EXPECT_TRUE(ctx.columns_to_do_index_compaction.contains(1));
         EXPECT_TRUE(ctx.columns_to_do_index_compaction.contains(2));
         EXPECT_TRUE(compaction._output_rowset->num_segments() == 1);
+        ASSERT_TRUE(compaction._output_rowset->rowset_meta()->has_segment_ids());
+        ASSERT_EQ(compaction._output_rowset->rowset_meta()->segment_ids().size(), 1);
+        EXPECT_EQ(compaction._output_rowset->rowset_meta()->segment_id(0), output_segment_start_id);
     };
 
     RowsetSharedPtr output_rowset_index;
     auto st = IndexCompactionUtils::do_compaction(rowsets, _engine_ref, _tablet, true,
-                                                  output_rowset_index, custom_check_index);
+                                                  output_rowset_index, custom_check_index, 100000,
+                                                  output_segment_start_id);
     EXPECT_TRUE(st.ok()) << st.to_string();
 
-    const auto& seg_path = output_rowset_index->segment_path(0);
+    const auto& seg_path = output_rowset_index->segment(0).path();
     EXPECT_TRUE(seg_path.has_value()) << seg_path.error();
     auto inverted_index_file_reader_index = IndexCompactionUtils::init_index_file_reader(
             output_rowset_index, seg_path.value(),

--- a/be/test/storage/index/inverted/compaction/index_compaction_test.cpp
+++ b/be/test/storage/index/inverted/compaction/index_compaction_test.cpp
@@ -702,8 +702,9 @@ protected:
                 // check index file terms for multiple segments
                 std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>> dirs_idx(
                         num_segments_idx);
-                for (int i = 0; i < num_segments_idx; i++) {
-                    const auto& seg_path = output_rowset_index->segment_path(i);
+                size_t idx_pos = 0;
+                for (auto seg : output_rowset_index->segments()) {
+                    const auto& seg_path = seg.path();
                     EXPECT_TRUE(seg_path.has_value()) << seg_path.error();
                     auto inverted_index_file_reader_index =
                             IndexCompactionUtils::init_index_file_reader(
@@ -711,12 +712,13 @@ protected:
                                     _tablet_schema->get_inverted_index_storage_format());
                     auto dir_idx = inverted_index_file_reader_index->_open(idx, "");
                     EXPECT_TRUE(dir_idx.has_value()) << dir_idx.error();
-                    dirs_idx[i] = std::move(dir_idx.value());
+                    dirs_idx[idx_pos++] = std::move(dir_idx.value());
                 }
                 std::vector<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>> dirs_normal(
                         num_segments_normal);
-                for (int i = 0; i < num_segments_normal; i++) {
-                    const auto& seg_path = output_rowset_normal->segment_path(i);
+                size_t normal_pos = 0;
+                for (auto seg : output_rowset_normal->segments()) {
+                    const auto& seg_path = seg.path();
                     EXPECT_TRUE(seg_path.has_value()) << seg_path.error();
                     auto inverted_index_file_reader_normal =
                             IndexCompactionUtils::init_index_file_reader(
@@ -724,7 +726,7 @@ protected:
                                     _tablet_schema->get_inverted_index_storage_format());
                     auto dir_normal = inverted_index_file_reader_normal->_open(idx, "");
                     EXPECT_TRUE(dir_normal.has_value()) << dir_normal.error();
-                    dirs_normal[i] = std::move(dir_normal.value());
+                    dirs_normal[normal_pos++] = std::move(dir_normal.value());
                 }
                 st = IndexCompactionUtils::check_idx_file_correctness(dirs_idx, dirs_normal);
                 EXPECT_TRUE(st.ok()) << st.to_string();
@@ -758,20 +760,26 @@ TEST_F(IndexCompactionTest, tes_write_index_normally) {
             _data_dir, _tablet_schema, _tablet, _engine_ref, rowsets, data_files, _inc_id,
             custom_check_build_rowsets);
 
-    auto custom_check_index = [](const BaseCompaction& compaction, const RowsetWriterContext& ctx) {
+    constexpr int32_t output_segment_start_id = 10;
+    auto custom_check_index = [output_segment_start_id](const BaseCompaction& compaction,
+                                                        const RowsetWriterContext& ctx) {
         EXPECT_EQ(compaction._cur_tablet_schema->inverted_indexes().size(), 4);
         EXPECT_TRUE(ctx.columns_to_do_index_compaction.size() == 2);
         EXPECT_TRUE(ctx.columns_to_do_index_compaction.contains(1));
         EXPECT_TRUE(ctx.columns_to_do_index_compaction.contains(2));
         EXPECT_TRUE(compaction._output_rowset->num_segments() == 1);
+        ASSERT_TRUE(compaction._output_rowset->rowset_meta()->has_segment_ids());
+        ASSERT_EQ(compaction._output_rowset->rowset_meta()->segment_ids().size(), 1);
+        EXPECT_EQ(compaction._output_rowset->rowset_meta()->segment_id(0), output_segment_start_id);
     };
 
     RowsetSharedPtr output_rowset_index;
     auto st = IndexCompactionUtils::do_compaction(rowsets, _engine_ref, _tablet, true,
-                                                  output_rowset_index, custom_check_index);
+                                                  output_rowset_index, custom_check_index, 100000,
+                                                  output_segment_start_id);
     EXPECT_TRUE(st.ok()) << st.to_string();
 
-    const auto& seg_path = output_rowset_index->segment_path(0);
+    const auto& seg_path = output_rowset_index->segment(0).path();
     EXPECT_TRUE(seg_path.has_value()) << seg_path.error();
     auto inverted_index_file_reader_index = IndexCompactionUtils::init_index_file_reader(
             output_rowset_index, seg_path.value(),

--- a/be/test/storage/index/inverted/compaction/util/index_compaction_utils.cpp
+++ b/be/test/storage/index/inverted/compaction/util/index_compaction_utils.cpp
@@ -427,7 +427,7 @@ class IndexCompactionUtils {
             const TabletSharedPtr& tablet, bool is_index_compaction, RowsetSharedPtr& rowset_ptr,
             const std::function<void(const BaseCompaction&, const RowsetWriterContext&)>
                     custom_check = nullptr,
-            int64_t max_rows_per_segment = 100000) {
+            int64_t max_rows_per_segment = 100000, int32_t output_segment_start_id = 0) {
         config::inverted_index_compaction_enable = is_index_compaction;
         // control max rows in one block
         config::compaction_batch_size = max_rows_per_segment;
@@ -442,6 +442,9 @@ class IndexCompactionUtils {
         RowsetWriterContext ctx;
         ctx.max_rows_per_segment = max_rows_per_segment;
         RETURN_IF_ERROR(compaction.construct_output_rowset_writer(ctx));
+        if (output_segment_start_id != 0) {
+            compaction._output_rs_writer->set_segment_start_id(output_segment_start_id);
+        }
 
         compaction._stats.rowid_conversion = compaction._rowid_conversion.get();
         RETURN_IF_ERROR(Merger::vertical_merge_rowsets(
@@ -567,19 +570,19 @@ class IndexCompactionUtils {
                                     const std::map<int, QueryData>& query_map) {
         CHECK_EQ(output_rowset->num_segments(), 1);
         // check rowset meta and file
-        int seg_id = 0;
+        auto seg = output_rowset->segment(0);
         // meta
-        const auto& index_info = output_rowset->_rowset_meta->inverted_index_file_info(seg_id);
+        auto index_info = seg.inverted_index_file_info();
         EXPECT_TRUE(index_info.has_index_size());
         const auto& fs = output_rowset->_rowset_meta->fs();
         const auto& file_name = fmt::format("{}/{}_{}.idx", output_rowset->tablet_path(),
-                                            output_rowset->rowset_id().to_string(), seg_id);
+                                            output_rowset->rowset_id().to_string(), seg.id());
         int64_t file_size = 0;
         EXPECT_TRUE(fs->file_size(file_name, &file_size).ok());
         EXPECT_EQ(index_info.index_size(), file_size);
 
         // file
-        const auto& seg_path = output_rowset->segment_path(seg_id);
+        auto seg_path = seg.path();
         EXPECT_TRUE(seg_path.has_value());
         const auto& index_file_path_prefix =
                 InvertedIndexDescriptor::get_index_file_path_prefix(seg_path.value());
@@ -716,18 +719,18 @@ class IndexCompactionUtils {
                     << rowsets[i]->num_segments();
 
             // check rowset meta and file
-            for (int seg_id = 0; seg_id < rowsets[i]->num_segments(); seg_id++) {
-                const auto& index_info = rowsets[i]->_rowset_meta->inverted_index_file_info(seg_id);
+            for (auto seg : rowsets[i]->segments()) {
+                auto index_info = seg.inverted_index_file_info();
                 EXPECT_TRUE(index_info.has_index_size());
                 const auto& fs = rowsets[i]->_rowset_meta->fs();
                 const auto& file_name = fmt::format("{}/{}_{}.idx", rowsets[i]->tablet_path(),
-                                                    rowsets[i]->rowset_id().to_string(), seg_id);
+                                                    rowsets[i]->rowset_id().to_string(), seg.id());
                 int64_t file_size = 0;
                 Status st = fs->file_size(file_name, &file_size);
                 EXPECT_TRUE(st.ok()) << st.to_string();
                 EXPECT_EQ(index_info.index_size(), file_size);
 
-                const auto& seg_path = rowsets[i]->segment_path(seg_id);
+                auto seg_path = seg.path();
                 EXPECT_TRUE(seg_path.has_value());
                 const auto& index_file_path_prefix =
                         InvertedIndexDescriptor::get_index_file_path_prefix(seg_path.value());

--- a/be/test/storage/index/inverted/compaction/util/index_compaction_utils.h
+++ b/be/test/storage/index/inverted/compaction/util/index_compaction_utils.h
@@ -429,7 +429,7 @@ class IndexCompactionUtils {
             const TabletSharedPtr& tablet, bool is_index_compaction, RowsetSharedPtr& rowset_ptr,
             const std::function<void(const BaseCompaction&, const RowsetWriterContext&)>
                     custom_check = nullptr,
-            int64_t max_rows_per_segment = 100000,
+            int64_t max_rows_per_segment = 100000, int32_t output_segment_start_id = 0,
             const std::optional<StorageResource>& output_storage_resource = std::nullopt) {
         config::inverted_index_compaction_enable = is_index_compaction;
         // control max rows in one block
@@ -447,6 +447,9 @@ class IndexCompactionUtils {
         // Empty for a local output rowset, which is what is_local_rowset() keys off.
         ctx.storage_resource = output_storage_resource;
         RETURN_IF_ERROR(compaction.construct_output_rowset_writer(ctx));
+        if (output_segment_start_id != 0) {
+            compaction._output_rs_writer->set_segment_start_id(output_segment_start_id);
+        }
 
         compaction._stats.rowid_conversion = compaction._rowid_conversion.get();
         RETURN_IF_ERROR(Merger::vertical_merge_rowsets(
@@ -572,19 +575,19 @@ class IndexCompactionUtils {
                                     const std::map<int, QueryData>& query_map) {
         CHECK_EQ(output_rowset->num_segments(), 1);
         // check rowset meta and file
-        int seg_id = 0;
+        auto seg = output_rowset->segment(0);
         // meta
-        const auto& index_info = output_rowset->_rowset_meta->inverted_index_file_info(seg_id);
+        auto index_info = seg.inverted_index_file_info();
         EXPECT_TRUE(index_info.has_index_size());
         const auto& fs = output_rowset->_rowset_meta->fs();
         const auto& file_name = fmt::format("{}/{}_{}.idx", output_rowset->tablet_path(),
-                                            output_rowset->rowset_id().to_string(), seg_id);
+                                            output_rowset->rowset_id().to_string(), seg.id());
         int64_t file_size = 0;
         EXPECT_TRUE(fs->file_size(file_name, &file_size).ok());
         EXPECT_EQ(index_info.index_size(), file_size);
 
         // file
-        const auto& seg_path = output_rowset->segment_path(seg_id);
+        auto seg_path = seg.path();
         EXPECT_TRUE(seg_path.has_value());
         const auto& index_file_path_prefix =
                 InvertedIndexDescriptor::get_index_file_path_prefix(seg_path.value());
@@ -734,19 +737,21 @@ class IndexCompactionUtils {
 
             // check rowset meta and file -- local only: the paths below are local, so a remote
             // rowset would always report size 0 here.
-            for (int seg_id = 0; rowsets[i]->is_local() && seg_id < rowsets[i]->num_segments();
-                 seg_id++) {
-                const auto& index_info = rowsets[i]->_rowset_meta->inverted_index_file_info(seg_id);
+            if (!rowsets[i]->is_local()) {
+                continue;
+            }
+            for (auto seg : rowsets[i]->segments()) {
+                auto index_info = seg.inverted_index_file_info();
                 EXPECT_TRUE(index_info.has_index_size());
                 const auto& fs = rowsets[i]->_rowset_meta->fs();
                 const auto& file_name = fmt::format("{}/{}_{}.idx", rowsets[i]->tablet_path(),
-                                                    rowsets[i]->rowset_id().to_string(), seg_id);
+                                                    rowsets[i]->rowset_id().to_string(), seg.id());
                 int64_t file_size = 0;
                 Status st = fs->file_size(file_name, &file_size);
                 EXPECT_TRUE(st.ok()) << st.to_string();
                 EXPECT_EQ(index_info.index_size(), file_size);
 
-                const auto& seg_path = rowsets[i]->segment_path(seg_id);
+                auto seg_path = seg.path();
                 EXPECT_TRUE(seg_path.has_value());
                 const auto& index_file_path_prefix =
                         InvertedIndexDescriptor::get_index_file_path_prefix(seg_path.value());

--- a/be/test/storage/index/inverted/similarity/collection_statistics_test.cpp
+++ b/be/test/storage/index/inverted/similarity/collection_statistics_test.cpp
@@ -186,9 +186,7 @@ private:
 class MockRowset : public Rowset {
 public:
     MockRowset(TabletSchemaSPtr schema, RowsetMetaSharedPtr rowset_meta)
-            : Rowset(schema, rowset_meta, "/mock/tablet/path") {
-        _num_segments = 0;
-    }
+            : Rowset(schema, rowset_meta, "/mock/tablet/path") {}
 
     Status create_reader(std::shared_ptr<RowsetReader>* result) override {
         return Status::NotSupported("MockRowset::create_reader not implemented");
@@ -228,8 +226,6 @@ public:
 
     Status check_current_rowset_segment() override { return Status::OK(); }
 
-    int64_t num_segments() const override { return _num_segments; }
-
     Result<std::string> segment_path(int64_t seg_id) override {
         _segment_path_requests.push_back(seg_id);
         if (_segment_paths.find(seg_id) != _segment_paths.end()) {
@@ -242,12 +238,11 @@ public:
         _segment_paths[seg_id] = path;
     }
 
-    void set_num_segments(int64_t num) { _num_segments = num; }
+    void set_num_segments(int64_t num) { rowset_meta()->set_num_segments(num); }
 
     const std::vector<int64_t>& segment_path_requests() const { return _segment_path_requests; }
 
 private:
-    int64_t _num_segments;
     std::map<int64_t, std::string> _segment_paths;
     std::vector<int64_t> _segment_path_requests;
 };

--- a/be/test/storage/index/snii/bench/snii_vs_v3_benchmark_test.cpp
+++ b/be/test/storage/index/snii/bench/snii_vs_v3_benchmark_test.cpp
@@ -1245,7 +1245,7 @@ protected:
                             result.index_compaction_columns = static_cast<int64_t>(
                                     cctx.columns_to_do_index_compaction.size());
                         },
-                        10000000, storage_resource);
+                        10000000, /*output_segment_start_id=*/0, storage_resource);
             });
             EXPECT_TRUE(compaction_status.ok()) << compaction_status.to_string();
         } else {

--- a/be/test/storage/rowid_conversion_test.cpp
+++ b/be/test/storage/rowid_conversion_test.cpp
@@ -399,14 +399,14 @@ protected:
             for (auto s_id = 0; s_id < input_data[rs_id].size(); s_id++) {
                 for (auto row_id = 0; row_id < input_data[rs_id][s_id].size(); row_id++) {
                     RowLocation src(input_rowsets[rs_id]->rowset_id(), s_id, row_id);
-                    RowLocation dst;
+                    RowIdConversion::DestinationRowId dst;
                     int res = rowid_conversion.get(src, &dst);
                     if (res < 0) {
                         continue;
                     }
                     size_t rowid_in_output_data = dst.row_id;
-                    EXPECT_GT(segment_num_rows[dst.segment_id], dst.row_id);
-                    for (auto n = 1; n <= dst.segment_id; n++) {
+                    EXPECT_GT(segment_num_rows[dst.segment_pos], dst.row_id);
+                    for (auto n = 1; n <= dst.segment_pos; n++) {
                         rowid_in_output_data += segment_num_rows[n - 1];
                     }
                     EXPECT_EQ(std::get<0>(output_data[rowid_in_output_data]),
@@ -491,12 +491,14 @@ TEST_F(TestRowIdConversion, Basic) {
     }
     RowIdConversion rowid_conversion;
     src_rowset.init(0);
+    std::vector<uint32_t> rs0_segment_ids = {0, 1};
     std::vector<uint32_t> rs0_segment_num_rows = {4, 3};
-    auto st = rowid_conversion.init_segment_map(src_rowset, rs0_segment_num_rows);
+    auto st = rowid_conversion.init_segment_map(src_rowset, rs0_segment_ids, rs0_segment_num_rows);
     EXPECT_EQ(st.ok(), true);
     src_rowset.init(1);
+    std::vector<uint32_t> rs1_segment_ids = {0};
     std::vector<uint32_t> rs1_segment_num_rows = {4};
-    st = rowid_conversion.init_segment_map(src_rowset, rs1_segment_num_rows);
+    st = rowid_conversion.init_segment_map(src_rowset, rs1_segment_ids, rs1_segment_num_rows);
     EXPECT_EQ(st.ok(), true);
     rowid_conversion.set_dst_rowset_id(dst_rowset);
 
@@ -506,45 +508,87 @@ TEST_F(TestRowIdConversion, Basic) {
     int res = 0;
     src_rowset.init(0);
     RowLocation src0(src_rowset, 0, 0);
-    RowLocation dst0;
+    RowIdConversion::DestinationRowId dst0;
     res = rowid_conversion.get(src0, &dst0);
 
-    EXPECT_EQ(dst0.rowset_id, dst_rowset);
-    EXPECT_EQ(dst0.segment_id, 0);
+    EXPECT_EQ(rowid_conversion.get_dst_rowset_id(), dst_rowset);
+    EXPECT_EQ(dst0.segment_pos, 0);
     EXPECT_EQ(dst0.row_id, 0);
     EXPECT_EQ(res, 0);
 
     src_rowset.init(0);
     RowLocation src1(src_rowset, 1, 2);
-    RowLocation dst1;
+    RowIdConversion::DestinationRowId dst1;
     res = rowid_conversion.get(src1, &dst1);
 
-    EXPECT_EQ(dst1.rowset_id, dst_rowset);
-    EXPECT_EQ(dst1.segment_id, 1);
+    EXPECT_EQ(dst1.segment_pos, 1);
     EXPECT_EQ(dst1.row_id, 2);
     EXPECT_EQ(res, 0);
 
     src_rowset.init(1);
     RowLocation src2(src_rowset, 0, 3);
-    RowLocation dst2;
+    RowIdConversion::DestinationRowId dst2;
     res = rowid_conversion.get(src2, &dst2);
 
-    EXPECT_EQ(dst2.rowset_id, dst_rowset);
-    EXPECT_EQ(dst2.segment_id, 2);
+    EXPECT_EQ(dst2.segment_pos, 2);
     EXPECT_EQ(dst2.row_id, 3);
     EXPECT_EQ(res, 0);
 
     src_rowset.init(1);
     RowLocation src3(src_rowset, 0, 4);
-    RowLocation dst3;
+    RowIdConversion::DestinationRowId dst3;
     res = rowid_conversion.get(src3, &dst3);
     EXPECT_EQ(res, -1);
 
     src_rowset.init(100);
     RowLocation src4(src_rowset, 5, 4);
-    RowLocation dst4;
+    RowIdConversion::DestinationRowId dst4;
     res = rowid_conversion.get(src4, &dst4);
     EXPECT_EQ(res, -1);
+}
+
+TEST_F(TestRowIdConversion, ConvertDestinationPositionToPhysicalSegmentId) {
+    auto tablet_schema = create_schema(UNIQUE_KEYS);
+    auto input_rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(input_rowset_meta, 2, 2);
+    RowsetId input_rowset_id;
+    input_rowset_id.init(100);
+    input_rowset_meta->set_rowset_id(input_rowset_id);
+    input_rowset_meta->set_segment_ids({10});
+    auto input_rowset =
+            std::make_shared<BetaRowset>(tablet_schema, input_rowset_meta, absolute_dir);
+
+    auto output_rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(output_rowset_meta, 2, 2);
+    RowsetId output_rowset_id;
+    output_rowset_id.init(200);
+    output_rowset_meta->set_rowset_id(output_rowset_id);
+    output_rowset_meta->set_segment_ids({100});
+    auto output_rowset =
+            std::make_shared<BetaRowset>(tablet_schema, output_rowset_meta, absolute_dir);
+
+    RowIdConversion rowid_conversion;
+    ASSERT_TRUE(rowid_conversion.init_segment_map(input_rowset_id, {10}, {1}).ok());
+    rowid_conversion.set_dst_rowset_id(output_rowset_id);
+    rowid_conversion.add({RowLocation(input_rowset_id, 10, 0)}, {1});
+
+    DeleteBitmap input_delete_bitmap(1);
+    input_delete_bitmap.add({input_rowset_id, 10, 5}, 0);
+    DeleteBitmap output_delete_bitmap(1);
+    std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>> location_map;
+    auto tablet = create_tablet(*tablet_schema, true);
+    tablet->calc_compaction_output_rowset_delete_bitmap(
+            {input_rowset}, output_rowset, rowid_conversion, 0, 10, nullptr, &location_map,
+            input_delete_bitmap, &output_delete_bitmap);
+
+    EXPECT_TRUE(output_delete_bitmap.contains({output_rowset_id, 100, 5}, 0));
+    EXPECT_FALSE(output_delete_bitmap.contains({output_rowset_id, 0, 5}, 0));
+    ASSERT_EQ(location_map.size(), 1);
+    ASSERT_EQ(location_map.at(input_rowset).size(), 1);
+    const auto& [src, dst] = location_map.at(input_rowset).front();
+    EXPECT_EQ(src.segment_id, 10);
+    EXPECT_EQ(dst.rowset_id, output_rowset_id);
+    EXPECT_EQ(dst.segment_id, 100);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/be/test/storage/rowid_conversion_test.cpp
+++ b/be/test/storage/rowid_conversion_test.cpp
@@ -401,14 +401,14 @@ protected:
             for (auto s_id = 0; s_id < input_data[rs_id].size(); s_id++) {
                 for (auto row_id = 0; row_id < input_data[rs_id][s_id].size(); row_id++) {
                     RowLocation src(input_rowsets[rs_id]->rowset_id(), s_id, row_id);
-                    RowLocation dst;
+                    RowIdConversion::DestinationRowId dst;
                     int res = rowid_conversion.get(src, &dst);
                     if (res < 0) {
                         continue;
                     }
                     size_t rowid_in_output_data = dst.row_id;
-                    EXPECT_GT(segment_num_rows[dst.segment_id], dst.row_id);
-                    for (auto n = 1; n <= dst.segment_id; n++) {
+                    EXPECT_GT(segment_num_rows[dst.segment_pos], dst.row_id);
+                    for (auto n = 1; n <= dst.segment_pos; n++) {
                         rowid_in_output_data += segment_num_rows[n - 1];
                     }
                     EXPECT_EQ(std::get<0>(output_data[rowid_in_output_data]),
@@ -493,12 +493,14 @@ TEST_F(TestRowIdConversion, Basic) {
     }
     RowIdConversion rowid_conversion;
     src_rowset.init(0);
+    std::vector<uint32_t> rs0_segment_ids = {0, 1};
     std::vector<uint32_t> rs0_segment_num_rows = {4, 3};
-    auto st = rowid_conversion.init_segment_map(src_rowset, rs0_segment_num_rows);
+    auto st = rowid_conversion.init_segment_map(src_rowset, rs0_segment_ids, rs0_segment_num_rows);
     EXPECT_EQ(st.ok(), true);
     src_rowset.init(1);
+    std::vector<uint32_t> rs1_segment_ids = {0};
     std::vector<uint32_t> rs1_segment_num_rows = {4};
-    st = rowid_conversion.init_segment_map(src_rowset, rs1_segment_num_rows);
+    st = rowid_conversion.init_segment_map(src_rowset, rs1_segment_ids, rs1_segment_num_rows);
     EXPECT_EQ(st.ok(), true);
     rowid_conversion.set_dst_rowset_id(dst_rowset);
 
@@ -508,45 +510,87 @@ TEST_F(TestRowIdConversion, Basic) {
     int res = 0;
     src_rowset.init(0);
     RowLocation src0(src_rowset, 0, 0);
-    RowLocation dst0;
+    RowIdConversion::DestinationRowId dst0;
     res = rowid_conversion.get(src0, &dst0);
 
-    EXPECT_EQ(dst0.rowset_id, dst_rowset);
-    EXPECT_EQ(dst0.segment_id, 0);
+    EXPECT_EQ(rowid_conversion.get_dst_rowset_id(), dst_rowset);
+    EXPECT_EQ(dst0.segment_pos, 0);
     EXPECT_EQ(dst0.row_id, 0);
     EXPECT_EQ(res, 0);
 
     src_rowset.init(0);
     RowLocation src1(src_rowset, 1, 2);
-    RowLocation dst1;
+    RowIdConversion::DestinationRowId dst1;
     res = rowid_conversion.get(src1, &dst1);
 
-    EXPECT_EQ(dst1.rowset_id, dst_rowset);
-    EXPECT_EQ(dst1.segment_id, 1);
+    EXPECT_EQ(dst1.segment_pos, 1);
     EXPECT_EQ(dst1.row_id, 2);
     EXPECT_EQ(res, 0);
 
     src_rowset.init(1);
     RowLocation src2(src_rowset, 0, 3);
-    RowLocation dst2;
+    RowIdConversion::DestinationRowId dst2;
     res = rowid_conversion.get(src2, &dst2);
 
-    EXPECT_EQ(dst2.rowset_id, dst_rowset);
-    EXPECT_EQ(dst2.segment_id, 2);
+    EXPECT_EQ(dst2.segment_pos, 2);
     EXPECT_EQ(dst2.row_id, 3);
     EXPECT_EQ(res, 0);
 
     src_rowset.init(1);
     RowLocation src3(src_rowset, 0, 4);
-    RowLocation dst3;
+    RowIdConversion::DestinationRowId dst3;
     res = rowid_conversion.get(src3, &dst3);
     EXPECT_EQ(res, -1);
 
     src_rowset.init(100);
     RowLocation src4(src_rowset, 5, 4);
-    RowLocation dst4;
+    RowIdConversion::DestinationRowId dst4;
     res = rowid_conversion.get(src4, &dst4);
     EXPECT_EQ(res, -1);
+}
+
+TEST_F(TestRowIdConversion, ConvertDestinationPositionToPhysicalSegmentId) {
+    auto tablet_schema = create_schema(UNIQUE_KEYS);
+    auto input_rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(input_rowset_meta, 2, 2);
+    RowsetId input_rowset_id;
+    input_rowset_id.init(100);
+    input_rowset_meta->set_rowset_id(input_rowset_id);
+    input_rowset_meta->set_segment_ids({10});
+    auto input_rowset =
+            std::make_shared<BetaRowset>(tablet_schema, input_rowset_meta, absolute_dir);
+
+    auto output_rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(output_rowset_meta, 2, 2);
+    RowsetId output_rowset_id;
+    output_rowset_id.init(200);
+    output_rowset_meta->set_rowset_id(output_rowset_id);
+    output_rowset_meta->set_segment_ids({100});
+    auto output_rowset =
+            std::make_shared<BetaRowset>(tablet_schema, output_rowset_meta, absolute_dir);
+
+    RowIdConversion rowid_conversion;
+    ASSERT_TRUE(rowid_conversion.init_segment_map(input_rowset_id, {10}, {1}).ok());
+    rowid_conversion.set_dst_rowset_id(output_rowset_id);
+    rowid_conversion.add({RowLocation(input_rowset_id, 10, 0)}, {1});
+
+    DeleteBitmap input_delete_bitmap(1);
+    input_delete_bitmap.add({input_rowset_id, 10, 5}, 0);
+    DeleteBitmap output_delete_bitmap(1);
+    std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>> location_map;
+    auto tablet = create_tablet(*tablet_schema, true);
+    tablet->calc_compaction_output_rowset_delete_bitmap(
+            {input_rowset}, output_rowset, rowid_conversion, 0, 10, nullptr, &location_map,
+            input_delete_bitmap, &output_delete_bitmap);
+
+    EXPECT_TRUE(output_delete_bitmap.contains({output_rowset_id, 100, 5}, 0));
+    EXPECT_FALSE(output_delete_bitmap.contains({output_rowset_id, 0, 5}, 0));
+    ASSERT_EQ(location_map.size(), 1);
+    ASSERT_EQ(location_map.at(input_rowset).size(), 1);
+    const auto& [src, dst] = location_map.at(input_rowset).front();
+    EXPECT_EQ(src.segment_id, 10);
+    EXPECT_EQ(dst.rowset_id, output_rowset_id);
+    EXPECT_EQ(dst.segment_id, 100);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -51,6 +52,7 @@
 #include "storage/data_dir.h"
 #include "storage/olap_common.h"
 #include "storage/options.h"
+#include "storage/rowset/beta_rowset_writer.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/rowset_reader.h"
@@ -59,6 +61,7 @@
 #include "storage/storage_engine.h"
 #include "storage/storage_policy.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/utils.h"
 #include "util/s3_util.h"
 
 namespace Aws {
@@ -230,6 +233,13 @@ protected:
 
 private:
     std::unique_ptr<DataDir> _data_dir;
+};
+
+class BetaRowsetWriterForTest : public BetaRowsetWriter {
+public:
+    explicit BetaRowsetWriterForTest(StorageEngine& engine) : BetaRowsetWriter(engine) {}
+
+    Status build_tmp(RowsetSharedPtr& rowset) { return _build_tmp(rowset); }
 };
 
 class S3ClientMock : public Aws::S3::S3Client {
@@ -412,6 +422,93 @@ TEST_F(BetaRowsetTest, GetIndexFileNames) {
         ASSERT_EQ(file_names[0], "540085_0.idx");
         ASSERT_EQ(file_names[1], "540085_1.idx");
     }
+}
+
+TEST_F(BetaRowsetTest, SegmentViewUsesRealSegmentId) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    schema_pb.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::V1);
+    construct_column(schema_pb.add_column(), schema_pb.add_index(), 10000, "key_index", 0, "INT",
+                     "key");
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(schema_pb);
+
+    auto rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(rowset_meta, 1, 1);
+    rowset_meta->set_segment_ids({100, 102, 105});
+
+    BetaRowset rowset(tablet_schema, rowset_meta, kTestDir);
+    auto first_seg_path = rowset.segment(0).path();
+    ASSERT_TRUE(first_seg_path.has_value()) << first_seg_path.error();
+    EXPECT_EQ(first_seg_path.value(), kTestDir + "/540085_100.dat");
+
+    auto seg = rowset.segment(1);
+    EXPECT_EQ(seg.pos(), 1);
+    EXPECT_EQ(seg.id(), 102);
+    EXPECT_EQ(seg.file_name(), "540085_102.dat");
+
+    auto seg_path = seg.path();
+    ASSERT_TRUE(seg_path.has_value()) << seg_path.error();
+    EXPECT_EQ(seg_path.value(), kTestDir + "/540085_102.dat");
+    EXPECT_EQ(seg.file_cache_key(), segment_v2::Segment::file_cache_key("540085", 102));
+
+    auto delete_bitmap_key = seg.delete_bitmap_key(7);
+    EXPECT_EQ(std::get<0>(delete_bitmap_key), rowset.rowset_id());
+    EXPECT_EQ(std::get<1>(delete_bitmap_key), 102);
+    EXPECT_EQ(std::get<2>(delete_bitmap_key), 7);
+
+    auto row_location = seg.row_location(10);
+    EXPECT_EQ(row_location.rowset_id, rowset.rowset_id());
+    EXPECT_EQ(row_location.segment_id, 102);
+    EXPECT_EQ(row_location.row_id, 10);
+
+    auto index_file_names = seg.index_file_names();
+    ASSERT_EQ(index_file_names.size(), 1);
+    EXPECT_EQ(index_file_names[0], "540085_102_10000.idx");
+
+    auto index_file_cache_key = seg.index_file_cache_key(*tablet_schema->inverted_indexes()[0]);
+    ASSERT_TRUE(index_file_cache_key.has_value()) << index_file_cache_key.error();
+    EXPECT_EQ(index_file_cache_key.value(), kTestDir + "/540085_102_10000");
+}
+
+TEST_F(BetaRowsetTest, RowsetInfoShowsExplicitSegmentIds) {
+    auto rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(rowset_meta, 1, 1);
+    rowset_meta->set_num_segments(3);
+    rowset_meta->set_segments_overlap(NONOVERLAPPING);
+
+    BetaRowset rowset(nullptr, rowset_meta, "");
+    std::string legacy_rowset_info = rowset.get_rowset_info_str();
+    EXPECT_EQ(legacy_rowset_info.find(" []"), std::string::npos);
+
+    rowset_meta->set_segment_ids({100, 101, 200});
+    EXPECT_EQ(rowset.get_rowset_info_str(), legacy_rowset_info + " [100,101,200]");
+}
+
+TEST_F(BetaRowsetTest, TmpRowsetUsesCompletedSegmentIds) {
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    create_tablet_schema(tablet_schema);
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(tablet_schema, &writer_context);
+
+    EngineOptions options;
+    StorageEngine engine(options);
+    BetaRowsetWriterForTest writer(engine);
+    ASSERT_TRUE(writer.init(writer_context).ok());
+
+    SegmentStatistics segment_statistics;
+    segment_statistics.row_num = 10;
+    ASSERT_TRUE(writer.add_segment(6, segment_statistics).ok());
+    ASSERT_TRUE(writer.add_segment(2, segment_statistics).ok());
+
+    RowsetSharedPtr tmp_rowset;
+    ASSERT_TRUE(writer.build_tmp(tmp_rowset).ok());
+    ASSERT_NE(tmp_rowset, nullptr);
+    EXPECT_EQ(tmp_rowset->num_segments(), 2);
+    EXPECT_EQ(tmp_rowset->rowset_meta()->position_of(2), 0);
+    EXPECT_EQ(tmp_rowset->rowset_meta()->position_of(6), 1);
+    EXPECT_EQ(tmp_rowset->rowset_meta()->segment_id(0), 2);
+    EXPECT_EQ(tmp_rowset->rowset_meta()->segment_id(1), 6);
 }
 
 TEST_F(BetaRowsetTest, GetSegmentNumRowsFromMeta) {

--- a/be/test/storage/rowset/rowset_meta_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_test.cpp
@@ -455,4 +455,76 @@ TEST_F(RowsetMetaTest, TestSegmentsKeyBoundsAggregationTruncation) {
     EXPECT_TRUE(rs_meta.is_segments_key_bounds_truncated());
 }
 
+TEST_F(RowsetMetaTest, TestSegmentIdsAccessors) {
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+
+    // Legacy rowset (no segment_ids) falls back to contiguous ids [0, num_segments).
+    rowset_meta.set_num_segments(3);
+    EXPECT_FALSE(rowset_meta.has_segment_ids());
+    EXPECT_EQ(rowset_meta.num_segments(), 3);
+    EXPECT_EQ(rowset_meta.segment_id(0), 0);
+    EXPECT_EQ(rowset_meta.segment_id(2), 2);
+    EXPECT_EQ(rowset_meta.position_of(2), 2);
+
+    // Non-contiguous segment_ids: position <-> real id mapping.
+    rowset_meta.set_segment_ids({0, 2, 5});
+    EXPECT_TRUE(rowset_meta.has_segment_ids());
+    EXPECT_EQ(rowset_meta.num_segments(), 3);
+    EXPECT_EQ(rowset_meta.segment_id(0), 0);
+    EXPECT_EQ(rowset_meta.segment_id(1), 2);
+    EXPECT_EQ(rowset_meta.segment_id(2), 5);
+    EXPECT_EQ(rowset_meta.position_of(0), 0);
+    EXPECT_EQ(rowset_meta.position_of(2), 1);
+    EXPECT_EQ(rowset_meta.position_of(5), 2);
+}
+
+TEST_F(RowsetMetaTest, TestSegmentIdsMustBeStrictlyIncreasing) {
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+
+    EXPECT_DEATH(rowset_meta.set_segment_ids({0, 2, 2}),
+                 "Check failed: segment_id > prev_segment_id");
+    EXPECT_DEATH(rowset_meta.set_segment_ids({0, 2, 1}),
+                 "Check failed: segment_id > prev_segment_id");
+    EXPECT_DEATH(rowset_meta.set_segment_ids({0, -1, 2}), "Check failed: segment_id >= 0");
+}
+
+TEST_F(RowsetMetaTest, TestSegmentMetaView) {
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+    rowset_meta.set_segment_ids({0, 2, 5});
+    rowset_meta.add_segments_file_size({10, 20, 30});
+    rowset_meta.set_num_segment_rows({100, 200, 300});
+
+    std::vector<KeyBoundsPB> key_bounds(3);
+    key_bounds[0].set_min_key("a");
+    key_bounds[0].set_max_key("b");
+    key_bounds[1].set_min_key("c");
+    key_bounds[1].set_max_key("d");
+    key_bounds[2].set_min_key("e");
+    key_bounds[2].set_max_key("f");
+    rowset_meta.set_segments_key_bounds(key_bounds);
+
+    auto seg = rowset_meta.segment(1);
+    EXPECT_EQ(seg.pos(), 1);
+    EXPECT_EQ(seg.id(), 2);
+    EXPECT_EQ(seg.ref().pos, 1);
+    EXPECT_EQ(seg.ref().id, 2);
+    EXPECT_EQ(seg.file_size(), 20);
+    ASSERT_TRUE(seg.has_num_rows());
+    EXPECT_EQ(seg.num_rows(), 200);
+    ASSERT_TRUE(seg.has_position_key_bounds());
+    EXPECT_EQ(seg.key_bounds().min_key(), "c");
+    EXPECT_EQ(seg.key_bounds().max_key(), "d");
+
+    std::vector<int64_t> segment_ids;
+    for (auto segment : rowset_meta.segments()) {
+        segment_ids.push_back(segment.id());
+    }
+    EXPECT_EQ(segment_ids, std::vector<int64_t>({0, 2, 5}));
+}
+
 } // namespace doris

--- a/be/test/storage/rowset/rowset_meta_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_test.cpp
@@ -509,4 +509,76 @@ TEST_F(RowsetMetaTest, TestIsSegmentsOverlapping) {
     check(3, OVERLAP_UNKNOWN, 2, 5, false, false);
 }
 
+TEST_F(RowsetMetaTest, TestSegmentIdsAccessors) {
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+
+    // Legacy rowset (no segment_ids) falls back to contiguous ids [0, num_segments).
+    rowset_meta.set_num_segments(3);
+    EXPECT_FALSE(rowset_meta.has_segment_ids());
+    EXPECT_EQ(rowset_meta.num_segments(), 3);
+    EXPECT_EQ(rowset_meta.segment_id(0), 0);
+    EXPECT_EQ(rowset_meta.segment_id(2), 2);
+    EXPECT_EQ(rowset_meta.position_of(2), 2);
+
+    // Non-contiguous segment_ids: position <-> real id mapping.
+    rowset_meta.set_segment_ids({0, 2, 5});
+    EXPECT_TRUE(rowset_meta.has_segment_ids());
+    EXPECT_EQ(rowset_meta.num_segments(), 3);
+    EXPECT_EQ(rowset_meta.segment_id(0), 0);
+    EXPECT_EQ(rowset_meta.segment_id(1), 2);
+    EXPECT_EQ(rowset_meta.segment_id(2), 5);
+    EXPECT_EQ(rowset_meta.position_of(0), 0);
+    EXPECT_EQ(rowset_meta.position_of(2), 1);
+    EXPECT_EQ(rowset_meta.position_of(5), 2);
+}
+
+TEST_F(RowsetMetaTest, TestSegmentIdsMustBeStrictlyIncreasing) {
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+
+    EXPECT_DEATH(rowset_meta.set_segment_ids({0, 2, 2}),
+                 "Check failed: segment_id > prev_segment_id");
+    EXPECT_DEATH(rowset_meta.set_segment_ids({0, 2, 1}),
+                 "Check failed: segment_id > prev_segment_id");
+    EXPECT_DEATH(rowset_meta.set_segment_ids({0, -1, 2}), "Check failed: segment_id >= 0");
+}
+
+TEST_F(RowsetMetaTest, TestSegmentMetaView) {
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+    rowset_meta.set_segment_ids({0, 2, 5});
+    rowset_meta.add_segments_file_size({10, 20, 30});
+    rowset_meta.set_num_segment_rows({100, 200, 300});
+
+    std::vector<KeyBoundsPB> key_bounds(3);
+    key_bounds[0].set_min_key("a");
+    key_bounds[0].set_max_key("b");
+    key_bounds[1].set_min_key("c");
+    key_bounds[1].set_max_key("d");
+    key_bounds[2].set_min_key("e");
+    key_bounds[2].set_max_key("f");
+    rowset_meta.set_segments_key_bounds(key_bounds);
+
+    auto seg = rowset_meta.segment(1);
+    EXPECT_EQ(seg.pos(), 1);
+    EXPECT_EQ(seg.id(), 2);
+    EXPECT_EQ(seg.ref().pos, 1);
+    EXPECT_EQ(seg.ref().id, 2);
+    EXPECT_EQ(seg.file_size(), 20);
+    ASSERT_TRUE(seg.has_num_rows());
+    EXPECT_EQ(seg.num_rows(), 200);
+    ASSERT_TRUE(seg.has_position_key_bounds());
+    EXPECT_EQ(seg.key_bounds().min_key(), "c");
+    EXPECT_EQ(seg.key_bounds().max_key(), "d");
+
+    std::vector<int64_t> segment_ids;
+    for (auto segment : rowset_meta.segments()) {
+        segment_ids.push_back(segment.id());
+    }
+    EXPECT_EQ(segment_ids, std::vector<int64_t>({0, 2, 5}));
+}
+
 } // namespace doris

--- a/be/test/storage/rowset/segment_creator_test.cpp
+++ b/be/test/storage/rowset/segment_creator_test.cpp
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/rowset/segment_creator.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "storage/rowset/beta_rowset_writer.h"
+
+namespace doris {
+
+class SegmentCreatorTest : public testing::Test {
+protected:
+    SegmentCreatorTest() : _segment_creator(_context, _segment_files, _index_files) {}
+
+    RowsetWriterContext _context;
+    SegmentFileCollection _segment_files;
+    InvertedIndexFileCollection _index_files;
+    SegmentCreator _segment_creator;
+};
+
+TEST_F(SegmentCreatorTest, AllocateWithoutLimit) {
+    _segment_creator.set_segment_start_id(10);
+
+    auto first_segment_id = _segment_creator.allocate_segment_id();
+    ASSERT_TRUE(first_segment_id.has_value()) << first_segment_id.error();
+    EXPECT_EQ(first_segment_id.value(), 10);
+
+    auto second_segment_id = _segment_creator.allocate_segment_id();
+    ASSERT_TRUE(second_segment_id.has_value()) << second_segment_id.error();
+    EXPECT_EQ(second_segment_id.value(), 11);
+}
+
+TEST_F(SegmentCreatorTest, RejectAllocationOverLimit) {
+    _segment_creator.set_segment_start_id(10, 2);
+
+    auto first_segment_id = _segment_creator.allocate_segment_id();
+    ASSERT_TRUE(first_segment_id.has_value()) << first_segment_id.error();
+    EXPECT_EQ(first_segment_id.value(), 10);
+
+    auto second_segment_id = _segment_creator.allocate_segment_id();
+    ASSERT_TRUE(second_segment_id.has_value()) << second_segment_id.error();
+    EXPECT_EQ(second_segment_id.value(), 11);
+
+    auto exceeded_segment_id = _segment_creator.allocate_segment_id();
+    ASSERT_FALSE(exceeded_segment_id.has_value());
+    EXPECT_TRUE(exceeded_segment_id.error().is<ErrorCode::TOO_MANY_SEGMENTS>());
+    EXPECT_EQ(_segment_creator.get_allocated_segment_id(), 12);
+}
+
+TEST_F(SegmentCreatorTest, RejectAllocationWithZeroLimit) {
+    _segment_creator.set_segment_start_id(10, 0);
+
+    auto segment_id = _segment_creator.allocate_segment_id();
+    ASSERT_FALSE(segment_id.has_value());
+    EXPECT_TRUE(segment_id.error().is<ErrorCode::TOO_MANY_SEGMENTS>());
+    EXPECT_EQ(_segment_creator.get_allocated_segment_id(), 10);
+}
+
+TEST_F(SegmentCreatorTest, ConcurrentAllocationRespectsLimit) {
+    constexpr int32_t kStartSegmentId = 100;
+    constexpr int32_t kMaxSegmentNum = 64;
+    constexpr int32_t kThreadNum = 8;
+    constexpr int32_t kAllocationNumPerThread = 16;
+    _segment_creator.set_segment_start_id(kStartSegmentId, kMaxSegmentNum);
+
+    std::mutex allocated_ids_lock;
+    std::vector<int32_t> allocated_ids;
+    std::atomic<int32_t> exceeded_count = 0;
+    std::atomic<int32_t> unexpected_error_count = 0;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadNum);
+    for (int32_t thread_idx = 0; thread_idx < kThreadNum; ++thread_idx) {
+        threads.emplace_back([&] {
+            for (int32_t allocation_idx = 0; allocation_idx < kAllocationNumPerThread;
+                 ++allocation_idx) {
+                auto segment_id = _segment_creator.allocate_segment_id();
+                if (segment_id.has_value()) {
+                    std::lock_guard lock(allocated_ids_lock);
+                    allocated_ids.push_back(segment_id.value());
+                } else if (segment_id.error().is<ErrorCode::TOO_MANY_SEGMENTS>()) {
+                    exceeded_count.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    unexpected_error_count.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    ASSERT_EQ(allocated_ids.size(), static_cast<size_t>(kMaxSegmentNum));
+    std::sort(allocated_ids.begin(), allocated_ids.end());
+    for (size_t index = 0; index < allocated_ids.size(); ++index) {
+        EXPECT_EQ(allocated_ids[index], kStartSegmentId + static_cast<int32_t>(index));
+    }
+    EXPECT_EQ(exceeded_count.load(std::memory_order_relaxed),
+              kThreadNum * kAllocationNumPerThread - kMaxSegmentNum);
+    EXPECT_EQ(unexpected_error_count.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(_segment_creator.get_allocated_segment_id(), kStartSegmentId + kMaxSegmentNum);
+}
+
+} // namespace doris

--- a/be/test/storage/segment/inverted_index_file_writer_test.cpp
+++ b/be/test/storage/segment/inverted_index_file_writer_test.cpp
@@ -1381,7 +1381,7 @@ public:
     int64_t num_rows_filtered() const override { return 0; }
     RowsetId rowset_id() override { return _context.rowset_id; }
     RowsetTypePB type() const override { return BETA_ROWSET; }
-    int32_t allocate_segment_id() override { return 0; }
+    Result<int32_t> allocate_segment_id() override { return 0; }
     int32_t get_allocated_segment_id() override { return 0; }
     std::shared_ptr<PartialUpdateInfo> get_partial_update_info() override { return nullptr; }
     bool is_partial_update() override { return false; }

--- a/be/test/storage/segment/inverted_index_file_writer_test.cpp
+++ b/be/test/storage/segment/inverted_index_file_writer_test.cpp
@@ -1354,7 +1354,7 @@ public:
     int64_t num_rows_filtered() const override { return 0; }
     RowsetId rowset_id() override { return _context.rowset_id; }
     RowsetTypePB type() const override { return BETA_ROWSET; }
-    int32_t allocate_segment_id() override { return 0; }
+    Result<int32_t> allocate_segment_id() override { return 0; }
     int32_t get_allocated_segment_id() override { return 0; }
     std::shared_ptr<PartialUpdateInfo> get_partial_update_info() override { return nullptr; }
     bool is_partial_update() override { return false; }

--- a/be/test/storage/tablet/tablet_meta_test.cpp
+++ b/be/test/storage/tablet/tablet_meta_test.cpp
@@ -383,13 +383,13 @@ TEST(TabletMetaTest, TestDeleteBitmap) {
         ASSERT_EQ(bm->cardinality(), 100 * (version + 1));
     }
 
-    std::vector<std::pair<RowsetId, int64_t>> rowset_ids;
+    std::vector<DeleteBitmap::RowsetIdWithSegmentIds> rowsets;
     auto rowset_id1 = RowsetId {2, 0, 1, 0};
     auto rowset_id2 = RowsetId {2, 0, 1, 1};
-    rowset_ids.emplace_back(std::make_pair(rowset_id1, 2));
-    rowset_ids.emplace_back(std::make_pair(rowset_id2, 2));
+    rowsets.emplace_back(rowset_id1, std::vector<DeleteBitmap::SegmentId> {0, 1});
+    rowsets.emplace_back(rowset_id2, std::vector<DeleteBitmap::SegmentId> {0, 1});
     DeleteBitmap subset_delete_map(10086);
-    dbmp->subset_and_agg(rowset_ids, 5, 9, &subset_delete_map);
+    dbmp->subset_and_agg(rowsets, 5, 9, &subset_delete_map);
     ASSERT_EQ(subset_delete_map.delete_bitmap.size(), 4);
 
     roaring::Roaring d;
@@ -401,6 +401,31 @@ TEST(TabletMetaTest, TestDeleteBitmap) {
     EXPECT_EQ(d.cardinality(), 500);
     subset_delete_map.get({rowset_id2, 1, 9}, &d);
     EXPECT_EQ(d.cardinality(), 500);
+}
+
+TEST(TabletMetaTest, TestDeleteBitmapSubsetAndAggWithSegmentList) {
+    DeleteBitmap delete_bitmap(10086);
+    RowsetId rowset_id {2, 0, 1, 0};
+    delete_bitmap.add({rowset_id, 0, 5}, 100);
+    delete_bitmap.add({rowset_id, 10, 5}, 101);
+    delete_bitmap.add({rowset_id, 10, 9}, 102);
+    delete_bitmap.add({rowset_id, 12, 7}, 103);
+
+    std::vector<DeleteBitmap::RowsetIdWithSegmentIds> rowsets;
+    rowsets.emplace_back(rowset_id, std::vector<DeleteBitmap::SegmentId> {10, 12});
+    DeleteBitmap subset_delete_map(10086);
+    delete_bitmap.subset_and_agg(rowsets, 5, 9, &subset_delete_map);
+
+    ASSERT_EQ(subset_delete_map.delete_bitmap.size(), 2);
+    roaring::Roaring segment_delete_bitmap;
+    ASSERT_EQ(subset_delete_map.get({rowset_id, 10, 9}, &segment_delete_bitmap), 0);
+    EXPECT_EQ(segment_delete_bitmap.cardinality(), 2);
+    EXPECT_TRUE(segment_delete_bitmap.contains(101));
+    EXPECT_TRUE(segment_delete_bitmap.contains(102));
+    ASSERT_EQ(subset_delete_map.get({rowset_id, 12, 9}, &segment_delete_bitmap), 0);
+    EXPECT_EQ(segment_delete_bitmap.cardinality(), 1);
+    EXPECT_TRUE(segment_delete_bitmap.contains(103));
+    EXPECT_NE(subset_delete_map.get({rowset_id, 0, 9}, &segment_delete_bitmap), 0);
 }
 
 } // namespace doris

--- a/be/test/testutil/index_storage_test_util.cpp
+++ b/be/test/testutil/index_storage_test_util.cpp
@@ -606,7 +606,8 @@ void collect_variant_column_layout(const ColumnMetaPB& column_meta, IndexSegment
 }
 
 Result<IndexSegmentLayout> probe_segment(const RowsetSharedPtr& rowset, int64_t segment_id) {
-    auto segment_path = rowset->segment_path(segment_id);
+    auto seg = rowset->segment(rowset->rowset_meta()->position_of(segment_id));
+    auto segment_path = seg.path();
     if (!segment_path.has_value()) {
         return ResultError(segment_path.error());
     }
@@ -616,8 +617,7 @@ Result<IndexSegmentLayout> probe_segment(const RowsetSharedPtr& rowset, int64_t 
     auto status = segment_v2::Segment::open(
             rowset->rowset_meta()->fs(), segment_path.value(), rowset->rowset_meta()->tablet_id(),
             static_cast<uint32_t>(segment_id), rowset->rowset_id(), rowset->tablet_schema(),
-            io::FileReaderOptions {}, &segment,
-            rowset->rowset_meta()->inverted_index_file_info(static_cast<int>(segment_id)), &stats);
+            io::FileReaderOptions {}, &segment, seg.inverted_index_file_info(), &stats);
     if (!status.ok()) {
         return ResultError(status);
     }
@@ -1518,8 +1518,8 @@ Result<IndexRowsetProbe> IndexStorageTestFixture::probe_rowset(const RowsetShare
     }
     probe.index_files = std::move(index_files).value();
 
-    for (int64_t segment_id = 0; segment_id < rowset->num_segments(); ++segment_id) {
-        auto segment_probe = probe_segment(rowset, segment_id);
+    for (auto seg : rowset->segments()) {
+        auto segment_probe = probe_segment(rowset, seg.id());
         if (!segment_probe.has_value()) {
             return ResultError(segment_probe.error());
         }

--- a/be/test/testutil/index_storage_test_util.cpp
+++ b/be/test/testutil/index_storage_test_util.cpp
@@ -625,7 +625,8 @@ void collect_variant_column_layout(const ColumnMetaPB& column_meta, IndexSegment
 }
 
 Result<IndexSegmentLayout> probe_segment(const RowsetSharedPtr& rowset, int64_t segment_id) {
-    auto segment_path = rowset->segment_path(segment_id);
+    auto seg = rowset->segment(rowset->rowset_meta()->position_of(segment_id));
+    auto segment_path = seg.path();
     if (!segment_path.has_value()) {
         return ResultError(segment_path.error());
     }
@@ -635,8 +636,7 @@ Result<IndexSegmentLayout> probe_segment(const RowsetSharedPtr& rowset, int64_t 
     auto status = segment_v2::Segment::open(
             rowset->rowset_meta()->fs(), segment_path.value(), rowset->rowset_meta()->tablet_id(),
             static_cast<uint32_t>(segment_id), rowset->rowset_id(), rowset->tablet_schema(),
-            io::FileReaderOptions {}, &segment,
-            rowset->rowset_meta()->inverted_index_file_info(static_cast<int>(segment_id)), &stats);
+            io::FileReaderOptions {}, &segment, seg.inverted_index_file_info(), &stats);
     if (!status.ok()) {
         return ResultError(status);
     }
@@ -1563,8 +1563,8 @@ Result<IndexRowsetProbe> IndexStorageTestFixture::probe_rowset(const RowsetShare
     }
     probe.index_files = std::move(index_files).value();
 
-    for (int64_t segment_id = 0; segment_id < rowset->num_segments(); ++segment_id) {
-        auto segment_probe = probe_segment(rowset, segment_id);
+    for (auto seg : rowset->segments()) {
+        auto segment_probe = probe_segment(rowset, seg.id());
         if (!segment_probe.has_value()) {
             return ResultError(segment_probe.error());
         }

--- a/cloud/src/common/rowset_segment_id.h
+++ b/cloud/src/common/rowset_segment_id.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <cstdint>
+
+namespace doris::cloud {
+
+template <typename RowsetMetaPB>
+int64_t rowset_segment_id(const RowsetMetaPB& rowset_meta, int64_t pos) {
+    DCHECK_GE(pos, 0);
+    DCHECK_LT(pos, rowset_meta.num_segments());
+    if (rowset_meta.segment_ids_size() == 0) {
+        return pos;
+    }
+    DCHECK_EQ(rowset_meta.segment_ids_size(), rowset_meta.num_segments());
+    return rowset_meta.segment_ids(static_cast<int>(pos));
+}
+
+} // namespace doris::cloud

--- a/cloud/src/recycler/checker.cpp
+++ b/cloud/src/recycler/checker.cpp
@@ -46,6 +46,7 @@
 #include "common/defer.h"
 #include "common/encryption_util.h"
 #include "common/logging.h"
+#include "common/rowset_segment_id.h"
 #include "common/util.h"
 #include "cpp/sync_point.h"
 #include "meta-service/meta_service.h"
@@ -710,7 +711,8 @@ int InstanceChecker::do_check() {
         }
 
         for (int i = 0; i < rs_meta.num_segments(); ++i) {
-            auto path = segment_path(rs_meta.tablet_id(), rs_meta.rowset_id_v2(), i);
+            auto segment_id = rowset_segment_id(rs_meta, i);
+            auto path = segment_path(rs_meta.tablet_id(), rs_meta.rowset_id_v2(), segment_id);
 
             // Skip check if segment is already packed into a larger file
             const auto& index_map = rs_meta.packed_slice_locations();
@@ -778,20 +780,21 @@ int InstanceChecker::do_check() {
                             ? rs_meta.inverted_index_storage_format()
                             : rs_meta.tablet_schema().inverted_index_storage_format();
             for (int i = 0; i < rs_meta.num_segments(); ++i) {
+                auto segment_id = rowset_segment_id(rs_meta, i);
                 std::vector<std::string> index_path_v;
                 if (index_format == InvertedIndexStorageFormatPB::V1) {
                     for (const auto& index_id : index_ids) {
                         LOG(INFO) << "check inverted index, tablet_id=" << rs_meta.tablet_id()
-                                  << " rowset_id=" << rs_meta.rowset_id_v2() << " segment_id=" << i
-                                  << " index_id=" << index_id.first
+                                  << " rowset_id=" << rs_meta.rowset_id_v2()
+                                  << " segment_id=" << segment_id << " index_id=" << index_id.first
                                   << " index_suffix_name=" << index_id.second;
-                        index_path_v.emplace_back(
-                                inverted_index_path_v1(rs_meta.tablet_id(), rs_meta.rowset_id_v2(),
-                                                       i, index_id.first, index_id.second));
+                        index_path_v.emplace_back(inverted_index_path_v1(
+                                rs_meta.tablet_id(), rs_meta.rowset_id_v2(), segment_id,
+                                index_id.first, index_id.second));
                     }
                 } else {
-                    index_path_v.emplace_back(
-                            inverted_index_path_v2(rs_meta.tablet_id(), rs_meta.rowset_id_v2(), i));
+                    index_path_v.emplace_back(inverted_index_path_v2(
+                            rs_meta.tablet_id(), rs_meta.rowset_id_v2(), segment_id));
                 }
 
                 if (std::ranges::all_of(index_path_v, [&](const auto& idx_file_path) {
@@ -1643,8 +1646,8 @@ int InstanceChecker::check_inverted_index_file_storage_format_v1(
                 return -1;
             }
 
-            for (size_t i = 0; i < rs_meta.num_segments(); i++) {
-                rowset_index_cache_v1.segment_ids.insert(i);
+            for (int64_t i = 0; i < rs_meta.num_segments(); i++) {
+                rowset_index_cache_v1.segment_ids.insert(rowset_segment_id(rs_meta, i));
             }
 
             for (const auto& i : rs_meta.tablet_schema().index()) {
@@ -1744,8 +1747,8 @@ int InstanceChecker::check_inverted_index_file_storage_format_v2(
                 return -1;
             }
 
-            for (size_t i = 0; i < rs_meta.num_segments(); i++) {
-                rowset_index_cache_v2.segment_ids.insert(i);
+            for (int64_t i = 0; i < rs_meta.num_segments(); i++) {
+                rowset_index_cache_v2.segment_ids.insert(rowset_segment_id(rs_meta, i));
             }
 
             if (!it->has_next()) {

--- a/cloud/src/recycler/checker.cpp
+++ b/cloud/src/recycler/checker.cpp
@@ -45,6 +45,7 @@
 #include "common/defer.h"
 #include "common/encryption_util.h"
 #include "common/logging.h"
+#include "common/rowset_segment_id.h"
 #include "common/util.h"
 #include "cpp/sync_point.h"
 #include "meta-service/meta_service.h"
@@ -651,7 +652,8 @@ int InstanceChecker::do_check() {
         }
 
         for (int i = 0; i < rs_meta.num_segments(); ++i) {
-            auto path = segment_path(rs_meta.tablet_id(), rs_meta.rowset_id_v2(), i);
+            auto segment_id = rowset_segment_id(rs_meta, i);
+            auto path = segment_path(rs_meta.tablet_id(), rs_meta.rowset_id_v2(), segment_id);
 
             // Skip check if segment is already packed into a larger file
             const auto& index_map = rs_meta.packed_slice_locations();
@@ -715,21 +717,22 @@ int InstanceChecker::do_check() {
         if (!index_ids.empty()) {
             const auto& index_map = rs_meta.packed_slice_locations();
             for (int i = 0; i < rs_meta.num_segments(); ++i) {
+                auto segment_id = rowset_segment_id(rs_meta, i);
                 std::vector<std::string> index_path_v;
                 if (rs_meta.tablet_schema().inverted_index_storage_format() ==
                     InvertedIndexStorageFormatPB::V1) {
                     for (const auto& index_id : index_ids) {
                         LOG(INFO) << "check inverted index, tablet_id=" << rs_meta.tablet_id()
-                                  << " rowset_id=" << rs_meta.rowset_id_v2() << " segment_id=" << i
-                                  << " index_id=" << index_id.first
+                                  << " rowset_id=" << rs_meta.rowset_id_v2()
+                                  << " segment_id=" << segment_id << " index_id=" << index_id.first
                                   << " index_suffix_name=" << index_id.second;
-                        index_path_v.emplace_back(
-                                inverted_index_path_v1(rs_meta.tablet_id(), rs_meta.rowset_id_v2(),
-                                                       i, index_id.first, index_id.second));
+                        index_path_v.emplace_back(inverted_index_path_v1(
+                                rs_meta.tablet_id(), rs_meta.rowset_id_v2(), segment_id,
+                                index_id.first, index_id.second));
                     }
                 } else {
-                    index_path_v.emplace_back(
-                            inverted_index_path_v2(rs_meta.tablet_id(), rs_meta.rowset_id_v2(), i));
+                    index_path_v.emplace_back(inverted_index_path_v2(
+                            rs_meta.tablet_id(), rs_meta.rowset_id_v2(), segment_id));
                 }
 
                 if (std::ranges::all_of(index_path_v, [&](const auto& idx_file_path) {
@@ -1581,8 +1584,8 @@ int InstanceChecker::check_inverted_index_file_storage_format_v1(
                 return -1;
             }
 
-            for (size_t i = 0; i < rs_meta.num_segments(); i++) {
-                rowset_index_cache_v1.segment_ids.insert(i);
+            for (int64_t i = 0; i < rs_meta.num_segments(); i++) {
+                rowset_index_cache_v1.segment_ids.insert(rowset_segment_id(rs_meta, i));
             }
 
             for (const auto& i : rs_meta.tablet_schema().index()) {
@@ -1682,8 +1685,8 @@ int InstanceChecker::check_inverted_index_file_storage_format_v2(
                 return -1;
             }
 
-            for (size_t i = 0; i < rs_meta.num_segments(); i++) {
-                rowset_index_cache_v2.segment_ids.insert(i);
+            for (int64_t i = 0; i < rs_meta.num_segments(); i++) {
+                rowset_index_cache_v2.segment_ids.insert(rowset_segment_id(rs_meta, i));
             }
 
             if (!it->has_next()) {

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -69,6 +69,7 @@
 #include "common/config.h"
 #include "common/encryption_util.h"
 #include "common/logging.h"
+#include "common/rowset_segment_id.h"
 #include "common/simple_thread_pool.h"
 #include "common/util.h"
 #include "cpp/sync_point.h"
@@ -3834,19 +3835,21 @@ int InstanceRecycler::delete_rowset_data(const RowsetMetaCloudPB& rs_meta_pb) {
     int64_t tablet_id = rs_meta_pb.tablet_id();
     const auto& rowset_id = rs_meta_pb.rowset_id_v2();
     for (int64_t i = 0; i < num_segments; ++i) {
-        add_file_to_delete_if_not_packed(rs_meta_pb, segment_path(tablet_id, rowset_id, i),
+        auto segment_id = rowset_segment_id(rs_meta_pb, i);
+        add_file_to_delete_if_not_packed(rs_meta_pb, segment_path(tablet_id, rowset_id, segment_id),
                                          &file_paths);
         if (index_format == InvertedIndexStorageFormatPB::V1) {
             for (const auto& index_id : index_ids) {
                 add_file_to_delete_if_not_packed(
                         rs_meta_pb,
-                        inverted_index_path_v1(tablet_id, rowset_id, i, index_id.first,
+                        inverted_index_path_v1(tablet_id, rowset_id, segment_id, index_id.first,
                                                index_id.second),
                         &file_paths);
             }
         } else if (!index_ids.empty()) {
             add_file_to_delete_if_not_packed(
-                    rs_meta_pb, inverted_index_path_v2(tablet_id, rowset_id, i), &file_paths);
+                    rs_meta_pb, inverted_index_path_v2(tablet_id, rowset_id, segment_id),
+                    &file_paths);
         }
     }
 
@@ -4595,13 +4598,14 @@ int InstanceRecycler::delete_rowset_data(
             continue;
         }
         for (int64_t i = 0; i < num_segments; ++i) {
-            add_file_to_delete_if_not_packed(rs, segment_path(tablet_id, rowset_id, i),
+            auto segment_id = rowset_segment_id(rs, i);
+            add_file_to_delete_if_not_packed(rs, segment_path(tablet_id, rowset_id, segment_id),
                                              &file_paths);
             if (index_format == InvertedIndexStorageFormatPB::V1) {
                 for (const auto& index_id : index_ids) {
                     add_file_to_delete_if_not_packed(
                             rs,
-                            inverted_index_path_v1(tablet_id, rowset_id, i, index_id.first,
+                            inverted_index_path_v1(tablet_id, rowset_id, segment_id, index_id.first,
                                                    index_id.second),
                             &file_paths);
                 }
@@ -4613,10 +4617,10 @@ int InstanceRecycler::delete_rowset_data(
                     LOG_INFO("delete rowset data schema kv not found, try to delete index file")
                             .tag("instance_id", instance_id_)
                             .tag("inverted index v2 path",
-                                 inverted_index_path_v2(tablet_id, rowset_id, i));
+                                 inverted_index_path_v2(tablet_id, rowset_id, segment_id));
                 }
                 add_file_to_delete_if_not_packed(
-                        rs, inverted_index_path_v2(tablet_id, rowset_id, i), &file_paths);
+                        rs, inverted_index_path_v2(tablet_id, rowset_id, segment_id), &file_paths);
             }
         }
     }

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -68,6 +68,7 @@
 #include "common/config.h"
 #include "common/encryption_util.h"
 #include "common/logging.h"
+#include "common/rowset_segment_id.h"
 #include "common/simple_thread_pool.h"
 #include "common/util.h"
 #include "cpp/sync_point.h"
@@ -3190,19 +3191,21 @@ int InstanceRecycler::delete_rowset_data(const RowsetMetaCloudPB& rs_meta_pb) {
     int64_t tablet_id = rs_meta_pb.tablet_id();
     const auto& rowset_id = rs_meta_pb.rowset_id_v2();
     for (int64_t i = 0; i < num_segments; ++i) {
-        add_file_to_delete_if_not_packed(rs_meta_pb, segment_path(tablet_id, rowset_id, i),
+        auto segment_id = rowset_segment_id(rs_meta_pb, i);
+        add_file_to_delete_if_not_packed(rs_meta_pb, segment_path(tablet_id, rowset_id, segment_id),
                                          &file_paths);
         if (index_format == InvertedIndexStorageFormatPB::V1) {
             for (const auto& index_id : index_ids) {
                 add_file_to_delete_if_not_packed(
                         rs_meta_pb,
-                        inverted_index_path_v1(tablet_id, rowset_id, i, index_id.first,
+                        inverted_index_path_v1(tablet_id, rowset_id, segment_id, index_id.first,
                                                index_id.second),
                         &file_paths);
             }
         } else if (!index_ids.empty()) {
             add_file_to_delete_if_not_packed(
-                    rs_meta_pb, inverted_index_path_v2(tablet_id, rowset_id, i), &file_paths);
+                    rs_meta_pb, inverted_index_path_v2(tablet_id, rowset_id, segment_id),
+                    &file_paths);
         }
     }
 
@@ -3946,13 +3949,14 @@ int InstanceRecycler::delete_rowset_data(
             continue;
         }
         for (int64_t i = 0; i < num_segments; ++i) {
-            add_file_to_delete_if_not_packed(rs, segment_path(tablet_id, rowset_id, i),
+            auto segment_id = rowset_segment_id(rs, i);
+            add_file_to_delete_if_not_packed(rs, segment_path(tablet_id, rowset_id, segment_id),
                                              &file_paths);
             if (index_format == InvertedIndexStorageFormatPB::V1) {
                 for (const auto& index_id : index_ids) {
                     add_file_to_delete_if_not_packed(
                             rs,
-                            inverted_index_path_v1(tablet_id, rowset_id, i, index_id.first,
+                            inverted_index_path_v1(tablet_id, rowset_id, segment_id, index_id.first,
                                                    index_id.second),
                             &file_paths);
                 }
@@ -3964,10 +3968,10 @@ int InstanceRecycler::delete_rowset_data(
                     LOG_INFO("delete rowset data schema kv not found, try to delete index file")
                             .tag("instance_id", instance_id_)
                             .tag("inverted index v2 path",
-                                 inverted_index_path_v2(tablet_id, rowset_id, i));
+                                 inverted_index_path_v2(tablet_id, rowset_id, segment_id));
                 }
                 add_file_to_delete_if_not_packed(
-                        rs, inverted_index_path_v2(tablet_id, rowset_id, i), &file_paths);
+                        rs, inverted_index_path_v2(tablet_id, rowset_id, segment_id), &file_paths);
             }
         }
     }

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -7681,6 +7681,88 @@ TEST(RecyclerTest, delete_rowset_data) {
     }
 }
 
+TEST(RecyclerTest, delete_v2_inverted_index_with_segment_list) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    constexpr std::string_view resource_id = "delete_v2_index_with_segment_list";
+    InstanceInfoPB instance;
+    instance.set_instance_id(instance_id);
+    auto obj_info = instance.add_obj_info();
+    obj_info->set_id(std::string(resource_id));
+    obj_info->set_ak(config::test_s3_ak);
+    obj_info->set_sk(config::test_s3_sk);
+    obj_info->set_endpoint(config::test_s3_endpoint);
+    obj_info->set_region(config::test_s3_region);
+    obj_info->set_bucket(config::test_s3_bucket);
+    obj_info->set_prefix(std::string(resource_id));
+
+    InstanceRecycler recycler(txn_kv, instance, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    auto accessor = recycler.accessor_map_.begin()->second;
+
+    doris::TabletSchemaCloudPB schema;
+    schema.set_schema_version(1);
+    schema.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::V2);
+    auto index = schema.add_index();
+    index->set_index_id(100);
+    index->set_index_type(IndexType::INVERTED);
+
+    constexpr int num_segments = 2;
+    constexpr std::array<int64_t, num_segments> segment_ids = {10, 12};
+    auto rowset = create_rowset(std::string(resource_id), 10002, 10001, num_segments, schema);
+    for (auto segment_id : segment_ids) {
+        rowset.add_segment_ids(segment_id);
+        ASSERT_EQ(accessor->put_file(
+                          segment_path(rowset.tablet_id(), rowset.rowset_id_v2(), segment_id), ""),
+                  0);
+        ASSERT_EQ(accessor->put_file(inverted_index_path_v2(rowset.tablet_id(),
+                                                            rowset.rowset_id_v2(), segment_id),
+                                     ""),
+                  0);
+    }
+
+    ASSERT_EQ(recycler.delete_rowset_data(rowset), 0);
+    for (auto segment_id : segment_ids) {
+        EXPECT_EQ(accessor->exists(
+                          segment_path(rowset.tablet_id(), rowset.rowset_id_v2(), segment_id)),
+                  1);
+        EXPECT_EQ(accessor->exists(inverted_index_path_v2(rowset.tablet_id(), rowset.rowset_id_v2(),
+                                                          segment_id)),
+                  1);
+    }
+
+    auto batch_rowset = create_rowset(std::string(resource_id), 10003, 10001, num_segments, schema);
+    for (auto segment_id : segment_ids) {
+        batch_rowset.add_segment_ids(segment_id);
+        ASSERT_EQ(accessor->put_file(segment_path(batch_rowset.tablet_id(),
+                                                  batch_rowset.rowset_id_v2(), segment_id),
+                                     ""),
+                  0);
+        ASSERT_EQ(
+                accessor->put_file(inverted_index_path_v2(batch_rowset.tablet_id(),
+                                                          batch_rowset.rowset_id_v2(), segment_id),
+                                   ""),
+                0);
+    }
+
+    std::map<std::string, doris::RowsetMetaCloudPB> rowsets;
+    rowsets.emplace(batch_rowset.rowset_id_v2(), batch_rowset);
+    RecyclerMetricsContext metrics_context;
+    ASSERT_EQ(recycler.delete_rowset_data(rowsets, RowsetRecyclingState::FORMAL_ROWSET,
+                                          metrics_context),
+              0);
+    for (auto segment_id : segment_ids) {
+        EXPECT_EQ(accessor->exists(segment_path(batch_rowset.tablet_id(),
+                                                batch_rowset.rowset_id_v2(), segment_id)),
+                  1);
+        EXPECT_EQ(accessor->exists(inverted_index_path_v2(batch_rowset.tablet_id(),
+                                                          batch_rowset.rowset_id_v2(), segment_id)),
+                  1);
+    }
+}
+
 TEST(RecyclerTest, delete_rowset_data_without_delete_bitmap_meta) {
     auto txn_kv = std::make_shared<MemTxnKv>();
     ASSERT_EQ(txn_kv->init(), 0);

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -6134,6 +6134,88 @@ TEST(RecyclerTest, delete_rowset_data) {
     }
 }
 
+TEST(RecyclerTest, delete_v2_inverted_index_with_segment_list) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    constexpr std::string_view resource_id = "delete_v2_index_with_segment_list";
+    InstanceInfoPB instance;
+    instance.set_instance_id(instance_id);
+    auto obj_info = instance.add_obj_info();
+    obj_info->set_id(std::string(resource_id));
+    obj_info->set_ak(config::test_s3_ak);
+    obj_info->set_sk(config::test_s3_sk);
+    obj_info->set_endpoint(config::test_s3_endpoint);
+    obj_info->set_region(config::test_s3_region);
+    obj_info->set_bucket(config::test_s3_bucket);
+    obj_info->set_prefix(std::string(resource_id));
+
+    InstanceRecycler recycler(txn_kv, instance, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    auto accessor = recycler.accessor_map_.begin()->second;
+
+    doris::TabletSchemaCloudPB schema;
+    schema.set_schema_version(1);
+    schema.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::V2);
+    auto index = schema.add_index();
+    index->set_index_id(100);
+    index->set_index_type(IndexType::INVERTED);
+
+    constexpr int num_segments = 2;
+    constexpr std::array<int64_t, num_segments> segment_ids = {10, 12};
+    auto rowset = create_rowset(std::string(resource_id), 10002, 10001, num_segments, schema);
+    for (auto segment_id : segment_ids) {
+        rowset.add_segment_ids(segment_id);
+        ASSERT_EQ(accessor->put_file(
+                          segment_path(rowset.tablet_id(), rowset.rowset_id_v2(), segment_id), ""),
+                  0);
+        ASSERT_EQ(accessor->put_file(inverted_index_path_v2(rowset.tablet_id(),
+                                                            rowset.rowset_id_v2(), segment_id),
+                                     ""),
+                  0);
+    }
+
+    ASSERT_EQ(recycler.delete_rowset_data(rowset), 0);
+    for (auto segment_id : segment_ids) {
+        EXPECT_EQ(accessor->exists(
+                          segment_path(rowset.tablet_id(), rowset.rowset_id_v2(), segment_id)),
+                  1);
+        EXPECT_EQ(accessor->exists(inverted_index_path_v2(rowset.tablet_id(), rowset.rowset_id_v2(),
+                                                          segment_id)),
+                  1);
+    }
+
+    auto batch_rowset = create_rowset(std::string(resource_id), 10003, 10001, num_segments, schema);
+    for (auto segment_id : segment_ids) {
+        batch_rowset.add_segment_ids(segment_id);
+        ASSERT_EQ(accessor->put_file(segment_path(batch_rowset.tablet_id(),
+                                                  batch_rowset.rowset_id_v2(), segment_id),
+                                     ""),
+                  0);
+        ASSERT_EQ(
+                accessor->put_file(inverted_index_path_v2(batch_rowset.tablet_id(),
+                                                          batch_rowset.rowset_id_v2(), segment_id),
+                                   ""),
+                0);
+    }
+
+    std::map<std::string, doris::RowsetMetaCloudPB> rowsets;
+    rowsets.emplace(batch_rowset.rowset_id_v2(), batch_rowset);
+    RecyclerMetricsContext metrics_context;
+    ASSERT_EQ(recycler.delete_rowset_data(rowsets, RowsetRecyclingState::FORMAL_ROWSET,
+                                          metrics_context),
+              0);
+    for (auto segment_id : segment_ids) {
+        EXPECT_EQ(accessor->exists(segment_path(batch_rowset.tablet_id(),
+                                                batch_rowset.rowset_id_v2(), segment_id)),
+                  1);
+        EXPECT_EQ(accessor->exists(inverted_index_path_v2(batch_rowset.tablet_id(),
+                                                          batch_rowset.rowset_id_v2(), segment_id)),
+                  1);
+    }
+}
+
 TEST(RecyclerTest, delete_rowset_data_without_delete_bitmap_meta) {
     auto txn_kv = std::make_shared<MemTxnKv>();
     ASSERT_EQ(txn_kv->init(), 0);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -949,6 +949,7 @@ message RecycleCacheMeta {
     optional string rowset_id = 2;
     optional int64 num_segments = 3;
     repeated string index_file_names = 4;
+    repeated int64 segment_ids = 5;
 }
 
 message PRecycleCacheRequest {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -948,6 +948,7 @@ message RecycleCacheMeta {
     optional string rowset_id = 2;
     optional int64 num_segments = 3;
     repeated string index_file_names = 4;
+    repeated int64 segment_ids = 5;
 }
 
 message PRecycleCacheRequest {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -115,7 +115,7 @@ message RowsetMetaPB {
     // For alpha rowset, it's the same as PDelta.creation_time
     optional int64 creation_time = 20;
     optional PUniqueId tablet_uid = 21;
-    // total number of segments
+    // total number of segments. If segment_ids is set, this is segment_ids.size().
     optional int64 num_segments = 22;
     // rowset id definition, it will replace required rowset id 
     optional string rowset_id_v2 = 23;
@@ -126,6 +126,7 @@ message RowsetMetaPB {
     // latest write time
     optional int64 newest_write_timestamp = 26 [default = -1];
     // the encoded segment min/max key of segments in this rowset,
+    // If segment_ids is set, the i-th entry belongs to segment_ids[i].
     // ATTN: segments_key_bounds may be truncated! please refer to field `segments_key_bounds_truncated`
     // to check if these are truncated segments key bounds
     repeated KeyBoundsPB segments_key_bounds = 27;
@@ -142,7 +143,7 @@ message RowsetMetaPB {
     // indicate that whether the segments key bounds is truncated
     optional bool segments_key_bounds_truncated = 55;
 
-    // rows count for each segment
+    // rows count for each segment. If segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 num_segment_rows = 56;
 
     // If true, `segments_key_bounds` contains a single aggregated
@@ -155,7 +156,7 @@ message RowsetMetaPB {
     // For cloud
     // for data recycling
     optional int64 txn_expiration = 1000;
-    // the field is a vector, rename it
+    // The field is a vector; if segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 segments_file_size = 1001;
     // index_id, schema_version -> schema
     optional int64 index_id = 1002;
@@ -186,6 +187,11 @@ message RowsetMetaPB {
     // Actual inverted-index format used by this rowset's files. It is independent
     // from the shared (index_id, schema_version) schema key.
     optional InvertedIndexStorageFormatPB inverted_index_storage_format = 1018;
+
+    // For cloud segment-list rowset layout.
+    // Real segment ids in rowset position order. Empty means legacy continuous ids [0, num_segments).
+    repeated int64 segment_ids = 200;
+
 }
 
 message SchemaDictKeyList {
@@ -233,7 +239,7 @@ message RowsetMetaCloudPB {
     // For alpha rowset, it's the same as PDelta.creation_time
     optional int64 creation_time = 20;
     optional PUniqueId tablet_uid = 21;
-    // total number of segments
+    // total number of segments. If segment_ids is set, this is segment_ids.size().
     optional int64 num_segments = 22;
     // rowset id definition, it will replace required rowset id
     optional string rowset_id_v2 = 23;
@@ -244,6 +250,7 @@ message RowsetMetaCloudPB {
     // latest write time
     optional int64 newest_write_timestamp = 26 [default = -1];
     // the encoded segment min/max key of segments in this rowset,
+    // If segment_ids is set, the i-th entry belongs to segment_ids[i].
     // ATTN: segments_key_bounds may be truncated! please refer to field `segments_key_bounds_truncated`
     // to check if these are truncated segments key bounds
     repeated KeyBoundsPB segments_key_bounds = 27;
@@ -262,7 +269,7 @@ message RowsetMetaCloudPB {
     // indicate that whether the segments key bounds is truncated
     optional bool segments_key_bounds_truncated = 55;
 
-    // rows count for each segment
+    // rows count for each segment. If segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 num_segment_rows = 56;
 
     // If true, `segments_key_bounds` contains a single aggregated
@@ -273,7 +280,7 @@ message RowsetMetaCloudPB {
     optional bool is_row_binlog = 58 [default = false];
 
     // cloud
-    // the field is a vector, rename it
+    // The field is a vector; if segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 segments_file_size = 100;
     // index_id, schema_version -> schema
     optional int64 index_id = 101;
@@ -307,6 +314,10 @@ message RowsetMetaCloudPB {
     // Actual inverted-index format used by this rowset's files. It is independent
     // from the shared (index_id, schema_version) schema key.
     optional InvertedIndexStorageFormatPB inverted_index_storage_format = 117;
+    // For cloud segment-list rowset layout.
+    // Real segment ids in rowset position order. Empty means legacy continuous ids [0, num_segments).
+    repeated int64 segment_ids = 200;
+
 }
 
 message SegmentStatisticsPB {
@@ -316,7 +327,8 @@ message SegmentStatisticsPB {
     optional KeyBoundsPB key_bounds = 4;
 }
 
-// kv value for reclaiming remote rowset
+// Local-mode only kv value for reclaiming remote rowset.
+// Cloud segment-list rowset layout does not use this metadata, so segment_ids is not needed here.
 message RemoteRowsetGcPB {
     required string resource_id = 1;
     required int64 tablet_id = 2;
@@ -816,6 +828,8 @@ message DeleteBitmapPB {
     repeated bytes segment_delete_bitmaps = 4;
 }
 
+// Local-mode only binlog metadata.
+// Cloud segment-list rowset layout does not use this metadata, so segment_ids is not needed here.
 message BinlogMetaEntryPB {
     optional int64 version = 1;
     optional int64 tablet_id = 2;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -115,7 +115,7 @@ message RowsetMetaPB {
     // For alpha rowset, it's the same as PDelta.creation_time
     optional int64 creation_time = 20;
     optional PUniqueId tablet_uid = 21;
-    // total number of segments
+    // total number of segments. If segment_ids is set, this is segment_ids.size().
     optional int64 num_segments = 22;
     // rowset id definition, it will replace required rowset id 
     optional string rowset_id_v2 = 23;
@@ -126,6 +126,7 @@ message RowsetMetaPB {
     // latest write time
     optional int64 newest_write_timestamp = 26 [default = -1];
     // the encoded segment min/max key of segments in this rowset,
+    // If segment_ids is set, the i-th entry belongs to segment_ids[i].
     // ATTN: segments_key_bounds may be truncated! please refer to field `segments_key_bounds_truncated`
     // to check if these are truncated segments key bounds
     repeated KeyBoundsPB segments_key_bounds = 27;
@@ -142,7 +143,7 @@ message RowsetMetaPB {
     // indicate that whether the segments key bounds is truncated
     optional bool segments_key_bounds_truncated = 55;
 
-    // rows count for each segment
+    // rows count for each segment. If segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 num_segment_rows = 56;
 
     // If true, `segments_key_bounds` contains a single aggregated
@@ -155,7 +156,7 @@ message RowsetMetaPB {
     // For cloud
     // for data recycling
     optional int64 txn_expiration = 1000;
-    // the field is a vector, rename it
+    // The field is a vector; if segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 segments_file_size = 1001;
     // index_id, schema_version -> schema
     optional int64 index_id = 1002;
@@ -183,6 +184,11 @@ message RowsetMetaPB {
     // For row binlog LSN allocation (FE auto-inc RPC)
     optional int64 db_id = 1016;
     optional int64 table_id = 1017;
+
+    // For cloud segment-list rowset layout.
+    // Real segment ids in rowset position order. Empty means legacy continuous ids [0, num_segments).
+    repeated int64 segment_ids = 200;
+
 }
 
 message SchemaDictKeyList {
@@ -230,7 +236,7 @@ message RowsetMetaCloudPB {
     // For alpha rowset, it's the same as PDelta.creation_time
     optional int64 creation_time = 20;
     optional PUniqueId tablet_uid = 21;
-    // total number of segments
+    // total number of segments. If segment_ids is set, this is segment_ids.size().
     optional int64 num_segments = 22;
     // rowset id definition, it will replace required rowset id
     optional string rowset_id_v2 = 23;
@@ -241,6 +247,7 @@ message RowsetMetaCloudPB {
     // latest write time
     optional int64 newest_write_timestamp = 26 [default = -1];
     // the encoded segment min/max key of segments in this rowset,
+    // If segment_ids is set, the i-th entry belongs to segment_ids[i].
     // ATTN: segments_key_bounds may be truncated! please refer to field `segments_key_bounds_truncated`
     // to check if these are truncated segments key bounds
     repeated KeyBoundsPB segments_key_bounds = 27;
@@ -259,7 +266,7 @@ message RowsetMetaCloudPB {
     // indicate that whether the segments key bounds is truncated
     optional bool segments_key_bounds_truncated = 55;
 
-    // rows count for each segment
+    // rows count for each segment. If segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 num_segment_rows = 56;
 
     // If true, `segments_key_bounds` contains a single aggregated
@@ -270,7 +277,7 @@ message RowsetMetaCloudPB {
     optional bool is_row_binlog = 58 [default = false];
 
     // cloud
-    // the field is a vector, rename it
+    // The field is a vector; if segment_ids is set, the i-th entry belongs to segment_ids[i].
     repeated int64 segments_file_size = 100;
     // index_id, schema_version -> schema
     optional int64 index_id = 101;
@@ -301,6 +308,10 @@ message RowsetMetaCloudPB {
     optional int64 db_id = 115;
     optional int64 table_id = 116;
 
+    // For cloud segment-list rowset layout.
+    // Real segment ids in rowset position order. Empty means legacy continuous ids [0, num_segments).
+    repeated int64 segment_ids = 200;
+
 }
 
 message SegmentStatisticsPB {
@@ -310,7 +321,8 @@ message SegmentStatisticsPB {
     optional KeyBoundsPB key_bounds = 4;
 }
 
-// kv value for reclaiming remote rowset
+// Local-mode only kv value for reclaiming remote rowset.
+// Cloud segment-list rowset layout does not use this metadata, so segment_ids is not needed here.
 message RemoteRowsetGcPB {
     required string resource_id = 1;
     required int64 tablet_id = 2;
@@ -799,6 +811,8 @@ message DeleteBitmapPB {
     repeated bool is_binlog_delvec = 5;
 }
 
+// Local-mode only binlog metadata.
+// Cloud segment-list rowset layout does not use this metadata, so segment_ids is not needed here.
 message BinlogMetaEntryPB {
     optional int64 version = 1;
     optional int64 tablet_id = 2;

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/RowsetInfoUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/RowsetInfoUtils.groovy
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.regression.util
+
+class RowsetInfoUtils {
+    private static final int LEGACY_FIELD_COUNT = 8
+    private static final int SEGMENT_LIST_FIELD_COUNT = 9
+    private static final int DATA_SIZE_FIELD_INDEX = 5
+    private static final int DATA_SIZE_UNIT_FIELD_INDEX = 6
+    private static final int COMPACTION_LEVEL_FIELD_INDEX = 7
+    private static final String COMPACTION_LEVEL_PATTERN = /level=[0-9]+/
+    private static final String SEGMENT_LIST_PATTERN = /\[[0-9]+(?:,[0-9]+)*\]/
+
+    static List<String> dataSizeFields(String rowsetInfo) {
+        String[] fields = rowsetInfo.split(" ")
+        if (fields.length != LEGACY_FIELD_COUNT && fields.length != SEGMENT_LIST_FIELD_COUNT) {
+            throw new IllegalArgumentException("Unexpected rowset info: ${rowsetInfo}")
+        }
+        if (!(fields[COMPACTION_LEVEL_FIELD_INDEX] ==~ COMPACTION_LEVEL_PATTERN)) {
+            throw new IllegalArgumentException("Unexpected compaction level in rowset info: ${rowsetInfo}")
+        }
+        if (fields.length == SEGMENT_LIST_FIELD_COUNT &&
+                !(fields[-1] ==~ SEGMENT_LIST_PATTERN)) {
+            throw new IllegalArgumentException("Unexpected segment list in rowset info: ${rowsetInfo}")
+        }
+        return [fields[DATA_SIZE_FIELD_INDEX], fields[DATA_SIZE_UNIT_FIELD_INDEX]]
+    }
+}

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/RowsetInfoUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/RowsetInfoUtils.groovy
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.regression.util
+
+class RowsetInfoUtils {
+    private static final int LEGACY_FIELD_COUNT = 7
+    private static final int SEGMENT_LIST_FIELD_COUNT = 8
+    private static final int DATA_SIZE_FIELD_INDEX = 5
+    private static final int DATA_SIZE_UNIT_FIELD_INDEX = 6
+    private static final String SEGMENT_LIST_PATTERN = /\[[0-9]+(?:,[0-9]+)*\]/
+
+    static List<String> dataSizeFields(String rowsetInfo) {
+        String[] fields = rowsetInfo.split(" ")
+        if (fields.length != LEGACY_FIELD_COUNT && fields.length != SEGMENT_LIST_FIELD_COUNT) {
+            throw new IllegalArgumentException("Unexpected rowset info: ${rowsetInfo}")
+        }
+        if (fields.length == SEGMENT_LIST_FIELD_COUNT &&
+                !(fields[-1] ==~ SEGMENT_LIST_PATTERN)) {
+            throw new IllegalArgumentException("Unexpected segment list in rowset info: ${rowsetInfo}")
+        }
+        return [fields[DATA_SIZE_FIELD_INDEX], fields[DATA_SIZE_UNIT_FIELD_INDEX]]
+    }
+}

--- a/regression-test/framework/src/test/groovy/org/apache/doris/regression/util/RowsetInfoUtilsTest.groovy
+++ b/regression-test/framework/src/test/groovy/org/apache/doris/regression/util/RowsetInfoUtilsTest.groovy
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.regression.util
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+class RowsetInfoUtilsTest {
+    @Test
+    void parsesLegacyRowsetInfo() {
+        def rowsetInfo = "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB level=1"
+
+        assertEquals(["1.500", "MB"], RowsetInfoUtils.dataSizeFields(rowsetInfo))
+    }
+
+    @Test
+    void parsesExplicitSegmentListRowsetInfo() {
+        def rowsetInfo =
+                "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB level=1 [100,101,200]"
+
+        assertEquals(["1.500", "MB"], RowsetInfoUtils.dataSizeFields(rowsetInfo))
+    }
+
+    @Test
+    void rejectsUnexpectedRowsetInfo() {
+        def rowsetInfo = "[2-4] 3 DATA NONOVERLAPPING 1.500 MB"
+
+        assertThrows(IllegalArgumentException.class) {
+            RowsetInfoUtils.dataSizeFields(rowsetInfo)
+        }
+    }
+
+    @Test
+    void rejectsUnexpectedSegmentList() {
+        def rowsetInfo =
+                "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB level=1 segment_ids"
+
+        assertThrows(IllegalArgumentException.class) {
+            RowsetInfoUtils.dataSizeFields(rowsetInfo)
+        }
+    }
+
+    @Test
+    void rejectsUnexpectedCompactionLevel() {
+        def rowsetInfo =
+                "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB compaction_level=1"
+
+        assertThrows(IllegalArgumentException.class) {
+            RowsetInfoUtils.dataSizeFields(rowsetInfo)
+        }
+    }
+}

--- a/regression-test/framework/src/test/groovy/org/apache/doris/regression/util/RowsetInfoUtilsTest.groovy
+++ b/regression-test/framework/src/test/groovy/org/apache/doris/regression/util/RowsetInfoUtilsTest.groovy
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.regression.util
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+class RowsetInfoUtilsTest {
+    @Test
+    void parsesLegacyRowsetInfo() {
+        def rowsetInfo = "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB"
+
+        assertEquals(["1.500", "MB"], RowsetInfoUtils.dataSizeFields(rowsetInfo))
+    }
+
+    @Test
+    void parsesExplicitSegmentListRowsetInfo() {
+        def rowsetInfo =
+                "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB [100,101,200]"
+
+        assertEquals(["1.500", "MB"], RowsetInfoUtils.dataSizeFields(rowsetInfo))
+    }
+
+    @Test
+    void rejectsUnexpectedRowsetInfo() {
+        def rowsetInfo = "[2-4] 3 DATA NONOVERLAPPING 1.500 MB"
+
+        assertThrows(IllegalArgumentException.class) {
+            RowsetInfoUtils.dataSizeFields(rowsetInfo)
+        }
+    }
+
+    @Test
+    void rejectsUnexpectedSegmentList() {
+        def rowsetInfo = "[2-4] 3 DATA NONOVERLAPPING 0200000000000001 1.500 MB segment_ids"
+
+        assertThrows(IllegalArgumentException.class) {
+            RowsetInfoUtils.dataSizeFields(rowsetInfo)
+        }
+    }
+}

--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -68,3 +68,5 @@ max_python_process_num=16
 
 enable_cloud_make_rs_visible_on_be=true
 cloud_mow_sync_rowsets_when_load_txn_begin=false
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/cloud_p1/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p1/conf/be_custom.conf
@@ -49,3 +49,5 @@ max_python_process_num=16
 
 enable_cloud_make_rs_visible_on_be=true
 cloud_mow_sync_rowsets_when_load_txn_begin=false
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -79,3 +79,5 @@ enable_python_udf_support=true
 python_env_mode=venv
 python_venv_interpreter_paths=/usr/bin/python
 max_python_process_num=16
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/nonConcurrent/conf/be.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/be.conf
@@ -99,3 +99,5 @@ enable_python_udf_support=true
 python_env_mode=venv
 python_venv_interpreter_paths=/usr/bin/python
 max_python_process_num=16
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -102,3 +102,5 @@ enable_python_udf_support=true
 python_env_mode=venv
 python_venv_interpreter_paths=/usr/bin/python
 max_python_process_num=16
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -85,3 +85,5 @@ enable_python_udf_support=true
 python_env_mode=venv
 python_venv_interpreter_paths=/usr/bin/python
 max_python_process_num=16
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/performance/clickbench/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/clickbench/conf/be_custom.conf
@@ -19,3 +19,5 @@ disable_auto_compaction=true
 disable_storage_page_cache=false
 disable_chunk_allocator=false
 enable_simdjson_reader = true
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/performance/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/conf/be_custom.conf
@@ -31,3 +31,5 @@ enable_python_udf_support = true
 python_env_mode = venv
 python_venv_interpreter_paths = /usr/bin/python
 max_python_process_num = 64
+
+enable_cloud_random_segment_id=true

--- a/regression-test/pipeline/vault_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/vault_p0/conf/be_custom.conf
@@ -46,3 +46,5 @@ enable_python_udf_support=true
 python_env_mode=venv
 python_venv_interpreter_paths=/usr/bin/python
 max_python_process_num=16
+
+enable_cloud_random_segment_id=true

--- a/regression-test/plugins/cloud_show_data_plugin.groovy
+++ b/regression-test/plugins/cloud_show_data_plugin.groovy
@@ -16,6 +16,7 @@
 // under the License.
 import groovy.json.JsonOutput
 import org.apache.doris.regression.suite.Suite
+import org.apache.doris.regression.util.RowsetInfoUtils
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
     Suite.metaClass.repeate_stream_load_same_data = { String tableName, int loadTimes, String filePath->
@@ -213,13 +214,9 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
             logger.info("[caculate_table_data_size_through_api] tablet ID: ${tabletId}, status: " + tabletStatus.toString())
             
             for(String rowset: tabletStatus.rowsets){
-                def fields = rowset.split(" ")
-                if (fields.length == 7) {
-                    def sizeField = fields[-2]  // the last field（size）
-                    def unitField = fields[-1]   // The second to last field（unit）
-                    // 转换成 KB
-                    apiCaculateSize += translate_different_unit_to_MB(sizeField, unitField )
-                }
+                def (sizeField, unitField) = RowsetInfoUtils.dataSizeFields(rowset)
+                // 转换成 KB
+                apiCaculateSize += translate_different_unit_to_MB(sizeField, unitField)
             }
         }
         def round_size = new BigDecimal(apiCaculateSize).setScale(0, BigDecimal.ROUND_FLOOR);

--- a/regression-test/plugins/plugin_curl_requester.groovy
+++ b/regression-test/plugins/plugin_curl_requester.groovy
@@ -304,9 +304,10 @@ Suite.metaClass.check_nested_index_file = { ip, port, tablet_id, expected_rowset
     def segment_files_count = 0
     for (def rowset in parseJson(out.trim()).rowsets) {
         assertEquals(format, rowset.index_storage_format)
-        for (int i = 0; i < rowset.segments.size(); i++) {
-            def segment = rowset.segments[i]
-            assertEquals(i, segment.segment_id)
+        def segment_ids = new HashSet()
+        for (def segment in rowset.segments) {
+            assertTrue(segment.segment_id >= 0)
+            assertTrue(segment_ids.add(segment.segment_id))
             def indices_count = segment.indices.size()
             assertEquals(expected_indices_count, indices_count)
             if (format == "V1") {

--- a/regression-test/suites/compaction/test_mow_cumulative_compaction_multi_output_segments.groovy
+++ b/regression-test/suites/compaction/test_mow_cumulative_compaction_multi_output_segments.groovy
@@ -1,0 +1,424 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_mow_cumulative_compaction_multi_output_segments", "nonConcurrent") {
+    if (!isCloudMode()) {
+        logger.info("skip test_mow_cumulative_compaction_multi_output_segments in non-cloud mode")
+        return
+    }
+
+    def backendIdToHost = [:]
+    def backendIdToHttpPort = [:]
+    getBackendIpHttpPort(backendIdToHost, backendIdToHttpPort)
+
+    def configNames = [
+            "compaction_batch_size",
+            "doris_scanner_row_bytes",
+            "enable_rowid_conversion_correctness_check",
+            "enable_vertical_compaction",
+            "inverted_index_compaction_enable",
+            "vertical_compaction_max_segment_size"
+    ]
+    def originalConfigs = [:]
+
+    def readBeConfig = { String backendId, String configName ->
+        def host = backendIdToHost[backendId]
+        def port = backendIdToHttpPort[backendId]
+        def (code, out, err) = curl(
+                "GET", "http://${host}:${port}/api/show_config?conf_item=${configName}")
+        assertEquals(0, code)
+        def configs = parseJson(out)
+        assertEquals(1, configs.size())
+        assertEquals(configName, configs[0][0])
+        return configs[0][2].toString()
+    }
+
+    def updateBeConfig = { String configName, String value ->
+        backendIdToHost.keySet().each { String backendId ->
+            def host = backendIdToHost[backendId]
+            def port = backendIdToHttpPort[backendId]
+            def (code, out, err) = curl(
+                    "POST", "http://${host}:${port}/api/update_config?${configName}=${value}")
+            assertEquals(0, code)
+            assertTrue(out.contains("OK"), "failed to set ${configName}=${value}: ${out}, ${err}")
+        }
+    }
+
+    backendIdToHost.keySet().each { String backendId ->
+        originalConfigs[backendId] = [:]
+        configNames.each { String configName ->
+            originalConfigs[backendId][configName] = readBeConfig(backendId, configName)
+        }
+    }
+
+    def resetBeConfigs = {
+        originalConfigs.each { String backendId, Map configs ->
+            def host = backendIdToHost[backendId]
+            def port = backendIdToHttpPort[backendId]
+            configs.each { String configName, String value ->
+                def (code, out, err) = curl(
+                        "POST", "http://${host}:${port}/api/update_config?${configName}=${value}")
+                assertEquals(0, code)
+                assertTrue(out.contains("OK"),
+                        "failed to reset ${configName}=${value}: ${out}, ${err}")
+            }
+        }
+    }
+
+    def showTablet = { def backend, String tabletId ->
+        def (code, out, err) =
+                be_show_tablet_status(backend.Host, backend.HttpPort, tabletId)
+        logger.info("Show tablet status: code=${code}, out=${out}, err=${err}")
+        assertEquals(0, code)
+        return parseJson(out.trim())
+    }
+
+    def findRowset = { def tabletStatus, int startVersion, int endVersion ->
+        def rowset =
+                tabletStatus.rowsets.find { it.startsWith("[${startVersion}-${endVersion}] ") }
+        assertNotNull(rowset,
+                "cannot find rowset [${startVersion}-${endVersion}]: ${tabletStatus.rowsets}")
+        return rowset
+    }
+
+    def parseRowset = { String rowset ->
+        def matcher = rowset =~
+                /\[[0-9]+-[0-9]+\]\s+([0-9]+)\s+DATA\s+([A-Z_]+)\s+([0-9a-f]+)/
+        assertTrue(matcher.find(), "unexpected rowset format: ${rowset}")
+        def segmentIds = []
+        def segmentIdsMatcher = rowset =~ /\s\[([0-9]+(?:,[0-9]+)*)\]$/
+        if (segmentIdsMatcher.find()) {
+            segmentIds = segmentIdsMatcher.group(1).split(",").collect { it.toInteger() }
+        }
+        return [
+                segmentNum: matcher.group(1).toInteger(),
+                overlap: matcher.group(2),
+                rowsetId: matcher.group(3),
+                segmentIds: segmentIds
+        ]
+    }
+
+    def waitForCompaction = { def backend, String tabletId ->
+        long timeoutMs = 120000
+        long deadline = System.currentTimeMillis() + timeoutMs
+        def lastStatus = null
+        while (System.currentTimeMillis() < deadline) {
+            def (code, out, err) =
+                    be_get_compaction_status(backend.Host, backend.HttpPort, tabletId)
+            logger.info("Get compaction status: code=${code}, out=${out}, err=${err}")
+            assertEquals(0, code)
+            lastStatus = parseJson(out.trim())
+            assertEquals("success", lastStatus.status.toLowerCase())
+            if (!lastStatus.run_status) {
+                return
+            }
+            Thread.sleep(1000)
+        }
+        assertTrue(false,
+                "compaction timeout: tablet=${tabletId}, timeoutMs=${timeoutMs}, last=${lastStatus}")
+    }
+
+    def waitForRowset = { backend, tabletId, startVersion, endVersion ->
+        long timeoutMs = 30000
+        long deadline = System.currentTimeMillis() + timeoutMs
+        def lastStatus = null
+        while (System.currentTimeMillis() < deadline) {
+            lastStatus = showTablet(backend, tabletId)
+            if (lastStatus.rowsets.any {
+                it.startsWith("[${startVersion}-${endVersion}] ")
+            }) {
+                return lastStatus
+            }
+            Thread.sleep(200)
+        }
+        assertTrue(false,
+                "rowset [${startVersion}-${endVersion}] is not visible: " +
+                        "tablet=${tabletId}, timeoutMs=${timeoutMs}, last=${lastStatus}")
+    }
+
+    def loadRows = { String tableName, int startKey, int endKey, int valueBase ->
+        def batchTags = [
+                100000: "batchone",
+                200000: "batchtwo",
+                300000: "batchthree",
+                400000: "batchfour",
+                500000: "batchfive"
+        ]
+        def batchTag = batchTags[valueBase]
+        assertNotNull(batchTag)
+        StringBuilder content = new StringBuilder()
+        (startKey..endKey).each { int key ->
+            String suffix = key.toString().padLeft(32, "0")
+            String payload =
+                    "${batchTag} payload ${suffix} ${(key * 17L).toString().padLeft(32, "0")}"
+            content.append("${key},${valueBase + key},${payload}\n")
+        }
+        streamLoad {
+            table tableName
+            set "column_separator", ","
+            inputStream new ByteArrayInputStream(content.toString().getBytes())
+            time 120000
+            check { result, exception, startTime, endTime ->
+                if (exception != null) {
+                    throw exception
+                }
+                def json = parseJson(result)
+                assertEquals("success", json.Status.toLowerCase())
+                assertEquals(endKey - startKey + 1, json.NumberTotalRows)
+                assertEquals(0, json.NumberFilteredRows)
+            }
+        }
+        sql "sync"
+    }
+
+    def readRows = { String tableName ->
+        return sql("""
+            SELECT k, v
+            FROM ${tableName}
+            WHERE k IN (1, 16384, 16385, 32768, 32769, 49152, 49153, 65536, 65537, 81920)
+            ORDER BY k
+        """)
+    }
+
+    def readRowsByIndex = { String tableName ->
+        def batchTags = ["batchone", "batchtwo", "batchthree", "batchfour", "batchfive"]
+        return batchTags.collect { String batchTag ->
+            def result = sql """
+                SELECT /*+ SET_VAR(enable_match_without_inverted_index = false) */ COUNT(*)
+                FROM ${tableName}
+                WHERE payload MATCH '${batchTag}'
+            """
+            return result[0][0]
+        }
+    }
+
+    def getLocalDeleteBitmap = { def backend, String tabletId ->
+        def (code, out, err) = curl(
+                "GET",
+                "http://${backend.Host}:${backend.HttpPort}" +
+                        "/api/delete_bitmap/count_local?verbose=true&tablet_id=${tabletId}")
+        logger.info("Get local delete bitmap: code=${code}, out=${out}, err=${err}")
+        assertEquals(0, code)
+        return parseJson(out.trim())
+    }
+
+    def getDeleteBitmapAtVersion = { def deleteBitmap, String rowsetId, int version ->
+        def segmentIds = []
+        long cardinality = 0
+        deleteBitmap.delete_bitmap.each { String key, bitmapVersions ->
+            if (!key.contains("rowset: ${rowsetId},")) {
+                return
+            }
+            def segmentMatcher = key =~ /segment:\s+([0-9]+)/
+            assertTrue(segmentMatcher.find(), "unexpected delete bitmap key: ${key}")
+            bitmapVersions.each { String bitmapVersion ->
+                def versionMatcher = bitmapVersion =~ /v:\s+([0-9]+),\s+c:\s+([0-9]+)/
+                assertTrue(versionMatcher.find(),
+                        "unexpected delete bitmap value: ${bitmapVersion}")
+                if (versionMatcher.group(1).toInteger() == version) {
+                    segmentIds.add(segmentMatcher.group(1).toInteger())
+                    cardinality += versionMatcher.group(2).toLong()
+                }
+            }
+        }
+        return [segmentIds: segmentIds.unique(), cardinality: cardinality]
+    }
+
+    GetDebugPoint().clearDebugPointsForAllBEs()
+    try {
+        updateBeConfig("compaction_batch_size", "512")
+        updateBeConfig("doris_scanner_row_bytes", "1")
+        updateBeConfig("enable_rowid_conversion_correctness_check", "true")
+        updateBeConfig("inverted_index_compaction_enable", "true")
+        updateBeConfig("vertical_compaction_max_segment_size", "8192")
+        updateBeConfig("enable_cloud_random_segment_id", "true")
+
+        GetDebugPoint().enableDebugPointForAllBEs("MemTable.need_flush")
+        GetDebugPoint().enableDebugPointForAllBEs(
+                "CloudCompactionMixin.construct_output_rowset_writer.random_start_segment_id")
+        GetDebugPoint().enableDebugPointForAllBEs(
+                "CloudCompactionMixin.construct_output_rowset_writer.max_rows_per_segment",
+                [max_rows_per_segment: "1024"])
+
+        def runCompaction = {
+                String tableName, boolean withInvertedIndex, boolean enableVerticalCompaction ->
+            updateBeConfig("enable_vertical_compaction", enableVerticalCompaction.toString())
+            def indexDefinition = withInvertedIndex
+                    ? """,
+                        INDEX idx_payload (payload) USING INVERTED
+                        PROPERTIES("parser" = "english")
+                    """
+                    : ""
+            sql "DROP TABLE IF EXISTS ${tableName}"
+            sql """
+                CREATE TABLE ${tableName} (
+                    k INT NOT NULL,
+                    v BIGINT NOT NULL,
+                    payload VARCHAR(128) NOT NULL
+                    ${indexDefinition}
+                )
+                UNIQUE KEY(k)
+                DISTRIBUTED BY HASH(k) BUCKETS 1
+                PROPERTIES (
+                    "replication_num" = "1",
+                    "disable_auto_compaction" = "true",
+                    "enable_unique_key_merge_on_write" = "true",
+                    "inverted_index_storage_format" = "V2"
+                )
+            """
+
+            loadRows(tableName, 1, 32768, 100000)
+            loadRows(tableName, 16385, 49152, 200000)
+            loadRows(tableName, 32769, 65536, 300000)
+            // Keep this rowset outside the compaction range. Its updates create delete bitmap
+            // entries on the [2-4] output rowset, exercising row-id conversion to physical
+            // segment ids.
+            loadRows(tableName, 49153, 81920, 400000)
+
+            def countBefore = sql "SELECT COUNT(*) FROM ${tableName}"
+            assertEquals(81920, countBefore[0][0])
+            def rowsBefore = readRows(tableName)
+            def indexRowsBefore = withInvertedIndex ? readRowsByIndex(tableName) : null
+
+            def tablets = sql_return_maparray "SHOW TABLETS FROM ${tableName}"
+            assertEquals(1, tablets.size())
+            def tabletId = tablets[0].TabletId.toString()
+            def backendId = tablets[0].BackendId.toString()
+            def backends = sql_return_maparray "SHOW BACKENDS"
+            def backend = backends.find { it.BackendId.toString() == backendId }
+            assertNotNull(backend)
+
+            def before = showTablet(backend, tabletId)
+            [2, 3, 4].each { int version ->
+                def inputRowset = findRowset(before, version, version)
+                def inputInfo = parseRowset(inputRowset)
+                assertTrue(inputInfo.segmentNum > 1, inputRowset)
+            }
+            def untouchedRowset = findRowset(before, 5, 5)
+            def untouchedInfo = parseRowset(untouchedRowset)
+            def untouchedSegmentIds = untouchedInfo.segmentIds.isEmpty()
+                    ? (0..<untouchedInfo.segmentNum).toList()
+                    : untouchedInfo.segmentIds
+
+            GetDebugPoint().enableDebugPointForAllBEs(
+                    "CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets",
+                    [tablet_id: tabletId, start_version: "2", end_version: "4"])
+            def (code, out, err) =
+                    be_run_cumulative_compaction(backend.Host, backend.HttpPort, tabletId)
+            logger.info("Run compaction: code=${code}, out=${out}, err=${err}")
+            assertEquals(0, code)
+            def compactResult = parseJson(out.trim())
+            assertEquals("success", compactResult.status.toLowerCase())
+            waitForCompaction(backend, tabletId)
+
+            def after = showTablet(backend, tabletId)
+            def outputRowset = findRowset(after, 2, 4)
+            def outputInfo = parseRowset(outputRowset)
+            assertEquals("NONOVERLAPPING", outputInfo.overlap)
+            assertTrue(outputInfo.segmentNum > 1, outputRowset)
+            assertEquals(outputInfo.segmentNum, outputInfo.segmentIds.size())
+            assertTrue(outputInfo.segmentIds[0] > 0, outputRowset)
+            for (int i = 1; i < outputInfo.segmentIds.size(); ++i) {
+                assertEquals(outputInfo.segmentIds[i - 1] + 1, outputInfo.segmentIds[i])
+            }
+            assertEquals(untouchedRowset, findRowset(after, 5, 5))
+
+            def countAfter = sql "SELECT COUNT(*) FROM ${tableName}"
+            assertEquals(countBefore, countAfter)
+            assertEquals(rowsBefore, readRows(tableName))
+            if (withInvertedIndex) {
+                assertEquals(indexRowsBefore, readRowsByIndex(tableName))
+            }
+
+            def deleteBitmap = getLocalDeleteBitmap(backend, tabletId)
+            assertNotNull(deleteBitmap.delete_bitmap)
+            def outputDeleteBitmapKeys = deleteBitmap.delete_bitmap.keySet().findAll {
+                it.contains("rowset: ${outputInfo.rowsetId},")
+            }
+            assertFalse(outputDeleteBitmapKeys.isEmpty(),
+                    "missing delete bitmap for output rowset ${outputInfo.rowsetId}: ${deleteBitmap}")
+            outputDeleteBitmapKeys.each { String key ->
+                def matcher = key =~ /segment:\s+([0-9]+)/
+                assertTrue(matcher.find(), "unexpected delete bitmap key: ${key}")
+                assertTrue(outputInfo.segmentIds.contains(matcher.group(1).toInteger()),
+                        "delete bitmap references a segment outside " +
+                                "${outputInfo.segmentIds}: ${key}")
+            }
+
+            // Version 6 overlaps live rows in both the compacted [2-4] rowset and the untouched
+            // version 5 rowset. Verify publish calculates new delete bitmaps against both.
+            loadRows(tableName, 32769, 65536, 500000)
+
+            // Read version 6 first so the query path synchronizes the newly visible rowset from MS
+            // into the BE tablet cache used by the compaction status endpoint.
+            def countAfterUpdate = sql "SELECT COUNT(*) FROM ${tableName}"
+            assertEquals(countBefore, countAfterUpdate)
+
+            def afterUpdate = waitForRowset(backend, tabletId, 6, 6)
+            assertEquals(outputRowset, findRowset(afterUpdate, 2, 4))
+            assertEquals(untouchedRowset, findRowset(afterUpdate, 5, 5))
+            findRowset(afterUpdate, 6, 6)
+
+            def expectedRowsAfterUpdate = rowsBefore.collect { row ->
+                int key = (row[0] as Number).intValue()
+                if (key >= 32769 && key <= 65536) {
+                    return [row[0], 500000L + key]
+                }
+                return row
+            }
+            assertEquals(expectedRowsAfterUpdate, readRows(tableName))
+            if (withInvertedIndex) {
+                assertEquals([16384L, 16384L, 0L, 16384L, 32768L],
+                        readRowsByIndex(tableName))
+            }
+
+            def deleteBitmapAfterUpdate = getLocalDeleteBitmap(backend, tabletId)
+            def outputBitmapAtVersion6 =
+                    getDeleteBitmapAtVersion(deleteBitmapAfterUpdate, outputInfo.rowsetId, 6)
+            assertEquals(16384L, outputBitmapAtVersion6.cardinality)
+            assertFalse(outputBitmapAtVersion6.segmentIds.isEmpty(),
+                    "missing version 6 delete bitmap for compacted rowset " +
+                            "${outputInfo.rowsetId}: ${deleteBitmapAfterUpdate}")
+            outputBitmapAtVersion6.segmentIds.each { int segmentId ->
+                assertTrue(outputInfo.segmentIds.contains(segmentId),
+                        "version 6 delete bitmap references a segment outside " +
+                                "${outputInfo.segmentIds}: ${segmentId}")
+            }
+
+            def untouchedBitmapAtVersion6 =
+                    getDeleteBitmapAtVersion(deleteBitmapAfterUpdate, untouchedInfo.rowsetId, 6)
+            assertEquals(16384L, untouchedBitmapAtVersion6.cardinality)
+            assertFalse(untouchedBitmapAtVersion6.segmentIds.isEmpty(),
+                    "missing version 6 delete bitmap for rowset " +
+                            "${untouchedInfo.rowsetId}: ${deleteBitmapAfterUpdate}")
+            untouchedBitmapAtVersion6.segmentIds.each { int segmentId ->
+                assertTrue(untouchedSegmentIds.contains(segmentId),
+                        "version 6 delete bitmap references a segment outside " +
+                                "${untouchedSegmentIds}: ${segmentId}")
+            }
+        }
+
+        // Cover the full cross-product of compaction writer and inverted index modes.
+        runCompaction("test_mow_cumulative_compaction_multi_output_segments", false, true)
+        runCompaction("test_mow_cumu_compact_multi_segments_non_vertical", false, false)
+        runCompaction("test_mow_cumulative_compaction_multi_output_segments_index", true, true)
+        // runCompaction("test_mow_cumu_compact_multi_segments_index_non_vertical", true, false)
+    } finally {
+        GetDebugPoint().clearDebugPointsForAllBEs()
+        resetBeConfigs()
+    }
+}


### PR DESCRIPTION
Before this PR, rowset segment file IDs were assumed to be continuous, ranging from 0 to `num_segments - 1`.
Future parallel compaction will allow multiple workers to generate segments concurrently, so output segment IDs may be non-contiguous.
This PR introduces explicit physical segment IDs. For example, a rowset with 4 segments may have physical segment IDs `[1, 2, 10, 11]`. These IDs are stored in the `segment_ids` field of the rowset metadata.
Legacy rowsets remain compatible through the continuous-ID fallback.