### PR TITLE
[fix](test) Fix decommission backend UT bucket count

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/clone/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/DecommissionTest.java
@@ -81,6 +81,7 @@ public class DecommissionTest {
         Config.max_scheduling_tablets = 10000;
         Config.schedule_batch_size = 10000;
         Config.disable_balance = true;
+        Config.max_bucket_num_per_partition = 0;
         // 4 backends:
         // 127.0.0.1
         // 127.0.0.2
@@ -144,7 +145,7 @@ public class DecommissionTest {
         // test colocate tablet repair
         String createStr = "create table test.tbl1\n"
                 + "(k1 date, k2 int)\n"
-                + "distributed by hash(k2) buckets 64\n"
+                + "distributed by hash(k2) buckets 2400\n"
                 + "properties\n"
                 + "(\n"
                 + "    \"replication_num\" = \"1\"\n"


### PR DESCRIPTION
### What problem does this PR solve?

On branch-4.1, `DecommissionTest.testDecommissionBackend` creates `test.tbl1` with `buckets 64`, but still verifies balance with `totalReplicaNum = 1 * 2400`.

That makes the initial round-robin tablet distribution `[16, 16, 16, 16]` look unbalanced because `checkBalance()` computes the expected average from 2400 replicas.

This PR aligns the branch-4.1 test with the master-side handling:

- disable `Config.max_bucket_num_per_partition` for this UT
- restore the DDL to `buckets 2400`
- keep `totalReplicaNum = 1 * 2400` unchanged

### Check List

- [x] `git diff --check HEAD~1..HEAD`
- [ ] `./run-fe-ut.sh --run org.apache.doris.clone.DecommissionTest#testDecommissionBackend` (blocked locally before Java UT: `/Users/keshu/dudu/doris/thirdparty/installed/bin/protoc` is missing)
- [ ] `mvn test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dtest=org.apache.doris.clone.DecommissionTest#testDecommissionBackend` (blocked locally before `fe-core`: generated `org.apache.doris.thrift` classes are missing because generated sources cannot be produced without `protoc`)

### Release note

None
