### PR TITLE
[fix](fe) fix HttpURLUtil class code issue because of duplecative getHttpPort method declaration

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -33,10 +33,6 @@ import javax.net.ssl.HttpsURLConnection;
 
 public class HttpURLUtil {
 
-    public static int getHttpPort() {
-        return Config.enable_https ? Config.https_port : Config.http_port;
-    }
-
     public static HttpURLConnection getConnectionWithNodeIdent(String request) throws IOException {
         try {
             SecurityChecker.getInstance().startSSRFChecking(request);


### PR DESCRIPTION

### What problem does this PR solve?

HttpURLUtil class code issue because of duplecative getHttpPort method declaration cause fe compile error

Problem Summary:
fix HttpURLUtil class code issue because of duplecative getHttpPort method declaration

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

