### PR TITLE
[opt](column) Reuse varbinary payload storage for derived columns

### DIFF
--- a/be/src/core/auxiliary_data_set.h
+++ b/be/src/core/auxiliary_data_set.h
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <memory>
+#include <vector>
+
+namespace doris {
+
+// AuxiliaryDataSet keeps shared ownership of payload objects referenced by
+// lightweight views. It intentionally stores shared_ptr<const void> so current
+// users can keep arbitrary owners alive without introducing a common base class.
+// If future users need type-specific operations such as memory accounting, this
+// can evolve to a typed holder/base-class model similar to DuckDB's
+// AuxiliaryDataHolder.
+//
+// Owners are de-duplicated by shared_ptr ownership identity. De-duplication is
+// not required for correctness, but avoids retaining the same owner repeatedly
+// across chained derived columns.
+class AuxiliaryDataSet {
+public:
+    using ConstOwnerPtr = std::shared_ptr<const void>;
+
+    void clear() { _refs.clear(); }
+
+    template <typename T>
+    T* add_owner(std::shared_ptr<T> owner) {
+        T* ptr = owner.get();
+        add_owner_ref(ConstOwnerPtr(std::move(owner)));
+        return ptr;
+    }
+
+    void add_owners_from(const AuxiliaryDataSet& other) {
+        for (const auto& ref : other._refs) {
+            add_owner_ref(ref);
+        }
+    }
+
+private:
+    void add_owner_ref(ConstOwnerPtr owner) {
+        DCHECK(owner != nullptr);
+        for (const auto& ref : _refs) {
+            if (same_owner(ref, owner)) {
+                return;
+            }
+        }
+        _refs.push_back(std::move(owner));
+    }
+
+    static bool same_owner(const ConstOwnerPtr& lhs, const ConstOwnerPtr& rhs) {
+        return !lhs.owner_before(rhs) && !rhs.owner_before(lhs);
+    }
+
+    std::vector<ConstOwnerPtr> _refs;
+};
+
+} // namespace doris

--- a/be/src/core/block/block.cpp
+++ b/be/src/core/block/block.cpp
@@ -1297,7 +1297,7 @@ size_t MutableBlock::allocated_bytes() const {
     return res;
 }
 
-void MutableBlock::clear_column_data() noexcept {
+void MutableBlock::clear_column_data() {
     SCOPED_SKIP_MEMORY_CHECK();
     for (auto& col : _columns) {
         if (col) {

--- a/be/src/core/block/block.h
+++ b/be/src/core/block/block.h
@@ -666,7 +666,7 @@ public:
 
     // Clear owned mutable columns in place. MutableBlock already owns its
     // columns exclusively, so this does not perform COW detaching or cloning.
-    void clear_column_data() noexcept;
+    void clear_column_data();
 
     size_t allocated_bytes() const;
 

--- a/be/src/core/column/column_varbinary.cpp
+++ b/be/src/core/column/column_varbinary.cpp
@@ -95,13 +95,18 @@ ColumnPtr ColumnVarbinary::filter(const IColumn::Filter& filt, ssize_t result_si
     const UInt8* filt_pos = filt.data();
     const UInt8* filt_end = filt_pos + size;
     const auto* data_pos = _data.data();
+    bool has_non_inline_value = false;
 
     while (filt_pos < filt_end) {
         if (*filt_pos) {
-            res->insert_data(data_pos->data(), data_pos->size());
+            has_non_inline_value |= !data_pos->isInline();
+            res_data.push_back(*data_pos);
         }
         ++filt_pos;
         ++data_pos;
+    }
+    if (has_non_inline_value) {
+        res->_auxiliary_data.add_owners_from(_auxiliary_data);
     }
     return res;
 };
@@ -111,13 +116,7 @@ size_t ColumnVarbinary::filter(const IColumn::Filter& filter) {
     const Self& src_vec = *this;
     for (size_t i = 0; i < filter.size(); i++) {
         if (filter[i]) {
-            if (src_vec.get_data()[i].isInline()) {
-                _data[pos] = src_vec.get_data()[i];
-            } else {
-                auto val = src_vec.get_data()[i];
-                const auto* dst = _arena.insert(val.data(), val.size());
-                _data[pos] = doris::StringView(dst, val.size());
-            }
+            _data[pos] = src_vec.get_data()[i];
             pos++;
         }
     }
@@ -138,14 +137,14 @@ MutableColumnPtr ColumnVarbinary::permute(const IColumn::Permutation& perm, size
 
     auto res = doris::ColumnVarbinary::create(limit);
     typename Self::Container& res_data = res->get_data();
+    bool has_non_inline_value = false;
     for (size_t i = 0; i < limit; ++i) {
         auto val = _data[perm[i]];
-        if (val.isInline()) {
-            res_data[i] = val;
-            continue;
-        }
-        const auto* dst = res->_arena.insert(val.data(), val.size());
-        res_data[i] = doris::StringView(dst, val.size());
+        has_non_inline_value |= !val.isInline();
+        res_data[i] = val;
+    }
+    if (has_non_inline_value) {
+        res->_auxiliary_data.add_owners_from(_auxiliary_data);
     }
 
     return res;
@@ -159,7 +158,8 @@ void ColumnVarbinary::replace_column_data(const IColumn& rhs, size_t row, size_t
         _data[self_row] = val;
         return;
     }
-    const auto* dst = _arena.insert(val.data(), val.size());
+    DCHECK(_arena != nullptr);
+    const auto* dst = _arena->insert(val.data(), val.size());
     _data[self_row] = doris::StringView(dst, val.size());
 }
 

--- a/be/src/core/column/column_varbinary.h
+++ b/be/src/core/column/column_varbinary.h
@@ -24,6 +24,7 @@
 
 #include "core/arena.h"
 #include "core/assert_cast.h"
+#include "core/auxiliary_data_set.h"
 #include "core/column/column.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/data_type/primitive_type.h"
@@ -42,9 +43,10 @@ public:
     using Container = PaddedPODArray<doris::StringView>;
 
 private:
-    ColumnVarbinary() = default;
-    ColumnVarbinary(const size_t n) : _data(n) {}
+    ColumnVarbinary() { reset_to_new_local_storage(); }
+    ColumnVarbinary(const size_t n) : _data(n) { reset_to_new_local_storage(); }
     ColumnVarbinary(const ColumnVarbinary& src) {
+        reset_to_new_local_storage();
         _data.reserve(src._data.size());
         for (const auto& value : src._data) {
             insert_data(value.data(), value.size());
@@ -60,12 +62,17 @@ public:
 
     Container& get_data() { return _data; }
 
+    // Keep payloads alive after copying non-inline StringView metadata from another column.
+    void add_auxiliary_owners_from(const ColumnVarbinary& other) {
+        _auxiliary_data.add_owners_from(other._auxiliary_data);
+    }
+
     // Notice: after this buffer maybe have some useless data
     void resize(size_t n) override { _data.resize(n); }
 
     void clear() override {
         _data.clear();
-        _arena.clear();
+        reset_to_new_local_storage();
     }
 
     Field operator[](size_t n) const override {
@@ -78,7 +85,10 @@ public:
 
     StringRef get_data_at(size_t n) const override { return _data[n].to_string_ref(); }
 
-    char* alloc(size_t length) { return _arena.alloc(length); }
+    char* alloc(size_t length) {
+        DCHECK(_arena != nullptr);
+        return _arena->alloc(length);
+    }
 
     void insert(const Field& x) override {
         const auto& value = x.get<TYPE_VARBINARY>();
@@ -105,7 +115,8 @@ public:
     }
 
     void insert_to_buffer(const char* pos, size_t length) {
-        const char* dst = _arena.insert(pos, length);
+        DCHECK(_arena != nullptr);
+        const char* dst = _arena->insert(pos, length);
         _data.push_back(doris::StringView(dst, cast_set<uint32_t>(length)));
     }
 
@@ -145,11 +156,18 @@ public:
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override;
 
-    size_t allocated_bytes() const override { return _data.allocated_bytes() + _arena.size(); }
+    // TODO: AuxiliaryDataSet currently keeps borrowed payload owners alive but
+    // does not charge their memory here. If Block-level memory accounting needs
+    // to include borrowed payloads, add owner-level accounting with de-duplication.
+    size_t allocated_bytes() const override {
+        DCHECK(_arena != nullptr);
+        return _data.allocated_bytes() + _arena->size();
+    }
 
     size_t byte_size() const override {
+        DCHECK(_arena != nullptr);
         size_t bytes = _data.size() * sizeof(doris::StringView);
-        return bytes + _arena.used_size();
+        return bytes + _arena->used_size();
     }
 
     bool has_enough_capacity(const IColumn& src) const override {
@@ -193,7 +211,14 @@ public:
                      EqualRange& range, bool last_column) const override;
 
 private:
+    void reset_to_new_local_storage() {
+        auto new_arena = std::make_shared<Arena>();
+        _auxiliary_data.clear();
+        _arena = _auxiliary_data.add_owner(std::move(new_arena));
+    }
+
     Container _data;
-    Arena _arena;
+    Arena* _arena = nullptr;
+    AuxiliaryDataSet _auxiliary_data;
 };
 } // namespace doris

--- a/be/src/exec/common/varbinaryop_subbinary.h
+++ b/be/src/exec/common/varbinaryop_subbinary.h
@@ -86,6 +86,7 @@ private:
     static void vectors(const ColumnVarbinary* binarys, const ColumnInt32* start,
                         const ColumnInt32* len, ColumnVarbinary* res, size_t size) {
         res->get_data().reserve(size);
+        bool has_non_inline_value = false;
 
         for (size_t i = 0; i < size; ++i) {
             doris::StringView binary = binarys->get_data()[index_check_const<binary_const>(i)];
@@ -107,8 +108,14 @@ private:
                 fixed_pos = binary_size + fixed_pos + 1;
             }
             int fixed_len = std::min(binary_size - fixed_pos, len_value);
+            const auto result_size = cast_set<uint32_t>(fixed_len);
 
-            res->insert_data(binary.data() + fixed_pos, fixed_len);
+            has_non_inline_value |= !StringView::isInline(result_size);
+            res->get_data().emplace_back(binary.data() + fixed_pos, result_size);
+        }
+
+        if (has_non_inline_value) {
+            res->add_auxiliary_owners_from(*binarys);
         }
     }
 };

--- a/be/test/core/auxiliary_data_set_test.cpp
+++ b/be/test/core/auxiliary_data_set_test.cpp
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/auxiliary_data_set.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace doris {
+
+namespace {
+struct Payload {
+    explicit Payload(int* destroy_count_, int value_)
+            : destroy_count(destroy_count_), value(value_) {}
+
+    ~Payload() { ++*destroy_count; }
+
+    int* destroy_count;
+    int value;
+};
+} // namespace
+
+TEST(AuxiliaryDataSetTest, AddOwnerReturnsTypedPointerAndKeepsOwnerAlive) {
+    AuxiliaryDataSet auxiliary_data;
+    int destroy_count = 0;
+    auto owner = std::make_shared<Payload>(&destroy_count, 42);
+    std::weak_ptr<Payload> weak_owner = owner;
+
+    auto* payload = auxiliary_data.add_owner(owner);
+    ASSERT_EQ(payload, owner.get());
+    EXPECT_EQ(payload->value, 42);
+
+    owner.reset();
+    ASSERT_FALSE(weak_owner.expired());
+    EXPECT_EQ(payload->value, 42);
+
+    auxiliary_data.clear();
+    EXPECT_TRUE(weak_owner.expired());
+    EXPECT_EQ(destroy_count, 1);
+}
+
+TEST(AuxiliaryDataSetTest, AddOwnerDeduplicatesBySharedOwnership) {
+    AuxiliaryDataSet auxiliary_data;
+    int destroy_count = 0;
+    auto owner = std::make_shared<Payload>(&destroy_count, 7);
+    std::shared_ptr<int> alias(owner, &owner->value);
+
+    auxiliary_data.add_owner(owner);
+    EXPECT_EQ(owner.use_count(), 3);
+
+    auxiliary_data.add_owner(alias);
+    EXPECT_EQ(owner.use_count(), 3);
+
+    auxiliary_data.clear();
+    EXPECT_EQ(owner.use_count(), 2);
+    EXPECT_EQ(destroy_count, 0);
+
+    alias.reset();
+    owner.reset();
+    EXPECT_EQ(destroy_count, 1);
+}
+
+TEST(AuxiliaryDataSetTest, AddOwnersFromKeepsSourceOwnersAndDeduplicates) {
+    AuxiliaryDataSet source;
+    AuxiliaryDataSet target;
+    int destroy_count = 0;
+    auto owner = std::make_shared<Payload>(&destroy_count, 99);
+    std::weak_ptr<Payload> weak_owner = owner;
+
+    source.add_owner(owner);
+    EXPECT_EQ(owner.use_count(), 2);
+
+    target.add_owners_from(source);
+    EXPECT_EQ(owner.use_count(), 3);
+
+    target.add_owners_from(source);
+    EXPECT_EQ(owner.use_count(), 3);
+
+    source.clear();
+    owner.reset();
+    ASSERT_FALSE(weak_owner.expired());
+
+    target.clear();
+    EXPECT_TRUE(weak_owner.expired());
+    EXPECT_EQ(destroy_count, 1);
+}
+
+} // namespace doris

--- a/be/test/core/column/column_varbinary_test.cpp
+++ b/be/test/core/column/column_varbinary_test.cpp
@@ -201,6 +201,34 @@ TEST_F(ColumnVarbinaryTest, FilterBothModes) {
     }
 }
 
+TEST_F(ColumnVarbinaryTest, FilterKeepsSourceStorageAfterSourceClear) {
+    auto col = ColumnVarbinary::create();
+    std::vector<std::string> vals = {
+            make_bytes(doris::StringView::kInlineSize + 5, 0x91),
+            make_bytes(3, 0x12),
+            make_bytes(doris::StringView::kInlineSize + 7, 0x92),
+    };
+    for (auto& v : vals) {
+        col->insert_data(v.data(), v.size());
+    }
+
+    IColumn::Filter filter = {1, 0, 1};
+    ColumnPtr filtered = col->filter(filter, -1);
+    col->clear();
+    auto new_value = make_bytes(doris::StringView::kInlineSize + 11, 0xA1);
+    col->insert_data(new_value.data(), new_value.size());
+
+    const auto& filtered_col = assert_cast<const ColumnVarbinary&>(*filtered);
+    ASSERT_EQ(filtered_col.size(), 2U);
+    std::vector<size_t> kept_idx = {0, 2};
+    for (size_t i = 0; i < kept_idx.size(); ++i) {
+        auto r = filtered_col.get_data_at(i);
+        const auto& expect = vals[kept_idx[i]];
+        ASSERT_EQ(r.size, expect.size());
+        ASSERT_EQ(memcmp(r.data, expect.data(), r.size), 0);
+    }
+}
+
 TEST_F(ColumnVarbinaryTest, Permute) {
     auto col = ColumnVarbinary::create();
     // Include large (non-inline) entries to exercise arena path
@@ -233,6 +261,33 @@ TEST_F(ColumnVarbinaryTest, Permute) {
     ASSERT_EQ(c2.size(), vals.size());
     for (size_t i = 0; i < vals.size(); ++i) {
         auto r = c2.get_data_at(i);
+        const auto& expect = vals[perm[i]];
+        ASSERT_EQ(r.size, expect.size());
+        ASSERT_EQ(memcmp(r.data, expect.data(), r.size), 0);
+    }
+}
+
+TEST_F(ColumnVarbinaryTest, PermuteKeepsSourceStorageAfterSourceClear) {
+    auto col = ColumnVarbinary::create();
+    std::vector<std::string> vals = {
+            make_bytes(doris::StringView::kInlineSize + 3, 0xA0),
+            make_bytes(2, 0x21),
+            make_bytes(doris::StringView::kInlineSize + 8, 0xA1),
+    };
+    for (auto& v : vals) {
+        col->insert_data(v.data(), v.size());
+    }
+
+    IColumn::Permutation perm = {2, 0, 1};
+    ColumnPtr permuted = col->permute(perm, vals.size());
+    col->clear();
+    auto new_value = make_bytes(doris::StringView::kInlineSize + 13, 0xB1);
+    col->insert_data(new_value.data(), new_value.size());
+
+    const auto& permuted_col = assert_cast<const ColumnVarbinary&>(*permuted);
+    ASSERT_EQ(permuted_col.size(), vals.size());
+    for (size_t i = 0; i < vals.size(); ++i) {
+        auto r = permuted_col.get_data_at(i);
         const auto& expect = vals[perm[i]];
         ASSERT_EQ(r.size, expect.size());
         ASSERT_EQ(memcmp(r.data, expect.data(), r.size), 0);

--- a/be/test/exprs/function/function_varbinary_test.cpp
+++ b/be/test/exprs/function/function_varbinary_test.cpp
@@ -408,6 +408,44 @@ TEST(function_binary_test, function_subbinary_test) {
     }
 }
 
+TEST(function_binary_test, function_subbinary_reuses_non_inline_payload) {
+    auto binary = ColumnVarbinary::create();
+    std::string value = "0123456789abcdefghijklmnopqrstuvwxyz";
+    binary->insert_data(value.data(), value.size());
+    binary->insert_data(value.data(), value.size());
+    const char* source_data = binary->get_data_at(0).data;
+    const char* second_source_data = binary->get_data_at(1).data;
+    auto* binary_ptr = binary.get();
+
+    auto start = ColumnInt32::create();
+    start->insert_value(5);
+    start->insert_value(5);
+    auto length = ColumnInt32::create();
+    length->insert_value(20);
+    length->insert_value(5);
+
+    auto varbinary_type = std::make_shared<DataTypeVarbinary>();
+    Block block({{std::move(binary), varbinary_type, "binary"},
+                 {std::move(start), std::make_shared<DataTypeInt32>(), "start"},
+                 {std::move(length), std::make_shared<DataTypeInt32>(), "length"},
+                 {varbinary_type->create_column(), varbinary_type, "result"}});
+
+    SubBinaryUtil::sub_binary_execute(block, {0, 1, 2}, 3, 2);
+
+    const auto& result = assert_cast<const ColumnVarbinary&>(*block.get_by_position(3).column);
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(result.get_data_at(0).data, source_data + 4);
+    EXPECT_EQ(result.get_data_at(0).to_string(), value.substr(4, 20));
+    EXPECT_NE(result.get_data_at(1).data, second_source_data + 4);
+    EXPECT_EQ(result.get_data_at(1).to_string(), value.substr(4, 5));
+
+    binary_ptr->clear();
+    std::string replacement(value.size(), 'x');
+    binary_ptr->insert_data(replacement.data(), replacement.size());
+    EXPECT_EQ(result.get_data_at(0).to_string(), value.substr(4, 20));
+    EXPECT_EQ(result.get_data_at(1).to_string(), value.substr(4, 5));
+}
+
 TEST(function_binary_test, function_to_binary_test) {
     std::string func_name = "to_binary";
     InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR};


### PR DESCRIPTION
### What problem does this PR solve?


`ColumnVarbinary` previously copied non-inline payload bytes when filtering, permuting, or evaluating `sub_binary`. Root cause: derived `StringView` values could not safely reference source Arena memory after the source column was cleared or reused.

This PR adds a generic auxiliary owner set to retain referenced payload storage. `filter`, `permute`, and `sub_binary` now reuse non-inline payloads by copying only `StringView` metadata while preserving owner lifetimes. New unit cases cover owner retention and source-clear safety.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

