### PR TITLE
[fix](regression) Batch export_p0 generated VALUES inserts

### DIFF
--- a/regression-test/suites/export_p0/outfile/native/test_outfile_native.groovy
+++ b/regression-test/suites/export_p0/outfile/native/test_outfile_native.groovy
@@ -63,18 +63,21 @@ suite("test_outfile_native", "p0") {
         DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
         """
 
-        // Insert 10 rows of test data (the last row is all NULL)
-        StringBuilder sb = new StringBuilder()
+        // Avoid a single huge VALUES statement: Cloud P0 can spend over 120s
+        // preparing the plan fragment when all 10k rows are inserted at once.
+        List<String> rows = []
         int i = 1
         for (; i < 10000; i ++) {
-            sb.append("""
-                (${i}, '2024-01-01', '2024-01-01 00:00:00', 's${i}', ${i}, ${i % 128}, true, ${i}.${i}),
+            rows.add("""
+                (${i}, '2024-01-01', '2024-01-01 00:00:00', 's${i}', ${i}, ${i % 128}, true, ${i}.${i})
             """)
         }
-        sb.append("""
+        rows.add("""
                 (${i}, '2024-01-01', '2024-01-01 00:00:00', NULL, NULL, NULL, NULL, NULL)
             """)
-        sql """ INSERT INTO ${tableName} VALUES ${sb.toString()} """
+        rows.collate(500).each { batch ->
+            sql """ INSERT INTO ${tableName} VALUES ${batch.join(",")} """
+        }
 
         // baseline: local table query result
         qt_select_default """ SELECT * FROM ${tableName} t ORDER BY id limit 10; """

--- a/regression-test/suites/export_p0/test_outfile.groovy
+++ b/regression-test/suites/export_p0/test_outfile.groovy
@@ -86,19 +86,19 @@ suite("test_outfile") {
             )
             DISTRIBUTED BY HASH(user_id) PROPERTIES("replication_num" = "1");
         """
-        StringBuilder sb = new StringBuilder()
+        List<String> rows = []
         int i = 1
         for (; i < 1000; i ++) {
-            sb.append("""
-                (${i}, '2017-10-01', '2017-10-01 00:00:00', '2017-10-01', '2017-10-01 00:00:00.111111', '2017-10-01 00:00:00.111111', '2017-10-01 00:00:00.111111', 'Beijing', ${i}, ${i % 128}, true, ${i}, ${i}, ${i}, ${i}.${i}, ${i}.${i}, 'char${i}', ${i}),
+            rows.add("""
+                (${i}, '2017-10-01', '2017-10-01 00:00:00', '2017-10-01', '2017-10-01 00:00:00.111111', '2017-10-01 00:00:00.111111', '2017-10-01 00:00:00.111111', 'Beijing', ${i}, ${i % 128}, true, ${i}, ${i}, ${i}, ${i}.${i}, ${i}.${i}, 'char${i}', ${i})
             """)
         }
-        sb.append("""
+        rows.add("""
                 (${i}, '2017-10-01', '2017-10-01 00:00:00', '2017-10-01', '2017-10-01 00:00:00.111111', '2017-10-01 00:00:00.111111', '2017-10-01 00:00:00.111111', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
             """)
-        sql """ INSERT INTO ${tableName} VALUES
-             ${sb.toString()}
-            """
+        rows.collate(500).each { batch ->
+            sql """ INSERT INTO ${tableName} VALUES ${batch.join(",")} """
+        }
         qt_select_default """ SELECT * FROM ${tableName} t ORDER BY user_id; """
 
         // check outfile

--- a/regression-test/suites/export_p0/test_outfile_expr.groovy
+++ b/regression-test/suites/export_p0/test_outfile_expr.groovy
@@ -82,19 +82,19 @@ suite("test_outfile_expr") {
             )
             DISTRIBUTED BY HASH(user_id) PROPERTIES("replication_num" = "1");
         """
-        StringBuilder sb = new StringBuilder()
+        List<String> rows = []
         int i = 1
         for (; i < 1000; i ++) {
-            sb.append("""
-                (${i}, '2017-10-01', '2017-10-01 00:00:00', 'Beijing', ${i}, ${i % 128}, true, ${i}, ${i}, ${i}, ${i}.${i}, ${i}.${i}, 'char${i}', ${i}),
+            rows.add("""
+                (${i}, '2017-10-01', '2017-10-01 00:00:00', 'Beijing', ${i}, ${i % 128}, true, ${i}, ${i}, ${i}, ${i}.${i}, ${i}.${i}, 'char${i}', ${i})
             """)
         }
-        sb.append("""
+        rows.add("""
                 (${i}, '2017-10-01', '2017-10-01 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
             """)
-        sql """ INSERT INTO ${tableName} VALUES
-             ${sb.toString()}
-            """
+        rows.collate(500).each { batch ->
+            sql """ INSERT INTO ${tableName} VALUES ${batch.join(",")} """
+        }
         qt_select_default """ SELECT user_id+1, age+sex, repeat(char_col, 10) FROM ${tableName} t ORDER BY user_id; """
 
         // check outfile


### PR DESCRIPTION
## Summary

- Split large generated VALUES setup inserts in export_p0 into 500-row batches.
- Keep the same data volume and OUTFILE validation coverage.
- Avoid single huge literal INSERT statements that can exceed the Cloud P0 send-fragments RPC deadline during fragment preparation.

Related: DORIS-26804

## Testing

- [x] git diff --check
- [x] groovyc syntax compile for the three changed Groovy suites
- [ ] Not run Cloud P0 locally: no Doris regression cluster available in this workspace