### PR TITLE
[fix](test) fix time series compaction rowset count

### DIFF
--- a/regression-test/suites/compaction/test_time_series_compaction_level2.groovy
+++ b/regression-test/suites/compaction/test_time_series_compaction_level2.groovy
@@ -120,20 +120,20 @@ suite("test_time_series_compaction_level2", "nonConcurrent") {
 
             int rowsetCount = get_rowset_count.call(tablets);
             println "rowsetCount: ${rowsetCount}"
-            assert (rowsetCount == 10 * replicaNum + i + 1)
+            assert (rowsetCount == (10 + i + 1) * replicaNum)
 
             trigger_cumulative_compaction_on_tablets.call(tablets)
             wait_cumulative_compaction_done.call(tablets)
         }
 
         int rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 10 * replicaNum + 1)
+        assert (rowsetCount == (10 + 1) * replicaNum)
 
         trigger_cumulative_compaction_on_tablets.call(tablets)
         wait_cumulative_compaction_done.call(tablets)
 
         rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 1 + 1) : "10 level-1 rowsets should be level-2 compacted into 1; expected 2 rowsets, got ${rowsetCount}"
+        assert (rowsetCount == (1 + 1) * replicaNum) : "10 level-1 rowsets should be level-2 compacted into 1; expected ${2 * replicaNum} rowsets, got ${rowsetCount}"
     } finally {
         GetDebugPoint().disableDebugPointForAllBEs("time_series_level2_file_count")
     }


### PR DESCRIPTION
## Summary

Fix `compaction/test_time_series_compaction_level2.groovy` rowset count assertions for branch-4.1 environments that force table replication to 3.

The test counts rowsets across every tablet replica returned by `SHOW TABLETS`. In the failing x64 branch-4.1 NonConcurrent build, `force_olap_table_replication_num=3` overrides the case's `replication_num=1`, so the base rowset exists on each replica too. The previous assertions multiplied inserted/compacted rowsets by `replicaNum` but counted the base rowset only once, causing the first check to expect 31 while the actual rowset count is 33.

This patch applies `replicaNum` consistently to:

- the per-round pre-compaction rowset count
- the post-loop level-1 rowset count
- the final base + level-2 rowset count

## Testing

- [x] `git diff --check`
- [x] Checked TeamCity occurrence: build 201293, occurrence 2000000344
- [ ] Runtime regression validation: pending `run buildall`
