### PR TITLE
[fix](regression) stabilize index change wait

### DIFF
--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_6.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_6.groovy
@@ -18,15 +18,15 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_index_change_6") {
-    def timeout = 60000
+    def timeout = 300000
     def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
 
     def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
+        def finished = false
+        def alter_res = []
+        for(int t = 0; t <= OpTimeout; t += delta_time){
             alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
             def expected_finished_num = alter_res.size();
             def finished_num = 0;
@@ -38,12 +38,15 @@ suite("test_index_change_6") {
             }
             if (finished_num == expected_finished_num) {
                 logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
+                finished = true
                 break
             }
-            useTime = t
+            if (t >= OpTimeout) {
+                break
+            }
             sleep(delta_time)
         }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
+        assertTrue(finished, "wait_for_build_index_on_partition_finish timeout, latest result: ${alter_res}")
     }
     
     def tableName = "test_index_change_6"
@@ -180,9 +183,9 @@ suite("test_index_change_6") {
 
     // drop inverted index idx_user_id, idx_note
     sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_build_index_on_partition_finish(tableName, timeout)
     sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_build_index_on_partition_finish(tableName, timeout)
 
     // create inverted index
     sql """ CREATE INDEX idx_user_id ON ${tableName}(`user_id`) USING INVERTED """


### PR DESCRIPTION
## Proposed changes

Stabilize `inverted_index_p0/index_change/test_index_change_6.groovy` for Cloud P0 index-change latency:

- Increase the case-local index-change wait timeout from 60s to 300s.
- Make the wait helper succeed only after all `SHOW BUILD INDEX` rows are observed as `FINISHED`.
- Include the latest `SHOW BUILD INDEX` result in the timeout assertion for better triage.
- Use the fixed case-local helper for the V1 drop-index waits as well.

## Root cause

The failing Cloud P0 run executed `DROP INDEX idx_user_id`, then repeatedly observed the generated `SHOW BUILD INDEX` job as `RUNNING` for the full 60s window. The previous helper still passed at the timeout boundary because it asserted `useTime <= OpTimeout`, so the case immediately submitted `DROP INDEX idx_note` while the first Cloud index-change job was unfinished.

Cloud mode intentionally rejects a second unfinished index-change job on the same partition, which produced:

```text
partition test_index_change_6 has been built specified index. please check your build stmt.
```

This is a case wait robustness issue rather than a product semantic regression.

## Test

- `git diff --check`
