### PR TITLE
[fix](regression) Fix test_query_stmt size assertion

### DIFF
--- a/regression-test/suites/http_rest_api/post/test_query_stmt.groovy
+++ b/regression-test/suites/http_rest_api/post/test_query_stmt.groovy
@@ -152,7 +152,7 @@ suite("test_query_stmt") {
     assertEquals(obj.msg, SUCCESS_MSG)
     assertEquals(obj.code, SUCCESS_CODE)
     // we can only check the number is correctly
-    assertEquals(obj.data.data.size, 3)
+    assertEquals(obj.data.data.size(), 3)
 
     url = "/api/query_schema/default_cluster/" + context.config.defaultDb
     def stmt5 = " select * from ${tableName}"


### PR DESCRIPTION
## Summary

Pick master PR #62455 to branch-4.1 for `http_rest_api.post.test_query_stmt`.

The branch-4.1 case still uses Groovy property access:

```groovy
obj.data.data.size
```

Under the current regression runtime this can be interpreted as GPath property access over the nested list and fail with:

```text
groovy.lang.MissingPropertyException: No such property: size for class: java.lang.Integer
```

Use the explicit method call instead:

```groovy
obj.data.data.size()
```

## Testing

- [x] Cherry-picked master commit `50cbb9f82a1` (`apache/doris#62455`) onto branch-4.1.
- [x] Verified the branch diff only changes `regression-test/suites/http_rest_api/post/test_query_stmt.groovy`.
- [ ] `run buildall`
