### PR TITLE
[fix](decimal) Compare DecimalV2 fractional values correctly

### DIFF
--- a/be/src/vec/core/accurate_comparison.h
+++ b/be/src/vec/core/accurate_comparison.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "common/compare.h"
+#include "runtime/decimalv2_value.h"
 #include "runtime/primitive_type.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
@@ -63,7 +64,8 @@ struct EqualsOp {
 
 template <>
 struct EqualsOp<TYPE_DECIMALV2> {
-    static UInt8 apply(const Int128& a, const Int128& b) { return a == b; }
+    using SymmetricOp = EqualsOp<TYPE_DECIMALV2>;
+    static UInt8 apply(const DecimalV2Value& a, const DecimalV2Value& b) { return a == b; }
 };
 
 template <>
@@ -177,7 +179,8 @@ struct LessOp {
 
 template <>
 struct LessOp<TYPE_DECIMALV2> {
-    static UInt8 apply(Int128 a, Int128 b) { return a < b; }
+    using SymmetricOp = GreaterOp<TYPE_DECIMALV2>;
+    static UInt8 apply(const DecimalV2Value& a, const DecimalV2Value& b) { return a < b; }
 };
 
 template <>
@@ -235,7 +238,8 @@ struct GreaterOp {
 
 template <>
 struct GreaterOp<TYPE_DECIMALV2> {
-    static UInt8 apply(Int128 a, Int128 b) { return a > b; }
+    using SymmetricOp = LessOp<TYPE_DECIMALV2>;
+    static UInt8 apply(const DecimalV2Value& a, const DecimalV2Value& b) { return a > b; }
 };
 
 template <>

--- a/be/src/vec/core/decimal_comparison.h
+++ b/be/src/vec/core/decimal_comparison.h
@@ -252,8 +252,8 @@ private:
     static UInt8 apply(typename PrimitiveTypeTraits<A>::CppType a,
                        typename PrimitiveTypeTraits<B>::CppType b,
                        CompareInt scale [[maybe_unused]]) {
-        CompareInt x = a;
-        CompareInt y = b;
+        CompareInt x = get_compare_value<A>(a);
+        CompareInt y = get_compare_value<B>(b);
 
         if constexpr (_check_overflow) {
             bool overflow = false;
@@ -279,6 +279,15 @@ private:
         }
 
         return Op::apply(x, y);
+    }
+
+    template <PrimitiveType T>
+    static CompareInt get_compare_value(typename PrimitiveTypeTraits<T>::CppType value) {
+        if constexpr (T == TYPE_DECIMALV2) {
+            return value.value();
+        } else {
+            return value;
+        }
     }
 
     template <bool scale_left, bool scale_right>

--- a/be/test/vec/core/accurate_comparison_test.cpp
+++ b/be/test/vec/core/accurate_comparison_test.cpp
@@ -19,6 +19,9 @@
 
 #include <gtest/gtest.h>
 
+#include "runtime/decimalv2_value.h"
+#include "vec/core/decimal_comparison.h"
+
 namespace doris::vectorized {
 TEST(VAccurateComparison, TestsOP) {
     EXPECT_TRUE((EqualsOp<TYPE_INT>::apply(1, 1)));
@@ -34,6 +37,25 @@ TEST(VAccurateComparison, TestsOP) {
     EXPECT_FALSE((LessOrEqualsOp<TYPE_INT>::apply(2, 1)));
     EXPECT_TRUE((GreaterOrEqualsOp<TYPE_INT>::apply(2, 1)));
     EXPECT_TRUE((GreaterOrEqualsOp<TYPE_INT>::apply(1, 1)));
+}
+
+TEST(VAccurateComparison, DecimalV2CompareFraction) {
+    DecimalV2Value five(std::string("5.0"));
+    DecimalV2Value five_fraction(std::string("5.5555"));
+
+    EXPECT_FALSE((EqualsOp<TYPE_DECIMALV2>::apply(five_fraction, five)));
+    EXPECT_TRUE((NotEqualsOp<TYPE_DECIMALV2>::apply(five_fraction, five)));
+    EXPECT_TRUE((LessOp<TYPE_DECIMALV2>::apply(five, five_fraction)));
+    EXPECT_TRUE((GreaterOp<TYPE_DECIMALV2>::apply(five_fraction, five)));
+
+    EXPECT_FALSE((DecimalComparison<TYPE_DECIMALV2, TYPE_DECIMALV2, EqualsOp>::compare(
+            five_fraction, five, DecimalV2Value::SCALE, DecimalV2Value::SCALE)));
+    EXPECT_TRUE((DecimalComparison<TYPE_DECIMALV2, TYPE_DECIMALV2, NotEqualsOp>::compare(
+            five_fraction, five, DecimalV2Value::SCALE, DecimalV2Value::SCALE)));
+    EXPECT_TRUE((DecimalComparison<TYPE_DECIMALV2, TYPE_DECIMALV2, LessOp>::compare(
+            five, five_fraction, DecimalV2Value::SCALE, DecimalV2Value::SCALE)));
+    EXPECT_TRUE((DecimalComparison<TYPE_DECIMALV2, TYPE_DECIMALV2, GreaterOp>::compare(
+            five_fraction, five, DecimalV2Value::SCALE, DecimalV2Value::SCALE)));
 }
 
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -1452,6 +1452,15 @@ public class TypeCoercionUtils {
             DecimalV3Type decimalV3Type = (DecimalV3Type) commonType;
             return DecimalV2Type.createDecimalV2Type(decimalV3Type.getPrecision(), decimalV3Type.getScale());
         }
+        // DecimalV2 slot vs DecimalV2 literal. Keep the slot side uncast so simple delete predicates
+        // can still be pushed to storage as column-name predicates.
+        if (shouldDowngrade(DecimalV2Type.class, DecimalV2Type.class,
+                commonType, target,
+                d -> true,
+                o -> o.isLiteral() && o.getDataType().isDecimalV2Type(),
+                compareExpressions)) {
+            return target.getDataType();
+        }
         // cast to datev1 for datev1 slot in (datev1 or datev2 literal)
         if (shouldDowngrade(DateV2Type.class, DateType.class,
                 commonType, target,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -202,6 +202,17 @@ public class TypeCoercionUtilsTest {
         decimalDowngrade = (InPredicate) TypeCoercionUtils.processInPredicate(decimalDowngrade);
         Assertions.assertEquals(DecimalV2Type.createDecimalV2Type(16, 7), decimalDowngrade.getCompareExpr().getDataType());
 
+        // DecimalV2 slot vs DecimalV2 literal should keep the slot side uncast for delete predicates.
+        DecimalV2Type decimalV2ColumnType = DecimalV2Type.createDecimalV2Type(8, 5);
+        InPredicate decimalV2Downgrade = new InPredicate(
+                new SlotReference("c1", decimalV2ColumnType),
+                ImmutableList.of(
+                        new DecimalLiteral(new BigDecimal("5.0")),
+                        new DecimalLiteral(new BigDecimal("5.5555"))));
+        decimalV2Downgrade = (InPredicate) TypeCoercionUtils.processInPredicate(decimalV2Downgrade);
+        Assertions.assertEquals(decimalV2ColumnType, decimalV2Downgrade.getCompareExpr().getDataType());
+        Assertions.assertTrue(decimalV2Downgrade.getCompareExpr() instanceof SlotReference);
+
         // DateV1 slot vs DateV2 literal
         InPredicate dateDowngrade = new InPredicate(
                 new SlotReference("c1", DateType.INSTANCE),
@@ -232,6 +243,16 @@ public class TypeCoercionUtilsTest {
         );
         decimalDowngrade = (EqualTo) TypeCoercionUtils.processComparisonPredicate(decimalDowngrade);
         Assertions.assertEquals(DecimalV2Type.createDecimalV2Type(16, 7), decimalDowngrade.left().getDataType());
+
+        // DecimalV2 slot vs DecimalV2 literal should keep the slot side uncast for delete predicates.
+        DecimalV2Type decimalV2ColumnType = DecimalV2Type.createDecimalV2Type(8, 5);
+        EqualTo decimalV2Downgrade = new EqualTo(
+                new SlotReference("c1", decimalV2ColumnType),
+                new DecimalLiteral(new BigDecimal("5.0"))
+        );
+        decimalV2Downgrade = (EqualTo) TypeCoercionUtils.processComparisonPredicate(decimalV2Downgrade);
+        Assertions.assertEquals(decimalV2ColumnType, decimalV2Downgrade.left().getDataType());
+        Assertions.assertTrue(decimalV2Downgrade.left() instanceof SlotReference);
 
         // DateV1 slot vs DateV2 literal (this case cover right slot vs left literal)
         EqualTo dateDowngrade = new EqualTo(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: DecimalV2 vectorized comparisons converted `DecimalV2Value` through integer casts before applying equality and range operators. The cast drops the fractional part, so values such as `5.5555` could compare equal to `5.0` and make DecimalV2 predicates return incorrect rows.

This PR compares DecimalV2 by its full scaled value. It also keeps DecimalV2 slot-vs-literal predicates uncast on the slot side during type coercion so simple delete predicates can still be pushed to storage.

### Release note

Fix incorrect DecimalV2 comparison results when fractional parts differ.

### Check List (For Author)

- Test:
    - Unit Test: `./run-be-ut.sh --run --filter=VAccurateComparison.*`
    - Unit Test: `./run-fe-ut.sh --run org.apache.doris.nereids.util.TypeCoercionUtilsTest`
    - Regression test: `doris-local-regression --network 10.26.20.3/24 run -d datatype_p0/decimalv2 -s test_decimalv2_common`
    - Build: `BUILD_TYPE=ASAN doris-local-regression --network 10.26.20.3/24 build`
    - Format: `build-support/clang-format.sh be/src/vec/core/accurate_comparison.h be/src/vec/core/decimal_comparison.h be/test/vec/core/accurate_comparison_test.cpp`, `build-support/check-format.sh`, `git diff --check`
- Behavior changed: Yes. DecimalV2 comparisons now consider fractional digits correctly.
- Does this need documentation: No
