### PR TITLE
[opt](column) avoid redundant column clones

### DIFF
--- a/be/src/exec/operator/multi_cast_data_stream_source.cpp
+++ b/be/src/exec/operator/multi_cast_data_stream_source.cpp
@@ -110,7 +110,7 @@ Status MultiCastDataStreamerSourceOperatorX::get_block_impl(RuntimeState* state,
     if (!local_state._output_expr_contexts.empty() && output_block->rows() > 0) {
         SCOPED_TIMER(local_state._materialize_data_timer);
         RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(
-                local_state._output_expr_contexts, *output_block, block, true));
+                local_state._output_expr_contexts, *output_block, block));
         materialize_block_inplace(*block);
     }
     return Status::OK();

--- a/be/src/exec/operator/operator.cpp
+++ b/be/src/exec/operator/operator.cpp
@@ -353,8 +353,6 @@ Status OperatorXBase::do_projections(RuntimeState* state, Block* origin_block,
 
     scoped_mutable_block.restore();
 
-    auto empty_columns = origin_block->clone_empty_columns();
-    origin_block->set_columns(std::move(empty_columns));
     DCHECK_EQ(output_block->rows(), rows);
 
     return Status::OK();

--- a/be/src/exec/operator/operator.cpp
+++ b/be/src/exec/operator/operator.cpp
@@ -325,77 +325,37 @@ Status OperatorXBase::do_projections(RuntimeState* state, Block* origin_block,
     }
     Block input_block = *origin_block;
 
-    size_t bytes_usage = 0;
-    ColumnsWithTypeAndName new_columns;
+    std::vector<int> result_column_ids;
     for (const auto& projections : local_state->_intermediate_projections) {
-        if (projections.empty()) {
-            return Status::InternalError("meet empty intermediate projection, node id: {}",
-                                         node_id());
-        }
-        new_columns.resize(projections.size());
+        result_column_ids.resize(projections.size());
         for (int i = 0; i < projections.size(); i++) {
-            RETURN_IF_ERROR(projections[i]->execute(&input_block, new_columns[i]));
-            if (new_columns[i].column->size() != rows) {
-                return Status::InternalError(
-                        "intermediate projection result column size {} not equal input rows {}, "
-                        "expr: {}",
-                        new_columns[i].column->size(), rows,
-                        projections[i]->root()->debug_string());
-            }
+            RETURN_IF_ERROR(projections[i]->execute(&input_block, &result_column_ids[i]));
         }
-        Block tmp_block {new_columns};
-        bytes_usage += tmp_block.allocated_bytes();
-        input_block.swap(tmp_block);
+        input_block.shuffle_columns(result_column_ids);
     }
 
-    if (input_block.rows() != rows) {
-        return Status::InternalError(
-                "after intermediate projections input block rows {} not equal origin rows {}, "
-                "input_block: {}",
-                input_block.rows(), rows, input_block.dump_structure());
-    }
-    auto insert_column_datas = [&](auto& to, ColumnPtr& from, size_t rows) {
-        if (is_column_nullable(*to) && !is_column_nullable(*from)) {
-            if (_keep_origin || !from->is_exclusive()) {
-                auto& null_column = reinterpret_cast<ColumnNullable&>(*to);
-                null_column.get_nested_column().insert_range_from(*from, 0, rows);
-                null_column.get_null_map_column().get_data().resize_fill(rows, 0);
-                bytes_usage += null_column.allocated_bytes();
-            } else {
-                to = make_nullable(from, false)->assert_mutable();
-            }
-        } else {
-            if (_keep_origin || !from->is_exclusive()) {
-                to->insert_range_from(*from, 0, rows);
-                bytes_usage += from->allocated_bytes();
-            } else {
-                to = from->assert_mutable();
-            }
-        }
-    };
-
+    DCHECK_EQ(rows, input_block.rows());
     auto scoped_mutable_block = VectorizedUtils::build_scoped_mutable_mem_reuse_block(
             output_block, *_output_row_descriptor);
     auto& mutable_block = scoped_mutable_block.mutable_block();
     auto& mutable_columns = mutable_block.mutable_columns();
-    if (rows != 0) {
-        DCHECK_EQ(mutable_columns.size(), local_state->_projections.size()) << debug_string();
-        for (int i = 0; i < mutable_columns.size(); ++i) {
-            ColumnPtr column_ptr;
-            RETURN_IF_ERROR(local_state->_projections[i]->execute(&input_block, column_ptr));
-            if (column_ptr->size() != rows) {
-                return Status::InternalError(
-                        "projection result column size {} not equal input rows {}, expr: {}",
-                        column_ptr->size(), rows,
-                        local_state->_projections[i]->root()->debug_string());
-            }
-            column_ptr = column_ptr->convert_to_full_column_if_const();
-            bytes_usage += column_ptr->allocated_bytes();
-            insert_column_datas(mutable_columns[i], column_ptr, rows);
+    DCHECK_EQ(mutable_columns.size(), local_state->_projections.size()) << debug_string();
+
+    for (int i = 0; i < mutable_columns.size(); ++i) {
+        ColumnPtr column_ptr;
+        RETURN_IF_ERROR(local_state->_projections[i]->execute(&input_block, column_ptr));
+        column_ptr = column_ptr->convert_to_full_column_if_const();
+        if (mutable_columns[i]->is_nullable() != column_ptr->is_nullable()) {
+            throw Exception(ErrorCode::INTERNAL_ERROR, "Nullable mismatch");
         }
-        DCHECK(mutable_block.rows() == rows);
+        mutable_columns[i] = IColumn::mutate(std::move(column_ptr));
     }
-    local_state->_estimate_memory_usage += bytes_usage;
+
+    scoped_mutable_block.restore();
+
+    auto empty_columns = origin_block->clone_empty_columns();
+    origin_block->set_columns(std::move(empty_columns));
+    DCHECK_EQ(output_block->rows(), rows);
 
     return Status::OK();
 }

--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -1012,10 +1012,6 @@ protected:
     std::string _op_name;
     int _parallel_tasks = 0;
 
-    //_keep_origin is used to avoid copying during projection,
-    // currently set to false only in the nestloop join.
-    bool _keep_origin = true;
-
     // _blockable is true if the operator contains expressions that may block execution
     bool _blockable = false;
 };

--- a/be/src/exec/sink/writer/iceberg/viceberg_table_writer.cpp
+++ b/be/src/exec/sink/writer/iceberg/viceberg_table_writer.cpp
@@ -206,7 +206,7 @@ Status VIcebergTableWriter::write(RuntimeState* state, Block& block) {
     }
     Block output_block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_vec_output_expr_ctxs, block,
-                                                                       &output_block, false));
+                                                                       &output_block));
     materialize_block_inplace(output_block);
     return _write_prepared_block(output_block);
 }
@@ -436,23 +436,8 @@ Status VIcebergTableWriter::_write_prepared_block(Block& output_block) {
 
 Status VIcebergTableWriter::_filter_block(doris::Block& block, const IColumn::Filter* filter,
                                           doris::Block* output_block) {
-    const ColumnsWithTypeAndName& columns_with_type_and_name =
-            block.get_columns_with_type_and_name();
-    ColumnsWithTypeAndName result_columns;
-    for (const auto& col : columns_with_type_and_name) {
-        result_columns.emplace_back(col.column->clone_resized(col.column->size()), col.type,
-                                    col.name);
-    }
-    *output_block = {std::move(result_columns)};
-
-    std::vector<uint32_t> columns_to_filter;
-    int column_to_keep = output_block->columns();
-    columns_to_filter.resize(column_to_keep);
-    for (uint32_t i = 0; i < column_to_keep; ++i) {
-        columns_to_filter[i] = i;
-    }
-
-    Block::filter_block_internal(output_block, columns_to_filter, *filter);
+    *output_block = block;
+    Block::filter_block_internal(output_block, *filter);
     return Status::OK();
 }
 

--- a/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
+++ b/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
@@ -145,7 +145,7 @@ Status VMCTableWriter::write(RuntimeState* state, Block& block) {
 
     Block output_block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_vec_output_expr_ctxs, block,
-                                                                       &output_block, false));
+                                                                       &output_block));
     materialize_block_inplace(output_block);
 
     _row_count += output_block.rows();

--- a/be/src/exec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/exec/sink/writer/vhive_table_writer.cpp
@@ -92,7 +92,7 @@ Status VHiveTableWriter::write(RuntimeState* state, Block& block) {
     }
     Block output_block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_vec_output_expr_ctxs, block,
-                                                                       &output_block, false));
+                                                                       &output_block));
     materialize_block_inplace(output_block);
 
     std::unordered_map<std::shared_ptr<VHivePartitionWriter>, IColumn::Filter> writer_positions;
@@ -220,24 +220,8 @@ Status VHiveTableWriter::write(RuntimeState* state, Block& block) {
 
 Status VHiveTableWriter::_filter_block(doris::Block& block, const IColumn::Filter* filter,
                                        doris::Block* output_block) {
-    const ColumnsWithTypeAndName& columns_with_type_and_name =
-            block.get_columns_with_type_and_name();
-    ColumnsWithTypeAndName result_columns;
-    for (int i = 0; i < columns_with_type_and_name.size(); ++i) {
-        const auto& col = columns_with_type_and_name[i];
-        result_columns.emplace_back(col.column->clone_resized(col.column->size()), col.type,
-                                    col.name);
-    }
-    *output_block = {std::move(result_columns)};
-
-    std::vector<uint32_t> columns_to_filter;
-    int column_to_keep = output_block->columns();
-    columns_to_filter.resize(column_to_keep);
-    for (uint32_t i = 0; i < column_to_keep; ++i) {
-        columns_to_filter[i] = i;
-    }
-
-    Block::filter_block_internal(output_block, columns_to_filter, *filter);
+    *output_block = block;
+    Block::filter_block_internal(output_block, *filter);
     return Status::OK();
 }
 

--- a/be/src/exprs/function/if.cpp
+++ b/be/src/exprs/function/if.cpp
@@ -420,8 +420,8 @@ public:
         handled = false;
 
         if (cond_is_null) {
-            block.replace_by_position(result,
-                                      arg_else.column->clone_resized(arg_cond.column->size()));
+            DCHECK_EQ(arg_else.column->size(), arg_cond.column->size());
+            block.replace_by_position(result, arg_else.column);
             handled = true;
             return Status::OK();
         }

--- a/be/src/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/exprs/lambda_function/varray_map_function.cpp
@@ -121,7 +121,7 @@ public:
         auto outside_null_map = ColumnUInt8::create(
                 arguments[0].column->convert_to_full_column_if_const()->size(), 0);
         // offset column
-        MutableColumnPtr array_column_offset;
+        ColumnPtr array_column_offset;
         size_t nested_array_column_rows = 0;
         ColumnPtr first_array_offsets = nullptr;
         //2. get the result column from executed expr, and the needed is nested column of array
@@ -158,8 +158,7 @@ public:
             if (i == 0) {
                 nested_array_column_rows = col_array.get_data_ptr()->size();
                 first_array_offsets = col_array.get_offsets_ptr();
-                const auto& off_data = col_array.get_offsets_column();
-                array_column_offset = off_data.clone_resized(col_array.get_offsets_column().size());
+                array_column_offset = first_array_offsets;
                 args_info.offsets_ptr = &col_array.get_offsets();
             } else {
                 // select array_map((x,y)->x+y,c_array1,[0,1,2,3]) from array_test2;
@@ -200,8 +199,8 @@ public:
             auto empty_nested_column = assert_cast<const DataTypeArray*>(nested_type.get())
                                                ->get_nested_type()
                                                ->create_column();
-            auto result_array_column = ColumnArray::create(std::move(empty_nested_column),
-                                                           std::move(array_column_offset));
+            auto result_array_column =
+                    ColumnArray::create(std::move(empty_nested_column), array_column_offset);
 
             if (is_nullable) {
                 result_column = ColumnNullable::create(std::move(result_array_column),
@@ -300,7 +299,7 @@ public:
         if (result_type->is_nullable()) {
             if (res_type->is_nullable()) {
                 result_column = ColumnNullable::create(
-                        ColumnArray::create(std::move(result_col), std::move(array_column_offset)),
+                        ColumnArray::create(std::move(result_col), array_column_offset),
                         std::move(outside_null_map));
             } else {
                 // deal with eg: select array_map(x -> x is null, [null, 1, 2]);
@@ -310,19 +309,18 @@ public:
                 result_column = ColumnNullable::create(
                         ColumnArray::create(ColumnNullable::create(std::move(result_col),
                                                                    std::move(nested_null_map)),
-                                            std::move(array_column_offset)),
+                                            array_column_offset),
                         std::move(outside_null_map));
             }
         } else {
             if (res_type->is_nullable()) {
-                result_column =
-                        ColumnArray::create(std::move(result_col), std::move(array_column_offset));
+                result_column = ColumnArray::create(std::move(result_col), array_column_offset);
             } else {
                 auto nested_null_map = ColumnUInt8::create(result_col->size(), 0);
 
                 result_column = ColumnArray::create(
                         ColumnNullable::create(std::move(result_col), std::move(nested_null_map)),
-                        std::move(array_column_offset));
+                        array_column_offset);
             }
         }
         return Status::OK();

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -369,7 +369,8 @@ Status VectorizedIfExpr::execute_for_null_condition(Block& block, const ColumnNu
     handled = false;
 
     if (cond_is_null) {
-        block.replace_by_position(result, arg_else.column->clone_resized(arg_cond.column->size()));
+        DCHECK_EQ(arg_else.column->size(), arg_cond.column->size());
+        block.replace_by_position(result, arg_else.column);
         handled = true;
         return Status::OK();
     }

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -435,15 +435,8 @@ Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs&
     return Status::OK();
 }
 
-// do_projection: for some query(e.g. in MultiCastDataStreamerSourceOperator::get_block()),
-// output_vexpr_ctxs will output the same column more than once, and if the output_block
-// is mem-reused later, it will trigger DCHECK_EQ(d.column->use_count(), 1) failure when
-// doing Block::clear_column_data, set do_projection to true to copy the column data to
-// avoid this problem.
 Status VExprContext::get_output_block_after_execute_exprs(
-        const VExprContextSPtrs& output_vexpr_ctxs, const Block& input_block, Block* output_block,
-        bool do_projection) {
-    auto rows = input_block.rows();
+        const VExprContextSPtrs& output_vexpr_ctxs, const Block& input_block, Block* output_block) {
     ColumnsWithTypeAndName result_columns;
     _reset_memory_usage(output_vexpr_ctxs);
 
@@ -455,12 +448,7 @@ Status VExprContext::get_output_block_after_execute_exprs(
         const auto& name = vexpr_ctx->expr_name();
 
         vexpr_ctx->_memory_usage += result_column->allocated_bytes();
-        if (do_projection) {
-            result_columns.emplace_back(result_column->clone_resized(rows), type, name);
-
-        } else {
-            result_columns.emplace_back(result_column, type, name);
-        }
+        result_columns.emplace_back(result_column, type, name);
     }
     *output_block = {result_columns};
     return Status::OK();

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -329,8 +329,7 @@ public:
                                                      int column_to_keep, IColumn::Filter& filter);
 
     [[nodiscard]] static Status get_output_block_after_execute_exprs(const VExprContextSPtrs&,
-                                                                     const Block&, Block*,
-                                                                     bool do_projection = false);
+                                                                     const Block&, Block*);
 
     int get_last_result_column_id() const {
         DCHECK(_last_result_column_id != -1);


### PR DESCRIPTION
### What problem does this PR solve?


Some column execution paths copied full column data even when the result could safely share existing column storage and rely on COW before mutation. Root cause: projection, partition filtering, array offsets, and null-condition IF handling used clone_resized() as a defensive ownership boundary.

This change removes those redundant clones by reusing expression result columns directly, sharing array offsets in array_map, filtering copied blocks through the existing COW-aware block filter path, and reusing the else column when an IF condition is entirely null.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

