### PR TITLE
[chore](be) Add code owners for format v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@ be/src/io                                                    @liaoxin01 @gavinch
 be/src/io/cache                                              @liaoxin01 @gavinchou @morningman @Gabriel39
 be/src/io/fs                                                 @liaoxin01 @gavinchou @morningman @Gabriel39
 be/src/io/tools                                              @liaoxin01 @gavinchou
+be/src/format_v2                                             @Gabriel39 @yiguolei
 be/src/load                                                  @liaoxin01 @gavinchou
 be/src/load/channel                                          @liaoxin01 @gavinchou
 be/src/load/delta_writer                                     @liaoxin01 @gavinchou


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Add explicit CODEOWNERS coverage for `be/src/format_v2`, assigning reviews to `@Gabriel39` and `@yiguolei`.

### Release note

None

### Check List (For Author)

- Test: No need to test (CODEOWNERS metadata-only change)
- Behavior changed: No
- Does this need documentation: No
