### PR TITLE
[fix](https) normalize internal FE HTTP URLs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -267,8 +267,7 @@ public class DorisFE {
                 httpServer.setKeyStorePassword(Config.key_store_password);
                 httpServer.setKeyStoreType(Config.key_store_type);
                 httpServer.setKeyStoreAlias(Config.key_store_alias);
-                httpServer.setEnableHttps(Config.enable_https
-                        && !(Config.enable_tls && TlsProtocolSet.isProtocolIncluded(TlsProtocolSet.Protocol.HTTP)));
+                httpServer.setEnableHttps(Config.enable_https && !TlsProtocolSet.isHttpTlsActive());
                 httpServer.setMaxThreads(Config.jetty_threadPool_maxThreads);
                 httpServer.setMinThreads(Config.jetty_threadPool_minThreads);
                 httpServer.setMaxHttpHeaderSize(Config.jetty_server_max_http_header_size);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -122,6 +122,7 @@ import org.apache.doris.ha.BDBHA;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.ha.HAProtocol;
 import org.apache.doris.ha.MasterInfo;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.meta.MetaBaseAction;
 import org.apache.doris.httpv2.rest.RestApiStatusCode;
@@ -1468,7 +1469,8 @@ public class Env {
                 try {
                     String url = "http://" + NetUtils
                             .getHostPortInAccessibleFormat(rightHelperNode.getHost(), Config.http_port) + "/check";
-                    HttpURLConnection conn = HttpURLUtil.getConnectionWithNodeIdent(url);
+                    HttpURLConnection conn = HttpURLUtil.getInternalConnectionWithNodeIdent(url,
+                            InternalHttpClientProvider.Target.FE);
                     conn.setConnectTimeout(2 * 1000);
                     conn.setReadTimeout(2 * 1000);
                     String clusterIdString = conn.getHeaderField(MetaBaseAction.CLUSTER_ID);
@@ -1566,7 +1568,8 @@ public class Env {
                 String url = "http://" + NetUtils.getHostPortInAccessibleFormat(helperNode.getHost(), Config.http_port)
                         + "/role?host=" + selfNode.getHost()
                         + "&port=" + selfNode.getPort();
-                HttpURLConnection conn = HttpURLUtil.getConnectionWithNodeIdent(url);
+                HttpURLConnection conn = HttpURLUtil.getInternalConnectionWithNodeIdent(url,
+                        InternalHttpClientProvider.Target.FE);
                 if (conn.getResponseCode() != 200) {
                     LOG.warn("failed to get fe node type from helper node: {}. response code: {}", helperNode,
                             conn.getResponseCode());

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
@@ -43,6 +43,7 @@ import org.apache.doris.common.Triple;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.nereids.trees.plans.commands.CancelWarmUpJobCommand;
@@ -1072,7 +1073,7 @@ public class CacheHotspotManager extends MasterDaemon {
                 String url = "http://"
                         + NetUtils.getHostPortInAccessibleFormat(be.getHost(), be.getHttpPort())
                         + "/api/warmup_event_driven_stats";
-                String json = HttpUtils.doGet(url, authHeaders, 5000);
+                String json = HttpUtils.doInternalGet(url, authHeaders, 5000, InternalHttpClientProvider.Target.BE);
                 return Pair.of(cluster, json);
             });
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -30,6 +30,8 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
+import org.apache.doris.httpv2.client.InternalHttpClientProviderFactory;
 import org.apache.doris.statistics.query.QueryStatsUtil;
 import org.apache.doris.system.Backend;
 
@@ -112,8 +114,12 @@ public class ReplicasProcNode implements ProcNodeInterface {
             String host = (be == null ? Backend.DUMMY_IP : be.getHost());
             int port = (be == null ? 0 : be.getHttpPort());
             String hostPort = NetUtils.getHostPortInAccessibleFormat(host, port);
-            String metaUrl = String.format("http://" + hostPort + "/api/meta/header/%d", tabletId);
-            String compactionUrl = String.format("http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId);
+            String metaUrl = InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(
+                    String.format("http://" + hostPort + "/api/meta/header/%d", tabletId),
+                    InternalHttpClientProvider.Target.BE);
+            String compactionUrl = InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(
+                    String.format("http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId),
+                    InternalHttpClientProvider.Target.BE);
 
             String path = "";
             if (be != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -34,6 +34,8 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
+import org.apache.doris.httpv2.client.InternalHttpClientProviderFactory;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.query.QueryStatsUtil;
 import org.apache.doris.system.Backend;
@@ -216,10 +218,13 @@ public class TabletsProcDir implements ProcDirInterface {
                         String host = (be == null ? Backend.DUMMY_IP : be.getHost());
                         int port = (be == null ? 0 : be.getHttpPort());
                         String hostPort = NetUtils.getHostPortInAccessibleFormat(host, port);
-                        String metaUrl = String.format("http://" + hostPort + "/api/meta/header/%d", tabletId);
+                        String metaUrl = InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(
+                                String.format("http://" + hostPort + "/api/meta/header/%d", tabletId),
+                                InternalHttpClientProvider.Target.BE);
                         tabletInfo.add(metaUrl);
-                        String compactionUrl = String.format(
-                                "http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId);
+                        String compactionUrl = InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(
+                                String.format("http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId),
+                                InternalHttpClientProvider.Target.BE);
                         tabletInfo.add(compactionUrl);
                         tabletInfo.add(tablet.getCooldownReplicaId());
                         if (replica.getCooldownMetaId() == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -19,6 +19,8 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.security.SecurityChecker;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
+import org.apache.doris.httpv2.client.InternalHttpClientProviderFactory;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.collect.Maps;
@@ -48,6 +50,27 @@ public class HttpURLUtil {
         }
     }
 
+    public static HttpURLConnection getInternalConnectionWithNodeIdent(String request,
+            InternalHttpClientProvider.Target target) throws IOException {
+        HttpURLConnection conn = getInternalConnection(request, target);
+        setNodeIdentHeaders(conn);
+        return conn;
+    }
+
+    public static HttpURLConnection getInternalConnection(String request,
+            InternalHttpClientProvider.Target target) throws IOException {
+        InternalHttpClientProvider provider = InternalHttpClientProviderFactory.getProvider();
+        String normalizedRequest = provider.normalizeInternalUrl(request, target);
+        try {
+            SecurityChecker.getInstance().startSSRFChecking(normalizedRequest);
+            return provider.openConnection(normalizedRequest, target);
+        } catch (Exception e) {
+            throw e instanceof IOException ? (IOException) e : new IOException(e);
+        } finally {
+            SecurityChecker.getInstance().stopSSRFChecking();
+        }
+    }
+
     public static Map<String, String> getNodeIdentHeaders() throws IOException {
         Map<String, String> headers = Maps.newHashMap();
         // Must use Env.getServingEnv() instead of getCurrentEnv(),
@@ -56,6 +79,12 @@ public class HttpURLUtil {
         headers.put(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
         headers.put(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
         return headers;
+    }
+
+    private static void setNodeIdentHeaders(HttpURLConnection conn) throws IOException {
+        HostInfo selfNode = Env.getServingEnv().getSelfNode();
+        conn.setRequestProperty(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
+        conn.setRequestProperty(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/client/InternalHttpClientProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/client/InternalHttpClientProvider.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.client;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public interface InternalHttpClientProvider {
+    enum Target {
+        FE,
+        BE
+    }
+
+    String normalizeInternalUrl(String url, Target target);
+
+    HttpURLConnection openConnection(String url, Target target) throws IOException;
+
+    CloseableHttpClient getHttpClient(Target target);
+
+    RestTemplate getRestTemplate(Target target);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/client/InternalHttpClientProviderFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/client/InternalHttpClientProviderFactory.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.client;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+public final class InternalHttpClientProviderFactory {
+    private static final Logger LOG = LogManager.getLogger(InternalHttpClientProviderFactory.class);
+    private static final InternalHttpClientProvider INSTANCE = loadProvider();
+
+    private InternalHttpClientProviderFactory() {
+    }
+
+    public static InternalHttpClientProvider getProvider() {
+        return INSTANCE;
+    }
+
+    private static InternalHttpClientProvider loadProvider() {
+        ServiceLoader<InternalHttpClientProvider> loader = ServiceLoader.load(InternalHttpClientProvider.class);
+        Iterator<InternalHttpClientProvider> iterator = loader.iterator();
+        if (iterator.hasNext()) {
+            InternalHttpClientProvider provider = iterator.next();
+            LOG.info("Using InternalHttpClientProvider implementation: {}", provider.getClass().getName());
+            return provider;
+        }
+        LOG.info("No custom InternalHttpClientProvider found, fallback to OSS implementation");
+        return new OssInternalHttpClientProvider();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/client/OssInternalHttpClientProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/client/OssInternalHttpClientProvider.java
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.client;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.tls.server.TlsProtocolSet;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class OssInternalHttpClientProvider implements InternalHttpClientProvider {
+    private static final int MAX_CONN_TOTAL = 256;
+    private static final int MAX_CONN_PER_ROUTE = 64;
+
+    private final CloseableHttpClient httpClient;
+    private final RestTemplate restTemplate;
+
+    public OssInternalHttpClientProvider() {
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(MAX_CONN_TOTAL);
+        connectionManager.setDefaultMaxPerRoute(MAX_CONN_PER_ROUTE);
+        httpClient = HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .evictExpiredConnections()
+                .evictIdleConnections(30, java.util.concurrent.TimeUnit.SECONDS)
+                .build();
+        restTemplate = new RestTemplate();
+    }
+
+    @Override
+    public String normalizeInternalUrl(String url, Target target) {
+        if (TlsProtocolSet.isHttpTlsActive()) {
+            throw new UnsupportedOperationException("FE HTTP TLS requires TLS module");
+        }
+        if (!Config.enable_https || target != Target.FE || isHttps(url)) {
+            return url;
+        }
+        return rewriteSchemeAndPort(url, "https", Config.https_port);
+    }
+
+    @Override
+    public HttpURLConnection openConnection(String url, Target target) throws IOException {
+        return (HttpURLConnection) new URL(normalizeInternalUrl(url, target)).openConnection();
+    }
+
+    @Override
+    public CloseableHttpClient getHttpClient(Target target) {
+        return httpClient;
+    }
+
+    @Override
+    public RestTemplate getRestTemplate(Target target) {
+        return restTemplate;
+    }
+
+    private static boolean isHttps(String url) {
+        return url != null && url.regionMatches(true, 0, "https://", 0, "https://".length());
+    }
+
+    private static String rewriteSchemeAndPort(String url, String scheme, int port) {
+        try {
+            URI uri = new URI(url);
+            URI rewritten = new URI(scheme, uri.getUserInfo(), uri.getHost(), port,
+                    uri.getPath(), uri.getQuery(), uri.getFragment());
+            return rewritten.toString();
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid internal HTTP URL: " + url, e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/BaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/BaseController.java
@@ -30,6 +30,8 @@ import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.httpv2.HttpAuthManager;
 import org.apache.doris.httpv2.HttpAuthManager.SessionValue;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
+import org.apache.doris.httpv2.client.InternalHttpClientProviderFactory;
 import org.apache.doris.httpv2.exception.UnauthorizedException;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
@@ -369,13 +371,9 @@ public class BaseController {
     }
 
     protected String getCurrentFrontendURL() {
-        if (Config.enable_https) {
-            // this could be the result of redirection.
-            return "https://" + NetUtils
-                    .getHostPortInAccessibleFormat(FrontendOptions.getLocalHostAddress(), Config.https_port);
-        } else {
-            return "http://" + NetUtils
-                    .getHostPortInAccessibleFormat(FrontendOptions.getLocalHostAddress(), Config.http_port);
-        }
+        String url = "http://" + NetUtils
+                .getHostPortInAccessibleFormat(FrontendOptions.getLocalHostAddress(), Config.http_port);
+        return InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(url,
+                InternalHttpClientProvider.Target.FE);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
@@ -20,6 +20,8 @@ package org.apache.doris.httpv2.controller;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
@@ -118,8 +120,9 @@ public class SessionController extends RestBaseController {
                                                           Frontend frontend) throws IOException {
         Map<String, String> header = Maps.newHashMap();
         header.put(NodeAction.AUTHORIZATION, request.getHeader(NodeAction.AUTHORIZATION));
-        String res = HttpUtils.doGet(String.format("http://%s:%s/rest/v1/session",
-                frontend.getHost(), Env.getCurrentEnv().getMasterHttpPort()), header);
+        String res = HttpUtils.doInternalGet(String.format("http://%s/rest/v1/session",
+                NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Env.getCurrentEnv().getMasterHttpPort())),
+                header, InternalHttpClientProvider.Target.FE);
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> jsonMap = objectMapper.readValue(res,
             new TypeReference<Map<String, Object>>() {});

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -44,6 +44,7 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.BeSelectionPolicy;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.tls.server.TlsProtocolSet;
 
 import com.google.common.base.Strings;
 import com.google.common.net.HostAndPort;
@@ -852,6 +853,11 @@ public class LoadAction extends RestBaseController {
 
         // Check if group commit forwarding is needed
         if (!Config.isCloudMode() || !groupCommit || !Config.enable_group_commit_streamload_be_forward) {
+            return selectRedirectBackend(request, groupCommit, tableId);
+        }
+        if (TlsProtocolSet.isHttpTlsActive()) {
+            LOG.warn("Group commit stream load BE forward is disabled under HTTP TLS, fall back to normal redirect,"
+                    + " db: {}, tbl: {}, label: {}", dbName, tableName, label);
             return selectRedirectBackend(request, groupCommit, tableId);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -23,6 +23,8 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
+import org.apache.doris.httpv2.client.InternalHttpClientProviderFactory;
 import org.apache.doris.httpv2.controller.BaseController;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.exception.UnauthorizedException;
@@ -292,7 +294,10 @@ public class RestBaseController extends BaseController {
 
             HttpEntity<Object> entity = new HttpEntity<>(body, headers);
 
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate = InternalHttpClientProviderFactory.getProvider()
+                    .getRestTemplate(InternalHttpClientProvider.Target.FE);
+            redirectUrl = InternalHttpClientProviderFactory.getProvider()
+                    .normalizeInternalUrl(redirectUrl, InternalHttpClientProvider.Target.FE);
 
             ResponseEntity<Object> responseEntity;
             switch (method) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -21,6 +21,8 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
+import org.apache.doris.httpv2.client.InternalHttpClientProviderFactory;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.system.Frontend;
@@ -88,14 +90,32 @@ public class HttpUtils {
         return url.toString();
     }
 
+    public static String concatInternalUrl(Pair<String, Integer> ipPort, String path, Map<String, String> arguments,
+            InternalHttpClientProvider.Target target) {
+        return InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(concatUrl(ipPort, path, arguments),
+                target);
+    }
+
     public static String doGet(String url, Map<String, String> headers, int timeoutMs) throws IOException {
         HttpGet httpGet = new HttpGet(url);
         setRequestConfig(httpGet, headers, timeoutMs);
         return executeRequest(httpGet);
     }
 
+    public static String doInternalGet(String url, Map<String, String> headers, int timeoutMs,
+            InternalHttpClientProvider.Target target) throws IOException {
+        HttpGet httpGet = new HttpGet(normalizeInternalUrl(url, target));
+        setRequestConfig(httpGet, headers, timeoutMs);
+        return executeInternalRequest(httpGet, target);
+    }
+
     public static String doGet(String url, Map<String, String> headers) throws IOException {
         return doGet(url, headers, DEFAULT_TIME_OUT_MS);
+    }
+
+    public static String doInternalGet(String url, Map<String, String> headers,
+            InternalHttpClientProvider.Target target) throws IOException {
+        return doInternalGet(url, headers, DEFAULT_TIME_OUT_MS, target);
     }
 
     public static String doPost(String url, Map<String, String> headers, Object body) throws IOException {
@@ -108,6 +128,19 @@ public class HttpUtils {
 
         setRequestConfig(httpPost, headers, DEFAULT_TIME_OUT_MS);
         return executeRequest(httpPost);
+    }
+
+    public static String doInternalPost(String url, Map<String, String> headers, Object body,
+            InternalHttpClientProvider.Target target) throws IOException {
+        HttpPost httpPost = new HttpPost(normalizeInternalUrl(url, target));
+        if (Objects.nonNull(body)) {
+            String jsonString = GsonUtils.GSON.toJson(body);
+            StringEntity stringEntity = new StringEntity(jsonString, "UTF-8");
+            httpPost.setEntity(stringEntity);
+        }
+
+        setRequestConfig(httpPost, headers, DEFAULT_TIME_OUT_MS);
+        return executeInternalRequest(httpPost, target);
     }
 
     private static void setRequestConfig(HttpRequestBase request, Map<String, String> headers, int timeoutMs) {
@@ -129,9 +162,23 @@ public class HttpUtils {
         return HttpClientBuilder.create().build();
     }
 
+    public static CloseableHttpClient getInternalHttpClient(InternalHttpClientProvider.Target target) {
+        return InternalHttpClientProviderFactory.getProvider().getHttpClient(target);
+    }
+
     private static String executeRequest(HttpRequestBase request) throws IOException {
         CloseableHttpClient client = getHttpClient();
         return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
+    }
+
+    private static String executeInternalRequest(HttpRequestBase request,
+            InternalHttpClientProvider.Target target) throws IOException {
+        CloseableHttpClient client = getInternalHttpClient(target);
+        return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
+    }
+
+    public static String normalizeInternalUrl(String url, InternalHttpClientProvider.Target target) {
+        return InternalHttpClientProviderFactory.getProvider().normalizeInternalUrl(url, target);
     }
 
     static String parseResponse(String response) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -30,6 +30,7 @@ import org.apache.doris.common.proc.ProcService;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.ha.FrontendNodeType;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.controller.BaseController.ActionAuthorizationInfo;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
@@ -204,7 +205,7 @@ public class NodeAction extends RestBaseController {
                 Backend be = Env.getCurrentSystemInfo().getBackend(beIds.get(0));
                 String url = "http://" + NetUtils.getHostPortInAccessibleFormat(be.getHost(), be.getHttpPort())
                         + "/api/show_config";
-                String questResult = HttpUtils.doGet(url, null);
+                String questResult = HttpUtils.doInternalGet(url, null, InternalHttpClientProvider.Target.BE);
                 List<List<String>> configs = GsonUtils.GSON.fromJson(questResult, new TypeToken<List<List<String>>>() {
                 }.getType());
                 for (List<String> config : configs) {
@@ -374,9 +375,11 @@ public class NodeAction extends RestBaseController {
             String address = NetUtils.getHostPortInAccessibleFormat(hostPort.first, hostPort.second);
             configRequestDoneSignal.addMark(address, -1);
             String url = "http://" + address + questPath;
+            InternalHttpClientProvider.Target target = nodeType.equalsIgnoreCase("FE")
+                    ? InternalHttpClientProvider.Target.FE : InternalHttpClientProvider.Target.BE;
             httpExecutor.submit(
-                    new HttpConfigInfoTask(url, hostPort, authorization, nodeType, confNames, configRequestDoneSignal,
-                            configInfoTotal.get(i)));
+                    new HttpConfigInfoTask(url, hostPort, authorization, nodeType, target, confNames,
+                            configRequestDoneSignal, configInfoTotal.get(i)));
         }
         List<List<String>> resultConfigs = Lists.newArrayList();
         try {
@@ -419,17 +422,20 @@ public class NodeAction extends RestBaseController {
         private Pair<String, Integer> hostPort;
         private String authorization;
         private String nodeType;
+        private InternalHttpClientProvider.Target target;
         private List<String> confNames;
         private MarkedCountDownLatch<String, Integer> configRequestDoneSignal;
         private List<List<String>> config;
 
         public HttpConfigInfoTask(String url, Pair<String, Integer> hostPort, String authorization, String nodeType,
-                List<String> confNames, MarkedCountDownLatch<String, Integer> configRequestDoneSignal,
+                InternalHttpClientProvider.Target target, List<String> confNames,
+                MarkedCountDownLatch<String, Integer> configRequestDoneSignal,
                 List<List<String>> config) {
             this.url = url;
             this.hostPort = hostPort;
             this.authorization = authorization;
             this.nodeType = nodeType;
+            this.target = target;
             this.confNames = confNames;
             this.configRequestDoneSignal = configRequestDoneSignal;
             this.config = config;
@@ -439,8 +445,8 @@ public class NodeAction extends RestBaseController {
         public void run() {
             String configInfo;
             try {
-                configInfo = HttpUtils.doGet(url,
-                        ImmutableMap.<String, String>builder().put(AUTHORIZATION, authorization).build());
+                configInfo = HttpUtils.doInternalGet(url,
+                        ImmutableMap.<String, String>builder().put(AUTHORIZATION, authorization).build(), target);
                 List<List<String>> configs = GsonUtils.GSON.fromJson(configInfo, new TypeToken<List<List<String>>>() {
                 }.getType());
                 for (List<String> conf : configs) {
@@ -452,7 +458,8 @@ public class NodeAction extends RestBaseController {
                         .getHostPortInAccessibleFormat(hostPort.first, hostPort.second), -1);
             } catch (Exception e) {
                 LOG.warn("get config from {}:{} failed.", hostPort.first, hostPort.second, e);
-                configRequestDoneSignal.countDown();
+                configRequestDoneSignal.markedCountDown(NetUtils
+                        .getHostPortInAccessibleFormat(hostPort.first, hostPort.second), -1);
             }
         }
 
@@ -507,7 +514,7 @@ public class NodeAction extends RestBaseController {
             if (!nodeConfigs.getConfigs(true).isEmpty()) {
                 String url = concatFeSetConfigUrl(nodeConfigs, true);
                 try {
-                    String responsePersist = HttpUtils.doGet(url, header);
+                    String responsePersist = HttpUtils.doInternalGet(url, header, InternalHttpClientProvider.Target.FE);
                     parseFeSetConfigResponse(responsePersist, nodeConfigs.getHostPort(), failedTotal);
                 } catch (Exception e) {
                     addSetConfigErrNode(nodeConfigs.getConfigs(true), nodeConfigs.getHostPort(), e.getMessage(),
@@ -517,7 +524,7 @@ public class NodeAction extends RestBaseController {
             if (!nodeConfigs.getConfigs(false).isEmpty()) {
                 String url = concatFeSetConfigUrl(nodeConfigs, false);
                 try {
-                    String responseTemp = HttpUtils.doGet(url, header);
+                    String responseTemp = HttpUtils.doInternalGet(url, header, InternalHttpClientProvider.Target.FE);
                     parseFeSetConfigResponse(responseTemp, nodeConfigs.getHostPort(), failedTotal);
                 } catch (Exception e) {
                     addSetConfigErrNode(nodeConfigs.getConfigs(false), nodeConfigs.getHostPort(), e.getMessage(),
@@ -569,7 +576,8 @@ public class NodeAction extends RestBaseController {
     private String concatFeSetConfigUrl(NodeConfigs nodeConfigs, boolean isPersist) {
         StringBuilder sb = new StringBuilder();
         Pair<String, Integer> hostPort = nodeConfigs.getHostPort();
-        sb.append("http://").append(hostPort.first).append(":").append(hostPort.second).append("/api/_set_config");
+        sb.append("http://").append(NetUtils.getHostPortInAccessibleFormat(hostPort.first, hostPort.second))
+                .append("/api/_set_config");
         Map<String, String> configs = nodeConfigs.getConfigs(isPersist);
         boolean addAnd = false;
         for (Map.Entry<String, String> entry : configs.entrySet()) {
@@ -867,7 +875,8 @@ public class NodeAction extends RestBaseController {
     private String concatBeSetConfigUrl(String host, Integer port, String configName, String configValue,
             boolean isPersist) {
         StringBuilder stringBuffer = new StringBuilder();
-        stringBuffer.append("http://").append(host).append(":").append(port).append("/api/update_config").append("?")
+        stringBuffer.append("http://").append(NetUtils.getHostPortInAccessibleFormat(host, port))
+                .append("/api/update_config").append("?")
                 .append(configName).append("=").append(configValue);
         if (isPersist) {
             stringBuffer.append("&persist=true");
@@ -913,8 +922,9 @@ public class NodeAction extends RestBaseController {
         @Override
         public void run() {
             try {
-                String response = HttpUtils.doPost(url,
-                        ImmutableMap.<String, String>builder().put(AUTHORIZATION, authorization).build(), null);
+                String response = HttpUtils.doInternalPost(url,
+                        ImmutableMap.<String, String>builder().put(AUTHORIZATION, authorization).build(), null,
+                        InternalHttpClientProvider.Target.BE);
                 JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
                 String status = jsonObject.get("status").getAsString();
                 if (!status.equals("OK")) {
@@ -928,7 +938,10 @@ public class NodeAction extends RestBaseController {
                 LOG.warn("set be:{} config:{} failed.", NetUtils
                         .getHostPortInAccessibleFormat(hostPort.first, hostPort.second),
                         configName + "=" + configValue, e);
-                beSetConfigDoneSignal.countDown();
+                addFailedConfig(configName, configValue, NetUtils
+                        .getHostPortInAccessibleFormat(hostPort.first, hostPort.second), e.getMessage(), failed);
+                beSetConfigDoneSignal.markedCountDown(
+                        concatNodeConfig(hostPort.first, hostPort.second, configName, configValue), -1);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.profile.ProfileManager;
 import org.apache.doris.common.profile.ProfileManager.ProfileElement;
 import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.controller.BaseController.ActionAuthorizationInfo;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
@@ -134,9 +135,11 @@ public class QueryProfileAction extends RestBaseController {
             try {
                 String data = null;
                 if (method == HttpMethod.GET) {
-                    data = HttpUtils.parseResponse(HttpUtils.doGet(url, header));
+                    data = HttpUtils.parseResponse(HttpUtils.doInternalGet(url, header,
+                            InternalHttpClientProvider.Target.FE));
                 } else if (method == HttpMethod.POST) {
-                    data = HttpUtils.parseResponse(HttpUtils.doPost(url, header, null));
+                    data = HttpUtils.parseResponse(HttpUtils.doInternalPost(url, header, null,
+                            InternalHttpClientProvider.Target.FE));
                 }
                 if (!Strings.isNullOrEmpty(data) && !data.equals("{}")) {
                     dataList.add(data);
@@ -349,7 +352,7 @@ public class QueryProfileAction extends RestBaseController {
                     continue;
                 }
                 String url = HttpUtils.concatUrl(ipPort, httpPath, arguments);
-                String responseJson = HttpUtils.doGet(url, header);
+                String responseJson = HttpUtils.doInternalGet(url, header, InternalHttpClientProvider.Target.FE);
                 JsonObject jObj = JsonParser.parseString(responseJson).getAsJsonObject();
                 int code = jObj.get("code").getAsInt();
                 if (code == HttpUtils.REQUEST_SUCCESS_CODE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/ClusterGuardAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/ClusterGuardAction.java
@@ -21,6 +21,7 @@ import org.apache.doris.cluster.ClusterGuard;
 import org.apache.doris.cluster.ClusterGuardException;
 import org.apache.doris.cluster.ClusterGuardFactory;
 import org.apache.doris.common.Pair;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
@@ -124,7 +125,7 @@ public class ClusterGuardAction extends RestBaseController {
             String nodeKey = ipPort.first + ":" + ipPort.second;
             String url = HttpUtils.concatUrl(ipPort, httpPath, arguments);
             try {
-                String resp = HttpUtils.doPost(url, header, null);
+                String resp = HttpUtils.doInternalPost(url, header, null, InternalHttpClientProvider.Target.FE);
                 JsonObject jsonObj = JsonParser.parseString(resp).getAsJsonObject();
                 int code = jsonObj.get("code").getAsInt();
                 if (code == HttpUtils.REQUEST_SUCCESS_CODE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/LoadSubmitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/LoadSubmitter.java
@@ -21,7 +21,9 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.ThreadPoolManager;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.rest.UploadAction;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.BeSelectionPolicy;
@@ -42,7 +44,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -87,8 +88,8 @@ public class LoadSubmitter {
 
             String hostPort = NetUtils.getHostPortInAccessibleFormat(be.getHost(), be.getHttpPort());
             String loadUrlStr = String.format(STREAM_LOAD_URL_PATTERN, hostPort, loadContext.db, loadContext.tbl);
-            URL loadUrl = new URL(loadUrlStr);
-            HttpURLConnection conn = (HttpURLConnection) loadUrl.openConnection();
+            HttpURLConnection conn = HttpURLUtil.getInternalConnection(loadUrlStr,
+                    InternalHttpClientProvider.Target.BE);
             conn.setRequestMethod("PUT");
             String auth = String.format("%s:%s", loadContext.user,
                     loadContext.passwd);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -31,8 +31,10 @@ import org.apache.doris.common.LoadException;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.ByteBufferNetworkInputStream;
+import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
 import org.apache.doris.load.LoadJobRowResult;
 import org.apache.doris.load.StreamLoadHandler;
@@ -61,7 +63,6 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -187,7 +188,9 @@ public class MysqlLoadManager {
         MySqlLoadContext loadContext = new MySqlLoadContext();
         loadContextMap.put(loadId, loadContext);
         LOG.info("Executing mysql load with id: {}.", loadId);
-        try (final CloseableHttpClient httpclient = HttpUtils.getHttpClient()) {
+        final CloseableHttpClient httpclient =
+                HttpUtils.getInternalHttpClient(InternalHttpClientProvider.Target.BE);
+        try {
             for (String file : filePaths) {
                 InputStreamEntity entity = getInputStreamEntity(context, clientLocal, file, loadId);
                 HttpPut request = generateRequestForMySqlLoadV2(entity, dataDesc, database, table, token);
@@ -254,7 +257,9 @@ public class MysqlLoadManager {
         MySqlLoadContext loadContext = new MySqlLoadContext();
         loadContextMap.put(loadId, loadContext);
         LOG.info("Executing mysql load with id: {}.", loadId);
-        try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
+        final CloseableHttpClient httpclient =
+                HttpUtils.getInternalHttpClient(InternalHttpClientProvider.Target.BE);
+        try {
             for (String file : filePaths) {
                 InputStreamEntity entity = getInputStreamEntity(context, clientLocal, file, loadId);
                 HttpPut request = generateRequestForMySqlLoad(entity, dataDesc, database, table, token);
@@ -692,14 +697,12 @@ public class MysqlLoadManager {
 
         StringBuilder sb = new StringBuilder();
         sb.append("http://");
-        sb.append(backend.getHost());
-        sb.append(":");
-        sb.append(backend.getHttpPort());
+        sb.append(NetUtils.getHostPortInAccessibleFormat(backend.getHost(), backend.getHttpPort()));
         sb.append("/api/");
         sb.append(database);
         sb.append("/");
         sb.append(table);
         sb.append("/_stream_load");
-        return  sb.toString();
+        return HttpUtils.normalizeInternalUrl(sb.toString(), InternalHttpClientProvider.Target.BE);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -33,6 +33,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.rest.RestApiStatusCode;
 import org.apache.doris.metric.MetricRepo;
@@ -297,7 +298,8 @@ public class Checkpoint extends MasterDaemon {
                              * this lagging node can never get the deleted journal.
                              */
                             idURL = "http://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/journal_id";
-                            conn = HttpURLUtil.getConnectionWithNodeIdent(idURL);
+                            conn = HttpURLUtil.getInternalConnectionWithNodeIdent(idURL,
+                                    InternalHttpClientProvider.Target.FE);
                             conn.setConnectTimeout(CONNECT_TIMEOUT_SECOND * 1000);
                             conn.setReadTimeout(READ_TIMEOUT_SECOND * 1000);
                             String idString = conn.getHeaderField("id");

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.io.IOUtils;
 import org.apache.doris.common.util.HttpURLUtil;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -150,7 +151,7 @@ public class MetaHelper {
     public static <T> ResponseBody doGet(String url, int timeout, Class<T> clazz) throws IOException {
         Map<String, String> headers = HttpURLUtil.getNodeIdentHeaders();
         LOG.info("meta helper, url: {}, timeout{}, headers: {}", url, timeout, headers);
-        String response = HttpUtils.doGet(url, headers, timeout);
+        String response = HttpUtils.doInternalGet(url, headers, timeout, InternalHttpClientProvider.Target.FE);
         return parseResponse(response, clazz);
     }
 
@@ -161,7 +162,7 @@ public class MetaHelper {
         checkFile(file);
         OutputStream out = new FileOutputStream(file);
         try {
-            conn = HttpURLUtil.getConnectionWithNodeIdent(urlStr);
+            conn = HttpURLUtil.getInternalConnectionWithNodeIdent(urlStr, InternalHttpClientProvider.Target.FE);
             conn.setConnectTimeout(timeout);
             conn.setReadTimeout(timeout);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowConfigCommand.java
@@ -28,6 +28,9 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.PatternMatcherWrapper;
+import org.apache.doris.common.util.HttpURLUtil;
+import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -46,8 +49,7 @@ import org.json.JSONArray;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -126,10 +128,11 @@ public class ShowConfigCommand extends Command implements NoForward {
             Backend backend = systemInfoService.getBackend(beId);
             String host = backend.getHost();
             int httpPort = backend.getHttpPort();
-            String urlString = String.format("http://%s:%d/api/show_config", host, httpPort);
+            String urlString = String.format("http://%s/api/show_config",
+                    NetUtils.getHostPortInAccessibleFormat(host, httpPort));
             try {
-                URL url = new URL(urlString);
-                URLConnection urlConnection = url.openConnection();
+                HttpURLConnection urlConnection = HttpURLUtil.getInternalConnection(urlString,
+                        InternalHttpClientProvider.Target.BE);
                 urlConnection.setRequestProperty("Auth-Token", Env.getCurrentEnv().getTokenManager().acquireToken());
                 InputStream inputStream = urlConnection.getInputStream();
                 BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommand.java
@@ -29,7 +29,9 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.load.loadv2.LoadManager;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.trees.expressions.And;
@@ -58,9 +60,9 @@ import org.apache.logging.log4j.Logger;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -234,13 +236,14 @@ public class ShowLoadWarningsCommand extends ShowCommand {
 
         List<List<String>> rows = Lists.newArrayList();
         try {
-            URLConnection urlConnection = url.openConnection();
+            HttpURLConnection urlConnection = HttpURLUtil.getInternalConnection(url.toString(),
+                    InternalHttpClientProvider.Target.BE);
             urlConnection.setRequestProperty("Auth-Token", Env.getCurrentEnv().getTokenManager().acquireToken());
             InputStream inputStream = urlConnection.getInputStream();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
                 int limit = 100;
-                while (reader.ready() && limit > 0) {
-                    String line = reader.readLine();
+                String line;
+                while ((line = reader.readLine()) != null && limit > 0) {
                     rows.add(Lists.newArrayList("-1", FeConstants.null_string, line));
                     limit--;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditStreamLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditStreamLoader.java
@@ -21,6 +21,8 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchema;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.HttpURLUtil;
+import org.apache.doris.httpv2.client.InternalHttpClientProvider;
 import org.apache.doris.qe.GlobalVariable;
 
 import org.apache.logging.log4j.LogManager;
@@ -31,7 +33,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.Calendar;
 import java.util.stream.Collectors;
 
@@ -55,9 +56,19 @@ public class AuditStreamLoader {
         this.feIdentity = Env.getCurrentEnv().getSelfNode().getIdent().replaceAll("\\.", "_").replaceAll(":", "_");
     }
 
-    private HttpURLConnection getConnection(String urlStr, String label, String clusterToken) throws IOException {
-        URL url = new URL(urlStr);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    private HttpURLConnection getFeConnection(String urlStr, String label, String clusterToken) throws IOException {
+        HttpURLConnection conn = getConnection(urlStr, label, clusterToken, InternalHttpClientProvider.Target.FE);
+        conn.addRequestProperty("redirect-policy", "random-be");
+        return conn;
+    }
+
+    private HttpURLConnection getBeConnection(String urlStr, String label, String clusterToken) throws IOException {
+        return getConnection(urlStr, label, clusterToken, InternalHttpClientProvider.Target.BE);
+    }
+
+    private HttpURLConnection getConnection(String urlStr, String label, String clusterToken,
+            InternalHttpClientProvider.Target target) throws IOException {
+        HttpURLConnection conn = HttpURLUtil.getInternalConnection(urlStr, target);
         conn.setInstanceFollowRedirects(false);
         conn.setRequestMethod("PUT");
         conn.setRequestProperty("token", clusterToken);
@@ -72,7 +83,6 @@ public class AuditStreamLoader {
         conn.addRequestProperty("columns",
                 InternalSchema.AUDIT_SCHEMA.stream().map(c -> c.getName()).collect(
                         Collectors.joining(",")));
-        conn.addRequestProperty("redirect-policy", "random-be");
         conn.addRequestProperty("column_separator", AuditLoader.AUDIT_TABLE_COL_SEPARATOR_STR);
         conn.addRequestProperty("line_delimiter", AuditLoader.AUDIT_TABLE_LINE_DELIMITER_STR);
         conn.addRequestProperty("skip_record_to_audit_log_table", "true");
@@ -124,7 +134,7 @@ public class AuditStreamLoader {
         try {
             // build request and send to fe
             label = "audit" + label;
-            feConn = getConnection(auditLogLoadUrlStr, label, clusterToken);
+            feConn = getFeConnection(auditLogLoadUrlStr, label, clusterToken);
             int status = feConn.getResponseCode();
             // fe send back http response code TEMPORARY_REDIRECT 307 and new be location
             if (status != 307) {
@@ -136,7 +146,7 @@ public class AuditStreamLoader {
                 throw new Exception("redirect location is null");
             }
             // build request and send to new be location
-            beConn = getConnection(location, label, clusterToken);
+            beConn = getBeConnection(location, label, clusterToken);
             // send data to be
             try (BufferedOutputStream bos = new BufferedOutputStream(beConn.getOutputStream())) {
                 bos.write(sb.toString().getBytes());

--- a/fe/fe-core/src/main/java/org/apache/doris/tls/server/OssHttpServerTlsProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tls/server/OssHttpServerTlsProvider.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 public class OssHttpServerTlsProvider implements HttpServerTlsProvider {
     @Override
     public void customize(ConfigurableJettyWebServerFactory factory) {
-        if (Config.enable_tls && TlsProtocolSet.isProtocolIncluded(TlsProtocolSet.Protocol.HTTP)) {
+        if (TlsProtocolSet.isHttpTlsActive()) {
             throw new UnsupportedOperationException("FE HTTP TLS requires TLS module");
         }
         if (!Config.enable_https) {

--- a/fe/fe-core/src/main/java/org/apache/doris/tls/server/TlsProtocolSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tls/server/TlsProtocolSet.java
@@ -45,6 +45,10 @@ public final class TlsProtocolSet {
         return !excludedProtocols().contains(protocol.name().toLowerCase(Locale.ROOT));
     }
 
+    public static boolean isHttpTlsActive() {
+        return Config.enable_tls && isProtocolIncluded(Protocol.HTTP);
+    }
+
     private static Set<String> excludedProtocols() {
         String raw = Config.tls_excluded_protocols == null ? "" : Config.tls_excluded_protocols;
         if (raw.equals(cachedRaw)) {

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/client/OssInternalHttpClientProviderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/client/OssInternalHttpClientProviderTest.java
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.client;
+
+import org.apache.doris.common.Config;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OssInternalHttpClientProviderTest {
+    private boolean oldEnableHttps;
+    private int oldHttpsPort;
+    private boolean oldEnableTls;
+    private String oldTlsExcludedProtocols;
+
+    @Before
+    public void setUp() {
+        oldEnableHttps = Config.enable_https;
+        oldHttpsPort = Config.https_port;
+        oldEnableTls = Config.enable_tls;
+        oldTlsExcludedProtocols = Config.tls_excluded_protocols;
+        Config.enable_https = false;
+        Config.https_port = 8443;
+        Config.enable_tls = false;
+        Config.tls_excluded_protocols = "";
+    }
+
+    @After
+    public void tearDown() {
+        Config.enable_https = oldEnableHttps;
+        Config.https_port = oldHttpsPort;
+        Config.enable_tls = oldEnableTls;
+        Config.tls_excluded_protocols = oldTlsExcludedProtocols;
+    }
+
+    @Test
+    public void testDefaultConfigurationDoesNotRewriteUrl() {
+        OssInternalHttpClientProvider provider = new OssInternalHttpClientProvider();
+
+        Assert.assertEquals("http://fe-host:8080/rest/v1/session",
+                provider.normalizeInternalUrl("http://fe-host:8080/rest/v1/session",
+                        InternalHttpClientProvider.Target.FE));
+    }
+
+    @Test
+    public void testFeUrlRewrittenWhenOpenSourceHttpsEnabled() {
+        Config.enable_https = true;
+        OssInternalHttpClientProvider provider = new OssInternalHttpClientProvider();
+
+        Assert.assertEquals("https://fe-host:8443/rest/v1/session",
+                provider.normalizeInternalUrl("http://fe-host:8080/rest/v1/session",
+                        InternalHttpClientProvider.Target.FE));
+    }
+
+    @Test
+    public void testHttpsInputIsIdempotent() {
+        Config.enable_https = true;
+        OssInternalHttpClientProvider provider = new OssInternalHttpClientProvider();
+
+        Assert.assertEquals("https://fe-host:9443/rest/v1/session",
+                provider.normalizeInternalUrl("https://fe-host:9443/rest/v1/session",
+                        InternalHttpClientProvider.Target.FE));
+    }
+
+    @Test
+    public void testBeUrlIsNotRewrittenByOpenSourceHttps() {
+        Config.enable_https = true;
+        OssInternalHttpClientProvider provider = new OssInternalHttpClientProvider();
+
+        Assert.assertEquals("http://be-host:8040/api/show_config",
+                provider.normalizeInternalUrl("http://be-host:8040/api/show_config",
+                        InternalHttpClientProvider.Target.BE));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testHttpTlsRequiresTlsModuleProvider() {
+        Config.enable_tls = true;
+        Config.tls_excluded_protocols = "";
+        OssInternalHttpClientProvider provider = new OssInternalHttpClientProvider();
+
+        provider.normalizeInternalUrl("http://fe-host:8080/check", InternalHttpClientProvider.Target.FE);
+    }
+}


### PR DESCRIPTION
## Proposed changes

When `enable_https` is enabled, several FE-internal HTTP requests are still built with `http://` URLs. Relying on an HTTP-to-HTTPS redirect is fragile for these internal Java clients, especially for `HttpURLConnection` paths where cross-protocol redirects are not a good contract for internal node communication.

This PR adds an `InternalHttpClientProvider` abstraction for FE JVM internal HTTP clients and an OSS implementation that centralizes internal URL normalization:

- `Target.FE` URLs are rewritten to `https://...:${https_port}` when `enable_https=true`.
- `Target.BE` URLs are not rewritten by OSS HTTPS.
- Inputs that are already `https://` are left unchanged.
- External/user-provided HTTP clients are not moved to the internal provider.
- Existing FE HTTP TLS-module fail-fast behavior is kept centralized through `TlsProtocolSet.isHttpTlsActive()`.

Internal call sites migrated include FE-to-FE helper/meta paths, REST forwarding, audit loading, upload/stream-load submitter, MySQL LOAD, show config, show load warnings, node config manager paths, profile/session/cluster guard fan-out, BE proc display URLs, and BE warmup stats collection.

## Tests

```bash
./run-fe-ut.sh --run org.apache.doris.httpv2.client.OssInternalHttpClientProviderTest
```

Result:

```text
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```