### PR TITLE
branch-4.1: [fix](regression) handle E-2010 compaction wait

### DIFF
--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -155,12 +155,17 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
                     def newCumulativePoint = toLongOrNull(tabletStatus["cumulative point"])
                     def lastCumulativeStatus = "${tabletStatus["last cumulative status"]}".toLowerCase()
                     def baseSuccessTimeChanged = oldStatus["last base success time"] != tabletStatus["last base success time"]
+                    def cumulativeSuccessTimeChanged =
+                            oldStatus["last cumulative success time"] != tabletStatus["last cumulative success time"]
                     // E-2010 advances the cumulative point and lets base compaction handle delete-version rowsets.
+                    // In some timing windows, base success is already visible in the cached old status while
+                    // cumulative success advances later, so accept either success signal but not failure time alone.
                     handedOffToBaseCompactionAfterDeleteVersion = lastCumulativeStatus.contains("e-2010") &&
                             oldCumulativePoint != null && newCumulativePoint != null &&
                             newCumulativePoint > oldCumulativePoint
                     completedByBaseCompactionAfterDeleteVersion =
-                            handedOffToBaseCompactionAfterDeleteVersion && baseSuccessTimeChanged
+                            handedOffToBaseCompactionAfterDeleteVersion &&
+                            (baseSuccessTimeChanged || cumulativeSuccessTimeChanged)
                 }
                 def success_time_unchanged = (oldStatus["last ${compaction_type} success time"] == tabletStatus["last ${compaction_type} success time"])
                 def failure_time_unchanged = (oldStatus["last ${compaction_type} failure time"] == tabletStatus["last ${compaction_type} failure time"])

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -120,6 +120,16 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
 
     // 3. wait all compaction finished
     def running = triggered_tablets.size() > 0
+    def toLongOrNull = { value ->
+        if (value == null) {
+            return null
+        }
+        try {
+            return value.toString().trim().toLong()
+        } catch (Throwable ignored) {
+            return null
+        }
+    }
     Awaitility.await().atMost(timeout_seconds, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
         for (tablet in triggered_tablets) {
             def be_host = backendId_to_backendIP["${tablet.BackendId}"]
@@ -138,9 +148,26 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
                 def tabletStatus = parseJson(stdout.trim())
                 def oldStatus = be_tablet_compaction_status.get("${be_host}-${tablet.TabletId}")
                 // last compaction success/failure time isn't updated, indicates compaction is not started(so we treat it as running and wait)
+                def handedOffToBaseCompactionAfterDeleteVersion = false
+                def completedByBaseCompactionAfterDeleteVersion = false
+                if (compaction_type == "cumulative") {
+                    def oldCumulativePoint = toLongOrNull(oldStatus["cumulative point"])
+                    def newCumulativePoint = toLongOrNull(tabletStatus["cumulative point"])
+                    def lastCumulativeStatus = "${tabletStatus["last cumulative status"]}".toLowerCase()
+                    def baseSuccessTimeChanged = oldStatus["last base success time"] != tabletStatus["last base success time"]
+                    // E-2010 advances the cumulative point and lets base compaction handle delete-version rowsets.
+                    handedOffToBaseCompactionAfterDeleteVersion = lastCumulativeStatus.contains("e-2010") &&
+                            oldCumulativePoint != null && newCumulativePoint != null &&
+                            newCumulativePoint > oldCumulativePoint
+                    completedByBaseCompactionAfterDeleteVersion =
+                            handedOffToBaseCompactionAfterDeleteVersion && baseSuccessTimeChanged
+                }
                 def success_time_unchanged = (oldStatus["last ${compaction_type} success time"] == tabletStatus["last ${compaction_type} success time"])
                 def failure_time_unchanged = (oldStatus["last ${compaction_type} failure time"] == tabletStatus["last ${compaction_type} failure time"])
-                running = running || (success_time_unchanged && failure_time_unchanged)
+                def currentCompactionTimestampChanged = !success_time_unchanged || !failure_time_unchanged
+                def compactionFinished = completedByBaseCompactionAfterDeleteVersion ||
+                        (!handedOffToBaseCompactionAfterDeleteVersion && currentCompactionTimestampChanged)
+                running = running || !compactionFinished
                 if (running) {
                     logger.info("compaction is still running, be host: ${be_host}, tablet id: ${tablet.TabletId}, run status: ${compactionStatus.run_status}, old status: ${oldStatus}, new status: ${tabletStatus}")
                     return false


### PR DESCRIPTION
## Summary
- Backport #64945 and #65209 to branch-4.1.
- Handle cumulative compaction E-2010 delete-version handoff without waiting until timeout.

## Testing
- [x] git diff --check origin/branch-4.1...HEAD
- [ ] Not run: branch-4.1 regression rerun was not executed locally.