### PR TITLE
branch-4.0: [fix](paimon) fix runtime partition prune on partition splits

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -84,6 +84,7 @@
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_struct.h"
 #include "vec/exec/format/orc/orc_file_reader.h"
+#include "vec/exec/format/table/partition_column_filler.h"
 #include "vec/exec/format/table/transactional_hive_common.h"
 #include "vec/exec/scan/file_scanner.h"
 #include "vec/exprs/vbloom_predicate.h"
@@ -1067,6 +1068,18 @@ Status OrcReader::set_fill_columns(
         const std::unordered_map<std::string, VExprContextSPtr>& missing_columns) {
     SCOPED_RAW_TIMER(&_statistics.set_fill_column_time);
 
+    _lazy_read_ctx.partition_value_is_null.clear();
+    if (_scan_range.__isset.columns_from_path_is_null) {
+        DORIS_CHECK(_scan_range.__isset.columns_from_path_keys);
+        DORIS_CHECK(_scan_range.columns_from_path_keys.size() ==
+                    _scan_range.columns_from_path_is_null.size());
+        for (size_t i = 0; i < _scan_range.columns_from_path_keys.size(); ++i) {
+            _lazy_read_ctx.partition_value_is_null.emplace(
+                    _scan_range.columns_from_path_keys[i],
+                    _scan_range.columns_from_path_is_null[i]);
+        }
+    }
+
     // std::unordered_map<column_name, std::pair<col_id, slot_id>>
     std::unordered_map<std::string, std::pair<uint32_t, int>> predicate_table_columns;
     // visit_slot for lazy mat.
@@ -1383,23 +1396,12 @@ Status OrcReader::_fill_partition_columns(
         auto col_ptr = block->get_by_position((*_col_name_to_block_idx)[kv.first])
                                .column->assume_mutable();
         const auto& [value, slot_desc] = kv.second;
-        auto _text_serde = slot_desc->get_data_type_ptr()->get_serde();
-        Slice slice(value.data(), value.size());
-        uint64_t num_deserialized = 0;
-        if (_text_serde->deserialize_column_from_fixed_json(*col_ptr, slice, rows,
-                                                            &num_deserialized,
-                                                            _text_formatOptions) != Status::OK()) {
-            return Status::InternalError("Failed to fill partition column: {}={}",
-                                         slot_desc->col_name(), value);
-        }
-        if (num_deserialized != rows) {
-            return Status::InternalError(
-                    "Failed to fill partition column: {}={} ."
-                    "Number of rows expected to be written : {}, number of rows actually "
-                    "written : "
-                    "{}",
-                    slot_desc->col_name(), value, num_deserialized, rows);
-        }
+        auto null_it = _lazy_read_ctx.partition_value_is_null.find(kv.first);
+        RETURN_IF_ERROR(fill_partition_column_from_path_value(
+                *col_ptr, *slot_desc, value, rows,
+                null_it != _lazy_read_ctx.partition_value_is_null.end(),
+                null_it != _lazy_read_ctx.partition_value_is_null.end() && null_it->second,
+                _text_formatOptions));
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -109,6 +109,7 @@ struct LazyReadContext {
     // lazy read partition columns or all partition columns
     std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
             partition_columns;
+    std::unordered_map<std::string, bool> partition_value_is_null;
     std::unordered_map<std::string, VExprContextSPtr> predicate_missing_columns;
     // lazy read missing columns or all missing columns
     std::unordered_map<std::string, VExprContextSPtr> missing_columns;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -54,6 +54,7 @@
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+#include "vec/exec/format/table/partition_column_filler.h"
 #include "vec/exprs/vdirect_in_predicate.h"
 #include "vec/exprs/vectorized_fn_call.h"
 #include "vec/exprs/vexpr.h"
@@ -725,23 +726,12 @@ Status RowGroupReader::_fill_partition_columns(
         // obtained from block*, it is a mutable object.
         auto* col_ptr = const_cast<IColumn*>(doris_column.get());
         const auto& [value, slot_desc] = kv.second;
-        auto _text_serde = slot_desc->get_data_type_ptr()->get_serde();
-        Slice slice(value.data(), value.size());
-        uint64_t num_deserialized = 0;
-        // Be careful when reading empty rows from parquet row groups.
-        if (_text_serde->deserialize_column_from_fixed_json(*col_ptr, slice, rows,
-                                                            &num_deserialized,
-                                                            _text_formatOptions) != Status::OK()) {
-            return Status::InternalError("Failed to fill partition column: {}={}",
-                                         slot_desc->col_name(), value);
-        }
-        if (num_deserialized != rows) {
-            return Status::InternalError(
-                    "Failed to fill partition column: {}={} ."
-                    "Number of rows expected to be written : {}, number of rows actually written : "
-                    "{}",
-                    slot_desc->col_name(), value, num_deserialized, rows);
-        }
+        auto null_it = _lazy_read_ctx.partition_value_is_null.find(kv.first);
+        RETURN_IF_ERROR(fill_partition_column_from_path_value(
+                *col_ptr, *slot_desc, value, rows,
+                null_it != _lazy_read_ctx.partition_value_is_null.end(),
+                null_it != _lazy_read_ctx.partition_value_is_null.end() && null_it->second,
+                _text_formatOptions));
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -85,6 +85,7 @@ public:
         // ParquetReader::set_fill_columns(xxx, xxx) will set these two members
         std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
                 fill_partition_columns;
+        std::unordered_map<std::string, bool> partition_value_is_null;
         std::unordered_map<std::string, VExprContextSPtr> fill_missing_columns;
 
         phmap::flat_hash_map<int, std::vector<std::shared_ptr<ColumnPredicate>>>

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -466,6 +466,17 @@ Status ParquetReader::set_fill_columns(
                 partition_columns,
         const std::unordered_map<std::string, VExprContextSPtr>& missing_columns) {
     _lazy_read_ctx.fill_partition_columns = partition_columns;
+    _lazy_read_ctx.partition_value_is_null.clear();
+    if (_scan_range.__isset.columns_from_path_is_null) {
+        DORIS_CHECK(_scan_range.__isset.columns_from_path_keys);
+        DORIS_CHECK(_scan_range.columns_from_path_keys.size() ==
+                    _scan_range.columns_from_path_is_null.size());
+        for (size_t i = 0; i < _scan_range.columns_from_path_keys.size(); ++i) {
+            _lazy_read_ctx.partition_value_is_null.emplace(
+                    _scan_range.columns_from_path_keys[i],
+                    _scan_range.columns_from_path_is_null[i]);
+        }
+    }
     _lazy_read_ctx.fill_missing_columns = missing_columns;
 
     // std::unordered_map<column_name, std::pair<col_id, slot_id>>

--- a/be/src/vec/exec/format/table/partition_column_filler.h
+++ b/be/src/vec/exec/format/table/partition_column_filler.h
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <string>
+
+#include "common/status.h"
+#include "runtime/descriptors.h"
+#include "util/slice.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/common/assert_cast.h"
+#include "vec/data_types/serde/data_type_serde.h"
+
+namespace doris::vectorized {
+
+inline Status fill_partition_column_from_path_value(
+        IColumn& column, const SlotDescriptor& slot_desc, const std::string& value, size_t rows,
+        bool has_explicit_null_marker, bool explicit_null_marker,
+        DataTypeSerDe::FormatOptions text_format_options = {}) {
+    auto data_type = slot_desc.get_data_type_ptr();
+    auto text_serde = data_type->get_serde();
+    uint64_t num_deserialized = 0;
+
+    if (has_explicit_null_marker && explicit_null_marker) {
+        DCHECK(data_type->is_nullable());
+        column.insert_many_defaults(rows);
+        return Status::OK();
+    }
+
+    IColumn* value_column = &column;
+    DataTypeSerDeSPtr value_serde = text_serde;
+    ColumnNullable* nullable_column = nullptr;
+    // Legacy path partitions encode null as "\\N" and rely on nullable serde. Sources with an
+    // explicit null marker deserialize the nested value so a literal "\\N" remains non-null.
+    if (data_type->is_nullable() && has_explicit_null_marker) {
+        nullable_column = assert_cast<ColumnNullable*>(&column);
+        value_column = &nullable_column->get_nested_column();
+        value_serde = text_serde->get_nested_serdes()[0];
+    }
+
+    const size_t old_size = value_column->size();
+    Slice slice(value.data(), value.size());
+    Status status = value_serde->deserialize_column_from_fixed_json(
+            *value_column, slice, rows, &num_deserialized, text_format_options);
+    if (!status.ok()) {
+        value_column->resize(old_size);
+        return Status::InternalError("Failed to fill partition column: {}={}", slot_desc.col_name(),
+                                     value);
+    }
+    if (num_deserialized != rows) {
+        value_column->resize(old_size);
+        return Status::InternalError(
+                "Failed to fill partition column: {}={}. Expected rows: {}, actual: {}",
+                slot_desc.col_name(), value, rows, num_deserialized);
+    }
+    if (nullable_column != nullptr) {
+        nullable_column->get_null_map_column().insert_many_vals(0, rows);
+    }
+    return Status::OK();
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -70,6 +70,7 @@
 #include "vec/exec/format/table/max_compute_jni_reader.h"
 #include "vec/exec/format/table/paimon_jni_reader.h"
 #include "vec/exec/format/table/paimon_reader.h"
+#include "vec/exec/format/table/partition_column_filler.h"
 #include "vec/exec/format/table/remote_doris_reader.h"
 #include "vec/exec/format/table/transactional_hive_reader.h"
 #include "vec/exec/format/table/trino_connector_jni_reader.h"
@@ -253,33 +254,12 @@ Status FileScanner::_process_runtime_filters_partition_prune(bool& can_filter_al
     for (auto const& partition_col_desc : _partition_col_descs) {
         const auto& [partition_value, partition_slot_desc] = partition_col_desc.second;
         auto data_type = partition_slot_desc->get_data_type_ptr();
-        auto test_serde = data_type->get_serde();
         auto partition_value_column = data_type->create_column();
-        auto* col_ptr = static_cast<IColumn*>(partition_value_column.get());
-        Slice slice(partition_value.data(), partition_value.size());
-        uint64_t num_deserialized = 0;
-        DataTypeSerDe::FormatOptions options {};
-        if (_partition_value_is_null.contains(partition_slot_desc->col_name())) {
-            // for iceberg/paimon table
-            // NOTICE: column is always be nullable for iceberg/paimon table now
-            DCHECK(data_type->is_nullable());
-            test_serde = test_serde->get_nested_serdes()[0];
-            auto* null_column = assert_cast<ColumnNullable*>(col_ptr);
-            if (_partition_value_is_null[partition_slot_desc->col_name()]) {
-                null_column->insert_many_defaults(partition_value_column_size);
-            } else {
-                // If the partition value is not null, we set null map to 0 and deserialize it normally.
-                null_column->get_null_map_column().insert_many_vals(0, partition_value_column_size);
-                RETURN_IF_ERROR(test_serde->deserialize_column_from_fixed_json(
-                        null_column->get_nested_column(), slice, partition_value_column_size,
-                        &num_deserialized, options));
-            }
-        } else {
-            // for hive/hudi table, the null value is set as "\\N"
-            // TODO: this will be unified as iceberg/paimon table in the future
-            RETURN_IF_ERROR(test_serde->deserialize_column_from_fixed_json(
-                    *col_ptr, slice, partition_value_column_size, &num_deserialized, options));
-        }
+        auto null_it = _partition_value_is_null.find(partition_slot_desc->col_name());
+        RETURN_IF_ERROR(fill_partition_column_from_path_value(
+                *partition_value_column, *partition_slot_desc, partition_value,
+                partition_value_column_size, null_it != _partition_value_is_null.end(),
+                null_it != _partition_value_is_null.end() && null_it->second));
 
         partition_slot_id_to_column[partition_slot_desc->id()] = std::move(partition_value_column);
     }
@@ -291,20 +271,9 @@ Status FileScanner::_process_runtime_filters_partition_prune(bool& can_filter_al
     for (auto const* slot_desc : _real_tuple_desc->slots()) {
         if (partition_slot_id_to_column.find(slot_desc->id()) !=
             partition_slot_id_to_column.end()) {
-            auto data_type = slot_desc->get_data_type_ptr();
             auto partition_value_column = std::move(partition_slot_id_to_column[slot_desc->id()]);
-            if (data_type->is_nullable()) {
-                _runtime_filter_partition_prune_block.insert(
-                        index, ColumnWithTypeAndName(
-                                       ColumnNullable::create(
-                                               std::move(partition_value_column),
-                                               ColumnUInt8::create(partition_value_column_size, 0)),
-                                       data_type, slot_desc->col_name()));
-            } else {
-                _runtime_filter_partition_prune_block.insert(
-                        index, ColumnWithTypeAndName(std::move(partition_value_column), data_type,
-                                                     slot_desc->col_name()));
-            }
+            _runtime_filter_partition_prune_block.replace_by_position(
+                    index, std::move(partition_value_column));
             if (index == 0) {
                 first_column_filled = true;
             }
@@ -638,22 +607,10 @@ Status FileScanner::_fill_columns_from_path(size_t rows) {
         // _src_block_ptr points to a mutable block created by this class itself, so const_cast can be used here.
         IColumn* col_ptr = const_cast<IColumn*>(doris_column.get());
         auto& [value, slot_desc] = kv.second;
-        auto _text_serde = slot_desc->get_data_type_ptr()->get_serde();
-        Slice slice(value.data(), value.size());
-        uint64_t num_deserialized = 0;
-        if (_text_serde->deserialize_column_from_fixed_json(*col_ptr, slice, rows,
-                                                            &num_deserialized,
-                                                            _text_formatOptions) != Status::OK()) {
-            return Status::InternalError("Failed to fill partition column: {}={}",
-                                         slot_desc->col_name(), value);
-        }
-        if (num_deserialized != rows) {
-            return Status::InternalError(
-                    "Failed to fill partition column: {}={} ."
-                    "Number of rows expected to be written : {}, number of rows actually written : "
-                    "{}",
-                    slot_desc->col_name(), value, num_deserialized, rows);
-        }
+        auto null_it = _partition_value_is_null.find(kv.first);
+        RETURN_IF_ERROR(fill_partition_column_from_path_value(
+                *col_ptr, *slot_desc, value, rows, null_it != _partition_value_is_null.end(),
+                null_it != _partition_value_is_null.end() && null_it->second, _text_formatOptions));
     }
     return Status::OK();
 }
@@ -1585,10 +1542,14 @@ Status FileScanner::_generate_partition_columns() {
                     return Status::InternalError("Unknown source slot descriptor, slot_id={}",
                                                  slot_desc->id());
                 }
+                if (it->second >= range.columns_from_path.size()) {
+                    continue;
+                }
                 const std::string& column_from_path = range.columns_from_path[it->second];
                 _partition_col_descs.emplace(slot_desc->col_name(),
                                              std::make_tuple(column_from_path, slot_desc));
-                if (range.__isset.columns_from_path_is_null) {
+                if (range.__isset.columns_from_path_is_null &&
+                    it->second < range.columns_from_path_is_null.size()) {
                     _partition_value_is_null.emplace(slot_desc->col_name(),
                                                      range.columns_from_path_is_null[it->second]);
                 }

--- a/be/test/vec/exec/format/table/partition_column_filler_test.cpp
+++ b/be/test/vec/exec/format/table/partition_column_filler_test.cpp
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exec/format/table/partition_column_filler.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "vec/columns/column_nullable.h"
+#include "vec/common/assert_cast.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
+
+namespace doris::vectorized {
+
+TEST(PartitionColumnFillerTest, DistinguishLegacyAndExplicitNullMarkers) {
+    SlotDescriptor string_slot;
+    string_slot._type = make_nullable(std::make_shared<DataTypeString>());
+    string_slot._col_name = "part_col";
+
+    auto legacy_null_column = string_slot.get_empty_mutable_column();
+    ASSERT_TRUE(fill_partition_column_from_path_value(*legacy_null_column, string_slot, "\\N", 2,
+                                                      false, false)
+                        .ok());
+    const auto& legacy_nullable = assert_cast<const ColumnNullable&>(*legacy_null_column);
+    ASSERT_EQ(legacy_nullable.size(), 2);
+    EXPECT_TRUE(legacy_nullable.is_null_at(0));
+    EXPECT_TRUE(legacy_nullable.is_null_at(1));
+
+    auto literal_null_marker_column = string_slot.get_empty_mutable_column();
+    ASSERT_TRUE(fill_partition_column_from_path_value(*literal_null_marker_column, string_slot,
+                                                      "\\N", 1, true, false)
+                        .ok());
+    const auto& literal_nullable = assert_cast<const ColumnNullable&>(*literal_null_marker_column);
+    ASSERT_EQ(literal_nullable.size(), 1);
+    EXPECT_FALSE(literal_nullable.is_null_at(0));
+    EXPECT_EQ(literal_nullable.get_nested_column().get_data_at(0).to_string(), "\\N");
+
+    SlotDescriptor int_slot;
+    int_slot._type = make_nullable(std::make_shared<DataTypeInt32>());
+    int_slot._col_name = "int_part_col";
+    auto explicit_null_column = int_slot.get_empty_mutable_column();
+    ASSERT_TRUE(fill_partition_column_from_path_value(*explicit_null_column, int_slot, "", 1, true,
+                                                      true)
+                        .ok());
+    const auto& explicit_nullable = assert_cast<const ColumnNullable&>(*explicit_null_column);
+    ASSERT_EQ(explicit_nullable.size(), 1);
+    EXPECT_TRUE(explicit_nullable.is_null_at(0));
+}
+
+TEST(PartitionColumnFillerTest, RestoreColumnAfterDeserializeFailure) {
+    SlotDescriptor int_slot;
+    int_slot._type = std::make_shared<DataTypeInt32>();
+    int_slot._col_name = "int_part_col";
+    auto column = int_slot.get_empty_mutable_column();
+
+    auto status =
+            fill_partition_column_from_path_value(*column, int_slot, "not_an_int", 1, false, false);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(column->size(), 0);
+}
+
+} // namespace doris::vectorized

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -65,8 +65,11 @@ public class PaimonJniScanner extends JniScanner {
             LOG.debug("params:{}", params);
         }
         this.params = params;
-        String[] requiredFields = params.get("required_fields").split(",");
-        String[] requiredTypes = params.get("columns_types").split("#");
+        String[] requiredFields = splitParam(params.get("required_fields"), ",");
+        String[] requiredTypes = splitParam(params.get("columns_types"), "#");
+        Preconditions.checkArgument(requiredFields.length == requiredTypes.length,
+                "required_fields size %s does not match columns_types size %s",
+                requiredFields.length, requiredTypes.length);
         ColumnType[] columnTypes = new ColumnType[requiredTypes.length];
         for (int i = 0; i < requiredTypes.length; i++) {
             columnTypes[i] = ColumnType.parseType(requiredFields[i], requiredTypes[i]);
@@ -183,6 +186,9 @@ public class PaimonJniScanner extends JniScanner {
                         appendData(i, columnValue);
                     }
                     if (rows >= batchSize) {
+                        if (fields.length == 0) {
+                            vectorTable.appendVirtualData(rows);
+                        }
                         appendDataTime += System.nanoTime() - startTime;
                         return rows;
                     }
@@ -191,6 +197,9 @@ public class PaimonJniScanner extends JniScanner {
 
                 recordIterator.releaseBatch();
                 recordIterator = reader.readBatch();
+            }
+            if (fields.length == 0 && rows > 0) {
+                vectorTable.appendVirtualData(rows);
             }
         } catch (Exception e) {
             close();
@@ -226,5 +235,11 @@ public class PaimonJniScanner extends JniScanner {
         }
     }
 
-}
+    private static String[] splitParam(String value, String delimiter) {
+        if (value == null || value.isEmpty()) {
+            return new String[0];
+        }
+        return value.split(delimiter);
+    }
 
+}

--- a/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
+++ b/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.paimon;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaimonJniScannerTest {
+    @Test
+    public void testConstructorAcceptsEmptyProjection() {
+        Map<String, String> params = new HashMap<>();
+        params.put("required_fields", "");
+        params.put("columns_types", "");
+        params.put("paimon_split", "");
+        params.put("paimon_predicate", "");
+
+        new PaimonJniScanner(128, params);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
@@ -87,6 +87,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -462,7 +463,7 @@ public class PaimonUtil {
             try {
                 String partitionValue = serializePartitionValue(partitionType.getFields().get(i).type(),
                         partitionValuesArray[i], timeZone);
-                partitionInfoMap.put(partitionKeys.get(i), partitionValue);
+                partitionInfoMap.put(partitionKeys.get(i).toLowerCase(Locale.ROOT), partitionValue);
             } catch (UnsupportedOperationException e) {
                 LOG.warn("Failed to serialize table {} partition value for key {}: {}", table.name(),
                         partitionKeys.get(i), e.getMessage());
@@ -487,6 +488,16 @@ public class PaimonUtil {
                     return null;
                 }
                 return value.toString();
+            case FLOAT:
+                if (value == null) {
+                    return null;
+                }
+                return Float.toString((Float) value);
+            case DOUBLE:
+                if (value == null) {
+                    return null;
+                }
+                return Double.toString((Double) value);
             // case binary:
             // case varbinary: should not supported, because if return string with utf8,
             // the data maybe be corrupted

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -68,6 +68,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -213,6 +214,15 @@ public class PaimonScanNode extends FileQueryScanNode {
         }
     }
 
+    private List<String> getOrderedPathPartitionKeys() {
+        if (source == null) {
+            return Collections.emptyList();
+        }
+        return source.getPaimonTable().partitionKeys().stream()
+                .map(key -> key.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toList());
+    }
+
     private void setPaimonParams(TFileRangeDesc rangeDesc, PaimonSplit paimonSplit) {
         TTableFormatFileDesc tableFormatFileDesc = new TTableFormatFileDesc();
         tableFormatFileDesc.setTableFormatType(paimonSplit.getTableFormatType().value());
@@ -260,19 +270,29 @@ public class PaimonScanNode extends FileQueryScanNode {
             tableFormatFileDesc.setTableLevelRowCount(-1);
         }
         tableFormatFileDesc.setPaimonParams(fileDesc);
+        rangeDesc.unsetColumnsFromPath();
+        rangeDesc.unsetColumnsFromPathKeys();
+        rangeDesc.unsetColumnsFromPathIsNull();
         Map<String, String> partitionValues = paimonSplit.getPaimonPartitionValues();
-        if (partitionValues != null) {
+        List<String> orderedPartitionKeys = getOrderedPathPartitionKeys();
+        if (partitionValues != null && !orderedPartitionKeys.isEmpty()) {
             List<String> fromPathKeys = new ArrayList<>();
             List<String> fromPathValues = new ArrayList<>();
             List<Boolean> fromPathIsNull = new ArrayList<>();
-            for (Map.Entry<String, String> entry : partitionValues.entrySet()) {
-                fromPathKeys.add(entry.getKey());
-                fromPathValues.add(entry.getValue() != null ? entry.getValue() : "");
-                fromPathIsNull.add(entry.getValue() == null);
+            for (String partitionKey : orderedPartitionKeys) {
+                if (!partitionValues.containsKey(partitionKey)) {
+                    continue;
+                }
+                String partitionValue = partitionValues.get(partitionKey);
+                fromPathKeys.add(partitionKey);
+                fromPathValues.add(partitionValue != null ? partitionValue : "");
+                fromPathIsNull.add(partitionValue == null);
             }
-            rangeDesc.setColumnsFromPathKeys(fromPathKeys);
-            rangeDesc.setColumnsFromPath(fromPathValues);
-            rangeDesc.setColumnsFromPathIsNull(fromPathIsNull);
+            if (!fromPathKeys.isEmpty()) {
+                rangeDesc.setColumnsFromPathKeys(fromPathKeys);
+                rangeDesc.setColumnsFromPath(fromPathValues);
+                rangeDesc.setColumnsFromPathIsNull(fromPathIsNull);
+            }
         }
         rangeDesc.setTableFormatParams(tableFormatFileDesc);
     }
@@ -322,6 +342,7 @@ public class PaimonScanNode extends FileQueryScanNode {
         // partition data.
         // And for counting the number of selected partitions for this paimon table.
         Map<BinaryRow, Map<String, String>> partitionInfoMaps = new HashMap<>();
+        boolean needPartitionMetadata = !getOrderedPathPartitionKeys().isEmpty();
         // if applyCountPushdown is true, we can't split the DataSplit
         boolean hasDeterminedTargetFileSplitSize = false;
         long targetFileSplitSize = 0;
@@ -331,9 +352,7 @@ public class PaimonScanNode extends FileQueryScanNode {
 
             BinaryRow partitionValue = dataSplit.partition();
             Map<String, String> partitionInfoMap = null;
-            if (sessionVariable.isEnableRuntimeFilterPartitionPrune()) {
-                // If the partition value is not in the map, we need to calculate the partition
-                // info map and store it in the map.
+            if (needPartitionMetadata) {
                 partitionInfoMap = partitionInfoMaps.computeIfAbsent(partitionValue, k -> {
                     return PaimonUtil.getPartitionInfoMap(
                             source.getPaimonTable(), partitionValue, sessionVariable.getTimeZone());
@@ -524,10 +543,7 @@ public class PaimonScanNode extends FileQueryScanNode {
 
     @Override
     public List<String> getPathPartitionKeys() throws DdlException, MetaNotFoundException {
-        // return new ArrayList<>(source.getPaimonTable().partitionKeys());
-        // Paimon is not aware of partitions and bypasses some existing logic by
-        // returning an empty list
-        return new ArrayList<>();
+        return getOrderedPathPartitionKeys();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonSplit.java
@@ -26,6 +26,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,7 +42,7 @@ public class PaimonSplit extends FileSplit {
     private Map<String, String> paimonPartitionValues = null;
 
     public PaimonSplit(DataSplit split) {
-        super(DUMMY_PATH, 0, 0, 0, 0, null, null);
+        super(DUMMY_PATH, 0, 0, 0, 0, null, Collections.emptyList());
         this.split = split;
         this.tableFormatType = TableFormatType.PAIMON;
 
@@ -53,7 +54,8 @@ public class PaimonSplit extends FileSplit {
 
     private PaimonSplit(LocationPath file, long start, long length, long fileLength, long modificationTime,
             String[] hosts, List<String> partitionList) {
-        super(file, start, length, fileLength, modificationTime, hosts, partitionList);
+        super(file, start, length, fileLength, modificationTime, hosts,
+                partitionList == null ? Collections.emptyList() : partitionList);
         this.tableFormatType = TableFormatType.PAIMON;
         this.selfSplitWeight = length;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/PaimonUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/PaimonUtilTest.java
@@ -19,11 +19,21 @@ package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.catalog.Type;
 
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.types.CharType;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.VarCharType;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 public class PaimonUtilTest {
     @Test
@@ -35,5 +45,50 @@ public class PaimonUtilTest {
         Assert.assertTrue(type1.isVarchar());
         Assert.assertEquals(32, type1.getLength());
         Assert.assertEquals(14, type2.getLength());
+    }
+
+    @Test
+    public void testGetPartitionInfoMapSupportsFloatingPointPartitions() {
+        DataField floatPartition = DataTypes.FIELD(0, "float_partition", DataTypes.FLOAT());
+        DataField doublePartition = DataTypes.FIELD(1, "double_partition", DataTypes.DOUBLE());
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.name()).thenReturn("mock_table");
+        Mockito.when(table.partitionKeys()).thenReturn(Arrays.asList("float_partition", "double_partition"));
+        Mockito.when(table.rowType()).thenReturn(DataTypes.ROW(floatPartition, doublePartition));
+
+        float floatValue = Math.nextUp(0.1F);
+        double doubleValue = Math.nextUp(0.1D);
+        BinaryRow partitionValues = new BinaryRow(2);
+        BinaryRowWriter writer = new BinaryRowWriter(partitionValues);
+        writer.writeFloat(0, floatValue);
+        writer.writeDouble(1, doubleValue);
+        writer.complete();
+
+        Map<String, String> partitionInfoMap = PaimonUtil.getPartitionInfoMap(table, partitionValues, "UTC");
+
+        String serializedFloat = partitionInfoMap.get("float_partition");
+        String serializedDouble = partitionInfoMap.get("double_partition");
+        Assert.assertEquals(Float.toString(floatValue), serializedFloat);
+        Assert.assertEquals(Double.toString(doubleValue), serializedDouble);
+        Assert.assertEquals(Float.floatToIntBits(floatValue),
+                Float.floatToIntBits(Float.parseFloat(serializedFloat)));
+        Assert.assertEquals(Double.doubleToLongBits(doubleValue),
+                Double.doubleToLongBits(Double.parseDouble(serializedDouble)));
+    }
+
+    @Test
+    public void testGetPartitionInfoMapUsesLowerCaseKeys() {
+        DataField mixedCasePartition = DataTypes.FIELD(0, "Dt", DataTypes.STRING());
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.name()).thenReturn("mock_table");
+        Mockito.when(table.partitionKeys()).thenReturn(Collections.singletonList("Dt"));
+        Mockito.when(table.rowType()).thenReturn(DataTypes.ROW(mixedCasePartition));
+
+        BinaryRow partitionValues = BinaryRow.singleColumn(BinaryString.fromString("2026-05-26"));
+
+        Map<String, String> partitionInfoMap = PaimonUtil.getPartitionInfoMap(table, partitionValues, "UTC");
+
+        Assert.assertFalse(partitionInfoMap.containsKey("Dt"));
+        Assert.assertEquals("2026-05-26", partitionInfoMap.get("dt"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.RawFile;
 import org.junit.Assert;
@@ -63,7 +64,11 @@ public class PaimonScanNodeTest {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(3));
         PaimonScanNode paimonScanNode = new PaimonScanNode(new PlanNodeId(1), desc, false, sv, ScanContext.EMPTY);
 
-        paimonScanNode.setSource(new PaimonSource());
+        PaimonSource source = Mockito.spy(new PaimonSource());
+        Table paimonTable = Mockito.mock(Table.class);
+        Mockito.doReturn(paimonTable).when(source).getPaimonTable();
+        Mockito.when(paimonTable.partitionKeys()).thenReturn(Collections.emptyList());
+        paimonScanNode.setSource(source);
 
         DataFileMeta dfm1 = DataFileMeta.forAppend("f1.parquet", 64 * 1024 * 1024, 1, SimpleStats.EMPTY_STATS, 1, 1, 1,
                 Collections.emptyList(), null, null, null, null);

--- a/regression-test/data/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.out
+++ b/regression-test/data/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.out
@@ -95,6 +95,12 @@
 -- !null_partition_4 --
 1	\N	100.0
 
+-- !null_int_partition_column --
+6	Null Int	\N
+
+-- !null_timestamp_partition_column --
+6	Null Timestamp	\N
+
 -- !runtime_filter_partition_pruning_decimal1 --
 2
 
@@ -191,3 +197,8 @@
 -- !null_partition_4 --
 1	\N	100.0
 
+-- !null_int_partition_column --
+6	Null Int	\N
+
+-- !null_timestamp_partition_column --
+6	Null Timestamp	\N

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_partition_table.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_partition_table.groovy
@@ -53,9 +53,105 @@ suite("test_paimon_partition_table", "p0,external,doris,external_docker,external
            "$baseQueryName" """show partitions from ${tableName};"""
        }
 
+        sql """set enable_runtime_filter_partition_prune=true"""
+        sql """set force_jni_scanner=true"""
 
+        def salesByDateRows = sql """select sale_date from sales_by_date order by sale_date"""
+        assertEquals(
+                ["2024-01-15", "2024-01-15", "2024-01-16", "2024-01-16", "2024-01-17"],
+                salesByDateRows.collect { row -> row[0].toString() })
+
+        def salesByDateFilteredRows = sql """
+                select sale_date
+                from sales_by_date
+                where sale_date = '2024-01-16'
+                order by sale_date
+        """
+        assertEquals(
+                ["2024-01-16", "2024-01-16"],
+                salesByDateFilteredRows.collect { row -> row[0].toString() })
+
+        def salesByRegionRows = sql """select region from sales_by_region order by region"""
+        assertEquals(
+                ["China-Beijing", "Japan-Tokyo", "USA-California"],
+                salesByRegionRows.collect { row -> row[0].toString() })
+
+        def salesByDateRegionRows = sql """
+                select sale_date, region
+                from sales_by_date_region
+                order by sale_date, region
+        """
+        assertEquals(
+                [
+                        ["2024-01-15", "China-Beijing"],
+                        ["2024-01-15", "Japan-Tokyo"],
+                        ["2024-01-15", "USA-California"],
+                        ["2024-01-16", "China-Shanghai"],
+                        ["2024-01-16", "Japan-Osaka"],
+                        ["2024-01-16", "USA-New York"],
+                ],
+                salesByDateRegionRows.collect { row -> [row[0].toString(), row[1].toString()] })
+
+        def eventsByHourRows = sql """
+                select hour_partition
+                from events_by_hour
+                where hour_partition in ('2024-01-15-10', '2024-01-15-14')
+                order by hour_partition
+        """
+        assertEquals(
+                ["2024-01-15-10", "2024-01-15-10", "2024-01-15-14", "2024-01-15-14"],
+                eventsByHourRows.collect { row -> row[0].toString() })
+
+        def logsByDateHierarchyRows = sql """
+                select year_val, month_val, day_val
+                from logs_by_date_hierarchy
+                where year_val = 2024 and month_val = 1
+                order by day_val, year_val, month_val
+        """
+        assertEquals(
+                [
+                        [2024, 1, 15],
+                        [2024, 1, 15],
+                        [2024, 1, 16],
+                        [2024, 1, 16],
+                        [2024, 1, 17],
+                ],
+                logsByDateHierarchyRows.collect { row ->
+                    [(row[0] as Integer), (row[1] as Integer), (row[2] as Integer)]
+                })
+
+        def jniPartitionCounts = sql """
+                select sale_date, count(*)
+                from sales_by_date
+                where sale_date in ('2024-01-15', '2024-01-16')
+                group by sale_date
+                order by sale_date
+        """
+
+        sql """set force_jni_scanner=false"""
+
+        def nativePartitionCounts = sql """
+                select sale_date, count(*)
+                from sales_by_date
+                where sale_date in ('2024-01-15', '2024-01-16')
+                group by sale_date
+                order by sale_date
+        """
+        assertEquals(jniPartitionCounts, nativePartitionCounts)
+/*
+mysql> show partitions from sales_by_date;
++----------------------+--------------+-------------+-----------------+-----------+
+| Partition            | PartitionKey | RecordCount | FileSizeInBytes | FileCount |
++----------------------+--------------+-------------+-----------------+-----------+
+| sale_date=2024-01-15 | sale_date    | 2           | 2051            | 1         |
+| sale_date=2024-01-16 | sale_date    | 2           | 3899            | 2         |
+| sale_date=2024-01-17 | sale_date    | 1           | 1959            | 1         |
++----------------------+--------------+-------------+-----------------+-----------+
+3 rows in set (0.01 sec)
+FileSizeInBytes maybe changed, when upgrade paimon version.
+*/
     } finally {
+         sql """set force_jni_scanner=false"""
          sql """drop catalog if exists ${catalog_name}"""
     }
 }
-

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
@@ -252,6 +252,18 @@ suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,externa
             qt_null_partition_4 """
                 select * from null_str_partition_table where category is null;
             """
+            qt_null_int_partition_column """
+                select id, name, partition_key
+                from int_partitioned
+                where partition_key is null
+                order by id;
+            """
+            qt_null_timestamp_partition_column """
+                select id, name, partition_key
+                from timestamp_partitioned
+                where partition_key is null
+                order by id;
+            """
         }
 
         try {
@@ -267,5 +279,4 @@ suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,externa
         }
     }
 }
-
 


### PR DESCRIPTION
### What problem does this PR solve?

Fixes wrong partition pruning for Paimon external table splits when runtime partition pruning evaluates static partition predicates such as `partition IN (...)`.

The old BE path reused `_runtime_filter_partition_prune_block` across splits and inserted partition value columns by index. Repeated `insert(index, ...)` can corrupt the block column layout across splits, causing valid splits to be pruned incorrectly.

This also makes Paimon split partition metadata stable by passing ordered partition keys and values from FE to BE.

Related fix: apache/doris#62821
Related Jira: DORIS-26857
Backport of branch-4.1 PR: apache/doris#65307

### Check List

- [x] Added regression coverage for Paimon partition pruning with multiple partition values.
- [ ] Local build/regression not run; expected to be verified by CI.
