### PR TITLE
[fix](test) stabilize sql digest generation case

### DIFF
--- a/regression-test/suites/audit/test_sql_digest_generation.groovy
+++ b/regression-test/suites/audit/test_sql_digest_generation.groovy
@@ -43,7 +43,7 @@ suite("test_sql_digest_generation", "nonConcurrent") {
         Long prevSqlDigestCount = Long.valueOf(prevSqlDigestCountResult[0][0])
         logger.info("prev sql_digest count: " + prevSqlDigestCount)
 
-        sql "select * from audit_log_behavior"
+        sql "select *, sleep(1) from audit_log_behavior"
 
         Thread.sleep(10000)
         sql """call flush_audit_log()"""
@@ -66,7 +66,7 @@ suite("test_sql_digest_generation", "nonConcurrent") {
         Long prevSqlDigestCount = Long.valueOf(prevSqlDigestCountResult[0][0])
         logger.info("prev sql_digest count: " + prevSqlDigestCount)
 
-        sql "select * from audit_log_behavior"
+        sql "select *, sleep(1) from audit_log_behavior"
 
         Thread.sleep(10000)
         sql """call flush_audit_log()"""


### PR DESCRIPTION
## Summary
- Use a deterministic slow query in test_sql_digest_generation so threshold 0 reliably satisfies the FE condition elapseMs > sql_digest_generation_threshold_ms.
- Apply the same query in both low-threshold and high-threshold branches to keep the assertion target consistent.

## Testing
- [x] git diff --check
- [ ] Not run locally; regression environment not available in this session.