### PR TITLE
[fix](backup) Strip replica info from backup meta

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1688,6 +1688,13 @@ public class Config extends ConfigBase {
     public static boolean ignore_backup_tmp_partitions = false;
 
     /**
+     * When false, backup meta table copies strip tablet Replica objects to reduce snapshot size.
+     * Restore recreates replicas from replica allocation, so they are not needed in backup meta.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean backup_meta_reserve_replica_info = false;
+
+    /**
      * A internal config, to control the update interval of backup handler. Only used to speed up tests.
      */
     @ConfField(mutable = false)

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalTablet.java
@@ -273,6 +273,11 @@ public class LocalTablet extends Tablet {
     }
 
     @Override
+    public void clearReplicas() {
+        replicas = new ArrayList<>();
+    }
+
+    @Override
     public List<Replica> getReplicas() {
         // Volatile read: returns the current immutable snapshot; callers iterate without locking.
         return Collections.unmodifiableList(replicas);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2161,8 +2161,12 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
             for (MaterializedIndex idx : partition.getMaterializedIndices(extState)) {
                 idx.setState(IndexState.NORMAL);
                 for (Tablet tablet : idx.getTablets()) {
-                    for (Replica replica : tablet.getReplicas()) {
-                        replica.setState(ReplicaState.NORMAL);
+                    if (isForBackup && !Config.backup_meta_reserve_replica_info) {
+                        tablet.clearReplicas();
+                    } else {
+                        for (Replica replica : tablet.getReplicas()) {
+                            replica.setState(ReplicaState.NORMAL);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -155,6 +155,9 @@ public abstract class Tablet {
         addReplica(replica, false);
     }
 
+    // Only for detached backup table copies; must NOT be called on live catalog tablets.
+    public abstract void clearReplicas();
+
     public abstract List<Replica> getReplicas();
 
     public Set<Long> getBackendIds() {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTablet.java
@@ -107,6 +107,12 @@ public class CloudTablet extends Tablet implements GsonPostProcessable {
     }
 
     @Override
+    public void clearReplicas() {
+        this.replica = null;
+        this.replicas = null;
+    }
+
+    @Override
     public List<Replica> getReplicas() {
         if (replica == null) {
             return Collections.emptyList();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.info.IndexType;
 import org.apache.doris.cloud.common.util.CloudPropertyAnalyzer;
@@ -639,5 +640,78 @@ public class OlapTableTest {
         }
         }
         // CHECKSTYLE ONca
+    }
+
+    @Test
+    public void testSelectiveCopyBackupReplicaStripping() {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+
+            Database db = UnitTestUtil.createDb(10, 20, 30, 40, 50, 60, 1);
+            OlapTable srcTable = (OlapTable) db.getTableNullable(20);
+            Assert.assertNotNull(srcTable);
+
+            int srcReplicaCount = 0;
+            for (Partition p : srcTable.getPartitions()) {
+                for (MaterializedIndex idx : p.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                    for (Tablet t : idx.getTablets()) {
+                        srcReplicaCount += t.getReplicas().size();
+                    }
+                }
+            }
+            Assert.assertTrue(srcReplicaCount > 0);
+
+            boolean savedConfig = Config.backup_meta_reserve_replica_info;
+            try {
+                Config.backup_meta_reserve_replica_info = false;
+                OlapTable backupCopy = srcTable.selectiveCopy(null, IndexExtState.VISIBLE, true);
+                Assert.assertNotNull(backupCopy);
+                for (Partition p : backupCopy.getPartitions()) {
+                    for (MaterializedIndex idx : p.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                        for (Tablet t : idx.getTablets()) {
+                            Assert.assertEquals(0, t.getReplicas().size());
+                        }
+                    }
+                }
+
+                int srcAfterCount = 0;
+                for (Partition p : srcTable.getPartitions()) {
+                    for (MaterializedIndex idx : p.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                        for (Tablet t : idx.getTablets()) {
+                            srcAfterCount += t.getReplicas().size();
+                        }
+                    }
+                }
+                Assert.assertEquals(srcReplicaCount, srcAfterCount);
+
+                Config.backup_meta_reserve_replica_info = true;
+                OlapTable reservedCopy = srcTable.selectiveCopy(null, IndexExtState.VISIBLE, true);
+                Assert.assertNotNull(reservedCopy);
+                int reservedReplicaCount = 0;
+                for (Partition p : reservedCopy.getPartitions()) {
+                    for (MaterializedIndex idx : p.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                        for (Tablet t : idx.getTablets()) {
+                            reservedReplicaCount += t.getReplicas().size();
+                        }
+                    }
+                }
+                Assert.assertTrue(reservedReplicaCount > 0);
+
+                Config.backup_meta_reserve_replica_info = false;
+                OlapTable nonBackupCopy = srcTable.selectiveCopy(null, IndexExtState.VISIBLE, false);
+                Assert.assertNotNull(nonBackupCopy);
+                int nonBackupReplicaCount = 0;
+                for (Partition p : nonBackupCopy.getPartitions()) {
+                    for (MaterializedIndex idx : p.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                        for (Tablet t : idx.getTablets()) {
+                            nonBackupReplicaCount += t.getReplicas().size();
+                        }
+                    }
+                }
+                Assert.assertTrue(nonBackupReplicaCount > 0);
+            } finally {
+                Config.backup_meta_reserve_replica_info = savedConfig;
+            }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudTabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudTabletTest.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.catalog;
+
+import org.apache.doris.catalog.Replica;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CloudTabletTest {
+
+    @Test
+    public void testClearReplicasRemovesCloudReplica() {
+        CloudTablet tablet = new CloudTablet(10001L);
+        CloudReplica replica = new CloudReplica(20001L, -1L, Replica.ReplicaState.NORMAL, 1L, 0,
+                30001L, 40001L, 50001L, 60001L, 0L);
+
+        tablet.addReplica(replica, true);
+        Assertions.assertSame(replica, tablet.getCloudReplica());
+        Assertions.assertEquals(1, tablet.getReplicas().size());
+
+        tablet.clearReplicas();
+
+        Assertions.assertNull(tablet.getCloudReplica());
+        Assertions.assertTrue(tablet.getReplicas().isEmpty());
+        Assertions.assertNull(tablet.getReplicaById(replica.getId()));
+    }
+}

--- a/regression-test/suites/cloud_p0/snapshot/test_cloud_backup_snapshot_strip_replica.groovy
+++ b/regression-test/suites/cloud_p0/snapshot/test_cloud_backup_snapshot_strip_replica.groovy
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_cloud_backup_snapshot_strip_replica", "p0") {
+    if (!isCloudMode()) {
+        logger.info("not cloud mode, skip this test")
+        return
+    }
+
+    String suiteName = "test_cloud_backup_snapshot_strip_replica"
+    String repoName = "${suiteName}_repo_" + UUID.randomUUID().toString().replace("-", "")
+    String dbName = "test_cloud_backup_snapshot_strip_replica_db"
+    String tableName = "test_cloud_backup_snapshot_strip_replica_table"
+    String snapshotName = "test_cloud_backup_snapshot_strip_replica_snapshot"
+
+    def syncer = getSyncer()
+    syncer.createS3Repository(repoName)
+
+    sql "CREATE DATABASE IF NOT EXISTS ${dbName}"
+    sql "DROP TABLE IF EXISTS ${dbName}.${tableName}"
+    sql """
+        CREATE TABLE ${dbName}.${tableName} (
+            `id` int NOT NULL,
+            `value` varchar(32) NOT NULL
+        )
+        DUPLICATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES
+        (
+            "replication_num" = "1"
+        )
+        """
+
+    sql "INSERT INTO ${dbName}.${tableName} VALUES (1, 'cloud_backup')"
+    def result = sql "SELECT * FROM ${dbName}.${tableName} ORDER BY id"
+    assertEquals(1, result.size())
+
+    sql """
+        BACKUP SNAPSHOT ${dbName}.${snapshotName}
+        TO `${repoName}`
+        ON (${tableName})
+        PROPERTIES ("type" = "full")
+        """
+
+    syncer.waitSnapshotFinish(dbName)
+
+    def snapshot = syncer.getSnapshotTimestamp(repoName, snapshotName)
+    assertTrue(snapshot != null)
+
+    sql "DROP REPOSITORY `${repoName}`"
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
### Historical Context

Backup metadata has stored the full `Table` object since the original backup/restore implementation was introduced in #224. As a result, Replica objects were included implicitly through the catalog object hierarchy:

`OlapTable -> Partition -> MaterializedIndex -> Tablet -> Replica`

They were not added as a dedicated backup metadata object.

A later restore enhancement, #11942, introduced the `reserve_replica` property. That feature preserves the original replication allocation when requested, but it does not require preserving individual serialized Replica objects. During restore, Doris still recreates tablets and replicas with new ids and selected backend ids.

### Background

Large BACKUP jobs can generate very large backup metadata because Doris currently persists all Replica objects for every backed up tablet. For tables with many tablets and replicas, this increases both backup metadata size and FE memory usage.

### Root Cause

Backup metadata currently stores a detached copy of the full table metadata. Since Tablet metadata contains Replica objects, all replicas are serialized into backup metadata as part of the table object graph.

This is unnecessary for restore. Restore only needs the table structure, partition/index/tablet topology, version information, and replica allocation. The actual Replica objects are recreated during restore with new replica ids and selected backend ids.

### Changes

This PR strips replica information from the detached table copy used for backup metadata.

A mutable FE config `backup_meta_reserve_replica_info` is added as a fallback. The default value is `false`, which omits unused replica information from backup metadata. Setting it to `true` preserves the old behavior.

### Follow-up Work

This PR only addresses replica-info amplification in backup metadata. Follow-up PRs will handle larger serialization optimizations:

- Reduce RestoreJob JSON serialization/deserialization memory usage by streaming large RestoreJob fields such as `snapshotInfos` and `restoredVersionInfo`.
- Further reduce BACKUP job memory usage by introducing streaming JSON write/read paths for large backup metadata.

### Compatibility

Restore compatibility is kept because RESTORE does not depend on serialized Replica objects. The previous behavior can still be restored with `backup_meta_reserve_replica_info`.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

