### PR TITLE
[branch-4.0][test](auth) Move backup auth case to nonConcurrent

### DIFF
--- a/regression-test/suites/auth_call/test_ddl_backup_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_backup_auth.groovy
@@ -18,7 +18,7 @@
 import org.junit.Assert;
 import java.util.UUID
 
-suite("test_ddl_backup_auth","p0,auth_call") {
+suite("test_ddl_backup_auth","p0,auth_call,nonConcurrent") {
     UUID uuid = UUID.randomUUID()
     String randomValue = uuid.toString()
     int hashCode = randomValue.hashCode()


### PR DESCRIPTION
## Summary
- Move auth_call/test_ddl_backup_auth.groovy to nonConcurrent on branch-4.0
- Matches the master-side stabilization from #61384 for backup lock contention during the case

## Testing
- git diff --check
- Not run locally; regression case requires the branch-4.0 CI regression environment and S3 repository config