### PR TITLE
[fix](regression) stabilize flaky ann_index_basic and test_backup_restore_colocate

### DIFF
--- a/regression-test/suites/ann_index_p0/ann_index_basic.groovy
+++ b/regression-test/suites/ann_index_p0/ann_index_basic.groovy
@@ -21,6 +21,14 @@
 suite ("ann_index_basic") {
 		sql "set enable_common_expr_pushdown=true;"
 
+		// Gate ordered qt_ checks on data being visible to the normal scan path.
+		// Right after INSERT the in-memory ANN index can already be queryable while the
+		// freshly-written raw column rows are briefly not (num_rows()==0), which makes
+		// index-free fallback queries (e.g. inner_product ASC) intermittently return empty.
+		def waitRowCount = { tbl, expected ->
+			awaitUntil(30) { (sql("select count(*) from ${tbl}")[0][0] as long) == expected }
+		}
+
 		// 1) Basic L2 ANN table: dim=3
 		sql "drop table if exists tbl_ann_l2"
 		sql """
@@ -44,6 +52,7 @@ suite ("ann_index_basic") {
 		(2, [0.5, 2.1, 2.9]),
 		(3, [10.0, 10.0, 10.0]);
 		"""
+		waitRowCount("tbl_ann_l2", 3)
 
 		// Query: l2 distance ascending (closest first)
 		qt_sql_l2_query "select id, l2_distance_approximate(embedding, [1.0,2.0,3.0]) as dist from tbl_ann_l2 order by dist limit 3;"
@@ -71,6 +80,7 @@ suite ("ann_index_basic") {
 		(2, [0.5, 0.6, 0.7, 0.8]),
 		(3, [1.0, 1.0, 1.0, 1.0]);
 		"""
+		waitRowCount("tbl_ann_ip", 3)
 
 		// Query: inner product descending (higher score first)
 		qt_sql_ip_query "select id from tbl_ann_ip order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc limit 3;"
@@ -111,6 +121,7 @@ suite ("ann_index_basic") {
                 values.add("(${i}, [${a}, ${b}, ${c}])")
         }
         sql "INSERT INTO tbl_ann_l2_large VALUES ${values.join(',')};"
+        waitRowCount("tbl_ann_l2_large", 50)
 
         // topn with small predicate (id < 5) -> selects 4/50 = 8% (<30%), should exercise "will not use ann index" path
         qt_sql_l2_small_pred "select id from tbl_ann_l2_large where id < 5 order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) limit 5;"
@@ -137,6 +148,7 @@ suite ("ann_index_basic") {
         """
 
         sql "INSERT INTO ann_compound VALUES (1, [1.0,2.0,3.0], 'quick brown fox'), (2, [2.0,3.0,4.0], 'lazy dog fox'), (3, [10.0,10.0,10.0], 'unrelated text');"
+        waitRowCount("ann_compound", 3)
 
         qt_sql_compound "select id from ann_compound where txt match_any 'fox' order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) limit 3;"
 }

--- a/regression-test/suites/backup_restore/test_backup_restore_colocate.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_colocate.groovy
@@ -35,10 +35,16 @@ suite("test_backup_restore_colocate", "backup_restore,external") {
     }
 
     def checkColocateTabletHealth = { db_name ->
-        def result = showTabletHealth.call(db_name)
-        log.info(result as String)
-        assertNotNull(result)
-        assertTrue(result.ColocateMismatchNum as int == 0)
+        // After RESTORE creates a new colocate group, some tablets can transiently be
+        // COLOCATE_MISMATCH until the TabletScheduler clones them onto the group's
+        // BackendsPerBucketSeq. The group's cached IsStable flag can already be true
+        // while ColocateMismatchNum (read live) is still non-zero, so poll until it
+        // converges instead of asserting once. Still fails loud if it never heals.
+        awaitUntil(60) {
+            def result = showTabletHealth.call(db_name)
+            log.info(result as String)
+            result != null && (result.ColocateMismatchNum as int) == 0
+        }
     }
 
     def syncer = getSyncer()
@@ -371,10 +377,16 @@ suite("test_backup_restore_colocate_with_partition", "backup_restore") {
     }
 
     def checkColocateTabletHealth = { db_name ->
-        def result = showTabletHealth.call(db_name)
-        log.info(result as String)
-        assertNotNull(result)
-        assertTrue(result.ColocateMismatchNum as int == 0)
+        // After RESTORE creates a new colocate group, some tablets can transiently be
+        // COLOCATE_MISMATCH until the TabletScheduler clones them onto the group's
+        // BackendsPerBucketSeq. The group's cached IsStable flag can already be true
+        // while ColocateMismatchNum (read live) is still non-zero, so poll until it
+        // converges instead of asserting once. Still fails loud if it never heals.
+        awaitUntil(60) {
+            def result = showTabletHealth.call(db_name)
+            log.info(result as String)
+            result != null && (result.ColocateMismatchNum as int) == 0
+        }
     }
 
     def syncer = getSyncer()


### PR DESCRIPTION
## Proposed changes

Harden two long-standing flaky regression tests. Both are test-side races (not product regressions), each observed failing intermittently in branch-4.0 P0 CI (~2/25 recent runs).

### 1. `test_backup_restore_colocate` — `checkColocateTabletHealth`

`test 6 "restore to a new db"` intermittently failed on `assertTrue(result.ColocateMismatchNum as int == 0)`.

Root cause: after `RESTORE` creates a brand-new colocate group, some tablets are transiently `COLOCATE_MISMATCH` until the `TabletScheduler` clones them onto the group's `BackendsPerBucketSeq`. The test waited only for the group's **cached** `IsStable` flag (`waitForColocateGroupStable`) and then asserted the **live** `ColocateMismatchNum` once, so it could observe a mismatch the scheduler had not finished repairing yet (it self-heals, hence most runs pass). The race predates the recent wait-helper rename (#64980); the same failure was seen on older builds.

Fix: poll `ColocateMismatchNum` to zero via `awaitUntil(60)` instead of asserting once. Still fails loud if the mismatch never heals. Applied to both suites in the file (identical closure).

### 2. `ann_index_basic` — post-INSERT read visibility

`sql_ip_asc` (`inner_product_approximate ... ASC`, which falls back to a brute-force top-N read of the raw column) intermittently returned an empty result.

Root cause: the ordered `qt_` checks run immediately after `INSERT`, and the index-free fallback read can occasionally execute before the freshly-written rows are visible to the normal scan path, yielding an empty result. `tbl_ann_ip` has the tightest insert→read gap, so `sql_ip_asc` is the consistent victim. The ANN top-N direction decision and its brute-force fallback are themselves deterministic and correct.

Fix: add a small `waitRowCount` helper and gate each table's ordered checks on `count(*)` reaching the expected value after `INSERT`. Fail-loud (30s timeout); does not change any `.out` (uses plain `sql()`).

Note: the same test code exists on master; these fixes should be forward-ported there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
