### PR TITLE
[fix](fe) Stabilize RollupJobV2Test task execution

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -47,7 +47,9 @@ import org.apache.doris.nereids.trees.plans.commands.info.AddRollupOp;
 import org.apache.doris.nereids.trees.plans.commands.info.AlterOp;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
+import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTask;
+import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TTaskType;
@@ -59,6 +61,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -86,6 +90,7 @@ public class RollupJobV2Test {
 
     private FakeEnv fakeEnv;
     private FakeEditLog fakeEditLog;
+    private MockedStatic<AgentTaskExecutor> agentTaskExecutorMock;
 
     @Before
     public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
@@ -115,6 +120,9 @@ public class RollupJobV2Test {
         AgentTaskQueue.clearAllTasks();
 
         FakeEnv.setEnv(masterEnv);
+        agentTaskExecutorMock = Mockito.mockStatic(AgentTaskExecutor.class);
+        agentTaskExecutorMock.when(() -> AgentTaskExecutor.submit(Mockito.any(AgentBatchTask.class)))
+                .thenAnswer(invocation -> null);
     }
 
     @After
@@ -129,6 +137,9 @@ public class RollupJobV2Test {
         }
         if (fakeTransactionIDGenerator != null) {
             fakeTransactionIDGenerator.close();
+        }
+        if (agentTaskExecutorMock != null) {
+            agentTaskExecutorMock.close();
         }
     }
 
@@ -267,6 +278,53 @@ public class RollupJobV2Test {
 
         materializedViewHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.FINISHED, rollupJob.getJobState());
+    }
+
+    @Test
+    public void testSchemaChangeCancelWhenRollupTasksFailed() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(op);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        materializedViewHandler.process(alterOps, db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
+        Assert.assertEquals(1, alterJobsV2.size());
+        RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+
+        List<AgentTask> tasks = AgentTaskQueue.getTask(TTaskType.ALTER);
+        Assert.assertEquals(3, tasks.size());
+        long failedTabletId = tasks.get(0).getTabletId();
+        int failedTaskCount = 0;
+        for (AgentTask agentTask : tasks) {
+            if (agentTask.getTabletId() == failedTabletId) {
+                agentTask.failedWithMsg("backend " + agentTask.getBackendId() + " is not alive");
+                failedTaskCount++;
+            }
+            if (failedTaskCount == 2) {
+                break;
+            }
+        }
+        Assert.assertEquals(2, failedTaskCount);
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.CANCELLED, rollupJob.getJobState());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`RollupJobV2Test.testSchemaChange1` manually drives a rollup job through `WAITING_TXN`, `RUNNING`, and `FINISHED`. The test also allowed `AgentTaskExecutor.submit()` to schedule generated alter tasks asynchronously. In FE UT, that background executor can observe fake backend/system-info state and mark tasks failed, which can cancel the rollup job before the manually driven success path finishes.

The flaky CI symptom was `expected:<RUNNING> but was:<CANCELLED>`. This happens when the async `AgentBatchTask` marks generated alter tasks failed with `backend ... is not alive`; the next catalog-ready cycle then sees the rollup task failure threshold and cancels the rollup job.

This PR mocks `AgentTaskExecutor.submit()` in the fixture so the test-owned state transitions remain deterministic. It also adds `testSchemaChangeCancelWhenRollupTasksFailed` to keep explicit coverage for the cancellation branch: two rollup tasks on the same tablet are marked failed, and the job is asserted to become `CANCELLED`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.alter.RollupJobV2Test`
        - Passed before updating the branch to latest `origin/master`: `Tests run: 8, Failures: 0, Errors: 0, Skipped: 0`
        - After updating to latest `origin/master`, only static checks were rerun: `git diff --check` and `git diff --cached --check`
        - CI FE UT requested with `run feut`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
