### PR TITLE
[fix](regression) stabilize clickbench query10 shape

### DIFF
--- a/regression-test/suites/shape_check/clickbench/query10.groovy
+++ b/regression-test/suites/shape_check/clickbench/query10.groovy
@@ -18,6 +18,7 @@
  */
 
 suite("query10") {
+    sql "set parallel_pipeline_task_num=2"
     sql 'set enable_nereids_planner=true'
     sql 'set enable_nereids_distribute_planner=false'
     sql 'set enable_fallback_to_original_planner=false'


### PR DESCRIPTION
## Proposed changes

Stabilize `shape_check/clickbench/query10.groovy` by pinning:

```groovy
sql "set parallel_pipeline_task_num=2"
```

This matches the neighboring ClickBench shape cases that need a deterministic aggregate shape.

## Root cause

`query10` checks the Nereids physical `EXPLAIN SHAPE PLAN` for a mixed aggregate query with `COUNT(DISTINCT UserID)`.

The golden expects a lower `hashAgg[LOCAL]` below the hash distribute. When `parallel_pipeline_task_num` is left at its default `0`, the effective parallelism is derived from the current cluster executor size, and the optimizer may cost-select the alternate aggregate split shape without that local aggregate:

```text
Expect cell is: --------------hashAgg[LOCAL]
But real is   : --------------PhysicalProject
```

This is a case stability issue rather than a product correctness failure; the query result is not being checked here, only plan shape.

## Validation

- `git diff --check`
- Not run locally: no local Doris listener was present on `127.0.0.1:9030` / `127.0.0.1:8030`, and no prebuilt regression-test jar was available in `output/regression-test/lib`.

