### PR TITLE
[fix](regression) retry long stream load inputs

### DIFF
--- a/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
+++ b/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
@@ -152,6 +152,7 @@ suite('test_read_from_peer', 'docker') {
             // file """store_sales.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
             setFeAddr cluster.getAllFrontends().get(0).host, cluster.getAllFrontends().get(0).httpPort
 
             check { res, exception, startTime, endTime ->

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
@@ -70,6 +70,7 @@ suite("create_table_use_partition_policy") {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy_by_hdfs.groovy
@@ -73,6 +73,7 @@ suite("create_table_use_partition_policy_by_hdfs") {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_policy.groovy
@@ -70,6 +70,7 @@ suite("create_table_use_policy") {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_policy_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_policy_by_hdfs.groovy
@@ -73,6 +73,7 @@ suite("create_table_use_policy_by_hdfs") {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/load_colddata_to_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/load_colddata_to_hdfs.groovy
@@ -73,6 +73,7 @@ suite("load_colddata_to_hdfs") {
             // also, you can stream load a http stream, e.g. http://xxx/some.csv
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition.groovy
@@ -88,6 +88,7 @@ try {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition_by_hdfs.groovy
@@ -92,6 +92,7 @@ try {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
@@ -70,6 +70,7 @@ suite("table_modify_resouce") {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy_by_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy_by_hdfs.groovy
@@ -73,6 +73,7 @@ suite("table_modify_resouce_by_hdfs") {
             file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split${partnum}.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/compaction/test_base_compaction.groovy
+++ b/regression-test/suites/compaction/test_base_compaction.groovy
@@ -81,6 +81,7 @@ suite("test_base_compaction", "p2") {
         file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split01.gz"""
 
         time 10000 // limit inflight 10s
+        retryIfHttpError true
 
         // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 
@@ -116,6 +117,7 @@ suite("test_base_compaction", "p2") {
         file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split01.gz"""
 
         time 10000 // limit inflight 10s
+        retryIfHttpError true
 
         // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 
@@ -156,6 +158,7 @@ suite("test_base_compaction", "p2") {
         file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split00.gz"""
 
         time 10000 // limit inflight 10s
+        retryIfHttpError true
 
         // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/compaction/test_base_compaction_no_value.groovy
+++ b/regression-test/suites/compaction/test_base_compaction_no_value.groovy
@@ -81,6 +81,7 @@ suite("test_base_compaction_no_value", "p2") {
         file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split01.gz"""
 
         time 10000 // limit inflight 10s
+        retryIfHttpError true
 
         // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 
@@ -116,6 +117,7 @@ suite("test_base_compaction_no_value", "p2") {
         file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split01.gz"""
 
         time 10000 // limit inflight 10s
+        retryIfHttpError true
 
         // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 
@@ -156,6 +158,7 @@ suite("test_base_compaction_no_value", "p2") {
         file """${getS3Url()}/regression/tpch/sf1/lineitem.csv.split00.gz"""
 
         time 10000 // limit inflight 10s
+        retryIfHttpError true
 
         // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/compaction/test_filecache_with_base_compaction_thresthold.groovy
+++ b/regression-test/suites/compaction/test_filecache_with_base_compaction_thresthold.groovy
@@ -195,6 +195,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
             file """${getS3Url()}/regression/tpcds/sf1/store_sales.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
             check { res, exception, startTime, endTime ->
                 if (exception != null) {
                     throw exception
@@ -356,6 +357,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
             file """${getS3Url()}/regression/tpcds/sf1/store_sales.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
             check { res, exception, startTime, endTime ->
                 if (exception != null) {
                     throw exception
@@ -519,6 +521,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
             file """${getS3Url()}/regression/tpcds/sf1/store_sales.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
             check { res, exception, startTime, endTime ->
                 if (exception != null) {
                     throw exception
@@ -681,6 +684,7 @@ suite("test_filecache_with_base_compaction_thresthold", "docker") {
             file """${getS3Url()}/regression/tpcds/sf1/store_sales.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
             check { res, exception, startTime, endTime ->
                 if (exception != null) {
                     throw exception

--- a/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_multiple_client.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_multiple_client.groovy
@@ -105,6 +105,7 @@ l_shipmode,l_comment) select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, 
 
             set 'group_commit', 'async_mode'
             file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+            retryIfHttpError true
             unset 'label'
 
             check { result, exception, startTime, endTime ->

--- a/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_multiple_table.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_multiple_table.groovy
@@ -99,6 +99,7 @@ l_shipmode,l_comment) select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, 
 
             set 'group_commit', 'async_mode'
             file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+            retryIfHttpError true
             unset 'label'
 
             check { result, exception, startTime, endTime ->

--- a/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_normal.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_normal.groovy
@@ -98,6 +98,7 @@ l_shipmode,l_comment) select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, 
 
                     set 'group_commit', 'async_mode'
                     file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+                    retryIfHttpError true
                     unset 'label'
 
                     check { result, exception, startTime, endTime ->

--- a/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_schema_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_http_stream_lineitem_schema_change.groovy
@@ -168,6 +168,7 @@ l_shipmode,l_comment) select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, 
 
                     set 'group_commit', 'async_mode'
                     file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+                    retryIfHttpError true
                     unset 'label'
 
                     check { result, exception, startTime, endTime ->
@@ -197,6 +198,7 @@ l_comment) select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c14, c15, c
 
             set 'group_commit', 'async_mode'
             file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+            retryIfHttpError true
             unset 'label'
 
             check { result, exception, startTime, endTime ->

--- a/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_multiple_client.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_multiple_client.groovy
@@ -103,6 +103,7 @@ PROPERTIES (
             set 'group_commit', 'async_mode'
             unset 'label'
             file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+            retryIfHttpError true
 
             check { result, exception, startTime, endTime ->
                 checkStreamLoadResult(exception, result, rowCountArray[i - 1], rowCountArray[i - 1], 0, 0)

--- a/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_multiple_table.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_multiple_table.groovy
@@ -97,6 +97,7 @@ PROPERTIES (
             set 'group_commit', 'async_mode'
             unset 'label'
             file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+            retryIfHttpError true
 
             check { result, exception, startTime, endTime ->
                 checkStreamLoadResult(exception, result, rowCountArray[i - 1], rowCountArray[i - 1], 0, 0)

--- a/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_normal.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_normal.groovy
@@ -96,6 +96,7 @@ l_tax, l_returnflag,l_linestatus, l_shipdate,l_commitdate,l_receiptdate,l_shipin
                     set 'group_commit', 'async_mode'
                     unset 'label'
                     file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+                    retryIfHttpError true
 
                     check { result, exception, startTime, endTime ->
                         checkStreamLoadResult(exception, result, rowCountArray[i - 1], rowCountArray[i - 1], 0, 0)

--- a/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_schema_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_stream_load_lineitem_schema_change.groovy
@@ -166,6 +166,7 @@ PROPERTIES (
                     set 'group_commit', 'async_mode'
                     unset 'label'
                     file """${getS3Url()}/regression/tpch/sf1/lineitem.tbl.""" + i
+                    retryIfHttpError true
 
                     check { result, exception, startTime, endTime ->
                         checkStreamLoadResult(exception, result, rowCountArray[i - 1], rowCountArray[i - 1], 0, 0)

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_aggregate.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_aggregate.groovy
@@ -66,6 +66,7 @@ suite("txn_insert_concurrent_insert_aggregate") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_duplicate.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_duplicate.groovy
@@ -66,6 +66,7 @@ suite("txn_insert_concurrent_insert_duplicate") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mor.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mor.groovy
@@ -67,6 +67,7 @@ suite("txn_insert_concurrent_insert_mor") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mow.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_mow.groovy
@@ -66,6 +66,7 @@ suite("txn_insert_concurrent_insert_mow") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_ud.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_ud.groovy
@@ -68,6 +68,7 @@ suite("txn_insert_concurrent_insert_ud") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_update.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_concurrent_insert_update.groovy
@@ -69,6 +69,7 @@ suite("txn_insert_concurrent_insert_update") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/insert_p2/transaction/txn_insert_with_schema_change.groovy
+++ b/regression-test/suites/insert_p2/transaction/txn_insert_with_schema_change.groovy
@@ -69,6 +69,7 @@ suite("txn_insert_with_schema_change") {
                 set 'compress_type', 'GZ'
                 file """${getS3Url()}/regression/tpch/sf1/${file_name}"""
                 time 10000 // limit inflight 10s
+                retryIfHttpError true
                 check { result, exception, startTime, endTime ->
                     if (exception != null) {
                         throw exception

--- a/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
+++ b/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
@@ -82,6 +82,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpcds/sf1/${tableName}.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/load_p2/test_large_data_by_rpc.groovy
+++ b/regression-test/suites/load_p2/test_large_data_by_rpc.groovy
@@ -50,6 +50,7 @@ suite("test_large_data_by_rpc", "p2") {
         file """${getS3Url()}/regression/load/data/large_data_by_rpc.csv.gz"""
 
         time 30000
+        retryIfHttpError true
 
         check { result, exception, startTime, endTime ->
             if (exception != null) {

--- a/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/create_commit_mtmv_many_task.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/create_commit_mtmv_many_task.groovy
@@ -79,6 +79,7 @@ suite("create_commit_mtmv_many_tasks", "p2") {
             table table_name
             set 'column_separator', '|'
             file """${getS3Url() + '/regression/tpch/sf1/'}${src_file_name}"""
+            retryIfHttpError true
 
             check { result, exception, startTime, endTime ->
                 if (exception != null) {

--- a/regression-test/suites/tpcds_sf1_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_p1/load.groovy
@@ -82,6 +82,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpcds/sf1/${tableName}.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/tpcds_sf1_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf1_p2/load.groovy
@@ -51,6 +51,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpcds/sf1/${tableName}.dat.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/tpch_sf1_p2/load.groovy
+++ b/regression-test/suites/tpch_sf1_p2/load.groovy
@@ -57,6 +57,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpch/sf1/${tableName}.csv.split00.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 
@@ -92,6 +93,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpch/sf1/${tableName}.csv.split01.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 

--- a/regression-test/suites/tpch_sf1_unique_p2/load.groovy
+++ b/regression-test/suites/tpch_sf1_unique_p2/load.groovy
@@ -47,6 +47,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpch/sf1/${tableName}.csv.split00.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 
@@ -81,6 +82,7 @@ suite("load") {
             file """${getS3Url()}/regression/tpch/sf1/${tableName}.csv.split01.gz"""
 
             time 10000 // limit inflight 10s
+            retryIfHttpError true
 
             // stream load action will check result, include Success status, and NumberTotalRows == NumberLoadedRows
 


### PR DESCRIPTION
## Summary
- Enable retry for long-running stream load cases that read large TPCH/TPCDS or large-data files from S3/HTTP.
- Cover the flaky branch-4.1 P2 compaction case test_base_compaction_no_value and related long import cases.

## Testing
- git diff --check
- Static scan confirmed no matching long S3 streamLoad block remains without retry.