### PR TITLE
[branch-4.1][fix](test) backport check_before_quit variant round-trip fix

### DIFF
--- a/regression-test/suites/check_before_quit/check_before_quit.groovy
+++ b/regression-test/suites/check_before_quit/check_before_quit.groovy
@@ -253,6 +253,7 @@ suite("check_before_quit", "nonConcurrent,p0") {
     // parser bakes the current session default into the column. The per-connection
     // session-variable fuzzer randomizes these, which would otherwise make a bare-variant
     // origin re-render with PROPERTIES and break the round-trip comparison.
+    sql "set default_variant_enable_doc_mode = false;"
     sql "set default_variant_max_subcolumns_count = 0;"
     sql "set default_variant_sparse_hash_shard_count = 0;"
     sql """

--- a/regression-test/suites/variant_p0/doc_mode/predefine/load.groovy
+++ b/regression-test/suites/variant_p0/doc_mode/predefine/load.groovy
@@ -203,9 +203,9 @@ suite("test_variant_predefine_doc_value", "nonConcurrent"){
 
     // // schema change
     // // 1. add column
-    sql "alter table test_predefine1 add column v2 variant<'dcm':double,'dt':string> default null"
+    sql "alter table test_predefine1 add column v2 variant<'dcm':double,'dt':string, properties(\"variant_enable_doc_mode\" = \"false\")> default null"
     sql """insert into test_predefine1 values(101, '{"a" :1}', '{"dcm": 1111111}')""" 
-    sql "alter table test_predefine1 add column v3 variant<'dcm':double,'dt':string,'ip':string> default null"
+    sql "alter table test_predefine1 add column v3 variant<'dcm':double,'dt':string,'ip':string, properties(\"variant_enable_doc_mode\" = \"false\")> default null"
     sql """insert into test_predefine1 values(102, '{"a" :1}', '{"dcm": 1111111}', '{"dcm": 1111111}');"""
     // 2. todo support alter column type
     // sql "alter table test_predefine1 modify column v3 variant<dcm:decimal,dt:datetime,ip:ipv6>"


### PR DESCRIPTION
## Summary

Cherry-pick the master fix from #65093 to `branch-4.1`.

- Pin `default_variant_enable_doc_mode=false` before `check_before_quit` recreates tables from `SHOW CREATE TABLE`.
- Keep schema-change columns on the legacy `test_predefine1` flatten-nested table in non-doc mode, so the table left by `variant_p0/doc_mode/predefine/load.groovy` remains recreate-able by `SHOW CREATE TABLE`.

`branch-4.1` already had the older #64613 pinning for max subcolumns and sparse hash shard count. This backport adds the missing doc-mode pin and the follow-up flatten-nested table fix.

## Testing

- [x] `git diff --check origin/branch-4.1...HEAD`
- [ ] Not run locally. `check_before_quit` validates the state left by a full regression pipeline.
