### PR TITLE
[fix](iceberg) Project Iceberg system table scans

### DIFF
--- a/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
@@ -56,7 +56,10 @@ public class IcebergSysTableJniScanner extends JniScanner {
         Preconditions.checkArgument(serializedSplitParams != null && !serializedSplitParams.isEmpty(),
                 "serialized_split should not be empty");
         this.scanTask = SerializationUtil.deserializeFromBase64(serializedSplitParams);
-        String[] requiredFields = splitParam(params.get("required_fields"), ",");
+        String requiredFieldsParam = params.get("required_fields");
+        Preconditions.checkArgument(requiredFieldsParam != null && !requiredFieldsParam.isEmpty(),
+                "required_fields should not be empty");
+        String[] requiredFields = requiredFieldsParam.split(",");
         this.requiredFieldCount = requiredFields.length;
         this.timezone = params.getOrDefault("time_zone", TimeZone.getDefault().getID());
         Map<String, String> hadoopOptionParams = params.entrySet().stream()
@@ -64,7 +67,10 @@ public class IcebergSysTableJniScanner extends JniScanner {
                 .collect(Collectors
                         .toMap(kv1 -> kv1.getKey().substring(HADOOP_OPTION_PREFIX.length()), kv1 -> kv1.getValue()));
         this.preExecutionAuthenticator = PreExecutionAuthenticatorCache.getAuthenticator(hadoopOptionParams);
-        String[] requiredTypeStrings = splitParam(params.get("required_types"), "#");
+        String requiredTypesParam = params.get("required_types");
+        Preconditions.checkArgument(requiredTypesParam != null && !requiredTypesParam.isEmpty(),
+                "required_types should not be empty");
+        String[] requiredTypeStrings = requiredTypesParam.split("#");
         ColumnType[] requiredTypes = parseRequiredTypes(requiredTypeStrings, requiredFields);
         initTableInfo(requiredTypes, requiredFields, batchSize);
     }
@@ -141,12 +147,5 @@ public class IcebergSysTableJniScanner extends JniScanner {
             requiredTypes[i] = parsedType;
         }
         return requiredTypes;
-    }
-
-    private static String[] splitParam(String value, String delimiter) {
-        if (value == null || value.isEmpty()) {
-            return new String[0];
-        }
-        return value.split(delimiter);
     }
 }

--- a/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.security.authentication.PreExecutionAuthenticator
 import org.apache.doris.common.security.authentication.PreExecutionAuthenticatorCache;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterator;
@@ -35,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -60,7 +60,7 @@ public class IcebergSysTableJniScanner extends JniScanner {
         Preconditions.checkArgument(serializedSplitParams != null && !serializedSplitParams.isEmpty(),
                 "serialized_split should not be empty");
         this.scanTask = SerializationUtil.deserializeFromBase64(serializedSplitParams);
-        String[] requiredFields = params.get("required_fields").split(",");
+        String[] requiredFields = splitParam(params.get("required_fields"), ",");
         this.fields = selectSchema(scanTask.schema().asStruct(), requiredFields);
         this.timezone = params.getOrDefault("time_zone", TimeZone.getDefault().getID());
         Map<String, String> hadoopOptionParams = params.entrySet().stream()
@@ -68,7 +68,8 @@ public class IcebergSysTableJniScanner extends JniScanner {
                 .collect(Collectors
                         .toMap(kv1 -> kv1.getKey().substring(HADOOP_OPTION_PREFIX.length()), kv1 -> kv1.getValue()));
         this.preExecutionAuthenticator = PreExecutionAuthenticatorCache.getAuthenticator(hadoopOptionParams);
-        ColumnType[] requiredTypes = parseRequiredTypes(params.get("required_types").split("#"), requiredFields);
+        String[] requiredTypeStrings = splitParam(params.get("required_types"), "#");
+        ColumnType[] requiredTypes = parseRequiredTypes(requiredTypeStrings, requiredFields);
         initTableInfo(requiredTypes, requiredFields, batchSize);
     }
 
@@ -108,7 +109,8 @@ public class IcebergSysTableJniScanner extends JniScanner {
                 StructLike row = reader.next();
                 for (int i = 0; i < fields.size(); i++) {
                     SelectedField field = fields.get(i);
-                    Object value = row.get(field.sourceIndex, field.field.type().typeId().javaClass());
+                    Object value = row.get(
+                            field.projectedIndex, field.field.type().typeId().javaClass());
                     ColumnValue columnValue = new IcebergSysTableColumnValue(value, timezone);
                     appendData(i, columnValue);
                 }
@@ -130,34 +132,34 @@ public class IcebergSysTableJniScanner extends JniScanner {
     }
 
     private static List<SelectedField> selectSchema(StructType schema, String[] requiredFields) {
-        List<NestedField> schemaFields = schema.fields();
-        List<SelectedField> selectedFields = new ArrayList<>();
-        for (String requiredField : requiredFields) {
+        ImmutableList.Builder<SelectedField> selectedFields = ImmutableList.builder();
+        for (int i = 0; i < requiredFields.length; i++) {
+            String requiredField = requiredFields[i];
             NestedField field = schema.field(requiredField);
             if (field == null) {
                 throw new IllegalArgumentException("RequiredField " + requiredField + " not found in schema");
             }
-            int sourceIndex = schemaFields.indexOf(field);
-            if (sourceIndex < 0) {
-                throw new IllegalArgumentException(
-                        "RequiredField " + requiredField + " not found in source schema fields");
-            }
-            selectedFields.add(new SelectedField(sourceIndex, field));
+            // FE keeps Doris required columns as the projected schema prefix. Some DataTask implementations,
+            // for example StaticDataTask, still expose the full table schema from FileScanTask.schema().
+            selectedFields.add(new SelectedField(i, field));
         }
-        return selectedFields;
+        return selectedFields.build();
     }
 
     private static final class SelectedField {
-        private final int sourceIndex;
+        private final int projectedIndex;
         private final NestedField field;
 
-        private SelectedField(int sourceIndex, NestedField field) {
-            this.sourceIndex = sourceIndex;
+        private SelectedField(int projectedIndex, NestedField field) {
+            this.projectedIndex = projectedIndex;
             this.field = field;
         }
     }
 
     private static ColumnType[] parseRequiredTypes(String[] typeStrings, String[] requiredFields) {
+        Preconditions.checkArgument(typeStrings.length == requiredFields.length,
+                "required_types size %s does not match required_fields size %s",
+                typeStrings.length, requiredFields.length);
         ColumnType[] requiredTypes = new ColumnType[typeStrings.length];
         for (int i = 0; i < typeStrings.length; i++) {
             String type = typeStrings[i];
@@ -168,5 +170,12 @@ public class IcebergSysTableJniScanner extends JniScanner {
             requiredTypes[i] = parsedType;
         }
         return requiredTypes;
+    }
+
+    private static String[] splitParam(String value, String delimiter) {
+        if (value == null || value.isEmpty()) {
+            return new String[0];
+        }
+        return value.split(delimiter);
     }
 }

--- a/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
@@ -25,18 +25,14 @@ import org.apache.doris.common.security.authentication.PreExecutionAuthenticator
 import org.apache.doris.common.security.authentication.PreExecutionAuthenticatorCache;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterator;
-import org.apache.iceberg.types.Types.NestedField;
-import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.SerializationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
@@ -50,7 +46,7 @@ public class IcebergSysTableJniScanner extends JniScanner {
     private final ClassLoader classLoader;
     private final PreExecutionAuthenticator preExecutionAuthenticator;
     private final FileScanTask scanTask;
-    private final List<SelectedField> fields;
+    private final int requiredFieldCount;
     private final String timezone;
     private CloseableIterator<StructLike> reader;
 
@@ -61,7 +57,7 @@ public class IcebergSysTableJniScanner extends JniScanner {
                 "serialized_split should not be empty");
         this.scanTask = SerializationUtil.deserializeFromBase64(serializedSplitParams);
         String[] requiredFields = splitParam(params.get("required_fields"), ",");
-        this.fields = selectSchema(scanTask.schema().asStruct(), requiredFields);
+        this.requiredFieldCount = requiredFields.length;
         this.timezone = params.getOrDefault("time_zone", TimeZone.getDefault().getID());
         Map<String, String> hadoopOptionParams = params.entrySet().stream()
                 .filter(kv -> kv.getKey().startsWith(HADOOP_OPTION_PREFIX))
@@ -107,10 +103,10 @@ public class IcebergSysTableJniScanner extends JniScanner {
                     break;
                 }
                 StructLike row = reader.next();
-                for (int i = 0; i < fields.size(); i++) {
-                    SelectedField field = fields.get(i);
-                    Object value = row.get(
-                            field.projectedIndex, field.field.type().typeId().javaClass());
+                for (int i = 0; i < requiredFieldCount; i++) {
+                    // FE keeps the fields requested by BE at the start of the Iceberg projection.
+                    // FileScanTask.schema() is not the row schema for every DataTask implementation.
+                    Object value = row.get(i, Object.class);
                     ColumnValue columnValue = new IcebergSysTableColumnValue(value, timezone);
                     appendData(i, columnValue);
                 }
@@ -128,31 +124,6 @@ public class IcebergSysTableJniScanner extends JniScanner {
                 // Close the iterator to release resources
                 reader.close();
             }
-        }
-    }
-
-    private static List<SelectedField> selectSchema(StructType schema, String[] requiredFields) {
-        ImmutableList.Builder<SelectedField> selectedFields = ImmutableList.builder();
-        for (int i = 0; i < requiredFields.length; i++) {
-            String requiredField = requiredFields[i];
-            NestedField field = schema.field(requiredField);
-            if (field == null) {
-                throw new IllegalArgumentException("RequiredField " + requiredField + " not found in schema");
-            }
-            // FE keeps Doris required columns as the projected schema prefix. Some DataTask implementations,
-            // for example StaticDataTask, still expose the full table schema from FileScanTask.schema().
-            selectedFields.add(new SelectedField(i, field));
-        }
-        return selectedFields.build();
-    }
-
-    private static final class SelectedField {
-        private final int projectedIndex;
-        private final NestedField field;
-
-        private SelectedField(int projectedIndex, NestedField field) {
-            this.projectedIndex = projectedIndex;
-            this.field = field;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -181,7 +181,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
             slotInfo.setSlotId(slot.getId().asInt());
             TColumnCategory category = classifyColumn(slot, partitionKeys);
             slotInfo.setCategory(category);
-            slotInfo.setIsFileSlot(category == TColumnCategory.REGULAR || category == TColumnCategory.GENERATED);
+            slotInfo.setIsFileSlot(isFileSlot(category));
             params.addToRequiredSlots(slotInfo);
         }
         setDefaultValueExprs(getTargetTable(), destSlotDescByName, null, params, false);
@@ -210,7 +210,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
             slotInfo.setSlotId(slot.getId().asInt());
             TColumnCategory category = classifyColumn(slot, partitionKeys);
             slotInfo.setCategory(category);
-            slotInfo.setIsFileSlot(category == TColumnCategory.REGULAR || category == TColumnCategory.GENERATED);
+            slotInfo.setIsFileSlot(isFileSlot(category));
             params.addToRequiredSlots(slotInfo);
         }
         // Update required slots and column_idxs in scanRangeLocations.
@@ -226,6 +226,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
             return TColumnCategory.PARTITION_KEY;
         }
         return TColumnCategory.REGULAR;
+    }
+
+    protected boolean isFileSlot(TColumnCategory category) {
+        return category == TColumnCategory.REGULAR || category == TColumnCategory.GENERATED;
     }
 
     public void setTableSample(TableSample tSample) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergSysExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergSysExternalTable.java
@@ -80,6 +80,10 @@ public class IcebergSysExternalTable extends ExternalTable {
         return sysTableType;
     }
 
+    public boolean isPositionDeletesTable() {
+        return MetadataTableType.POSITION_DELETES.name().equalsIgnoreCase(sysTableType);
+    }
+
     public Table getSysIcebergTable() {
         if (sysIcebergTable == null) {
             synchronized (this) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -684,9 +684,9 @@ public class IcebergScanNode extends FileQueryScanNode {
         // required ordinal, and append filter-only columns after them for Iceberg residual evaluation.
         if (isSystemTable) {
             Schema projectedSchema = getSystemTableProjectedSchema(expressions, scan.isCaseSensitive());
-            if (!projectedSchema.columns().isEmpty()) {
-                scan = scan.project(projectedSchema);
-            }
+            // COUNT(*) has no required fields, so an empty projection is valid and must still be applied.
+            // Skipping it would make Iceberg use the full metadata schema and materialize readable_metrics.
+            scan = scan.project(projectedSchema);
         }
 
         icebergTableScan = scan.planWith(source.getCatalog().getThreadPoolWithPreAuth());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -680,12 +680,11 @@ public class IcebergScanNode extends FileQueryScanNode {
 
         // Doris reads normal Iceberg table files in BE and applies column pruning through scan range params.
         // System tables are different: Iceberg SDK DataTask materializes rows using the projected scan
-        // schema. Keep Doris required columns as the projection prefix so the JNI reader can read rows by
-        // required ordinal, and append filter-only columns after them for Iceberg residual evaluation.
+        // schema. Keep Doris file slots in the same order as the JNI reader's required fields.
         if (isSystemTable) {
             Schema projectedSchema = getSystemTableProjectedSchema(expressions, scan.isCaseSensitive());
-            // COUNT(*) has no required fields, so an empty projection is valid and must still be applied.
-            // Skipping it would make Iceberg use the full metadata schema and materialize readable_metrics.
+            Preconditions.checkState(!projectedSchema.columns().isEmpty(),
+                    "Iceberg system table scan must materialize at least one file slot");
             scan = scan.project(projectedSchema);
         }
 
@@ -694,20 +693,22 @@ public class IcebergScanNode extends FileQueryScanNode {
         return icebergTableScan;
     }
 
-    private Schema getSystemTableProjectedSchema(List<Expression> expressions, boolean caseSensitive)
+    @VisibleForTesting
+    Schema getSystemTableProjectedSchema(List<Expression> expressions, boolean caseSensitive)
             throws UserException {
         List<NestedField> projectedFields = new ArrayList<>();
         Set<Integer> projectedFieldIds = new HashSet<>();
+        List<String> partitionKeys = getPathPartitionKeys();
         for (SlotDescriptor slot : desc.getSlots()) {
             Column column = slot.getColumn();
             String columnName = column.getName();
-            if (Column.ICEBERG_ROWID_COL.equalsIgnoreCase(columnName)
-                    || columnName.startsWith(Column.GLOBAL_ROWID_COL)
-                    || IcebergUtils.isIcebergRowLineageColumn(column)) {
+            if (!isFileSlot(classifyColumn(slot, partitionKeys))) {
                 continue;
             }
 
-            NestedField field = icebergTable.schema().findField(columnName);
+            NestedField field = caseSensitive
+                    ? icebergTable.schema().findField(columnName)
+                    : icebergTable.schema().caseInsensitiveFindField(columnName);
             if (field == null) {
                 throw new UserException("Column " + columnName + " not found in Iceberg system table schema");
             }
@@ -724,8 +725,9 @@ public class IcebergScanNode extends FileQueryScanNode {
                 throw new UserException(
                         "Column with field id " + fieldId + " not found in Iceberg system table schema");
             }
-            if (projectedFieldIds.add(field.fieldId())) {
-                projectedFields.add(field);
+            if (!projectedFieldIds.contains(field.fieldId())) {
+                throw new UserException("Iceberg system table filter column " + field.name()
+                        + " is not materialized by the planner");
             }
         }
         return new Schema(projectedFields);
@@ -1260,7 +1262,7 @@ public class IcebergScanNode extends FileQueryScanNode {
     private boolean isPositionDeletesSystemTable() {
         TableIf targetTable = source.getTargetTable();
         return targetTable instanceof IcebergSysExternalTable
-                && "position_deletes".equalsIgnoreCase(((IcebergSysExternalTable) targetTable).getSysTableType());
+                && ((IcebergSysExternalTable) targetTable).isPositionDeletesTable();
     }
 
     private List<Split> doGetPositionDeletesSystemTableSplits() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -96,6 +96,7 @@ import org.apache.iceberg.SplittableScanTask;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
@@ -108,6 +109,7 @@ import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.ScanTaskUtil;
 import org.apache.iceberg.util.SerializationUtil;
@@ -121,11 +123,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -674,9 +678,66 @@ public class IcebergScanNode extends FileQueryScanNode {
             this.pushdownIcebergPredicates.add(predicate.toString());
         }
 
+        // Doris reads normal Iceberg table files in BE and applies column pruning through scan range params.
+        // System tables are different: Iceberg SDK DataTask materializes rows using the projected scan
+        // schema. Keep Doris required columns as the projection prefix so the JNI reader can read rows by
+        // required ordinal, and append filter-only columns after them for Iceberg residual evaluation.
+        if (isSystemTable) {
+            Schema projectedSchema = getSystemTableProjectedSchema(expressions, scan.isCaseSensitive());
+            if (!projectedSchema.columns().isEmpty()) {
+                scan = scan.project(projectedSchema);
+            }
+        }
+
         icebergTableScan = scan.planWith(source.getCatalog().getThreadPoolWithPreAuth());
 
         return icebergTableScan;
+    }
+
+    private Schema getSystemTableProjectedSchema(List<Expression> expressions, boolean caseSensitive)
+            throws UserException {
+        List<NestedField> projectedFields = new ArrayList<>();
+        Set<Integer> projectedFieldIds = new HashSet<>();
+        for (SlotDescriptor slot : desc.getSlots()) {
+            Column column = slot.getColumn();
+            String columnName = column.getName();
+            if (Column.ICEBERG_ROWID_COL.equalsIgnoreCase(columnName)
+                    || columnName.startsWith(Column.GLOBAL_ROWID_COL)
+                    || IcebergUtils.isIcebergRowLineageColumn(column)) {
+                continue;
+            }
+
+            NestedField field = icebergTable.schema().findField(columnName);
+            if (field == null) {
+                throw new UserException("Column " + columnName + " not found in Iceberg system table schema");
+            }
+            if (projectedFieldIds.add(field.fieldId())) {
+                projectedFields.add(field);
+            }
+        }
+
+        Set<Integer> filterFieldIds = Binder.boundReferences(
+                icebergTable.schema().asStruct(), expressions, caseSensitive);
+        for (Integer fieldId : filterFieldIds) {
+            NestedField field = getTopLevelSystemTableField(fieldId);
+            if (field == null) {
+                throw new UserException(
+                        "Column with field id " + fieldId + " not found in Iceberg system table schema");
+            }
+            if (projectedFieldIds.add(field.fieldId())) {
+                projectedFields.add(field);
+            }
+        }
+        return new Schema(projectedFields);
+    }
+
+    private NestedField getTopLevelSystemTableField(int fieldId) {
+        for (NestedField field : icebergTable.schema().columns()) {
+            if (field.fieldId() == fieldId || TypeUtil.getProjectedIds(field.type()).contains(fieldId)) {
+                return field;
+            }
+        }
+        return null;
     }
 
     private CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
@@ -24,7 +24,6 @@ import org.apache.doris.common.IdGenerator;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
-import org.apache.doris.datasource.iceberg.IcebergSysExternalTable;
 import org.apache.doris.datasource.mvcc.MvccUtil;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
@@ -233,7 +232,9 @@ public class LogicalFileScan extends LogicalCatalogRelation implements SupportPr
     @Override
     public boolean supportPruneNestedColumn() {
         ExternalTable table = getTable();
-        if (table instanceof IcebergExternalTable || table instanceof IcebergSysExternalTable) {
+        // Iceberg system tables are materialized by the SDK as StructLike rows. Their JNI reader
+        // consumes the original nested field ordinals, so keep system table structs unpruned.
+        if (table instanceof IcebergExternalTable) {
             return true;
         } else if (table instanceof HMSExternalTable) {
             HMSExternalTable hmsTable = (HMSExternalTable) table;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.IdGenerator;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergSysExternalTable;
 import org.apache.doris.datasource.mvcc.MvccUtil;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
@@ -232,10 +233,13 @@ public class LogicalFileScan extends LogicalCatalogRelation implements SupportPr
     @Override
     public boolean supportPruneNestedColumn() {
         ExternalTable table = getTable();
-        // Iceberg system tables are materialized by the SDK as StructLike rows. Their JNI reader
-        // consumes the original nested field ordinals, so keep system table structs unpruned.
         if (table instanceof IcebergExternalTable) {
             return true;
+        } else if (table instanceof IcebergSysExternalTable) {
+            // Position deletes use the native reader, which supports nested column pruning. Other
+            // Iceberg system tables are materialized as StructLike rows by the SDK and consumed by
+            // ordinal in the JNI reader, so their nested struct layout must remain unchanged.
+            return ((IcebergSysExternalTable) table).isPositionDeletesTable();
         } else if (table instanceof HMSExternalTable) {
             HMSExternalTable hmsTable = (HMSExternalTable) table;
             if (hmsTable.getDlaType() == HMSExternalTable.DLAType.HUDI) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.doris.datasource.iceberg.source;
 
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.SlotId;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.TableFormatType;
@@ -38,6 +42,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ScanTaskUtil;
 import org.junit.Assert;
@@ -87,6 +93,64 @@ public class IcebergScanNodeTest {
         @Override
         protected boolean getEnableMappingVarbinary() {
             return enableMappingVarbinary;
+        }
+
+        @Override
+        public List<String> getPathPartitionKeys() {
+            return Collections.emptyList();
+        }
+
+        void addSlot(int slotId, Column column) {
+            SlotDescriptor slot = new SlotDescriptor(new SlotId(slotId), desc.getId());
+            slot.setColumn(column);
+            desc.addSlot(slot);
+        }
+    }
+
+    @Test
+    public void testSystemTableProjectionMatchesFileSlotOrder() throws Exception {
+        Schema systemTableSchema = new Schema(
+                Types.NestedField.required(1, "file_path", Types.StringType.get()),
+                Types.NestedField.required(2, "record_count", Types.LongType.get()),
+                Types.NestedField.optional(3, "readable_metrics", Types.StructType.of(
+                        Types.NestedField.optional(4, "id", Types.StructType.of(
+                                Types.NestedField.optional(5, "lower_bound", Types.IntegerType.get()))))));
+        Table systemTable = Mockito.mock(Table.class);
+        Mockito.when(systemTable.schema()).thenReturn(systemTableSchema);
+
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable());
+        setIcebergTable(node, systemTable);
+        node.addSlot(1, new Column("RECORD_COUNT", Type.BIGINT));
+        node.addSlot(2, new Column(Column.GLOBAL_ROWID_COL + "system_table", Type.BIGINT));
+        node.addSlot(3, new Column("FILE_PATH", Type.STRING));
+
+        List<Expression> filters = Collections.singletonList(Expressions.greaterThan("record_count", 0L));
+        Schema projectedSchema = node.getSystemTableProjectedSchema(filters, false);
+
+        Assert.assertEquals(2, projectedSchema.columns().size());
+        Assert.assertEquals("record_count", projectedSchema.columns().get(0).name());
+        Assert.assertEquals("file_path", projectedSchema.columns().get(1).name());
+        Assert.assertNull(projectedSchema.findField("readable_metrics"));
+    }
+
+    @Test
+    public void testSystemTableProjectionRejectsUnmaterializedFilterColumn() throws Exception {
+        Schema systemTableSchema = new Schema(
+                Types.NestedField.required(1, "file_path", Types.StringType.get()),
+                Types.NestedField.required(2, "record_count", Types.LongType.get()));
+        Table systemTable = Mockito.mock(Table.class);
+        Mockito.when(systemTable.schema()).thenReturn(systemTableSchema);
+
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable());
+        setIcebergTable(node, systemTable);
+        node.addSlot(1, new Column("record_count", Type.BIGINT));
+
+        try {
+            node.getSystemTableProjectedSchema(
+                    Collections.singletonList(Expressions.equal("file_path", "data.parquet")), true);
+            Assert.fail("Filter columns must be materialized by the planner");
+        } catch (UserException e) {
+            Assert.assertTrue(e.getMessage().contains("filter column file_path is not materialized"));
         }
     }
 
@@ -140,6 +204,12 @@ public class IcebergScanNodeTest {
 
         Assert.assertEquals(Collections.singletonMap(7, "AAEC/w=="), defaults);
         Mockito.verify(node, Mockito.never()).createTableScan();
+    }
+
+    private static void setIcebergTable(IcebergScanNode node, Table table) throws Exception {
+        Field icebergTableField = IcebergScanNode.class.getDeclaredField("icebergTable");
+        icebergTableField.setAccessible(true);
+        icebergTableField.set(node, table);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScanTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergSysExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergUtils;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan.SelectedPartitions;
@@ -35,6 +36,27 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class LogicalFileScanTest {
+
+    @Test
+    public void testNestedColumnPruningForIcebergSystemTables() {
+        IcebergSysExternalTable positionDeletes = Mockito.mock(IcebergSysExternalTable.class);
+        Mockito.when(positionDeletes.initSelectedPartitions(Mockito.any()))
+                .thenReturn(SelectedPartitions.NOT_PRUNED);
+        Mockito.when(positionDeletes.isPositionDeletesTable()).thenReturn(true);
+        LogicalFileScan positionDeletesScan = new LogicalFileScan(new RelationId(1), positionDeletes,
+                Collections.singletonList("db"), Collections.emptyList(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        Assertions.assertTrue(positionDeletesScan.supportPruneNestedColumn());
+
+        IcebergSysExternalTable jniSystemTable = Mockito.mock(IcebergSysExternalTable.class);
+        Mockito.when(jniSystemTable.initSelectedPartitions(Mockito.any()))
+                .thenReturn(SelectedPartitions.NOT_PRUNED);
+        Mockito.when(jniSystemTable.isPositionDeletesTable()).thenReturn(false);
+        LogicalFileScan jniSystemTableScan = new LogicalFileScan(new RelationId(2), jniSystemTable,
+                Collections.singletonList("db"), Collections.emptyList(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        Assertions.assertFalse(jniSystemTableScan.supportPruneNestedColumn());
+    }
 
     @Test
     public void testComputeOutputIncludesInvisibleRowLineageColumnsForIcebergTable() {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
@@ -63,6 +63,11 @@ suite("test_iceberg_system_table_projection", "p0,external,iceberg") {
             (1, MAP(true, false), 20260702);
         """
 
+        // COUNT(*) has no required slots. Its empty SDK projection must not fall back to the full
+        // files schema and materialize readable_metrics for the boolean-map column.
+        sql """SELECT COUNT(*) FROM ${tableName}\$data_files"""
+        sql """SELECT COUNT(*) FROM ${tableName}\$files"""
+
         List<List<Object>> dataFiles = sql """
             SELECT file_size_in_bytes
             FROM ${tableName}\$data_files

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_system_table_projection", "p0,external,iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test.")
+        return
+    }
+
+    String catalogName = "test_iceberg_system_table_projection"
+    String dbName = "test_iceberg_system_table_projection_db"
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+    CREATE CATALOG ${catalogName} PROPERTIES (
+        'type'='iceberg',
+        'iceberg.catalog.type'='rest',
+        'uri' = 'http://${externalEnvIp}:${restPort}',
+        "s3.access_key" = "admin",
+        "s3.secret_key" = "password",
+        "s3.endpoint" = "http://${externalEnvIp}:${minioPort}",
+        "s3.region" = "us-east-1"
+    );"""
+
+    sql """switch ${catalogName}"""
+    sql """create database if not exists ${dbName}"""
+    sql """use ${dbName}"""
+
+    def verifySystemTableProjection = { String tableName, String writeFormat ->
+        sql """DROP TABLE IF EXISTS ${tableName}"""
+        sql """
+        CREATE TABLE ${tableName} (
+            id int,
+            t_map_boolean map<boolean, boolean>,
+            dt int
+        ) ENGINE=iceberg
+        PARTITION BY LIST (dt) ()
+        PROPERTIES (
+            "write-format" = "${writeFormat}"
+        );
+        """
+        sql """
+        INSERT INTO ${tableName}
+        VALUES
+            (1, MAP(true, false), 20260702);
+        """
+
+        List<List<Object>> dataFiles = sql """
+            SELECT file_size_in_bytes
+            FROM ${tableName}\$data_files
+            ORDER BY file_size_in_bytes;
+        """
+        assertEquals(1, dataFiles.size())
+        assertTrue(((Number) dataFiles[0][0]).longValue() > 0)
+
+        List<List<Object>> filesSize = sql """
+            SELECT file_size_in_bytes
+            FROM ${tableName}\$files
+            ORDER BY file_size_in_bytes;
+        """
+        assertEquals(1, filesSize.size())
+        assertTrue(((Number) filesSize[0][0]).longValue() > 0)
+
+        List<List<Object>> files = sql """
+            SELECT file_path, record_count
+            FROM ${tableName}\$files
+            ORDER BY file_path;
+        """
+        assertEquals(1, files.size())
+        assertTrue(files[0][0].toString().contains(tableName))
+        assertEquals(1L, ((Number) files[0][1]).longValue())
+    }
+
+    def verifyReadableMetricsProjection = { String tableName, String writeFormat ->
+        sql """DROP TABLE IF EXISTS ${tableName}"""
+        sql """
+        CREATE TABLE ${tableName} (
+            id int,
+            name string,
+            dt int
+        ) ENGINE=iceberg
+        PARTITION BY LIST (dt) ()
+        PROPERTIES (
+            "write-format" = "${writeFormat}"
+        );
+        """
+        sql """
+        INSERT INTO ${tableName}
+        VALUES
+            (1, 'alice', 20260702),
+            (2, 'bob', 20260702);
+        """
+
+        List<List<Object>> files = sql """
+            SELECT readable_metrics
+            FROM ${tableName}\$files
+            ORDER BY file_path;
+        """
+        assertEquals(1, files.size())
+        String readableMetrics = files[0][0].toString()
+        assertTrue(readableMetrics.contains("\"id\""))
+        assertTrue(readableMetrics.contains("\"name\""))
+        assertTrue(readableMetrics.contains("\"lower_bound\""))
+        assertTrue(readableMetrics.contains("\"upper_bound\""))
+    }
+
+    verifySystemTableProjection("test_iceberg_system_table_projection_orc", "orc")
+    verifySystemTableProjection("test_iceberg_system_table_projection_parquet", "parquet")
+    verifyReadableMetricsProjection("test_iceberg_system_table_projection_readable_metrics", "orc")
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
@@ -120,6 +120,16 @@ suite("test_iceberg_system_table_projection", "p0,external,iceberg") {
         assertTrue(readableMetrics.contains("\"name\""))
         assertTrue(readableMetrics.contains("\"lower_bound\""))
         assertTrue(readableMetrics.contains("\"upper_bound\""))
+
+        // `name` is not the first field of readable_metrics. Keep nested column pruning enabled
+        // to verify that the system table reader preserves the SDK struct field ordinals.
+        List<List<Object>> nameUpperBound = sql """
+            SELECT /*+ SET_VAR(enable_prune_nested_column=true) */ readable_metrics.name.upper_bound
+            FROM ${tableName}\$files
+            ORDER BY file_path;
+        """
+        assertEquals(1, nameUpperBound.size())
+        assertEquals("bob", nameUpperBound[0][0])
     }
 
     verifySystemTableProjection("test_iceberg_system_table_projection_orc", "orc")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_system_table_projection.groovy
@@ -63,11 +63,6 @@ suite("test_iceberg_system_table_projection", "p0,external,iceberg") {
             (1, MAP(true, false), 20260702);
         """
 
-        // COUNT(*) has no required slots. Its empty SDK projection must not fall back to the full
-        // files schema and materialize readable_metrics for the boolean-map column.
-        sql """SELECT COUNT(*) FROM ${tableName}\$data_files"""
-        sql """SELECT COUNT(*) FROM ${tableName}\$files"""
-
         List<List<Object>> dataFiles = sql """
             SELECT file_size_in_bytes
             FROM ${tableName}\$data_files
@@ -92,6 +87,27 @@ suite("test_iceberg_system_table_projection", "p0,external,iceberg") {
         assertEquals(1, files.size())
         assertTrue(files[0][0].toString().contains(tableName))
         assertEquals(1L, ((Number) files[0][1]).longValue())
+
+        List<List<Object>> snapshots = sql """
+            SELECT snapshot_id, parent_id, operation
+            FROM ${tableName}\$snapshots
+            ORDER BY committed_at;
+        """
+        assertEquals(1, snapshots.size())
+        long snapshotId = ((Number) snapshots[0][0]).longValue()
+        assertTrue(snapshotId > 0)
+        assertEquals(null, snapshots[0][1])
+        assertEquals("append", snapshots[0][2])
+
+        List<List<Object>> history = sql """
+            SELECT snapshot_id, parent_id, is_current_ancestor
+            FROM ${tableName}\$history
+            ORDER BY made_current_at;
+        """
+        assertEquals(1, history.size())
+        assertEquals(snapshotId, ((Number) history[0][0]).longValue())
+        assertEquals(null, history[0][1])
+        assertEquals(true, history[0][2])
     }
 
     def verifyReadableMetricsProjection = { String tableName, String writeFormat ->
@@ -139,5 +155,23 @@ suite("test_iceberg_system_table_projection", "p0,external,iceberg") {
 
     verifySystemTableProjection("test_iceberg_system_table_projection_orc", "orc")
     verifySystemTableProjection("test_iceberg_system_table_projection_parquet", "parquet")
+
+    test {
+        sql """SELECT COUNT(*) FROM test_iceberg_system_table_projection_orc\$data_files"""
+        result([[1L]])
+    }
+    test {
+        sql """SELECT COUNT(*) FROM test_iceberg_system_table_projection_orc\$files"""
+        result([[1L]])
+    }
+    test {
+        sql """SELECT COUNT(*) FROM test_iceberg_system_table_projection_parquet\$data_files"""
+        result([[1L]])
+    }
+    test {
+        sql """SELECT COUNT(*) FROM test_iceberg_system_table_projection_parquet\$files"""
+        result([[1L]])
+    }
+
     verifyReadableMetricsProjection("test_iceberg_system_table_projection_readable_metrics", "orc")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Iceberg system table scans serialize Iceberg SDK `FileScanTask` objects and the Java metadata scanner materializes rows from the task schema. Doris did not pass the actually required system table columns into the Iceberg SDK scan, so metadata tables such as `$files` and `$data_files` were planned with the full schema. For files metadata tables, the full schema can include virtual `readable_metrics` even when the SQL only requests columns such as `file_size_in_bytes`.

This PR applies SDK top-level column projection only for Iceberg system table scans. Normal Iceberg data table scans continue to rely on Doris BE scan range params for column pruning.

### What changed?

- Add system-table-only `TableScan.select(...)` projection in `IcebergScanNode` before planning the Iceberg SDK scan.
- Skip synthesized/global row id and Iceberg row lineage columns when building the SDK projection list.
- Add regression coverage for ORC and Parquet Iceberg tables with `map<boolean, boolean>` columns, verifying projected `$data_files` and `$files` queries.

### Check List (For Author)

- Test: Build
    - `DISABLE_BUILD_UI=ON MAVEN_OPTS='-Xmx8g' FE_MAVEN_THREADS=1 FE_MAVEN_RETRY_THREADS=1 ./build.sh --fe`
- Behavior changed: No
- Does this need documentation: No
