### PR TITLE
[fix](cloud) Track deleted instance recycle status

### DIFF
--- a/cloud/src/common/http_helper.cpp
+++ b/cloud/src/common/http_helper.cpp
@@ -370,7 +370,12 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                               return process_query_rate_limit((MS*)s, c);
                           },
                   .role = HttpRole::META_SERVICE}},
-
+                {"check_instance_recycle_completed",
+                 {.handler =
+                          [](void* s, brpc::Controller* c) {
+                              return process_check_instance_recycle_completed((MS*)s, c);
+                          },
+                  .role = HttpRole::META_SERVICE}},
                 // Recycler APIs
                 {"recycle_instance",
                  {.handler =
@@ -399,6 +404,12 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                 {"check_instance",
                  {.handler = [](void* s,
                                 brpc::Controller* c) { return process_check_instance((RS*)s, c); },
+                  .role = HttpRole::RECYCLER}},
+                {"set_instance_recycled_state",
+                 {.handler =
+                          [](void* s, brpc::Controller* c) {
+                              return process_set_instance_recycled_state((RS*)s, c);
+                          },
                   .role = HttpRole::RECYCLER}},
                 {"check_job_info",
                  {.handler = [](void* s,
@@ -561,6 +572,34 @@ HttpResponse process_alter_instance(MetaServiceImpl* service, brpc::Controller* 
     return http_json_reply(resp.status());
 }
 
+HttpResponse process_set_instance_recycled_state(RecyclerServiceImpl* service,
+                                                 brpc::Controller* ctrl) {
+    auto& uri = ctrl->http_request().uri();
+    std::string instance_id(http_query(uri, "instance_id"));
+    std::string recycled_state_str(http_query(uri, "recycled_state"));
+    if (instance_id.empty()) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "instance_id is empty");
+    }
+    if (recycled_state_str.empty()) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "recycled_state is empty");
+    }
+
+    InstanceRecycleState recycled_state;
+    if (!InstanceRecycleState_Parse(recycled_state_str, &recycled_state) ||
+        (recycled_state != InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING &&
+         recycled_state != InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED &&
+         recycled_state != InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED)) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
+                               "invalid recycled_state, supported values: "
+                               "INSTANCE_RECYCLE_STATE_CLEANUP_PENDING, "
+                               "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED, "
+                               "INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED");
+    }
+
+    auto [code, msg] = service->set_instance_recycled_state(instance_id, recycled_state);
+    return http_json_reply(code, msg);
+}
+
 HttpResponse process_abort_txn(MetaServiceImpl* service, brpc::Controller* ctrl) {
     AbortTxnRequest req;
     PARSE_MESSAGE_OR_RETURN(ctrl, req);
@@ -699,6 +738,32 @@ HttpResponse process_query_rate_limit(MetaServiceImpl* service, brpc::Controller
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
     d.Accept(writer);
     return http_json_reply(MetaServiceCode::OK, "", sb.GetString());
+}
+
+HttpResponse process_check_instance_recycle_completed(MetaServiceImpl* service,
+                                                      brpc::Controller* cntl) {
+    const auto* instance_id = cntl->http_request().uri().GetQuery("instance_id");
+    if (!instance_id || instance_id->empty()) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "no instance id");
+    }
+
+    bool finished = false;
+    std::string reason;
+    auto [code, msg] = service->check_instance_recycle_completed(*instance_id, finished, reason);
+    if (code != MetaServiceCode::OK) {
+        return http_json_reply(code, msg);
+    }
+
+    rapidjson::Document result;
+    result.SetObject();
+    result.AddMember("finished", finished, result.GetAllocator());
+    result.AddMember("reason",
+                     rapidjson::Value(reason.data(), reason.size(), result.GetAllocator()),
+                     result.GetAllocator());
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    result.Accept(writer);
+    return http_json_reply(code, msg, buffer.GetString());
 }
 
 // Recycler HTTP handlers

--- a/cloud/src/common/http_helper.h
+++ b/cloud/src/common/http_helper.h
@@ -124,6 +124,9 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
 [[maybe_unused]] HttpResponse process_query_rate_limit(MetaServiceImpl* service,
                                                        brpc::Controller* cntl);
 
+[[maybe_unused]] HttpResponse process_check_instance_recycle_completed(MetaServiceImpl* service,
+                                                                       brpc::Controller* cntl);
+
 [[maybe_unused]] HttpResponse process_decode_key(MetaServiceImpl*, brpc::Controller* ctrl);
 
 [[maybe_unused]] HttpResponse process_encode_key(MetaServiceImpl*, brpc::Controller* ctrl);
@@ -199,6 +202,9 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                                                        brpc::Controller* cntl);
 [[maybe_unused]] HttpResponse process_check_instance(RecyclerServiceImpl* service,
                                                      brpc::Controller* cntl);
+
+[[maybe_unused]] HttpResponse process_set_instance_recycled_state(RecyclerServiceImpl* service,
+                                                                  brpc::Controller* ctrl);
 
 [[maybe_unused]] HttpResponse process_check_job_info(RecyclerServiceImpl* service,
                                                      brpc::Controller* cntl);

--- a/cloud/src/meta-service/meta_service.h
+++ b/cloud/src/meta-service/meta_service.h
@@ -430,6 +430,9 @@ public:
                           const CompactSnapshotRequest* request, CompactSnapshotResponse* response,
                           ::google::protobuf::Closure* done) override;
 
+    std::pair<MetaServiceCode, std::string> check_instance_recycle_completed(
+            const std::string& instance_id, bool& finished, std::string& reason);
+
 private:
     std::pair<MetaServiceCode, std::string> alter_instance(
             const AlterInstanceRequest* request,

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2562,6 +2562,9 @@ static std::pair<MetaServiceCode, std::string> drop_single_instance(const std::s
 
     instance->set_status(InstanceInfoPB::DELETED);
     instance->set_mtime(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
+    instance->set_recycled_state(INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    instance->set_recycled_state_update_time_ms(
+            duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
 
     std::string serialized = instance->SerializeAsString();
     if (serialized.empty()) {
@@ -2634,6 +2637,11 @@ static std::pair<MetaServiceCode, std::string> drop_instance_chain(
     for (auto& instance : predecessors) {
         instance.set_status(InstanceInfoPB::DELETED);
         instance.set_mtime(now);
+        if (!instance.has_recycled_state()) {
+            instance.set_recycled_state(INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+            instance.set_recycled_state_update_time_ms(
+                    duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+        }
         std::string serialized;
         if (!instance.SerializeToString(&serialized)) {
             std::string msg =
@@ -2645,8 +2653,13 @@ static std::pair<MetaServiceCode, std::string> drop_instance_chain(
         LOG(INFO) << "marking chain predecessor as DELETED, instance_id=" << instance.instance_id();
     }
 
-    tail_instance->set_status(InstanceInfoPB::DELETED);
     tail_instance->set_mtime(now);
+    if (!tail_instance->has_recycled_state()) {
+        tail_instance->set_recycled_state(INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+        tail_instance->set_recycled_state_update_time_ms(
+                duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+    }
+    tail_instance->set_status(InstanceInfoPB::DELETED);
     std::string serialized = tail_instance->SerializeAsString();
     if (serialized.empty()) {
         std::string msg = "failed to serialize";
@@ -2656,6 +2669,132 @@ static std::pair<MetaServiceCode, std::string> drop_instance_chain(
     LOG(INFO) << "drop instance_id=" << tail_instance_id << " and " << predecessors.size()
               << " predecessor instances, json=" << proto_to_json(*tail_instance);
     return {MetaServiceCode::OK, std::move(serialized)};
+}
+
+std::pair<MetaServiceCode, std::string> MetaServiceImpl::check_instance_recycle_completed(
+        const std::string& instance_id, bool& finished, std::string& reason) {
+    // Recycler preserves this invariant for an instance chain:
+    //
+    //   original A  ->  B  ->  tail C
+    //   cleanup:        A, B, and C reach CLEANUP_COMPLETED first
+    //   key removal:    C  ->  B  ->  A
+    //
+    // A missing target key is therefore a valid completion signal: the target and its whole
+    // chain have already passed cleanup before the key could be removed. If a chain successor key
+    // still exists, verify its state and walk the original-to-target links to check every
+    // predecessor.
+    reason.clear();
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg = fmt::format("failed to create txn, err={}", err);
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::KV_TXN_CREATE_ERR, std::move(msg)};
+    }
+
+    std::string key = instance_key({instance_id});
+    std::string value;
+    err = txn->get(key, &value);
+    if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+        // The recycler only removes keys after cleanup is complete, so do not treat this as an
+        // incomplete or unknown state.
+        finished = true;
+        reason = fmt::format(
+                "instance recycling is considered completed because the instance key does not "
+                "exist, instance_id={}",
+                instance_id);
+        return {MetaServiceCode::OK, "OK"};
+    }
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg =
+                fmt::format("failed to get instance, instance_id={}, err={}", instance_id, err);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::KV_TXN_GET_ERR, std::move(msg)};
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        std::string msg = fmt::format("malformed instance info, key={}", hex(key));
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
+    }
+
+    finished = instance.recycled_state() ==
+               InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED;
+    if (!finished) {
+        reason = fmt::format(
+                "instance has not completed recycling, instance_id={}, recycled_state={}",
+                instance_id, InstanceRecycleState_Name(instance.recycled_state()));
+        return {MetaServiceCode::OK, "OK"};
+    }
+
+    if (instance.original_instance_id().empty()) {
+        reason = fmt::format("instance recycling has completed, instance_id={}, recycled_state={}",
+                             instance_id, InstanceRecycleState_Name(instance.recycled_state()));
+        return {MetaServiceCode::OK, "OK"};
+    }
+
+    // Walk from the original instance to the queried instance through successor links. For a
+    // chain A -> B -> C queried by instance_id=C, the expected walk is:
+    //
+    //   predecessor=A --read/check--> B --read/check--> C
+    //       |                            |               |
+    //       +-- state incomplete ------> +-- state incomplete --> finished=false
+    //       |
+    //       +-- successor becomes empty before C ----------------> finished=false
+    //
+    // The loop stops only when the current id is empty or reaches the target. Each predecessor
+    // must be CLEANUP_COMPLETED before the walk can advance to its successor.
+    std::string predecessor_instance_id = instance.original_instance_id();
+    while (!predecessor_instance_id.empty() && predecessor_instance_id != instance_id) {
+        key = instance_key({predecessor_instance_id});
+        err = txn->get(key, &value);
+        if (err != TxnErrorCode::TXN_OK) {
+            std::string msg = fmt::format(
+                    "failed to get predecessor instance, instance_id={}, "
+                    "predecessor_instance_id={}, err={}",
+                    instance_id, predecessor_instance_id, err);
+            LOG(WARNING) << msg;
+            return {MetaServiceCode::KV_TXN_GET_ERR, std::move(msg)};
+        }
+
+        InstanceInfoPB predecessor_instance;
+        if (!predecessor_instance.ParseFromString(value)) {
+            std::string msg = fmt::format("malformed predecessor instance info, key={}", hex(key));
+            LOG(WARNING) << msg;
+            return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
+        }
+
+        finished = predecessor_instance.recycled_state() ==
+                   InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED;
+        if (!finished) {
+            reason = fmt::format(
+                    "referenced instance has not completed recycling, predecessor_instance_id={}, "
+                    "recycled_state={}",
+                    predecessor_instance.instance_id(),
+                    InstanceRecycleState_Name(predecessor_instance.recycled_state()));
+            return {MetaServiceCode::OK, "OK"};
+        }
+        predecessor_instance_id = predecessor_instance.successor_instance_id();
+    }
+
+    // The walk must reach the queried instance instead of ending at an empty successor:
+    //
+    //   valid:    A -> B -> C(target)   predecessor_instance_id == instance_id
+    //   broken:   A -> B -> ""          predecessor_instance_id != instance_id
+    //                     ^
+    //                     +-- the chain ended before reaching C, so finished=false
+    if (predecessor_instance_id != instance_id) {
+        finished = false;
+        reason = fmt::format(
+                "instance chain ends before reaching target, "
+                "instance_id={}",
+                instance_id);
+        return {MetaServiceCode::OK, "OK"};
+    }
+    reason = fmt::format("instance recycling has completed, instance_id={}, recycled_state={}",
+                         instance_id, InstanceRecycleState_Name(instance.recycled_state()));
+    return {MetaServiceCode::OK, "OK"};
 }
 
 void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller,
@@ -2686,6 +2825,12 @@ void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller
     switch (request->op()) {
     case AlterInstanceRequest::DROP: {
         ret = alter_instance(request, [&instance_id](Transaction* txn, InstanceInfoPB* instance) {
+            if (instance->status() == InstanceInfoPB::DELETED) {
+                std::string msg = "failed to drop instance, instance has already been recycled";
+                LOG(WARNING) << msg << " instance_id=" << instance_id;
+                return std::make_pair(MetaServiceCode::INVALID_ARGUMENT, std::move(msg));
+            }
+
             // check instance doesn't have any cluster.
             if (instance->clusters_size() != 0) {
                 std::string msg = "failed to drop instance, instance has clusters";

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -756,6 +756,12 @@ int InstanceRecycler::init_storage_vault_accessors() {
 }
 
 int InstanceRecycler::init() {
+    if (instance_info_.status() == InstanceInfoPB::DELETED &&
+        (instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED ||
+         instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED)) {
+        return 0;
+    }
+
     int ret = init_obj_store_accessors();
     if (ret != 0) {
         return ret;
@@ -854,6 +860,30 @@ int InstanceRecycler::recycle_deleted_instance() {
                      << "s, instance_id=" << instance_id_;
     };
 
+    switch (instance_info_.recycled_state()) {
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING:
+        ret = recycle_deleted_instance_data();
+        break;
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED:
+        ret = recycle_deleted_instance_metadata();
+        break;
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED:
+        ret = remove_instance_key();
+        break;
+    default:
+        LOG_WARNING("invalid instance recycle state")
+                .tag("instance_id", instance_id_)
+                .tag("recycled_state", instance_info_.recycled_state());
+        ret = -1;
+        break;
+    }
+
+    return ret;
+}
+
+int InstanceRecycler::recycle_deleted_instance_data() {
+    int ret = 0;
+
     // Step 1: Recycle tmp rowsets (contains ref count but txn is not committed)
     auto recycle_tmp_rowsets_with_mark_delete_enabled = [&]() -> int {
         int res = recycle_tmp_rowsets();
@@ -866,23 +896,21 @@ int InstanceRecycler::recycle_deleted_instance() {
         }
         return res;
     };
+
     if (recycle_tmp_rowsets_with_mark_delete_enabled() != 0) {
         LOG_WARNING("failed to recycle tmp rowsets").tag("instance_id", instance_id_);
-        ret = -1;
         return -1;
     }
 
     // Step 2: Recycle versioned rowsets in recycle space (already marked for deletion)
     if (recycle_versioned_rowsets() != 0) {
         LOG_WARNING("failed to recycle versioned rowsets").tag("instance_id", instance_id_);
-        ret = -1;
         return -1;
     }
 
     // Step 3: Recycle operation logs (can recycle logs not referenced by snapshots)
     if (recycle_operation_logs() != 0) {
         LOG_WARNING("failed to recycle operation logs").tag("instance_id", instance_id_);
-        ret = -1;
         return -1;
     }
 
@@ -890,7 +918,6 @@ int InstanceRecycler::recycle_deleted_instance() {
     bool has_snapshots = false;
     if (has_cluster_snapshots(&has_snapshots) != 0) {
         LOG(WARNING) << "check instance cluster snapshots failed, instance_id=" << instance_id_;
-        ret = -1;
         return -1;
     } else if (has_snapshots) {
         LOG(INFO) << "instance has cluster snapshots, skip recycling, instance_id=" << instance_id_;
@@ -904,17 +931,16 @@ int InstanceRecycler::recycle_deleted_instance() {
         bool has_unrecycled_rowsets = false;
         if (recycle_ref_rowsets(&has_unrecycled_rowsets) != 0) {
             LOG_WARNING("failed to recycle ref rowsets").tag("instance_id", instance_id_);
-            ret = -1;
             return -1;
         } else if (has_unrecycled_rowsets) {
             LOG_INFO("instance has referenced rowsets, skip recycling")
                     .tag("instance_id", instance_id_);
-            return ret;
+            return 0;
         }
     } else { // delete all remote data if snapshot is disabled
         for (auto& [_, accessor] : accessor_map_) {
             if (stopped()) {
-                return ret;
+                return 0;
             }
 
             LOG(INFO) << "begin to delete all objects in " << accessor->uri();
@@ -934,7 +960,17 @@ int InstanceRecycler::recycle_deleted_instance() {
         }
     }
 
-    // Check successor instance, if exists, skip deleting kv because successor instance may still need the data in kv
+    if (update_instance_recycled_state(
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int InstanceRecycler::recycle_deleted_instance_metadata() {
+    // Keep metadata until the successor instance finishes cleanup because it may still reference it.
     if (instance_info_.has_successor_instance_id() &&
         !instance_info_.successor_instance_id().empty()) {
         std::string key = instance_key(instance_info_.successor_instance_id());
@@ -944,22 +980,29 @@ int InstanceRecycler::recycle_deleted_instance() {
             LOG(WARNING) << "failed to create txn, instance_id=" << instance_id_
                          << " successor_instance_id=" << instance_info_.successor_instance_id()
                          << " err=" << err;
-            ret = -1;
             return -1;
         }
 
         std::string value;
         err = txn->get(key, &value);
         if (err == TxnErrorCode::TXN_OK) {
-            LOG(INFO) << "instance successor instance is still exist, skip deleting kv,"
-                      << " instance_id=" << instance_id_
-                      << " successor_instance_id=" << instance_info_.successor_instance_id();
-            return 0;
+            InstanceInfoPB successor_instance;
+            if (!successor_instance.ParseFromString(value)) {
+                LOG(WARNING) << "failed to parse successor instance, instance_id=" << instance_id_
+                             << " successor_instance_id=" << instance_info_.successor_instance_id();
+                return -1;
+            }
+            if (successor_instance.recycled_state() !=
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+                LOG(INFO) << "successor instance has not completed cleanup, skip deleting kv,"
+                          << " instance_id=" << instance_id_
+                          << " successor_instance_id=" << instance_info_.successor_instance_id();
+                return 0;
+            }
         } else if (err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
             LOG(WARNING) << "failed to get successor instance, instance_id=" << instance_id_
                          << " successor_instance_id=" << instance_info_.successor_instance_id()
                          << " err=" << err;
-            ret = -1;
             return -1;
         }
     }
@@ -969,7 +1012,6 @@ int InstanceRecycler::recycle_deleted_instance() {
     TxnErrorCode err = txn_kv_->create_txn(&txn);
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to create txn";
-        ret = -1;
         return -1;
     }
     LOG(INFO) << "begin to delete all kv, instance_id=" << instance_id_;
@@ -1020,33 +1062,190 @@ int InstanceRecycler::recycle_deleted_instance() {
     std::string versioned_log_key_start = versioned::log_key_prefix(instance_id_);
     std::string versioned_log_key_end = versioned::log_key_prefix(instance_id_ + '\x00');
     txn->remove(versioned_log_key_start, versioned_log_key_end);
-    err = txn->commit();
-    if (err != TxnErrorCode::TXN_OK) {
-        LOG(WARNING) << "failed to delete all kv, instance_id=" << instance_id_ << ", err=" << err;
-        ret = -1;
+
+    // Updating the recycle state also commits this transaction, making the metadata deletions
+    // and state transition atomic.
+    if (update_instance_recycled_state(
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED, txn.get()) != 0) {
+        return -1;
     }
 
-    if (ret == 0) {
-        // remove instance kv
-        // ATTN: MUST ensure that cloud platform won't regenerate the same instance id
-        err = txn_kv_->create_txn(&txn);
-        if (err != TxnErrorCode::TXN_OK) {
-            LOG(WARNING) << "failed to create txn";
-            ret = -1;
-            return ret;
+    return 0;
+}
+
+int InstanceRecycler::remove_instance_key() {
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to create txn";
+        return -1;
+    }
+
+    // Check that the original instance is complete before deleting any chain key. This ensures the
+    // whole chain has finished cleanup and prevents a missing key from reporting completion early.
+    //
+    //   A(original) -> B -> C
+    //        |
+    //        +-- not complete: keep all keys
+    //        +-- complete:     key removal may start
+    if (instance_info_.has_original_instance_id() &&
+        !instance_info_.original_instance_id().empty()) {
+        std::string value;
+        err = txn->get(instance_key({instance_info_.original_instance_id()}), &value);
+        if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            LOG(INFO) << "original instance key is missing, skip deleting instance key"
+                      << ", instance_id=" << instance_id_
+                      << " original_instance_id=" << instance_info_.original_instance_id();
+            return 0;
         }
-        std::string key;
-        instance_key({instance_id_}, &key);
-        txn->atomic_add(system_meta_service_instance_update_key(), 1);
-        txn->remove(key);
-        err = txn->commit();
         if (err != TxnErrorCode::TXN_OK) {
-            LOG(WARNING) << "failed to delete instance kv, instance_id=" << instance_id_
+            LOG(WARNING) << "failed to get original instance, instance_id=" << instance_id_
+                         << " original_instance_id=" << instance_info_.original_instance_id()
                          << " err=" << err;
-            ret = -1;
+            return -1;
+        }
+
+        InstanceInfoPB original_instance;
+        if (!original_instance.ParseFromString(value)) {
+            LOG(WARNING) << "failed to parse original instance, instance_id=" << instance_id_
+                         << " original_instance_id=" << instance_info_.original_instance_id();
+            return -1;
+        }
+        if (original_instance.recycled_state() !=
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+            LOG(INFO) << "original instance has not completed cleanup, skip deleting instance key"
+                      << ", instance_id=" << instance_id_
+                      << " original_instance_id=" << instance_info_.original_instance_id();
+            return 0;
         }
     }
-    return ret;
+
+    // Check that the successor key is gone before deleting the current key. This keeps key removal
+    // in tail-to-original order.
+    //
+    //   current B -> successor C
+    //                  |
+    //                  +-- C key exists: keep B key
+    //                  +-- C key gone:   B key may be removed
+    if (instance_info_.has_successor_instance_id() &&
+        !instance_info_.successor_instance_id().empty()) {
+        std::string value;
+        err = txn->get(instance_key({instance_info_.successor_instance_id()}), &value);
+        if (err == TxnErrorCode::TXN_OK) {
+            LOG(INFO) << "successor instance key still exists, skip deleting instance key"
+                      << ", instance_id=" << instance_id_
+                      << " successor_instance_id=" << instance_info_.successor_instance_id();
+            return 0;
+        }
+        if (err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            LOG(WARNING) << "failed to get successor instance, instance_id=" << instance_id_
+                         << " successor_instance_id=" << instance_info_.successor_instance_id()
+                         << " err=" << err;
+            return -1;
+        }
+    }
+
+    txn->atomic_add(system_meta_service_instance_update_key(), 1);
+    txn->remove(instance_key({instance_id_}));
+    err = txn->commit();
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to delete instance kv, instance_id=" << instance_id_
+                     << " err=" << err;
+        return -1;
+    }
+    return 0;
+}
+
+int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState expected_state,
+                                                     InstanceRecycleState target_state) {
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to create txn";
+        return -1;
+    }
+    return update_instance_recycled_state(expected_state, target_state, txn.get());
+}
+
+int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState current_state,
+                                                     InstanceRecycleState target_state,
+                                                     Transaction* txn) {
+    const bool valid_transition = (current_state == INSTANCE_RECYCLE_STATE_CLEANUP_PENDING &&
+                                   target_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED) ||
+                                  (current_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED &&
+                                   target_state == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+
+    if (!valid_transition) {
+        LOG_WARNING("invalid instance recycled state transition")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+
+    std::string key = instance_key({instance_id_});
+    std::string value;
+    TxnErrorCode err = txn->get(key, &value);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG_WARNING("failed to get instance when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state))
+                .tag("err", err);
+        return -1;
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        LOG_WARNING("failed to parse InstanceInfoPB when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+    if (instance.status() != InstanceInfoPB::DELETED) {
+        LOG_WARNING("instance is not deleted when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("status", instance.status())
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+    if (instance.recycled_state() != current_state) {
+        LOG_WARNING("instance recycled state changed before update")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(instance.recycled_state()))
+                .tag("expected_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+
+    instance.set_recycled_state(target_state);
+    instance.set_recycled_state_update_time_ms(
+            duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+    if (!instance.SerializeToString(&value)) {
+        LOG_WARNING("failed to serialize InstanceInfoPB when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("expected_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+
+    txn->atomic_add(system_meta_service_instance_update_key(), 1);
+    txn->put(key, value);
+    err = txn->commit();
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to commit fdb txn when updating instance recycled state, "
+                     << "instance_id=" << instance_id_ << ", err=" << err;
+        return -1;
+    }
+
+    instance_info_.Swap(&instance);
+    LOG_INFO("updated instance recycled state")
+            .tag("instance_id", instance_id_)
+            .tag("recycled_state", InstanceRecycleState_Name(target_state));
+    return 0;
 }
 
 int InstanceRecycler::check_rowset_exists(int64_t tablet_id, const std::string& rowset_id,

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -288,6 +288,16 @@ public:
     // returns 0 for success otherwise error
     int recycle_deleted_instance();
 
+    int recycle_deleted_instance_data();
+
+    int recycle_deleted_instance_metadata();
+
+    int update_instance_recycled_state(InstanceRecycleState expected_state,
+                                       InstanceRecycleState target_state);
+
+    int update_instance_recycled_state(InstanceRecycleState expected_state,
+                                       InstanceRecycleState target_state, Transaction* txn);
+
     // scan and recycle expired indexes:
     // 1. dropped table, dropped mv
     // 2. half-successtable/index when create
@@ -430,6 +440,9 @@ public:
                                        const SnapshotPB& snapshot_pb);
 
 private:
+    // returns 0 for success otherwise error
+    int remove_instance_key();
+
     // returns 0 for success otherwise error
     int init_obj_store_accessors();
 

--- a/cloud/src/recycler/recycler_service.cpp
+++ b/cloud/src/recycler/recycler_service.cpp
@@ -27,6 +27,7 @@
 #include <rapidjson/stringbuffer.h>
 
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -396,6 +397,77 @@ void RecyclerServiceImpl::check_instance(const std::string& instance_id, MetaSer
         }
         checker_->pending_instance_cond_.notify_all();
     }
+}
+
+std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::set_instance_recycled_state(
+        const std::string& instance_id, InstanceRecycleState target_state) {
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg = fmt::format("failed to create txn, err={}", err);
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::KV_TXN_CREATE_ERR, std::move(msg)};
+    }
+
+    std::string key = instance_key({instance_id});
+    std::string value;
+    err = txn->get(key, &value);
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg =
+                fmt::format("failed to get instance, instance_id={}, err={}", instance_id, err);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::KV_TXN_GET_ERR, std::move(msg)};
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        std::string msg = fmt::format("malformed instance info, key={}", hex(key));
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
+    }
+    if (instance.status() != InstanceInfoPB::DELETED) {
+        std::string msg = fmt::format(
+                "failed to set instance recycle state, instance is not deleted, instance_id={}",
+                instance_id);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
+    }
+    const auto current_state = instance.recycled_state();
+    if (current_state == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED ||
+        !(current_state == InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING &&
+          target_state == InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED)) {
+        std::string msg = fmt::format(
+                "invalid instance recycled state transition, instance_id={}, current_state={}, "
+                "target_state={}",
+                instance_id, InstanceRecycleState_Name(current_state),
+                InstanceRecycleState_Name(target_state));
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
+    }
+
+    instance.set_recycled_state(target_state);
+    instance.set_recycled_state_update_time_ms(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::system_clock::now().time_since_epoch())
+                    .count());
+    if (!instance.SerializeToString(&value)) {
+        std::string msg = "failed to serialize InstanceInfoPB";
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::PROTOBUF_SERIALIZE_ERR, std::move(msg)};
+    }
+
+    txn->atomic_add(system_meta_service_instance_update_key(), 1);
+    txn->put(key, value);
+    err = txn->commit();
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg = fmt::format("failed to commit kv txn, err={}", err);
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::KV_TXN_COMMIT_ERR, std::move(msg)};
+    }
+
+    LOG(INFO) << "set instance recycle state, instance_id=" << instance_id
+              << " recycled_state=" << InstanceRecycleState_Name(target_state);
+    return {MetaServiceCode::OK, "OK"};
 }
 
 void recycle_copy_jobs(const std::shared_ptr<TxnKv>& txn_kv, const std::string& instance_id,

--- a/cloud/src/recycler/recycler_service.h
+++ b/cloud/src/recycler/recycler_service.h
@@ -50,6 +50,9 @@ public:
 
     void check_instance(const std::string& instance_id, MetaServiceCode& code, std::string& msg);
 
+    std::pair<MetaServiceCode, std::string> set_instance_recycled_state(
+            const std::string& instance_id, InstanceRecycleState target_state);
+
     std::shared_ptr<TxnKv> txn_kv() { return txn_kv_; }
     Recycler* recycler() { return recycler_; }
     Checker* checker() { return checker_; }

--- a/cloud/src/recycler/recycler_snapshot.cpp
+++ b/cloud/src/recycler/recycler_snapshot.cpp
@@ -40,6 +40,10 @@
 namespace doris::cloud {
 
 int InstanceRecycler::recycle_cluster_snapshots() {
+    if (instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED ||
+        instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+        return 0;
+    }
     return snapshot_manager_->recycle_snapshots(this);
 }
 

--- a/cloud/test/meta_service_snapshot_test.cpp
+++ b/cloud/test/meta_service_snapshot_test.cpp
@@ -24,14 +24,127 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <tuple>
 
 #include "common/defer.h"
 #include "cpp/sync_point.h"
 #include "meta-service/meta_service.h"
+#include "meta-store/keys.h"
+#include "meta-store/mem_txn_kv.h"
+#include "rate-limiter/rate_limiter.h"
+#include "resource-manager/resource_manager.h"
+#include "snapshot/snapshot_manager.h"
 
 namespace doris::cloud {
 
 extern std::unique_ptr<MetaServiceProxy> get_meta_service(bool mock_resource_mgr);
+
+TEST(MetaServiceSnapshotTest, CheckInstanceRecycleCompletedForInstanceChain) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+    auto resource_mgr = std::make_shared<ResourceManager>(txn_kv);
+    auto rate_limiter = std::make_shared<RateLimiter>();
+    auto snapshot_manager = std::make_shared<SnapshotManager>(txn_kv);
+    MetaServiceImpl meta_service(txn_kv, resource_mgr, rate_limiter, snapshot_manager);
+
+    InstanceInfoPB original_instance;
+    original_instance.set_instance_id("original_instance");
+    original_instance.set_status(InstanceInfoPB::DELETED);
+    original_instance.set_successor_instance_id("middle_instance");
+    original_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    InstanceInfoPB middle_instance;
+    middle_instance.set_instance_id("middle_instance");
+    middle_instance.set_status(InstanceInfoPB::DELETED);
+    middle_instance.set_original_instance_id(original_instance.instance_id());
+    middle_instance.set_successor_instance_id("tail_instance");
+    middle_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    InstanceInfoPB tail_instance;
+    tail_instance.set_instance_id("tail_instance");
+    tail_instance.set_status(InstanceInfoPB::DELETED);
+    tail_instance.set_original_instance_id(original_instance.instance_id());
+    tail_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    txn->put(instance_key({original_instance.instance_id()}),
+             original_instance.SerializeAsString());
+    txn->put(instance_key({middle_instance.instance_id()}), middle_instance.SerializeAsString());
+    txn->put(instance_key({tail_instance.instance_id()}), tail_instance.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    bool finished = true;
+    std::string reason;
+    auto [code, msg] = meta_service.check_instance_recycle_completed(tail_instance.instance_id(),
+                                                                     finished, reason);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+    ASSERT_FALSE(finished);
+    ASSERT_EQ(reason,
+              "instance has not completed recycling, instance_id=tail_instance, "
+              "recycled_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
+
+    tail_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    txn->put(instance_key({tail_instance.instance_id()}), tail_instance.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    std::tie(code, msg) = meta_service.check_instance_recycle_completed(tail_instance.instance_id(),
+                                                                        finished, reason);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+    ASSERT_FALSE(finished);
+    ASSERT_EQ(reason,
+              "referenced instance has not completed recycling, "
+              "predecessor_instance_id=original_instance, "
+              "recycled_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
+
+    original_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    txn->put(instance_key({original_instance.instance_id()}),
+             original_instance.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    std::tie(code, msg) = meta_service.check_instance_recycle_completed(tail_instance.instance_id(),
+                                                                        finished, reason);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+    ASSERT_FALSE(finished);
+    ASSERT_EQ(reason,
+              "referenced instance has not completed recycling, "
+              "predecessor_instance_id=middle_instance, "
+              "recycled_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
+
+    middle_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    txn->put(instance_key({middle_instance.instance_id()}), middle_instance.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    std::tie(code, msg) = meta_service.check_instance_recycle_completed(tail_instance.instance_id(),
+                                                                        finished, reason);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+    ASSERT_TRUE(finished);
+    ASSERT_EQ(reason,
+              "instance recycling has completed, instance_id=tail_instance, "
+              "recycled_state=INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED");
+
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    txn->remove(instance_key({tail_instance.instance_id()}));
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    finished = false;
+    std::tie(code, msg) = meta_service.check_instance_recycle_completed(tail_instance.instance_id(),
+                                                                        finished, reason);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+    ASSERT_TRUE(finished);
+    ASSERT_EQ(reason,
+              "instance recycling is considered completed because the instance key does not "
+              "exist, instance_id=tail_instance");
+}
 
 TEST(MetaServiceSnapshotTest, DISABLED_BeginSnapshotTest) {
     auto meta_service = get_meta_service(true);

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -591,6 +591,17 @@ TEST(MetaServiceTest, CreateInstanceTest) {
         instance.ParseFromString(val);
         ASSERT_EQ(instance.status(), InstanceInfoPB::DELETED);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+
+        instance.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+        txn->put(key, instance.SerializeAsString());
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+        AlterInstanceResponse retry_res;
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &retry_res, nullptr);
+        ASSERT_EQ(retry_res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+        ASSERT_NE(retry_res.status().msg().find("instance has already been recycled"),
+                  std::string::npos);
     }
 
     // case: normal refresh instance

--- a/cloud/test/recycle_versioned_keys_test.cpp
+++ b/cloud/test/recycle_versioned_keys_test.cpp
@@ -1859,6 +1859,7 @@ TEST(RecycleVersionedKeysTest, RecycleDeletedInstance) {
     {
         // Recycle deleted instance
         ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+        ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
     }
 
     {

--- a/cloud/test/recycler_operation_log_test.cpp
+++ b/cloud/test/recycler_operation_log_test.cpp
@@ -2516,9 +2516,10 @@ TEST(RecycleOperationLogTest, RecycleDeletedInstance) {
     }
 
     ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+    ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
 
-    // Verify all keys are deleted, expecting the instance_update
-    ASSERT_EQ(count_range(txn_kv.get()), 1) << dump_range(txn_kv.get());
+    // Verify all data keys are deleted, keeping the instance status and instance_update keys.
+    ASSERT_EQ(count_range(txn_kv.get()), 2) << dump_range(txn_kv.get());
 }
 
 // Test OperationLogRecycleChecker class

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -42,6 +42,7 @@
 #include "common/bvars.h"
 #include "common/config.h"
 #include "common/defer.h"
+#include "common/http_helper.h"
 #include "common/logging.h"
 #include "common/simple_thread_pool.h"
 #include "common/util.h"
@@ -58,6 +59,7 @@
 #include "rate-limiter/rate_limiter.h"
 #include "recycler/checker.h"
 #include "recycler/recycler.cpp"
+#include "recycler/recycler_service.h"
 #include "recycler/storage_vault_accessor.h"
 #include "recycler/util.h"
 #include "recycler/white_black_list.h"
@@ -1152,6 +1154,13 @@ static int create_instance(const std::string& internal_stage_id,
 
     instance_info.set_instance_id(instance_id);
     return 0;
+}
+
+static void put_instance_info(TxnKv* txn_kv, const InstanceInfoPB& instance_info) {
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    txn->put(instance_key({instance_info.instance_id()}), instance_info.SerializeAsString());
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->commit());
 }
 
 static int create_copy_job(TxnKv* txn_kv, const std::string& stage_id, int64_t table_id,
@@ -3611,6 +3620,8 @@ TEST(RecyclerTest, recycle_deleted_instance) {
 
     InstanceInfoPB instance_info;
     create_instance(internal_stage_id, external_stage_id, instance_info);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    put_instance_info(txn_kv.get(), instance_info);
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
     ASSERT_EQ(recycler.init(), 0);
@@ -3682,6 +3693,8 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+              recycler.instance_info().recycled_state());
 
     {
         // No thing to recycle
@@ -3701,6 +3714,19 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+              recycler.instance_info().recycled_state());
+    ASSERT_EQ(0, recycler.recycle_deleted_instance());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED,
+              recycler.instance_info().recycled_state());
+    ASSERT_EQ(0, recycler.recycle_deleted_instance());
+
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+        std::string value;
+        ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND, txn->get(instance_key({instance_id}), &value));
+    }
 
     // check if all the objects are deleted
     std::for_each(recycler.accessor_map_.begin(), recycler.accessor_map_.end(),
@@ -3764,6 +3790,323 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 }
 
+TEST(RecyclerTest, init_deleted_instance_with_terminal_recycled_state) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    instance_info.add_resource_ids("deleted_vault");
+
+    InstanceRecycler recycler(txn_kv, instance_info, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    ASSERT_EQ(recycler.do_recycle(), 0);
+}
+
+TEST(RecyclerTest, recycle_legacy_deleted_instance_without_recycled_state) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.add_obj_info()->set_id("legacy_instance_obj");
+    ASSERT_FALSE(instance_info.has_recycled_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+              instance_info.recycled_state());
+    put_instance_info(txn_kv.get(), instance_info);
+
+    InstanceRecycler recycler(txn_kv, instance_info, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_id}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_TRUE(instance_info.has_recycled_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+              instance_info.recycled_state());
+}
+
+TEST(RecyclerTest, reject_stale_instance_recycled_state_update) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB stale_instance;
+    stale_instance.set_instance_id(instance_id);
+    stale_instance.set_status(InstanceInfoPB::DELETED);
+    stale_instance.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+
+    InstanceInfoPB latest_instance = stale_instance;
+    latest_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), latest_instance);
+
+    InstanceRecycler stale_recycler(txn_kv, stale_instance, thread_group,
+                                    std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_NE(stale_recycler.update_instance_recycled_state(
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED),
+              0);
+    ASSERT_NE(stale_recycler.update_instance_recycled_state(
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED),
+              0);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_id}), &value));
+    ASSERT_TRUE(latest_instance.ParseFromString(value));
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED,
+              latest_instance.recycled_state());
+}
+
+TEST(RecyclerServiceTest, set_instance_recycled_state) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id("set_recycled_state_instance");
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    put_instance_info(txn_kv.get(), instance_info);
+
+    RecyclerServiceImpl service(txn_kv, nullptr, nullptr, nullptr);
+    auto [code, msg] = service.set_instance_recycled_state(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_GT(instance_info.recycled_state_update_time_ms(), 0);
+
+    std::tie(code, msg) = service.set_instance_recycled_state(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("invalid instance recycled state transition"), std::string::npos);
+
+    std::tie(code, msg) = service.set_instance_recycled_state(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("invalid instance recycled state transition"), std::string::npos);
+
+    auto call_http = [&](std::string_view query) {
+        brpc::Controller ctrl;
+        ctrl.http_request().uri() = fmt::format("/?{}", query);
+        return process_set_instance_recycled_state(&service, &ctrl);
+    };
+
+    auto response = call_http("");
+    ASSERT_EQ(response.status_code, 400);
+    ASSERT_NE(response.body.find("instance_id is empty"), std::string::npos);
+
+    response = call_http("instance_id=set_recycled_state_instance");
+    ASSERT_EQ(response.status_code, 400);
+    ASSERT_NE(response.body.find("recycled_state is empty"), std::string::npos);
+
+    response = call_http(
+            "instance_id=set_recycled_state_instance&recycled_state="
+            "INSTANCE_RECYCLE_STATE_UNSPECIFIED");
+    ASSERT_EQ(response.status_code, 400);
+    ASSERT_NE(response.body.find("invalid recycled_state"), std::string::npos);
+
+    response = call_http(
+            "instance_id=set_recycled_state_instance&recycled_state="
+            "INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED");
+    ASSERT_EQ(response.status_code, 400);
+    ASSERT_NE(response.body.find("invalid instance recycled state transition"), std::string::npos);
+    ASSERT_NE(response.body.find("INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED"), std::string::npos);
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    instance_info.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), instance_info);
+    std::tie(code, msg) = service.set_instance_recycled_state(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("invalid instance recycled state transition"), std::string::npos);
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+
+    instance_info.set_status(InstanceInfoPB::NORMAL);
+    put_instance_info(txn_kv.get(), instance_info);
+    std::tie(code, msg) = service.set_instance_recycled_state(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+}
+
+TEST(RecyclerTest, recycle_deleted_instance_metadata_waits_for_successor) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    instance_info.set_successor_instance_id("successor_instance");
+    put_instance_info(txn_kv.get(), instance_info);
+
+    InstanceInfoPB successor_instance;
+    successor_instance.set_instance_id(instance_info.successor_instance_id());
+    successor_instance.set_status(InstanceInfoPB::DELETED);
+    successor_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), successor_instance);
+
+    std::string metadata_key = txn_label_key({instance_id, 1, "label"});
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+        txn->put(metadata_key, "value");
+        ASSERT_EQ(TxnErrorCode::TXN_OK, txn->commit());
+    }
+
+    InstanceRecycler recycler(txn_kv, instance_info, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    ASSERT_EQ(recycler.recycle_deleted_instance_metadata(), 0);
+    ASSERT_EQ(recycler.instance_info().recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(metadata_key, &value));
+
+    successor_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), successor_instance);
+
+    ASSERT_EQ(recycler.recycle_deleted_instance_metadata(), 0);
+    ASSERT_EQ(recycler.instance_info().recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND, txn->get(metadata_key, &value));
+    ASSERT_EQ(TxnErrorCode::TXN_OK,
+              txn->get(instance_key({successor_instance.instance_id()}), &value));
+}
+
+TEST(RecyclerTest, remove_instance_key_in_successor_order) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB original_instance;
+    original_instance.set_instance_id("original_instance");
+    original_instance.set_status(InstanceInfoPB::DELETED);
+    original_instance.set_successor_instance_id("middle_instance");
+    original_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    InstanceInfoPB middle_instance;
+    middle_instance.set_instance_id("middle_instance");
+    middle_instance.set_status(InstanceInfoPB::DELETED);
+    middle_instance.set_original_instance_id(original_instance.instance_id());
+    middle_instance.set_successor_instance_id("tail_instance");
+    middle_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    InstanceInfoPB tail_instance;
+    tail_instance.set_instance_id("tail_instance");
+    tail_instance.set_status(InstanceInfoPB::DELETED);
+    tail_instance.set_original_instance_id(original_instance.instance_id());
+    tail_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+
+    put_instance_info(txn_kv.get(), original_instance);
+    put_instance_info(txn_kv.get(), middle_instance);
+    put_instance_info(txn_kv.get(), tail_instance);
+
+    InstanceRecycler tail_recycler(txn_kv, tail_instance, thread_group,
+                                   std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(tail_recycler.init(), 0);
+    ASSERT_EQ(tail_recycler.recycle_deleted_instance(), 0);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK,
+              txn->get(instance_key({original_instance.instance_id()}), &value));
+    ASSERT_EQ(TxnErrorCode::TXN_OK,
+              txn->get(instance_key({middle_instance.instance_id()}), &value));
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({tail_instance.instance_id()}), &value));
+
+    original_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), original_instance);
+
+    ASSERT_EQ(tail_recycler.recycle_deleted_instance(), 0);
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND,
+              txn->get(instance_key({tail_instance.instance_id()}), &value));
+
+    InstanceRecycler middle_recycler(txn_kv, middle_instance, thread_group,
+                                     std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(middle_recycler.init(), 0);
+    ASSERT_EQ(middle_recycler.recycle_deleted_instance(), 0);
+    ASSERT_EQ(middle_recycler.instance_info().recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    ASSERT_EQ(middle_recycler.recycle_deleted_instance(), 0);
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_OK,
+              txn->get(instance_key({original_instance.instance_id()}), &value));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND,
+              txn->get(instance_key({middle_instance.instance_id()}), &value));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND,
+              txn->get(instance_key({tail_instance.instance_id()}), &value));
+
+    InstanceRecycler original_recycler(txn_kv, original_instance, thread_group,
+                                       std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(original_recycler.init(), 0);
+    ASSERT_EQ(original_recycler.recycle_deleted_instance(), 0);
+    ASSERT_EQ(original_recycler.instance_info().recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    ASSERT_EQ(original_recycler.recycle_deleted_instance(), 0);
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND,
+              txn->get(instance_key({original_instance.instance_id()}), &value));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND,
+              txn->get(instance_key({middle_instance.instance_id()}), &value));
+    ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND,
+              txn->get(instance_key({tail_instance.instance_id()}), &value));
+}
+
 // Regression test: if commit_rowset is called but the txn is never committed,
 // the rowset stays in meta_rowset_tmp_key with data_rowset_ref_count_key=1.
 // recycle_deleted_instance() must call recycle_tmp_rowsets() first so that
@@ -3783,20 +4126,14 @@ TEST(RecyclerTest, recycle_deleted_instance_with_orphan_tmp_rowset) {
     // Create instance with multi-version read/write and snapshot support
     InstanceInfoPB instance_info;
     instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
     instance_info.set_multi_version_status(MultiVersionStatus::MULTI_VERSION_READ_WRITE);
     instance_info.set_snapshot_switch_status(SnapshotSwitchStatus::SNAPSHOT_SWITCH_ON);
     auto* obj_info = instance_info.add_obj_info();
     obj_info->set_id("orphan_tmp_rowset_test");
 
     // Write instance info to FDB (required by OperationLogRecycleChecker::init())
-    {
-        std::unique_ptr<Transaction> txn;
-        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
-        std::string key = instance_key({instance_id});
-        std::string val = instance_info.SerializeAsString();
-        txn->put(key, val);
-        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
-    }
+    put_instance_info(txn_kv.get(), instance_info);
 
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -100,12 +100,19 @@ enum KeySetType {
     MULTI_VERSION_META_ROWSET = 21;
 }
 
+enum InstanceRecycleState {
+    INSTANCE_RECYCLE_STATE_CLEANUP_PENDING = 0;
+    INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED = 1;
+    INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED = 2;
+}
+
 message InstanceInfoPB {
     enum Status {
         NORMAL = 0;
         DELETED = 1;
         OVERDUE = 2;
     }
+
     optional string user_id = 1;
     optional string instance_id = 2;
     optional string name = 3;
@@ -152,6 +159,10 @@ message InstanceInfoPB {
     // It is not always same as source_instance_id, because the source instance may inherit from another
     // instance during rollback, and the predecessor instance is the real instance which to execute the rollback.
     optional string predecessor_instance_id = 124;
+
+    optional InstanceRecycleState recycled_state = 125 [default = INSTANCE_RECYCLE_STATE_CLEANUP_PENDING];
+    // Last time when recycled_state was updated by a recycle step.
+    optional int64 recycled_state_update_time_ms = 126;
 }
 
 message StagePB {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

After dropping an instance, the control plane waits for Doris to finish recycling before revoking the instance's object storage permission.

Previously, an instance key could be removed before all related instances completed cleanup. The control plane could then revoke permission too early, leaving Recycler unable to finish its work.

This PR introduces an explicit recycle state machine:

```text
CLEANUP_PENDING
       |
       | Object data is cleaned
       v
DATA_CLEANUP_COMPLETED
       |
       | Metadata is cleaned
       v
CLEANUP_COMPLETED
       |
       | Ordering checks pass
       v
Remove instance key
```

#### Instance without snapshot support

An instance without snapshot support owns its object storage data exclusively.

```text
Drop instance
      |
      v
Delete all objects
      |
      v
Delete instance metadata
      |
      v
Remove instance key
```

#### Snapshot-enabled instance

A snapshot-enabled instance may share objects with snapshots or other instances. Recycler must not run `delete_all` on the shared object storage.

```text
Rowset reference count == 0  -> Delete the rowset object
Rowset reference count > 0   -> Keep the object and retry later
```

The instance remains in `CLEANUP_PENDING` until all remaining references have been handled.

An instance cannot be dropped while it still has an active cluster snapshot:

```text
snapshot != SNAPSHOT_RECYCLED
             |
             v
     Reject drop_instance
```

#### Normal snapshot clone

A normal clone keeps a reference from the source snapshot to the derived instance:

```text
Base instance A
       |
       | Snapshot S
       v
Derived instance B

Reference: A / S / B
```

Dropping B only removes the `A/S/B` snapshot reference. It does not drop A or delete objects still referenced by A, S, or another clone.

#### Snapshot rollback chain

A snapshot rollback may create an instance chain:

```text
A (original/base) -> B (derived) -> C (current tail)
```

Only the chain tail can be dropped:

```text
Drop A or B -> Rejected
Drop C      -> Mark A, B, and C as DELETED
```

Each instance cleans its object data according to reference counts. Metadata cleanup then runs from the tail back to the base:

```text
Metadata cleanup: C -> B -> A
Instance key removal: C -> B -> A
```

Instance key removal starts only after A, B, and C have all reached `CLEANUP_COMPLETED`.

#### Completion check

For a single instance:

```text
State is not CLEANUP_COMPLETED -> finished=false
State is CLEANUP_COMPLETED     -> finished=true
Instance key does not exist    -> finished=true
```

For a rollback chain, checking C also checks all predecessors:

```text
Check C
   |
   +-- C is incomplete --------------------> finished=false
   |
   +-- Check A -> Check B -> Reach C
                     |
                     +-- Any instance is incomplete
                             |
                             v
                       finished=false
   |
   +-- A, B, and C are complete -----------> finished=true

The control plane can revoke the dropped instance's object storage sub-account permission only after `finished=true`. Other instances sharing the same object storage keep their permissions and referenced objects.

### Release note

Improve cloud instance recycling and completion reporting for snapshot-enabled instances and instances sharing object storage data.