### PR TITLE
[fix](regression) stabilize branch-4.1 colocate column order test

### DIFF
--- a/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
+++ b/regression-test/suites/correctness_p0/test_colocate_join_of_column_order.groovy
@@ -101,21 +101,9 @@ suite("test_colocate_join_of_column_order") {
     sql """insert into test_colocate_join_of_column_order_tb values(1,1);"""
     sql """insert into test_colocate_join_of_column_order_tc values(1,1);"""
 
-    // Pin column statistics so the cost-based COLOCATE-vs-PARTITIONED choice is deterministic.
-    // Freshly-created tables have rowCountReported=false (only the async CloudTabletStatMgr sets it,
-    // up to a full tick after INSERT); with unreliable stats the optimizer can fall back to a
-    // PARTITIONED shuffle join, which makes the COLOCATE assertion below flaky. Injecting stats
-    // (userInjected) bypasses the async-report dependency. See nereids_p0/join/initial_join_order.
-    sql """alter table test_colocate_join_of_column_order_ta modify column c1 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_ta modify column c2 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tb modify column c1 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tb modify column c2 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tc modify column c1 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-    sql """alter table test_colocate_join_of_column_order_tc modify column c2 set stats ('row_count'='1', 'ndv'='1', 'num_nulls'='0', 'min_value'='1', 'max_value'='1')"""
-
     waitForColocateGroupStable("group_column_order3")
     explain {
-        sql("""select /*+ set_var(disable_join_reorder=true) */ * from test_colocate_join_of_column_order_ta join [shuffle] (select cast((c2 + 1) as bigint) c2 from test_colocate_join_of_column_order_tb) test_colocate_join_of_column_order_tb  on test_colocate_join_of_column_order_ta.c1 = test_colocate_join_of_column_order_tb.c2 join [shuffle] test_colocate_join_of_column_order_tc on test_colocate_join_of_column_order_tb.c2 = test_colocate_join_of_column_order_tc.c1;""");
+        sql("""select /*+ set_var(disable_join_reorder=true, parallel_pipeline_task_num=1) */ * from test_colocate_join_of_column_order_ta join [shuffle] (select cast((c2 + 1) as bigint) c2 from test_colocate_join_of_column_order_tb) test_colocate_join_of_column_order_tb  on test_colocate_join_of_column_order_ta.c1 = test_colocate_join_of_column_order_tb.c2 join [shuffle] test_colocate_join_of_column_order_tc on test_colocate_join_of_column_order_tb.c2 = test_colocate_join_of_column_order_tc.c1;""");
         contains "COLOCATE"
     }
 


### PR DESCRIPTION
## Proposed changes

Backport the final master-side stabilization for `test_colocate_join_of_column_order` to branch-4.1.

Master PR #64940 fixed this case by pinning `parallel_pipeline_task_num=1` in the three-table colocate explain query. Branch-4.1 still had the earlier stats-injection workaround from #64613, but later failure evidence showed stats pinning was not the root cause: the flaky plan shape is driven by bucket-shuffle downgrade under higher runtime parallelism.

This patch removes the obsolete stats injection and pins `parallel_pipeline_task_num=1` for the target explain SQL.

Related to #64960.
Follow-up/backport of #64940.

## Testing

- [x] `git diff --check`
- [ ] Not run regression locally; requires Cloud P0-compatible regression environment.
