### PR TITLE
[fix](regression) Stabilize cloud docker regression cases

### DIFF
--- a/regression-test/suites/cloud_p0/multi_cluster/test_auto_start.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/test_auto_start.groovy
@@ -77,6 +77,10 @@ suite('test_auto_start_in_cloud', 'multi_cluster, docker') {
     }
 
     docker(options) {
+        // The audit loader uses stream load to write __internal_schema.audit_log. That background
+        // load updates fragment status and can break the idle-window assertion below.
+        sql '''set global audit_plugin_max_batch_bytes=5000000000'''
+        sql '''set global audit_plugin_max_batch_interval_sec=10000000'''
         sql "set global enable_audit_plugin = false"
         sql """
             CREATE TABLE table1 (

--- a/regression-test/suites/cloud_p0/multi_cluster/test_unfinished_txn_2pc.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/test_unfinished_txn_2pc.groovy
@@ -34,13 +34,14 @@ suite('test_unfinished_txn_2pc', 'multi_cluster,docker') {
 
         def dbName = context.config.getDbNameByFile(context.file)
         def tableName = 'test_unfinished_txn_2pc_tbl'
+        def (feHost, feHttpPort) = cluster.getFeByIndex(1).getHttpAddress()
         Long txnId = null
 
         def doStreamLoad2pcOperation = { long id, String operation ->
             def command = "curl -sS -X PUT --location-trusted -u ${context.config.feHttpUser}:${context.config.feHttpPassword}" +
                     " -H txn_id:${id}" +
                     " -H txn_operation:${operation}" +
-                    " http://${context.config.feHttpAddress}/api/${dbName}/${tableName}/_stream_load_2pc"
+                    " http://${feHost}:${feHttpPort}/api/${dbName}/${tableName}/_stream_load_2pc"
             logger.info("execute stream load 2pc operation: {}", command)
 
             def process = command.execute()
@@ -65,7 +66,7 @@ suite('test_unfinished_txn_2pc', 'multi_cluster,docker') {
                 PROPERTIES ("replication_num" = "1")
             """
 
-            String content = "1,10\\n2,20\\n3,30\\n"
+            String content = "1,10\n2,20\n3,30\n"
             streamLoad {
                 table "${tableName}"
                 set 'column_separator', ','


### PR DESCRIPTION
Problem Summary: Two cloud docker regression cases were failing because the tests encoded invalid input or allowed unrelated background load activity. The 2PC stream load case used literal escaped newlines, so the load parsed the intended three rows as one malformed row, and its cleanup used the non-docker FE HTTP address. The auto-start case expects a 20-second idle window, but the audit log plugin can flush audit events through a background stream load and update fragment activity during that window.

This change fixes the 2PC test data and docker FE cleanup address, and disables plus delays audit loader flushes in the auto-start docker case without changing its idle-window assertion.

### Release note

None


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

