### PR TITLE
branch-4.0: [test](schema-change) log alter job state in test_schema_change_mow_with_empty_rowset

### DIFF
--- a/regression-test/suites/schema_change_p0/test_schema_change_mow_with_empty_rowset.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_mow_with_empty_rowset.groovy
@@ -68,6 +68,7 @@ suite("test_schema_change_mow_with_empty_rowset", "p0") {
     Awaitility.await().atMost(30, TimeUnit.SECONDS).pollDelay(10, TimeUnit.MILLISECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(
         {
             String res = getJobState(tableName)
+            logger.info("alter table ${tableName} job state: ${res}")
             if (res == "FINISHED" || res == "CANCELLED") {
                 assertEquals("FINISHED", res)
                 return true


### PR DESCRIPTION
## Summary

Cherry-pick #64903 to branch-4.0.

This adds the polled schema-change job state to
`test_schema_change_mow_with_empty_rowset` logs so future branch-4.0 failures
show whether the job is still running or has become `CANCELLED`.

This is a logging-only backport and does not change the case assertion or the
Cloud MOW schema-change behavior. The product-side delete-bitmap lock failure
for this case is still tracked separately by DORIS-26740.

## Testing

- [x] Cherry-picked cleanly onto branch-4.0
- [x] Verified diff is one inserted `logger.info` line
- [ ] Not run locally; requires a Doris Cloud branch-4.0 regression environment
