### PR TITLE
[fix](test) pin insert visible timeout case to master FE

### DIFF
--- a/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
+++ b/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
@@ -25,12 +25,12 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
     }
 
     def debugPoint = "PublishVersionDaemon.stop_publish"
-    // PublishVersionDaemon runs on the master FE. Use the configured runner-reachable host and master FE ports,
-    // because SHOW FRONTENDS can expose loopback or internal addresses in regression deployments.
-    def feHost = context.config.feHttpAddress.split(":")[0]
-    def feHttpPort = getMasterPort()
-    def feQueryPort = getMasterPort("query")
-    def masterJdbcUrl = Config.buildUrlWithDb(feHost, feQueryPort, context.dbName)
+    // PublishVersionDaemon runs on the master FE. The pipeline config provides runner-facing
+    // master FE endpoints; do not replace their mapped ports with raw SHOW FRONTENDS values.
+    def feHttpAddress = context.config.feHttpAddress
+    def feHost = feHttpAddress.split(":")[0]
+    def feHttpPort = Integer.parseInt(feHttpAddress.split(":")[1])
+    def masterJdbcUrl = Config.buildUrlWithDb(context.getJdbcUrl(), context.dbName)
     context.connectTo(masterJdbcUrl, context.config.jdbcUser, context.config.jdbcPassword)
 
     // Prepare a single-replica table so publish blocking deterministically drives the visible timeout path.

--- a/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
+++ b/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.Config
 import org.apache.doris.regression.util.DebugPoint
 import org.apache.doris.regression.util.NodeType
 
@@ -24,10 +25,12 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
     }
 
     def debugPoint = "PublishVersionDaemon.stop_publish"
-    // Use the configured FE HTTP endpoint so the case also works when SHOW FRONTENDS exposes loopback addresses.
-    def feHttpAddress = context.config.feHttpAddress
-    def feHost = feHttpAddress.split(":")[0]
-    def feHttpPort = Integer.parseInt(feHttpAddress.split(":")[1])
+    // PublishVersionDaemon runs on the master FE, so keep both the session and debug point on master.
+    def feHost = getMasterIp()
+    def feHttpPort = getMasterPort()
+    def feQueryPort = getMasterPort("query")
+    def masterJdbcUrl = Config.buildUrlWithDb(feHost, feQueryPort, context.dbName)
+    context.connectTo(masterJdbcUrl, context.config.jdbcUser, context.config.jdbcPassword)
 
     // Prepare a single-replica table so publish blocking deterministically drives the visible timeout path.
     sql """ DROP TABLE IF EXISTS test_insert_visible_timeout_return_mode_tbl FORCE """

--- a/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
+++ b/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
@@ -25,8 +25,9 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
     }
 
     def debugPoint = "PublishVersionDaemon.stop_publish"
-    // PublishVersionDaemon runs on the master FE, so keep both the session and debug point on master.
-    def feHost = getMasterIp()
+    // PublishVersionDaemon runs on the master FE. Use the configured runner-reachable host and master FE ports,
+    // because SHOW FRONTENDS can expose loopback or internal addresses in regression deployments.
+    def feHost = context.config.feHttpAddress.split(":")[0]
     def feHttpPort = getMasterPort()
     def feQueryPort = getMasterPort("query")
     def masterJdbcUrl = Config.buildUrlWithDb(feHost, feQueryPort, context.dbName)


### PR DESCRIPTION
## Summary

- Pin `test_insert_visible_timeout_return_mode` to the master FE before running the INSERT checks.
- Use the same master FE for the session connection and `PublishVersionDaemon.stop_publish` debug point.
- Avoid targeting a non-master FE in master-observers branch-4.1 regression deployments, where publish is driven by the master FE.

## Testing

- [x] `git diff --check`
- [ ] Not run locally: no confirmed branch-4.1 regression cluster was available in this local context.

Failure evidence:

- Branch-4.1 NonConcurrent build 201293, occurrence 2000000222
- Failed runs returned too quickly and did not enter the expected visible-timeout path.
