### PR TITLE
[fix](eager-agg) Skip eager aggregation for empty relation context

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriter.java
@@ -150,9 +150,9 @@ public class EagerAggRewriter extends DefaultPlanRewriter<PushDownAggContext> {
                 context.needOutputCount(), rightFuncs);
         boolean rightNeedOutputCount = needOutputCountForJoinChild(join, toRight, toLeft,
                 context.needOutputCount(), leftFuncs);
-        Optional<PushDownAggContext> leftChildContext = toLeft ? Optional.of(context.forOneBranch(leftFuncs,
+        Optional<PushDownAggContext> leftChildContext = toLeft ? Optional.ofNullable(context.forOneBranch(leftFuncs,
                 leftAliasMap, leftChildGroupByKeys, passThroughBigJoin, leftNeedOutputCount)) : Optional.empty();
-        Optional<PushDownAggContext> rightChildContext = toRight ? Optional.of(context.forOneBranch(rightFuncs,
+        Optional<PushDownAggContext> rightChildContext = toRight ? Optional.ofNullable(context.forOneBranch(rightFuncs,
                 rightAliasMap, rightChildGroupByKeys, passThroughBigJoin, rightNeedOutputCount)) : Optional.empty();
 
         Plan newLeft = join.left();
@@ -744,6 +744,9 @@ public class EagerAggRewriter extends DefaultPlanRewriter<PushDownAggContext> {
 
     @Override
     public Plan visitLogicalRelation(LogicalRelation relation, PushDownAggContext context) {
+        if (context.aggFuncAndGroupKeyAllEmpty()) {
+            return relation;
+        }
         return genAggregate(relation, context);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/PushDownAggContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/PushDownAggContext.java
@@ -153,6 +153,9 @@ public class PushDownAggContext {
     public PushDownAggContext forOneBranch(List<AggregateFunction> branchAggFunctions,
             Map<AggregateFunction, Alias> branchAliasMap, List<SlotReference> groupKeys,
             boolean passThroughBigJoin, boolean needOutputCount) {
+        if (branchAggFunctions.isEmpty() && groupKeys.isEmpty()) {
+            return null;
+        }
         return new PushDownAggContext(branchAggFunctions, groupKeys, branchAliasMap,
                 cascadesContext, passThroughBigJoin, hasDecomposedAggIf, hasCaseWhen,
                 bilateralState, needOutputCount);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriterTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
@@ -461,6 +462,27 @@ class EagerAggRewriterTest extends TestWithFeService implements MemoPatternMatch
         } finally {
             connectContext.getSessionVariable().setEagerAggregationMode(0);
             connectContext.getSessionVariable().setDisableJoinReorder(false);
+        }
+    }
+
+    @Test
+    void testEmptyContextDoesNotAddRelationAggregate() {
+        connectContext.getSessionVariable().setEagerAggregationMode(1);
+        try {
+            PlanChecker planChecker = PlanChecker.from(connectContext).analyze("select * from t1");
+            Plan analyzedPlan = planChecker.getPlan();
+            LogicalRelation relation = findFirstPlan(analyzedPlan, LogicalRelation.class);
+            Assertions.assertNotNull(relation, analyzedPlan.treeString());
+            PushDownAggContext context = new PushDownAggContext(
+                    Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(),
+                    planChecker.getCascadesContext(),
+                    true, false, false, new BilateralState(), false);
+
+            Plan rewritten = relation.accept(new EagerAggRewriter(), context);
+
+            Assertions.assertSame(relation, rewritten, rewritten.treeString());
+        } finally {
+            connectContext.getSessionVariable().setEagerAggregationMode(0);
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63690

Problem Summary: Eager aggregation could reach a logical relation with no aggregate functions or group keys and generate an invalid empty aggregate. Return the relation unchanged for this empty push-down context and add a focused unit test covering the visitor path.

### Release note

Prevent eager aggregation rewrite from generating an empty aggregate on a relation.

### Check List (For Author)

- Test: Unit Test

    - ./run-fe-ut.sh --run org.apache.doris.nereids.rules.rewrite.eageraggregation.EagerAggRewriterTest

    - ./run-fe-ut.sh --run org.apache.doris.nereids.rules.rewrite.eageraggregation.EagerAggRewriterTest#testEmptyContextDoesNotAddRelationAggregate

- Behavior changed: Yes (empty eager-aggregation contexts now leave relations unchanged)

- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

