### PR TITLE
[branch-4.0][fix](regression) Isolate MySQL streaming duplicate job case

### DIFF
--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_dup.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_dup.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_streaming_mysql_job_dup", "p0,external,mysql,external_docker,external_docker_mysql,nondatalake") {
-    def jobName = "test_streaming_mysql_job_name"
+    def jobName = "test_streaming_mysql_job_name_dup"
     def currentDb = (sql "select database()")[0][0]
     def table1 = "test_streaming_mysql_job_dup"
     def mysqlDb = "test_cdc_db"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary: The MySQL duplicate-job regression case reused the same streaming job name as the normal MySQL streaming job case on branch-4.0. When the two cases run concurrently, the duplicate-job case can drop the normal case's running job and make its later jobs() query return no rows. This patch gives the duplicate-job case its own job name.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Verified the diff only changes the duplicate-job case name, and the normal and duplicate MySQL streaming cases now use distinct job names.
- Behavior changed: No
- Does this need documentation: No
