### PR TITLE
branch-4.0: [fix](test) isolate streaming mysql dup job name

### DIFF
--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_dup.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_dup.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_streaming_mysql_job_dup", "p0,external,mysql,external_docker,external_docker_mysql,nondatalake") {
-    def jobName = "test_streaming_mysql_job_name"
+    def jobName = "test_streaming_mysql_job_name_dup"
     def currentDb = (sql "select database()")[0][0]
     def table1 = "test_streaming_mysql_job_dup"
     def mysqlDb = "test_cdc_db"


### PR DESCRIPTION
## Summary
- Fix branch-4.0 External Regression flaky failure in `test_streaming_mysql_job`.
- `test_streaming_mysql_job_dup` used the same streaming job name as `test_streaming_mysql_job`, so concurrent execution could drop the main case job while it was waiting for CDC incremental data.
- Use an isolated job name for the dup case, matching branch-4.1/master behavior.

## Testing
- [x] `git diff --check`
- [x] Verified diff is limited to `test_streaming_mysql_job_dup.groovy`
- [ ] External Regression / buildall pending

Failure evidence: TeamCity build 986509, `jobInfo: []` at `test_streaming_mysql_job.groovy:158` after concurrent `DROP JOB ... test_streaming_mysql_job_name` from `test_streaming_mysql_job_dup.groovy`.