### PR TITLE
[fix](regression) fix full compaction run status case

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_full_compaciton_run_status.groovy
+++ b/regression-test/suites/fault_injection_p0/test_full_compaciton_run_status.groovy
@@ -66,12 +66,13 @@ suite("test_full_compaction_run_status","nonConcurrent") {
             backend_id = tablet.BackendId
 
             def times = 1
+            def runCode, runOut, runErr
             do{
-                def (code, out, err) = be_run_full_compaction(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
+                (runCode, runOut, runErr) = be_run_full_compaction(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
+                logger.info("Run compaction: code=" + runCode + ", out=" + runOut + ", err=" + runErr)
                 ++times
                 sleep(1000)
-            } while (parseJson(out.trim()).status.toLowerCase()!="success" && times<=10)
+            } while (parseJson(runOut.trim()).status.toLowerCase()!="success" && times<=10)
 
             def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
             logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)


### PR DESCRIPTION
## Summary

- Fix the Groovy scope bug in `test_full_compaciton_run_status`.
- Keep the full-compaction trigger response in loop-scoped `runCode`, `runOut`, and `runErr` variables so the `do ... while` condition can parse the latest response instead of resolving `out` as a missing `Suite` property.

## Testing

- [x] `git diff --check -- regression-test/suites/fault_injection_p0/test_full_compaciton_run_status.groovy`
- [x] `groovy -e "new GroovyShell().parse(new File('/Users/keshu/dudu/fix-cases/worktrees/doris-full-compaction-run-status-branch41/regression-test/suites/fault_injection_p0/test_full_compaciton_run_status.groovy'))"`
- [ ] Full regression case run, not run locally because it requires a live Doris regression environment with BE debug-point support.
