### PR TITLE
(opt)(regression) SlotReference.shapeInfo() do not print table name

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-
 import javax.annotation.Nullable;
 
 /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
+
 import javax.annotation.Nullable;
 
 /**
@@ -206,9 +207,9 @@ public class SlotReference extends Slot {
     @Override
     public String computeToSql() {
         if (subPath.isEmpty()) {
-            return name.get();
+            return shapeInfo();
         } else {
-            return name.get() + "['" + String.join("']['", subPath) + "']";
+            return shapeInfo() + "['" + String.join("']['", subPath) + "']";
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -206,9 +206,9 @@ public class SlotReference extends Slot {
     @Override
     public String computeToSql() {
         if (subPath.isEmpty()) {
-            return shapeInfo();
+            return name.get();
         } else {
-            return shapeInfo() + "['" + String.join("']['", subPath) + "']";
+            return name.get() + "['" + String.join("']['", subPath) + "']";
         }
     }
 
@@ -223,11 +223,7 @@ public class SlotReference extends Slot {
 
     @Override
     public String shapeInfo() {
-        if (qualifier.isEmpty()) {
-            return name.get();
-        } else {
-            return qualifier.get(qualifier.size() - 1) + "." + name.get();
-        }
+        return name.get();
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?
some regression case output are not stable, like query_p0/hint/multi_leading.groovy
```
Exception:
java.lang.IllegalStateException: Check tag 'sql5_2' failed:
Check tag 'sql5_2' failed, line 6, CHAR result mismatch.
Expect cell is: ------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > avg(t1.c11) / 20.0)
But real is   : ------NestedLoopJoin[INNER_JOIN](cast(sum(c11) as DOUBLE) > (avg(c11) / 20.0))
```
After this pr, the explain output is fixed to avg(t1.c11)

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

