### PR TITLE
[branch-4.1][regression-test](variant) Fix schema change wait timeout

### DIFF
--- a/regression-test/suites/variant_p0/schema_change/schema_change.groovy
+++ b/regression-test/suites/variant_p0/schema_change/schema_change.groovy
@@ -28,22 +28,23 @@ suite("regression_test_variant_schema_change", "variant_type"){
         DISTRIBUTED BY HASH(k) BUCKETS 4
         properties("replication_num" = "1");
     """
-    def timeout = 60000
+    def timeout = 120000
     def delta_time = 1000
-    def useTime = 0
     def wait_for_latest_op_on_table_finish = { tableName, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            def alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${tableName}" ORDER BY CreateTime DESC LIMIT 1;"""
+        boolean finished = false
+        def alter_res = null
+        for (int t = delta_time; t <= OpTimeout; t += delta_time) {
+            alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${tableName}" ORDER BY CreateTime DESC LIMIT 1;"""
             alter_res = alter_res.toString()
             if(alter_res.contains("FINISHED")) {
                 sleep(3000) // wait change table state to normal
                 logger.info(tableName + " latest alter job finished, detail: " + alter_res)
+                finished = true
                 break
             }
-            useTime = t
             sleep(delta_time)
         }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_op_on_table_finish timeout")
+        assertTrue(finished, "wait_for_latest_op_on_table_finish timeout, last alter result: " + alter_res)
     }
 
     // sql "set experimental_enable_nereids_planner = true"


### PR DESCRIPTION
## Summary

Backport #65139 to branch-4.1.

Fixes a flaky Cloud P0 failure in `variant_p0/schema_change/schema_change.groovy`.

The case waits for the latest schema-change job before issuing the next ALTER. The old helper could return after timeout without observing `FINISHED`, because `useTime == OpTimeout` still passed `assertTrue(useTime <= OpTimeout)`. Then the case could run `DROP INDEX` while the table was still in `SCHEMA_CHANGE`.

This backport:

- Increases the schema-change wait timeout from 60s to 120s.
- Requires an explicit `FINISHED` observation before continuing.
- Includes the last `SHOW ALTER TABLE COLUMN` result in timeout failures.

## Testing

- [x] `git diff --check origin/branch-4.1...HEAD`
- [ ] Not run locally; regression validation should run in CI.
