### PR TITLE
[refine](be) Remove null literal data type flag

### DIFF
--- a/be/src/core/data_type/data_type.h
+++ b/be/src/core/data_type/data_type.h
@@ -145,9 +145,6 @@ public:
 
     virtual bool is_nullable() const { return false; }
 
-    /* the data type create from type_null, NULL literal*/
-    virtual bool is_null_literal() const { return false; }
-
     virtual int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                                       int be_exec_version) const = 0;
     virtual char* serialize(const IColumn& column, char* buf, int be_exec_version) const = 0;

--- a/be/src/core/data_type/data_type_factory.cpp
+++ b/be/src/core/data_type/data_type_factory.cpp
@@ -489,11 +489,8 @@ DataTypePtr DataTypeFactory::create_data_type(const PrimitiveType primitive_type
     case TYPE_DECIMAL256:
         nested = create_decimal(precision, scale, false);
         break;
-    // Just Mock A NULL Type in Vec Exec Engine
     case TYPE_NULL: {
-        auto temp_nested = std::make_shared<DataTypeUInt8>();
-        temp_nested->set_null_literal(true);
-        nested = std::move(temp_nested);
+        nested = std::make_shared<DataTypeNothing>();
         break;
     }
     case TYPE_VARBINARY:

--- a/be/src/core/data_type/data_type_nullable.h
+++ b/be/src/core/data_type/data_type_nullable.h
@@ -91,7 +91,6 @@ public:
     bool is_nullable() const override { return true; }
 
     const DataTypePtr& get_nested_type() const { return nested_data_type; }
-    bool is_null_literal() const override { return nested_data_type->is_null_literal(); }
 
     using SerDeType = DataTypeNullableSerDe;
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {

--- a/be/src/core/data_type/data_type_number_base.h
+++ b/be/src/core/data_type/data_type_number_base.h
@@ -80,8 +80,6 @@ public:
     size_t get_size_of_value_in_memory() const override {
         return sizeof(typename PrimitiveTypeTraits<T>::CppType);
     }
-    bool is_null_literal() const override { return _is_null_literal; }
-    void set_null_literal(bool flag) { _is_null_literal = flag; }
     using SerDeType = DataTypeNumberSerDe<T>;
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
         return std::make_shared<SerDeType>(nesting_level);
@@ -92,6 +90,5 @@ public:
 
 protected:
 private:
-    bool _is_null_literal = false;
 };
 } // namespace doris

--- a/be/src/exprs/function/cast/function_cast.cpp
+++ b/be/src/exprs/function/cast/function_cast.cpp
@@ -19,6 +19,7 @@
 
 #include "core/data_type/data_type_agg_state.h"
 #include "core/data_type/data_type_decimal.h"
+#include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_number.h" // IWYU pragma: keep
 #include "core/data_type/data_type_quantilestate.h"
 #include "core/data_type/primitive_type.h"
@@ -80,7 +81,7 @@ WrapperType prepare_unpack_dictionaries(FunctionContext* context, const DataType
     const auto& from_nested = from_type;
     const auto& to_nested = to_type;
 
-    if (from_type->is_null_literal()) {
+    if (remove_nullable(from_type)->get_primitive_type() == INVALID_TYPE) {
         if (!to_nested->is_nullable()) {
             return CastWrapper::create_unsupport_wrapper(
                     "Cannot convert NULL to a non-nullable type");

--- a/be/test/core/data_type/common_data_type_test.h
+++ b/be/test/core/data_type/common_data_type_test.h
@@ -40,7 +40,6 @@
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
 //         get_field
-//         is_null_literal, is_value_unambiguously_represented_in_fixed_size_contiguous_memory_region
 // 2. datatype creation with column: create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size),  get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -108,7 +107,6 @@ public:
         size_t size_of_value_in_memory = -1;
         size_t precision = -1;
         size_t scale = -1;
-        bool is_null_literal = true;
         PColumnMeta* pColumnMeta = nullptr;
         DataTypeSerDeSPtr serde = nullptr;
         Field default_field;
@@ -144,7 +142,6 @@ public:
             EXPECT_EQ(data_type->get_precision(), 0);
             EXPECT_EQ(data_type->get_scale(), 0);
         }
-        ASSERT_EQ(data_type->is_null_literal(), meta_info.is_null_literal);
     }
 
     // create column assert with default field is simple and can be used for all DataType

--- a/be/test/core/data_type/data_type_agg_state_test.cpp
+++ b/be/test/core/data_type/data_type_agg_state_test.cpp
@@ -44,7 +44,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -85,7 +84,6 @@ TEST_P(DataTypeAggStateTest, MetaInfoTest) {
             .size_of_value_in_memory = size_t(-1),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_STRING>(String()),
     };

--- a/be/test/core/data_type/data_type_array_test.cpp
+++ b/be/test/core/data_type/data_type_array_test.cpp
@@ -48,7 +48,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -351,7 +350,6 @@ TEST_F(DataTypeArrayTest, MetaInfoTest) {
                 .size_of_value_in_memory = size_t(-1),
                 .precision = size_t(-1),
                 .scale = size_t(-1),
-                .is_null_literal = false,
                 .pColumnMeta = col_meta.get(),
                 .default_field = Field::create_field<TYPE_ARRAY>(Array()),
         };

--- a/be/test/core/data_type/data_type_bitmap_test.cpp
+++ b/be/test/core/data_type/data_type_bitmap_test.cpp
@@ -40,7 +40,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -76,7 +75,6 @@ TEST_P(DataTypeBitMapTest, MetaInfoTest) {
             .size_of_value_in_memory = size_t(-1),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_BITMAP>(BitmapValue::empty_bitmap()),
     };

--- a/be/test/core/data_type/data_type_datetime_v1_test.cpp
+++ b/be/test/core/data_type/data_type_datetime_v1_test.cpp
@@ -80,11 +80,6 @@ TEST_F(DataTypeDateTimeV1Test, simple_func_test) {
         EXPECT_TRUE(dt.have_maximum_size_of_value());
         EXPECT_EQ(dt.get_size_of_value_in_memory(), sizeof(FieldType));
 
-        EXPECT_FALSE(dt.is_null_literal());
-        dt.set_null_literal(true);
-        EXPECT_TRUE(dt.is_null_literal());
-        dt.set_null_literal(false);
-
         EXPECT_TRUE(dt.equals(dt));
     };
     test_func(dt_date);

--- a/be/test/core/data_type/data_type_datetime_v2_test.cpp
+++ b/be/test/core/data_type/data_type_datetime_v2_test.cpp
@@ -106,11 +106,6 @@ TEST_F(DataTypeDateTimeV2Test, simple_func_test) {
         EXPECT_TRUE(dt.have_maximum_size_of_value());
         EXPECT_EQ(dt.get_size_of_value_in_memory(), sizeof(FieldType));
 
-        EXPECT_FALSE(dt.is_null_literal());
-        dt.set_null_literal(true);
-        EXPECT_TRUE(dt.is_null_literal());
-        dt.set_null_literal(false);
-
         EXPECT_TRUE(dt.equals(dt));
     };
     test_func(dt_datetime_v2_0);

--- a/be/test/core/data_type/data_type_decimal_test.cpp
+++ b/be/test/core/data_type/data_type_decimal_test.cpp
@@ -213,7 +213,6 @@ TEST_F(DataTypeDecimalTest, MetaInfoTest) {
             .size_of_value_in_memory = sizeof(Decimal32),
             .precision = tmp_dt->get_precision(),
             .scale = tmp_dt->get_scale(),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_DECIMAL32>(Decimal32(0)),
     };
@@ -259,8 +258,6 @@ TEST_F(DataTypeDecimalTest, simple_func_test) {
         using FieldType = typename std::remove_reference<DataType>::type::FieldType;
         EXPECT_TRUE(dt.have_maximum_size_of_value());
         EXPECT_EQ(dt.get_size_of_value_in_memory(), sizeof(FieldType));
-
-        EXPECT_FALSE(dt.is_null_literal());
 
         EXPECT_TRUE(dt.equals(dt));
 

--- a/be/test/core/data_type/data_type_fixed_length_object_test.cpp
+++ b/be/test/core/data_type/data_type_fixed_length_object_test.cpp
@@ -41,7 +41,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -76,7 +75,6 @@ TEST_P(DataTypeFixedLengthObjectTest, MetaInfoTest) {
             .size_of_value_in_memory = size_t(-1),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_STRING>(String()),
     };

--- a/be/test/core/data_type/data_type_hll_test.cpp
+++ b/be/test/core/data_type/data_type_hll_test.cpp
@@ -40,7 +40,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -77,7 +76,6 @@ TEST_P(DataTypeHLLTest, MetaInfoTest) {
             .size_of_value_in_memory = size_t(-1),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_HLL>(HyperLogLog::empty()),
     };

--- a/be/test/core/data_type/data_type_ip_test.cpp
+++ b/be/test/core/data_type/data_type_ip_test.cpp
@@ -38,7 +38,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to), from_string (ReadBuffer &rb, IColumn *column)
@@ -84,7 +83,6 @@ TEST_F(DataTypeIPTest, MetaInfoTest) {
             .size_of_value_in_memory = sizeof(IPv4),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_IPV4>(IPv4(0)),
     };
@@ -101,7 +99,6 @@ TEST_F(DataTypeIPTest, MetaInfoTest) {
                                        .size_of_value_in_memory = sizeof(IPv6),
                                        .precision = size_t(-1),
                                        .scale = size_t(-1),
-                                       .is_null_literal = false,
                                        .pColumnMeta = col_meta6.get(),
                                        .default_field = Field::create_field<TYPE_IPV6>(IPv6(0))};
     meta_info_assert(dt_ipv4, ipv4_meta_info_to_assert);

--- a/be/test/core/data_type/data_type_jsonb_test.cpp
+++ b/be/test/core/data_type/data_type_jsonb_test.cpp
@@ -93,7 +93,6 @@ TEST_F(DataTypeJsonbTest, MetaInfoTest) {
             .size_of_value_in_memory = 0,
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_JSONB>(JsonbField())};
     auto tmp_dt = DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_JSONB, false);
@@ -235,8 +234,6 @@ TEST_F(DataTypeJsonbTest, ser_deser) {
 TEST_F(DataTypeJsonbTest, simple_func_test) {
     auto test_func = [](auto& dt) {
         EXPECT_FALSE(dt.have_maximum_size_of_value());
-
-        EXPECT_FALSE(dt.is_null_literal());
 
         EXPECT_TRUE(dt.equals(dt));
 

--- a/be/test/core/data_type/data_type_number_test.cpp
+++ b/be/test/core/data_type/data_type_number_test.cpp
@@ -123,7 +123,6 @@ TEST_F(DataTypeNumberTest, MetaInfoTest) {
             .size_of_value_in_memory = sizeof(Int8),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_TINYINT>((Int8)0),
     };
@@ -410,11 +409,6 @@ TEST_F(DataTypeNumberTest, simple_func_test) {
         using FieldType = typename std::remove_reference<DataType>::type::FieldType;
         EXPECT_TRUE(dt.have_maximum_size_of_value());
         EXPECT_EQ(dt.get_size_of_value_in_memory(), sizeof(FieldType));
-
-        EXPECT_FALSE(dt.is_null_literal());
-        dt.set_null_literal(true);
-        EXPECT_TRUE(dt.is_null_literal());
-        dt.set_null_literal(false);
 
         EXPECT_TRUE(dt.equals(dt));
     };

--- a/be/test/core/data_type/data_type_quantile_state_test.cpp
+++ b/be/test/core/data_type/data_type_quantile_state_test.cpp
@@ -40,7 +40,6 @@
 //         get_family_name, get_is_parametric,
 //         have_maximum_size_of_value, get_maximum_size_of_value_in_memory, get_size_of_value_in_memory
 //         get_precision, get_scale
-//         is_null_literal
 // 2. datatype creation with column : create_column, create_column_const (size_t size, const Field &field), create_column_const_with_default_value (size_t size), get_uncompressed_serialized_bytes (const IColumn &column, int be_exec_version)
 // 3. serde related: get_serde (int nesting_level=1)
 //          to_string (const IColumn &column, size_t row_num, BufferWritable &ostr), to_string (const IColumn &column, size_t row_num), to_string_batch (const IColumn &column, ColumnString &column_to)
@@ -77,7 +76,6 @@ TEST_P(DataTypeQuantileStateTest, MetaInfoTest) {
             .size_of_value_in_memory = size_t(-1),
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_QUANTILE_STATE>(QuantileState()),
     };

--- a/be/test/core/data_type/data_type_string_test.cpp
+++ b/be/test/core/data_type/data_type_string_test.cpp
@@ -96,7 +96,6 @@ TEST_F(DataTypeStringTest, MetaInfoTest) {
             .size_of_value_in_memory = 0,
             .precision = size_t(-1),
             .scale = size_t(-1),
-            .is_null_literal = false,
             .pColumnMeta = col_meta.get(),
             .default_field = Field::create_field<TYPE_STRING>(""),
     };
@@ -238,8 +237,6 @@ TEST_F(DataTypeStringTest, ser_deser) {
 TEST_F(DataTypeStringTest, simple_func_test) {
     auto test_func = [](auto& dt) {
         EXPECT_FALSE(dt.have_maximum_size_of_value());
-
-        EXPECT_FALSE(dt.is_null_literal());
 
         EXPECT_TRUE(dt.equals(dt));
 


### PR DESCRIPTION

### What problem does this PR solve?


BE previously represented FE `NULL_TYPE` as a mocked `DataTypeUInt8` with an `is_null_literal` flag. Root cause: NULL literal handling was attached to ordinary numeric data types instead of using the existing `DataTypeNothing` representation for unknown/null-only values. This PR removes the `is_null_literal` API and flag, maps `TYPE_NULL` to `DataTypeNothing`, and updates cast handling to recognize `Nothing` after removing nullable wrappers. The related data type unit test metadata is simplified by removing the obsolete flag expectations.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

