### PR TITLE
[fix](regression) relax audit queue time assertion

### DIFF
--- a/regression-test/suites/audit/test_audit_log_queue_time.groovy
+++ b/regression-test/suites/audit/test_audit_log_queue_time.groovy
@@ -59,6 +59,7 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
 
     // Submit concurrent queries with marker for later lookup
     def sqlSleepTime = 5
+    def queueTimeToleranceMs = 1000
     def queuedSqlCnt = 1
     def queryCnt = maxConcurrency + queuedSqlCnt
     def readyLatch = new java.util.concurrent.CountDownLatch(queryCnt)
@@ -120,6 +121,10 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
 
     log.info("audit queue time result for marker ${testMarker}: ${auditResult}")
     assertTrue(auditResult.size() >= queuedSqlCnt)
+    // The workers are released together above, so this lower bound proves queue wait behind a sleep query.
+    def minExpectedQueueTimeMs = sqlSleepTime * 1000 - queueTimeToleranceMs
+    def hasExpectedQueuedQuery = auditResult.any { row -> row[1] >= minExpectedQueueTimeMs }
+    assertTrue(hasExpectedQueuedQuery)
 
     // Cleanup
     sql "drop table if exists ${tableName}"

--- a/regression-test/suites/audit/test_audit_log_queue_time.groovy
+++ b/regression-test/suites/audit/test_audit_log_queue_time.groovy
@@ -60,6 +60,7 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
     // Submit concurrent queries with marker for later lookup
     def sqlSleepTime = 5
     def queuedSqlCnt = 1
+    def queueTimeToleranceMs = 1000
     def threads = []
     for (int i = 0; i < maxConcurrency + queuedSqlCnt; i++) {
         def idx = i
@@ -110,11 +111,12 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
         auditResult = sql "${query}"
     }
 
-    auditResult.each { row ->
-        assertTrue(row[1] >= sqlSleepTime * 1000)
+    log.info("audit queue time result for marker ${testMarker}: ${auditResult}")
+    def minExpectedQueueTimeMs = sqlSleepTime * 1000 - queueTimeToleranceMs
+    def queuedRows = auditResult.findAll { row ->
+        row[1] >= minExpectedQueueTimeMs
     }
-
-    assertTrue(auditResult.size() >= queuedSqlCnt)
+    assertTrue(queuedRows.size() >= queuedSqlCnt)
 
     // Cleanup
     sql "drop table if exists ${tableName}"

--- a/regression-test/suites/audit/test_audit_log_queue_time.groovy
+++ b/regression-test/suites/audit/test_audit_log_queue_time.groovy
@@ -60,13 +60,17 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
     // Submit concurrent queries with marker for later lookup
     def sqlSleepTime = 5
     def queuedSqlCnt = 1
-    def queueTimeToleranceMs = 1000
+    def queryCnt = maxConcurrency + queuedSqlCnt
+    def readyLatch = new java.util.concurrent.CountDownLatch(queryCnt)
+    def startLatch = new java.util.concurrent.CountDownLatch(1)
     def threads = []
-    for (int i = 0; i < maxConcurrency + queuedSqlCnt; i++) {
+    for (int i = 0; i < queryCnt; i++) {
         def idx = i
         threads << Thread.start {
             try {
                 sql "set workload_group=${wgName}"
+                readyLatch.countDown()
+                startLatch.await()
                 // Use sleep function to simulate long query, ensuring subsequent queries need to queue
                 sql """
                     select sleep(${sqlSleepTime}), '${testMarker}_${idx}' as marker
@@ -79,7 +83,10 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
     }
 
     // Wait for all queries to complete
+    def allQueriesReady = readyLatch.await(30, java.util.concurrent.TimeUnit.SECONDS)
+    startLatch.countDown()
     threads.each { it.join() }
+    assertTrue(allQueriesReady)
 
     // Wait for audit log to flush
     Thread.sleep(5000)
@@ -112,11 +119,7 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
     }
 
     log.info("audit queue time result for marker ${testMarker}: ${auditResult}")
-    def minExpectedQueueTimeMs = sqlSleepTime * 1000 - queueTimeToleranceMs
-    def queuedRows = auditResult.findAll { row ->
-        row[1] >= minExpectedQueueTimeMs
-    }
-    assertTrue(queuedRows.size() >= queuedSqlCnt)
+    assertTrue(auditResult.size() >= queuedSqlCnt)
 
     // Cleanup
     sql "drop table if exists ${tableName}"

--- a/regression-test/suites/audit/test_audit_log_queue_time.groovy
+++ b/regression-test/suites/audit/test_audit_log_queue_time.groovy
@@ -105,6 +105,8 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
         select query_id, queue_time_ms, stmt
         from __internal_schema.audit_log
         where stmt like '%${testMarker}%'
+        and stmt like '%sleep(${sqlSleepTime})%'
+        and stmt not like '%__internal_schema.audit_log%'
         and queue_time_ms > 0
         order by time
     """
@@ -123,8 +125,8 @@ suite("test_audit_log_queue_time", "nonConcurrent") {
     assertTrue(auditResult.size() >= queuedSqlCnt)
     // The workers are released together above, so this lower bound proves queue wait behind a sleep query.
     def minExpectedQueueTimeMs = sqlSleepTime * 1000 - queueTimeToleranceMs
-    def hasExpectedQueuedQuery = auditResult.any { row -> row[1] >= minExpectedQueueTimeMs }
-    assertTrue(hasExpectedQueuedQuery)
+    def maxQueueTimeMs = auditResult.collect { row -> Long.parseLong(row[1].toString()) }.max()
+    assertTrue(maxQueueTimeMs >= minExpectedQueueTimeMs)
 
     // Cleanup
     sql "drop table if exists ${tableName}"


### PR DESCRIPTION
## Summary

Deflake `test_audit_log_queue_time` by removing the exact `queue_time_ms >= sleep(5) * 1000` assumption while keeping a meaningful queue-wait lower bound.

The flaky failure in TeamCity build 986222 showed the queued query did enter `test_queue_time_wg`, but its audit record had `QueueTimeMs=4984` for a `sleep(5)` query. That is expected because queue time is measured from the queued query's own `QueueToken` start time, and unsynchronized test threads do not enter the workload queue at the exact same millisecond.

This patch keeps the test focused on the intended behavior:

- synchronize worker threads after `set workload_group` so the concurrent `select sleep(5)` statements are released together
- filter audit rows down to the worker `select sleep(...)` statements and exclude audit-log polling SQL, because the polling SQL also contains the test marker in its `LIKE` predicate
- verify that at least the expected number of worker audit rows report positive `queue_time_ms`
- verify that the maximum worker `queue_time_ms` is `>= sleep(5) - tolerance`, proving one worker waited behind a sleep query
- log the collected audit rows to make future failures easier to diagnose

## Testing

- `git diff --check`
- Analyzed TeamCity build 986222 FE audit log:
  - first query: `QueueTimeMs=0`
  - queued query: `QueueTimeMs=4984`
