### PR TITLE
[fix](fe) Fix show data all result row width

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommand.java
@@ -403,9 +403,9 @@ public class ShowDataCommand extends ShowCommand {
                     DebugUtil.printByteWithUnit(totalRemoteInvertedSize),
                     DebugUtil.printByteWithUnit(totalBinlogSize)));
             totalRows.add(Arrays.asList("Quota", String.valueOf(replicaQuota),
-                    DebugUtil.printByteWithUnit(quota), "", "", "", "", ""));
+                    DebugUtil.printByteWithUnit(quota), "", "", "", "", "", ""));
             totalRows.add(Arrays.asList("Left", String.valueOf(replicaCountLeft),
-                    DebugUtil.printByteWithUnit(left), "", "", "", "", ""));
+                    DebugUtil.printByteWithUnit(left), "", "", "", "", "", ""));
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommandTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -142,6 +143,58 @@ public class ShowDataCommandTest {
         Assertions.assertTrue(command.getMetaData().getColumns().stream()
                         .anyMatch(c -> c.getName().equalsIgnoreCase("BinlogSize")),
                 "SHOW DATA should contain BinlogSize column");
+    }
+
+    @Test
+    public void testValidateShowDetailedDataRowsMatchMetaData() throws Exception {
+        Mockito.when(connectContext.getDatabase()).thenReturn(CatalogMocker.TEST_DB_NAME);
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        mockedEnv.when(Env::getCurrentInvertedIndex).thenReturn(Mockito.mock(TabletInvertedIndex.class));
+        Database mockDb = CatalogMocker.mockDb();
+        Mockito.when(catalog.getDbOrAnalysisException(Mockito.anyString())).thenReturn(mockDb);
+        Mockito.when(accessControllerManager.checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(PrivPredicate.class))).thenReturn(true);
+
+        ShowDataCommand command = new ShowDataCommand(null, null, new HashMap<>(), true);
+
+        ShowResultSet rs = command.doRun(connectContext, null);
+        int columnCount = rs.getMetaData().getColumnCount();
+        Assertions.assertEquals(9, columnCount);
+        for (List<String> row : rs.getResultRows()) {
+            Assertions.assertEquals(columnCount, row.size());
+        }
+    }
+
+    @Test
+    public void testValidateShowDetailedDataRowsMatchMetaDataForEmptyDb() throws Exception {
+        Mockito.when(connectContext.getDatabase()).thenReturn(CatalogMocker.TEST_DB_NAME);
+        Mockito.when(catalog.getDbOrAnalysisException(Mockito.anyString())).thenReturn(database);
+        Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN)).thenReturn(true);
+        Mockito.when(database.getTables()).thenReturn(ImmutableList.of());
+        Mockito.when(database.getDataQuota()).thenReturn(1024L);
+        Mockito.when(database.getReplicaQuota()).thenReturn(10L);
+        Mockito.doNothing().when(database).readLock();
+        Mockito.doNothing().when(database).readUnlock();
+
+        ShowDataCommand command = new ShowDataCommand(null, null, new HashMap<>(), true);
+
+        ShowResultSet rs = command.doRun(connectContext, null);
+        List<List<String>> rows = rs.getResultRows();
+
+        Assertions.assertEquals(9, rs.getMetaData().getColumnCount());
+        Assertions.assertEquals(3, rows.size());
+        Assertions.assertEquals(ImmutableList.of("Total", "0", DebugUtil.printByteWithUnit(0L),
+                DebugUtil.printByteWithUnit(0L), DebugUtil.printByteWithUnit(0L), DebugUtil.printByteWithUnit(0L),
+                DebugUtil.printByteWithUnit(0L), DebugUtil.printByteWithUnit(0L),
+                DebugUtil.printByteWithUnit(0L)), rows.get(0));
+        Assertions.assertEquals(ImmutableList.of("Quota", "10", DebugUtil.printByteWithUnit(1024L),
+                "", "", "", "", "", ""), rows.get(1));
+        Assertions.assertEquals(ImmutableList.of("Left", "10", DebugUtil.printByteWithUnit(1024L),
+                "", "", "", "", "", ""), rows.get(2));
+        for (List<String> row : rows) {
+            Assertions.assertEquals(rs.getMetaData().getColumnCount(), row.size());
+        }
     }
 
     @Test

--- a/regression-test/suites/show_p0/test_show_data_all_db.groovy
+++ b/regression-test/suites/show_p0/test_show_data_all_db.groovy
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_data_all_db") {
+    def dbName = "test_show_data_all_db";
+    def tableName = "test_show_data_all_tb";
+    sql """DROP DATABASE IF EXISTS ${dbName}"""
+    sql """CREATE DATABASE IF NOT EXISTS ${dbName}"""
+    sql """USE ${dbName}"""
+    sql """DROP TABLE IF EXISTS ${tableName}"""
+    sql """CREATE TABLE IF NOT EXISTS ${tableName} (
+            `id` int(11) NOT NULL,
+            `name` varchar(50) NOT NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 5
+        PROPERTIES (
+            "replication_num" = "1"
+    )"""
+    sql """insert into ${tableName} values(1, "test1"), (2, "test2"), (3, "test3");"""
+    def result = sql"""show data all;"""
+    logger.info("show data result:${result}");
+    assertTrue(result.size() > 0);
+    for (int i = 0; i < result.size(); i++) {
+        assertTrue(result[i].size() == 9);
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #62058 

Problem Summary: `SHOW DATA ALL` returns detailed database data with 9 metadata columns after `LocalBinlogSize` was added, but the `Quota` and `Left` summary rows still contained only 8 values. The FE MySQL protocol writer sends the 9-column metadata first and then serializes each row as-is, so MySQL clients see an inconsistent result packet and report `ERROR 2027 (HY000): Malformed packet`. This change pads the detailed `Quota` and `Left` rows with the missing `LocalBinlogSize` column and adds unit coverage to assert detailed `SHOW DATA` rows match metadata width.

For examples:
```sql
mysql> show data all;  <<< No Quota and Left
+---------------+--------------------+------+------------+------------+-------------+-------------------+
| DbId          | DbName             | Size | RemoteSize | BinlogSize | RecycleSize | RecycleRemoteSize |
+---------------+--------------------+------+------------+------------+-------------+-------------------+
| 0             | information_schema | 0    | 0          | 0          | 0           | 0                 |
| 1             | mysql              | 0    | 0          | 0          | 0           | 0                 |
| 1783146087105 | __internal_schema  | 0    | 0          | 0          | 0           | 0                 |
| Total         | NULL               | 0    | 0          | 0          | 0           | 0                 |
+---------------+--------------------+------+------------+------------+-------------+-------------------+
mysql> create database test;
mysql> use test;
mysql> show data all;  <<< Here will display Quota and Left
ERROR 2027 (HY000): Malformed packet
```

Fix:
Add an empty column for `Quota` and `Left row` to align with the other rows.


### Release note

Fix `SHOW DATA ALL` malformed packet caused by inconsistent result row width.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Regression test:
`./run-regression-test.sh --run -d show_p0 -s test_show_data_all_db`

Unit Test:
`./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.ShowDataCommandTest`

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
