### PR TITLE
[fix](regression) handle E-2010 compaction success wait

### DIFF
--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -89,7 +89,6 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
     }
     // 2. trigger compaction
     def triggered_tablets = []
-    def ignoredTriggerResults = []
     for (tablet in tablets) {
         def be_host = backendId_to_backendIP["${tablet.BackendId}"]
         def be_port = backendId_to_backendHttpPort["${tablet.BackendId}"]
@@ -111,17 +110,13 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
         def trigger_status = parseJson(stdout.trim())
         if (trigger_status.status.toLowerCase() != "success") {
             def status_lower = trigger_status.status.toLowerCase()
-            def triggerResult = "be host: ${be_host}, tablet id: ${tablet.TabletId}, status: ${trigger_status.status}"
             if (status_lower == "already_exist") {
                 triggered_tablets.add(tablet) // compaction already in queue, treat it as successfully triggered
             } else if (!auto_compaction_disabled) {
-                ignoredTriggerResults.add("${triggerResult}, reason: auto compaction enabled")
                 // ignore the error if auto compaction enabled
             } else if (status_lower.contains("e-2000") || status_lower.contains("e-2010")) {
-                ignoredTriggerResults.add("${triggerResult}, reason: known no-op status")
                 // ignore this tablet compaction.
             } else if (ignored_errors.any { error -> status_lower.contains(error.toLowerCase()) }) {
-                ignoredTriggerResults.add("${triggerResult}, reason: ignored_errors=${ignored_errors}")
                 // ignore this tablet compaction if the error is in the ignored_errors list
             } else {
                 throw new Exception("trigger compaction failed, be host: ${be_host}, tablet id: ${tablet.TabletId}, status: ${trigger_status.status}")
@@ -129,13 +124,6 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
         } else {
             triggered_tablets.add(tablet)
         }
-    }
-    if (triggered_tablets.isEmpty()) {
-        throw new Exception("trigger compaction did not trigger any tablet, table: ${table_name}, " +
-                "compaction type: ${compaction_type}, tablet count: ${tablets.size()}, " +
-                "auto_compaction_disabled: ${auto_compaction_disabled}, " +
-                "ignored/no-op trigger statuses: ${ignoredTriggerResults}. " +
-                "trigger_and_wait_compaction cannot guarantee compaction effect.")
     }
 
     // 3. wait all compaction finished

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -89,6 +89,7 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
     }
     // 2. trigger compaction
     def triggered_tablets = []
+    def ignoredTriggerResults = []
     for (tablet in tablets) {
         def be_host = backendId_to_backendIP["${tablet.BackendId}"]
         def be_port = backendId_to_backendHttpPort["${tablet.BackendId}"]
@@ -110,13 +111,17 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
         def trigger_status = parseJson(stdout.trim())
         if (trigger_status.status.toLowerCase() != "success") {
             def status_lower = trigger_status.status.toLowerCase()
+            def triggerResult = "be host: ${be_host}, tablet id: ${tablet.TabletId}, status: ${trigger_status.status}"
             if (status_lower == "already_exist") {
                 triggered_tablets.add(tablet) // compaction already in queue, treat it as successfully triggered
             } else if (!auto_compaction_disabled) {
+                ignoredTriggerResults.add("${triggerResult}, reason: auto compaction enabled")
                 // ignore the error if auto compaction enabled
             } else if (status_lower.contains("e-2000") || status_lower.contains("e-2010")) {
+                ignoredTriggerResults.add("${triggerResult}, reason: known no-op status")
                 // ignore this tablet compaction.
             } else if (ignored_errors.any { error -> status_lower.contains(error.toLowerCase()) }) {
+                ignoredTriggerResults.add("${triggerResult}, reason: ignored_errors=${ignored_errors}")
                 // ignore this tablet compaction if the error is in the ignored_errors list
             } else {
                 throw new Exception("trigger compaction failed, be host: ${be_host}, tablet id: ${tablet.TabletId}, status: ${trigger_status.status}")
@@ -124,6 +129,13 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
         } else {
             triggered_tablets.add(tablet)
         }
+    }
+    if (triggered_tablets.isEmpty()) {
+        throw new Exception("trigger compaction did not trigger any tablet, table: ${table_name}, " +
+                "compaction type: ${compaction_type}, tablet count: ${tablets.size()}, " +
+                "auto_compaction_disabled: ${auto_compaction_disabled}, " +
+                "ignored/no-op trigger statuses: ${ignoredTriggerResults}. " +
+                "trigger_and_wait_compaction cannot guarantee compaction effect.")
     }
 
     // 3. wait all compaction finished

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -163,12 +163,17 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
                     def newCumulativePoint = toLongOrNull(tabletStatus["cumulative point"])
                     def lastCumulativeStatus = "${tabletStatus["last cumulative status"]}".toLowerCase()
                     def baseSuccessTimeChanged = oldStatus["last base success time"] != tabletStatus["last base success time"]
+                    def cumulativeSuccessTimeChanged =
+                            oldStatus["last cumulative success time"] != tabletStatus["last cumulative success time"]
                     // E-2010 advances the cumulative point and lets base compaction handle delete-version rowsets.
+                    // In some timing windows, base success is already visible in the cached old status while
+                    // cumulative success advances later, so accept either success signal but not failure time alone.
                     handedOffToBaseCompactionAfterDeleteVersion = lastCumulativeStatus.contains("e-2010") &&
                             oldCumulativePoint != null && newCumulativePoint != null &&
                             newCumulativePoint > oldCumulativePoint
                     completedByBaseCompactionAfterDeleteVersion =
-                            handedOffToBaseCompactionAfterDeleteVersion && baseSuccessTimeChanged
+                            handedOffToBaseCompactionAfterDeleteVersion &&
+                            (baseSuccessTimeChanged || cumulativeSuccessTimeChanged)
                 }
                 def success_time_unchanged = (oldStatus["last ${compaction_type} success time"] == tabletStatus["last ${compaction_type} success time"])
                 def failure_time_unchanged = (oldStatus["last ${compaction_type} failure time"] == tabletStatus["last ${compaction_type} failure time"])


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #64945

Problem Summary:

`trigger_and_wait_compaction` has special handling for cumulative compaction that meets delete-version rowsets and reports `E-2010`. PR #64945 made the helper wait for base compaction success before treating that handoff as finished.

Build `985491` exposed another valid timing window in `compaction/test_compaction_agg_keys_with_delete.groovy`: for tablet `1783077858744`, base success was already visible in the cached old tablet status, while cumulative success advanced later.

The final polled state was not stuck:

- `run_status=false`
- `cumulative point` advanced from `7` to `12`
- `last cumulative status` changed to `[E-2010]cumulative compaction meet delete version`
- `last cumulative success time` advanced from `2026-07-03 19:46:16.439` to `2026-07-03 19:46:16.945`
- rowsets were compacted from separate `[8-8]`, `[9-9]`, `[10-10]` rowsets to `[8-10]`

However, the helper only accepted the E-2010 handoff when `last base success time` changed after the cached old status. In this timing window that timestamp did not change, so the helper kept returning "still running" until the 5-minute Awaitility timeout.

This patch keeps the previous safety guard: E-2010 plus cumulative point movement alone is still not enough. It now accepts the handoff when either base success time changes or cumulative success time changes, so a pure E-2010 failure timestamp change is not treated as completion.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `git diff --check`
        - Local Groovy condition simulation for the build `985491` final tablet state: passes with `baseSuccessTimeChanged=false` and `cumulativeSuccessTimeChanged=true`.
        - Local Groovy negative simulation: E-2010 plus cumulative point movement without base/cumulative success time change is still not treated as completion.
        - Checked follow-up TeamCity failures after trying an empty-trigger hard fail. The hard fail was too broad because existing callers legitimately hit all `E-2000`/`E-2010` no-op trigger results, so that guard was reverted and is not part of this PR's effective diff.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
