### PR TITLE
[test](asan) Deterministic reproducer for the ASAN thrift-reopen BE crash [DO NOT MERGE / CI repro]

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -790,6 +790,20 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RE
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${MALLOCLIB})
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN" OR "${CMAKE_BUILD_TYPE}" STREQUAL "ASAN_UT")
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${ASAN_LIBS})
+    if (OS_LINUX)
+        # The fully static link resolves __cxa_throw/__cxa_rethrow to
+        # libstdc++.a's strong definitions, silently bypassing the ASAN
+        # runtime's weak interceptors, so __asan_handle_no_return() never runs
+        # when un-instrumented third-party code (libthrift, ...) throws. The
+        # unwound instrumented frames keep their stack-shadow poison and the
+        # next deep call over the same stack range aborts with the
+        # kCurrentStackFrameMagic CHECK (thrift retry/reopen crashes: QA-202,
+        # DORIS-1073, DORIS-15154, google/glog#978, google/sanitizers#1010).
+        # Redirect every reference to wrappers that restore the shadow
+        # cleanup. See asan-glog-rca.md at the repository root and
+        # be/src/common/asan_cxa_throw_wrap.cpp.
+        set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} -Wl,--wrap=__cxa_throw -Wl,--wrap=__cxa_rethrow)
+    endif()
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "LSAN")
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${LSAN_LIBS})
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "UBSAN")

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -800,9 +800,12 @@ elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN" OR "${CMAKE_BUILD_TYPE}" STREQUAL 
         # kCurrentStackFrameMagic CHECK (thrift retry/reopen crashes: QA-202,
         # DORIS-1073, DORIS-15154, google/glog#978, google/sanitizers#1010).
         # Redirect every reference to wrappers that restore the shadow
-        # cleanup. See asan-glog-rca.md at the repository root and
+        # cleanup. _Unwind_RaiseException is wrapped too: std::rethrow_exception
+        # and foreign-language unwinders raise through it without touching
+        # __cxa_throw. See asan-glog-rca.md at the repository root and
         # be/src/common/asan_cxa_throw_wrap.cpp.
-        set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} -Wl,--wrap=__cxa_throw -Wl,--wrap=__cxa_rethrow)
+        set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} -Wl,--wrap=__cxa_throw -Wl,--wrap=__cxa_rethrow
+            -Wl,--wrap=_Unwind_RaiseException)
     endif()
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "LSAN")
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${LSAN_LIBS})

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -91,18 +91,14 @@ Status MasterServerClient::finish_task(const TFinishTaskRequest& request, TMaste
     try {
         try {
             client->finishTask(*result, request);
-        } catch ([[maybe_unused]] TTransportException& e) {
-#ifndef ADDRESS_SANITIZER
+        } catch (TTransportException& e) {
             LOG(WARNING) << "master client, retry finishTask: " << e.what();
-#endif
             client_status = client.reopen(config::thrift_rpc_timeout_ms);
             if (!client_status.ok()) {
-#ifndef ADDRESS_SANITIZER
                 LOG(WARNING) << "fail to get master client from cache. "
                              << "host=" << _cluster_info->master_fe_addr.hostname
                              << ", port=" << _cluster_info->master_fe_addr.port
                              << ", code=" << client_status.code();
-#endif
                 return Status::RpcError("Master client finish task failed");
             }
             client->finishTask(*result, request);
@@ -137,19 +133,15 @@ Status MasterServerClient::report(const TReportRequest& request, TMasterResult* 
         } catch (TTransportException& e) {
             TTransportException::TTransportExceptionType type = e.getType();
             if (type != TTransportException::TTransportExceptionType::TIMED_OUT) {
-#ifndef ADDRESS_SANITIZER
                 // if not TIMED_OUT, retry
                 LOG(WARNING) << "master client, retry finishTask: " << e.what();
-#endif
 
                 client_status = client.reopen(config::thrift_rpc_timeout_ms);
                 if (!client_status.ok()) {
-#ifndef ADDRESS_SANITIZER
                     LOG(WARNING) << "fail to get master client from cache. "
                                  << "host=" << _cluster_info->master_fe_addr.hostname
                                  << ", port=" << _cluster_info->master_fe_addr.port
                                  << ", code=" << client_status.code();
-#endif
                     return Status::InternalError("Fail to get master client from cache");
                 }
 
@@ -157,9 +149,7 @@ Status MasterServerClient::report(const TReportRequest& request, TMasterResult* 
             } else {
                 // TIMED_OUT exception. do not retry
                 // actually we don't care what FE returns.
-#ifndef ADDRESS_SANITIZER
                 LOG(WARNING) << "fail to report to master: " << e.what();
-#endif
                 return Status::InternalError("Fail to report to master");
             }
         }
@@ -193,10 +183,8 @@ Status MasterServerClient::confirm_unused_remote_files(
         } catch (TTransportException& e) {
             TTransportException::TTransportExceptionType type = e.getType();
             if (type != TTransportException::TTransportExceptionType::TIMED_OUT) {
-#ifndef ADDRESS_SANITIZER
                 // if not TIMED_OUT, retry
                 LOG(WARNING) << "master client, retry finishTask: " << e.what();
-#endif
 
                 client_status = client.reopen(config::thrift_rpc_timeout_ms);
                 if (!client_status.ok()) {

--- a/be/src/common/CMakeLists.txt
+++ b/be/src/common/CMakeLists.txt
@@ -23,6 +23,16 @@ add_library(Common STATIC ${SRC_FILES})
 
 pch_reuse(Common)
 
+# asan_repro_uninstrumented.cpp emulates an un-instrumented third-party
+# library (like libthrift) for the ASAN stale-stack-poison reproducer, so it
+# must be compiled without sanitizer instrumentation, without builtin
+# memset/memcpy expansion (the calls must reach the ASAN interceptors), and
+# without the sanitizer-flavored precompiled header.
+# See asan-glog-rca.md at the repository root.
+set_source_files_properties(asan_repro_uninstrumented.cpp PROPERTIES
+    COMPILE_OPTIONS "-fno-sanitize=all;-fno-builtin"
+    SKIP_PRECOMPILE_HEADERS ON)
+
 # Generate env_config.h according to env_config.h.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/env_config.h.in ${GENSRC_DIR}/common/env_config.h)
 target_include_directories(Common PUBLIC ${GENSRC_DIR}/common/)

--- a/be/src/common/asan_cxa_throw_wrap.cpp
+++ b/be/src/common/asan_cxa_throw_wrap.cpp
@@ -32,12 +32,20 @@
 //
 // ASAN builds therefore link with
 //     -Wl,--wrap=__cxa_throw -Wl,--wrap=__cxa_rethrow
+//     -Wl,--wrap=_Unwind_RaiseException
 // (see the ASAN branch in be/CMakeLists.txt). --wrap redirects every
 // reference from every input object -- including the members of the
 // un-instrumented third-party archives and of libstdc++.a itself -- to the
 // wrappers below, which restore exactly what the official interceptors do:
 // wipe the stack shadow above the throw point, then forward to the real
 // implementation (__real___cxa_throw resolves to libstdc++'s definition).
+//
+// _Unwind_RaiseException is wrapped as well because not every raise funnels
+// through __cxa_throw: std::rethrow_exception (libstdc++'s eh_ptr.cc) and
+// foreign-language unwinders call it directly. This matches the official
+// ASAN interceptor set for the unwind entry points. Throws via __cxa_throw
+// run the shadow wipe twice (once per wrapper); that is idempotent and is
+// also what happens with the stock interceptors.
 
 #if defined(ADDRESS_SANITIZER) && defined(__linux__)
 
@@ -46,9 +54,11 @@ extern "C" {
 void __asan_handle_no_return();
 void __real___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*));
 void __real___cxa_rethrow();
+int __real__Unwind_RaiseException(void* exception_object);
 
 void __wrap___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*));
 void __wrap___cxa_rethrow();
+int __wrap__Unwind_RaiseException(void* exception_object);
 
 void __wrap___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*)) {
     __asan_handle_no_return();
@@ -58,6 +68,13 @@ void __wrap___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*)
 void __wrap___cxa_rethrow() {
     __asan_handle_no_return();
     __real___cxa_rethrow();
+}
+
+// Unlike the two above this one RETURNS when no handler is found (the caller
+// then calls std::terminate), so the return value must be forwarded.
+int __wrap__Unwind_RaiseException(void* exception_object) {
+    __asan_handle_no_return();
+    return __real__Unwind_RaiseException(exception_object);
 }
 
 } // extern "C"

--- a/be/src/common/asan_cxa_throw_wrap.cpp
+++ b/be/src/common/asan_cxa_throw_wrap.cpp
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Fix for the ASAN stale-stack-poison crashes on the thrift retry/reopen
+// path (internal QA-202 / DORIS-1073 / DORIS-15154, google/glog#978,
+// google/sanitizers#1010). See asan-glog-rca.md at the repository root.
+//
+// The BE's fully static link (-static-libstdc++/-static-libgcc plus a static
+// sanitizer runtime) resolves __cxa_throw/__cxa_rethrow to libstdc++.a's
+// strong definitions, silently discarding the ASAN runtime's weak interceptor
+// versions. So when un-instrumented code (libthrift and the other third-party
+// static libs) throws, __asan_handle_no_return() never runs, the unwound
+// instrumented frames keep their stack-shadow poison, and the next deep call
+// chain over the same stack range dies with a false positive that ASAN cannot
+// even report:
+//     AddressSanitizer: CHECK failed: asan_thread.cpp:...
+//         "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
+//
+// ASAN builds therefore link with
+//     -Wl,--wrap=__cxa_throw -Wl,--wrap=__cxa_rethrow
+// (see the ASAN branch in be/CMakeLists.txt). --wrap redirects every
+// reference from every input object -- including the members of the
+// un-instrumented third-party archives and of libstdc++.a itself -- to the
+// wrappers below, which restore exactly what the official interceptors do:
+// wipe the stack shadow above the throw point, then forward to the real
+// implementation (__real___cxa_throw resolves to libstdc++'s definition).
+
+#if defined(ADDRESS_SANITIZER) && defined(__linux__)
+
+extern "C" {
+
+void __asan_handle_no_return();
+void __real___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*));
+void __real___cxa_rethrow();
+
+void __wrap___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*));
+void __wrap___cxa_rethrow();
+
+void __wrap___cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*)) {
+    __asan_handle_no_return();
+    __real___cxa_throw(thrown_exception, tinfo, dest);
+}
+
+void __wrap___cxa_rethrow() {
+    __asan_handle_no_return();
+    __real___cxa_rethrow();
+}
+
+} // extern "C"
+
+#endif // ADDRESS_SANITIZER && __linux__

--- a/be/src/common/asan_repro.cpp
+++ b/be/src/common/asan_repro.cpp
@@ -284,7 +284,7 @@ void real_path_sweep(int port) {
                       st.to_string().c_str());
             continue;
         }
-        real_rpc_attempt(&client);  // poison: real TTransportException from libthrift
+        real_rpc_attempt(&client); // poison: real TTransportException from libthrift
         stuff_pending_bytes(&client);
         padded_close(&client, pad); // Jira crash site: close -> flush -> getSocketInfo
         // ~ThriftClient runs close() again: one more shot at a slightly
@@ -316,36 +316,40 @@ void repro_thread_body() {
 
     ProbeResult control;
     run_scenario(false, &control);
-    repro_log("[ASAN-REPRO] part1 control (throw from INSTRUMENTED code):   %d/%d probe frames "
-              "on stale poison, first level=%d addr=%p\n",
-              control.poisoned_levels, kProbeDepth, control.first_poisoned_level,
-              control.first_poisoned_addr);
+    repro_log(
+            "[ASAN-REPRO] part1 control (throw from INSTRUMENTED code):   %d/%d probe frames "
+            "on stale poison, first level=%d addr=%p\n",
+            control.poisoned_levels, kProbeDepth, control.first_poisoned_level,
+            control.first_poisoned_addr);
 
     ProbeResult test;
     run_scenario(true, &test);
-    repro_log("[ASAN-REPRO] part1 test    (throw from UN-INSTRUMENTED code): %d/%d probe frames "
-              "on stale poison, first level=%d addr=%p\n",
-              test.poisoned_levels, kProbeDepth, test.first_poisoned_level,
-              test.first_poisoned_addr);
+    repro_log(
+            "[ASAN-REPRO] part1 test    (throw from UN-INSTRUMENTED code): %d/%d probe frames "
+            "on stale poison, first level=%d addr=%p\n",
+            test.poisoned_levels, kProbeDepth, test.first_poisoned_level, test.first_poisoned_addr);
     if (test.poisoned_levels > 0) {
-        repro_log("[ASAN-REPRO] part1 verdict: stale stack shadow poison CONFIRMED after an "
-                  "un-instrumented throw. Expecting part2 to crash at the Jira stack site.\n");
+        repro_log(
+                "[ASAN-REPRO] part1 verdict: stale stack shadow poison CONFIRMED after an "
+                "un-instrumented throw. Expecting part2 to crash at the Jira stack site.\n");
     } else {
-        repro_log("[ASAN-REPRO] part1 verdict: no stale poison detected. Running part2 as "
-                  "confirmation; it should survive.\n");
+        repro_log(
+                "[ASAN-REPRO] part1 verdict: no stale poison detected. Running part2 as "
+                "confirmation; it should survive.\n");
     }
 
 #if defined(__linux__)
     DeadPeerServer server;
     if (server.start()) {
-        repro_log("[ASAN-REPRO] part2: dead-peer FE listening on 127.0.0.1:%d, driving the real "
-                  "path: report() fails -> ThriftClientImpl::close() -> TBufferedTransport::"
-                  "close/flush -> TSocket::write_partial -> getSocketInfo()\n"
-                  "[ASAN-REPRO] part2: a crash below with frames like the Jira stacks IS the "
-                  "expected POSITIVE result, e.g.\n"
-                  "[ASAN-REPRO]   AddressSanitizer: CHECK failed: asan_thread.cpp:... "
-                  "\"((ptr[0] == kCurrentStackFrameMagic)) != (0)\" (0x0, 0x0)\n",
-                  server.port());
+        repro_log(
+                "[ASAN-REPRO] part2: dead-peer FE listening on 127.0.0.1:%d, driving the real "
+                "path: report() fails -> ThriftClientImpl::close() -> TBufferedTransport::"
+                "close/flush -> TSocket::write_partial -> getSocketInfo()\n"
+                "[ASAN-REPRO] part2: a crash below with frames like the Jira stacks IS the "
+                "expected POSITIVE result, e.g.\n"
+                "[ASAN-REPRO]   AddressSanitizer: CHECK failed: asan_thread.cpp:... "
+                "\"((ptr[0] == kCurrentStackFrameMagic)) != (0)\" (0x0, 0x0)\n",
+                server.port());
         real_path_sweep(server.port());
         server.stop();
         repro_log("[ASAN-REPRO] part2: sweep finished WITHOUT crashing.\n");
@@ -357,19 +361,22 @@ void repro_thread_body() {
 #endif
 
     if (test.poisoned_levels == 0) {
-        repro_log("[ASAN-REPRO] RESULT: NEGATIVE - no stale stack shadow poison after an "
-                  "un-instrumented throw and the real path survived. The bug is NOT present in "
-                  "this build (fixed, or the link layout changed). BE continues to start.\n");
+        repro_log(
+                "[ASAN-REPRO] RESULT: NEGATIVE - no stale stack shadow poison after an "
+                "un-instrumented throw and the real path survived. The bug is NOT present in "
+                "this build (fixed, or the link layout changed). BE continues to start.\n");
         return;
     }
 
-    repro_log("[ASAN-REPRO] part3: real path survived although poison exists (alignment luck); "
-              "triggering the synthetic crash site via an intercepted memset() instead.\n"
-              "[ASAN-REPRO] expected: AddressSanitizer: CHECK failed: asan_thread.cpp:... "
-              "\"((ptr[0] == kCurrentStackFrameMagic)) != (0)\" (0x0, 0x0)\n");
+    repro_log(
+            "[ASAN-REPRO] part3: real path survived although poison exists (alignment luck); "
+            "triggering the synthetic crash site via an intercepted memset() instead.\n"
+            "[ASAN-REPRO] expected: AddressSanitizer: CHECK failed: asan_thread.cpp:... "
+            "\"((ptr[0] == kCurrentStackFrameMagic)) != (0)\" (0x0, 0x0)\n");
     asan_repro::descend_and_boom(0, kProbeDepth);
-    repro_log("[ASAN-REPRO] UNEXPECTED: part3 returned without crashing although stale poison "
-              "was found. Please report this output.\n");
+    repro_log(
+            "[ASAN-REPRO] UNEXPECTED: part3 returned without crashing although stale poison "
+            "was found. Please report this output.\n");
 }
 
 } // namespace
@@ -379,13 +386,14 @@ void run_asan_stale_poison_repro() {
         repro_log("[ASAN-REPRO] disabled by DORIS_DISABLE_ASAN_REPRO\n");
         return;
     }
-    repro_log("[ASAN-REPRO] ==============================================================\n"
-              "[ASAN-REPRO] Deliberate reproducer for the ASAN stale-stack-poison BE crash\n"
-              "[ASAN-REPRO] (thrift reopen / glog LOG(WARNING) cores: QA-202, DORIS-1073,\n"
-              "[ASAN-REPRO] DORIS-15154, google/glog#978, google/sanitizers#1010).\n"
-              "[ASAN-REPRO] Root cause analysis: asan-glog-rca.md in the repository root.\n"
-              "[ASAN-REPRO] A crash right below IS the expected POSITIVE result.\n"
-              "[ASAN-REPRO] ==============================================================\n");
+    repro_log(
+            "[ASAN-REPRO] ==============================================================\n"
+            "[ASAN-REPRO] Deliberate reproducer for the ASAN stale-stack-poison BE crash\n"
+            "[ASAN-REPRO] (thrift reopen / glog LOG(WARNING) cores: QA-202, DORIS-1073,\n"
+            "[ASAN-REPRO] DORIS-15154, google/glog#978, google/sanitizers#1010).\n"
+            "[ASAN-REPRO] Root cause analysis: asan-glog-rca.md in the repository root.\n"
+            "[ASAN-REPRO] A crash right below IS the expected POSITIVE result.\n"
+            "[ASAN-REPRO] ==============================================================\n");
     // A dedicated thread gives a pristine stack, which makes the layout (and
     // therefore the reproduction) deterministic.
     std::thread t(repro_thread_body);

--- a/be/src/common/asan_repro.cpp
+++ b/be/src/common/asan_repro.cpp
@@ -1,0 +1,404 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Instrumented half of the ASAN stale-stack-poison reproducer.
+// See asan-glog-rca.md at the repository root for the analysis.
+//
+// Part 1 (deterministic evidence, never crashes):
+//   descend instrumented frames -> throw from an UN-instrumented TU ->
+//   catch -> prove with __asan_region_is_poisoned() that the unwound region
+//   kept its shadow poison. A control run throwing from INSTRUMENTED code
+//   shows the asymmetry (the compiler emits __asan_handle_no_return() before
+//   instrumented throws only).
+//
+// Part 2 (the real Jira crash site):
+//   drive the exact production path from QA-202 / DORIS-1073 / DORIS-15154
+//   with a real ThriftClient<FrontendServiceClient> against an in-process
+//   dead peer that RSTs every connection:
+//       report() RPC fails -> libthrift (un-instrumented) throws
+//       TTransportException through the instrumented gensrc frames (poison)
+//       -> ThriftClientImpl::close() -> TBufferedTransport::close() ->
+//       flush() -> TSocket::write_partial() -> getSocketInfo() locals land
+//       on the stale poison -> ASAN false positive -> kCurrentStackFrameMagic
+//       CHECK abort.
+//   Alignment between the poison stripes and thrift's locals is the only
+//   probabilistic part, so the close() descent is swept over 257 different
+//   stack offsets with an alloca() pad (8-byte step over 2KB).
+//
+// Part 3 (fallback): if part 2 somehow survives while part 1 proved the
+//   poison exists, trigger the synthetic crash site instead so CI still
+//   fails deterministically.
+
+#include "common/asan_repro.h"
+
+#ifdef ADDRESS_SANITIZER
+
+#include <unistd.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#if defined(__linux__)
+#include <alloca.h>
+#include <arpa/inet.h>
+#include <gen_cpp/FrontendService.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <atomic>
+
+#include "common/status.h"
+#include "util/thrift_client.h"
+#endif // __linux__
+
+// Provided by the statically linked ASAN runtime. Query-only, never reports.
+extern "C" void* __asan_region_is_poisoned(void* beg, size_t size);
+
+namespace doris {
+namespace {
+
+using asan_repro::ProbeResult;
+
+// Depth of the instrumented descent that the exception unwinds, and depth of
+// the un-instrumented probe descent. Instrumented frames are much fatter
+// (redzones around every local), so the probe descends deeper to be sure it
+// spans the whole poisoned region.
+constexpr int kThrowDepth = 32;
+constexpr int kProbeDepth = 160;
+
+// Deterministic logging even when the deep stack region carries stale
+// poison: vsnprintf/write only get a global buffer range checked by their
+// interceptors, never a stack local placed in the dirty zone.
+char g_log_buf[4096];
+
+void repro_log(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int len = vsnprintf(g_log_buf, sizeof(g_log_buf), fmt, ap);
+    va_end(ap);
+    if (len <= 0) {
+        return;
+    }
+    size_t to_write = static_cast<size_t>(len) < sizeof(g_log_buf) ? static_cast<size_t>(len)
+                                                                   : sizeof(g_log_buf) - 1;
+    ssize_t written = write(STDERR_FILENO, g_log_buf, to_write);
+    (void)written;
+}
+
+// ---------------------------------------------------------------------------
+// Part 1: deterministic stale-poison measurement (synthetic frames)
+// ---------------------------------------------------------------------------
+
+__attribute__((noinline)) void instrumented_throw() {
+    // Control case: for a throw compiled WITH ASAN instrumentation the
+    // compiler emits __asan_handle_no_return() right before __cxa_throw,
+    // which wipes the shadow of everything below the catch frame, so no
+    // stale poison is left behind.
+    throw 42;
+}
+
+__attribute__((noinline)) void deep_instrumented(int level, bool use_uninstrumented_throw) {
+    // Three separate arrays so every frame contributes dense left/mid/right
+    // redzone stripes to the shadow. No destructors and no try-blocks: the
+    // frames must not have landing pads, so phase-2 unwinding skips them
+    // without running any cleanup code.
+    char a[96];
+    char b[96];
+    char c[96];
+    a[0] = b[0] = c[0] = static_cast<char>(level);
+    asm volatile("" : : "r"(a), "r"(b), "r"(c) : "memory");
+    if (level + 1 < kThrowDepth) {
+        deep_instrumented(level + 1, use_uninstrumented_throw);
+    } else if (use_uninstrumented_throw) {
+        asan_repro::uninstrumented_throw();
+    } else {
+        instrumented_throw();
+    }
+}
+
+__attribute__((noinline)) void run_scenario(bool use_uninstrumented_throw, ProbeResult* out) {
+    try {
+        deep_instrumented(0, use_uninstrumented_throw);
+    } catch (int) {
+        // The frames between the throw site and here have been unwound. If
+        // __asan_handle_no_return() did not run at throw time, their shadow
+        // poison is still on this thread's stack.
+    }
+    // Immediately re-enter the unwound region from un-instrumented code,
+    // exactly like the production retry path does.
+    asan_repro::probe_and_scrub(0, kProbeDepth, out);
+}
+
+// ---------------------------------------------------------------------------
+// Part 2: the real production path (Jira stack site)
+// ---------------------------------------------------------------------------
+
+#if defined(__linux__)
+
+// A minimal in-process "dead FE": accepts every connection and immediately
+// closes it with SO_LINGER=0 so the peer gets a hard RST. Any later thrift
+// write on the client side fails inside TSocket::write_partial(), which is
+// where getSocketInfo()/GlobalOutput.perror() build their error strings --
+// the exact crash frames of QA-202 / DORIS-1073 / DORIS-15154.
+class DeadPeerServer {
+public:
+    bool start() {
+        _listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (_listen_fd < 0) {
+            return false;
+        }
+        int reuse = 1;
+        ::setsockopt(_listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+        sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0; // ephemeral
+        if (::bind(_listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 ||
+            ::listen(_listen_fd, 128) != 0) {
+            ::close(_listen_fd);
+            _listen_fd = -1;
+            return false;
+        }
+        socklen_t len = sizeof(addr);
+        if (::getsockname(_listen_fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+            ::close(_listen_fd);
+            _listen_fd = -1;
+            return false;
+        }
+        _port = ntohs(addr.sin_port);
+        _accept_thread = std::thread([this]() { accept_loop(); });
+        return true;
+    }
+
+    void stop() {
+        _stopping.store(true);
+        if (_listen_fd >= 0) {
+            ::shutdown(_listen_fd, SHUT_RDWR);
+            ::close(_listen_fd);
+        }
+        if (_accept_thread.joinable()) {
+            _accept_thread.join();
+        }
+    }
+
+    int port() const { return _port; }
+
+private:
+    void accept_loop() {
+        while (!_stopping.load()) {
+            int conn = ::accept(_listen_fd, nullptr, nullptr);
+            if (conn < 0) {
+                if (_stopping.load()) {
+                    break;
+                }
+                continue;
+            }
+            struct linger lg;
+            lg.l_onoff = 1;
+            lg.l_linger = 0;
+            ::setsockopt(conn, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)); // close => RST
+            ::close(conn);
+        }
+    }
+
+    int _listen_fd = -1;
+    int _port = 0;
+    std::atomic<bool> _stopping {false};
+    std::thread _accept_thread;
+};
+
+// The real failed RPC of the production stacks: FrontendServiceClient::report
+// serializes TReportRequest through the instrumented gensrc frames and fails
+// inside un-instrumented libthrift (peer RST) -> TTransportException unwinds
+// through the gensrc frames -> stale poison. Also doubles as a sync point:
+// once this throws, the RST has definitely arrived on this connection.
+__attribute__((noinline)) bool real_rpc_attempt(ThriftClient<FrontendServiceClient>* client) {
+    try {
+        TMasterResult res;
+        TReportRequest req;
+        client->iface()->report(res, req);
+    } catch (const std::exception&) {
+        return true; // thrown from libthrift, as in production
+    }
+    return false;
+}
+
+// Make sure TBufferedTransport still holds unflushed bytes, so that the
+// following close() takes the close -> flush -> write_partial path of the
+// Jira stacks. The write is buffer-only unless the buffer overflows, in
+// which case it throws just like production; both outcomes are fine.
+void stuff_pending_bytes(ThriftClient<FrontendServiceClient>* client) {
+    try {
+        uint8_t junk[64];
+        memset(junk, 'x', sizeof(junk));
+        client->iface()->getOutputProtocol()->getTransport()->write(
+                junk, static_cast<uint32_t>(sizeof(junk)));
+    } catch (const std::exception&) {
+        // buffer overflow flush on a dead socket: same poison, keep going
+    }
+}
+
+// The crash site of QA-202 / DORIS-15154: ThriftClientImpl::close() ->
+// TBufferedTransport::close() -> flush() -> TSocket::write_partial() ->
+// getSocketInfo(). The alloca pad shifts the whole descent by `pad` bytes so
+// that across the sweep thrift's locals are guaranteed to overlap the stale
+// poison stripes at some offset.
+__attribute__((noinline)) void padded_close(ThriftClientImpl* client, int pad) {
+    char* p = static_cast<char*>(alloca(static_cast<size_t>(pad) + 16));
+    p[0] = 1;
+    asm volatile("" : : "r"(p) : "memory");
+    client->close();
+}
+
+// Returns only if the bug did not trigger (e.g. a fixed build).
+void real_path_sweep(int port) {
+    for (int pad = 0; pad <= 2048; pad += 8) {
+        if (pad % 256 == 0) {
+            repro_log("[ASAN-REPRO] part2: sweep pad=%d/2048 (still alive)\n", pad);
+        }
+        ThriftClient<FrontendServiceClient> client("127.0.0.1", port);
+        client.set_conn_timeout(2000);
+        client.set_send_timeout(2000);
+        client.set_recv_timeout(2000);
+        Status st = client.open();
+        if (!st.ok()) {
+            repro_log("[ASAN-REPRO] part2: open failed at pad=%d: %s\n", pad,
+                      st.to_string().c_str());
+            continue;
+        }
+        real_rpc_attempt(&client);  // poison: real TTransportException from libthrift
+        stuff_pending_bytes(&client);
+        padded_close(&client, pad); // Jira crash site: close -> flush -> getSocketInfo
+        // ~ThriftClient runs close() again: one more shot at a slightly
+        // different depth, matching ClientCacheHelper::reopen_client's
+        // close() + delete sequence.
+    }
+}
+
+#endif // __linux__
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+void repro_thread_body() {
+    char sym[512];
+    asan_repro::describe_repro_symbols(sym, sizeof(sym));
+    repro_log("%s", sym);
+
+    {
+        // Probe calibration: __asan_region_is_poisoned() must see the
+        // redzone right after this 16-byte local, otherwise the probe
+        // methodology itself is broken.
+        char cal[16];
+        asm volatile("" : : "r"(cal) : "memory");
+        const void* redzone = __asan_region_is_poisoned(cal, 64);
+        repro_log("[ASAN-REPRO] probe calibration (expect non-null): %p\n", redzone);
+    }
+
+    ProbeResult control;
+    run_scenario(false, &control);
+    repro_log("[ASAN-REPRO] part1 control (throw from INSTRUMENTED code):   %d/%d probe frames "
+              "on stale poison, first level=%d addr=%p\n",
+              control.poisoned_levels, kProbeDepth, control.first_poisoned_level,
+              control.first_poisoned_addr);
+
+    ProbeResult test;
+    run_scenario(true, &test);
+    repro_log("[ASAN-REPRO] part1 test    (throw from UN-INSTRUMENTED code): %d/%d probe frames "
+              "on stale poison, first level=%d addr=%p\n",
+              test.poisoned_levels, kProbeDepth, test.first_poisoned_level,
+              test.first_poisoned_addr);
+    if (test.poisoned_levels > 0) {
+        repro_log("[ASAN-REPRO] part1 verdict: stale stack shadow poison CONFIRMED after an "
+                  "un-instrumented throw. Expecting part2 to crash at the Jira stack site.\n");
+    } else {
+        repro_log("[ASAN-REPRO] part1 verdict: no stale poison detected. Running part2 as "
+                  "confirmation; it should survive.\n");
+    }
+
+#if defined(__linux__)
+    DeadPeerServer server;
+    if (server.start()) {
+        repro_log("[ASAN-REPRO] part2: dead-peer FE listening on 127.0.0.1:%d, driving the real "
+                  "path: report() fails -> ThriftClientImpl::close() -> TBufferedTransport::"
+                  "close/flush -> TSocket::write_partial -> getSocketInfo()\n"
+                  "[ASAN-REPRO] part2: a crash below with frames like the Jira stacks IS the "
+                  "expected POSITIVE result, e.g.\n"
+                  "[ASAN-REPRO]   AddressSanitizer: CHECK failed: asan_thread.cpp:... "
+                  "\"((ptr[0] == kCurrentStackFrameMagic)) != (0)\" (0x0, 0x0)\n",
+                  server.port());
+        real_path_sweep(server.port());
+        server.stop();
+        repro_log("[ASAN-REPRO] part2: sweep finished WITHOUT crashing.\n");
+    } else {
+        repro_log("[ASAN-REPRO] part2: failed to start in-process dead peer, skipped\n");
+    }
+#else
+    repro_log("[ASAN-REPRO] part2: real-path repro is linux-only, skipped\n");
+#endif
+
+    if (test.poisoned_levels == 0) {
+        repro_log("[ASAN-REPRO] RESULT: NEGATIVE - no stale stack shadow poison after an "
+                  "un-instrumented throw and the real path survived. The bug is NOT present in "
+                  "this build (fixed, or the link layout changed). BE continues to start.\n");
+        return;
+    }
+
+    repro_log("[ASAN-REPRO] part3: real path survived although poison exists (alignment luck); "
+              "triggering the synthetic crash site via an intercepted memset() instead.\n"
+              "[ASAN-REPRO] expected: AddressSanitizer: CHECK failed: asan_thread.cpp:... "
+              "\"((ptr[0] == kCurrentStackFrameMagic)) != (0)\" (0x0, 0x0)\n");
+    asan_repro::descend_and_boom(0, kProbeDepth);
+    repro_log("[ASAN-REPRO] UNEXPECTED: part3 returned without crashing although stale poison "
+              "was found. Please report this output.\n");
+}
+
+} // namespace
+
+void run_asan_stale_poison_repro() {
+    if (getenv("DORIS_DISABLE_ASAN_REPRO") != nullptr) {
+        repro_log("[ASAN-REPRO] disabled by DORIS_DISABLE_ASAN_REPRO\n");
+        return;
+    }
+    repro_log("[ASAN-REPRO] ==============================================================\n"
+              "[ASAN-REPRO] Deliberate reproducer for the ASAN stale-stack-poison BE crash\n"
+              "[ASAN-REPRO] (thrift reopen / glog LOG(WARNING) cores: QA-202, DORIS-1073,\n"
+              "[ASAN-REPRO] DORIS-15154, google/glog#978, google/sanitizers#1010).\n"
+              "[ASAN-REPRO] Root cause analysis: asan-glog-rca.md in the repository root.\n"
+              "[ASAN-REPRO] A crash right below IS the expected POSITIVE result.\n"
+              "[ASAN-REPRO] ==============================================================\n");
+    // A dedicated thread gives a pristine stack, which makes the layout (and
+    // therefore the reproduction) deterministic.
+    std::thread t(repro_thread_body);
+    t.join();
+    repro_log("[ASAN-REPRO] done (process still alive => bug not reproduced)\n");
+}
+
+} // namespace doris
+
+#else // !ADDRESS_SANITIZER
+
+namespace doris {
+void run_asan_stale_poison_repro() {}
+} // namespace doris
+
+#endif // ADDRESS_SANITIZER

--- a/be/src/common/asan_repro.h
+++ b/be/src/common/asan_repro.h
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstddef>
+
+// Minimal, self-contained reproducer for the historical ASAN-only BE crash
+// around thrift RPC retry (reopen) / glog LOG(WARNING) paths:
+//
+//   AddressSanitizer: CHECK failed: asan_thread.cpp:36x
+//       "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
+//
+// (internal Jira QA-202 / DORIS-1073 / DORIS-15154, google/glog#978,
+// google/sanitizers#1010). Root cause analysis: asan-glog-rca.md at the
+// repository root.
+//
+// The whole reproducer is a no-op unless the BE is compiled with
+// BUILD_TYPE=ASAN (-DADDRESS_SANITIZER).
+
+namespace doris {
+
+// Called once at BE startup (doris_main.cpp), runs on a dedicated thread.
+// If the bug is present it crashes the process with the historical ASAN
+// CHECK signature, preferably at the exact Jira stack site (a real
+// FrontendServiceClient RPC against an in-process dead peer, then
+// ThriftClientImpl::close() -> TBufferedTransport::close/flush ->
+// TSocket::write_partial -> getSocketInfo()). Otherwise it prints
+// "[ASAN-REPRO] RESULT: NEGATIVE" and returns so the BE starts normally.
+// Set DORIS_DISABLE_ASAN_REPRO=1 to skip it.
+void run_asan_stale_poison_repro();
+
+namespace asan_repro {
+
+struct ProbeResult {
+    int poisoned_levels = 0;
+    int first_poisoned_level = -1;
+    const void* first_poisoned_addr = nullptr;
+};
+
+#ifdef ADDRESS_SANITIZER
+// The functions below are implemented in asan_repro_uninstrumented.cpp,
+// which is compiled WITHOUT sanitizer instrumentation (see
+// common/CMakeLists.txt) to emulate an un-instrumented third-party static
+// library such as libthrift.
+
+// Throws int(42) from un-instrumented code. Deliberately NOT declared
+// [[noreturn]]: otherwise the instrumented caller would emit
+// __asan_handle_no_return() before the call and mask the bug.
+void uninstrumented_throw();
+
+// Descends max_depth un-instrumented frames over the region that was just
+// unwound, records which local buffers sit on stale shadow poison, and
+// overwrites the region with plain (unchecked) stores so the dead frames'
+// on-stack descriptors lose their kCurrentStackFrameMagic.
+void probe_and_scrub(int level, int max_depth, ProbeResult* out);
+
+// Descends again and calls memset() (intercepted by ASAN) on the first local
+// buffer that overlaps stale poison -> reproduces the historical crash.
+void descend_and_boom(int level, int max_depth);
+
+// Prints whether __cxa_throw / _Unwind_RaiseException resolve to the ASAN
+// interceptors or to the real (statically linked) implementations.
+void describe_repro_symbols(char* out, size_t out_size);
+#endif
+
+} // namespace asan_repro
+} // namespace doris

--- a/be/src/common/asan_repro_uninstrumented.cpp
+++ b/be/src/common/asan_repro_uninstrumented.cpp
@@ -49,11 +49,12 @@ extern "C" void __cxa_throw(void*, void*, void (*)(void*));
 extern "C" int _Unwind_RaiseException(void*);
 extern "C" __attribute__((weak)) void __interceptor___cxa_throw(void*, void*, void (*)(void*));
 extern "C" __attribute__((weak)) int __interceptor__Unwind_RaiseException(void*);
-// Defined in asan_cxa_throw_wrap.cpp and linked with -Wl,--wrap=__cxa_throw
-// when the fix is active: then &__cxa_throw above resolves to this wrapper,
-// which re-inserts the __asan_handle_no_return() shadow cleanup. Weak, so the
-// diagnosis still links in builds without the fix.
+// Defined in asan_cxa_throw_wrap.cpp and linked with -Wl,--wrap=<symbol>
+// when the fix is active: then the references above resolve to these
+// wrappers, which re-insert the __asan_handle_no_return() shadow cleanup.
+// Weak, so the diagnosis still links in builds without the fix.
 extern "C" __attribute__((weak)) void __wrap___cxa_throw(void*, void*, void (*)(void*));
+extern "C" __attribute__((weak)) int __wrap__Unwind_RaiseException(void*);
 #endif
 
 namespace doris::asan_repro {
@@ -134,14 +135,13 @@ void describe_repro_symbols(char* out, size_t out_size) {
     } else {
         throw_state = "NOT intercepted (bypassed by static link)";
     }
+    void* wrap_raise = reinterpret_cast<void*>(&__wrap__Unwind_RaiseException);
     const char* raise_state;
     if (icept_raise != nullptr && real_raise == icept_raise) {
         raise_state = "INTERCEPTED";
-    } else if (wrap_active) {
+    } else if (wrap_raise != nullptr && real_raise == wrap_raise) {
         raise_state =
-                "NOT intercepted (plain `throw` is covered by the wrapped "
-                "__cxa_throw; std::rethrow_exception from un-instrumented code "
-                "remains a residual gap, see RCA §5.2)";
+                "WRAPPED by __wrap__Unwind_RaiseException (fix active, shadow cleanup restored)";
     } else {
         raise_state = "NOT intercepted (bypassed by static link)";
     }

--- a/be/src/common/asan_repro_uninstrumented.cpp
+++ b/be/src/common/asan_repro_uninstrumented.cpp
@@ -49,6 +49,11 @@ extern "C" void __cxa_throw(void*, void*, void (*)(void*));
 extern "C" int _Unwind_RaiseException(void*);
 extern "C" __attribute__((weak)) void __interceptor___cxa_throw(void*, void*, void (*)(void*));
 extern "C" __attribute__((weak)) int __interceptor__Unwind_RaiseException(void*);
+// Defined in asan_cxa_throw_wrap.cpp and linked with -Wl,--wrap=__cxa_throw
+// when the fix is active: then &__cxa_throw above resolves to this wrapper,
+// which re-inserts the __asan_handle_no_return() shadow cleanup. Weak, so the
+// diagnosis still links in builds without the fix.
+extern "C" __attribute__((weak)) void __wrap___cxa_throw(void*, void*, void (*)(void*));
 #endif
 
 namespace doris::asan_repro {
@@ -115,20 +120,36 @@ void describe_repro_symbols(char* out, size_t out_size) {
 #if defined(__linux__)
     void* real_throw = reinterpret_cast<void*>(&__cxa_throw);
     void* icept_throw = reinterpret_cast<void*>(&__interceptor___cxa_throw);
+    void* wrap_throw = reinterpret_cast<void*>(&__wrap___cxa_throw);
     void* real_raise = reinterpret_cast<void*>(&_Unwind_RaiseException);
     void* icept_raise = reinterpret_cast<void*>(&__interceptor__Unwind_RaiseException);
+    const bool wrap_active = wrap_throw != nullptr && real_throw == wrap_throw;
+    const char* throw_state;
+    if (icept_throw != nullptr && real_throw == icept_throw) {
+        throw_state = "INTERCEPTED";
+    } else if (wrap_active) {
+        // --wrap fix active: every __cxa_throw reference (this one included)
+        // resolves to __wrap___cxa_throw, which restores the shadow cleanup.
+        throw_state = "WRAPPED by __wrap___cxa_throw (fix active, shadow cleanup restored)";
+    } else {
+        throw_state = "NOT intercepted (bypassed by static link)";
+    }
+    const char* raise_state;
+    if (icept_raise != nullptr && real_raise == icept_raise) {
+        raise_state = "INTERCEPTED";
+    } else if (wrap_active) {
+        raise_state =
+                "NOT intercepted (plain `throw` is covered by the wrapped "
+                "__cxa_throw; std::rethrow_exception from un-instrumented code "
+                "remains a residual gap, see RCA §5.2)";
+    } else {
+        raise_state = "NOT intercepted (bypassed by static link)";
+    }
     snprintf(out, out_size,
              "[ASAN-REPRO] __cxa_throw=%p, __interceptor___cxa_throw=%p => %s\n"
              "[ASAN-REPRO] _Unwind_RaiseException=%p, __interceptor__Unwind_RaiseException=%p "
              "=> %s\n",
-             real_throw, icept_throw,
-             (icept_throw != nullptr && real_throw == icept_throw)
-                     ? "INTERCEPTED"
-                     : "NOT intercepted (bypassed by static link)",
-             real_raise, icept_raise,
-             (icept_raise != nullptr && real_raise == icept_raise)
-                     ? "INTERCEPTED"
-                     : "NOT intercepted (bypassed by static link)");
+             real_throw, icept_throw, throw_state, real_raise, icept_raise, raise_state);
 #else
     snprintf(out, out_size, "[ASAN-REPRO] symbol diagnosis is only implemented on linux\n");
 #endif

--- a/be/src/common/asan_repro_uninstrumented.cpp
+++ b/be/src/common/asan_repro_uninstrumented.cpp
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This translation unit is compiled WITHOUT sanitizer instrumentation
+// (-fno-sanitize=all -fno-builtin, no PCH; see common/CMakeLists.txt).
+// It plays the role of an un-instrumented third-party static library such as
+// libthrift in the production crashes:
+//   * it throws a C++ exception from un-instrumented code (like TSocket
+//     throwing TTransportException when the FE restarts), and
+//   * it re-enters the just-unwound stack region without rewriting ASAN
+//     shadow memory (like thrift's reopen -> close -> flush ->
+//     TSocket::getSocketInfo() path), where its innocent stack locals land
+//     on stale poison left behind by the unwind.
+// See asan-glog-rca.md at the repository root for the full analysis.
+
+#include "common/asan_repro.h"
+
+#ifdef ADDRESS_SANITIZER
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+// Provided by the statically linked ASAN runtime. Query-only, never reports.
+extern "C" void* __asan_region_is_poisoned(void* beg, size_t size);
+
+#if defined(__linux__)
+// Real symbols vs. their ASAN interceptors. If the resolved addresses differ,
+// calls to the real symbol are NOT intercepted, so __asan_handle_no_return()
+// never runs for exceptions thrown by un-instrumented code and the unwound
+// stack region keeps its shadow poison. The interceptor symbols are declared
+// weak: they exist in ASAN builds, but this keeps the file link-safe
+// everywhere else.
+extern "C" void __cxa_throw(void*, void*, void (*)(void*));
+extern "C" int _Unwind_RaiseException(void*);
+extern "C" __attribute__((weak)) void __interceptor___cxa_throw(void*, void*, void (*)(void*));
+extern "C" __attribute__((weak)) int __interceptor__Unwind_RaiseException(void*);
+#endif
+
+namespace doris::asan_repro {
+
+namespace {
+// Forces the compiler to keep the buffers and stores.
+volatile uint8_t g_sink = 0;
+} // namespace
+
+__attribute__((noinline)) void uninstrumented_throw() {
+    // No compiler-emitted __asan_handle_no_return() here (this TU is not
+    // instrumented), and per the RCA the __cxa_throw/_Unwind_RaiseException
+    // interceptors are bypassed by the fully static link. So unwinding this
+    // exception leaves the instrumented frames below the catch point with
+    // their stack shadow poison still in place.
+    throw 42;
+}
+
+__attribute__((noinline)) void probe_and_scrub(int level, int max_depth, ProbeResult* out) {
+    char buf[256];
+    void* poisoned = __asan_region_is_poisoned(buf, sizeof(buf));
+    if (poisoned != nullptr) {
+        ++out->poisoned_levels;
+        if (out->first_poisoned_level < 0) {
+            out->first_poisoned_level = level;
+            out->first_poisoned_addr = poisoned;
+        }
+    }
+    // Plain stores: un-instrumented and not intercepted, so they change the
+    // memory but NOT the shadow. This overwrites the dead instrumented
+    // frames' on-stack descriptors (kCurrentStackFrameMagic) with zeroes,
+    // which is what turns the later false positive into the historical
+    // "CHECK failed ... (0x0, 0x0)" abort instead of a regular ASAN report.
+    for (size_t i = 0; i < sizeof(buf); ++i) {
+        buf[i] = 0;
+    }
+    g_sink = static_cast<uint8_t>(g_sink + buf[0]);
+    if (level + 1 < max_depth) {
+        probe_and_scrub(level + 1, max_depth, out);
+    }
+    asm volatile("" : : "r"(buf) : "memory");
+}
+
+__attribute__((noinline)) void descend_and_boom(int level, int max_depth) {
+    char buf[256];
+    if (__asan_region_is_poisoned(buf, sizeof(buf)) != nullptr) {
+        // memset IS intercepted by the ASAN runtime and validates the shadow
+        // of the destination range: writing to this perfectly valid local
+        // buffer raises a false-positive report, and while describing the
+        // address ASAN walks the (scrubbed) frame descriptor and dies with
+        // the kCurrentStackFrameMagic CHECK. This mirrors thrift's
+        // getSocketInfo()/TOutput::perror() locals being written through
+        // intercepted memcpy/memset/localtime_r in the production stacks.
+        memset(buf, 0, sizeof(buf));
+        g_sink = static_cast<uint8_t>(g_sink + buf[0]); // not reached if the bug is present
+    }
+    if (level + 1 < max_depth) {
+        descend_and_boom(level + 1, max_depth);
+    }
+    asm volatile("" : : "r"(buf) : "memory");
+}
+
+void describe_repro_symbols(char* out, size_t out_size) {
+#if defined(__linux__)
+    void* real_throw = reinterpret_cast<void*>(&__cxa_throw);
+    void* icept_throw = reinterpret_cast<void*>(&__interceptor___cxa_throw);
+    void* real_raise = reinterpret_cast<void*>(&_Unwind_RaiseException);
+    void* icept_raise = reinterpret_cast<void*>(&__interceptor__Unwind_RaiseException);
+    snprintf(out, out_size,
+             "[ASAN-REPRO] __cxa_throw=%p, __interceptor___cxa_throw=%p => %s\n"
+             "[ASAN-REPRO] _Unwind_RaiseException=%p, __interceptor__Unwind_RaiseException=%p "
+             "=> %s\n",
+             real_throw, icept_throw,
+             (icept_throw != nullptr && real_throw == icept_throw)
+                     ? "INTERCEPTED"
+                     : "NOT intercepted (bypassed by static link)",
+             real_raise, icept_raise,
+             (icept_raise != nullptr && real_raise == icept_raise)
+                     ? "INTERCEPTED"
+                     : "NOT intercepted (bypassed by static link)");
+#else
+    snprintf(out, out_size, "[ASAN-REPRO] symbol diagnosis is only implemented on linux\n");
+#endif
+}
+
+} // namespace doris::asan_repro
+
+#endif // ADDRESS_SANITIZER

--- a/be/src/exec/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/exec/pipeline/pipeline_fragment_context.cpp
@@ -2535,12 +2535,10 @@ void PipelineFragmentContext::_coordinator_callback(const ReportStatusRequest& r
     try {
         try {
             (*coord)->reportExecStatus(res, params);
-        } catch ([[maybe_unused]] apache::thrift::transport::TTransportException& e) {
-#ifndef ADDRESS_SANITIZER
+        } catch (apache::thrift::transport::TTransportException& e) {
             LOG(WARNING) << "Retrying ReportExecStatus. query id: " << print_id(req.query_id)
                          << ", instance id: " << print_id(req.fragment_instance_id) << " to "
                          << req.coord_addr << ", err: " << e.what();
-#endif
             rpc_status = coord->reopen();
 
             if (!rpc_status.ok()) {

--- a/be/src/runtime/runtime_query_statistics_mgr.cpp
+++ b/be/src/runtime/runtime_query_statistics_mgr.cpp
@@ -69,7 +69,6 @@ static Status _do_report_exec_stats_rpc(const TNetworkAddress& coor_addr,
         try {
             rpc_client->reportExecStatus(res, req);
         } catch (const apache::thrift::transport::TTransportException& e) {
-#ifndef ADDRESS_SANITIZER
             LOG_WARNING("Transport exception from {}, reason: {}, reopening",
                         PrintThriftNetworkAddress(coor_addr), e.what());
             client_status = rpc_client.reopen(config::thrift_rpc_timeout_ms);
@@ -79,9 +78,6 @@ static Status _do_report_exec_stats_rpc(const TNetworkAddress& coor_addr,
             }
 
             rpc_client->reportExecStatus(res, req);
-#else
-            return Status::RpcError("Transport exception when report query profile, {}", e.what());
-#endif
         }
     } catch (apache::thrift::TApplicationException& e) {
         if (e.getType() == e.UNKNOWN_METHOD) {
@@ -433,13 +429,9 @@ void RuntimeQueryStatisticsMgr::report_runtime_query_statistics() {
                 rpc_result[addr] = true;
             } catch (apache::thrift::transport::TTransportException& e) {
                 rpc_status = reopen_coord();
-#ifndef ADDRESS_SANITIZER
                 LOG_WARNING(
                         "[report_query_statistics] report to fe {} failed, reason:{}, try reopen.",
                         add_str, e.what());
-#else
-                std::cerr << "thrift error, reason=" << e.what();
-#endif
                 if (rpc_status.ok()) {
                     coord->reportExecStatus(res, params);
                     rpc_result[addr] = true;

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -63,6 +63,7 @@
 #include <thrift/TOutput.h>
 
 #include "agent/heartbeat_server.h"
+#include "common/asan_repro.h"
 #include "common/config.h"
 #include "common/daemon.h"
 #include "common/logging.h"
@@ -347,6 +348,14 @@ int main(int argc, char** argv) {
             exit(0);
         }
     }
+
+    // Deliberate reproducer for the historical ASAN stale-stack-poison crash
+    // (thrift reopen / glog LOG(WARNING) cores). No-op in non-ASAN builds; on
+    // ASAN builds it either crashes here with the historical signature
+    // (positive reproduction) or prints "[ASAN-REPRO] RESULT: NEGATIVE" and
+    // lets the BE start. See asan-glog-rca.md at the repository root.
+    // Set DORIS_DISABLE_ASAN_REPRO=1 to skip.
+    doris::run_asan_stale_poison_repro();
 
     if (getenv("DORIS_HOME") == nullptr) {
         fprintf(stderr, "you need set DORIS_HOME environment variable.\n");

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -77,21 +77,16 @@ Status ThriftRpcHelper::rpc(std::function<TNetworkAddress()> address_provider,
     DBUG_EXECUTE_IF("thriftRpcHelper.rpc.error", { timeout_ms = 30000; });
     ClientConnection<T> client(_s_exec_env->get_client_cache<T>(), address, timeout_ms, &status);
     if (!status.ok()) {
-#ifndef ADDRESS_SANITIZER
         LOG(WARNING) << "Connect frontend failed, address=" << address << ", status=" << status;
-#endif
         return status;
     }
     try {
         try {
             callback(client);
         } catch (apache::thrift::transport::TTransportException& e) {
-            std::cerr << "thrift error, reason=" << e.what();
-#ifndef ADDRESS_SANITIZER
             LOG(WARNING) << "retrying call frontend service after "
                          << config::thrift_client_retry_interval_ms << " ms, address=" << address
                          << ", reason=" << e.what();
-#endif
             std::this_thread::sleep_for(
                     std::chrono::milliseconds(config::thrift_client_retry_interval_ms));
             TNetworkAddress retry_address = address_provider();
@@ -99,37 +94,29 @@ Status ThriftRpcHelper::rpc(std::function<TNetworkAddress()> address_provider,
                 return Status::Error<ErrorCode::SERVICE_UNAVAILABLE>("FE address is not available");
             }
             if (retry_address.hostname != address.hostname || retry_address.port != address.port) {
-#ifndef ADDRESS_SANITIZER
                 LOG(INFO) << "retrying call frontend service with new address=" << retry_address;
-#endif
                 Status retry_status;
                 ClientConnection<T> retry_client(_s_exec_env->get_client_cache<T>(), retry_address,
                                                  timeout_ms, &retry_status);
                 if (!retry_status.ok()) {
-#ifndef ADDRESS_SANITIZER
                     LOG(WARNING) << "Connect frontend failed, address=" << retry_address
                                  << ", status=" << retry_status;
-#endif
                     return retry_status;
                 }
                 callback(retry_client);
             } else {
                 status = client.reopen(timeout_ms);
                 if (!status.ok()) {
-#ifndef ADDRESS_SANITIZER
                     LOG(WARNING) << "client reopen failed. address=" << address
                                  << ", status=" << status;
-#endif
                     return status;
                 }
                 callback(client);
             }
         }
     } catch (apache::thrift::TException& e) {
-#ifndef ADDRESS_SANITIZER
         LOG(WARNING) << "call frontend service failed, address=" << address
                      << ", reason=" << e.what();
-#endif
         std::this_thread::sleep_for(
                 std::chrono::milliseconds(config::thrift_client_retry_interval_ms * 2));
         // just reopen to disable this connection


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE.** This is the reproduction + fix-validation branch. It carries a
> deliberate startup-time reproducer that must not land on master. The verified fix
> will be split out into separate mergeable PRs (see **Next steps** at the bottom).

## Status: root-caused, fixed, and A/B-verified on this pipeline

| CI run | Head | `[ASAN-REPRO]` signals in `be.out` | Outcome |
|---|---|---|---|
| baseline | aa76347 (reproducer only) | `__cxa_throw ... => NOT intercepted (bypassed by static link)` · `part1 test 58/160` probe frames on stale poison · part2 crashed at `pad=0` with `AddressSanitizer: CHECK failed: asan_thread.cpp:369 "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)`, thrift `TSocket`/`TConfiguration` stack locals sitting on the stale poison | **Crash reproduced deterministically, twice in a row** |
| fix | 4a50f84 (+ `--wrap` fix) | `__cxa_throw ... => WRAPPED by __wrap___cxa_throw (fix active, shadow cleanup restored)` · `part1 test 0/160` (probe calibration still non-null, so this is a true negative, not a broken probe) · part2 swept all 257 stack offsets alive · `RESULT: NEGATIVE` | **Fix verified — BE started normally and proceeded into the regression run** |

## The problem

For years the BE has crashed **only in ASAN builds**, on the thrift RPC
retry/`reopen` path (and, before the `#ifndef ADDRESS_SANITIZER` log guards were
added, inside `glog` `LOG(WARNING)`), always with the same signature:

```
AddressSanitizer: CHECK failed: asan_thread.cpp:36x
    "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
```

References: internal QA-202 / DORIS-1073 / DORIS-15154, google/glog#978,
google/sanitizers#1010. It was never root-caused, only worked around by the
scattered `#ifndef ADDRESS_SANITIZER` log guards — and #49516 showed those
ASAN-only forks hatch real bugs of their own.

## Root cause (summary)

`libthrift` and the other third-party static libs are built **without** ASAN
instrumentation. Under the BE's fully static link (`-static-libstdc++` /
`-static-libgcc` / static sanitizer runtime) the linker resolves
`__cxa_throw` / `__cxa_rethrow` / `_Unwind_RaiseException` to libstdc++.a's /
libgcc_eh.a's **strong** definitions, silently discarding the ASAN runtime's
**weak** interceptor definitions. So `__asan_handle_no_return()` never runs when
un-instrumented code throws (e.g. `TSocket` throwing `TTransportException` when
the FE restarts). The unwound instrumented frames keep their **stack shadow
poison**; the retry path immediately re-descends and thrift/glog put innocent
stack locals on that stale poison. The next intercepted libc call
(`memcpy`/`memset`/`localtime_r`/…) raises a **false positive**, and ASAN aborts
while walking the already-overwritten frame descriptor — hence
`CHECK failed ... (0x0, 0x0)` instead of a normal report. RELEASE/DEBUG builds
have no shadow memory and the accessed memory is entirely valid, which is why
this never happens outside ASAN.

## The fix (now on this branch)

`be/src/common/asan_cxa_throw_wrap.cpp` + link flags in the ASAN/ASAN_UT branch
of `be/CMakeLists.txt` (Linux only; production builds are byte-identical):

```
-Wl,--wrap=__cxa_throw -Wl,--wrap=__cxa_rethrow -Wl,--wrap=_Unwind_RaiseException
```

`--wrap` rewrites every reference from every input object — including the
un-instrumented third-party archives and libstdc++.a itself — to wrappers that
call `__asan_handle_no_return()` and then forward to the real implementation:
exactly what the official (bypassed) interceptors do. The flags are attached to
`DORIS_LINK_LIBS`, so any executable that receives them also links `Common`,
which carries the wrapper definitions — flags and definitions cannot drift
apart.

`_Unwind_RaiseException` is wrapped as well (added after the base fix was
verified): `std::rethrow_exception` (libstdc++ `eh_ptr.cc`, reached via
`std::promise::set_exception` / `std::future::get`) and foreign-language
unwinders raise through it without touching `__cxa_throw`. Unlike the `__cxa_*`
wrappers it forwards the return value, since `_Unwind_RaiseException` returns
when no handler is found.

## The cleanup (also on this branch)

With the throw path fixed, the ASAN-only forks are removed — **15**
`#ifndef ADDRESS_SANITIZER` sites in `thrift_rpc_helper.cpp` (6),
`agent/utils.cpp` (6), `runtime_query_statistics_mgr.cpp` (2),
`pipeline_fragment_context.cpp` (1) — including one that skipped the whole
reopen+retry under ASAN (the #49516 failure pattern) and the leftover
`std::cerr` LOG substitutes from #37134. ASAN CI now runs the exact production
retry/reopen/logging code, so the original crash sites are re-validated by every
FE-restart-ish regression, not just by the startup reproducer.

## What the reproducer does

Runs once at BE startup, **ASAN builds only** (no-op otherwise; skip with
`DORIS_DISABLE_ASAN_REPRO=1`):

1. **part 1** — measures the stale poison deterministically with
   `__asan_region_is_poisoned()`, plus a control run that throws from
   *instrumented* code to show the asymmetry (the compiler emits
   `__asan_handle_no_return()` only for instrumented throws).
2. **part 2** — drives the **real Jira stack site**: a real
   `ThriftClient<FrontendServiceClient>` `report()` against an in-process dead
   peer that RSTs the connection, then `ThriftClientImpl::close()` →
   `TBufferedTransport::close/flush` → `TSocket::write_partial` →
   `getSocketInfo()`, swept over 257 stack offsets so the poison/local overlap
   is hit deterministically.
3. **part 3** — synthetic fallback crash site if part 2 gets lucky.

`be/src/common/asan_repro_uninstrumented.cpp` is compiled with
`-fno-sanitize=all -fno-builtin` to emulate an un-instrumented third-party lib.

## How to read the CI output (grep `[ASAN-REPRO]` in `be.out`)

Expected on the current (fixed + hardened) head:

- **both** symbol lines: `WRAPPED by __wrap___cxa_throw / __wrap__Unwind_RaiseException (fix active, shadow cleanup restored)`
- `part1 control 0/160` and `part1 test 0/160`
- `part2: sweep finished WITHOUT crashing.`
- `RESULT: NEGATIVE ... BE continues to start.`

Any `NOT intercepted` line, `part1 test N/160` with `N > 0`, or a startup crash
means the fix regressed.

## Next steps

1. One more full pipeline on the current head (`_Unwind_RaiseException` wrap +
   guards removed) — expected all-green with the signals above, now exercising
   the original production log/retry paths under ASAN.
2. Split into mergeable PRs and close this one:
   - `[fix](asan)` — the wrappers + CMake flags (commits 4a50f84 + 8160e0c)
   - `[chore](asan)` — remove the ASAN-only guards/forks (commit 382819f)
   - the reproducer commits (d42e52c + aa76347) stay here as evidence and do
     not land on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
