### PR TITLE
[refine](exec) simplify DataQueue eos handling

### DIFF
--- a/be/src/exec/operator/cache_sink_operator.cpp
+++ b/be/src/exec/operator/cache_sink_operator.cpp
@@ -54,12 +54,13 @@ Status CacheSinkOperatorX::sink_impl(RuntimeState* state, Block* in_block, bool 
     SCOPED_TIMER(local_state.exec_time_counter());
     COUNTER_UPDATE(local_state.rows_input_counter(), (int64_t)in_block->rows());
 
-    if (in_block->rows() > 0) {
-        RETURN_IF_ERROR(local_state._shared_state->data_queue.push_block(
-                Block::create_unique(std::move(*in_block)), 0));
-    }
-    if (UNLIKELY(eos)) {
-        local_state._shared_state->data_queue.set_finish(0);
+    if (in_block->rows() > 0 || eos) {
+        std::unique_ptr<Block> output_block;
+        if (in_block->rows() > 0) {
+            output_block = Block::create_unique(std::move(*in_block));
+        }
+        RETURN_IF_ERROR(
+                local_state._shared_state->data_queue.push_block(std::move(output_block), 0, eos));
     }
     return Status::OK();
 }

--- a/be/src/exec/operator/cache_source_operator.cpp
+++ b/be/src/exec/operator/cache_source_operator.cpp
@@ -111,9 +111,8 @@ std::string CacheSourceLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer, "{}", Base::debug_string(indentation_level));
     if (_shared_state) {
-        fmt::format_to(debug_string_buffer, ", data_queue: (is_all_finish = {}, has_data = {})",
-                       _shared_state->data_queue.is_all_finish(),
-                       _shared_state->data_queue.has_more_data());
+        fmt::format_to(debug_string_buffer, ", data_queue: {}",
+                       _shared_state->data_queue.debug_string());
     }
     return fmt::to_string(debug_string_buffer);
 }

--- a/be/src/exec/operator/cache_source_operator.cpp
+++ b/be/src/exec/operator/cache_source_operator.cpp
@@ -140,18 +140,14 @@ Status CacheSourceOperatorX::get_block_impl(RuntimeState* state, Block* block, b
             }
         });
 
-        std::unique_ptr<Block> output_block;
-        int child_idx = 0;
-        RETURN_IF_ERROR(local_state._shared_state->data_queue.get_block_from_queue(&output_block,
-                                                                                   &child_idx));
-        // Here, check the value of `_has_data(state)` again after `data_queue.is_all_finish()` is TRUE
-        // as there may be one or more blocks when `data_queue.is_all_finish()` is TRUE.
-        *eos = !_has_data(state) && local_state._shared_state->data_queue.is_all_finish();
+        auto queue_block = DORIS_TRY(local_state._shared_state->data_queue.get_block_from_queue());
+        *eos = queue_block.eos;
 
-        if (!output_block) {
+        if (!queue_block.block) {
             return Status::OK();
         }
 
+        auto& output_block = queue_block.block;
         if (local_state._need_insert_cache) {
             if (need_clone_empty) {
                 *block = output_block->clone_empty();

--- a/be/src/exec/operator/cache_source_operator.h
+++ b/be/src/exec/operator/cache_source_operator.h
@@ -90,10 +90,6 @@ public:
 
 private:
     TQueryCacheParam _cache_param;
-    bool _has_data(RuntimeState* state) const {
-        auto& local_state = get_local_state(state);
-        return local_state._shared_state->data_queue.remaining_has_data();
-    }
     friend class CacheSourceLocalState;
 };
 

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -134,13 +134,16 @@ std::unique_ptr<Block> DataQueue::get_free_block(int child_idx) {
     return Block::create_unique();
 }
 
-void DataQueue::push_free_block(std::unique_ptr<Block> block, int child_idx) {
-    DCHECK(block->rows() == 0);
+void DataQueue::push_free_block(DataQueueBlock&& queue_block) {
+    if (!queue_block.block) {
+        return;
+    }
+    DCHECK(queue_block.block->rows() == 0);
 
     if (!_is_low_memory_mode) {
-        auto& sub = *_sub_queues[child_idx];
+        auto& sub = *_sub_queues[queue_block.child_idx];
         LockGuard l(sub.free_lock);
-        sub.free_blocks.emplace_back(std::move(block));
+        sub.free_blocks.emplace_back(std::move(queue_block.block));
     }
 }
 
@@ -154,70 +157,70 @@ void DataQueue::clear_free_blocks() {
 
 void DataQueue::terminate() {
     for (int i = 0; i < _child_count; ++i) {
-        set_finish(i);
+        mark_finish(i);
         _sub_queues[i]->clear_blocks();
     }
+    _cur_blocks_total_nums = 0;
     clear_free_blocks();
+    set_source_ready();
 }
 
-//check which queue have data, and save the idx in _flag_queue_idx,
-//so next loop, will check the record idx + 1 first
-//maybe it's useful with many queue, others maybe always 0
-bool DataQueue::remaining_has_data() {
-    int count = _child_count;
-    while (--count >= 0) {
-        _flag_queue_idx++;
-        if (_flag_queue_idx == _child_count) {
-            _flag_queue_idx = 0;
+Result<DataQueueBlock> DataQueue::get_block_from_queue() {
+    DataQueueBlock result;
+    const int start_idx = (_flag_queue_idx + 1) % _child_count;
+    for (int offset = 0; offset < _child_count; ++offset) {
+        const int idx = (start_idx + offset) % _child_count;
+        if (_sub_queues[idx]->blocks_in_queue.load() == 0) {
+            continue;
         }
-        if (_sub_queues[_flag_queue_idx]->blocks_in_queue.load() > 0) {
-            return true;
-        }
-    }
-    return false;
-}
 
-//the _flag_queue_idx indicate which queue has data, and in check can_read
-//will be set idx in remaining_has_data function
-Status DataQueue::get_block_from_queue(std::unique_ptr<Block>* output_block, int* child_idx) {
-    const int idx = _flag_queue_idx;
-    auto& sub = *_sub_queues[idx];
-
-    sub.try_pop(output_block);
-    if (*output_block) {
-        if (child_idx) {
-            *child_idx = idx;
+        auto& sub = *_sub_queues[idx];
+        sub.try_pop(&result.block);
+        if (!result.block) {
+            continue;
         }
+        result.child_idx = idx;
+        _flag_queue_idx = idx;
         auto old_total = _cur_blocks_total_nums.fetch_sub(1);
         if (old_total == 1) {
             set_source_block();
         }
+        break;
     }
-    return Status::OK();
+
+    result.eos = !has_more_data() && is_all_finish();
+    return result;
 }
 
-Status DataQueue::push_block(std::unique_ptr<Block> block, int child_idx) {
-    if (!block) {
+Status DataQueue::push_block(std::unique_ptr<Block> block, int child_idx, bool eos) {
+    DCHECK(block || eos);
+    if (!block && !eos) {
         return Status::OK();
     }
-    auto& sub = *_sub_queues[child_idx];
-    // total_counter is incremented inside try_push under queue_lock, only when the
-    // block is actually enqueued. This ensures get_block_from_queue() always observes
-    // _cur_blocks_total_nums >= 1 when it successfully pops a block, with no risk of
-    // underflow or the need for a rollback on failure.
-    if (!sub.try_push(std::move(block), _cur_blocks_total_nums)) {
-        return Status::EndOfFile("SubQueue already finished");
+
+    if (block) {
+        auto& sub = *_sub_queues[child_idx];
+        // total_counter is incremented inside try_push under queue_lock, only when the
+        // block is actually enqueued. This ensures get_block_from_queue() always observes
+        // _cur_blocks_total_nums >= 1 when it successfully pops a block, with no risk of
+        // underflow or the need for a rollback on failure.
+        if (!sub.try_push(std::move(block), _cur_blocks_total_nums)) {
+            return Status::EndOfFile("SubQueue already finished");
+        }
+    }
+
+    if (eos) {
+        mark_finish(child_idx);
     }
     set_source_ready();
     return Status::OK();
 }
 
-void DataQueue::set_finish(int child_idx) {
+void DataQueue::mark_finish(int child_idx) {
     auto& sub = *_sub_queues[child_idx];
     if (!sub.mark_finished(_un_finished_counter, _is_all_finished)) {
         return;
     }
-    set_source_ready();
 }
 
 bool DataQueue::is_all_finish() {

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -25,6 +25,7 @@
 #include "common/thread_safety_annotations.h"
 #include "core/block/block.h"
 #include "exec/pipeline/dependency.h"
+#include "fmt/format.h"
 
 namespace doris {
 
@@ -97,6 +98,10 @@ bool DataQueue::has_more_data() const {
     return _cur_blocks_total_nums.load() > 0;
 }
 
+std::string DataQueue::debug_string() const {
+    return fmt::format("(is_all_finish = {}, has_data = {})", is_all_finish(), has_more_data());
+}
+
 void DataQueue::set_source_dependency(std::shared_ptr<Dependency> source_dependency)
         NO_THREAD_SAFETY_ANALYSIS {
     _source_dependency = std::move(source_dependency);
@@ -162,7 +167,7 @@ void DataQueue::terminate() {
     }
     _cur_blocks_total_nums = 0;
     clear_free_blocks();
-    set_source_ready();
+    set_source_always_ready();
 }
 
 Result<DataQueueBlock> DataQueue::get_block_from_queue() {
@@ -225,7 +230,7 @@ void DataQueue::mark_finish(int child_idx) {
     }
 }
 
-bool DataQueue::is_all_finish() {
+bool DataQueue::is_all_finish() const {
     return _is_all_finished;
 }
 
@@ -233,6 +238,13 @@ void DataQueue::set_source_ready() {
     LockGuard lc(_source_lock);
     if (_source_dependency) {
         _source_dependency->set_ready();
+    }
+}
+
+void DataQueue::set_source_always_ready() {
+    LockGuard lc(_source_lock);
+    if (_source_dependency) {
+        _source_dependency->set_always_ready();
     }
 }
 

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -188,7 +188,9 @@ Result<DataQueueBlock> DataQueue::get_block_from_queue() {
         break;
     }
 
-    result.eos = !has_more_data() && is_all_finish();
+    // A producer enqueues its final block before marking the child finished. Observe completion
+    // first, then recheck queued data to avoid reporting EOS while the final block is still queued.
+    result.eos = is_all_finish() && !has_more_data();
     return result;
 }
 

--- a/be/src/exec/operator/data_queue.h
+++ b/be/src/exec/operator/data_queue.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "common/status.h"
@@ -97,9 +98,7 @@ public:
     std::unique_ptr<Block> get_free_block(int child_idx = 0);
     void push_free_block(DataQueueBlock&& queue_block);
 
-    bool is_all_finish();
-
-    bool has_more_data() const;
+    std::string debug_string() const;
 
     void set_source_dependency(std::shared_ptr<Dependency> source_dependency)
             NO_THREAD_SAFETY_ANALYSIS;
@@ -110,9 +109,12 @@ public:
     void terminate();
 
 private:
+    bool is_all_finish() const;
+    bool has_more_data() const;
     void clear_free_blocks();
     void mark_finish(int child_idx);
     void set_source_ready();
+    void set_source_always_ready();
     void set_source_block();
 
     std::vector<std::unique_ptr<SubQueue>> _sub_queues;

--- a/be/src/exec/operator/data_queue.h
+++ b/be/src/exec/operator/data_queue.h
@@ -30,6 +30,15 @@ namespace doris {
 
 class Dependency;
 
+struct DataQueueBlock {
+    std::unique_ptr<Block> block;
+    bool eos = false;
+
+private:
+    int child_idx = 0;
+    friend class DataQueue;
+};
+
 // Per child sub-queue. Groups all parallel state so that the lock/field
 // relationship is explicit and can be checked by clang -Wthread-safety.
 struct SubQueue {
@@ -46,7 +55,7 @@ struct SubQueue {
     AnnotatedMutex free_lock;
     std::deque<std::unique_ptr<Block>> free_blocks GUARDED_BY(free_lock);
 
-    // blocks_in_queue is readable from lock-free fast paths (remaining_has_data),
+    // blocks_in_queue is readable from lock-free fast paths (get_block_from_queue),
     // so it remains atomic and is intentionally not GUARDED_BY.
     std::atomic_uint32_t blocks_in_queue {0};
 
@@ -82,17 +91,14 @@ public:
     DataQueue(int child_count = 1);
     ~DataQueue() = default;
 
-    Status get_block_from_queue(std::unique_ptr<Block>* block, int* child_idx = nullptr);
-    Status push_block(std::unique_ptr<Block> block, int child_idx = 0);
+    Result<DataQueueBlock> get_block_from_queue();
+    Status push_block(std::unique_ptr<Block> block, int child_idx, bool eos);
 
     std::unique_ptr<Block> get_free_block(int child_idx = 0);
-    void push_free_block(std::unique_ptr<Block> output_block, int child_idx = 0);
+    void push_free_block(DataQueueBlock&& queue_block);
 
-    void set_finish(int child_idx = 0);
     bool is_all_finish();
 
-    // This function is not thread safe, should be called in Operator::get_block()
-    bool remaining_has_data();
     bool has_more_data() const;
 
     void set_source_dependency(std::shared_ptr<Dependency> source_dependency)
@@ -105,6 +111,7 @@ public:
 
 private:
     void clear_free_blocks();
+    void mark_finish(int child_idx);
     void set_source_ready();
     void set_source_block();
 
@@ -117,7 +124,7 @@ private:
     std::atomic_uint32_t _cur_blocks_total_nums = 0;
 
     //this will be indicate which queue has data, it's useful when have many queues
-    std::atomic_int _flag_queue_idx = 0;
+    int _flag_queue_idx = 0;
     // only used by streaming agg source operator
 
     std::atomic_bool _is_low_memory_mode = false;

--- a/be/src/exec/operator/union_sink_operator.cpp
+++ b/be/src/exec/operator/union_sink_operator.cpp
@@ -100,44 +100,21 @@ Status UnionSinkOperatorX::sink_impl(RuntimeState* state, Block* in_block, bool 
     }
     SCOPED_TIMER(local_state.exec_time_counter());
     COUNTER_UPDATE(local_state.rows_input_counter(), (int64_t)in_block->rows());
-    if (local_state._output_block == nullptr) {
-        local_state._output_block =
-                local_state._shared_state->data_queue.get_free_block(_cur_child_id);
-    }
-    if (_cur_child_id < _get_first_materialized_child_idx()) { //pass_through
-        if (in_block->rows() > 0) {
-            local_state._output_block->swap(*in_block);
-            RETURN_IF_ERROR(local_state._shared_state->data_queue.push_block(
-                    std::move(local_state._output_block), _cur_child_id));
-        }
+    auto output_block = local_state._shared_state->data_queue.get_free_block(_cur_child_id);
+    if (is_child_passthrough(_cur_child_id)) { //pass_through
+        output_block->swap(*in_block);
     } else if (_get_first_materialized_child_idx() != children_count() &&
                _cur_child_id < children_count()) { //need materialized
-        RETURN_IF_ERROR(materialize_child_block(state, _cur_child_id, in_block,
-                                                local_state._output_block.get()));
+        RETURN_IF_ERROR(
+                materialize_child_block(state, _cur_child_id, in_block, output_block.get()));
     } else {
         return Status::InternalError("maybe can't reach here, execute const expr: {}, {}, {}",
                                      _cur_child_id, _get_first_materialized_child_idx(),
                                      children_count());
     }
-    if (UNLIKELY(eos)) {
-        //if _cur_child_id eos, need check to push block
-        //Now here can't check _output_block rows, even it's row==0, also need push block
-        //because maybe sink is eos and queue have none data, if not push block
-        //the source can't can_read again and can't set source finished
-        if (local_state._output_block) {
-            RETURN_IF_ERROR(local_state._shared_state->data_queue.push_block(
-                    std::move(local_state._output_block), _cur_child_id));
-        }
 
-        local_state._shared_state->data_queue.set_finish(_cur_child_id);
-        return Status::OK();
-    }
-    // not eos and block rows is enough to output,so push block
-    if (local_state._output_block && (local_state._output_block->rows() >= state->batch_size())) {
-        RETURN_IF_ERROR(local_state._shared_state->data_queue.push_block(
-                std::move(local_state._output_block), _cur_child_id));
-    }
-    return Status::OK();
+    return local_state._shared_state->data_queue.push_block(std::move(output_block), _cur_child_id,
+                                                            eos);
 }
 
 } // namespace doris

--- a/be/src/exec/operator/union_sink_operator.h
+++ b/be/src/exec/operator/union_sink_operator.h
@@ -51,8 +51,7 @@ class UnionSinkOperatorX;
 class UnionSinkLocalState final : public PipelineXSinkLocalState<UnionSharedState> {
 public:
     ENABLE_FACTORY_CREATOR(UnionSinkLocalState);
-    UnionSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state)
-            : Base(parent, state), _child_row_idx(0) {}
+    UnionSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state) : Base(parent, state) {}
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
     Status open(RuntimeState* state) override;
     friend class UnionSinkOperatorX;
@@ -60,8 +59,6 @@ public:
     using Parent = UnionSinkOperatorX;
 
 private:
-    std::unique_ptr<Block> _output_block;
-
     /// Const exprs materialized by this node. These exprs don't refer to any children.
     /// Only materialized by the first fragment instance to avoid duplication.
     VExprContextSPtrs _const_expr;
@@ -69,8 +66,6 @@ private:
     /// Exprs materialized by this node. The i-th result expr list refers to the i-th child.
     VExprContextSPtrs _child_expr;
 
-    /// Index of current row in child_row_block_.
-    int _child_row_idx;
     RuntimeProfile::Counter* _expr_timer = nullptr;
 };
 
@@ -168,7 +163,6 @@ private:
                 RETURN_IF_ERROR(
                         materialize_block(local_state._child_expr, input_block, &res, false));
             }
-            local_state._child_row_idx += res.rows();
             RETURN_IF_ERROR(mblock.merge(res));
         }
         return Status::OK();

--- a/be/src/exec/operator/union_source_operator.cpp
+++ b/be/src/exec/operator/union_source_operator.cpp
@@ -92,9 +92,8 @@ std::string UnionSourceLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer, "{}", Base::debug_string(indentation_level));
     if (_shared_state) {
-        fmt::format_to(debug_string_buffer, ", data_queue: (is_all_finish = {}, has_data = {})",
-                       _shared_state->data_queue.is_all_finish(),
-                       _shared_state->data_queue.has_more_data());
+        fmt::format_to(debug_string_buffer, ", data_queue: {}",
+                       _shared_state->data_queue.debug_string());
     }
     return fmt::to_string(debug_string_buffer);
 }

--- a/be/src/exec/operator/union_source_operator.cpp
+++ b/be/src/exec/operator/union_source_operator.cpp
@@ -30,7 +30,6 @@
 #include "exec/operator/union_sink_operator.h"
 #include "exec/pipeline/dependency.h"
 #include "runtime/descriptors.h"
-#include "util/defer_op.h"
 
 namespace doris {
 class RuntimeState;
@@ -102,40 +101,25 @@ std::string UnionSourceLocalState::debug_string(int indentation_level) const {
 
 Status UnionSourceOperatorX::get_block_impl(RuntimeState* state, Block* block, bool* eos) {
     auto& local_state = get_local_state(state);
-    Defer set_eos {[&]() {
-        // the eos check of union operator is complex, need check all logical if you want modify
-        // could ref this PR: https://github.com/apache/doris/pull/29677
-        // have executing const expr, queue have no data anymore, and child could be closed
-        if (_child_size == 0 && !local_state._need_read_for_const_expr) {
-            *eos = true;
-        } else if (_has_data(state)) {
-            *eos = false;
-        } else if (local_state._shared_state->data_queue.is_all_finish()) {
-            // Here, check the value of `_has_data(state)` again after `data_queue.is_all_finish()` is TRUE
-            // as there may be one or more blocks when `data_queue.is_all_finish()` is TRUE.
-            *eos = !_has_data(state);
-        } else {
-            *eos = false;
-        }
-    }};
-
+    *eos = false;
     SCOPED_TIMER(local_state.exec_time_counter());
     if (local_state._need_read_for_const_expr) {
         if (has_more_const(state)) {
             RETURN_IF_ERROR(get_next_const(state, block));
         }
         local_state._need_read_for_const_expr = has_more_const(state);
+        if (_child_size == 0 && !local_state._need_read_for_const_expr) {
+            *eos = true;
+        }
     } else if (_child_size != 0) {
-        std::unique_ptr<Block> output_block;
-        int child_idx = 0;
-        RETURN_IF_ERROR(local_state._shared_state->data_queue.get_block_from_queue(&output_block,
-                                                                                   &child_idx));
-        if (!output_block) {
+        auto queue_block = DORIS_TRY(local_state._shared_state->data_queue.get_block_from_queue());
+        *eos = queue_block.eos;
+        if (!queue_block.block) {
             return Status::OK();
         }
-        block->swap(*output_block);
-        output_block->clear_column_data(row_descriptor().num_materialized_slots());
-        local_state._shared_state->data_queue.push_free_block(std::move(output_block), child_idx);
+        block->swap(*queue_block.block);
+        queue_block.block->clear_column_data(row_descriptor().num_materialized_slots());
+        local_state._shared_state->data_queue.push_free_block(std::move(queue_block));
     }
     local_state.reached_limit(block, eos);
     return Status::OK();

--- a/be/src/exec/operator/union_source_operator.h
+++ b/be/src/exec/operator/union_source_operator.h
@@ -122,13 +122,6 @@ public:
     }
 
 private:
-    bool _has_data(RuntimeState* state) const {
-        auto& local_state = get_local_state(state);
-        if (_child_size == 0) {
-            return local_state._need_read_for_const_expr;
-        }
-        return local_state._shared_state->data_queue.remaining_has_data();
-    }
     bool has_more_const(RuntimeState* state) const {
         auto& local_state = get_local_state(state);
         return state->per_fragment_instance_idx() == 0 &&

--- a/be/test/exec/operator/union_operator_test.cpp
+++ b/be/test/exec/operator/union_operator_test.cpp
@@ -254,7 +254,9 @@ TEST_F(UnionOperatorTest, test_sink_and_source) {
 
     {
         for (int i = 0; i < child_size; i++) {
-            sink_state[i]->_batch_size = 2;
+            // Each sink input should be queued immediately, including materialized children whose
+            // input is smaller than the runtime batch size.
+            sink_state[i]->_batch_size = 10;
             Block block = ColumnHelper::create_block<DataTypeInt64>({1, 2}, {3, 4});
             EXPECT_TRUE(sink_ops[i]->sink(sink_state[i].get(), &block, false));
         }

--- a/be/test/exec/pipeline/data_queue_test.cpp
+++ b/be/test/exec/pipeline/data_queue_test.cpp
@@ -221,8 +221,7 @@ public:
 
 // Initial state: no data, no finish.
 TEST_F(DataQueueTest, InitialState) {
-    EXPECT_FALSE(data_queue->has_more_data());
-    EXPECT_FALSE(data_queue->is_all_finish());
+    EXPECT_EQ(data_queue->debug_string(), "(is_all_finish = false, has_data = false)");
     auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
     EXPECT_EQ(queue_block.block, nullptr);
     EXPECT_FALSE(queue_block.eos);
@@ -231,22 +230,25 @@ TEST_F(DataQueueTest, InitialState) {
 // Push one block and retrieve it.
 TEST_F(DataQueueTest, SinglePushPop) {
     EXPECT_TRUE(data_queue->push_block(make_block(), 0, false).ok());
-    EXPECT_TRUE(data_queue->has_more_data());
+    EXPECT_EQ(data_queue->debug_string(), "(is_all_finish = false, has_data = true)");
 
     auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
     EXPECT_NE(queue_block.block, nullptr);
     EXPECT_FALSE(queue_block.eos);
-    EXPECT_FALSE(data_queue->has_more_data());
+    EXPECT_EQ(data_queue->debug_string(), "(is_all_finish = false, has_data = false)");
 }
 
 // is_all_finish only becomes true after all children push eos.
 TEST_F(DataQueueTest, IsAllFinishAfterAllChildren) {
     EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
-    EXPECT_FALSE(data_queue->is_all_finish());
+    auto first_queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_FALSE(first_queue_block.eos);
     EXPECT_TRUE(data_queue->push_block(nullptr, 1, true).ok());
-    EXPECT_FALSE(data_queue->is_all_finish());
+    auto second_queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_FALSE(second_queue_block.eos);
     EXPECT_TRUE(data_queue->push_block(nullptr, 2, true).ok());
-    EXPECT_TRUE(data_queue->is_all_finish());
+    auto last_queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_TRUE(last_queue_block.eos);
 }
 
 // eos push is idempotent.
@@ -255,7 +257,8 @@ TEST_F(DataQueueTest, EosPushIdempotent) {
     EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
     EXPECT_TRUE(data_queue->push_block(nullptr, 1, true).ok());
     EXPECT_TRUE(data_queue->push_block(nullptr, 2, true).ok());
-    EXPECT_TRUE(data_queue->is_all_finish());
+    auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_TRUE(queue_block.eos);
 }
 
 // DataQueueBlock can return a popped block to the originating child free list.
@@ -321,7 +324,9 @@ TEST_F(DataQueueTest, Terminate) {
 
     data_queue->terminate();
 
-    EXPECT_TRUE(data_queue->is_all_finish());
+    EXPECT_EQ(data_queue->debug_string(), "(is_all_finish = true, has_data = false)");
+    source_dep->block();
+    EXPECT_TRUE(source_dep->ready());
     auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
     EXPECT_EQ(queue_block.block, nullptr);
     EXPECT_TRUE(queue_block.eos);
@@ -422,7 +427,7 @@ TEST_F(DataQueueTest, MultiTest) {
     output1.join();
 
     EXPECT_EQ(output_count, 150);
-    EXPECT_TRUE(data_queue->is_all_finish());
+    EXPECT_EQ(data_queue->debug_string(), "(is_all_finish = true, has_data = false)");
 }
 
 // ./run-be-ut.sh --run --filter=DataQueueTest.*

--- a/be/test/exec/pipeline/data_queue_test.cpp
+++ b/be/test/exec/pipeline/data_queue_test.cpp
@@ -223,55 +223,54 @@ public:
 TEST_F(DataQueueTest, InitialState) {
     EXPECT_FALSE(data_queue->has_more_data());
     EXPECT_FALSE(data_queue->is_all_finish());
-    EXPECT_FALSE(data_queue->remaining_has_data());
+    auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_EQ(queue_block.block, nullptr);
+    EXPECT_FALSE(queue_block.eos);
 }
 
 // Push one block and retrieve it.
 TEST_F(DataQueueTest, SinglePushPop) {
-    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0, false).ok());
     EXPECT_TRUE(data_queue->has_more_data());
 
-    // Find the queue with data.
-    EXPECT_TRUE(data_queue->remaining_has_data());
-
-    std::unique_ptr<Block> out;
-    int child_idx = -1;
-    EXPECT_TRUE(data_queue->get_block_from_queue(&out, &child_idx).ok());
-    EXPECT_NE(out, nullptr);
-    EXPECT_EQ(child_idx, 0);
+    auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_NE(queue_block.block, nullptr);
+    EXPECT_FALSE(queue_block.eos);
     EXPECT_FALSE(data_queue->has_more_data());
 }
 
-// is_all_finish only becomes true after all children call set_finish.
+// is_all_finish only becomes true after all children push eos.
 TEST_F(DataQueueTest, IsAllFinishAfterAllChildren) {
-    data_queue->set_finish(0);
+    EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
     EXPECT_FALSE(data_queue->is_all_finish());
-    data_queue->set_finish(1);
+    EXPECT_TRUE(data_queue->push_block(nullptr, 1, true).ok());
     EXPECT_FALSE(data_queue->is_all_finish());
-    data_queue->set_finish(2);
+    EXPECT_TRUE(data_queue->push_block(nullptr, 2, true).ok());
     EXPECT_TRUE(data_queue->is_all_finish());
 }
 
-// set_finish is idempotent.
-TEST_F(DataQueueTest, SetFinishIdempotent) {
-    data_queue->set_finish(0);
-    data_queue->set_finish(0); // second call must not double-decrement
-    data_queue->set_finish(1);
-    data_queue->set_finish(2);
+// eos push is idempotent.
+TEST_F(DataQueueTest, EosPushIdempotent) {
+    EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
+    EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
+    EXPECT_TRUE(data_queue->push_block(nullptr, 1, true).ok());
+    EXPECT_TRUE(data_queue->push_block(nullptr, 2, true).ok());
     EXPECT_TRUE(data_queue->is_all_finish());
 }
 
-// child_idx returned by get_block_from_queue reflects the actual queue.
-TEST_F(DataQueueTest, ChildIdxReturned) {
+// DataQueueBlock can return a popped block to the originating child free list.
+TEST_F(DataQueueTest, ReturnBlockToChildFreeList) {
     // Push to child 1 only.
-    EXPECT_TRUE(data_queue->push_block(make_block(), 1).ok());
-    data_queue->remaining_has_data(); // advance _flag_queue_idx to find child 1
+    EXPECT_TRUE(data_queue->push_block(make_block(), 1, false).ok());
 
-    std::unique_ptr<Block> out;
-    int child_idx = -1;
-    EXPECT_TRUE(data_queue->get_block_from_queue(&out, &child_idx).ok());
-    EXPECT_NE(out, nullptr);
-    EXPECT_EQ(child_idx, 1);
+    auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_NE(queue_block.block, nullptr);
+    queue_block.block->clear();
+    auto* returned_block = queue_block.block.get();
+    data_queue->push_free_block(std::move(queue_block));
+
+    auto reused_block = data_queue->get_free_block(1);
+    EXPECT_EQ(reused_block.get(), returned_block);
 }
 
 // get_free_block returns a new block when free list is empty, reuses when not.
@@ -282,7 +281,9 @@ TEST_F(DataQueueTest, FreeBlockReuse) {
 
     // Return it to the free list.
     block->clear(); // ensure rows == 0
-    data_queue->push_free_block(std::move(block), 0);
+    DataQueueBlock queue_block;
+    queue_block.block = std::move(block);
+    data_queue->push_free_block(std::move(queue_block));
 
     // Second call: must return the recycled block.
     auto block2 = data_queue->get_free_block(0);
@@ -292,7 +293,9 @@ TEST_F(DataQueueTest, FreeBlockReuse) {
 // In low-memory mode push_free_block discards blocks and max drops to 1.
 TEST_F(DataQueueTest, LowMemoryMode) {
     // Pre-populate the free list.
-    data_queue->push_free_block(Block::create_unique(), 0);
+    DataQueueBlock queue_block;
+    queue_block.block = Block::create_unique();
+    data_queue->push_free_block(std::move(queue_block));
 
     data_queue->set_low_memory_mode();
 
@@ -303,7 +306,9 @@ TEST_F(DataQueueTest, LowMemoryMode) {
 
     // push_free_block now discards.
     block->clear();
-    data_queue->push_free_block(std::move(block), 0);
+    DataQueueBlock low_memory_block;
+    low_memory_block.block = std::move(block);
+    data_queue->push_free_block(std::move(low_memory_block));
     auto block2 = data_queue->get_free_block(0);
     // Still gets a fresh allocation (free list stays empty).
     EXPECT_NE(block2, nullptr);
@@ -311,15 +316,15 @@ TEST_F(DataQueueTest, LowMemoryMode) {
 
 // terminate() finishes all children and clears pending blocks from sub-queues.
 TEST_F(DataQueueTest, Terminate) {
-    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
-    EXPECT_TRUE(data_queue->push_block(make_block(), 1).ok());
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0, false).ok());
+    EXPECT_TRUE(data_queue->push_block(make_block(), 1, false).ok());
 
     data_queue->terminate();
 
     EXPECT_TRUE(data_queue->is_all_finish());
-    // remaining_has_data() checks blocks_in_queue per sub-queue,
-    // which clear_blocks() resets to 0.
-    EXPECT_FALSE(data_queue->remaining_has_data());
+    auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_EQ(queue_block.block, nullptr);
+    EXPECT_TRUE(queue_block.eos);
 }
 
 // set_max_blocks_in_sub_queue propagates to every sub-queue.
@@ -327,12 +332,12 @@ TEST_F(DataQueueTest, SetMaxBlocksInSubQueue) {
     data_queue->set_max_blocks_in_sub_queue(5);
     // Push 5 blocks to child 0 — sink must stay ready (not over the limit yet).
     for (int i = 0; i < 5; i++) {
-        EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+        EXPECT_TRUE(data_queue->push_block(make_block(), 0, false).ok());
     }
     EXPECT_TRUE(sink_deps[0]->ready());
 
     // 6th push exceeds limit → sink blocked.
-    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0, false).ok());
     EXPECT_FALSE(sink_deps[0]->ready());
 }
 
@@ -341,8 +346,26 @@ TEST_F(DataQueueTest, SourceReadyOnPush) {
     source_dep->block(); // start blocked
     EXPECT_FALSE(source_dep->ready());
 
-    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0, false).ok());
     EXPECT_TRUE(source_dep->ready());
+}
+
+TEST_F(DataQueueTest, SourceReadyOnEosOnly) {
+    source_dep->block();
+    EXPECT_FALSE(source_dep->ready());
+
+    EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
+    EXPECT_TRUE(source_dep->ready());
+}
+
+TEST_F(DataQueueTest, EosOnlyAfterAllChildren) {
+    EXPECT_TRUE(data_queue->push_block(nullptr, 0, true).ok());
+    EXPECT_TRUE(data_queue->push_block(nullptr, 1, true).ok());
+    EXPECT_TRUE(data_queue->push_block(nullptr, 2, true).ok());
+
+    auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+    EXPECT_EQ(queue_block.block, nullptr);
+    EXPECT_TRUE(queue_block.eos);
 }
 
 // ---------------------------------------------------------------------------
@@ -355,19 +378,9 @@ TEST_F(DataQueueTest, MultiTest) {
         while (true) {
             bool eos = false;
             if (source_dep->ready()) {
-                Defer set_eos {[&]() {
-                    if (data_queue->remaining_has_data()) {
-                        eos = false;
-                    } else if (data_queue->is_all_finish()) {
-                        eos = !data_queue->remaining_has_data();
-                    } else {
-                        eos = false;
-                    }
-                }};
-                std::unique_ptr<Block> output_block;
-                int child_idx = 0;
-                EXPECT_TRUE(data_queue->get_block_from_queue(&output_block, &child_idx));
-                if (output_block) {
+                auto queue_block = TEST_TRY(data_queue->get_block_from_queue());
+                eos = queue_block.eos;
+                if (queue_block.block) {
                     output_count++;
                 }
             }
@@ -392,11 +405,11 @@ TEST_F(DataQueueTest, MultiTest) {
         int i = 0;
         while (i < 50) {
             if (sink_deps[id]->ready()) {
-                EXPECT_TRUE(data_queue->push_block(std::move(input_blocks[id][i]), id).ok());
+                EXPECT_TRUE(data_queue->push_block(std::move(input_blocks[id][i]), id, false).ok());
                 i++;
             }
         }
-        data_queue->set_finish(id);
+        EXPECT_TRUE(data_queue->push_block(nullptr, id, true).ok());
     };
 
     std::thread input1(input_func, 0);


### PR DESCRIPTION

### What problem does this PR solve?

DataQueue exposed its internal child-finish and queue-selection protocol to source and sink operators, which made EOS handling duplicated and difficult to follow.

This change carries EOS through `push_block()` and `DataQueueBlock`, moves child selection into DataQueue, and updates Union and Cache operators to consume the unified result. Union sink also forwards each input block immediately instead of retaining a cross-call output 


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

