### PR TITLE
[fix](regression) wait for rollup before update test

### DIFF
--- a/regression-test/suites/nereids_p0/update/update_after_create_rollup.groovy
+++ b/regression-test/suites/nereids_p0/update/update_after_create_rollup.groovy
@@ -123,16 +123,7 @@ suite('update_after_create_rollup') {
     sql """
         ALTER TABLE mow_table ADD ROLLUP rollup1(event_date, event_time, user_id, country, update_time)
     """
-    sleep(10000)
-    explain {
-        sql('''
-            SELECT event_date, country, count(*) 
-            FROM mow_table 
-            WHERE event_date = '2025-09-22'
-            GROUP BY event_date, country
-        ''')
-        contains "rollup1"
-    }
+    assertEquals("FINISHED", getAlterRollupFinalState("mow_table"))
     
     // Test 1: UPDATE column not in rollup1 (city)
     sql 'UPDATE mow_table SET city = "beijing" WHERE user_id = 2000'


### PR DESCRIPTION
## Summary

Fix `update_after_create_rollup` to wait for the rollup schema-change job to finish before running partial update checks.

The case is intended to verify partial update correctness after a rollup exists. A fixed `sleep(10000)` plus `EXPLAIN contains "rollup1"` can be sensitive to async rollup completion and planner choice, while the product behavior under test is covered by the following UPDATE result assertions.

## Testing

- [x] `git diff --check`
- [ ] Not run the regression case locally; it requires a Doris regression test environment.
