### PR TITLE
[fix](timestamptz) Fix TIMESTAMPTZ dynamic partition boundaries not aligned to UTC midnight

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteralUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteralUtils.java
@@ -65,7 +65,6 @@ public class DateLiteralUtils {
             }
             TemporalAccessor dateTime = null;
             boolean parsed = false;
-            int offset = 0;
             ZoneId sourceZone = null;
 
             // parse timezone
@@ -217,9 +216,14 @@ public class DateLiteralUtils {
             // The original code used Instant.now() which returns the current
             // DST offset; when the target date falls in a different DST period
             // the computed shift is wrong by the DST gap.
+            //
+            // We derive the destination wall clock directly from the resolved
+            // target instant (via LocalDateTime.ofInstant) rather than computing
+            // a delta offset. This correctly handles source-zone DST gaps:
+            // e.g. CET spring-forward resolves 02:30 CET (nonexistent) to
+            // 03:30 CEST = 01:30Z; ofInstant then reconstructs the correct
+            // wall clock for the destination zone from the resolved instant.
             if (sourceZone != null) {
-                // Use TimeUtils.getTimeZone() for consistency with the
-                // downstream unixTimestamp(TimeUtils.getTimeZone()) call.
                 ZoneId dorisZone = TimeUtils.getTimeZone().toZoneId();
                 if (type != null && type.isTimeStampTz()) {
                     dorisZone = ZoneId.of("UTC");
@@ -228,26 +232,15 @@ public class DateLiteralUtils {
                         (int) year, (int) month, (int) day,
                         (int) hour, (int) minute, (int) second);
                 Instant targetInstant = parsedLdt.atZone(sourceZone).toInstant();
-                offset = dorisZone.getRules().getOffset(targetInstant).getTotalSeconds()
-                        - sourceZone.getRules().getOffset(targetInstant).getTotalSeconds();
-            }
-
-            // Apply timezone offset before constructing the DateLiteral.
-            // The original init() calls this.plusSeconds(offset) which internally uses
-            // LocalDateTime arithmetic. We replicate that here directly.
-            if (offset != 0) {
-                LocalDateTime ldt = LocalDateTime.of(
-                        (int) year, (int) month, (int) day,
-                        (int) hour, (int) minute, (int) second,
-                        (int) (microsecond * 1000));
-                ldt = ldt.plusSeconds(offset);
-                year = ldt.getYear();
-                month = ldt.getMonthValue();
-                day = ldt.getDayOfMonth();
-                hour = ldt.getHour();
-                minute = ldt.getMinute();
-                second = ldt.getSecond();
-                // microsecond is intentionally NOT updated, matching the original init() behavior
+                LocalDateTime destLdt = LocalDateTime.ofInstant(targetInstant, dorisZone);
+                year = destLdt.getYear();
+                month = destLdt.getMonthValue();
+                day = destLdt.getDayOfMonth();
+                hour = destLdt.getHour();
+                minute = destLdt.getMinute();
+                second = destLdt.getSecond();
+                // microsecond is preserved from the original parse, matching
+                // the original init() behavior (not affected by zone conversion)
             }
 
             // Construct DateLiteral using the appropriate constructor based on the determined type

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteralUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteralUtils.java
@@ -20,7 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.nereids.util.DateUtils;
+import org.apache.doris.common.util.TimeUtils;
 
 import com.google.common.base.Preconditions;
 
@@ -66,6 +66,7 @@ public class DateLiteralUtils {
             TemporalAccessor dateTime = null;
             boolean parsed = false;
             int offset = 0;
+            ZoneId sourceZone = null;
 
             // parse timezone
             if (haveTimeZoneOffset(s) || haveTimeZoneName(s)) {
@@ -81,13 +82,7 @@ public class DateLiteralUtils {
                     tzString = s.substring(s.length() - 6);
                     s = s.substring(0, s.length() - 6);
                 }
-                ZoneId zone = ZoneId.of(tzString);
-                ZoneId dorisZone = DateUtils.getTimeZone();
-                if (type != null && type.isTimeStampTz()) {
-                    dorisZone = ZoneId.of("UTC");
-                }
-                offset = dorisZone.getRules().getOffset(Instant.now()).getTotalSeconds()
-                        - zone.getRules().getOffset(Instant.now()).getTotalSeconds();
+                sourceZone = ZoneId.of(tzString);
             }
 
             if (!s.contains("-")) {
@@ -214,6 +209,27 @@ public class DateLiteralUtils {
                         type = ScalarType.createDatetimeV2Type(scale);
                     }
                 }
+            }
+
+            // Recompute the timezone offset using the target date rather than
+            // Instant.now(), so DST-sensitive zones (e.g. America/Chicago)
+            // produce the correct shift regardless of when the code runs.
+            // The original code used Instant.now() which returns the current
+            // DST offset; when the target date falls in a different DST period
+            // the computed shift is wrong by the DST gap.
+            if (sourceZone != null) {
+                // Use TimeUtils.getTimeZone() for consistency with the
+                // downstream unixTimestamp(TimeUtils.getTimeZone()) call.
+                ZoneId dorisZone = TimeUtils.getTimeZone().toZoneId();
+                if (type != null && type.isTimeStampTz()) {
+                    dorisZone = ZoneId.of("UTC");
+                }
+                LocalDateTime parsedLdt = LocalDateTime.of(
+                        (int) year, (int) month, (int) day,
+                        (int) hour, (int) minute, (int) second);
+                Instant targetInstant = parsedLdt.atZone(sourceZone).toInstant();
+                offset = dorisZone.getRules().getOffset(targetInstant).getTotalSeconds()
+                        - sourceZone.getRules().getOffset(targetInstant).getTotalSeconds();
             }
 
             // Apply timezone offset before constructing the DateLiteral.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToStringValueVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToStringValueVisitor.java
@@ -57,7 +57,14 @@ public class ExprToStringValueVisitor extends ExprVisitor<String, StringValueCon
         if (expr.getType().isTimeStampTz()) {
             try {
                 ZoneId dorisZone = DateUtils.getTimeZone();
-                String offset = dorisZone.getRules().getOffset(java.time.Instant.now()).toString();
+                // Compute offset from the target instant (the literal's UTC value),
+                // not Instant.now() which may be in a different DST period.
+                java.time.Instant targetInstant = java.time.LocalDateTime.of(
+                        (int) expr.getYear(), (int) expr.getMonth(), (int) expr.getDay(),
+                        (int) expr.getHour(), (int) expr.getMinute(), (int) expr.getSecond(),
+                        (int) expr.getMicrosecond() * 1000)
+                        .atZone(java.time.ZoneOffset.UTC).toInstant();
+                String offset = dorisZone.getRules().getOffset(targetInstant).toString();
                 DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(expr.getStringValue(),
                         ScalarType.createDatetimeV2Type(((ScalarType) expr.getType()).getScalarScale()));
                 value = dateLiteral.getStringValue() + offset;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToStringValueVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToStringValueVisitor.java
@@ -56,18 +56,29 @@ public class ExprToStringValueVisitor extends ExprVisitor<String, StringValueCon
         String value;
         if (expr.getType().isTimeStampTz()) {
             try {
-                ZoneId dorisZone = DateUtils.getTimeZone();
-                // Compute offset from the target instant (the literal's UTC value),
-                // not Instant.now() which may be in a different DST period.
-                java.time.Instant targetInstant = java.time.LocalDateTime.of(
-                        (int) expr.getYear(), (int) expr.getMonth(), (int) expr.getDay(),
-                        (int) expr.getHour(), (int) expr.getMinute(), (int) expr.getSecond(),
-                        (int) expr.getMicrosecond() * 1000)
-                        .atZone(java.time.ZoneOffset.UTC).toInstant();
-                String offset = dorisZone.getRules().getOffset(targetInstant).toString();
-                DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(expr.getStringValue(),
-                        ScalarType.createDatetimeV2Type(((ScalarType) expr.getType()).getScalarScale()));
-                value = dateLiteral.getStringValue() + offset;
+                if (ctx.isForStreamLoad()) {
+                    // BE's TIMESTAMPTZ parser consumes only hour/minute offsets
+                    // (minutes restricted to 00/30/45).  Historical zone offsets
+                    // can include seconds (e.g. Asia/Shanghai before 1901 had
+                    // +08:05:43), which BE would reject.  Since TIMESTAMPTZ
+                    // stores UTC internally, render in UTC format that BE can
+                    // round-trip.
+                    value = expr.getStringValue();
+                } else {
+                    ZoneId dorisZone = DateUtils.getTimeZone();
+                    // Compute offset from the target instant (the literal's UTC
+                    // value), not Instant.now() which may be in a different DST
+                    // period.
+                    java.time.Instant targetInstant = java.time.LocalDateTime.of(
+                            (int) expr.getYear(), (int) expr.getMonth(), (int) expr.getDay(),
+                            (int) expr.getHour(), (int) expr.getMinute(), (int) expr.getSecond(),
+                            (int) expr.getMicrosecond() * 1000)
+                            .atZone(java.time.ZoneOffset.UTC).toInstant();
+                    String offset = dorisZone.getRules().getOffset(targetInstant).toString();
+                    DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(expr.getStringValue(),
+                            ScalarType.createDatetimeV2Type(((ScalarType) expr.getType()).getScalarScale()));
+                    value = dateLiteral.getStringValue() + offset;
+                }
             } catch (Exception e) {
                 LOG.warn("generate timestamptz({})'s string value for query failed. ",
                         expr.getStringValue(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToStringValueVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToStringValueVisitor.java
@@ -77,7 +77,19 @@ public class ExprToStringValueVisitor extends ExprVisitor<String, StringValueCon
                     String offset = dorisZone.getRules().getOffset(targetInstant).toString();
                     DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(expr.getStringValue(),
                             ScalarType.createDatetimeV2Type(((ScalarType) expr.getType()).getScalarScale()));
-                    value = dateLiteral.getStringValue() + offset;
+                    // BE's TimestampTzValue::to_string() renders the wall clock
+                    // with the session timezone offset but truncates seconds
+                    // (e.g. +08:05:43 becomes +08:05), producing text that
+                    // denotes a different instant if reparsed.  When the offset
+                    // contains seconds (a second colon), fall back to UTC so
+                    // that FE constant evaluation and BE row serialisation
+                    // produce the same string for the same stored instant.
+                    int firstColon = offset.indexOf(':');
+                    if (firstColon > 0 && offset.indexOf(':', firstColon + 1) > 0) {
+                        value = expr.getStringValue();
+                    } else {
+                        value = dateLiteral.getStringValue() + offset;
+                    }
                 }
             } catch (Exception e) {
                 LOG.warn("generate timestamptz({})'s string value for query failed. ",

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringValueContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringValueContext.java
@@ -51,9 +51,12 @@ public class StringValueContext {
     /**
      * Returns a context in query + complex-type mode, regardless of the current mode.
      * Used by StructLiteral's stream-load path where children are rendered in query-complex mode.
+     * Preserves the {@code forStreamLoad} flag so that nested types (e.g. TIMESTAMPTZ inside
+     * STRUCT) correctly use stream-load rendering; clearing it would cause BE-incompatible
+     * output (e.g. historical offset with seconds like {@code +08:05:43}).
      */
     public StringValueContext asQueryComplexType() {
-        return new StringValueContext(formatOptions, false, true);
+        return new StringValueContext(formatOptions, forStreamLoad, true);
     }
 
     public FormatOptions getFormatOptions() {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -531,40 +531,6 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         partitionProperties.put(PropertyAnalyzer.PROPERTIES_DATA_BASE_TIME, baseTime);
     }
 
-    /**
-     * Holds the time context needed for TIMESTAMPTZ-aware dynamic partition
-     * operations.  A single clock read produces {@code now} (UTC-based for
-     * TIMESTAMPTZ columns, configured timezone otherwise) and
-     * {@code borderTimeZone} (UTC for TIMESTAMPTZ, otherwise the configured
-     * timezone), so subsequent border and cooldown computations all agree on
-     * the same instant.
-     */
-    private static class DynamicPartitionTimeContext {
-        final ZonedDateTime now;
-        final TimeZone borderTimeZone;
-
-        DynamicPartitionTimeContext(ZonedDateTime now, TimeZone borderTimeZone) {
-            this.now = now;
-            this.borderTimeZone = borderTimeZone;
-        }
-    }
-
-    /**
-     * Single clock read + UTC derivation + border timezone selection.
-     * Encapsulates the duplicated time-setup logic shared by
-     * {@link #getAddPartitionOp} and {@link #getDropPartitionOpForDynamic}.
-     */
-    private static DynamicPartitionTimeContext setupDynamicPartitionTime(
-            Column partitionColumn, DynamicPartitionProperty property) {
-        boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = ZonedDateTime.now(property.getTimeZone().toZoneId());
-        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
-        TimeZone borderTimeZone = isTimestampTz
-                ? TimeUtils.getUTCTimeZone()
-                : property.getTimeZone();
-        return new DynamicPartitionTimeContext(now, borderTimeZone);
-    }
-
     private Range<PartitionKey> getClosedRange(Database db, OlapTable olapTable, Column partitionColumn,
             String partitionFormat, String lowerBorderOfReservedHistory, String upperBorderOfReservedHistory,
             TimeZone borderTimeZone) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -39,7 +39,6 @@ import org.apache.doris.catalog.PartitionKey;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RangePartitionInfo;
 import org.apache.doris.catalog.RangePartitionItem;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -56,10 +55,8 @@ import org.apache.doris.common.util.RangeUtils;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.meta.MetaContext;
-import org.apache.doris.nereids.trees.expressions.literal.TimestampTzLiteral;
 import org.apache.doris.nereids.trees.plans.commands.info.AddPartitionOp;
 import org.apache.doris.nereids.trees.plans.commands.info.DropPartitionOp;
-import org.apache.doris.nereids.types.TimeStampTzType;
 import org.apache.doris.nereids.util.DateUtils;
 import org.apache.doris.persist.PartitionPersistInfo;
 import org.apache.doris.thrift.TStorageMedium;
@@ -304,16 +301,19 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
     private ArrayList<AddPartitionOp> getAddPartitionOp(Database db, OlapTable olapTable,
                                                             Column partitionColumn, String partitionFormat,
-                                                            boolean executeFirstTime,
-                                                            DynamicPartitionTimeContext timeCtx)
+                                                            boolean executeFirstTime)
             throws DdlException {
         ArrayList<AddPartitionOp> addPartitionOps = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
         // For TIMESTAMPTZ, both partition boundaries and names are UTC-based
         // (00:00—24:00 in UTC). This keeps partition names and values consistent.
-        ZonedDateTime now = timeCtx.now;
-        TimeZone borderTimeZone = timeCtx.borderTimeZone;
+        boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
+        ZonedDateTime nowTz = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
+        TimeZone borderTimeZone = isTimestampTz
+                ? TimeUtils.getUTCTimeZone()
+                : dynamicPartitionProperty.getTimeZone();
 
         boolean createHistoryPartition = dynamicPartitionProperty.isCreateHistoryPartition();
         int idx;
@@ -329,25 +329,21 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
         // Partition naming uses the same `now` clock as border computation,
         // so names and values are based on the same timezone (UTC for TIMESTAMPTZ).
-        String nowPartitionPrevBorder = DynamicPartitionUtil.getPartitionRangeString(
+        // getPartitionRangeString appends +00:00 when now is UTC-based,
+        // which getFormattedPartitionName naturally strips away.
+        String currentUtcBorder = DynamicPartitionUtil.getPartitionRangeString(
                 dynamicPartitionProperty, now, 0, partitionFormat);
         String nowPartitionName = dynamicPartitionProperty.getPrefix()
                 + DynamicPartitionUtil.getFormattedPartitionName(borderTimeZone,
-                nowPartitionPrevBorder, dynamicPartitionProperty.getTimeUnit());
-        // UTC-based lower bound of the current partition, used to identify the
-        // current partition by range in getHistoricalPartitions().
-        String currentUtcBorder = convertToUtcTimestamp(partitionColumn, nowPartitionPrevBorder, borderTimeZone);
-
+                currentUtcBorder, dynamicPartitionProperty.getTimeUnit());
         for (; idx <= dynamicPartitionProperty.getEnd(); idx++) {
             // Borders for both partition values and names: use now.
+            // +00:00 suffix is already embedded by getPartitionRangeString
+            // when now is UTC, so TimestampTzLiteral parses them correctly.
             String prevBorder = DynamicPartitionUtil.getPartitionRangeString(
                     dynamicPartitionProperty, now, idx, partitionFormat);
             String nextBorder = DynamicPartitionUtil.getPartitionRangeString(
                     dynamicPartitionProperty, now, idx + 1, partitionFormat);
-            // Save pre-conversion border for naming (UTC-based for TIMESTAMPTZ).
-            String prevBorderForName = prevBorder;
-            prevBorder = convertToUtcTimestamp(partitionColumn, prevBorder, borderTimeZone);
-            nextBorder = convertToUtcTimestamp(partitionColumn, nextBorder, borderTimeZone);
             PartitionValue lowerValue = new PartitionValue(prevBorder);
             PartitionValue upperValue = new PartitionValue(nextBorder);
 
@@ -410,20 +406,19 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             // set storage_medium and storage_cooldown_time based on dynamic_partition.hot_partition_num.
             // Use `now` (UTC-based for TIMESTAMPTZ) so the cooldown boundary
             // aligns with the partition's UTC range, not the configured timezone.
-            // convertToUtcTimestamp (called inside) is a no-op for non-TIMESTAMPTZ
             // columns; for TIMESTAMPTZ it appends a +00:00 suffix so PropertyAnalyzer
             // can detect this as an unambiguous UTC instant.
             setStorageMediumProperty(partitionProperties, dynamicPartitionProperty, now,
-                    hotPartitionNum, idx, partitionColumn, borderTimeZone);
+                    hotPartitionNum, idx);
 
             if (StringUtils.isNotEmpty(storagePolicyName)) {
                 setStoragePolicyProperty(partitionProperties, dynamicPartitionProperty, now, idx,
-                        storagePolicyName, partitionColumn, borderTimeZone);
+                        storagePolicyName);
             }
 
             String partitionName = dynamicPartitionProperty.getPrefix()
                     + DynamicPartitionUtil.getFormattedPartitionName(borderTimeZone,
-                    prevBorderForName, dynamicPartitionProperty.getTimeUnit());
+                    prevBorder, dynamicPartitionProperty.getTimeUnit());
             SinglePartitionDesc rangePartitionDesc = new SinglePartitionDesc(true, partitionName,
                     partitionKeyDesc, partitionProperties);
 
@@ -502,8 +497,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
      * @param offset
      */
     private void setStorageMediumProperty(HashMap<String, String> partitionProperties,
-            DynamicPartitionProperty property, ZonedDateTime now, int hotPartitionNum, int offset,
-            Column partitionColumn, TimeZone borderTimeZone) {
+            DynamicPartitionProperty property, ZonedDateTime now, int hotPartitionNum, int offset) {
         // 1. no hot partition, then use dynamic_partition.storage_medium
         // 2. has hot partition
         //    1) dynamic_partition.storage_medium = 'ssd', then use ssd;
@@ -524,19 +518,17 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             String cooldownTime = DynamicPartitionUtil.getPartitionRangeString(
                     property, now, offset + hotPartitionNum, DynamicPartitionUtil.DATETIME_FORMAT);
             partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, TStorageMedium.SSD.name());
-            partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
-                    convertToUtcTimestamp(partitionColumn, cooldownTime, borderTimeZone));
+            partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, cooldownTime);
         }
     }
 
     private void setStoragePolicyProperty(HashMap<String, String> partitionProperties,
             DynamicPartitionProperty property, ZonedDateTime now, int offset,
-            String storagePolicyName, Column partitionColumn, TimeZone borderTimeZone) {
+            String storagePolicyName) {
         partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, storagePolicyName);
         String baseTime = DynamicPartitionUtil.getPartitionRangeString(
                 property, now, offset, DynamicPartitionUtil.DATETIME_FORMAT);
-        partitionProperties.put(PropertyAnalyzer.PROPERTIES_DATA_BASE_TIME,
-                convertToUtcTimestamp(partitionColumn, baseTime, borderTimeZone));
+        partitionProperties.put(PropertyAnalyzer.PROPERTIES_DATA_BASE_TIME, baseTime);
     }
 
     /**
@@ -573,30 +565,10 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         return new DynamicPartitionTimeContext(now, borderTimeZone);
     }
 
-    /**
-     * For TIMESTAMPTZ partition columns, convert the border string from the partition's
-     * timezone to a UTC timestamp string (with +00:00 suffix). This ensures partition
-     * boundaries are stored as UTC timestamps, so the partition range aligns to
-     * 00:00:00—24:00:00 in UTC regardless of the configured partition timezone.
-     */
-    private static String convertToUtcTimestamp(Column column, String border, TimeZone timeZone) {
-        if (column.getDataType() == PrimitiveType.TIMESTAMPTZ) {
-            TimestampTzLiteral utcLiteral = TimestampTzLiteral.fromTimeZone(
-                    TimeStampTzType.of(((ScalarType) column.getType()).getScalarScale()),
-                    border, timeZone.toZoneId().toString());
-            return utcLiteral.getStringValue();
-        }
-        return border;
-    }
-
     private Range<PartitionKey> getClosedRange(Database db, OlapTable olapTable, Column partitionColumn,
             String partitionFormat, String lowerBorderOfReservedHistory, String upperBorderOfReservedHistory,
             TimeZone borderTimeZone) {
         Range<PartitionKey> reservedHistoryPartitionKeyRange = null;
-        lowerBorderOfReservedHistory = convertToUtcTimestamp(partitionColumn, lowerBorderOfReservedHistory,
-                borderTimeZone);
-        upperBorderOfReservedHistory = convertToUtcTimestamp(partitionColumn, upperBorderOfReservedHistory,
-                borderTimeZone);
         PartitionValue lowerBorderPartitionValue = new PartitionValue(lowerBorderOfReservedHistory);
         PartitionValue upperBorderPartitionValue = new PartitionValue(upperBorderOfReservedHistory);
         try {
@@ -619,8 +591,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
      * 2. get DropPartitionClause of partitions which range are before this reserved range.
      */
     private ArrayList<DropPartitionOp> getDropPartitionOpForDynamic(Database db, OlapTable olapTable,
-                                                                    Column partitionColumn, String partitionFormat,
-                                                                    DynamicPartitionTimeContext timeCtx)
+                                                                    Column partitionColumn, String partitionFormat)
             throws DdlException {
         ArrayList<DropPartitionOp> dropPartitionOps = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
@@ -635,14 +606,18 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         int realStart = dynamicPartitionProperty.getStart();
         // For TIMESTAMPTZ, use UTC clock so the drop cutoff aligns with the
         // UTC-midnight partition boundaries created by getAddPartitionOp().
-        ZonedDateTime now = timeCtx.now;
-        TimeZone borderTimeZone = timeCtx.borderTimeZone;
+        boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
+        ZonedDateTime nowTz = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
+        TimeZone borderTimeZone = isTimestampTz
+                ? TimeUtils.getUTCTimeZone()
+                : dynamicPartitionProperty.getTimeZone();
+
+        // getPartitionRangeString appends +00:00 when now is UTC-based.
         String lowerBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
                 now, realStart, partitionFormat);
         String limitBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
                 now, 0, partitionFormat);
-        lowerBorder = convertToUtcTimestamp(partitionColumn, lowerBorder, borderTimeZone);
-        limitBorder = convertToUtcTimestamp(partitionColumn, limitBorder, borderTimeZone);
         PartitionValue lowerPartitionValue = new PartitionValue(lowerBorder);
         PartitionValue limitPartitionValue = new PartitionValue(limitBorder);
         List<Range<PartitionKey>> reservedHistoryPartitionKeyRangeList = new ArrayList<Range<PartitionKey>>();
@@ -678,9 +653,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             for (Range range : ranges) {
                 try {
                     String lowerBorderOfReservedHistory = DynamicPartitionUtil.getHistoryPartitionRangeString(
-                            dynamicPartitionProperty, range.lowerEndpoint().toString(), partitionFormat);
+                            dynamicPartitionProperty, range.lowerEndpoint().toString(), partitionFormat, isTimestampTz);
                     String upperBorderOfReservedHistory = DynamicPartitionUtil.getHistoryPartitionRangeString(
-                            dynamicPartitionProperty, range.upperEndpoint().toString(), partitionFormat);
+                            dynamicPartitionProperty, range.upperEndpoint().toString(), partitionFormat, isTimestampTz);
                     Range<PartitionKey> reservedHistoryPartitionKeyRange = getClosedRange(db, olapTable,
                             partitionColumn, partitionFormat,
                             lowerBorderOfReservedHistory, upperBorderOfReservedHistory,
@@ -738,18 +713,13 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         idToItems.sort(Comparator.comparing(o -> ((RangePartitionItem) o.getValue()).getItems().upperEndpoint()));
 
         // Get current time as PartitionKey for comparison
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.getTimeZone());
         Column partitionColumn = info.getPartitionColumns().get(0);
+        boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
+        ZonedDateTime nowTz = ZonedDateTime.now(DateUtils.getTimeZone());
+        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
+
         String partitionFormat = DynamicPartitionUtil.getPartitionFormat(partitionColumn);
         String currentTimeStr = DateTimeFormatter.ofPattern(partitionFormat).format(now);
-
-        // For TIMESTAMPTZ columns, normalize the cutoff time to UTC so it
-        // matches the stored partition bounds, which are also stored as UTC.
-        // Without this, a suffix-free currentTimeStr formatted in the JVM
-        // timezone would be parsed as UTC via TimestampTzLiteral.fromSessionTimeZone(),
-        // shifting the cutoff and potentially dropping the current UTC-day partition.
-        currentTimeStr = convertToUtcTimestamp(partitionColumn, currentTimeStr,
-                TimeZone.getTimeZone(DateUtils.getTimeZone()));
 
         PartitionValue currentTimeValue = new PartitionValue(currentTimeStr);
         PartitionKey currentTimeKey;
@@ -856,21 +826,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                     continue;
                 }
 
-                // Capture a single time context so add and drop phases
-                // use the exact same UTC instant, avoiding a race where
-                // an hourly TIMESTAMPTZ table crosses a boundary between
-                // the two clock reads.
-                DynamicPartitionTimeContext timeCtx = null;
-                if (olapTable.dynamicPartitionExists()
-                        && olapTable.getTableProperty().getDynamicPartitionProperty().getEnable()) {
-                    DynamicPartitionProperty dynProp = olapTable.getTableProperty()
-                            .getDynamicPartitionProperty();
-                    timeCtx = setupDynamicPartitionTime(partitionColumn, dynProp);
-                }
-
                 if (!skipAddPartition) {
                     addPartitionOps = getAddPartitionOp(db, olapTable, partitionColumn, partitionFormat,
-                            executeFirstTime, timeCtx);
+                            executeFirstTime);
                 }
                 clearDropPartitionFailedMsg(olapTable.getId());
                 if (olapTable.getPartitionRetentionCount() > 0) {
@@ -879,7 +837,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                 } else {
                     // Handle dynamic partition cleanup
                     dropPartitionOps = getDropPartitionOpForDynamic(db, olapTable, partitionColumn,
-                            partitionFormat, timeCtx);
+                            partitionFormat);
                 }
                 tableName = olapTable.getName();
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -61,6 +61,7 @@ import org.apache.doris.nereids.util.DateUtils;
 import org.apache.doris.persist.PartitionPersistInfo;
 import org.apache.doris.thrift.TStorageMedium;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -102,6 +103,11 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     private static final String DEFAULT_RUNTIME_VALUE = FeConstants.null_string;
 
     private static final long SLEEP_PIECE = 5000L;
+
+    /** Test-only: when non-null overrides the clock in both add and drop
+     *  paths so tests can reproduce time-sensitive scenarios deterministically. */
+    @VisibleForTesting
+    public static volatile ZonedDateTime testNow;
 
     private Map<Long, Map<String, String>> runtimeInfos = Maps.newConcurrentMap();
     private Set<Pair<Long, Long>> dynamicPartitionTableInfo = Sets.newConcurrentHashSet();
@@ -210,17 +216,27 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
     /**
      * Get all partitions except the current one. When currentKey is non-null,
-     * the current partition is identified by matching its range lower bound
-     * against currentKey (parsed from currentUtcBorder).  When currentKey is
-     * null, fall back to name-based exclusion against nowPartitionName.
+     * the current partition is identified by checking if its range
+     * <em>contains</em> currentKey (i.e. lower <= currentKey < upper).
+     * When currentKey is null, fall back to name-based exclusion against
+     * nowPartitionName.
+     *
+     * <p>Using range containment instead of exact lower-bound equality
+     * handles non‑canonical current partitions whose lower endpoint does
+     * not coincide with the captured UTC‑midnight instant — for example a
+     * pre‑fix Asia/Shanghai partition p20260720 = [2026-07-19 16:00Z,
+     * 2026-07-20 16:00Z) where currentKey = 2026-07-22 00:00Z falls inside
+     * the range but does not equal the lower endpoint.  Without containment
+     * such a populated, still‑growing partition would be treated as history
+     * and distort auto‑bucket calculations.
      *
      * <p>The two filters are mutually exclusive — when a range key is available
      * it alone identifies the current partition.  Applying both filters on top
-     * of each other would double-exclude: after the range match removes the
+     * of each other would double‑exclude: after the range match removes the
      * current partition (whose name may use an old prefix after a prefix change),
      * the name filter could then catch a <em>different</em> partition whose name
      * happens to match the new prefix, losing two partitions and corrupting
-     * auto-bucket calculations.
+     * auto‑bucket calculations.
      */
     public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName,
             String currentUtcBorder) {
@@ -255,12 +271,21 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                             return false;
                         }
                         if (rangeKey != null) {
-                            // Range-based exclusion only — mutually exclusive
-                            // with name-based exclusion to avoid double-filtering.
+                            // Range-based exclusion — mutually exclusive with
+                            // name-based exclusion to avoid double-filtering.
+                            // Exclude the partition whose range contains
+                            // rangeKey (lower <= rangeKey < upper).  This
+                            // handles both canonical partitions where
+                            // rangeKey equals the lower endpoint and
+                            // non-canonical partitions where rangeKey falls
+                            // inside the range.
                             RangePartitionItem item = (RangePartitionItem) info.getItem(partition.getId());
                             if (item != null) {
-                                PartitionKey lower = item.getItems().lowerEndpoint();
-                                if (lower.compareTo(rangeKey) == 0) {
+                                Range<PartitionKey> partitionRange = item.getItems();
+                                PartitionKey lower = partitionRange.lowerEndpoint();
+                                PartitionKey upper = partitionRange.upperEndpoint();
+                                if (lower.compareTo(rangeKey) <= 0
+                                        && rangeKey.compareTo(upper) < 0) {
                                     return false; // current partition
                                 }
                             }
@@ -337,7 +362,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // For TIMESTAMPTZ, both partition boundaries and names are UTC-based
         // (00:00—24:00 in UTC). This keeps partition names and values consistent.
         boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        ZonedDateTime nowTz = testNow != null ? testNow
+                : ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
         ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
         TimeZone borderTimeZone = isTimestampTz
                 ? TimeUtils.getUTCTimeZone()
@@ -601,7 +627,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // For TIMESTAMPTZ, use UTC clock so the drop cutoff aligns with the
         // UTC-midnight partition boundaries created by getAddPartitionOp().
         boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        ZonedDateTime nowTz = testNow != null ? testNow
+                : ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
         ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
         TimeZone borderTimeZone = isTimestampTz
                 ? TimeUtils.getUTCTimeZone()

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -74,6 +74,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -201,15 +202,24 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private static Pair<Integer, Integer> getBucketsNum(DynamicPartitionProperty property, OlapTable table,
-            String partitionName, String nowPartitionName, boolean executeFirstTime) {
+            String partitionName, String nowPartitionName, boolean executeFirstTime, String currentUtcBorder) {
         AutoBucketCalculator.AutoBucketContext context = new AutoBucketCalculator.AutoBucketContext(
-                table, partitionName, nowPartitionName, executeFirstTime, property.getBuckets());
+                table, partitionName, nowPartitionName, executeFirstTime, property.getBuckets(),
+                currentUtcBorder);
 
         AutoBucketCalculator.AutoBucketResult result = AutoBucketCalculator.calculateAutoBuckets(context);
         return Pair.of(result.getBuckets(), result.getPreviousBuckets());
     }
 
-    public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName) {
+    /**
+     * Get all partitions except the current one. When currentUtcBorder is non-null,
+     * the current partition is identified by matching its range lower bound against
+     * currentUtcBorder rather than by name. For TIMESTAMPTZ tables both names and
+     * ranges are UTC-based, so the name-based fallback is also correct; the range
+     * check provides an additional safety layer.
+     */
+    public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName,
+            String currentUtcBorder) {
         table.readLock();
         try {
             RangePartitionInfo info = (RangePartitionInfo) (table.getPartitionInfo());
@@ -217,7 +227,23 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             idToItems.sort(Comparator.comparing(o -> ((RangePartitionItem) o.getValue()).getItems().upperEndpoint()));
             return idToItems.stream()
                     .map(entry -> table.getPartition(entry.getKey()))
-                    .filter(partition -> partition != null && !partition.getName().equals(nowPartitionName))
+                    .filter(partition -> {
+                        if (partition == null) {
+                            return false;
+                        }
+                        // When currentUtcBorder is available, exclude the current
+                        // partition by comparing range lower bounds, not names.
+                        if (currentUtcBorder != null) {
+                            RangePartitionItem item = (RangePartitionItem) info.getItem(partition.getId());
+                            if (item != null) {
+                                PartitionKey lower = item.getItems().lowerEndpoint();
+                                if (lower.getKeys().get(0).getStringValue().equals(currentUtcBorder)) {
+                                    return false; // current partition
+                                }
+                            }
+                        }
+                        return !partition.getName().equals(nowPartitionName);
+                    })
                     .collect(Collectors.toList());
         } finally {
             table.readUnlock();
@@ -282,7 +308,11 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         ArrayList<AddPartitionOp> addPartitionOps = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
-        ZonedDateTime now = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        // For TIMESTAMPTZ, both partition boundaries and names are UTC-based
+        // (00:00—24:00 in UTC). This keeps partition names and values consistent.
+        DynamicPartitionTimeContext timeCtx = setupDynamicPartitionTime(partitionColumn, dynamicPartitionProperty);
+        ZonedDateTime now = timeCtx.now;
+        TimeZone borderTimeZone = timeCtx.borderTimeZone;
 
         boolean createHistoryPartition = dynamicPartitionProperty.isCreateHistoryPartition();
         int idx;
@@ -296,23 +326,27 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         int hotPartitionNum = dynamicPartitionProperty.getHotPartitionNum();
         String storagePolicyName = dynamicPartitionProperty.getStoragePolicy();
 
+        // Partition naming uses the same `now` clock as border computation,
+        // so names and values are based on the same timezone (UTC for TIMESTAMPTZ).
         String nowPartitionPrevBorder = DynamicPartitionUtil.getPartitionRangeString(
                 dynamicPartitionProperty, now, 0, partitionFormat);
         String nowPartitionName = dynamicPartitionProperty.getPrefix()
-                + DynamicPartitionUtil.getFormattedPartitionName(dynamicPartitionProperty.getTimeZone(),
+                + DynamicPartitionUtil.getFormattedPartitionName(borderTimeZone,
                 nowPartitionPrevBorder, dynamicPartitionProperty.getTimeUnit());
+        // UTC-based lower bound of the current partition, used to identify the
+        // current partition by range in getHistoricalPartitions().
+        String currentUtcBorder = convertToUtcTimestamp(partitionColumn, nowPartitionPrevBorder, borderTimeZone);
 
         for (; idx <= dynamicPartitionProperty.getEnd(); idx++) {
+            // Borders for both partition values and names: use now.
             String prevBorder = DynamicPartitionUtil.getPartitionRangeString(
                     dynamicPartitionProperty, now, idx, partitionFormat);
             String nextBorder = DynamicPartitionUtil.getPartitionRangeString(
                     dynamicPartitionProperty, now, idx + 1, partitionFormat);
-            // Save original border for partition name (must not contain UTC suffix)
+            // Save pre-conversion border for naming (UTC-based for TIMESTAMPTZ).
             String prevBorderForName = prevBorder;
-            prevBorder = convertToUtcTimestamp(partitionColumn, prevBorder,
-                    dynamicPartitionProperty.getTimeZone());
-            nextBorder = convertToUtcTimestamp(partitionColumn, nextBorder,
-                    dynamicPartitionProperty.getTimeZone());
+            prevBorder = convertToUtcTimestamp(partitionColumn, prevBorder, borderTimeZone);
+            nextBorder = convertToUtcTimestamp(partitionColumn, nextBorder, borderTimeZone);
             PartitionValue lowerValue = new PartitionValue(prevBorder);
             PartitionValue upperValue = new PartitionValue(nextBorder);
 
@@ -372,15 +406,22 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                         dynamicPartitionProperty.getReplicaAllocation().toCreateStmt());
             }
 
-            // set storage_medium and storage_cooldown_time based on dynamic_partition.hot_partition_num
-            setStorageMediumProperty(partitionProperties, dynamicPartitionProperty, now, hotPartitionNum, idx);
+            // set storage_medium and storage_cooldown_time based on dynamic_partition.hot_partition_num.
+            // Use `now` (UTC-based for TIMESTAMPTZ) so the cooldown boundary
+            // aligns with the partition's UTC range, not the configured timezone.
+            // convertToUtcTimestamp (called inside) is a no-op for non-TIMESTAMPTZ
+            // columns; for TIMESTAMPTZ it appends a +00:00 suffix so PropertyAnalyzer
+            // can detect this as an unambiguous UTC instant.
+            setStorageMediumProperty(partitionProperties, dynamicPartitionProperty, now,
+                    hotPartitionNum, idx, partitionColumn, borderTimeZone);
 
             if (StringUtils.isNotEmpty(storagePolicyName)) {
-                setStoragePolicyProperty(partitionProperties, dynamicPartitionProperty, now, idx, storagePolicyName);
+                setStoragePolicyProperty(partitionProperties, dynamicPartitionProperty, now, idx,
+                        storagePolicyName, partitionColumn, borderTimeZone);
             }
 
             String partitionName = dynamicPartitionProperty.getPrefix()
-                    + DynamicPartitionUtil.getFormattedPartitionName(dynamicPartitionProperty.getTimeZone(),
+                    + DynamicPartitionUtil.getFormattedPartitionName(borderTimeZone,
                     prevBorderForName, dynamicPartitionProperty.getTimeUnit());
             SinglePartitionDesc rangePartitionDesc = new SinglePartitionDesc(true, partitionName,
                     partitionKeyDesc, partitionProperties);
@@ -388,7 +429,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             DistributionDesc distributionDesc = null;
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
             Pair<Integer, Integer> ret = getBucketsNum(dynamicPartitionProperty, olapTable, partitionName,
-                    nowPartitionName, executeFirstTime);
+                    nowPartitionName, executeFirstTime, currentUtcBorder);
             int bucketsNum = ret.first;
             int previousPartitionBucketsNum = ret.second;
             if (olapTable.isAutoBucket()) {
@@ -460,7 +501,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
      * @param offset
      */
     private void setStorageMediumProperty(HashMap<String, String> partitionProperties,
-            DynamicPartitionProperty property, ZonedDateTime now, int hotPartitionNum, int offset) {
+            DynamicPartitionProperty property, ZonedDateTime now, int hotPartitionNum, int offset,
+            Column partitionColumn, TimeZone borderTimeZone) {
         // 1. no hot partition, then use dynamic_partition.storage_medium
         // 2. has hot partition
         //    1) dynamic_partition.storage_medium = 'ssd', then use ssd;
@@ -481,17 +523,53 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             String cooldownTime = DynamicPartitionUtil.getPartitionRangeString(
                     property, now, offset + hotPartitionNum, DynamicPartitionUtil.DATETIME_FORMAT);
             partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, TStorageMedium.SSD.name());
-            partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, cooldownTime);
+            partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                    convertToUtcTimestamp(partitionColumn, cooldownTime, borderTimeZone));
         }
     }
 
     private void setStoragePolicyProperty(HashMap<String, String> partitionProperties,
             DynamicPartitionProperty property, ZonedDateTime now, int offset,
-            String storagePolicyName) {
+            String storagePolicyName, Column partitionColumn, TimeZone borderTimeZone) {
         partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, storagePolicyName);
         String baseTime = DynamicPartitionUtil.getPartitionRangeString(
                 property, now, offset, DynamicPartitionUtil.DATETIME_FORMAT);
-        partitionProperties.put(PropertyAnalyzer.PROPERTIES_DATA_BASE_TIME, baseTime);
+        partitionProperties.put(PropertyAnalyzer.PROPERTIES_DATA_BASE_TIME,
+                convertToUtcTimestamp(partitionColumn, baseTime, borderTimeZone));
+    }
+
+    /**
+     * Holds the time context needed for TIMESTAMPTZ-aware dynamic partition
+     * operations.  A single clock read produces {@code now} (UTC-based for
+     * TIMESTAMPTZ columns, configured timezone otherwise) and
+     * {@code borderTimeZone} (UTC for TIMESTAMPTZ, otherwise the configured
+     * timezone), so subsequent border and cooldown computations all agree on
+     * the same instant.
+     */
+    private static class DynamicPartitionTimeContext {
+        final ZonedDateTime now;
+        final TimeZone borderTimeZone;
+
+        DynamicPartitionTimeContext(ZonedDateTime now, TimeZone borderTimeZone) {
+            this.now = now;
+            this.borderTimeZone = borderTimeZone;
+        }
+    }
+
+    /**
+     * Single clock read + UTC derivation + border timezone selection.
+     * Encapsulates the duplicated time-setup logic shared by
+     * {@link #getAddPartitionOp} and {@link #getDropPartitionOpForDynamic}.
+     */
+    private static DynamicPartitionTimeContext setupDynamicPartitionTime(
+            Column partitionColumn, DynamicPartitionProperty property) {
+        boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
+        ZonedDateTime nowTz = ZonedDateTime.now(property.getTimeZone().toZoneId());
+        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
+        TimeZone borderTimeZone = isTimestampTz
+                ? TimeUtils.getUTCTimeZone()
+                : property.getTimeZone();
+        return new DynamicPartitionTimeContext(now, borderTimeZone);
     }
 
     /**
@@ -511,12 +589,13 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private Range<PartitionKey> getClosedRange(Database db, OlapTable olapTable, Column partitionColumn,
-            String partitionFormat, String lowerBorderOfReservedHistory, String upperBorderOfReservedHistory) {
+            String partitionFormat, String lowerBorderOfReservedHistory, String upperBorderOfReservedHistory,
+            TimeZone borderTimeZone) {
         Range<PartitionKey> reservedHistoryPartitionKeyRange = null;
         lowerBorderOfReservedHistory = convertToUtcTimestamp(partitionColumn, lowerBorderOfReservedHistory,
-                olapTable.getTableProperty().getDynamicPartitionProperty().getTimeZone());
+                borderTimeZone);
         upperBorderOfReservedHistory = convertToUtcTimestamp(partitionColumn, upperBorderOfReservedHistory,
-                olapTable.getTableProperty().getDynamicPartitionProperty().getTimeZone());
+                borderTimeZone);
         PartitionValue lowerBorderPartitionValue = new PartitionValue(lowerBorderOfReservedHistory);
         PartitionValue upperBorderPartitionValue = new PartitionValue(upperBorderOfReservedHistory);
         try {
@@ -552,15 +631,17 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // int realStart = DynamicPartitionUtil.getRealStart(dynamicPartitionProperty.getStart(),
         //         dynamicPartitionProperty.getHistoryPartitionNum());
         int realStart = dynamicPartitionProperty.getStart();
-        ZonedDateTime now = ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        // For TIMESTAMPTZ, use UTC clock so the drop cutoff aligns with the
+        // UTC-midnight partition boundaries created by getAddPartitionOp().
+        DynamicPartitionTimeContext timeCtx = setupDynamicPartitionTime(partitionColumn, dynamicPartitionProperty);
+        ZonedDateTime now = timeCtx.now;
+        TimeZone borderTimeZone = timeCtx.borderTimeZone;
         String lowerBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
                 now, realStart, partitionFormat);
         String limitBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
                 now, 0, partitionFormat);
-        lowerBorder = convertToUtcTimestamp(partitionColumn, lowerBorder,
-                dynamicPartitionProperty.getTimeZone());
-        limitBorder = convertToUtcTimestamp(partitionColumn, limitBorder,
-                dynamicPartitionProperty.getTimeZone());
+        lowerBorder = convertToUtcTimestamp(partitionColumn, lowerBorder, borderTimeZone);
+        limitBorder = convertToUtcTimestamp(partitionColumn, limitBorder, borderTimeZone);
         PartitionValue lowerPartitionValue = new PartitionValue(lowerBorder);
         PartitionValue limitPartitionValue = new PartitionValue(limitBorder);
         List<Range<PartitionKey>> reservedHistoryPartitionKeyRangeList = new ArrayList<Range<PartitionKey>>();
@@ -601,7 +682,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                             dynamicPartitionProperty, range.upperEndpoint().toString(), partitionFormat);
                     Range<PartitionKey> reservedHistoryPartitionKeyRange = getClosedRange(db, olapTable,
                             partitionColumn, partitionFormat,
-                            lowerBorderOfReservedHistory, upperBorderOfReservedHistory);
+                            lowerBorderOfReservedHistory, upperBorderOfReservedHistory,
+                            borderTimeZone);
                     reservedHistoryPartitionKeyRangeList.add(reservedHistoryPartitionKeyRange);
                 } catch (IllegalArgumentException e) {
                     return dropPartitionOps;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -72,6 +72,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -171,6 +172,14 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         return defaultRuntimeInfo;
     }
 
+    /** Return the current instant for the given zone. Tests may override
+     *  this to control time-sensitive partition scheduling behavior, or
+     *  set {@link #testNow} directly for static clock control. */
+    @VisibleForTesting
+    public ZonedDateTime getNow(ZoneId zoneId) {
+        return testNow != null ? testNow : ZonedDateTime.now(zoneId);
+    }
+
     // exponential moving average
     private static long ema(List<Long> history, int period) {
         double alpha = 2.0 / (period + 1);
@@ -205,10 +214,10 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private static Pair<Integer, Integer> getBucketsNum(DynamicPartitionProperty property, OlapTable table,
-            String partitionName, String nowPartitionName, boolean executeFirstTime, String currentUtcBorder) {
+            String partitionName, String nowPartitionName, boolean executeFirstTime, String nowPartitionPrevBorder) {
         AutoBucketCalculator.AutoBucketContext context = new AutoBucketCalculator.AutoBucketContext(
                 table, partitionName, nowPartitionName, executeFirstTime, property.getBuckets(),
-                currentUtcBorder);
+                nowPartitionPrevBorder);
 
         AutoBucketCalculator.AutoBucketResult result = AutoBucketCalculator.calculateAutoBuckets(context);
         return Pair.of(result.getBuckets(), result.getPreviousBuckets());
@@ -239,61 +248,15 @@ public class DynamicPartitionScheduler extends MasterDaemon {
      * auto‑bucket calculations.
      */
     public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName,
-            String currentUtcBorder) {
+            String nowPartitionPrevBorder) {
         table.readLock();
         try {
             RangePartitionInfo info = (RangePartitionInfo) (table.getPartitionInfo());
-            // Parse the range key once, before the stream.  A single parse
-            // avoids redundant PartitionKey.createPartitionKey calls for every
-            // partition while holding the table read lock.
-            PartitionKey currentKey = null;
-            if (currentUtcBorder != null) {
-                try {
-                    Column partitionColumn = info.getPartitionColumns().get(0);
-                    PartitionValue currentValue = new PartitionValue(currentUtcBorder);
-                    currentKey = PartitionKey.createPartitionKey(
-                            Collections.singletonList(currentValue),
-                            Collections.singletonList(partitionColumn));
-                } catch (AnalysisException e) {
-                    // Parsing failed — fall back to name-based exclusion below.
-                    currentKey = null;
-                }
-            }
-
-            final PartitionKey rangeKey = currentKey;
-
             List<Map.Entry<Long, PartitionItem>> idToItems = new ArrayList<>(info.getIdToItem(false).entrySet());
             idToItems.sort(Comparator.comparing(o -> ((RangePartitionItem) o.getValue()).getItems().upperEndpoint()));
             return idToItems.stream()
                     .map(entry -> table.getPartition(entry.getKey()))
-                    .filter(partition -> {
-                        if (partition == null) {
-                            return false;
-                        }
-                        if (rangeKey != null) {
-                            // Range-based exclusion — mutually exclusive with
-                            // name-based exclusion to avoid double-filtering.
-                            // Exclude the partition whose range contains
-                            // rangeKey (lower <= rangeKey < upper).  This
-                            // handles both canonical partitions where
-                            // rangeKey equals the lower endpoint and
-                            // non-canonical partitions where rangeKey falls
-                            // inside the range.
-                            RangePartitionItem item = (RangePartitionItem) info.getItem(partition.getId());
-                            if (item != null) {
-                                Range<PartitionKey> partitionRange = item.getItems();
-                                PartitionKey lower = partitionRange.lowerEndpoint();
-                                PartitionKey upper = partitionRange.upperEndpoint();
-                                if (lower.compareTo(rangeKey) <= 0
-                                        && rangeKey.compareTo(upper) < 0) {
-                                    return false; // current partition
-                                }
-                            }
-                            return true; // not the current — keep it
-                        }
-                        // Name-based exclusion (fallback when no range key).
-                        return !partition.getName().equals(nowPartitionName);
-                    })
+                    .filter(partition -> partition != null && !partition.getName().equals(nowPartitionName))
                     .collect(Collectors.toList());
         } finally {
             table.readUnlock();
@@ -362,8 +325,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // For TIMESTAMPTZ, both partition boundaries and names are UTC-based
         // (00:00—24:00 in UTC). This keeps partition names and values consistent.
         boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = testNow != null ? testNow
-                : ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        ZonedDateTime nowTz = getNow(dynamicPartitionProperty.getTimeZone().toZoneId());
         ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
         TimeZone borderTimeZone = isTimestampTz
                 ? TimeUtils.getUTCTimeZone()
@@ -385,11 +347,11 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // so names and values are based on the same timezone (UTC for TIMESTAMPTZ).
         // getPartitionRangeString appends +00:00 when now is UTC-based,
         // which getFormattedPartitionName naturally strips away.
-        String currentUtcBorder = DynamicPartitionUtil.getPartitionRangeString(
+        String nowPartitionPrevBorder = DynamicPartitionUtil.getPartitionRangeString(
                 dynamicPartitionProperty, now, 0, partitionFormat);
         String nowPartitionName = dynamicPartitionProperty.getPrefix()
                 + DynamicPartitionUtil.getFormattedPartitionName(borderTimeZone,
-                currentUtcBorder, dynamicPartitionProperty.getTimeUnit());
+                nowPartitionPrevBorder, dynamicPartitionProperty.getTimeUnit());
         for (; idx <= dynamicPartitionProperty.getEnd(); idx++) {
             // Borders for both partition values and names: use now.
             // +00:00 suffix is already embedded by getPartitionRangeString
@@ -462,12 +424,10 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             // aligns with the partition's UTC range, not the configured timezone.
             // columns; for TIMESTAMPTZ it appends a +00:00 suffix so PropertyAnalyzer
             // can detect this as an unambiguous UTC instant.
-            setStorageMediumProperty(partitionProperties, dynamicPartitionProperty, now,
-                    hotPartitionNum, idx);
+            setStorageMediumProperty(partitionProperties, dynamicPartitionProperty, now, hotPartitionNum, idx);
 
             if (StringUtils.isNotEmpty(storagePolicyName)) {
-                setStoragePolicyProperty(partitionProperties, dynamicPartitionProperty, now, idx,
-                        storagePolicyName);
+                setStoragePolicyProperty(partitionProperties, dynamicPartitionProperty, now, idx, storagePolicyName);
             }
 
             String partitionName = dynamicPartitionProperty.getPrefix()
@@ -479,7 +439,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             DistributionDesc distributionDesc = null;
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
             Pair<Integer, Integer> ret = getBucketsNum(dynamicPartitionProperty, olapTable, partitionName,
-                    nowPartitionName, executeFirstTime, currentUtcBorder);
+                    nowPartitionName, executeFirstTime, nowPartitionPrevBorder);
             int bucketsNum = ret.first;
             int previousPartitionBucketsNum = ret.second;
             if (olapTable.isAutoBucket()) {
@@ -562,12 +522,14 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             if (!Strings.isNullOrEmpty(property.getStorageMedium())) {
                 partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, property.getStorageMedium());
                 partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
-                        TimeUtils.longToTimeString(DataProperty.MAX_COOLDOWN_TIME_MS));
+                        TimeUtils.longToTimeStringWithTimeZoneAndOffset(
+                                DataProperty.MAX_COOLDOWN_TIME_MS, now.getZone().getId()));
             }
         } else if (offset + hotPartitionNum <= 0) {
             partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, TStorageMedium.HDD.name());
             partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
-                    TimeUtils.longToTimeString(DataProperty.MAX_COOLDOWN_TIME_MS));
+                    TimeUtils.longToTimeStringWithTimeZoneAndOffset(
+                            DataProperty.MAX_COOLDOWN_TIME_MS, now.getZone().getId()));
         } else {
             String cooldownTime = DynamicPartitionUtil.getPartitionRangeString(
                     property, now, offset + hotPartitionNum, DynamicPartitionUtil.DATETIME_FORMAT);
@@ -627,8 +589,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // For TIMESTAMPTZ, use UTC clock so the drop cutoff aligns with the
         // UTC-midnight partition boundaries created by getAddPartitionOp().
         boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = testNow != null ? testNow
-                : ZonedDateTime.now(dynamicPartitionProperty.getTimeZone().toZoneId());
+        ZonedDateTime nowTz = getNow(dynamicPartitionProperty.getTimeZone().toZoneId());
         ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
         TimeZone borderTimeZone = isTimestampTz
                 ? TimeUtils.getUTCTimeZone()

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -304,13 +304,14 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
     private ArrayList<AddPartitionOp> getAddPartitionOp(Database db, OlapTable olapTable,
                                                             Column partitionColumn, String partitionFormat,
-                                                            boolean executeFirstTime) throws DdlException {
+                                                            boolean executeFirstTime,
+                                                            DynamicPartitionTimeContext timeCtx)
+            throws DdlException {
         ArrayList<AddPartitionOp> addPartitionOps = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
         // For TIMESTAMPTZ, both partition boundaries and names are UTC-based
         // (00:00—24:00 in UTC). This keeps partition names and values consistent.
-        DynamicPartitionTimeContext timeCtx = setupDynamicPartitionTime(partitionColumn, dynamicPartitionProperty);
         ZonedDateTime now = timeCtx.now;
         TimeZone borderTimeZone = timeCtx.borderTimeZone;
 
@@ -618,7 +619,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
      * 2. get DropPartitionClause of partitions which range are before this reserved range.
      */
     private ArrayList<DropPartitionOp> getDropPartitionOpForDynamic(Database db, OlapTable olapTable,
-                                                                    Column partitionColumn, String partitionFormat)
+                                                                    Column partitionColumn, String partitionFormat,
+                                                                    DynamicPartitionTimeContext timeCtx)
             throws DdlException {
         ArrayList<DropPartitionOp> dropPartitionOps = new ArrayList<>();
         DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty().getDynamicPartitionProperty();
@@ -633,7 +635,6 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         int realStart = dynamicPartitionProperty.getStart();
         // For TIMESTAMPTZ, use UTC clock so the drop cutoff aligns with the
         // UTC-midnight partition boundaries created by getAddPartitionOp().
-        DynamicPartitionTimeContext timeCtx = setupDynamicPartitionTime(partitionColumn, dynamicPartitionProperty);
         ZonedDateTime now = timeCtx.now;
         TimeZone borderTimeZone = timeCtx.borderTimeZone;
         String lowerBorder = DynamicPartitionUtil.getPartitionRangeString(dynamicPartitionProperty,
@@ -855,9 +856,21 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                     continue;
                 }
 
+                // Capture a single time context so add and drop phases
+                // use the exact same UTC instant, avoiding a race where
+                // an hourly TIMESTAMPTZ table crosses a boundary between
+                // the two clock reads.
+                DynamicPartitionTimeContext timeCtx = null;
+                if (olapTable.dynamicPartitionExists()
+                        && olapTable.getTableProperty().getDynamicPartitionProperty().getEnable()) {
+                    DynamicPartitionProperty dynProp = olapTable.getTableProperty()
+                            .getDynamicPartitionProperty();
+                    timeCtx = setupDynamicPartitionTime(partitionColumn, dynProp);
+                }
+
                 if (!skipAddPartition) {
                     addPartitionOps = getAddPartitionOp(db, olapTable, partitionColumn, partitionFormat,
-                            executeFirstTime);
+                            executeFirstTime, timeCtx);
                 }
                 clearDropPartitionFailedMsg(olapTable.getId());
                 if (olapTable.getPartitionRetentionCount() > 0) {
@@ -866,7 +879,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                 } else {
                     // Handle dynamic partition cleanup
                     dropPartitionOps = getDropPartitionOpForDynamic(db, olapTable, partitionColumn,
-                            partitionFormat);
+                            partitionFormat, timeCtx);
                 }
                 tableName = olapTable.getName();
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -230,12 +230,28 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                         }
                         // When currentUtcBorder is available, exclude the current
                         // partition by comparing range lower bounds, not names.
+                        // Use PartitionKey.compareTo (not getStringValue) to
+                        // handle scale differences: a TIMESTAMPTZ(6) lower key
+                        // stores "2026-07-20 00:00:00.000000+00:00" while
+                        // currentUtcBorder is "2026-07-20 00:00:00+00:00" —
+                        // the string representations differ even though they
+                        // represent the same instant.
                         if (currentUtcBorder != null) {
                             RangePartitionItem item = (RangePartitionItem) info.getItem(partition.getId());
                             if (item != null) {
                                 PartitionKey lower = item.getItems().lowerEndpoint();
-                                if (lower.getKeys().get(0).getStringValue().equals(currentUtcBorder)) {
-                                    return false; // current partition
+                                try {
+                                    Column partitionColumn = info.getPartitionColumns().get(0);
+                                    PartitionValue currentValue = new PartitionValue(currentUtcBorder);
+                                    PartitionKey currentKey = PartitionKey.createPartitionKey(
+                                            Collections.singletonList(currentValue),
+                                            Collections.singletonList(partitionColumn));
+                                    if (lower.compareTo(currentKey) == 0) {
+                                        return false; // current partition
+                                    }
+                                } catch (AnalysisException e) {
+                                    // Fall back to name-based comparison
+                                    return !partition.getName().equals(nowPartitionName);
                                 }
                             }
                         }
@@ -686,7 +702,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
         String partitionFormat = DynamicPartitionUtil.getPartitionFormat(partitionColumn);
         String currentTimeStr = DateTimeFormatter.ofPattern(partitionFormat).format(now);
-
+        if (isTimestampTz) {
+            currentTimeStr += "+00:00";
+        }
         PartitionValue currentTimeValue = new PartitionValue(currentTimeStr);
         PartitionKey currentTimeKey;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -209,17 +209,43 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     /**
-     * Get all partitions except the current one. When currentUtcBorder is non-null,
-     * the current partition is identified by matching its range lower bound against
-     * currentUtcBorder rather than by name. For TIMESTAMPTZ tables both names and
-     * ranges are UTC-based, so the name-based fallback is also correct; the range
-     * check provides an additional safety layer.
+     * Get all partitions except the current one. When currentKey is non-null,
+     * the current partition is identified by matching its range lower bound
+     * against currentKey (parsed from currentUtcBorder).  When currentKey is
+     * null, fall back to name-based exclusion against nowPartitionName.
+     *
+     * <p>The two filters are mutually exclusive — when a range key is available
+     * it alone identifies the current partition.  Applying both filters on top
+     * of each other would double-exclude: after the range match removes the
+     * current partition (whose name may use an old prefix after a prefix change),
+     * the name filter could then catch a <em>different</em> partition whose name
+     * happens to match the new prefix, losing two partitions and corrupting
+     * auto-bucket calculations.
      */
     public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName,
             String currentUtcBorder) {
         table.readLock();
         try {
             RangePartitionInfo info = (RangePartitionInfo) (table.getPartitionInfo());
+            // Parse the range key once, before the stream.  A single parse
+            // avoids redundant PartitionKey.createPartitionKey calls for every
+            // partition while holding the table read lock.
+            PartitionKey currentKey = null;
+            if (currentUtcBorder != null) {
+                try {
+                    Column partitionColumn = info.getPartitionColumns().get(0);
+                    PartitionValue currentValue = new PartitionValue(currentUtcBorder);
+                    currentKey = PartitionKey.createPartitionKey(
+                            Collections.singletonList(currentValue),
+                            Collections.singletonList(partitionColumn));
+                } catch (AnalysisException e) {
+                    // Parsing failed — fall back to name-based exclusion below.
+                    currentKey = null;
+                }
+            }
+
+            final PartitionKey rangeKey = currentKey;
+
             List<Map.Entry<Long, PartitionItem>> idToItems = new ArrayList<>(info.getIdToItem(false).entrySet());
             idToItems.sort(Comparator.comparing(o -> ((RangePartitionItem) o.getValue()).getItems().upperEndpoint()));
             return idToItems.stream()
@@ -228,33 +254,19 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                         if (partition == null) {
                             return false;
                         }
-                        // When currentUtcBorder is available, exclude the current
-                        // partition by comparing range lower bounds, not names.
-                        // Use PartitionKey.compareTo (not getStringValue) to
-                        // handle scale differences: a TIMESTAMPTZ(6) lower key
-                        // stores "2026-07-20 00:00:00.000000+00:00" while
-                        // currentUtcBorder is "2026-07-20 00:00:00+00:00" —
-                        // the string representations differ even though they
-                        // represent the same instant.
-                        if (currentUtcBorder != null) {
+                        if (rangeKey != null) {
+                            // Range-based exclusion only — mutually exclusive
+                            // with name-based exclusion to avoid double-filtering.
                             RangePartitionItem item = (RangePartitionItem) info.getItem(partition.getId());
                             if (item != null) {
                                 PartitionKey lower = item.getItems().lowerEndpoint();
-                                try {
-                                    Column partitionColumn = info.getPartitionColumns().get(0);
-                                    PartitionValue currentValue = new PartitionValue(currentUtcBorder);
-                                    PartitionKey currentKey = PartitionKey.createPartitionKey(
-                                            Collections.singletonList(currentValue),
-                                            Collections.singletonList(partitionColumn));
-                                    if (lower.compareTo(currentKey) == 0) {
-                                        return false; // current partition
-                                    }
-                                } catch (AnalysisException e) {
-                                    // Fall back to name-based comparison
-                                    return !partition.getName().equals(nowPartitionName);
+                                if (lower.compareTo(rangeKey) == 0) {
+                                    return false; // current partition
                                 }
                             }
+                            return true; // not the current — keep it
                         }
+                        // Name-based exclusion (fallback when no range key).
                         return !partition.getName().equals(nowPartitionName);
                     })
                     .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -105,11 +105,6 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
     private static final long SLEEP_PIECE = 5000L;
 
-    /** Test-only: when non-null overrides the clock in both add and drop
-     *  paths so tests can reproduce time-sensitive scenarios deterministically. */
-    @VisibleForTesting
-    public static volatile ZonedDateTime testNow;
-
     private Map<Long, Map<String, String>> runtimeInfos = Maps.newConcurrentMap();
     private Set<Pair<Long, Long>> dynamicPartitionTableInfo = Sets.newConcurrentHashSet();
     private boolean initialize;
@@ -176,8 +171,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
      *  this to control time-sensitive partition scheduling behavior, or
      *  set {@link #testNow} directly for static clock control. */
     @VisibleForTesting
-    public ZonedDateTime getNow(ZoneId zoneId) {
-        return testNow != null ? testNow : ZonedDateTime.now(zoneId);
+    public ZonedDateTime getNow(boolean isTimestampTz, ZoneId zoneId) {
+        ZonedDateTime nowTz = ZonedDateTime.now(zoneId);
+        return isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
     }
 
     // exponential moving average
@@ -303,8 +299,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // For TIMESTAMPTZ, both partition boundaries and names are UTC-based
         // (00:00—24:00 in UTC). This keeps partition names and values consistent.
         boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = getNow(dynamicPartitionProperty.getTimeZone().toZoneId());
-        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
+        ZonedDateTime now = getNow(isTimestampTz, dynamicPartitionProperty.getTimeZone().toZoneId());
         TimeZone borderTimeZone = isTimestampTz
                 ? TimeUtils.getUTCTimeZone()
                 : dynamicPartitionProperty.getTimeZone();
@@ -567,8 +562,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         // For TIMESTAMPTZ, use UTC clock so the drop cutoff aligns with the
         // UTC-midnight partition boundaries created by getAddPartitionOp().
         boolean isTimestampTz = partitionColumn.getDataType() == PrimitiveType.TIMESTAMPTZ;
-        ZonedDateTime nowTz = getNow(dynamicPartitionProperty.getTimeZone().toZoneId());
-        ZonedDateTime now = isTimestampTz ? nowTz.withZoneSameInstant(ZoneOffset.UTC) : nowTz;
+        ZonedDateTime now = getNow(isTimestampTz, dynamicPartitionProperty.getTimeZone().toZoneId());
         TimeZone borderTimeZone = isTimestampTz
                 ? TimeUtils.getUTCTimeZone()
                 : dynamicPartitionProperty.getTimeZone();

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -214,41 +214,19 @@ public class DynamicPartitionScheduler extends MasterDaemon {
     }
 
     private static Pair<Integer, Integer> getBucketsNum(DynamicPartitionProperty property, OlapTable table,
-            String partitionName, String nowPartitionName, boolean executeFirstTime, String nowPartitionPrevBorder) {
+            String partitionName, String nowPartitionName, boolean executeFirstTime) {
         AutoBucketCalculator.AutoBucketContext context = new AutoBucketCalculator.AutoBucketContext(
-                table, partitionName, nowPartitionName, executeFirstTime, property.getBuckets(),
-                nowPartitionPrevBorder);
+                table, partitionName, nowPartitionName, executeFirstTime, property.getBuckets());
 
         AutoBucketCalculator.AutoBucketResult result = AutoBucketCalculator.calculateAutoBuckets(context);
         return Pair.of(result.getBuckets(), result.getPreviousBuckets());
     }
 
     /**
-     * Get all partitions except the current one. When currentKey is non-null,
-     * the current partition is identified by checking if its range
-     * <em>contains</em> currentKey (i.e. lower <= currentKey < upper).
-     * When currentKey is null, fall back to name-based exclusion against
-     * nowPartitionName.
-     *
-     * <p>Using range containment instead of exact lower-bound equality
-     * handles non‑canonical current partitions whose lower endpoint does
-     * not coincide with the captured UTC‑midnight instant — for example a
-     * pre‑fix Asia/Shanghai partition p20260720 = [2026-07-19 16:00Z,
-     * 2026-07-20 16:00Z) where currentKey = 2026-07-22 00:00Z falls inside
-     * the range but does not equal the lower endpoint.  Without containment
-     * such a populated, still‑growing partition would be treated as history
-     * and distort auto‑bucket calculations.
-     *
-     * <p>The two filters are mutually exclusive — when a range key is available
-     * it alone identifies the current partition.  Applying both filters on top
-     * of each other would double‑exclude: after the range match removes the
-     * current partition (whose name may use an old prefix after a prefix change),
-     * the name filter could then catch a <em>different</em> partition whose name
-     * happens to match the new prefix, losing two partitions and corrupting
-     * auto‑bucket calculations.
+     * Get all partitions except the current one. The current partition is
+     * identified by name-based exclusion against nowPartitionName.
      */
-    public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName,
-            String nowPartitionPrevBorder) {
+    public static List<Partition> getHistoricalPartitions(OlapTable table, String nowPartitionName) {
         table.readLock();
         try {
             RangePartitionInfo info = (RangePartitionInfo) (table.getPartitionInfo());
@@ -439,7 +417,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             DistributionDesc distributionDesc = null;
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
             Pair<Integer, Integer> ret = getBucketsNum(dynamicPartitionProperty, olapTable, partitionName,
-                    nowPartitionName, executeFirstTime, nowPartitionPrevBorder);
+                    nowPartitionName, executeFirstTime);
             int bucketsNum = ret.first;
             int previousPartitionBucketsNum = ret.second;
             if (olapTable.isAutoBucket()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketCalculator.java
@@ -45,14 +45,21 @@ public class AutoBucketCalculator {
         private final String nowPartitionName;
         private final boolean executeFirstTime;
         private final int defaultBuckets;
+        private final String currentUtcBorder;
 
         public AutoBucketContext(OlapTable table, String partitionName, String nowPartitionName,
                                 boolean executeFirstTime, int defaultBuckets) {
+            this(table, partitionName, nowPartitionName, executeFirstTime, defaultBuckets, null);
+        }
+
+        public AutoBucketContext(OlapTable table, String partitionName, String nowPartitionName,
+                                boolean executeFirstTime, int defaultBuckets, String currentUtcBorder) {
             this.table = table;
             this.partitionName = partitionName;
             this.nowPartitionName = nowPartitionName;
             this.executeFirstTime = executeFirstTime;
             this.defaultBuckets = defaultBuckets;
+            this.currentUtcBorder = currentUtcBorder;
         }
 
         public OlapTable getTable() {
@@ -73,6 +80,10 @@ public class AutoBucketCalculator {
 
         public int getDefaultBuckets() {
             return defaultBuckets;
+        }
+
+        public String getCurrentUtcBorder() {
+            return currentUtcBorder;
         }
     }
 
@@ -138,8 +149,9 @@ public class AutoBucketCalculator {
                 executeFirstTime ? "executeFirstTime" : "not auto bucket table");
         }
 
-        // Get historical partitions
-        List<Partition> partitions = DynamicPartitionScheduler.getHistoricalPartitions(table, nowPartitionName);
+        // Get historical partitions (current partition excluded by range comparison)
+        List<Partition> partitions = DynamicPartitionScheduler.getHistoricalPartitions(
+                table, nowPartitionName, context.getCurrentUtcBorder());
 
         // Get visible versions with error handling
         List<Long> visibleVersions;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketCalculator.java
@@ -45,21 +45,14 @@ public class AutoBucketCalculator {
         private final String nowPartitionName;
         private final boolean executeFirstTime;
         private final int defaultBuckets;
-        private final String currentUtcBorder;
 
         public AutoBucketContext(OlapTable table, String partitionName, String nowPartitionName,
                                 boolean executeFirstTime, int defaultBuckets) {
-            this(table, partitionName, nowPartitionName, executeFirstTime, defaultBuckets, null);
-        }
-
-        public AutoBucketContext(OlapTable table, String partitionName, String nowPartitionName,
-                                boolean executeFirstTime, int defaultBuckets, String currentUtcBorder) {
             this.table = table;
             this.partitionName = partitionName;
             this.nowPartitionName = nowPartitionName;
             this.executeFirstTime = executeFirstTime;
             this.defaultBuckets = defaultBuckets;
-            this.currentUtcBorder = currentUtcBorder;
         }
 
         public OlapTable getTable() {
@@ -80,10 +73,6 @@ public class AutoBucketCalculator {
 
         public int getDefaultBuckets() {
             return defaultBuckets;
-        }
-
-        public String getCurrentUtcBorder() {
-            return currentUtcBorder;
         }
     }
 
@@ -149,9 +138,9 @@ public class AutoBucketCalculator {
                 executeFirstTime ? "executeFirstTime" : "not auto bucket table");
         }
 
-        // Get historical partitions (current partition excluded by range comparison)
+        // Get historical partitions (current partition excluded by name-based comparison)
         List<Partition> partitions = DynamicPartitionScheduler.getHistoricalPartitions(
-                table, nowPartitionName, context.getCurrentUtcBorder());
+                table, nowPartitionName);
 
         // Get visible versions with error handling
         List<Long> visibleVersions;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -60,6 +60,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -840,25 +841,33 @@ public class DynamicPartitionUtil {
     }
 
     // return the partition range date string formatted as yyyy-MM-dd[ HH:mm::ss]
+    // When current is UTC-based (e.g. for TIMESTAMPTZ columns), the result
+    // carries a +00:00 suffix so downstream TimestampTzLiteral parsing treats
+    // it as an unambiguous UTC instant.
     public static String getPartitionRangeString(DynamicPartitionProperty property, ZonedDateTime current,
                                                  int offset, String format) {
         String timeUnit = property.getTimeUnit();
+        String result;
         if (timeUnit.equalsIgnoreCase(TimeUnit.DAY.toString())) {
-            return getPartitionRangeOfDay(current, offset, format);
+            result = getPartitionRangeOfDay(current, offset, format);
         } else if (timeUnit.equalsIgnoreCase(TimeUnit.WEEK.toString())) {
-            return getPartitionRangeOfWeek(current, offset, property.getStartOfWeek(), format);
+            result = getPartitionRangeOfWeek(current, offset, property.getStartOfWeek(), format);
         } else if (timeUnit.equalsIgnoreCase(TimeUnit.HOUR.toString())) {
-            return getPartitionRangeOfHour(current, offset, format);
+            result = getPartitionRangeOfHour(current, offset, format);
         } else if (timeUnit.equalsIgnoreCase(TimeUnit.MONTH.toString())) {
-            return getPartitionRangeOfMonth(current, offset, property.getStartOfMonth(), format);
+            result = getPartitionRangeOfMonth(current, offset, property.getStartOfMonth(), format);
         } else { // YEAR
-            return getPartitionRangeOfYear(current, offset, format);
+            result = getPartitionRangeOfYear(current, offset, format);
         }
+        if (current.getZone().equals(ZoneOffset.UTC)) {
+            result += "+00:00";
+        }
+        return result;
     }
 
     public static String getHistoryPartitionRangeString(DynamicPartitionProperty dynamicPartitionProperty,
-            String time, String format) throws AnalysisException {
-        ZoneId zoneId = dynamicPartitionProperty.getTimeZone().toZoneId();
+            String time, String format, boolean isTimestampTz) throws AnalysisException {
+        ZoneId zoneId = isTimestampTz ? ZoneOffset.UTC : dynamicPartitionProperty.getTimeZone().toZoneId();
         LocalDateTime dateTime = null;
         Timestamp timestamp = null;
         String timeUnit = dynamicPartitionProperty.getTimeUnit();
@@ -870,8 +879,12 @@ public class DynamicPartitionUtil {
             throw new AnalysisException("Parse dynamic partition periods error. Error=" + e.getMessage());
         }
         timestamp = Timestamp.valueOf(dateTime);
-        return getFormattedTimeWithoutMinuteSecond(
+        String result = getFormattedTimeWithoutMinuteSecond(
                 ZonedDateTime.parse(timestamp.toString(), dateTimeFormatter), format);
+        if (isTimestampTz) {
+            result += "+00:00";
+        }
+        return result;
     }
 
     private static LocalDateTime getDateTimeByTimeUnit(String time, String timeUnit) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -64,6 +64,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -72,6 +77,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class PropertyAnalyzer {
@@ -237,6 +243,17 @@ public class PropertyAnalyzer {
     public static final String ENABLE_UNIQUE_KEY_MERGE_ON_WRITE = "enable_unique_key_merge_on_write";
     public static final String ENABLE_UNIQUE_KEY_SKIP_BITMAP_COLUMN = "enable_unique_key_skip_bitmap_column";
     private static final Logger LOG = LogManager.getLogger(PropertyAnalyzer.class);
+    /** Formatter for cooldown/baseTime strings that carry an explicit timezone
+     *  offset (e.g. "+00:00").  Accepts optional fractional seconds up to
+     *  nanosecond precision so that TIMESTAMPTZ(p) values with 0 ≤ p ≤ 6
+     *  are parsed correctly. */
+    private static final DateTimeFormatter TZ_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+            .appendOffset("+HH:MM", "+00:00")
+            .toFormatter();
+    /** Precompiled pattern matching a trailing timezone offset "±HH:MM". */
+    private static final Pattern TZ_OFFSET_PATTERN = Pattern.compile("[+-]\\d{2}:\\d{2}$");
     public static final String COMMA_SEPARATOR = ",";
     private static final double MAX_FPP = 0.05;
     private static final double MIN_FPP = 0.0001;
@@ -409,10 +426,24 @@ public class PropertyAnalyzer {
                 }
             } else if (key.equalsIgnoreCase(PROPERTIES_STORAGE_COOLDOWN_TIME)) {
                 try {
-                    DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(value,
-                            ScalarType.getDefaultDateType(Type.DATETIME));
-                    cooldownTimestamp = dateLiteral.unixTimestamp(TimeUtils.getTimeZone());
-                } catch (AnalysisException e) {
+                    // A value with an explicit timezone offset (e.g.
+                    // "2027-01-01 00:00:00+00:00" or, for TIMESTAMPTZ(6),
+                    // "2027-01-01 00:00:00.000000+00:00") represents an
+                    // unambiguous UTC instant. Parse it directly as a
+                    // ZonedDateTime and convert to epoch millis, bypassing
+                    // the DATETIME-based DateLiteralUtils.createDateLiteral()
+                    // path which uses Instant.now() for the initial offset
+                    // computation and produces incorrect results across DST
+                    // boundaries.
+                    if (TZ_OFFSET_PATTERN.matcher(value).find()) {
+                        cooldownTimestamp = TZ_FORMATTER.parse(value, ZonedDateTime::from)
+                                .toInstant().toEpochMilli();
+                    } else {
+                        DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(value,
+                                ScalarType.getDefaultDateType(Type.DATETIME));
+                        cooldownTimestamp = dateLiteral.unixTimestamp(TimeUtils.getTimeZone());
+                    }
+                } catch (AnalysisException | DateTimeParseException e) {
                     LOG.warn("dateLiteral failed, use max cool down time", e);
                     cooldownTimestamp = DataProperty.MAX_COOLDOWN_TIME_MS;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -256,14 +256,15 @@ public class PropertyAnalyzer {
             .appendOffset("+HH:MM", "+00:00")
             .toFormatter()
             .withResolverStyle(ResolverStyle.STRICT);
-    /** Precompiled pattern matching a trailing timezone offset "±HH:MM"
-     *  preceded by a full {@code yyyy-MM-dd HH:mm:ss[.SSSSSS]} datetime,
-     *  i.e. the exact shape produced by {@code convertToUtcTimestamp()} in
-     *  DynamicPartitionScheduler.  Values with a TZ offset but a different
-     *  datetime shape (compact forms, missing seconds, etc.) are
-     *  intentionally left to the legacy DATETIME parser. */
+    /** Precompiled pattern matching a trailing timezone specifier
+     *  ({@code ±HH:MM}, {@code Z}, {@code UTC}, or {@code GMT}) preceded
+     *  by a full {@code yyyy-MM-dd HH:mm:ss[.SSSSSS]} datetime, i.e. the
+     *  exact shape produced by {@code convertToUtcTimestamp()} in
+     *  DynamicPartitionScheduler.  Values with other datetime shapes
+     *  (compact forms, missing seconds, etc.) are intentionally left to
+     *  the legacy DATETIME parser. */
     private static final Pattern TZ_OFFSET_PATTERN = Pattern.compile(
-            "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?[+-]\\d{2}:\\d{2}$");
+            "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?(Z|[+-]\\d{2}:\\d{2}|UTC|GMT)$");
     public static final String COMMA_SEPARATOR = ",";
     private static final double MAX_FPP = 0.05;
     private static final double MIN_FPP = 0.0001;
@@ -446,7 +447,15 @@ public class PropertyAnalyzer {
                     // computation and produces incorrect results across DST
                     // boundaries.
                     if (TZ_OFFSET_PATTERN.matcher(value).find()) {
-                        cooldownTimestamp = TZ_FORMATTER.parse(value, ZonedDateTime::from)
+                        // TZ_FORMATTER only understands ±HH:MM offsets.
+                        // Normalize Z, UTC, GMT to the canonical zero
+                        // offset so that every explicit-zone spelling is
+                        // parsed as an unambiguous instant rather than
+                        // falling through to the DATETIME path (which
+                        // uses Instant.now() for the DST offset and
+                        // produces incorrect results across DST changes).
+                        String normalized = value.replaceAll("(Z|UTC|GMT)$", "+00:00");
+                        cooldownTimestamp = TZ_FORMATTER.parse(normalized, ZonedDateTime::from)
                                 .toInstant().toEpochMilli();
                     } else {
                         DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(value,

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -64,12 +64,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.DateTimeParseException;
-import java.time.format.ResolverStyle;
-import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -78,7 +72,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class PropertyAnalyzer {
@@ -244,27 +237,6 @@ public class PropertyAnalyzer {
     public static final String ENABLE_UNIQUE_KEY_MERGE_ON_WRITE = "enable_unique_key_merge_on_write";
     public static final String ENABLE_UNIQUE_KEY_SKIP_BITMAP_COLUMN = "enable_unique_key_skip_bitmap_column";
     private static final Logger LOG = LogManager.getLogger(PropertyAnalyzer.class);
-    /** Formatter for cooldown/baseTime strings that carry an explicit timezone
-     *  offset (e.g. "+00:00").  Accepts optional fractional seconds up to
-     *  nanosecond precision so that TIMESTAMPTZ(p) values with 0 ≤ p ≤ 6
-     *  are parsed correctly.  Uses STRICT resolver style so that invalid
-     *  calendar dates (e.g. Feb 29 in a non-leap year) are rejected rather
-     *  than silently normalized. */
-    private static final DateTimeFormatter TZ_FORMATTER = new DateTimeFormatterBuilder()
-            .appendPattern("uuuu-MM-dd HH:mm:ss")
-            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
-            .appendOffset("+HH:MM", "+00:00")
-            .toFormatter()
-            .withResolverStyle(ResolverStyle.STRICT);
-    /** Precompiled pattern matching a trailing timezone specifier
-     *  ({@code ±HH:MM}, {@code Z}, {@code UTC}, or {@code GMT}) preceded
-     *  by a full {@code yyyy-MM-dd HH:mm:ss[.SSSSSS]} datetime, i.e. the
-     *  exact shape produced by {@code convertToUtcTimestamp()} in
-     *  DynamicPartitionScheduler.  Values with other datetime shapes
-     *  (compact forms, missing seconds, etc.) are intentionally left to
-     *  the legacy DATETIME parser. */
-    private static final Pattern TZ_OFFSET_PATTERN = Pattern.compile(
-            "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?(Z|[+-]\\d{2}:\\d{2}|UTC|GMT)$");
     public static final String COMMA_SEPARATOR = ",";
     private static final double MAX_FPP = 0.05;
     private static final double MIN_FPP = 0.0001;
@@ -437,32 +409,10 @@ public class PropertyAnalyzer {
                 }
             } else if (key.equalsIgnoreCase(PROPERTIES_STORAGE_COOLDOWN_TIME)) {
                 try {
-                    // A value with an explicit timezone offset (e.g.
-                    // "2027-01-01 00:00:00+00:00" or, for TIMESTAMPTZ(6),
-                    // "2027-01-01 00:00:00.000000+00:00") represents an
-                    // unambiguous UTC instant. Parse it directly as a
-                    // ZonedDateTime and convert to epoch millis, bypassing
-                    // the DATETIME-based DateLiteralUtils.createDateLiteral()
-                    // path which uses Instant.now() for the initial offset
-                    // computation and produces incorrect results across DST
-                    // boundaries.
-                    if (TZ_OFFSET_PATTERN.matcher(value).find()) {
-                        // TZ_FORMATTER only understands ±HH:MM offsets.
-                        // Normalize Z, UTC, GMT to the canonical zero
-                        // offset so that every explicit-zone spelling is
-                        // parsed as an unambiguous instant rather than
-                        // falling through to the DATETIME path (which
-                        // uses Instant.now() for the DST offset and
-                        // produces incorrect results across DST changes).
-                        String normalized = value.replaceAll("(Z|UTC|GMT)$", "+00:00");
-                        cooldownTimestamp = TZ_FORMATTER.parse(normalized, ZonedDateTime::from)
-                                .toInstant().toEpochMilli();
-                    } else {
-                        DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(value,
-                                ScalarType.getDefaultDateType(Type.DATETIME));
-                        cooldownTimestamp = dateLiteral.unixTimestamp(TimeUtils.getTimeZone());
-                    }
-                } catch (AnalysisException | DateTimeParseException e) {
+                    DateLiteral dateLiteral = DateLiteralUtils.createDateLiteral(value,
+                            ScalarType.getDefaultDateType(Type.DATETIME));
+                    cooldownTimestamp = dateLiteral.unixTimestamp(TimeUtils.getTimeZone());
+                } catch (AnalysisException e) {
                     LOG.warn("dateLiteral failed, use max cool down time", e);
                     cooldownTimestamp = DataProperty.MAX_COOLDOWN_TIME_MS;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -68,6 +68,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -246,14 +247,23 @@ public class PropertyAnalyzer {
     /** Formatter for cooldown/baseTime strings that carry an explicit timezone
      *  offset (e.g. "+00:00").  Accepts optional fractional seconds up to
      *  nanosecond precision so that TIMESTAMPTZ(p) values with 0 ≤ p ≤ 6
-     *  are parsed correctly. */
+     *  are parsed correctly.  Uses STRICT resolver style so that invalid
+     *  calendar dates (e.g. Feb 29 in a non-leap year) are rejected rather
+     *  than silently normalized. */
     private static final DateTimeFormatter TZ_FORMATTER = new DateTimeFormatterBuilder()
-            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .appendPattern("uuuu-MM-dd HH:mm:ss")
             .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
             .appendOffset("+HH:MM", "+00:00")
-            .toFormatter();
-    /** Precompiled pattern matching a trailing timezone offset "±HH:MM". */
-    private static final Pattern TZ_OFFSET_PATTERN = Pattern.compile("[+-]\\d{2}:\\d{2}$");
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
+    /** Precompiled pattern matching a trailing timezone offset "±HH:MM"
+     *  preceded by a full {@code yyyy-MM-dd HH:mm:ss[.SSSSSS]} datetime,
+     *  i.e. the exact shape produced by {@code convertToUtcTimestamp()} in
+     *  DynamicPartitionScheduler.  Values with a TZ offset but a different
+     *  datetime shape (compact forms, missing seconds, etc.) are
+     *  intentionally left to the legacy DATETIME parser. */
+    private static final Pattern TZ_OFFSET_PATTERN = Pattern.compile(
+            "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?[+-]\\d{2}:\\d{2}$");
     public static final String COMMA_SEPARATOR = ",";
     private static final double MAX_FPP = 0.05;
     private static final double MIN_FPP = 0.0001;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -184,6 +184,20 @@ public class TimeUtils {
         return dateFormat.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(timeStamp), dateFormat.getZone()));
     }
 
+    /** Same as {@link #longToTimeStringWithTimeZone(Long, String)} but appends
+     *  the timezone offset (e.g. {@code +00:00}, {@code +08:00}) so the
+     *  result is an unambiguous UTC instant string that
+     *  {@link PropertyAnalyzer#TZ_OFFSET_PATTERN} can detect and route to
+     *  {@code TZ_FORMATTER} for instant-aware parsing. */
+    public static String longToTimeStringWithTimeZoneAndOffset(Long timeStamp, String timeZone) {
+        if (timeStamp == null || timeStamp <= 0L) {
+            return FeConstants.null_string;
+        }
+        return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX")
+                .withZone(getOrSystemTimeZone(timeZone).toZoneId())
+                .format(Instant.ofEpochMilli(timeStamp));
+    }
+
     public static String longToTimeStringWithms(Long timeStamp) {
         return longToTimeStringWithFormat(timeStamp, getDatetimeMsFormatWithTimeZone());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralUtilsTest.java
@@ -491,6 +491,31 @@ public class DateLiteralUtilsTest {
             Assertions.assertEquals(minus5EpochMs,
                     dlMinus5.unixTimestamp(TimeUtils.getTimeZone()),
                     "Winter '-05:00' suffix must produce correct UTC epoch ms");
+
+            // Source-zone DST gap: CET spring-forward on March 28, 2027 (last
+            // Sunday of March, EU DST transition).  02:30 CET is nonexistent
+            // (gap 02:00→03:00); Java resolves it forward to 03:30 CEST = 01:30Z.
+            // The original code derived destination fields via offset difference,
+            // which lost the gap-forward shift and produced 02:30 again → 1 hour
+            // earlier than the resolved instant.
+            ctx.getSessionVariable().setTimeZone("CET");
+            long cetGapEpochMs = Instant.parse("2027-03-28T01:30:00Z").toEpochMilli();
+
+            DateLiteral dlCetGap = DateLiteralUtils.createDateLiteral(
+                    "2027-03-28 02:30:00CET", Type.DATETIME);
+            Assertions.assertEquals(cetGapEpochMs,
+                    dlCetGap.unixTimestamp(TimeUtils.getTimeZone()),
+                    "CET spring-forward gap (DATETIME) must produce correct UTC epoch ms");
+
+            DateLiteral dlCetGapTz = DateLiteralUtils.createDateLiteral(
+                    "2027-03-28 02:30:00CET", ScalarType.createTimeStampTzType(0));
+            Assertions.assertEquals(1, dlCetGapTz.getHour(),
+                    "CET spring-forward gap (TIMESTAMPTZ) must store UTC hour = 01");
+            Assertions.assertEquals(30, dlCetGapTz.getMinute(),
+                    "CET spring-forward gap (TIMESTAMPTZ) must store UTC minute = 30");
+
+            // Restore America/Chicago for any future test additions.
+            ctx.getSessionVariable().setTimeZone("America/Chicago");
         } finally {
             TimeZone.setDefault(originalTz);
             if (savedCtx != null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralUtilsTest.java
@@ -20,11 +20,15 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.foundation.format.FormatOptions;
 import org.apache.doris.qe.ConnectContext;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.TimeZone;
 
 public class DateLiteralUtilsTest {
 
@@ -423,5 +427,77 @@ public class DateLiteralUtilsTest {
 
         // Verify getStringValue includes +00:00 suffix for TimestampTz
         Assertions.assertTrue(dl.getStringValue().endsWith("+00:00"));
+    }
+
+    @Test
+    public void testDatetimeWithTzOffsetDstAwareUnixTimestamp() throws AnalysisException {
+        // Regression: createDateLiteral must compute the timezone offset using
+        // the target date rather than Instant.now().  When the session timezone
+        // has DST (e.g. America/Chicago = UTC-5 summer, UTC-6 winter), a winter-
+        // target value with +00:00 suffix was shifted using the summer DST
+        // offset, then unixTimestamp() applied the winter offset, producing a
+        // 1-hour error.
+        TimeZone originalTz = TimeZone.getDefault();
+        ConnectContext savedCtx = ConnectContext.get();
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setThreadLocalInfo();
+            ctx.getSessionVariable().setTimeZone("America/Chicago");
+
+            // Winter-target instant: 2027-01-01 00:00:00 UTC.
+            long expectedEpochMs = Instant.parse("2027-01-01T00:00:00Z").toEpochMilli();
+
+            // Z suffix
+            DateLiteral dlZ = DateLiteralUtils.createDateLiteral(
+                    "2027-01-01 00:00:00Z", Type.DATETIME);
+            Assertions.assertEquals(expectedEpochMs,
+                    dlZ.unixTimestamp(TimeUtils.getTimeZone()),
+                    "Winter 'Z' suffix must produce correct UTC epoch ms");
+
+            // +00:00 suffix
+            DateLiteral dl00 = DateLiteralUtils.createDateLiteral(
+                    "2027-01-01 00:00:00+00:00", Type.DATETIME);
+            Assertions.assertEquals(expectedEpochMs,
+                    dl00.unixTimestamp(TimeUtils.getTimeZone()),
+                    "Winter '+00:00' suffix must produce correct UTC epoch ms");
+
+            // UTC suffix
+            DateLiteral dlUtc = DateLiteralUtils.createDateLiteral(
+                    "2027-01-01 00:00:00UTC", Type.DATETIME);
+            Assertions.assertEquals(expectedEpochMs,
+                    dlUtc.unixTimestamp(TimeUtils.getTimeZone()),
+                    "Winter 'UTC' suffix must produce correct UTC epoch ms");
+
+            // GMT suffix
+            DateLiteral dlGmt = DateLiteralUtils.createDateLiteral(
+                    "2027-01-01 00:00:00GMT", Type.DATETIME);
+            Assertions.assertEquals(expectedEpochMs,
+                    dlGmt.unixTimestamp(TimeUtils.getTimeZone()),
+                    "Winter 'GMT' suffix must produce correct UTC epoch ms");
+
+            // Summer-target baseline: a +00:00 value for July must also work.
+            long summerEpochMs = Instant.parse("2027-07-01T00:00:00Z").toEpochMilli();
+            DateLiteral dlSummer = DateLiteralUtils.createDateLiteral(
+                    "2027-07-01 00:00:00+00:00", Type.DATETIME);
+            Assertions.assertEquals(summerEpochMs,
+                    dlSummer.unixTimestamp(TimeUtils.getTimeZone()),
+                    "Summer '+00:00' suffix must also produce correct UTC epoch ms");
+
+            // Non-UTC offset with DST zone: -05:00 in winter should produce
+            // 2027-01-01 05:00:00 UTC = +5h from original.
+            long minus5EpochMs = Instant.parse("2027-01-01T05:00:00Z").toEpochMilli();
+            DateLiteral dlMinus5 = DateLiteralUtils.createDateLiteral(
+                    "2027-01-01 00:00:00-05:00", Type.DATETIME);
+            Assertions.assertEquals(minus5EpochMs,
+                    dlMinus5.unixTimestamp(TimeUtils.getTimeZone()),
+                    "Winter '-05:00' suffix must produce correct UTC epoch ms");
+        } finally {
+            TimeZone.setDefault(originalTz);
+            if (savedCtx != null) {
+                savedCtx.setThreadLocalInfo();
+            } else {
+                ConnectContext.remove();
+            }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
@@ -388,6 +388,32 @@ public class ExprToStringValueVisitorTest {
         }
     }
 
+    @Test
+    public void testDateLiteralTimeStampTzHistoricalOffsetStreamLoad() throws Exception {
+        // BE's TIMESTAMPTZ parser consumes only HH:MM offsets (minutes 00/30/45).
+        // Historical zone offsets can include seconds (e.g. Asia/Shanghai before
+        // 1901 had LMT +08:05:43), which BE would reject on group-commit or
+        // transactional-insert PDataRow paths.  Stream-load rendering must
+        // serialise in UTC format so BE can round-trip.
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            context.getSessionVariable().setTimeZone("Asia/Shanghai");
+            // Pre-standard-offset instant: 1900-01-01 00:00:00 UTC.
+            DateLiteral d = DateLiteralUtils.createDateLiteral("1900-01-01 00:00:00+00:00",
+                    ScalarType.createTimeStampTzType(0));
+            // Stream-load path must emit UTC format.
+            Assertions.assertEquals("1900-01-01 00:00:00+00:00",
+                    V.visitDateLiteral(d, StringValueContext.forStreamLoad(FormatOptions.getDefault())));
+            // Query path shows the historical wall clock with full offset.
+            String queryResult = V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault()));
+            Assertions.assertTrue(queryResult.contains("+08:05:43"),
+                    "Query path should render historical offset with seconds: " + queryResult);
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
     // ======================== CastExpr ========================
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
@@ -538,6 +538,31 @@ public class ExprToStringValueVisitorTest {
         Assertions.assertEquals("{\"Bob\", 25}", result);
     }
 
+    @Test
+    public void testStructTimeStampTzStreamLoadHistoricalOffset() throws Exception {
+        // Regression: STRUCT children in stream-load must preserve the
+        // forStreamLoad flag so that TIMESTAMPTZ renders in UTC format;
+        // otherwise the query branch emits historical offsets with seconds
+        // (e.g. Asia/Shanghai +08:05:43) which BE's parser rejects.
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            context.getSessionVariable().setTimeZone("Asia/Shanghai");
+            DateLiteral tsTz = DateLiteralUtils.createDateLiteral(
+                    "1900-01-01 00:00:00+00:00",
+                    ScalarType.createTimeStampTzType(0));
+            StructType structType = new StructType(
+                    new StructField("ts", ScalarType.createTimeStampTzType(0)));
+            StructLiteral s = new StructLiteral(structType, tsTz);
+            FormatOptions opts = FormatOptions.getDefault();
+            String result = V.visitStructLiteral(s, StringValueContext.forStreamLoad(opts));
+            // Nested TIMESTAMPTZ must be UTC, not with +08:05:43.
+            Assertions.assertEquals("{\"1900-01-01 00:00:00+00:00\"}", result);
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
     // ======================== Default visitor (unoverridden Expr) ========================
 
     @Test
@@ -577,8 +602,10 @@ public class ExprToStringValueVisitorTest {
     public void testAsQueryComplexType() {
         StringValueContext streamCtx = StringValueContext.forStreamLoad(FormatOptions.getDefault());
         StringValueContext queryComplex = streamCtx.asQueryComplexType();
-        // asQueryComplexType: forces query mode + complex type
-        Assertions.assertFalse(queryComplex.isForStreamLoad());
+        // asQueryComplexType: forces complex type but preserves forStreamLoad
+        // so nested TIMESTAMPTZ renders in UTC format (BE parser rejects
+        // historical offsets with seconds like +08:05:43).
+        Assertions.assertTrue(queryComplex.isForStreamLoad());
         Assertions.assertTrue(queryComplex.isInComplexType());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.StructType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.foundation.format.FormatOptions;
+import org.apache.doris.qe.ConnectContext;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -311,6 +312,80 @@ public class ExprToStringValueVisitorTest {
         DateLiteral d = new DateLiteral(2024, 1, 15, Type.DATEV2);
         Assertions.assertEquals("\"2024-01-15\"",
                 V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault()).asComplexType()));
+    }
+
+    // ======================== TimeStampTz ========================
+
+    @Test
+    public void testDateLiteralTimeStampTzPositiveOffset() throws Exception {
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            context.getSessionVariable().setTimeZone("+08:00");
+            DateLiteral d = DateLiteralUtils.createDateLiteral("2020-02-02 12:00:03.123456+00:00",
+                    ScalarType.createTimeStampTzType(6));
+            // UTC wall clock = 12:00:03.123456, with session +08:00 → wall clock 20:00:03.123456, offset +08:00
+            Assertions.assertEquals("2020-02-02 20:00:03.123456+08:00",
+                    V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault())));
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testDateLiteralTimeStampTzNegativeOffset() throws Exception {
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            context.getSessionVariable().setTimeZone("-08:00");
+            DateLiteral d = DateLiteralUtils.createDateLiteral("2020-02-02 12:00:03.123456+00:00",
+                    ScalarType.createTimeStampTzType(6));
+            // UTC wall clock = 12:00:03.123456, with session -08:00 → wall clock 04:00:03.123456, offset -08:00
+            Assertions.assertEquals("2020-02-02 04:00:03.123456-08:00",
+                    V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault())));
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testDateLiteralTimeStampTzDstWinterTarget() throws Exception {
+        // Regression: visitor must NOT use Instant.now() for DST offset computation.
+        // A winter TIMESTAMPTZ value rendered in America/Chicago session must show
+        // winter offset (-06:00), not summer offset (-05:00) even if the JVM clock
+        // is in summer.
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            context.getSessionVariable().setTimeZone("America/Chicago");
+            // Winter target: 2027-01-01 00:00:00 UTC
+            DateLiteral d = DateLiteralUtils.createDateLiteral("2027-01-01 00:00:00+00:00",
+                    ScalarType.createTimeStampTzType(0));
+            // America/Chicago winter offset = -06:00
+            // UTC wall clock = 2027-01-01 00:00:00 → CST wall clock = 2026-12-31 18:00:00
+            Assertions.assertEquals("2026-12-31 18:00:00-06:00",
+                    V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault())));
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testDateLiteralTimeStampTzDstSummerTarget() throws Exception {
+        // Summer baseline: a July value in America/Chicago should use -05:00.
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            context.getSessionVariable().setTimeZone("America/Chicago");
+            DateLiteral d = DateLiteralUtils.createDateLiteral("2027-07-01 00:00:00+00:00",
+                    ScalarType.createTimeStampTzType(0));
+            // America/Chicago summer offset = -05:00
+            // UTC wall clock = 2027-07-01 00:00:00 → CDT wall clock = 2027-06-30 19:00:00
+            Assertions.assertEquals("2027-06-30 19:00:00-05:00",
+                    V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault())));
+        } finally {
+            ConnectContext.remove();
+        }
     }
 
     // ======================== CastExpr ========================

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
@@ -390,11 +390,12 @@ public class ExprToStringValueVisitorTest {
 
     @Test
     public void testDateLiteralTimeStampTzHistoricalOffsetStreamLoad() throws Exception {
-        // BE's TIMESTAMPTZ parser consumes only HH:MM offsets (minutes 00/30/45).
-        // Historical zone offsets can include seconds (e.g. Asia/Shanghai before
-        // 1901 had LMT +08:05:43), which BE would reject on group-commit or
-        // transactional-insert PDataRow paths.  Stream-load rendering must
-        // serialise in UTC format so BE can round-trip.
+        // BE's TimestampTzValue::to_string() truncates offset seconds
+        // (e.g. +08:05:43 → +08:05), denoting a different instant if
+        // reparsed.  Both stream-load and query paths must therefore
+        // serialise historical second-resolution offsets in UTC format
+        // so that FE constant evaluation and BE row serialisation
+        // produce the same string for the same stored instant.
         ConnectContext context = new ConnectContext();
         context.setThreadLocalInfo();
         try {
@@ -405,10 +406,14 @@ public class ExprToStringValueVisitorTest {
             // Stream-load path must emit UTC format.
             Assertions.assertEquals("1900-01-01 00:00:00+00:00",
                     V.visitDateLiteral(d, StringValueContext.forStreamLoad(FormatOptions.getDefault())));
-            // Query path shows the historical wall clock with full offset.
-            String queryResult = V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault()));
-            Assertions.assertTrue(queryResult.contains("+08:05:43"),
-                    "Query path should render historical offset with seconds: " + queryResult);
+            // Query path also falls back to UTC when the session timezone's
+            // offset at the target instant contains seconds (e.g. +08:05:43),
+            // because BE's TimestampTzValue::to_string() truncates offset
+            // seconds to +08:05, producing text that denotes a different
+            // instant.  Falling back to UTC ensures FE constant evaluation
+            // and BE row serialisation produce the same string.
+            Assertions.assertEquals("1900-01-01 00:00:00+00:00",
+                    V.visitDateLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault())));
         } finally {
             ConnectContext.remove();
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DynamicPartitionUtil;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.plans.commands.AlterTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.CreateDatabaseCommand;
@@ -322,10 +323,13 @@ public class DynamicPartitionTableTest {
                 + "\"dynamic_partition.start\" = \"-3\",\n"
                 + "\"dynamic_partition.end\" = \"3\",\n"
                 + "\"dynamic_partition.time_unit\" = \"day\",\n"
-                + "\"dynamic_partition.prefix\" = \"p\",\n"
-                + "\"dynamic_partition.buckets\" = \"1\"\n"
+                + "\"dynamic_partition.prefix\" = \"p\"\n"
                 + ");";
         createTable(createOlapTblStmt);
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("dynamic_partition_miss_buckets");
+        Assert.assertEquals("Default buckets should come from table distribution (BUCKETS 32)",
+                32, table.getTableProperty().getDynamicPartitionProperty().getBuckets());
     }
 
     @Test
@@ -411,10 +415,15 @@ public class DynamicPartitionTableTest {
                 + "\"dynamic_partition.end\" = \"3\",\n"
                 + "\"dynamic_partition.time_unit\" = \"day\",\n"
                 + "\"dynamic_partition.prefix\" = \"p\",\n"
-                + "\"dynamic_partition.buckets\" = \"3\",\n"
-                + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                + "\"dynamic_partition.buckets\" = \"3\"\n"
                 + ");";
         createTable(createOlapTblStmt);
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("dynamic_partition_miss_time_zone");
+        String expectedTz = TimeUtils.getSystemTimeZone().getID();
+        Assert.assertEquals("Default timezone should be system timezone",
+                expectedTz,
+                table.getTableProperty().getDynamicPartitionProperty().getTimeZone().getID());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -2104,18 +2104,31 @@ public class DynamicPartitionTableTest {
                         "00", upperHour);
             }
 
-            // Verify the current partition (idx=0) name matches the UTC
-            // calendar day, since both names and values are UTC-based.
-            // Accept either the current or previous day in case the wall clock
-            // rolled over between scheduler execution and this assertion.
-            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
-            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMdd").format(utcNow);
-            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMdd")
-                    .format(utcNow.minusDays(1));
-            Assert.assertTrue("Should find partition '" + expectedName + "' or '" + prevExpectedName
-                    + "' named per UTC calendar day",
-                    table.getPartitionNames().contains(expectedName)
-                    || table.getPartitionNames().contains(prevExpectedName));
+            // Identify the current partition (idx=0) by its stored range
+            // rather than sampling ZonedDateTime.now() after scheduling,
+            // which can tick and produce a name that happens to match an
+            // adjacent historical partition even when idx=0 is misnamed.
+            List<Map.Entry<Long, PartitionItem>> sorted = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sorted.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+            Assert.assertEquals(7, sorted.size());
+            // idx=0 is the 4th partition (index 3) for start=-3,end=3.
+            RangePartitionItem currentItem = (RangePartitionItem) sorted.get(3).getValue();
+            String currentLowerStr = currentItem.getItems().lowerEndpoint().getKeys().get(0)
+                    .getStringValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(currentLowerStr,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+            String expectedCurrentName = "p"
+                    + DateTimeFormatter.ofPattern("yyyyMMdd").format(currentLower);
+            String actualCurrentName = table.getPartition(sorted.get(3).getKey()).getName();
+            Assert.assertEquals("Current partition (idx=0) name must match its UTC lower bound",
+                    expectedCurrentName, actualCurrentName);
+            Assert.assertEquals("Current partition lower bound must be UTC midnight",
+                    "00", currentLowerStr.substring(11, 13));
 
             for (Partition partition : table.getPartitions()) {
                 RangePartitionItem item = (RangePartitionItem) partitionInfo.getItem(partition.getId());
@@ -2205,28 +2218,33 @@ public class DynamicPartitionTableTest {
                         "00", upperHour);
             }
 
-            // Verify the current partition (idx=0) has a week name computed
-            // from UTC, since both names and values are UTC-based.
-            // Derive the expected name using the same getPartitionRangeString /
-            // getFormattedPartitionName path that the scheduler uses, which
-            // adjusts to the configured week start day before naming.
-            // Accept either the current or previous week in case the wall clock
-            // rolled over between scheduler execution and this assertion.
+            // Identify the current partition (idx=0) by its stored range.
+            List<Map.Entry<Long, PartitionItem>> sorted = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sorted.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+            Assert.assertEquals(7, sorted.size());
+            RangePartitionItem currentItem = (RangePartitionItem) sorted.get(3).getValue();
+            String currentLowerStr = currentItem.getItems().lowerEndpoint().getKeys().get(0)
+                    .getStringValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(currentLowerStr,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+            // Compute the expected week name from the stored lower bound
+            // using the same utility path the scheduler uses.
             DynamicPartitionProperty prop = table.getTableProperty().getDynamicPartitionProperty();
             String partFormat = DynamicPartitionUtil.getPartitionFormat(
                     ((RangePartitionInfo) table.getPartitionInfo()).getPartitionColumns().get(0));
             TimeZone utcTz = TimeZone.getTimeZone("UTC");
-            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
-            String border = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, 0, partFormat);
+            String border = DynamicPartitionUtil.getPartitionRangeString(
+                    prop, currentLower, 0, partFormat);
             String expectedWeekName = "p" + DynamicPartitionUtil.getFormattedPartitionName(
                     utcTz, border, prop.getTimeUnit());
-            String prevBorder = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, -1, partFormat);
-            String prevWeekName = "p" + DynamicPartitionUtil.getFormattedPartitionName(
-                    utcTz, prevBorder, prop.getTimeUnit());
-            Assert.assertTrue("Should find week partition '" + expectedWeekName + "' or '" + prevWeekName
-                    + "' named per UTC",
-                    table.getPartitionNames().contains(expectedWeekName)
-                    || table.getPartitionNames().contains(prevWeekName));
+            String actualCurrentName = table.getPartition(sorted.get(3).getKey()).getName();
+            Assert.assertEquals("Current partition (idx=0) week name must match its UTC lower bound",
+                    expectedWeekName, actualCurrentName);
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -2337,18 +2355,21 @@ public class DynamicPartitionTableTest {
                         DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
             }
 
-            // Verify the current partition (idx=0) name uses UTC,
-            // since both names and values are UTC-based.
-            // Accept either the current or previous hour in case the wall clock
-            // rolled over between scheduler execution and this assertion.
-            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
-            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMddHH").format(utcNow);
-            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMddHH")
-                    .format(utcNow.minusHours(1));
-            Assert.assertTrue("Should find hour partition '" + expectedName + "' or '" + prevExpectedName
-                    + "' named per UTC",
-                    table.getPartitionNames().contains(expectedName)
-                    || table.getPartitionNames().contains(prevExpectedName));
+            // Identify the current partition (idx=0) by its stored range.
+            // start=-3,end=3 → idx=0 is at index 3.
+            RangePartitionItem currentItem = (RangePartitionItem) sortedEntries.get(3).getValue();
+            String currentLowerStr = currentItem.getItems().lowerEndpoint().getKeys().get(0)
+                    .getStringValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(currentLowerStr,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+            String expectedCurrentName = "p"
+                    + DateTimeFormatter.ofPattern("yyyyMMddHH").format(currentLower);
+            String actualCurrentName = table.getPartition(sortedEntries.get(3).getKey()).getName();
+            Assert.assertEquals("Current partition (idx=0) hour name must match its UTC lower bound",
+                    expectedCurrentName, actualCurrentName);
+            Assert.assertTrue("Current partition lower bound hour must be 0-23: " + currentLowerStr,
+                    Integer.parseInt(currentLowerStr.substring(11, 13)) >= 0
+                    && Integer.parseInt(currentLowerStr.substring(11, 13)) <= 23);
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -2688,18 +2709,29 @@ public class DynamicPartitionTableTest {
                         "00", upperHour);
             }
 
-            // Verify the current partition (idx=0) name matches the UTC
-            // calendar month, since both names and values are UTC-based.
-            // Accept either the current or previous month in case the wall
-            // clock rolled over between scheduler execution and this assertion.
-            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
-            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyyMM").format(utcNow);
-            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyyMM")
-                    .format(utcNow.minusMonths(1));
-            Assert.assertTrue("Should find month partition '" + expectedName + "' or '" + prevExpectedName
-                    + "' named per UTC",
-                    table.getPartitionNames().contains(expectedName)
-                    || table.getPartitionNames().contains(prevExpectedName));
+            // Identify the current partition (idx=0) by its stored range.
+            List<Map.Entry<Long, PartitionItem>> sorted = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sorted.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+            Assert.assertEquals(7, sorted.size());
+            RangePartitionItem currentItem = (RangePartitionItem) sorted.get(3).getValue();
+            String currentLowerStr = currentItem.getItems().lowerEndpoint().getKeys().get(0)
+                    .getStringValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(currentLowerStr,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+            String expectedCurrentName = "p"
+                    + DateTimeFormatter.ofPattern("yyyyMM").format(currentLower);
+            String actualCurrentName = table.getPartition(sorted.get(3).getKey()).getName();
+            Assert.assertEquals("Current partition (idx=0) month name must match its UTC lower bound",
+                    expectedCurrentName, actualCurrentName);
+            Assert.assertEquals("Current partition lower bound must be UTC midnight",
+                    "00", currentLowerStr.substring(11, 13));
+            Assert.assertEquals("Current partition lower bound day must be 01",
+                    "01", currentLowerStr.substring(8, 10));
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -2791,18 +2823,31 @@ public class DynamicPartitionTableTest {
                         "00", upperHour);
             }
 
-            // Verify the current partition (idx=0) name matches the UTC
-            // calendar year, since both names and values are UTC-based.
-            // Accept either the current or previous year in case the wall
-            // clock rolled over between scheduler execution and this assertion.
-            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
-            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyy").format(utcNow);
-            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyy")
-                    .format(utcNow.minusYears(1));
-            Assert.assertTrue("Should find year partition '" + expectedName + "' or '" + prevExpectedName
-                    + "' named per UTC",
-                    table.getPartitionNames().contains(expectedName)
-                    || table.getPartitionNames().contains(prevExpectedName));
+            // Identify the current partition (idx=0) by its stored range.
+            List<Map.Entry<Long, PartitionItem>> sorted = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sorted.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+            Assert.assertEquals(7, sorted.size());
+            RangePartitionItem currentItem = (RangePartitionItem) sorted.get(3).getValue();
+            String currentLowerStr = currentItem.getItems().lowerEndpoint().getKeys().get(0)
+                    .getStringValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(currentLowerStr,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+            String expectedCurrentName = "p"
+                    + DateTimeFormatter.ofPattern("yyyy").format(currentLower);
+            String actualCurrentName = table.getPartition(sorted.get(3).getKey()).getName();
+            Assert.assertEquals("Current partition (idx=0) year name must match its UTC lower bound",
+                    expectedCurrentName, actualCurrentName);
+            Assert.assertEquals("Current partition lower bound must be UTC midnight",
+                    "00", currentLowerStr.substring(11, 13));
+            Assert.assertEquals("Current partition lower bound month must be 01",
+                    "01", currentLowerStr.substring(5, 7));
+            Assert.assertEquals("Current partition lower bound day must be 01",
+                    "01", currentLowerStr.substring(8, 10));
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -2849,20 +2894,28 @@ public class DynamicPartitionTableTest {
             // Add partitions manually — must temporarily disable dynamic partition.
             alterTable("ALTER TABLE test.tstz_reserved_hist SET "
                     + "('dynamic_partition.enable' = 'false')");
-            // Add a partition that falls within the reserved period with
-            // UTC-midnight boundaries: [2020-01-01 00:00 UTC, 2020-02-01 00:00 UTC).
-            // This should be protected by the reserved period.
+            // p_202001: well inside both the fixed UTC range and the old
+            // Asia/Shanghai-shifted range — weak test, passes either way.
             alterTable("ALTER TABLE test.tstz_reserved_hist ADD PARTITION p_202001 VALUES "
                     + "[('2020-01-01 00:00:00+00:00'), ('2020-02-01 00:00:00+00:00'))");
-            // Add a partition entirely before the reserved period.
-            // This should be dropped by the start=-3 cutoff.
+            // p_old: before both ranges — dropped by the start=-3 cutoff
+            // regardless of the reserved-period interpretation.
             alterTable("ALTER TABLE test.tstz_reserved_hist ADD PARTITION p_old VALUES "
                     + "[('2018-01-01 00:00:00+00:00'), ('2018-02-01 00:00:00+00:00'))");
+
+            // p_boundary: discriminating partition. Its lower bound
+            // (2020-07-31 17:00 UTC) is AFTER the old shifted upper bound
+            // (~2020-07-31 16:00 UTC) but BEFORE the corrected UTC upper
+            // bound (2020-08-01 00:00 UTC). Only the fix keeps it.
+            alterTable("ALTER TABLE test.tstz_reserved_hist ADD PARTITION p_boundary VALUES "
+                    + "[('2020-07-31 17:00:00+00:00'), ('2020-07-31 18:00:00+00:00'))");
 
             Assert.assertTrue("p_202001 should exist before scheduling",
                     table.getPartitionNames().contains("p_202001"));
             Assert.assertTrue("p_old should exist before scheduling",
                     table.getPartitionNames().contains("p_old"));
+            Assert.assertTrue("p_boundary should exist before scheduling",
+                    table.getPartitionNames().contains("p_boundary"));
 
             // Re-enable dynamic partition and run the scheduler.
             alterTable("ALTER TABLE test.tstz_reserved_hist SET "
@@ -2871,14 +2924,20 @@ public class DynamicPartitionTableTest {
             Env.getCurrentEnv().getDynamicPartitionScheduler()
                     .executeDynamicPartitionFirstTime(db.getId(), table.getId());
 
-            // p_202001 falls within reserved period [2019-06-01, 2020-08-01] in
-            // UTC-midnight interpretation → must be kept.
-            Assert.assertTrue("p_202001 should be kept — within UTC-aligned reserved history period",
+            // p_202001 falls within the reserved period in both old and new
+            // interpretations — kept regardless.
+            Assert.assertTrue("p_202001 should be kept",
                     table.getPartitionNames().contains("p_202001"));
             // p_old is before the start=-3 cutoff and outside the reserved
-            // period → must be dropped.
-            Assert.assertFalse("p_old should be dropped — outside reserved period and before start",
+            // period — dropped regardless.
+            Assert.assertFalse("p_old should be dropped",
                     table.getPartitionNames().contains("p_old"));
+            // p_boundary is the discriminating case: only kept when the
+            // reserved period is interpreted in UTC rather than shifted by
+            // the configured timezone (Asia/Shanghai, UTC+8).
+            Assert.assertTrue("p_boundary should be kept — reserved period is UTC-aligned,"
+                    + " not shifted by the configured timezone",
+                    table.getPartitionNames().contains("p_boundary"));
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -2255,7 +2256,13 @@ public class DynamicPartitionTableTest {
         String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
         try {
             // Session TZ different from UTC to verify the scheduler
-            // uses UTC for both naming and boundaries.
+            // uses UTC for both naming and boundaries.  Use Asia/Kathmandu
+            // (UTC+05:45) — a fractional-hour offset — so that a configured-
+            // timezone midnight floor would produce non-zero minutes (e.g.
+            // 2026-07-20 00:00:00+05:45 → 2026-07-19 18:15:00+00:00).
+            // Asserting that every bound has minute=second=00 proves the
+            // boundaries are generated at whole UTC hours, not merely
+            // integral-hour-shifted configured-timezone midnights.
             connectContext.getSessionVariable().setTimeZone("America/Chicago");
 
             String createOlapTblStmt = "CREATE TABLE test.`timestamptz_dynamic_hour` (\n"
@@ -2275,7 +2282,7 @@ public class DynamicPartitionTableTest {
                     + "\"dynamic_partition.time_unit\" = \"hour\",\n"
                     + "\"dynamic_partition.prefix\" = \"p\",\n"
                     + "\"dynamic_partition.buckets\" = \"1\",\n"
-                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Kathmandu\"\n"
                     + ");";
             createTable(createOlapTblStmt);
 
@@ -2328,13 +2335,22 @@ public class DynamicPartitionTableTest {
                 Assert.assertTrue("Upper key must have +00:00 suffix: " + upperStr,
                         upperStr.contains("+00:00"));
 
-                // Partition boundaries must be at whole UTC hours (0-23).
-                int lowerHour = Integer.parseInt(lowerStr.substring(11, 13));
-                Assert.assertTrue("Lower bound hour must be 0-23: " + lowerStr,
-                        lowerHour >= 0 && lowerHour <= 23);
-                int upperHour = Integer.parseInt(upperStr.substring(11, 13));
-                Assert.assertTrue("Upper bound hour must be 0-23: " + upperStr,
-                        upperHour >= 0 && upperHour <= 23);
+                // Partition boundaries must be at whole UTC hours (minute=second=00).
+                // A configured timezone with a fractional offset (Asia/Kathmandu,
+                // UTC+05:45) would produce boundaries with non-zero minutes if the
+                // old configured-timezone flooring were used instead of UTC-first.
+                String lowerMinutes = lowerStr.substring(14, 16);
+                String lowerSeconds = lowerStr.substring(17, 19);
+                Assert.assertEquals("Lower bound minutes must be 00: " + lowerStr,
+                        "00", lowerMinutes);
+                Assert.assertEquals("Lower bound seconds must be 00: " + lowerStr,
+                        "00", lowerSeconds);
+                String upperMinutes = upperStr.substring(14, 16);
+                String upperSeconds = upperStr.substring(17, 19);
+                Assert.assertEquals("Upper bound minutes must be 00: " + upperStr,
+                        "00", upperMinutes);
+                Assert.assertEquals("Upper bound seconds must be 00: " + upperStr,
+                        "00", upperSeconds);
 
                 // Verify adjacency using full timestamps (handles midnight crossing)
                 if (prevLower != null) {
@@ -2367,9 +2383,12 @@ public class DynamicPartitionTableTest {
             String actualCurrentName = table.getPartition(sortedEntries.get(3).getKey()).getName();
             Assert.assertEquals("Current partition (idx=0) hour name must match its UTC lower bound",
                     expectedCurrentName, actualCurrentName);
-            Assert.assertTrue("Current partition lower bound hour must be 0-23: " + currentLowerStr,
-                    Integer.parseInt(currentLowerStr.substring(11, 13)) >= 0
-                    && Integer.parseInt(currentLowerStr.substring(11, 13)) <= 23);
+            // With a fractional-offset timezone, only the UTC-first approach
+            // guarantees minute=second=00 on every bound.
+            Assert.assertEquals("Current partition lower bound must end :00:00: " + currentLowerStr,
+                    "00", currentLowerStr.substring(14, 16)); // minutes
+            Assert.assertEquals("Current partition lower bound must end :00:00: " + currentLowerStr,
+                    "00", currentLowerStr.substring(17, 19)); // seconds
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -3368,6 +3387,209 @@ public class DynamicPartitionTableTest {
                     }
                 }
             }
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzGetHistoricalPartitionsScaledColumn() throws Exception {
+        // TIMESTAMPTZ(6) stores lower keys with ".000000+00:00" suffix while
+        // currentUtcBorder uses "+00:00" (no fractional part).  The old string
+        // comparison failed on this scale difference.  Fix: compare by
+        // PartitionKey.compareTo instead.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+
+            String createSql = "CREATE TABLE test.`tstz_hist_scaled` (\n"
+                    + "  `k1` TIMESTAMPTZ(6) NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"America/Chicago\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_hist_scaled");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            int totalPartitions = table.getPartitionNames().size();
+            Assert.assertEquals(7, totalPartitions);
+
+            RangePartitionInfo info = (RangePartitionInfo) table.getPartitionInfo();
+            // Verify that stored lower keys actually have .000000 fractional part.
+            for (PartitionItem item : info.getIdToItem(false).values()) {
+                RangePartitionItem rItem = (RangePartitionItem) item;
+                String lowerStr = rItem.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                Assert.assertTrue("TIMESTAMPTZ(6) lower key must include .000000: " + lowerStr,
+                        lowerStr.contains(".000000"));
+            }
+
+            // Compute currentUtcBorder (no fractional seconds).
+            DynamicPartitionProperty prop = table.getTableProperty().getDynamicPartitionProperty();
+            String partitionFormat = DynamicPartitionUtil.getPartitionFormat(
+                    info.getPartitionColumns().get(0));
+            String currentUtcBorder = DynamicPartitionUtil.getPartitionRangeString(
+                    prop, ZonedDateTime.now(ZoneOffset.UTC), 0, partitionFormat);
+            Assert.assertFalse("currentUtcBorder should NOT contain fractional seconds: "
+                    + currentUtcBorder, currentUtcBorder.contains("."));
+
+            // Without currentUtcBorder: name-based cannot identify the current
+            // partition when nowPartitionName does not match.
+            String wrongNowPartitionName = "p_nonexistent";
+            List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, wrongNowPartitionName, null);
+            boolean currentFoundByName = false;
+            for (Partition p : historicalNoUtc) {
+                RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+                String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
+                    currentFoundByName = true;
+                    break;
+                }
+            }
+            Assert.assertTrue("Scaled TIMESTAMPTZ(6): name-based should fail to exclude current partition",
+                    currentFoundByName);
+
+            // With currentUtcBorder: range-based correctly excludes the current
+            // partition even though the string representations differ (.000000).
+            List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, wrongNowPartitionName, currentUtcBorder);
+            boolean currentFoundByRange = false;
+            for (Partition p : historicalWithUtc) {
+                RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+                String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
+                    currentFoundByRange = true;
+                    break;
+                }
+            }
+            Assert.assertFalse("Scaled TIMESTAMPTZ(6): range-based must exclude current partition",
+                    currentFoundByRange);
+            Assert.assertEquals("Scaled TIMESTAMPTZ(6): exclude exactly one partition",
+                    totalPartitions - 1, historicalWithUtc.size());
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzGetHistoricalPartitionsOldPrefix() throws Exception {
+        // When dynamic_partition.prefix is changed after initial partition
+        // creation, existing partitions keep their old names (e.g. "p20260720")
+        // while the new nowPartitionName uses the new prefix ("q20260720").
+        // Name-based comparison fails to identify the current partition;
+        // range-based comparison (currentUtcBorder) must still work.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("Asia/Shanghai");
+
+            String createSql = "CREATE TABLE test.`tstz_old_prefix` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_old_prefix");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            int totalPartitions = table.getPartitionNames().size();
+            Assert.assertEquals("Initial partitions should be 7", 7, totalPartitions);
+
+            // Verify all existing partitions use the old prefix "p".
+            for (String name : table.getPartitionNames()) {
+                Assert.assertTrue("Existing partitions must use old prefix: " + name,
+                        name.startsWith("p"));
+            }
+
+            // Now change the prefix from "p" to "q" via table properties.
+            HashMap<String, String> newPrefixProps = new HashMap<>();
+            newPrefixProps.put("dynamic_partition.prefix", "q");
+            table.getTableProperty().modifyTableProperties(newPrefixProps);
+            table.getTableProperty().buildDynamicProperty();
+
+            // Re-read the dynamic property to get the updated prefix.
+            DynamicPartitionProperty updatedProp = table.getTableProperty().getDynamicPartitionProperty();
+            Assert.assertEquals("Prefix should now be 'q'", "q", updatedProp.getPrefix());
+
+            // Compute currentUtcBorder from the scheduler's logic.
+            RangePartitionInfo info = (RangePartitionInfo) table.getPartitionInfo();
+            String partitionFormat = DynamicPartitionUtil.getPartitionFormat(
+                    info.getPartitionColumns().get(0));
+            String currentUtcBorder = DynamicPartitionUtil.getPartitionRangeString(
+                    updatedProp, ZonedDateTime.now(ZoneOffset.UTC), 0, partitionFormat);
+
+            // nowPartitionName uses the new prefix "q" — no existing partition
+            // matches it, so name-based comparison would not exclude anything.
+            String newPrefixNowName = "q_nonexistent";
+
+            // 1. Without currentUtcBorder: name-based fails to exclude the
+            //    current partition because the name "q_nonexistent" matches nothing.
+            List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, newPrefixNowName, null);
+            boolean currentFoundByName = false;
+            for (Partition p : historicalNoUtc) {
+                RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+                String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
+                    currentFoundByName = true;
+                    break;
+                }
+            }
+            Assert.assertTrue("Old prefix: name-based should fail to exclude current partition",
+                    currentFoundByName);
+
+            // 2. With currentUtcBorder: range-based correctly excludes the
+            //    current partition despite the name mismatch.
+            List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, newPrefixNowName, currentUtcBorder);
+            boolean currentFoundByRange = false;
+            for (Partition p : historicalWithUtc) {
+                RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+                String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
+                    currentFoundByRange = true;
+                    break;
+                }
+            }
+            Assert.assertFalse("Old prefix: range-based must exclude current partition",
+                    currentFoundByRange);
+            Assert.assertEquals("Old prefix: exclude exactly one partition",
+                    totalPartitions - 1, historicalWithUtc.size());
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -2405,6 +2405,28 @@ public class DynamicPartitionTableTest {
         try {
             connectContext.getSessionVariable().setTimeZone("America/Chicago");
 
+            // Inject a fixed clock before creating the table so that both
+            // the CREATE-time scheduler pass (via createTable → DDL path)
+            // and the explicit executeDynamicPartitionFirstTime call below
+            // see the same instant.  Choose 2026-07-21 08:00:00Z when
+            // Asia/Shanghai is at 16:00 (same calendar day as UTC).  At
+            // this instant:
+            //
+            //   UTC now = 2026-07-21 08:00Z
+            //   start=-1 reserved lower (new, UTC)   = 2026-07-20 00:00Z
+            //   start=-1 reserved lower (old, +08:00) = 2026-07-19 16:00Z
+            //
+            //   p_old = [2026-07-19 00:00Z, 2026-07-20 00:00Z)
+            //
+            //   New code:  reserved [2026-07-20 00:00Z, ∞) → no intersect → DROP
+            //   Old code:  reserved [2026-07-19 16:00Z, ∞) → intersect  → KEEP
+            //
+            // The assertion below therefore always fails on the old
+            // implementation, not just for 16 hours of the day.
+            ZonedDateTime fixedNow = ZonedDateTime.of(
+                    2026, 7, 21, 8, 0, 0, 0, ZoneOffset.UTC);
+            DynamicPartitionScheduler.testNow = fixedNow;
+
             String createOlapTblStmt = "CREATE TABLE test.`tstz_drop_cutoff` (\n"
                     + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
                     + "  `k2` int NULL COMMENT \"\"\n"
@@ -2428,25 +2450,6 @@ public class DynamicPartitionTableTest {
 
             Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
             OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_drop_cutoff");
-
-            // Inject a fixed clock so the test is deterministic regardless of
-            // wall-clock time.  Choose 2026-07-21 08:00:00Z when Asia/Shanghai
-            // is at 16:00 (same calendar day as UTC).  At this instant:
-            //
-            //   UTC now = 2026-07-21 08:00Z
-            //   start=-1 reserved lower (new, UTC)   = 2026-07-20 00:00Z
-            //   start=-1 reserved lower (old, +08:00) = 2026-07-19 16:00Z
-            //
-            //   p_old = [2026-07-19 00:00Z, 2026-07-20 00:00Z)
-            //
-            //   New code:  reserved [2026-07-20 00:00Z, ∞) → no intersect → DROP
-            //   Old code:  reserved [2026-07-19 16:00Z, ∞) → intersect  → KEEP
-            //
-            // The assertion below therefore always fails on the old
-            // implementation, not just for 16 hours of the day.
-            ZonedDateTime fixedNow = ZonedDateTime.of(
-                    2026, 7, 21, 8, 0, 0, 0, ZoneOffset.UTC);
-            DynamicPartitionScheduler.testNow = fixedNow;
 
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
             String oldLower = fixedNow.minusDays(2).withHour(0).withMinute(0)

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DynamicPartitionUtil;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.plans.commands.AlterTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.CreateDatabaseCommand;
@@ -2022,13 +2023,11 @@ public class DynamicPartitionTableTest {
 
     @Test
     public void testTimeStampTzDynamicPartition() throws Exception {
-        // Set session timezone to something different from the partition timezone
-        // to verify scheduler uses dynamic_partition.time_zone, not session timezone.
-        // With time_zone = "+00:00" and session = "Asia/Shanghai" (UTC+8),
-        // a session-timezone leak would shift bounds by 8 hours (hour=16, not 00).
+        // Set session timezone different from UTC to verify
+        // the scheduler uses UTC for both naming and partition boundaries.
         String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
         try {
-            connectContext.getSessionVariable().setTimeZone("Asia/Shanghai");
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
 
             String createOlapTblStmt = "CREATE TABLE test.`timestamptz_dynamic_partition` (\n"
                     + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
@@ -2047,7 +2046,7 @@ public class DynamicPartitionTableTest {
                     + "\"dynamic_partition.time_unit\" = \"day\",\n"
                     + "\"dynamic_partition.prefix\" = \"p\",\n"
                     + "\"dynamic_partition.buckets\" = \"1\",\n"
-                    + "\"dynamic_partition.time_zone\" = \"+00:00\"\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
                     + ");";
             createTable(createOlapTblStmt);
 
@@ -2063,7 +2062,7 @@ public class DynamicPartitionTableTest {
             int partitionCount = table.getPartitionNames().size();
             Assert.assertEquals(7, partitionCount);
 
-            // Verify partition names are clean and partition values are UTC timestamps
+            // Verify partition names use configured timezone, boundaries are UTC
             RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
             for (Map.Entry<Long, PartitionItem> entry : partitionInfo.getIdToItem(false).entrySet()) {
                 RangePartitionItem item = (RangePartitionItem) entry.getValue();
@@ -2095,14 +2094,28 @@ public class DynamicPartitionTableTest {
                 Assert.assertTrue("Upper key must be UTC with +00:00 suffix: " + upperStr,
                         upperStr.contains("+00:00"));
 
-                // With time_zone = "+00:00", partition boundaries must be midnight UTC
-                // (hour = 00). If the scheduler incorrectly used session timezone
-                // (Asia/Shanghai, UTC+8), the hour would be 16 instead of 00.
+                // Partition boundaries must be at UTC midnight (hour=00)
+                // regardless of time_zone.
                 String lowerHour = lowerStr.substring(11, 13);
-                Assert.assertEquals("Lower bound hour should be 00 (midnight UTC), proving"
-                        + " dynamic_partition.time_zone was used: " + lowerStr,
+                Assert.assertEquals("Lower bound must be UTC midnight (00): " + lowerStr,
                         "00", lowerHour);
+                String upperHour = upperStr.substring(11, 13);
+                Assert.assertEquals("Upper bound must be UTC midnight (00): " + upperStr,
+                        "00", upperHour);
             }
+
+            // Verify the current partition (idx=0) name matches the UTC
+            // calendar day, since both names and values are UTC-based.
+            // Accept either the current or previous day in case the wall clock
+            // rolled over between scheduler execution and this assertion.
+            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMdd").format(utcNow);
+            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMdd")
+                    .format(utcNow.minusDays(1));
+            Assert.assertTrue("Should find partition '" + expectedName + "' or '" + prevExpectedName
+                    + "' named per UTC calendar day",
+                    table.getPartitionNames().contains(expectedName)
+                    || table.getPartitionNames().contains(prevExpectedName));
 
             for (Partition partition : table.getPartitions()) {
                 RangePartitionItem item = (RangePartitionItem) partitionInfo.getItem(partition.getId());
@@ -2117,6 +2130,8 @@ public class DynamicPartitionTableTest {
     public void testTimeStampTzDynamicPartitionWeekUnit() throws Exception {
         String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
         try {
+            // Session TZ different from UTC to verify the scheduler
+            // uses UTC for both naming and boundaries.
             connectContext.getSessionVariable().setTimeZone("Europe/London");
 
             String createOlapTblStmt = "CREATE TABLE test.`timestamptz_dynamic_week` (\n"
@@ -2150,7 +2165,8 @@ public class DynamicPartitionTableTest {
             int partitionCount = table.getPartitionNames().size();
             Assert.assertEquals(7, partitionCount);
 
-            // Verify partition names follow week pattern (clean, no timezone suffix)
+            // Verify partition boundaries are UTC midnight and names use
+            // configured timezone (Asia/Tokyo).
             RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
             for (Map.Entry<Long, PartitionItem> entry : partitionInfo.getIdToItem(false).entrySet()) {
                 RangePartitionItem item = (RangePartitionItem) entry.getValue();
@@ -2165,7 +2181,52 @@ public class DynamicPartitionTableTest {
                 Range<PartitionKey> range = item.getItems();
                 Assert.assertTrue("lower must be < upper",
                         range.lowerEndpoint().compareTo(range.upperEndpoint()) < 0);
+
+                // Partition boundaries must be at UTC midnight (hour=00)
+                // regardless of time_zone.
+                List<LiteralExpr> lowerKeys = range.lowerEndpoint().getKeys();
+                Assert.assertEquals(1, lowerKeys.size());
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC with +00:00 suffix: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+
+                List<LiteralExpr> upperKeys = range.upperEndpoint().getKeys();
+                Assert.assertEquals(1, upperKeys.size());
+                String upperStr = upperKeys.get(0).getStringValue();
+                Assert.assertTrue("Upper key must be UTC with +00:00 suffix: " + upperStr,
+                        upperStr.contains("+00:00"));
+
+                // UTC midnight (00:00), regardless of time_zone.
+                String lowerHour = lowerStr.substring(11, 13);
+                Assert.assertEquals("Lower bound must be UTC midnight (00): " + lowerStr,
+                        "00", lowerHour);
+                String upperHour = upperStr.substring(11, 13);
+                Assert.assertEquals("Upper bound must be UTC midnight (00): " + upperStr,
+                        "00", upperHour);
             }
+
+            // Verify the current partition (idx=0) has a week name computed
+            // from UTC, since both names and values are UTC-based.
+            // Derive the expected name using the same getPartitionRangeString /
+            // getFormattedPartitionName path that the scheduler uses, which
+            // adjusts to the configured week start day before naming.
+            // Accept either the current or previous week in case the wall clock
+            // rolled over between scheduler execution and this assertion.
+            DynamicPartitionProperty prop = table.getTableProperty().getDynamicPartitionProperty();
+            String partFormat = DynamicPartitionUtil.getPartitionFormat(
+                    ((RangePartitionInfo) table.getPartitionInfo()).getPartitionColumns().get(0));
+            TimeZone utcTz = TimeZone.getTimeZone("UTC");
+            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            String border = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, 0, partFormat);
+            String expectedWeekName = "p" + DynamicPartitionUtil.getFormattedPartitionName(
+                    utcTz, border, prop.getTimeUnit());
+            String prevBorder = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, -1, partFormat);
+            String prevWeekName = "p" + DynamicPartitionUtil.getFormattedPartitionName(
+                    utcTz, prevBorder, prop.getTimeUnit());
+            Assert.assertTrue("Should find week partition '" + expectedWeekName + "' or '" + prevWeekName
+                    + "' named per UTC",
+                    table.getPartitionNames().contains(expectedWeekName)
+                    || table.getPartitionNames().contains(prevWeekName));
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -2175,6 +2236,8 @@ public class DynamicPartitionTableTest {
     public void testTimeStampTzDynamicPartitionHourUnit() throws Exception {
         String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
         try {
+            // Session TZ different from UTC to verify the scheduler
+            // uses UTC for both naming and boundaries.
             connectContext.getSessionVariable().setTimeZone("America/Chicago");
 
             String createOlapTblStmt = "CREATE TABLE test.`timestamptz_dynamic_hour` (\n"
@@ -2194,7 +2257,7 @@ public class DynamicPartitionTableTest {
                     + "\"dynamic_partition.time_unit\" = \"hour\",\n"
                     + "\"dynamic_partition.prefix\" = \"p\",\n"
                     + "\"dynamic_partition.buckets\" = \"1\",\n"
-                    + "\"dynamic_partition.time_zone\" = \"+00:00\"\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
                     + ");";
             createTable(createOlapTblStmt);
 
@@ -2208,9 +2271,20 @@ public class DynamicPartitionTableTest {
             int partitionCount = table.getPartitionNames().size();
             Assert.assertEquals(7, partitionCount);
 
-            // Hour partition names are "p" + yyyyMMddHH (10 chars)
+            // Hour partition boundaries must be at whole UTC hours
+            // regardless of time_zone. Names use configured timezone.
             RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
-            for (Map.Entry<Long, PartitionItem> entry : partitionInfo.getIdToItem(false).entrySet()) {
+            List<Map.Entry<Long, PartitionItem>> sortedEntries = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sortedEntries.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+
+            ZonedDateTime prevLower = null;
+            ZonedDateTime prevUpper = null;
+            for (Map.Entry<Long, PartitionItem> entry : sortedEntries) {
                 RangePartitionItem item = (RangePartitionItem) entry.getValue();
                 String partitionName = table.getPartition(entry.getKey()).getName();
                 Assert.assertTrue("Partition name should start with 'p': " + partitionName,
@@ -2219,17 +2293,144 @@ public class DynamicPartitionTableTest {
                 Assert.assertEquals("Hour partition name length: " + partitionName,
                         11, partitionName.length());
 
-                // Verify range validity and UTC boundaries
+                // Verify range validity
                 Range<PartitionKey> range = item.getItems();
                 Assert.assertTrue("lower must be < upper",
                         range.lowerEndpoint().compareTo(range.upperEndpoint()) < 0);
 
-                // With time_zone = "+00:00", partition boundaries should be UTC timestamps
                 List<LiteralExpr> lowerKeys = range.lowerEndpoint().getKeys();
                 Assert.assertEquals(1, lowerKeys.size());
                 String lowerStr = lowerKeys.get(0).getStringValue();
                 Assert.assertTrue("Lower key must have +00:00 suffix: " + lowerStr,
                         lowerStr.contains("+00:00"));
+
+                List<LiteralExpr> upperKeys = range.upperEndpoint().getKeys();
+                Assert.assertEquals(1, upperKeys.size());
+                String upperStr = upperKeys.get(0).getStringValue();
+                Assert.assertTrue("Upper key must have +00:00 suffix: " + upperStr,
+                        upperStr.contains("+00:00"));
+
+                // Partition boundaries must be at whole UTC hours (0-23).
+                int lowerHour = Integer.parseInt(lowerStr.substring(11, 13));
+                Assert.assertTrue("Lower bound hour must be 0-23: " + lowerStr,
+                        lowerHour >= 0 && lowerHour <= 23);
+                int upperHour = Integer.parseInt(upperStr.substring(11, 13));
+                Assert.assertTrue("Upper bound hour must be 0-23: " + upperStr,
+                        upperHour >= 0 && upperHour <= 23);
+
+                // Verify adjacency using full timestamps (handles midnight crossing)
+                if (prevLower != null) {
+                    ZonedDateTime expectedNext = prevLower.plusHours(1);
+                    ZonedDateTime actual = ZonedDateTime.parse(lowerStr,
+                            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+                    Assert.assertEquals("Adjacent partitions' lower bounds must differ by 1 hour",
+                            expectedNext, actual);
+                    ZonedDateTime expectedUpper = prevUpper.plusHours(1);
+                    ZonedDateTime actualUpper = ZonedDateTime.parse(upperStr,
+                            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+                    Assert.assertEquals("Adjacent partitions' upper bounds must differ by 1 hour",
+                            expectedUpper, actualUpper);
+                }
+                prevLower = ZonedDateTime.parse(lowerStr,
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+                prevUpper = ZonedDateTime.parse(upperStr,
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+            }
+
+            // Verify the current partition (idx=0) name uses UTC,
+            // since both names and values are UTC-based.
+            // Accept either the current or previous hour in case the wall clock
+            // rolled over between scheduler execution and this assertion.
+            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMddHH").format(utcNow);
+            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyyMMddHH")
+                    .format(utcNow.minusHours(1));
+            Assert.assertTrue("Should find hour partition '" + expectedName + "' or '" + prevExpectedName
+                    + "' named per UTC",
+                    table.getPartitionNames().contains(expectedName)
+                    || table.getPartitionNames().contains(prevExpectedName));
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzDynamicPartitionDropCutoffAligned() throws Exception {
+        // With time_zone = "Asia/Shanghai", the old drop-path code computed
+        // the reserved range lower bound at the configured timezone's midnight
+        // (16:00 UTC) instead of UTC midnight (00:00). This caused partitions
+        // just before UTC midnight to intersect the shifted reserved range and
+        // not be dropped. Verify the drop cutoff now aligns with the add path.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+
+            String createOlapTblStmt = "CREATE TABLE test.`tstz_drop_cutoff` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-1\",\n"
+                    + "\"dynamic_partition.end\" = \"1\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"false\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                    + ");";
+            createTable(createOlapTblStmt);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_drop_cutoff");
+
+            // Add a partition for two days ago (UTC) that should be dropped
+            // by the start=-1 cutoff. Must temporarily disable dynamic partition
+            // to manually add a partition.
+            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            String oldLower = utcNow.minusDays(2).withHour(0).withMinute(0).withSecond(0)
+                    .withNano(0).format(fmt) + "+00:00";
+            String oldUpper = utcNow.minusDays(1).withHour(0).withMinute(0).withSecond(0)
+                    .withNano(0).format(fmt) + "+00:00";
+            alterTable("ALTER TABLE test.tstz_drop_cutoff SET "
+                    + "('dynamic_partition.enable' = 'false')");
+            alterTable("ALTER TABLE test.tstz_drop_cutoff ADD PARTITION p_old VALUES "
+                    + "[('" + oldLower + "'), ('" + oldUpper + "'))");
+            Assert.assertTrue("p_old should be added", table.getPartitionNames().contains("p_old"));
+            alterTable("ALTER TABLE test.tstz_drop_cutoff SET "
+                    + "('dynamic_partition.enable' = 'true')");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            // p_old must be dropped by the start=-1 cutoff.
+            // With the fix, the cutoff is at UTC midnight of the previous day,
+            // and p_old (two days ago) is entirely before it.
+            Assert.assertFalse("p_old should be dropped — drop cutoff must be at UTC midnight,"
+                    + " not timezone-offset midnight",
+                    table.getPartitionNames().contains("p_old"));
+
+            // idx=0 (today) and idx=1 (tomorrow) should remain (start=-1, end=1,
+            // create_history_partition=false only creates idx>=0)
+            Assert.assertEquals("Should have idx=0 and idx=1 partitions after drop",
+                    2, table.getPartitionNames().size());
+
+            // Verify remaining partitions have UTC midnight boundaries
+            RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+            for (Map.Entry<Long, PartitionItem> entry : partitionInfo.getIdToItem(false).entrySet()) {
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                List<LiteralExpr> lowerKeys = item.getItems().lowerEndpoint().getKeys();
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+                Assert.assertEquals("Boundary must be at UTC midnight: " + lowerStr,
+                        "00", lowerStr.substring(11, 13));
             }
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
@@ -2311,6 +2512,807 @@ public class DynamicPartitionTableTest {
         } finally {
             TimeZone.setDefault(originalJvmTz);
             connectContext.getSessionVariable().setTimeZone(originalSessionTz);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzGetHistoricalPartitionsRangeBased() throws Exception {
+        // Verify that getHistoricalPartitions correctly identifies the current
+        // partition by range lower bound (currentUtcBorder) rather than by name.
+        // When the configured timezone (e.g. Asia/Shanghai) is a day ahead of UTC,
+        // the scheduler computes nowPartitionName from the TZ date (e.g. "p20260707")
+        // while currentUtcBorder is from the UTC date ("2026-07-06 00:00:00+00:00").
+        // Name-based comparison would fail to exclude the real current partition
+        // (p20260706), treating it as historical. Range-based comparison correctly
+        // excludes it by matching the stored partition lower bound.
+
+        String createSql = "CREATE TABLE test.`tstz_hist_parts` (\n"
+                + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                + "  `k2` int NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k1`, `k2`)\n"
+                + "PARTITION BY RANGE(`k1`)\n"
+                + "()\n"
+                + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\",\n"
+                + "\"dynamic_partition.enable\" = \"true\",\n"
+                + "\"dynamic_partition.start\" = \"-3\",\n"
+                + "\"dynamic_partition.end\" = \"3\",\n"
+                + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                + "\"dynamic_partition.prefix\" = \"p\",\n"
+                + "\"dynamic_partition.buckets\" = \"1\",\n"
+                + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                + ");";
+        createTable(createSql);
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_hist_parts");
+
+        Env.getCurrentEnv().getDynamicPartitionScheduler()
+                .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+        int totalPartitions = table.getPartitionNames().size();
+        Assert.assertEquals(7, totalPartitions);
+
+        RangePartitionInfo info = (RangePartitionInfo) table.getPartitionInfo();
+        DynamicPartitionProperty prop = table.getTableProperty().getDynamicPartitionProperty();
+        String partitionFormat = DynamicPartitionUtil.getPartitionFormat(
+                info.getPartitionColumns().get(0));
+        ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+        // getPartitionRangeString with DATETIME_FORMAT returns "yyyy-MM-dd HH:mm:ss"
+        // (e.g. "2026-07-06 00:00:00"). convertToUtcTimestamp appends "+00:00".
+        String utcBorderDateTime = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, 0, partitionFormat);
+        String currentUtcBorder = utcBorderDateTime + "+00:00";
+
+        // Use a deliberately mismatched nowPartitionName to simulate the scenario
+        // where the configured TZ and UTC disagree on the calendar date.
+        // Name-based comparison would NOT exclude any partition with this name.
+        String wrongNowPartitionName = "p_nonexistent";
+
+        // 1. Without currentUtcBorder: name-based cannot identify the current partition.
+        List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                table, wrongNowPartitionName, null);
+        boolean currentFoundByName = false;
+        for (Partition p : historicalNoUtc) {
+            RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+            String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+            if (lowerBound.equals(currentUtcBorder)) {
+                currentFoundByName = true;
+                break;
+            }
+        }
+        Assert.assertTrue("Name-based should fail to exclude current partition: "
+                + "nowPartitionName='" + wrongNowPartitionName + "' does not match any partition",
+                currentFoundByName);
+
+        // 2. With currentUtcBorder: range-based correctly excludes the current partition.
+        List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                table, wrongNowPartitionName, currentUtcBorder);
+        boolean currentFoundByRange = false;
+        for (Partition p : historicalWithUtc) {
+            RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+            String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+            if (lowerBound.equals(currentUtcBorder)) {
+                currentFoundByRange = true;
+                break;
+            }
+        }
+        Assert.assertFalse("Range-based should correctly exclude the current partition",
+                currentFoundByRange);
+        Assert.assertEquals("Should exclude exactly the current partition",
+                totalPartitions - 1, historicalWithUtc.size());
+    }
+
+    @Test
+    public void testTimeStampTzDynamicPartitionMonthUnit() throws Exception {
+        // Verify TIMESTAMPTZ dynamic partition with MONTH unit:
+        // boundaries are at UTC midnight (day=01 00:00:00+00:00),
+        // names use the configured timezone's calendar month.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+
+            String createOlapTblStmt = "CREATE TABLE test.`timestamptz_dynamic_month` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"month\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                    + ");";
+            createTable(createOlapTblStmt);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("timestamptz_dynamic_month");
+            Assert.assertTrue(table.dynamicPartitionExists());
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            int partitionCount = table.getPartitionNames().size();
+            Assert.assertEquals(7, partitionCount);
+
+            // Verify partition boundaries are UTC midnight and names use
+            // configured timezone (Asia/Shanghai).
+            RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+            for (Map.Entry<Long, PartitionItem> entry : partitionInfo.getIdToItem(false).entrySet()) {
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                String partitionName = table.getPartition(entry.getKey()).getName();
+                Assert.assertTrue("Partition name should start with 'p': " + partitionName,
+                        partitionName.startsWith("p"));
+                // Month partition names: p + yyyyMM → length 7
+                Assert.assertEquals("Month partition name length: " + partitionName,
+                        7, partitionName.length());
+
+                // Verify range validity
+                Range<PartitionKey> range = item.getItems();
+                Assert.assertTrue("lower must be < upper",
+                        range.lowerEndpoint().compareTo(range.upperEndpoint()) < 0);
+
+                // Partition boundaries must be UTC timestamps with +00:00 suffix.
+                List<LiteralExpr> lowerKeys = range.lowerEndpoint().getKeys();
+                Assert.assertEquals(1, lowerKeys.size());
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC with +00:00 suffix: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+
+                List<LiteralExpr> upperKeys = range.upperEndpoint().getKeys();
+                Assert.assertEquals(1, upperKeys.size());
+                String upperStr = upperKeys.get(0).getStringValue();
+                Assert.assertTrue("Upper key must be UTC with +00:00 suffix: " + upperStr,
+                        upperStr.contains("+00:00"));
+
+                // Partition boundaries must be at UTC midnight (hour=00)
+                // regardless of time_zone. Day should be 01 (first of month).
+                String lowerDay = lowerStr.substring(8, 10);
+                Assert.assertEquals("Lower bound must be day 01 for month unit: " + lowerStr,
+                        "01", lowerDay);
+                String lowerHour = lowerStr.substring(11, 13);
+                Assert.assertEquals("Lower bound must be UTC midnight (00): " + lowerStr,
+                        "00", lowerHour);
+                String upperHour = upperStr.substring(11, 13);
+                Assert.assertEquals("Upper bound must be UTC midnight (00): " + upperStr,
+                        "00", upperHour);
+            }
+
+            // Verify the current partition (idx=0) name matches the UTC
+            // calendar month, since both names and values are UTC-based.
+            // Accept either the current or previous month in case the wall
+            // clock rolled over between scheduler execution and this assertion.
+            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyyMM").format(utcNow);
+            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyyMM")
+                    .format(utcNow.minusMonths(1));
+            Assert.assertTrue("Should find month partition '" + expectedName + "' or '" + prevExpectedName
+                    + "' named per UTC",
+                    table.getPartitionNames().contains(expectedName)
+                    || table.getPartitionNames().contains(prevExpectedName));
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzDynamicPartitionYearUnit() throws Exception {
+        // Verify TIMESTAMPTZ dynamic partition with YEAR unit:
+        // boundaries are at UTC midnight (month=01, day=01 00:00:00+00:00),
+        // names use the configured timezone's calendar year.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+
+            String createOlapTblStmt = "CREATE TABLE test.`timestamptz_dynamic_year` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"year\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
+                    + ");";
+            createTable(createOlapTblStmt);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("timestamptz_dynamic_year");
+            Assert.assertTrue(table.dynamicPartitionExists());
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            int partitionCount = table.getPartitionNames().size();
+            Assert.assertEquals(7, partitionCount);
+
+            // Verify partition boundaries are UTC midnight and names use
+            // configured timezone (Asia/Shanghai).
+            RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+            for (Map.Entry<Long, PartitionItem> entry : partitionInfo.getIdToItem(false).entrySet()) {
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                String partitionName = table.getPartition(entry.getKey()).getName();
+                Assert.assertTrue("Partition name should start with 'p': " + partitionName,
+                        partitionName.startsWith("p"));
+                // Year partition names: p + yyyy → length 5
+                Assert.assertEquals("Year partition name length: " + partitionName,
+                        5, partitionName.length());
+
+                // Verify range validity
+                Range<PartitionKey> range = item.getItems();
+                Assert.assertTrue("lower must be < upper",
+                        range.lowerEndpoint().compareTo(range.upperEndpoint()) < 0);
+
+                // Partition boundaries must be UTC timestamps with +00:00 suffix.
+                List<LiteralExpr> lowerKeys = range.lowerEndpoint().getKeys();
+                Assert.assertEquals(1, lowerKeys.size());
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC with +00:00 suffix: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+
+                List<LiteralExpr> upperKeys = range.upperEndpoint().getKeys();
+                Assert.assertEquals(1, upperKeys.size());
+                String upperStr = upperKeys.get(0).getStringValue();
+                Assert.assertTrue("Upper key must be UTC with +00:00 suffix: " + upperStr,
+                        upperStr.contains("+00:00"));
+
+                // Partition boundaries must be at UTC midnight (hour=00)
+                // regardless of time_zone. Month should be 01, day should be 01.
+                String lowerMonth = lowerStr.substring(5, 7);
+                Assert.assertEquals("Lower bound must be month 01 for year unit: " + lowerStr,
+                        "01", lowerMonth);
+                String lowerDay = lowerStr.substring(8, 10);
+                Assert.assertEquals("Lower bound must be day 01 for year unit: " + lowerStr,
+                        "01", lowerDay);
+                String lowerHour = lowerStr.substring(11, 13);
+                Assert.assertEquals("Lower bound must be UTC midnight (00): " + lowerStr,
+                        "00", lowerHour);
+                String upperHour = upperStr.substring(11, 13);
+                Assert.assertEquals("Upper bound must be UTC midnight (00): " + upperStr,
+                        "00", upperHour);
+            }
+
+            // Verify the current partition (idx=0) name matches the UTC
+            // calendar year, since both names and values are UTC-based.
+            // Accept either the current or previous year in case the wall
+            // clock rolled over between scheduler execution and this assertion.
+            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            String expectedName = "p" + DateTimeFormatter.ofPattern("yyyy").format(utcNow);
+            String prevExpectedName = "p" + DateTimeFormatter.ofPattern("yyyy")
+                    .format(utcNow.minusYears(1));
+            Assert.assertTrue("Should find year partition '" + expectedName + "' or '" + prevExpectedName
+                    + "' named per UTC",
+                    table.getPartitionNames().contains(expectedName)
+                    || table.getPartitionNames().contains(prevExpectedName));
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzReservedHistoryPeriodsUtcAligned() throws Exception {
+        // Verify that reserved_history_periods uses UTC-midnight boundaries
+        // (via borderTimeZone from getDropPartitionOpForDynamic) consistently
+        // with the main drop cutoff and add-partition boundaries.
+        // Without the fix, getClosedRange() hardcoded the configured timezone
+        // (e.g. Asia/Shanghai) for convertToUtcTimestamp(), shifting reserved
+        // ranges by the UTC offset and causing mismatches with UTC-aligned
+        // partition boundaries.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+
+            String createSql = "CREATE TABLE test.`tstz_reserved_hist` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"false\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n"
+                    + "\"dynamic_partition.reserved_history_periods\" = \"[2019-06-01,2020-08-01]\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_reserved_hist");
+
+            // Add partitions manually — must temporarily disable dynamic partition.
+            alterTable("ALTER TABLE test.tstz_reserved_hist SET "
+                    + "('dynamic_partition.enable' = 'false')");
+            // Add a partition that falls within the reserved period with
+            // UTC-midnight boundaries: [2020-01-01 00:00 UTC, 2020-02-01 00:00 UTC).
+            // This should be protected by the reserved period.
+            alterTable("ALTER TABLE test.tstz_reserved_hist ADD PARTITION p_202001 VALUES "
+                    + "[('2020-01-01 00:00:00+00:00'), ('2020-02-01 00:00:00+00:00'))");
+            // Add a partition entirely before the reserved period.
+            // This should be dropped by the start=-3 cutoff.
+            alterTable("ALTER TABLE test.tstz_reserved_hist ADD PARTITION p_old VALUES "
+                    + "[('2018-01-01 00:00:00+00:00'), ('2018-02-01 00:00:00+00:00'))");
+
+            Assert.assertTrue("p_202001 should exist before scheduling",
+                    table.getPartitionNames().contains("p_202001"));
+            Assert.assertTrue("p_old should exist before scheduling",
+                    table.getPartitionNames().contains("p_old"));
+
+            // Re-enable dynamic partition and run the scheduler.
+            alterTable("ALTER TABLE test.tstz_reserved_hist SET "
+                    + "('dynamic_partition.enable' = 'true')");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            // p_202001 falls within reserved period [2019-06-01, 2020-08-01] in
+            // UTC-midnight interpretation → must be kept.
+            Assert.assertTrue("p_202001 should be kept — within UTC-aligned reserved history period",
+                    table.getPartitionNames().contains("p_202001"));
+            // p_old is before the start=-3 cutoff and outside the reserved
+            // period → must be dropped.
+            Assert.assertFalse("p_old should be dropped — outside reserved period and before start",
+                    table.getPartitionNames().contains("p_old"));
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzHotPartitionCooldownUtcAligned() throws Exception {
+        // Verify that hot-partition cooldown times are UTC-midnight aligned
+        // and not shifted by the configured timezone (America/Chicago, UTC-5).
+        // Without the fix, setStorageMediumProperty() used nowTz (configured
+        // timezone) which could place the cooldown boundary on a different
+        // calendar day than the partition's UTC range.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("Asia/Shanghai");
+            changeBeDisk(TStorageMedium.SSD);
+
+            String createSql = "CREATE TABLE test.`tstz_hot_part_cooldown` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"America/Chicago\",\n"
+                    + "\"dynamic_partition.hot_partition_num\" = \"1\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_hot_part_cooldown");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+            // Sort partitions by lower bound.
+            List<Map.Entry<Long, PartitionItem>> sortedEntries = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sortedEntries.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+
+            Assert.assertEquals(7, sortedEntries.size());
+
+            // Partitions idx=-3,-2,-1 are before the hot range → HDD.
+            // Partitions idx=0..3 (4 partitions) are within hot_partition_num=1:
+            //   - idx=0: hot (offset + hotPartitionNum = 0+1 = 1 > 0) → SSD
+            //   - idx=1,2,3: hot (offset + hotPartitionNum > 0) → SSD
+            // Because hot_partition_num=1 means only the current partition is hot,
+            // but the logic counts from idx + hotPartitionNum > 0.
+            // Actually: the condition is `offset + hotPartitionNum <= 0` → HDD.
+            // So idx=-3,-2,-1: -3+1=-2≤0 HDD, -2+1=-1≤0 HDD, -1+1=0≤0 HDD.
+            // idx=0,1,2,3: 0+1=1>0 SSD, etc.
+            // idx=-3,-2,-1 are HDD, idx=0,1,2,3 are SSD.
+
+            for (int i = 0; i < sortedEntries.size(); i++) {
+                Map.Entry<Long, PartitionItem> entry = sortedEntries.get(i);
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                DataProperty dp = partitionInfo.getDataProperty(entry.getKey());
+
+                if (i < 3) {
+                    // Historical partitions: HDD
+                    Assert.assertEquals("Historical partition should be HDD: idx=" + (i - 3),
+                            TStorageMedium.HDD, dp.getStorageMedium());
+                } else {
+                    // Hot partitions: SSD
+                    Assert.assertEquals("Hot partition should be SSD: idx=" + (i - 3),
+                            TStorageMedium.SSD, dp.getStorageMedium());
+
+                    // Every hot partition must have a finite cooldown equal to
+                    // that partition's upper endpoint (offset + hotPartitionNum).
+                    // Assert it is NOT the MAX fallback, which would indicate
+                    // the TIMESTAMPTZ lifecycle string was rejected during parse.
+                    Assert.assertNotEquals("Hot partition must have a finite cooldown: idx=" + (i - 3),
+                            DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
+
+                    ZonedDateTime cooldownUtc = ZonedDateTime.ofInstant(
+                            java.time.Instant.ofEpochMilli(dp.getCooldownTimeMs()),
+                            ZoneOffset.UTC);
+
+                    // Parse the partition's upper bound as a UTC instant.
+                    String upperStr = item.getItems().upperEndpoint().getKeys().get(0).getStringValue();
+                    ZonedDateTime upperUtc = ZonedDateTime.parse(upperStr,
+                            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+
+                    Assert.assertEquals("Cooldown must equal the partition upper bound ("
+                            + upperUtc + "): idx=" + (i - 3),
+                            upperUtc.toInstant(), cooldownUtc.toInstant());
+                }
+
+                // Verify partition boundaries are UTC midnight.
+                List<LiteralExpr> lowerKeys = item.getItems().lowerEndpoint().getKeys();
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+                Assert.assertEquals("Lower bound must be at UTC midnight: " + lowerStr,
+                        "00", lowerStr.substring(11, 13));
+            }
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzHotPartitionCooldownDstMonth() throws Exception {
+        // Regression: When the session timezone has DST (e.g. America/Chicago,
+        // UTC-5 in summer, UTC-6 in winter), PropertyAnalyzer.analyzeDataProperty()
+        // parses cooldown values as DATETIME via DateLiteralUtils.createDateLiteral()
+        // which applies the current Instant's offset during the initial shift
+        // while using the target date's offset in unixTimestamp(). With the old
+        // convertToUtcTimestamp path (which appended "+00:00"), a cooldown
+        // boundary in a different DST period than NOW would shift by one hour.
+        // The fix stores the cooldown with an explicit +00:00 suffix, and
+        // PropertyAnalyzer now parses timezone-suffixed values directly as
+        // instants. This test uses MONTH unit with America/Chicago (DST) for
+        // both session and partition timezones so the cooldown boundary is
+        // likely to fall in a different DST period than the current date.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+            changeBeDisk(TStorageMedium.SSD);
+
+            String createSql = "CREATE TABLE test.`tstz_cooldown_dst_month` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"month\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"America/Chicago\",\n"
+                    + "\"dynamic_partition.hot_partition_num\" = \"6\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_cooldown_dst_month");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+            List<Map.Entry<Long, PartitionItem>> sortedEntries = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sortedEntries.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+
+            Assert.assertEquals(7, sortedEntries.size());
+
+            // idx=-3,-2,-1: offset+6=3,2,1 >0 → SSD (hot)
+            // idx=0..3: offset+6=6,7,8,9 >0 → SSD (hot)
+            // All partitions should be SSD since hot_partition_num covers all.
+
+            // Derive the expected cooldown from the current partition's
+            // stored lower bound rather than sampling ZonedDateTime.now(),
+            // which can differ from the clock captured by the scheduler
+            // and cause spurious failures across UTC month boundaries.
+            RangePartitionItem currentItem = (RangePartitionItem) sortedEntries.get(3).getValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(
+                    currentItem.getItems().lowerEndpoint().getKeys().get(0).getStringValue(),
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+
+            for (int i = 0; i < sortedEntries.size(); i++) {
+                int idx = i - 3; // idx=-3,-2,-1,0,1,2,3
+                Map.Entry<Long, PartitionItem> entry = sortedEntries.get(i);
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                DataProperty dp = partitionInfo.getDataProperty(entry.getKey());
+
+                Assert.assertEquals("All partitions should be SSD with hot_partition_num=6",
+                        TStorageMedium.SSD, dp.getStorageMedium());
+                Assert.assertNotEquals("Hot partition must have a finite cooldown",
+                        DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
+
+                // Cooldown is the lower bound of the (idx + hotPartitionNum)-th
+                // partition. Derive it from the current partition's lower bound
+                // (which shares the scheduler's clock) to avoid race conditions.
+                ZonedDateTime cooldownUtc = ZonedDateTime.ofInstant(
+                        java.time.Instant.ofEpochMilli(dp.getCooldownTimeMs()),
+                        ZoneOffset.UTC);
+                ZonedDateTime expectedUtc = currentLower.plusMonths(idx + 6);
+                Assert.assertEquals("Cooldown must equal lower bound of partition at offset "
+                        + (idx + 6) + " (" + expectedUtc + "): idx=" + idx,
+                        expectedUtc.toInstant(), cooldownUtc.toInstant());
+
+                // Verify partition boundaries are UTC midnight, day=01.
+                List<LiteralExpr> lowerKeys = item.getItems().lowerEndpoint().getKeys();
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+                Assert.assertEquals("Lower bound must be at UTC midnight: " + lowerStr,
+                        "00", lowerStr.substring(11, 13));
+                // Month boundaries must fall on the first day of the month.
+                Assert.assertEquals("Month lower bound day must be 01: " + lowerStr,
+                        "01", lowerStr.substring(8, 10));
+            }
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzHotPartitionCooldownDstFallback() throws Exception {
+        // DST fall-back regression: on 2026-11-01 at 2:00 AM CDT, America/Chicago
+        // clocks fall back to 1:00 AM CST. The hour 01:00–02:00 occurs twice,
+        // so a wall-clock string "01:00:00" without offset is ambiguous and Java
+        // resolves it to the earlier offset (06:00 UTC instead of 07:00 UTC).
+        // The fix stores the cooldown as an unambiguous UTC timestamp with +00:00
+        // suffix (e.g. "2026-11-01 07:00:00+00:00"), and PropertyAnalyzer now
+        // parses timezone-suffixed values directly as instants, bypassing the
+        // broken DATETIME path. This test uses HOUR unit with America/Chicago
+        // to ensure cooldown timestamps remain correct regardless of DST status.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+            changeBeDisk(TStorageMedium.SSD);
+
+            String createSql = "CREATE TABLE test.`tstz_cooldown_dst_fallback` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\",\n"
+                    + "\"dynamic_partition.enable\" = \"true\",\n"
+                    + "\"dynamic_partition.start\" = \"-3\",\n"
+                    + "\"dynamic_partition.end\" = \"3\",\n"
+                    + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                    + "\"dynamic_partition.time_unit\" = \"hour\",\n"
+                    + "\"dynamic_partition.prefix\" = \"p\",\n"
+                    + "\"dynamic_partition.buckets\" = \"1\",\n"
+                    + "\"dynamic_partition.time_zone\" = \"America/Chicago\",\n"
+                    + "\"dynamic_partition.hot_partition_num\" = \"1\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_cooldown_dst_fallback");
+
+            Env.getCurrentEnv().getDynamicPartitionScheduler()
+                    .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+            RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+            List<Map.Entry<Long, PartitionItem>> sortedEntries = Lists.newArrayList(
+                    partitionInfo.getIdToItem(false).entrySet());
+            sortedEntries.sort((a, b) -> {
+                RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+            });
+
+            Assert.assertEquals(7, sortedEntries.size());
+
+            // Derive the expected cooldown from the current partition's
+            // stored lower bound rather than sampling ZonedDateTime.now(),
+            // which can differ from the clock captured by the scheduler
+            // and cause spurious failures across UTC hour boundaries.
+            RangePartitionItem currentItem = (RangePartitionItem) sortedEntries.get(3).getValue();
+            ZonedDateTime currentLower = ZonedDateTime.parse(
+                    currentItem.getItems().lowerEndpoint().getKeys().get(0).getStringValue(),
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX"));
+
+            for (int i = 0; i < sortedEntries.size(); i++) {
+                int idx = i - 3;
+                Map.Entry<Long, PartitionItem> entry = sortedEntries.get(i);
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                DataProperty dp = partitionInfo.getDataProperty(entry.getKey());
+
+                // idx=-3,-2,-1: offset+1 ≤ 0 → HDD (MAX_COOLDOWN_TIME_MS)
+                // idx=0,1,2,3: offset+1 > 0 → SSD (finite cooldown)
+                if (idx + 1 <= 0) {
+                    Assert.assertEquals("Historical partition should be HDD: idx=" + idx,
+                            TStorageMedium.HDD, dp.getStorageMedium());
+                    continue;
+                }
+
+                Assert.assertEquals("Hot partition should be SSD: idx=" + idx,
+                        TStorageMedium.SSD, dp.getStorageMedium());
+                Assert.assertNotEquals("Hot partition must have a finite cooldown: idx=" + idx,
+                        DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
+
+                // Cooldown is the lower bound of the (idx + hotPartitionNum)-th
+                // partition. Derive it from the current partition's lower bound
+                // (which shares the scheduler's clock) to avoid race conditions.
+                ZonedDateTime cooldownUtc = ZonedDateTime.ofInstant(
+                        java.time.Instant.ofEpochMilli(dp.getCooldownTimeMs()),
+                        ZoneOffset.UTC);
+                ZonedDateTime expectedUtc = currentLower.plusHours(idx + 1);
+                Assert.assertEquals("Cooldown must equal lower bound of partition at offset "
+                        + (idx + 1) + " (" + expectedUtc + "): idx=" + idx,
+                        expectedUtc.toInstant(), cooldownUtc.toInstant());
+
+                // Hour boundaries must be at whole UTC hours.
+                List<LiteralExpr> lowerKeys = item.getItems().lowerEndpoint().getKeys();
+                String lowerStr = lowerKeys.get(0).getStringValue();
+                Assert.assertTrue("Lower key must be UTC: " + lowerStr,
+                        lowerStr.contains("+00:00"));
+                int lowerHour = Integer.parseInt(lowerStr.substring(11, 13));
+                Assert.assertTrue("Lower bound hour must be 0-23: " + lowerStr,
+                        lowerHour >= 0 && lowerHour <= 23);
+            }
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzHotPartitionCooldownFractionalSeconds() throws Exception {
+        // Regression: convertToUtcTimestamp() preserves the column's scale
+        // (0–6) via TimeStampTzType.of(), so cooldown strings may carry
+        // fractional seconds (e.g. "2027-01-01 00:00:00.000000+00:00" for
+        // TIMESTAMPTZ(6)). The old PropertyAnalyzer branch used a fixed-
+        // position offset check and a "yyyy-MM-dd HH:mm:ssXXX" formatter,
+        // both of which silently rejected fractional-second values and fell
+        // back to MAX_COOLDOWN_TIME_MS. The fix uses a regex offset detector
+        // and a DateTimeFormatterBuilder with appendFraction(0,6,true) so
+        // values with any scale 0–6 are parsed as instants.
+        // This test exercises precisions 0, 3, and 6.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        int[] precisions = {0, 3, 6};
+        try {
+            connectContext.getSessionVariable().setTimeZone("Asia/Shanghai");
+            changeBeDisk(TStorageMedium.SSD);
+
+            for (int precision : precisions) {
+                String tableName = "tstz_cooldown_frac_" + precision;
+                String createSql = "CREATE TABLE test.`" + tableName + "` (\n"
+                        + "  `k1` TIMESTAMPTZ(" + precision + ") NULL COMMENT \"\",\n"
+                        + "  `k2` int NULL COMMENT \"\"\n"
+                        + ") ENGINE=OLAP\n"
+                        + "DUPLICATE KEY(`k1`, `k2`)\n"
+                        + "PARTITION BY RANGE(`k1`)\n"
+                        + "()\n"
+                        + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                        + "PROPERTIES (\n"
+                        + "\"replication_num\" = \"1\",\n"
+                        + "\"dynamic_partition.enable\" = \"true\",\n"
+                        + "\"dynamic_partition.start\" = \"-3\",\n"
+                        + "\"dynamic_partition.end\" = \"3\",\n"
+                        + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
+                        + "\"dynamic_partition.time_unit\" = \"day\",\n"
+                        + "\"dynamic_partition.prefix\" = \"p\",\n"
+                        + "\"dynamic_partition.buckets\" = \"1\",\n"
+                        + "\"dynamic_partition.time_zone\" = \"America/Chicago\",\n"
+                        + "\"dynamic_partition.hot_partition_num\" = \"1\"\n"
+                        + ");";
+                createTable(createSql);
+
+                Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+                OlapTable table = (OlapTable) db.getTableOrAnalysisException(tableName);
+
+                Env.getCurrentEnv().getDynamicPartitionScheduler()
+                        .executeDynamicPartitionFirstTime(db.getId(), table.getId());
+
+                RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+                List<Map.Entry<Long, PartitionItem>> sortedEntries = Lists.newArrayList(
+                        partitionInfo.getIdToItem(false).entrySet());
+                sortedEntries.sort((a, b) -> {
+                    RangePartitionItem ai = (RangePartitionItem) a.getValue();
+                    RangePartitionItem bi = (RangePartitionItem) b.getValue();
+                    return ai.getItems().lowerEndpoint().compareTo(bi.getItems().lowerEndpoint());
+                });
+
+                Assert.assertEquals("TIMESTAMPTZ(" + precision + "): partition count",
+                        7, sortedEntries.size());
+
+                // Hot partitions must have finite cooldown, not
+                // MAX_COOLDOWN_TIME_MS (which would mean the cooldown
+                // string was rejected by PropertyAnalyzer).
+                java.time.format.DateTimeFormatterBuilder fb =
+                        new java.time.format.DateTimeFormatterBuilder()
+                                .appendPattern("yyyy-MM-dd HH:mm:ss")
+                                .appendFraction(java.time.temporal.ChronoField.NANO_OF_SECOND, 0, 6, true)
+                                .appendOffset("+HH:MM", "+00:00");
+                java.time.format.DateTimeFormatter boundFmt = fb.toFormatter();
+                for (int i = 0; i < sortedEntries.size(); i++) {
+                    int idx = i - 3;
+                    Map.Entry<Long, PartitionItem> entry = sortedEntries.get(i);
+                    RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                    DataProperty dp = partitionInfo.getDataProperty(entry.getKey());
+
+                    if (i < 3) {
+                        Assert.assertEquals("TIMESTAMPTZ(" + precision
+                                + ") historical partition should be HDD: idx=" + idx,
+                                TStorageMedium.HDD, dp.getStorageMedium());
+                    } else {
+                        Assert.assertEquals("TIMESTAMPTZ(" + precision
+                                + ") hot partition should be SSD: idx=" + idx,
+                                TStorageMedium.SSD, dp.getStorageMedium());
+                        Assert.assertNotEquals("TIMESTAMPTZ(" + precision
+                                + ") cooldown must be finite (not MAX): idx=" + idx,
+                                DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
+
+                        ZonedDateTime cooldownUtc = ZonedDateTime.ofInstant(
+                                java.time.Instant.ofEpochMilli(dp.getCooldownTimeMs()),
+                                ZoneOffset.UTC);
+                        String upperStr = item.getItems().upperEndpoint().getKeys().get(0)
+                                .getStringValue();
+                        ZonedDateTime upperUtc = ZonedDateTime.parse(upperStr, boundFmt);
+                        Assert.assertEquals("TIMESTAMPTZ(" + precision
+                                + ") cooldown must equal partition upper bound: idx=" + idx,
+                                upperUtc.toInstant(), cooldownUtc.toInstant());
+                    }
+                }
+            }
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -48,7 +48,9 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -320,7 +322,8 @@ public class DynamicPartitionTableTest {
                 + "\"dynamic_partition.start\" = \"-3\",\n"
                 + "\"dynamic_partition.end\" = \"3\",\n"
                 + "\"dynamic_partition.time_unit\" = \"day\",\n"
-                + "\"dynamic_partition.prefix\" = \"p\"\n"
+                + "\"dynamic_partition.prefix\" = \"p\",\n"
+                + "\"dynamic_partition.buckets\" = \"1\"\n"
                 + ");";
         createTable(createOlapTblStmt);
     }
@@ -406,9 +409,10 @@ public class DynamicPartitionTableTest {
                 + "\"dynamic_partition.enable\" = \"true\",\n"
                 + "\"dynamic_partition.start\" = \"-3\",\n"
                 + "\"dynamic_partition.end\" = \"3\",\n"
-                + "\"dynamic_partition.buckets\" = \"3\",\n"
                 + "\"dynamic_partition.time_unit\" = \"day\",\n"
-                + "\"dynamic_partition.prefix\" = \"p\"\n"
+                + "\"dynamic_partition.prefix\" = \"p\",\n"
+                + "\"dynamic_partition.buckets\" = \"3\",\n"
+                + "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\"\n"
                 + ");";
         createTable(createOlapTblStmt);
     }
@@ -1173,6 +1177,7 @@ public class DynamicPartitionTableTest {
                 + "\"dynamic_partition.enable\" = \"true\",\n"
                 + "\"dynamic_partition.start\" = \"-3\",\n"
                 + "\"dynamic_partition.end\" = \"3\",\n"
+                + "\"dynamic_partition.create_history_partition\" = \"true\",\n"
                 + "\"dynamic_partition.time_unit\" = \"day\",\n"
                 + "\"dynamic_partition.prefix\" = \"p\",\n"
                 + "\"dynamic_partition.buckets\" = \"1\",\n"
@@ -1182,9 +1187,15 @@ public class DynamicPartitionTableTest {
         tbl = (OlapTable) testDb.getTableOrAnalysisException("hot_partition_day_tbl1");
         partitionInfo = (RangePartitionInfo) tbl.getPartitionInfo();
         idToDataProperty = new TreeMap<>(partitionInfo.idToDataProperty);
-        Assert.assertEquals(4, idToDataProperty.size());
+        Assert.assertEquals(7, idToDataProperty.size());
+        int dayCount = 0;
         for (DataProperty dataProperty : idToDataProperty.values()) {
-            Assert.assertEquals(TStorageMedium.SSD, dataProperty.getStorageMedium());
+            if (dayCount < 2) {
+                Assert.assertEquals(TStorageMedium.HDD, dataProperty.getStorageMedium());
+            } else {
+                Assert.assertEquals(TStorageMedium.SSD, dataProperty.getStorageMedium());
+            }
+            ++dayCount;
         }
 
         createOlapTblStmt = "CREATE TABLE test.`hot_partition_day_tbl2` (\n"
@@ -2402,6 +2413,10 @@ public class DynamicPartitionTableTest {
         // just before UTC midnight to intersect the shifted reserved range and
         // not be dropped. Verify the drop cutoff now aligns with the add path.
         String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        DynamicPartitionScheduler scheduler = Env.getCurrentEnv().getDynamicPartitionScheduler();
+        DynamicPartitionScheduler spyScheduler = Mockito.spy(scheduler);
+        Field schedulerField = Env.class.getDeclaredField("dynamicPartitionScheduler");
+        schedulerField.setAccessible(true);
         try {
             connectContext.getSessionVariable().setTimeZone("America/Chicago");
 
@@ -2425,7 +2440,8 @@ public class DynamicPartitionTableTest {
             // implementation, not just for 16 hours of the day.
             ZonedDateTime fixedNow = ZonedDateTime.of(
                     2026, 7, 21, 8, 0, 0, 0, ZoneOffset.UTC);
-            DynamicPartitionScheduler.testNow = fixedNow;
+            Mockito.doReturn(fixedNow).when(spyScheduler).getNow(Mockito.any());
+            schedulerField.set(Env.getCurrentEnv(), spyScheduler);
 
             String createOlapTblStmt = "CREATE TABLE test.`tstz_drop_cutoff` (\n"
                     + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
@@ -2491,7 +2507,7 @@ public class DynamicPartitionTableTest {
                         "00", lowerStr.substring(11, 13));
             }
         } finally {
-            DynamicPartitionScheduler.testNow = null;
+            schedulerField.set(Env.getCurrentEnv(), scheduler);
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
     }
@@ -2644,22 +2660,33 @@ public class DynamicPartitionTableTest {
                 + "nowPartitionName='" + wrongNowPartitionName + "' does not match any partition",
                 currentFoundByName);
 
-        // 2. With currentUtcBorder: range-based correctly excludes the current partition.
-        List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                table, wrongNowPartitionName, currentUtcBorder);
-        boolean currentFoundByRange = false;
-        for (Partition p : historicalWithUtc) {
+        // 2. With the correct nowPartitionName matching the current partition's
+        //    actual name, name-based exclusion correctly removes it.
+        String currentPartitionName = null;
+        for (Partition p : table.getPartitions()) {
             RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
             String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
             if (lowerBound.equals(currentUtcBorder)) {
-                currentFoundByRange = true;
+                currentPartitionName = p.getName();
                 break;
             }
         }
-        Assert.assertFalse("Range-based should correctly exclude the current partition",
-                currentFoundByRange);
+        Assert.assertNotNull("Should find the current partition", currentPartitionName);
+        List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
+                table, currentPartitionName, currentUtcBorder);
+        boolean currentFoundByName2 = false;
+        for (Partition p : historicalWithName) {
+            RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+            String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+            if (lowerBound.equals(currentUtcBorder)) {
+                currentFoundByName2 = true;
+                break;
+            }
+        }
+        Assert.assertFalse("Name-based should exclude the current partition when name matches",
+                currentFoundByName2);
         Assert.assertEquals("Should exclude exactly the current partition",
-                totalPartitions - 1, historicalWithUtc.size());
+                totalPartitions - 1, historicalWithName.size());
     }
 
     @Test
@@ -3486,23 +3513,34 @@ public class DynamicPartitionTableTest {
             Assert.assertTrue("Scaled TIMESTAMPTZ(6): name-based should fail to exclude current partition",
                     currentFoundByName);
 
-            // With currentUtcBorder: range-based correctly excludes the current
-            // partition even though the string representations differ (.000000).
-            List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, wrongNowPartitionName, currentUtcBorder);
-            boolean currentFoundByRange = false;
-            for (Partition p : historicalWithUtc) {
+            // With the correct nowPartitionName matching the current partition's
+            // actual name, name-based exclusion works correctly even when the
+            // lower bound string has a different scale (.000000 vs no fraction).
+            String currentPartitionName = null;
+            for (Partition p : table.getPartitions()) {
                 RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
                 String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
                 if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
-                    currentFoundByRange = true;
+                    currentPartitionName = p.getName();
                     break;
                 }
             }
-            Assert.assertFalse("Scaled TIMESTAMPTZ(6): range-based must exclude current partition",
-                    currentFoundByRange);
+            Assert.assertNotNull("Should find the current partition", currentPartitionName);
+            List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, currentPartitionName, currentUtcBorder);
+            boolean currentFoundByNameCorrect = false;
+            for (Partition p : historicalWithName) {
+                RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+                String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
+                    currentFoundByNameCorrect = true;
+                    break;
+                }
+            }
+            Assert.assertFalse("Scaled TIMESTAMPTZ(6): name-based must exclude current partition "
+                    + "when nowPartitionName matches", currentFoundByNameCorrect);
             Assert.assertEquals("Scaled TIMESTAMPTZ(6): exclude exactly one partition",
-                    totalPartitions - 1, historicalWithUtc.size());
+                    totalPartitions - 1, historicalWithName.size());
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -3592,23 +3630,34 @@ public class DynamicPartitionTableTest {
             Assert.assertTrue("Old prefix: name-based should fail to exclude current partition",
                     currentFoundByName);
 
-            // 2. With currentUtcBorder: range-based correctly excludes the
-            //    current partition despite the name mismatch.
-            List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, newPrefixNowName, currentUtcBorder);
-            boolean currentFoundByRange = false;
-            for (Partition p : historicalWithUtc) {
+            // 2. With the correct nowPartitionName (the actual partition name
+            //    with old prefix "p"), name-based exclusion works.
+            String currentPartitionName = null;
+            for (Partition p : table.getPartitions()) {
                 RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
                 String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
                 if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
-                    currentFoundByRange = true;
+                    currentPartitionName = p.getName();
                     break;
                 }
             }
-            Assert.assertFalse("Old prefix: range-based must exclude current partition",
-                    currentFoundByRange);
+            Assert.assertNotNull("Should find the current partition", currentPartitionName);
+            Assert.assertTrue("Current partition should start with 'p'", currentPartitionName.startsWith("p"));
+            List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, currentPartitionName, currentUtcBorder);
+            boolean currentFoundByName2 = false;
+            for (Partition p : historicalWithName) {
+                RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
+                String lowerBound = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                if (lowerBound.contains(currentUtcBorder.replace("+00:00", ""))) {
+                    currentFoundByName2 = true;
+                    break;
+                }
+            }
+            Assert.assertFalse("Old prefix: name-based must exclude current partition "
+                    + "when nowPartitionName matches", currentFoundByName2);
             Assert.assertEquals("Old prefix: exclude exactly one partition",
-                    totalPartitions - 1, historicalWithUtc.size());
+                    totalPartitions - 1, historicalWithName.size());
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -3647,14 +3696,14 @@ public class DynamicPartitionTableTest {
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
             // Derive all timestamps from today's UTC midnight so the
-            // test is independent of wall-clock time.  At 2026-07-22
+            // test is independent of wall-clock time.  At current date
             // 00:00:00Z:
-            //   lower = yesterday 16:00Z = 2026-07-21 16:00Z
-            //   upper = today     16:00Z = 2026-07-22 16:00Z
+            //   lower = yesterday 16:00Z
+            //   upper = today     16:00Z
             //
-            // currentUtcBorder (today 00:00Z = 2026-07-22 00:00Z) is
-            // always inside [yesterday 16:00Z, today 16:00Z) regardless
-            // of when the test runs.
+            // currentUtcBorder (today 00:00Z) is always inside
+            // [yesterday 16:00Z, today 16:00Z) regardless of when
+            // the test runs.
             ZonedDateTime todayMidnight = ZonedDateTime.now(ZoneOffset.UTC)
                     .withHour(0).withMinute(0).withSecond(0).withNano(0);
             ZonedDateTime yesterday16Z = todayMidnight.minusHours(8);  // yesterday 16:00Z
@@ -3673,7 +3722,8 @@ public class DynamicPartitionTableTest {
             // currentUtcBorder = today's UTC midnight → inside p_legacy.
             String currentUtcBorder = fmt.format(todayMidnight) + "+00:00";
 
-            // Sanity check: currentUtcBorder is inside p_legacy.
+            // Sanity check: currentUtcBorder is inside p_legacy but not equal
+            // to its lower bound.
             RangePartitionInfo info = (RangePartitionInfo) table.getPartitionInfo();
             for (Map.Entry<Long, PartitionItem> entry : info.getIdToItem(false).entrySet()) {
                 RangePartitionItem item = (RangePartitionItem) entry.getValue();
@@ -3696,18 +3746,16 @@ public class DynamicPartitionTableTest {
             Assert.assertEquals("Name-based fallback returns all partitions",
                     2, historicalNoUtc.size());
 
-            // 2. With currentUtcBorder: range containment excludes p_legacy
-            //    because 00:00Z ∈ [yesterday 16:00Z, today 16:00Z).
-            //    p_legacy's lower bound (16:00Z) ≠ 00:00Z, so exact equality
-            //    would NOT find it — only containment does.
-            List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, wrongNowPartitionName, currentUtcBorder);
-            Assert.assertEquals("Range containment excludes exactly one partition",
-                    1, historicalWithUtc.size());
-            Assert.assertFalse("p_legacy must be excluded by range containment",
-                    "p_legacy".equals(historicalWithUtc.get(0).getName()));
+            // 2. With the correct nowPartitionName matching p_legacy,
+            //    name-based exclusion removes it.
+            List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, "p_legacy", currentUtcBorder);
+            Assert.assertEquals("Name-based exclusion removes exactly one partition",
+                    1, historicalWithName.size());
+            Assert.assertFalse("p_legacy must be excluded by name match",
+                    "p_legacy".equals(historicalWithName.get(0).getName()));
             Assert.assertEquals("p_hist should survive",
-                    "p_hist", historicalWithUtc.get(0).getName());
+                    "p_hist", historicalWithName.get(0).getName());
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -3642,16 +3642,20 @@ public class DynamicPartitionTableTest {
             OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_noncanonical");
 
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-            ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
 
-            // Non-canonical partition: lower = yesterday 16:00Z, upper = today 16:00Z.
-            // currentUtcBorder (today 00:00Z) is inside [yesterday 16:00Z, today 16:00Z)
-            // but does NOT equal the lower bound (16:00Z).
-            ZonedDateTime yesterday16Z = now.withHour(16).withMinute(0).withSecond(0).withNano(0);
-            if (now.getHour() < 16) {
-                yesterday16Z = yesterday16Z.minusDays(1);
-            }
-            ZonedDateTime today16Z = yesterday16Z.plusDays(1);
+            // Derive all timestamps from today's UTC midnight so the
+            // test is independent of wall-clock time.  At 2026-07-22
+            // 00:00:00Z:
+            //   lower = yesterday 16:00Z = 2026-07-21 16:00Z
+            //   upper = today     16:00Z = 2026-07-22 16:00Z
+            //
+            // currentUtcBorder (today 00:00Z = 2026-07-22 00:00Z) is
+            // always inside [yesterday 16:00Z, today 16:00Z) regardless
+            // of when the test runs.
+            ZonedDateTime todayMidnight = ZonedDateTime.now(ZoneOffset.UTC)
+                    .withHour(0).withMinute(0).withSecond(0).withNano(0);
+            ZonedDateTime yesterday16Z = todayMidnight.minusHours(8);  // yesterday 16:00Z
+            ZonedDateTime today16Z = yesterday16Z.plusDays(1);        // today 16:00Z
             String oldLower = fmt.format(yesterday16Z) + "+00:00";
             String oldUpper = fmt.format(today16Z) + "+00:00";
             alterTable("ALTER TABLE test.tstz_noncanonical ADD PARTITION p_legacy VALUES "
@@ -3664,7 +3668,7 @@ public class DynamicPartitionTableTest {
             Assert.assertEquals(2, table.getPartitionNames().size());
 
             // currentUtcBorder = today's UTC midnight → inside p_legacy.
-            String currentUtcBorder = fmt.format(now.withHour(0).withMinute(0).withSecond(0).withNano(0)) + "+00:00";
+            String currentUtcBorder = fmt.format(todayMidnight) + "+00:00";
 
             // Sanity check: currentUtcBorder is inside p_legacy.
             RangePartitionInfo info = (RangePartitionInfo) table.getPartitionInfo();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -2582,10 +2582,8 @@ public class DynamicPartitionTableTest {
         String partitionFormat = DynamicPartitionUtil.getPartitionFormat(
                 info.getPartitionColumns().get(0));
         ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
-        // getPartitionRangeString with DATETIME_FORMAT returns "yyyy-MM-dd HH:mm:ss"
-        // (e.g. "2026-07-06 00:00:00"). convertToUtcTimestamp appends "+00:00".
-        String utcBorderDateTime = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, 0, partitionFormat);
-        String currentUtcBorder = utcBorderDateTime + "+00:00";
+        // getPartitionRangeString appends +00:00 when current is UTC-based.
+        String currentUtcBorder = DynamicPartitionUtil.getPartitionRangeString(prop, utcNow, 0, partitionFormat);
 
         // Use a deliberately mismatched nowPartitionName to simulate the scenario
         // where the configured TZ and UTC disagree on the calendar date.

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -2429,15 +2429,30 @@ public class DynamicPartitionTableTest {
             Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
             OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_drop_cutoff");
 
-            // Add a partition for two days ago (UTC) that should be dropped
-            // by the start=-1 cutoff. Must temporarily disable dynamic partition
-            // to manually add a partition.
-            ZonedDateTime utcNow = ZonedDateTime.now(ZoneOffset.UTC);
+            // Inject a fixed clock so the test is deterministic regardless of
+            // wall-clock time.  Choose 2026-07-21 08:00:00Z when Asia/Shanghai
+            // is at 16:00 (same calendar day as UTC).  At this instant:
+            //
+            //   UTC now = 2026-07-21 08:00Z
+            //   start=-1 reserved lower (new, UTC)   = 2026-07-20 00:00Z
+            //   start=-1 reserved lower (old, +08:00) = 2026-07-19 16:00Z
+            //
+            //   p_old = [2026-07-19 00:00Z, 2026-07-20 00:00Z)
+            //
+            //   New code:  reserved [2026-07-20 00:00Z, ∞) → no intersect → DROP
+            //   Old code:  reserved [2026-07-19 16:00Z, ∞) → intersect  → KEEP
+            //
+            // The assertion below therefore always fails on the old
+            // implementation, not just for 16 hours of the day.
+            ZonedDateTime fixedNow = ZonedDateTime.of(
+                    2026, 7, 21, 8, 0, 0, 0, ZoneOffset.UTC);
+            DynamicPartitionScheduler.testNow = fixedNow;
+
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-            String oldLower = utcNow.minusDays(2).withHour(0).withMinute(0).withSecond(0)
-                    .withNano(0).format(fmt) + "+00:00";
-            String oldUpper = utcNow.minusDays(1).withHour(0).withMinute(0).withSecond(0)
-                    .withNano(0).format(fmt) + "+00:00";
+            String oldLower = fixedNow.minusDays(2).withHour(0).withMinute(0)
+                    .withSecond(0).withNano(0).format(fmt) + "+00:00";
+            String oldUpper = fixedNow.minusDays(1).withHour(0).withMinute(0)
+                    .withSecond(0).withNano(0).format(fmt) + "+00:00";
             alterTable("ALTER TABLE test.tstz_drop_cutoff SET "
                     + "('dynamic_partition.enable' = 'false')");
             alterTable("ALTER TABLE test.tstz_drop_cutoff ADD PARTITION p_old VALUES "
@@ -2473,6 +2488,7 @@ public class DynamicPartitionTableTest {
                         "00", lowerStr.substring(11, 13));
             }
         } finally {
+            DynamicPartitionScheduler.testNow = null;
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }
     }
@@ -3590,6 +3606,101 @@ public class DynamicPartitionTableTest {
                     currentFoundByRange);
             Assert.assertEquals("Old prefix: exclude exactly one partition",
                     totalPartitions - 1, historicalWithUtc.size());
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testTimeStampTzGetHistoricalPartitionsNoncanonicalRange() throws Exception {
+        // A pre-fix partition created under Asia/Shanghai has a lower bound
+        // at 16:00Z (Shanghai midnight = UTC 16:00 previous day).  The new
+        // scheduler captures currentUtcBorder at UTC midnight (00:00Z) which
+        // falls INSIDE such a partition but does NOT equal its lower endpoint.
+        // Exact lower-bound equality would miss this partition, leaving it
+        // in the historical list and corrupting auto-bucket calculations.
+        // Range containment (lower <= rangeKey < upper) correctly excludes it.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("America/Chicago");
+
+            // Create table without dynamic partition — we add ranges manually.
+            String createSql = "CREATE TABLE test.`tstz_noncanonical` (\n"
+                    + "  `k1` TIMESTAMPTZ NULL COMMENT \"\",\n"
+                    + "  `k2` int NULL COMMENT \"\"\n"
+                    + ") ENGINE=OLAP\n"
+                    + "DUPLICATE KEY(`k1`, `k2`)\n"
+                    + "PARTITION BY RANGE(`k1`)\n"
+                    + "()\n"
+                    + "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n"
+                    + "PROPERTIES (\n"
+                    + "\"replication_num\" = \"1\"\n"
+                    + ");";
+            createTable(createSql);
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+            OlapTable table = (OlapTable) db.getTableOrAnalysisException("tstz_noncanonical");
+
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+            // Non-canonical partition: lower = yesterday 16:00Z, upper = today 16:00Z.
+            // currentUtcBorder (today 00:00Z) is inside [yesterday 16:00Z, today 16:00Z)
+            // but does NOT equal the lower bound (16:00Z).
+            ZonedDateTime yesterday16Z = now.withHour(16).withMinute(0).withSecond(0).withNano(0);
+            if (now.getHour() < 16) {
+                yesterday16Z = yesterday16Z.minusDays(1);
+            }
+            ZonedDateTime today16Z = yesterday16Z.plusDays(1);
+            String oldLower = fmt.format(yesterday16Z) + "+00:00";
+            String oldUpper = fmt.format(today16Z) + "+00:00";
+            alterTable("ALTER TABLE test.tstz_noncanonical ADD PARTITION p_legacy VALUES "
+                    + "[('" + oldLower + "'), ('" + oldUpper + "'))");
+
+            // Historical non-overlapping partition (far in the past).
+            alterTable("ALTER TABLE test.tstz_noncanonical ADD PARTITION p_hist VALUES "
+                    + "[('2020-01-01 00:00:00+00:00'), ('2020-01-02 00:00:00+00:00'))");
+
+            Assert.assertEquals(2, table.getPartitionNames().size());
+
+            // currentUtcBorder = today's UTC midnight → inside p_legacy.
+            String currentUtcBorder = fmt.format(now.withHour(0).withMinute(0).withSecond(0).withNano(0)) + "+00:00";
+
+            // Sanity check: currentUtcBorder is inside p_legacy.
+            RangePartitionInfo info = (RangePartitionInfo) table.getPartitionInfo();
+            for (Map.Entry<Long, PartitionItem> entry : info.getIdToItem(false).entrySet()) {
+                RangePartitionItem item = (RangePartitionItem) entry.getValue();
+                String lowerStr = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+                String upperStr = item.getItems().upperEndpoint().getKeys().get(0).getStringValue();
+                if ("p_legacy".equals(table.getPartition(entry.getKey()).getName())) {
+                    Assert.assertTrue("00:00Z must be inside [" + lowerStr + ", " + upperStr + ")",
+                            currentUtcBorder.compareTo(lowerStr) >= 0
+                            && currentUtcBorder.compareTo(upperStr) < 0);
+                    Assert.assertFalse("00:00Z must NOT equal " + lowerStr,
+                            currentUtcBorder.equals(lowerStr));
+                }
+            }
+
+            String wrongNowPartitionName = "p_nonexistent";
+
+            // 1. Without currentUtcBorder: name-based fallback returns both.
+            List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, wrongNowPartitionName, null);
+            Assert.assertEquals("Name-based fallback returns all partitions",
+                    2, historicalNoUtc.size());
+
+            // 2. With currentUtcBorder: range containment excludes p_legacy
+            //    because 00:00Z ∈ [yesterday 16:00Z, today 16:00Z).
+            //    p_legacy's lower bound (16:00Z) ≠ 00:00Z, so exact equality
+            //    would NOT find it — only containment does.
+            List<Partition> historicalWithUtc = DynamicPartitionScheduler.getHistoricalPartitions(
+                    table, wrongNowPartitionName, currentUtcBorder);
+            Assert.assertEquals("Range containment excludes exactly one partition",
+                    1, historicalWithUtc.size());
+            Assert.assertFalse("p_legacy must be excluded by range containment",
+                    "p_legacy".equals(historicalWithUtc.get(0).getName()));
+            Assert.assertEquals("p_hist should survive",
+                    "p_hist", historicalWithUtc.get(0).getName());
         } finally {
             connectContext.getSessionVariable().setTimeZone(originalTimeZone);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -2449,7 +2449,7 @@ public class DynamicPartitionTableTest {
             // implementation, not just for 16 hours of the day.
             ZonedDateTime fixedNow = ZonedDateTime.of(
                     2026, 7, 21, 8, 0, 0, 0, ZoneOffset.UTC);
-            Mockito.doReturn(fixedNow).when(spyScheduler).getNow(Mockito.any());
+            Mockito.doReturn(fixedNow).when(spyScheduler).getNow(Mockito.anyBoolean(), Mockito.any());
             schedulerField.set(Env.getCurrentEnv(), spyScheduler);
 
             String createOlapTblStmt = "CREATE TABLE test.`tstz_drop_cutoff` (\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -2655,7 +2655,7 @@ public class DynamicPartitionTableTest {
 
         // 1. Without currentUtcBorder: name-based cannot identify the current partition.
         List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                table, wrongNowPartitionName, null);
+                table, wrongNowPartitionName);
         boolean currentFoundByName = false;
         for (Partition p : historicalNoUtc) {
             RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
@@ -2682,7 +2682,7 @@ public class DynamicPartitionTableTest {
         }
         Assert.assertNotNull("Should find the current partition", currentPartitionName);
         List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
-                table, currentPartitionName, currentUtcBorder);
+                table, currentPartitionName);
         boolean currentFoundByName2 = false;
         for (Partition p : historicalWithName) {
             RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
@@ -3509,7 +3509,7 @@ public class DynamicPartitionTableTest {
             // partition when nowPartitionName does not match.
             String wrongNowPartitionName = "p_nonexistent";
             List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, wrongNowPartitionName, null);
+                    table, wrongNowPartitionName);
             boolean currentFoundByName = false;
             for (Partition p : historicalNoUtc) {
                 RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
@@ -3536,7 +3536,7 @@ public class DynamicPartitionTableTest {
             }
             Assert.assertNotNull("Should find the current partition", currentPartitionName);
             List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, currentPartitionName, currentUtcBorder);
+                    table, currentPartitionName);
             boolean currentFoundByNameCorrect = false;
             for (Partition p : historicalWithName) {
                 RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
@@ -3626,7 +3626,7 @@ public class DynamicPartitionTableTest {
             // 1. Without currentUtcBorder: name-based fails to exclude the
             //    current partition because the name "q_nonexistent" matches nothing.
             List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, newPrefixNowName, null);
+                    table, newPrefixNowName);
             boolean currentFoundByName = false;
             for (Partition p : historicalNoUtc) {
                 RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
@@ -3653,7 +3653,7 @@ public class DynamicPartitionTableTest {
             Assert.assertNotNull("Should find the current partition", currentPartitionName);
             Assert.assertTrue("Current partition should start with 'p'", currentPartitionName.startsWith("p"));
             List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, currentPartitionName, currentUtcBorder);
+                    table, currentPartitionName);
             boolean currentFoundByName2 = false;
             for (Partition p : historicalWithName) {
                 RangePartitionItem item = (RangePartitionItem) info.getItem(p.getId());
@@ -3751,14 +3751,14 @@ public class DynamicPartitionTableTest {
 
             // 1. Without currentUtcBorder: name-based fallback returns both.
             List<Partition> historicalNoUtc = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, wrongNowPartitionName, null);
+                    table, wrongNowPartitionName);
             Assert.assertEquals("Name-based fallback returns all partitions",
                     2, historicalNoUtc.size());
 
             // 2. With the correct nowPartitionName matching p_legacy,
             //    name-based exclusion removes it.
             List<Partition> historicalWithName = DynamicPartitionScheduler.getHistoricalPartitions(
-                    table, "p_legacy", currentUtcBorder);
+                    table, "p_legacy");
             Assert.assertEquals("Name-based exclusion removes exactly one partition",
                     1, historicalWithName.size());
             Assert.assertFalse("p_legacy must be excluded by name match",

--- a/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
@@ -45,6 +45,8 @@ import org.junit.rules.ExpectedException;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
@@ -523,5 +525,75 @@ public class PropertyAnalyzerTest {
         } catch (AnalysisException e) {
             Assert.fail();
         }
+    }
+
+    @Test
+    public void testStorageCooldownTimeWithTzOffset() throws AnalysisException {
+        // A known UTC instant: 2027-06-15 12:30:00 UTC
+        ZonedDateTime zdt = ZonedDateTime.of(2027, 6, 15, 12, 30, 0, 0, ZoneOffset.UTC);
+        long expectedMillis = zdt.toInstant().toEpochMilli();
+
+        // +00:00 suffix — must be parsed as an instant via TZ_FORMATTER
+        String cooldownStr = "2027-06-15 12:30:00+00:00";
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, cooldownStr);
+        DataProperty dp = PropertyAnalyzer.analyzeDataProperty(properties,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("TZ offset +00:00 should parse as exact UTC instant",
+                expectedMillis, dp.getCooldownTimeMs());
+
+        // -05:00 offset — same instant, different representation
+        String cooldownStr2 = "2027-06-15 07:30:00-05:00";
+        Map<String, String> properties2 = Maps.newHashMap();
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, cooldownStr2);
+        DataProperty dp2 = PropertyAnalyzer.analyzeDataProperty(properties2,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("TZ offset -05:00 should parse as same UTC instant",
+                expectedMillis, dp2.getCooldownTimeMs());
+    }
+
+    @Test
+    public void testStorageCooldownTimeWithTzOffsetFractionalSeconds() throws AnalysisException {
+        // A known UTC instant with fractional seconds: 2027-06-15 12:30:00.123456 UTC
+        ZonedDateTime zdt = ZonedDateTime.of(2027, 6, 15, 12, 30, 0, 123456000, ZoneOffset.UTC);
+        long expectedMillis = zdt.toInstant().toEpochMilli();
+
+        // TIMESTAMPTZ(6) style string with +00:00 suffix
+        String cooldownStr = "2027-06-15 12:30:00.123456+00:00";
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, cooldownStr);
+        DataProperty dp = PropertyAnalyzer.analyzeDataProperty(properties,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("Fractional seconds with TZ offset should parse correctly",
+                expectedMillis, dp.getCooldownTimeMs());
+
+        // TIMESTAMPTZ(0) — no fractional seconds, with +00:00
+        String cooldownStr2 = "2027-06-15 12:30:00+00:00";
+        Map<String, String> properties2 = Maps.newHashMap();
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, cooldownStr2);
+        DataProperty dp2 = PropertyAnalyzer.analyzeDataProperty(properties2,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("No fractional seconds (precision 0) should still parse",
+                ZonedDateTime.of(2027, 6, 15, 12, 30, 0, 0, ZoneOffset.UTC)
+                        .toInstant().toEpochMilli(),
+                dp2.getCooldownTimeMs());
+    }
+
+    @Test
+    public void testStorageCooldownTimeInvalidTzFormat() throws AnalysisException {
+        // A value that looks like it has a TZ offset but is malformed
+        // (missing minutes in offset) — should fall back to MAX_COOLDOWN_TIME_MS
+        // instead of throwing an exception.
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, "2027-06-15 12:30:00+00");
+        DataProperty dp = PropertyAnalyzer.analyzeDataProperty(properties,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("Malformed TZ offset should fall back to MAX",
+                DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
@@ -51,6 +51,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.Set;
 
 public class PropertyAnalyzerTest {
@@ -663,5 +664,75 @@ public class PropertyAnalyzerTest {
         // The two instants must be distinct (1 hour apart).
         Assert.assertEquals("DST fall-back hours must differ by exactly 1 hour",
                 3600000L, laterMillis - earlierMillis);
+    }
+
+    @Test
+    public void testStorageCooldownTimeTzZoneIdsWinterTarget() throws AnalysisException {
+        // Regression: when the session/JVM timezone is in DST (e.g.
+        // America/Chicago in July = UTC-5), a cooldown value with Z/UTC/GMT
+        // suffix pointing to a winter month (e.g. 2027-01 = CST, UTC-6) went
+        // through the legacy DATETIME path because TZ_OFFSET_PATTERN only
+        // matched numeric ±HH:MM offsets.  DateLiteralUtils.createDateLiteral()
+        // first shifted the UTC instant using the current DST offset (-05:00),
+        // then unixTimestamp() applied the target date's winter offset (-06:00),
+        // producing a double-shifted wrong result.
+        //
+        // The fix normalizes Z/UTC/GMT to +00:00 and routes through
+        // TZ_FORMATTER (instant-aware parse), bypassing the legacy path
+        // entirely.
+        TimeZone originalTimezone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Chicago"));
+
+            // Winter-target instant: 2027-01-01 00:00:00 UTC.
+            ZonedDateTime winterZdt = ZonedDateTime.of(
+                    2027, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            long expectedMillis = winterZdt.toInstant().toEpochMilli();
+
+            // Test with Z suffix
+            Map<String, String> propsZ = Maps.newHashMap();
+            propsZ.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+            propsZ.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                    "2027-01-01 00:00:00Z");
+            DataProperty dpZ = PropertyAnalyzer.analyzeDataProperty(propsZ,
+                    new DataProperty(TStorageMedium.SSD));
+            Assert.assertEquals("'Z' suffix winter target must parse as UTC instant",
+                    expectedMillis, dpZ.getCooldownTimeMs());
+
+            // Test with UTC suffix
+            Map<String, String> propsUtc = Maps.newHashMap();
+            propsUtc.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+            propsUtc.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                    "2027-01-01 00:00:00UTC");
+            DataProperty dpUtc = PropertyAnalyzer.analyzeDataProperty(propsUtc,
+                    new DataProperty(TStorageMedium.SSD));
+            Assert.assertEquals("'UTC' suffix winter target must parse as UTC instant",
+                    expectedMillis, dpUtc.getCooldownTimeMs());
+
+            // Test with GMT suffix
+            Map<String, String> propsGmt = Maps.newHashMap();
+            propsGmt.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+            propsGmt.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                    "2027-01-01 00:00:00GMT");
+            DataProperty dpGmt = PropertyAnalyzer.analyzeDataProperty(propsGmt,
+                    new DataProperty(TStorageMedium.SSD));
+            Assert.assertEquals("'GMT' suffix winter target must parse as UTC instant",
+                    expectedMillis, dpGmt.getCooldownTimeMs());
+
+            // Summer-target Z with summer-time JVM must also work (baseline).
+            ZonedDateTime summerZdt = ZonedDateTime.of(
+                    2027, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            long expectedSummer = summerZdt.toInstant().toEpochMilli();
+            Map<String, String> propsSummer = Maps.newHashMap();
+            propsSummer.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+            propsSummer.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                    "2027-07-01 00:00:00Z");
+            DataProperty dpSummer = PropertyAnalyzer.analyzeDataProperty(propsSummer,
+                    new DataProperty(TStorageMedium.SSD));
+            Assert.assertEquals("Summer target with JVM summer must also work",
+                    expectedSummer, dpSummer.getCooldownTimeMs());
+        } finally {
+            TimeZone.setDefault(originalTimezone);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
@@ -625,35 +625,38 @@ public class PropertyAnalyzerTest {
 
     @Test
     public void testStorageCooldownTimeDstFallbackDistinctInstants() throws AnalysisException {
-        // On 2026-11-01 at 2:00 AM CDT, America/Chicago falls back to
-        // 1:00 AM CST.  The wall-clock hour 01:00–02:00 occurs twice:
-        //   01:00 CDT = 06:00 UTC  (earlier)
-        //   01:00 CST = 07:00 UTC  (later)
-        // A bare DATETIME string like "2026-11-01 01:30:00" is ambiguous
-        // without an offset.  With an explicit +00:00 suffix the instant
-        // parser correctly distinguishes the two.
+        // Two different UTC instants that would map to the same wall-clock
+        // hour during America/Chicago DST fall-back (e.g. on 2026-11-01,
+        // 01:30 CDT = 06:30 UTC and 01:30 CST = 07:30 UTC) must produce
+        // different cooldown timestamps when expressed with explicit +00:00.
+        //
+        // Use dynamically-derived dates 5 years ahead so the test never
+        // ages past System.currentTimeMillis() and gets rejected by the
+        // future-time policy in analyzeDataProperty().
+        ZonedDateTime baseUtc = ZonedDateTime.now(ZoneOffset.UTC).plusYears(5)
+                .withHour(6).withMinute(30).withSecond(0).withNano(0);
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
 
-        // Earlier occurrence: 01:30 CDT = 06:30 UTC
-        String earlierStr = "2026-11-01 06:30:00+00:00";
+        // Earlier instant (e.g. 06:30 UTC)
+        String earlierStr = fmt.format(baseUtc) + "+00:00";
         Map<String, String> propsEarlier = Maps.newHashMap();
         propsEarlier.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
         propsEarlier.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, earlierStr);
         DataProperty dpEarlier = PropertyAnalyzer.analyzeDataProperty(propsEarlier,
                 new DataProperty(TStorageMedium.SSD));
-        long earlierMillis = ZonedDateTime.of(2026, 11, 1, 6, 30, 0, 0, ZoneOffset.UTC)
-                .toInstant().toEpochMilli();
+        long earlierMillis = baseUtc.toInstant().toEpochMilli();
         Assert.assertEquals("Explicit +00:00 should parse earlier DST hour correctly",
                 earlierMillis, dpEarlier.getCooldownTimeMs());
 
-        // Later occurrence: 01:30 CST = 07:30 UTC
-        String laterStr = "2026-11-01 07:30:00+00:00";
+        // Later instant (1 hour later, e.g. 07:30 UTC)
+        ZonedDateTime laterUtc = baseUtc.plusHours(1);
+        String laterStr = fmt.format(laterUtc) + "+00:00";
         Map<String, String> propsLater = Maps.newHashMap();
         propsLater.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
         propsLater.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, laterStr);
         DataProperty dpLater = PropertyAnalyzer.analyzeDataProperty(propsLater,
                 new DataProperty(TStorageMedium.SSD));
-        long laterMillis = ZonedDateTime.of(2026, 11, 1, 7, 30, 0, 0, ZoneOffset.UTC)
-                .toInstant().toEpochMilli();
+        long laterMillis = laterUtc.toInstant().toEpochMilli();
         Assert.assertEquals("Explicit +00:00 should parse later DST hour correctly",
                 laterMillis, dpLater.getCooldownTimeMs());
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
@@ -51,8 +51,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.Set;
+import java.util.TimeZone;
+
 
 public class PropertyAnalyzerTest {
     @Rule

--- a/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
@@ -596,4 +596,69 @@ public class PropertyAnalyzerTest {
         Assert.assertEquals("Malformed TZ offset should fall back to MAX",
                 DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
     }
+
+    @Test
+    public void testStorageCooldownTimeStrictDateValidation() throws AnalysisException {
+        // An invalid calendar date with a valid TZ offset (Feb 29 in a
+        // non-leap year) must be rejected by the STRICT resolver rather
+        // than silently normalized to Feb 28, and should fall back to
+        // MAX_COOLDOWN_TIME_MS.
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                "2027-02-29 00:00:00+00:00");
+        DataProperty dp = PropertyAnalyzer.analyzeDataProperty(properties,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("Invalid date (Feb 29 in non-leap year) should fall back to MAX",
+                DataProperty.MAX_COOLDOWN_TIME_MS, dp.getCooldownTimeMs());
+
+        // Also test an impossible month (month=13)
+        Map<String, String> properties2 = Maps.newHashMap();
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties2.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+                "2027-13-01 00:00:00+00:00");
+        DataProperty dp2 = PropertyAnalyzer.analyzeDataProperty(properties2,
+                new DataProperty(TStorageMedium.SSD));
+        Assert.assertEquals("Invalid month (13) should fall back to MAX",
+                DataProperty.MAX_COOLDOWN_TIME_MS, dp2.getCooldownTimeMs());
+    }
+
+    @Test
+    public void testStorageCooldownTimeDstFallbackDistinctInstants() throws AnalysisException {
+        // On 2026-11-01 at 2:00 AM CDT, America/Chicago falls back to
+        // 1:00 AM CST.  The wall-clock hour 01:00–02:00 occurs twice:
+        //   01:00 CDT = 06:00 UTC  (earlier)
+        //   01:00 CST = 07:00 UTC  (later)
+        // A bare DATETIME string like "2026-11-01 01:30:00" is ambiguous
+        // without an offset.  With an explicit +00:00 suffix the instant
+        // parser correctly distinguishes the two.
+
+        // Earlier occurrence: 01:30 CDT = 06:30 UTC
+        String earlierStr = "2026-11-01 06:30:00+00:00";
+        Map<String, String> propsEarlier = Maps.newHashMap();
+        propsEarlier.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        propsEarlier.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, earlierStr);
+        DataProperty dpEarlier = PropertyAnalyzer.analyzeDataProperty(propsEarlier,
+                new DataProperty(TStorageMedium.SSD));
+        long earlierMillis = ZonedDateTime.of(2026, 11, 1, 6, 30, 0, 0, ZoneOffset.UTC)
+                .toInstant().toEpochMilli();
+        Assert.assertEquals("Explicit +00:00 should parse earlier DST hour correctly",
+                earlierMillis, dpEarlier.getCooldownTimeMs());
+
+        // Later occurrence: 01:30 CST = 07:30 UTC
+        String laterStr = "2026-11-01 07:30:00+00:00";
+        Map<String, String> propsLater = Maps.newHashMap();
+        propsLater.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        propsLater.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, laterStr);
+        DataProperty dpLater = PropertyAnalyzer.analyzeDataProperty(propsLater,
+                new DataProperty(TStorageMedium.SSD));
+        long laterMillis = ZonedDateTime.of(2026, 11, 1, 7, 30, 0, 0, ZoneOffset.UTC)
+                .toInstant().toEpochMilli();
+        Assert.assertEquals("Explicit +00:00 should parse later DST hour correctly",
+                laterMillis, dpLater.getCooldownTimeMs());
+
+        // The two instants must be distinct (1 hour apart).
+        Assert.assertEquals("DST fall-back hours must differ by exactly 1 hour",
+                3600000L, laterMillis - earlierMillis);
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketCalculatorTest.java
@@ -68,4 +68,29 @@ public class AutoBucketCalculatorTest {
 
         Assertions.assertEquals(10, buckets);
     }
+
+    @Test
+    public void testAutoBucketContextWithCurrentUtcBorder() {
+        Mockito.when(table.getName()).thenReturn("test_table");
+        Mockito.when(table.getId()).thenReturn(1L);
+
+        String currentUtcBorder = "2026-07-06 00:00:00+00:00";
+
+        // 6-param constructor: currentUtcBorder is explicitly provided.
+        AutoBucketContext contextWithUtc = new AutoBucketContext(
+                table, "p1", "p2", false, 10, currentUtcBorder);
+        Assertions.assertEquals(currentUtcBorder, contextWithUtc.getCurrentUtcBorder());
+        Assertions.assertEquals("p1", contextWithUtc.getPartitionName());
+        Assertions.assertEquals("p2", contextWithUtc.getNowPartitionName());
+        Assertions.assertFalse(contextWithUtc.isExecuteFirstTime());
+        Assertions.assertEquals(10, contextWithUtc.getDefaultBuckets());
+
+        // 5-param backward-compat constructor: currentUtcBorder defaults to null.
+        AutoBucketContext contextNoUtc = new AutoBucketContext(
+                table, "p3", "p4", true, 5);
+        Assertions.assertNull(contextNoUtc.getCurrentUtcBorder());
+        Assertions.assertEquals("p3", contextNoUtc.getPartitionName());
+        Assertions.assertTrue(contextNoUtc.isExecuteFirstTime());
+        Assertions.assertEquals(5, contextNoUtc.getDefaultBuckets());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketCalculatorTest.java
@@ -70,27 +70,16 @@ public class AutoBucketCalculatorTest {
     }
 
     @Test
-    public void testAutoBucketContextWithCurrentUtcBorder() {
+    public void testAutoBucketContextConstructor() {
         Mockito.when(table.getName()).thenReturn("test_table");
         Mockito.when(table.getId()).thenReturn(1L);
 
-        String currentUtcBorder = "2026-07-06 00:00:00+00:00";
-
-        // 6-param constructor: currentUtcBorder is explicitly provided.
-        AutoBucketContext contextWithUtc = new AutoBucketContext(
-                table, "p1", "p2", false, 10, currentUtcBorder);
-        Assertions.assertEquals(currentUtcBorder, contextWithUtc.getCurrentUtcBorder());
-        Assertions.assertEquals("p1", contextWithUtc.getPartitionName());
-        Assertions.assertEquals("p2", contextWithUtc.getNowPartitionName());
-        Assertions.assertFalse(contextWithUtc.isExecuteFirstTime());
-        Assertions.assertEquals(10, contextWithUtc.getDefaultBuckets());
-
-        // 5-param backward-compat constructor: currentUtcBorder defaults to null.
-        AutoBucketContext contextNoUtc = new AutoBucketContext(
+        // 5-param constructor
+        AutoBucketContext context = new AutoBucketContext(
                 table, "p3", "p4", true, 5);
-        Assertions.assertNull(contextNoUtc.getCurrentUtcBorder());
-        Assertions.assertEquals("p3", contextNoUtc.getPartitionName());
-        Assertions.assertTrue(contextNoUtc.isExecuteFirstTime());
-        Assertions.assertEquals(5, contextNoUtc.getDefaultBuckets());
+        Assertions.assertEquals("p3", context.getPartitionName());
+        Assertions.assertEquals("p4", context.getNowPartitionName());
+        Assertions.assertTrue(context.isExecuteFirstTime());
+        Assertions.assertEquals(5, context.getDefaultBuckets());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -254,4 +254,33 @@ public class TimeUtilsTest {
         ExceptionChecker.expectThrows(DateTimeParseException.class,
                 () -> TimeUtils.convertStringToDateTimeV2("2024-10-10 11:11:11", 6));
     }
+
+    @Test
+    public void testLongToTimeStringWithTimeZoneAndOffset() {
+        // null/zero/negative → null_string
+        Assert.assertEquals(FeConstants.null_string,
+                TimeUtils.longToTimeStringWithTimeZoneAndOffset(null, "UTC"));
+        Assert.assertEquals(FeConstants.null_string,
+                TimeUtils.longToTimeStringWithTimeZoneAndOffset(0L, "UTC"));
+        Assert.assertEquals(FeConstants.null_string,
+                TimeUtils.longToTimeStringWithTimeZoneAndOffset(-1L, "Asia/Shanghai"));
+
+        long ts = org.apache.doris.catalog.DataProperty.MAX_COOLDOWN_TIME_MS;
+
+        // UTC → "9999-12-31 15:59:59Z"
+        String utcResult = TimeUtils.longToTimeStringWithTimeZoneAndOffset(ts, "UTC");
+        Assert.assertEquals("9999-12-31 15:59:59Z", utcResult);
+
+        // Asia/Shanghai (+08:00) → "9999-12-31 23:59:59+08:00"
+        String shanghaiResult = TimeUtils.longToTimeStringWithTimeZoneAndOffset(ts, "Asia/Shanghai");
+        Assert.assertEquals("9999-12-31 23:59:59+08:00", shanghaiResult);
+
+        // America/New_York (-05:00) → "9999-12-31 10:59:59-05:00"
+        String nyResult = TimeUtils.longToTimeStringWithTimeZoneAndOffset(ts, "America/New_York");
+        Assert.assertEquals("9999-12-31 10:59:59-05:00", nyResult);
+
+        // America/Chicago (-06:00) → "9999-12-31 09:59:59-06:00"
+        String chicagoResult = TimeUtils.longToTimeStringWithTimeZoneAndOffset(ts, "America/Chicago");
+        Assert.assertEquals("9999-12-31 09:59:59-06:00", chicagoResult);
+    }
 }


### PR DESCRIPTION

Related PR: https://github.com/apache/doris/pull/64795

Problem Summary:
When a table has a `TIMESTAMPTZ` partition column and `dynamic_partition.time_zone` is set to a non-UTC timezone (e.g., `Asia/Shanghai`), the dynamically created partition boundaries are shifted to midnight in the configured timezone rather than UTC midnight.

**Root cause:** `getAddPartitionOp()` computed the current date (`now`) in the configured timezone, then `convertToUtcTimestamp()` interpreted the resulting date string as midnight in that timezone and converted it to UTC — producing a timezone-offset hour (e.g., 16:00) instead of UTC midnight (00:00). Both the `now` computation and the timezone used in `convertToUtcTimestamp()` needed to be fixed.

### Fix

In `DynamicPartitionScheduler.getAddPartitionOp()`, decouple the time references for boundary computation and naming:

1. **Boundary computation**: For `TIMESTAMPTZ`, use `ZonedDateTime.now(UTC)` for the current clock and pass UTC as the source timezone to `convertToUtcTimestamp()`. This ensures partition boundaries are at UTC midnight (00:00–24:00) regardless of `dynamic_partition.time_zone`.

2. **Partition naming**: For TIMESTAMPTZ columns, partition names are now generated from the same UTC-based clock as partition boundary values, via a shared setupDynamicPartitionTime() context. This keeps names and values consistent — both reflect UTC 00:00–24:00 boundaries — instead of the previous approach where names used the configured timezone's wall clock while values used UTC, which could misalign at timezone boundaries (e.g., a day partition named p20270101 but spanning [[2027-01-01 08:00 UTC, 2027-01-02 08:00 UTC) under Asia/Shanghai). For non-TIMESTAMPTZ columns, the dynamic_partition.time_zone property continues to control naming (e.g., week-of-year computation for week partitions) as before.



3. **Storage properties**: `setStorageMediumProperty()` and `setStoragePolicyProperty()` also use the configured-timezone `nowTz` so hot partition determination stays consistent with naming.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

