### PR TITLE
[fix](fe) Reject unsupported array arguments for array functions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayPosition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayPosition.java
@@ -78,8 +78,15 @@ public class ArrayPosition extends ScalarFunction
     @Override
     public void checkLegalityBeforeTypeCoercion() {
         DataType argType = getArgument(0).getDataType();
-        if (argType.isArrayType() && ((ArrayType) argType).getItemType().isComplexType()) {
-            throw new AnalysisException("array_position does not support complex types: " + toSql());
+        if (argType.isArrayType() && (((ArrayType) argType).getItemType().isComplexType()
+                    || ((ArrayType) argType).getItemType().isVariantType()
+                    || ((ArrayType) argType).getItemType().isJsonType())) {
+            throw new AnalysisException("array_position does not support types: " + argType.toSql());
+        }
+        DataType itemType = getArgument(1).getDataType();
+        if (itemType.isComplexType() || itemType.isVariantType() || itemType.isJsonType()) {
+            throw new AnalysisException("array_position does not support types: "
+                    + ArrayType.of(itemType).toSql());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayRemove.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayRemove.java
@@ -78,6 +78,11 @@ public class ArrayRemove extends ScalarFunction
                     || ((ArrayType) argType).getItemType().isJsonType())) {
             throw new AnalysisException("array_remove does not support types: " + argType.toSql());
         }
+        DataType itemType = getArgument(1).getDataType();
+        if (itemType.isComplexType() || itemType.isVariantType() || itemType.isJsonType()) {
+            throw new AnalysisException("array_remove does not support types: "
+                    + ArrayType.of(itemType).toSql());
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayUnion.java
@@ -68,11 +68,13 @@ public class ArrayUnion extends ScalarFunction implements ExplicitlyCastableSign
 
     @Override
     public void checkLegalityBeforeTypeCoercion() {
-        DataType argType = getArgument(0).getDataType();
-        if (argType.isArrayType() && (((ArrayType) argType).getItemType().isComplexType()
-                    || ((ArrayType) argType).getItemType().isVariantType()
-                    || ((ArrayType) argType).getItemType().isJsonType())) {
-            throw new AnalysisException("array_union does not support types: " + argType.toSql());
+        for (Expression argument : getArguments()) {
+            DataType argType = argument.getDataType();
+            if (argType.isArrayType() && (((ArrayType) argType).getItemType().isComplexType()
+                        || ((ArrayType) argType).getItemType().isVariantType()
+                        || ((ArrayType) argType).getItemType().isJsonType())) {
+                throw new AnalysisException("array_union does not support types: " + argType.toSql());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArraysOverlap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArraysOverlap.java
@@ -68,11 +68,13 @@ public class ArraysOverlap extends ScalarFunction implements ExplicitlyCastableS
 
     @Override
     public void checkLegalityBeforeTypeCoercion() {
-        DataType argType = getArgument(0).getDataType();
-        if (argType.isArrayType() && (((ArrayType) argType).getItemType().isComplexType()
-                    || ((ArrayType) argType).getItemType().isVariantType()
-                    || ((ArrayType) argType).getItemType().isJsonType())) {
-            throw new AnalysisException("arrays_overlap does not support types: " + argType.toSql());
+        for (Expression argument : getArguments()) {
+            DataType argType = argument.getDataType();
+            if (argType.isArrayType() && (((ArrayType) argType).getItemType().isComplexType()
+                        || ((ArrayType) argType).getItemType().isVariantType()
+                        || ((ArrayType) argType).getItemType().isJsonType())) {
+                throw new AnalysisException("arrays_overlap does not support types: " + argType.toSql());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CountEqual.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CountEqual.java
@@ -70,6 +70,11 @@ public class CountEqual extends ScalarFunction
                     || ((ArrayType) argType).getItemType().isJsonType())) {
             throw new AnalysisException("countequal does not support types: " + argType.toSql());
         }
+        DataType itemType = getArgument(1).getDataType();
+        if (itemType.isComplexType() || itemType.isVariantType() || itemType.isJsonType()) {
+            throw new AnalysisException("countequal does not support types: "
+                    + ArrayType.of(itemType).toSql());
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
@@ -71,6 +71,46 @@ public class CheckExpressionLegalityTest implements MemoPatternMatchSupported {
     }
 
     @Test
+    public void testArrayFunctionsRejectNestedArrayFromNonFirstArgument() {
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "array_union does not support types: ARRAY<ARRAY<TINYINT>>", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select array_union([], [[1]])");
+                });
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "arrays_overlap does not support types: ARRAY<ARRAY<TINYINT>>", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select arrays_overlap([], [[1]])");
+                });
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "array_position does not support types: ARRAY<ARRAY<TINYINT>>", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select array_position([], [1])");
+                });
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "array_position does not support types: ARRAY<JSON>", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select array_position([], cast('{}' as json))");
+                });
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "array_position does not support types: ARRAY<variant", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select array_position([], cast('{}' as variant))");
+                });
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "array_remove does not support types: ARRAY<ARRAY<TINYINT>>", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select array_remove([], [1])");
+                });
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "countequal does not support types: ARRAY<ARRAY<TINYINT>>", () -> {
+                    PlanChecker.from(connectContext)
+                            .analyze("select countequal([], [1])");
+                });
+    }
+
+    @Test
     public void testCountDistinctBitmap() {
         ConnectContext connectContext = MemoTestUtils.createConnectContext();
         PlanChecker.from(connectContext)

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_nested_type_check.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_nested_type_check.groovy
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_array_nested_type_check") {
+    sql "set enable_nereids_planner = true"
+    sql "set enable_fallback_to_original_planner = false"
+
+    test {
+        sql "explain verbose select array_union([], [[1]])"
+        exception "array_union does not support types: ARRAY<ARRAY<TINYINT>>"
+    }
+
+    test {
+        sql "select array_union([], [[1]])"
+        exception "array_union does not support types: ARRAY<ARRAY<TINYINT>>"
+    }
+
+    test {
+        sql "select arrays_overlap([], [[1]])"
+        exception "arrays_overlap does not support types: ARRAY<ARRAY<TINYINT>>"
+    }
+
+    test {
+        sql "select array_position([], [1])"
+        exception "array_position does not support types: ARRAY<ARRAY<TINYINT>>"
+    }
+
+    test {
+        sql "select array_position([], cast('{}' as json))"
+        exception "array_position does not support types: ARRAY<JSON>"
+    }
+
+    test {
+        sql "select array_position([], cast('{}' as variant))"
+        exception "array_position does not support types: ARRAY<variant"
+    }
+
+    test {
+        sql "select array_remove([], [1])"
+        exception "array_remove does not support types: ARRAY<ARRAY<TINYINT>>"
+    }
+
+    test {
+        sql "select countequal([], [1])"
+        exception "countequal does not support types: ARRAY<ARRAY<TINYINT>>"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary: Some array scalar functions only validated the first array argument before type coercion. A bare empty array on the left side could therefore hide the unsupported element type carried by another argument, allowing unsupported inputs to pass analysis and fail later in BE execution. This change checks the argument that carries the unsupported type before coercion for array_union, arrays_overlap, array_position, array_remove, and countequal, so these cases fail during analysis with clear type errors. For array_position, JSON and VARIANT are also rejected because the BE array index implementation only dispatches comparable scalar element types and does not support JSON or VARIANT execution.

### Release note

Reject unsupported inputs to affected array functions during analysis.

### Check List (For Author)

- Test:
    - Unit Test: ./run-fe-ut.sh --run CheckExpressionLegalityTest
    - Regression test: doris-local-regression --network 10.26.20.3/24 all -d query_p0/sql_functions/array_functions -s test_array_nested_type_check
- Behavior changed: Yes. Unsupported inputs to the affected array functions are rejected during analysis instead of reaching BE execution.
- Does this need documentation: No
