### PR TITLE
[fix](regression) check partition minmax only

### DIFF
--- a/regression-test/suites/nereids_p0/stats/partition_key_minmax.groovy
+++ b/regression-test/suites/nereids_p0/stats/partition_key_minmax.groovy
@@ -38,14 +38,14 @@ suite("partition_key_minmax") {
         sql """memo plan
             select * from rangetable where a < 250;
             """
-        // case 1: partition col stats not available, partition row count not available
-        containsAny("a#0 -> ndv=2.6667, min=5.000000(5), max=30.000000(30)")
-        // case 2: partition col stats not available, partition row count available
-        containsAny("a#0 -> ndv=3.0000, min=5.000000(5), max=30.000000(30)")
-        // case 3: partition col stats available, partition row count not available
-        containsAny("a#0 -> ndv=2.6667, min=5.000000(5), max=22.000000(22)")
-        // case 4: partition col stats available, partition row count available
-        containsAny("a#0 -> ndv=3.0000, min=5.000000(5), max=22.000000(22)")
+        // Check partition-key min/max only. ndv/count depends on async physical row-count reporting.
+        check { explainString ->
+            explainString.readLines().any { line ->
+                line.contains("a#0 ->")
+                        && (line.contains("min=5.000000(5), max=30.000000(30)")
+                            || line.contains("min=5.000000(5), max=22.000000(22)"))
+            }
+        }
     }
 
     sql """
@@ -71,7 +71,12 @@ suite("partition_key_minmax") {
         sql """
          memo plan select * from listtable where id >=3;
         """
-        contains("id#0 -> ndv=1.0000, min=3.000000(3), max=3.000000(3), count=1.0000")
+        // Check partition-key min/max only. ndv/count depends on async physical row-count reporting.
+        check { explainString ->
+            explainString.readLines().any { line ->
+                line.contains("id#0 ->")
+                        && line.contains("min=3.000000(3), max=3.000000(3)")
+            }
+        }
     }
 }
-


### PR DESCRIPTION
## Proposed changes

Backport #65180 to branch-4.1. On branch-4.1, `partition_key_minmax` still lives under `nereids_p0/stats`, so this applies the same final fix to the branch-specific path instead of directly picking the master file path.

The case is intended to validate partition-pruned partition-key min/max. The previous checks also depended on `ndv/count`, which can vary with async physical row-count reporting. This patch keeps the existing RANGE/LIST queries and checks only the partition-key min/max invariants.

## Testing

- `git diff --check -- regression-test/suites/nereids_p0/stats/partition_key_minmax.groovy`
- `git diff --check HEAD^ HEAD -- regression-test/suites/nereids_p0/stats/partition_key_minmax.groovy`

Targeted regression was not run locally; CI will cover it.
