### PR TITLE
[fix](test) Set profile level for writer profile case

### DIFF
--- a/regression-test/suites/query_profile/test_writer_profile.groovy
+++ b/regression-test/suites/query_profile/test_writer_profile.groovy
@@ -45,6 +45,7 @@ suite('test_writer_profile', "nonConcurrent") {
     }
     
     sql "set enable_profile=true;"
+    sql "set profile_level=1;"
 
     def s3Endpoint = getS3Endpoint()
     def s3Region = getS3Region()


### PR DESCRIPTION
## Summary

Fix branch-4.1 query_profile/test_writer_profile by explicitly setting profile_level=1 before the first INSERT profile check.

The case verifies that writer details are hidden at profile level 1 and present at profile level 2. branch-4.1 now defaults profile_level to 2, so the first half must set the intended level explicitly instead of depending on the old default.

## Testing

- [x] git diff --check
- [ ] Runtime regression test not run locally; requires branch-4.1 regression environment with S3 credentials