### PR TITLE
[fix](regression) force cleanup routine load error info tables

### DIFF
--- a/regression-test/suites/load_p0/routine_load/test_routine_load_error_info.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_error_info.groovy
@@ -48,7 +48,7 @@ suite("test_routine_load_error_info","nonConcurrent") {
 
     def createTable = {tableName ->
         sql """
-            DROP TABLE IF EXISTS ${tableName}
+            DROP TABLE IF EXISTS ${tableName} FORCE
         """
         sql """
             CREATE TABLE IF NOT EXISTS ${tableName}
@@ -202,8 +202,8 @@ suite("test_routine_load_error_info","nonConcurrent") {
             }
         } finally {
             GetDebugPoint().disableDebugPointForAllBEs("BetaRowsetWriter._check_segment_number_limit_too_many_segments")
-            sql "stop routine load for ${jobName}"
-            sql "DROP TABLE IF EXISTS ${tableName}"
+            try_sql "stop routine load for ${jobName}"
+            try_sql "DROP TABLE IF EXISTS ${tableName} FORCE"
         }
     }
 
@@ -235,8 +235,8 @@ suite("test_routine_load_error_info","nonConcurrent") {
                 sleep(1000)
             }
         } finally {
-            sql "stop routine load for ${jobName}"
-            sql "DROP TABLE IF EXISTS ${tableName}"
+            try_sql "stop routine load for ${jobName}"
+            try_sql "DROP TABLE IF EXISTS ${tableName} FORCE"
         }
     }
 
@@ -271,8 +271,8 @@ suite("test_routine_load_error_info","nonConcurrent") {
             }
         } finally {
             GetDebugPoint().disableDebugPointForAllBEs("RoutineLoadTaskExecutor.submit_task.memory_limit")
-            sql "stop routine load for ${jobName}"
-            sql "DROP TABLE IF EXISTS ${tableName}"
+            try_sql "stop routine load for ${jobName}"
+            try_sql "DROP TABLE IF EXISTS ${tableName} FORCE"
         }
     }
 
@@ -317,8 +317,8 @@ suite("test_routine_load_error_info","nonConcurrent") {
             }
         } finally {
             GetDebugPoint().disableDebugPointForAllFEs(debugPoint)
-            sql "stop routine load for ${jobName}"
-            sql "DROP TABLE IF EXISTS ${tableName}"
+            try_sql "stop routine load for ${jobName}"
+            try_sql "DROP TABLE IF EXISTS ${tableName} FORCE"
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix `test_routine_load_error_info` cleanup after the Kafka `read_committed` lag hint assertion.

The failing NonConcurrent build showed the target assertion had already passed: `SHOW ROUTINE LOAD` exposed the expected `some records may be in uncommitted transactions` hint. The case then immediately stopped routine load and used a plain `DROP TABLE`, which raced a committed routine-load transaction still waiting to complete.

Use `try_sql` cleanup plus `DROP TABLE IF EXISTS ... FORCE` for this case's test-owned tables so cleanup does not mask a successful assertion with a transient committed-transaction drop failure. If setup/assertion fails earlier in a future run, cleanup will also avoid hiding the original failure.

## Testing

- [x] `git diff --check`
- [ ] Runtime regression not run locally; current machine does not have the required Doris/Kafka endpoints (`172.19.0.2:9131`, `127.0.0.1:19193`).
