### PR TITLE
[WIP][test](mtmv) reproduce stale relation cache after rename

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
@@ -18,12 +18,10 @@
 package org.apache.doris.mtmv;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.utframe.TestWithFeService;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +40,7 @@ public class AlterMTMVTest extends TestWithFeService {
                 + "DISTRIBUTED BY HASH(`sid`) BUCKETS 1\n"
                 + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1')");
 
-        createMvByNereids("CREATE MATERIALIZED VIEW mv_a BUILD IMMEDIATE REFRESH COMPLETE ON COMMIT\n"
+        createMvByNereids("CREATE MATERIALIZED VIEW mv_a BUILD DEFERRED REFRESH COMPLETE ON MANUAL\n"
                 + "DISTRIBUTED BY HASH(`sid`) BUCKETS 1\n"
                 + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1') "
                 + "AS select * from stu limit 1");
@@ -51,19 +49,19 @@ public class AlterMTMVTest extends TestWithFeService {
 
         MTMVRelationManager relationManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
         Table table = Env.getCurrentInternalCatalog().getDb("test").get().getTableOrMetaException("stu");
-        Set<MTMV> allMTMVs = relationManager.getCandidateMTMVs(Lists.newArrayList(new BaseTableInfo(table)));
+        Set<BaseTableInfo> allMTMVs = relationManager.getMtmvsByBaseTable(new BaseTableInfo(table));
         boolean hasMvA = false;
         boolean hasMvB = false;
-        for (MTMV mtmv : allMTMVs) {
-            if ("mv_a".equals(mtmv.getName())) {
+        for (BaseTableInfo mtmv : allMTMVs) {
+            if ("mv_a".equals(mtmv.getTableName())) {
                 hasMvA = true;
             }
-            if ("mv_b".equals(mtmv.getName())) {
+            if ("mv_b".equals(mtmv.getTableName())) {
                 hasMvB = true;
             }
         }
-        Assertions.assertFalse(hasMvA);
-        Assertions.assertTrue(hasMvB);
+        Assertions.assertFalse(hasMvA, "MTMV relation cache should remove the old name after rename");
+        Assertions.assertTrue(hasMvB, "MTMV relation cache should contain the new name after rename");
 
 
         createTable("CREATE TABLE `stu1` (`sid` int(32) NULL, `sname` varchar(32) NULL)\n"


### PR DESCRIPTION
### What problem does this PR solve?

This is a test-only reproduction for DORIS-26807.

It makes `AlterMTMVTest.testAlterMTMV` check the relation cache directly after:

```sql
CREATE MATERIALIZED VIEW mv_a BUILD DEFERRED REFRESH COMPLETE ON MANUAL ...
ALTER MATERIALIZED VIEW mv_a RENAME mv_b;
```

The relation cache should remove `mv_a` and contain `mv_b` after the rename.

### Why test-only?

The existing branch-4.1 test uses `BUILD IMMEDIATE`, so an asynchronous refresh can occasionally refresh the relation cache after rename and hide the synchronous rename-path bug. This PR switches the case to `BUILD DEFERRED ... ON MANUAL` and reads `getMtmvsByBaseTable(...)` directly to avoid that timing dependency.

This PR is expected to fail before the product fix. If CI reproduces the failure deterministically, a follow-up PR will fix the MTMV rename relation-cache update path.

### Check

- `git diff --check`
