### PR TITLE
[fix](profile) guard execution profile access

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -198,7 +198,12 @@ public class ProfileManager extends MasterDaemon {
     }
 
     public ExecutionProfile getExecutionProfile(TUniqueId queryId) {
-        return this.queryIdToExecutionProfiles.get(queryId);
+        readLock.lock();
+        try {
+            return this.queryIdToExecutionProfiles.get(queryId);
+        } finally {
+            readLock.unlock();
+        }
     }
 
     public void pushProfile(Profile profile) {

--- a/regression-test/suites/query_profile/dml_profile_safe.groovy
+++ b/regression-test/suites/query_profile/dml_profile_safe.groovy
@@ -60,7 +60,7 @@ def waitForProfile = { masterHTTPAddr, taskType, sqlToken ->
     return false
 }
 
-suite("dml_profile_safe") {
+suite("dml_profile_safe", "nonConcurrent") {
     sql """set enable_nereids_planner = true;"""
     sql """set enable_fallback_to_original_planner = false;"""
 


### PR DESCRIPTION
### What

Fix two profile stability issues found while investigating
`query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy`:

- Guard `ProfileManager.getExecutionProfile()` with the existing read lock,
  matching the write-locked updates/removals of `queryIdToExecutionProfiles`.
- Mark `query_profile/dml_profile_safe.groovy` as `nonConcurrent` because it runs
  `clean all profile`, which clears global FE profile state and can interfere
  with other profile suites that are waiting for a query profile to become
  complete.

### Why

CI evidence showed `dml_profile_safe.groovy` running `clean all profile` while
`adaptive_pipeline_task_serial_read_on_limit.groovy` was waiting on another
query's profile. The final BE profile report then reached FE after the target
`ExecutionProfile` had already been cleared, so the profile never became
complete for the waiting case.

The read-lock change is a small product hardening fix: `queryIdToExecutionProfiles`
is a regular map guarded by the profile manager read/write lock, so reads should
also use the read lock.

### Validation

- `git diff --check`
- PR diagnostic run before cleanup:
  - P0 Regression build `989990`: `SUCCESS`
  - Cloud P0 build `989992`: `SUCCESS`
- Remote log scan on `ci-selectdb` for builds `989990` and `989992`:
  - no final-report missing `ExecutionProfile`
  - no mark-finished missing `ExecutionProfile`
  - no `clean all profile` interference after isolating `dml_profile_safe`
  - sampled incomplete-profile logs were transient and later completed

Local FE build/regression was not run in this cleanup pass; validation is
expected from the refreshed PR pipeline.
