### PR TITLE
[fix](be) Align cast input nullability for Iceberg struct evolution

### DIFF
--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -994,8 +994,12 @@ protected:
         }
 
         DataTypePtr input_type = file_type;
+        // Cast wrappers unwrap nullable inputs according to the declared input type, so keep the
+        // root nullability of the declared type aligned with the actual column shape.
         if ((*column)->is_nullable() && !input_type->is_nullable()) {
             input_type = make_nullable(input_type);
+        } else if (!(*column)->is_nullable() && input_type->is_nullable()) {
+            input_type = remove_nullable(input_type);
         }
         Block cast_block;
         cast_block.insert({*column, input_type, column_name});

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -896,6 +896,11 @@ public:
     using TableReader::_truncate_char_or_varchar_column;
 };
 
+class TableReaderCastTestHelper final : public TableReader {
+public:
+    using TableReader::_cast_column_to_type;
+};
+
 TEST(TableReaderTest, TruncateCharOrVarcharPredicateOnlyAppliesToParquetStringWidthMismatch) {
     ColumnMapping mapping;
     mapping.table_type = std::make_shared<DataTypeString>(3, TYPE_VARCHAR);
@@ -1514,6 +1519,41 @@ TEST(TableReaderTest, ComplexRematerializeCastsScalarChildToTableType) {
     EXPECT_EQ(country_values.get_data_at(1).to_string(), "UK");
     EXPECT_EQ(city_values.get_data_at(0).to_string(), "New York");
     EXPECT_EQ(city_values.get_data_at(1).to_string(), "London");
+}
+
+TEST(TableReaderTest, ComplexRematerializeCastsNonNullableScalarChildWithNullableFileType) {
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto bigint_type = std::make_shared<DataTypeInt64>();
+    const auto nullable_int_type = make_nullable(int_type);
+    const auto nullable_bigint_type = make_nullable(bigint_type);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    TableReaderCastTestHelper reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = {},
+                                    .conjuncts = {},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+
+    auto column = ColumnInt32::create();
+    column->insert_value(10);
+    column->insert_value(20);
+    ColumnPtr result_column = std::move(column);
+    const auto status = reader._cast_column_to_type(&result_column, nullable_int_type,
+                                                    nullable_bigint_type, "struct_column.a");
+    ASSERT_TRUE(status.ok()) << status.to_string();
+
+    const auto& result_nullable = assert_cast<const ColumnNullable&>(*result_column);
+    const auto& child_values = assert_cast<const ColumnInt64&>(result_nullable.get_nested_column());
+    ASSERT_EQ(result_nullable.size(), 2);
+    EXPECT_FALSE(result_nullable.is_null_at(0));
+    EXPECT_FALSE(result_nullable.is_null_at(1));
+    EXPECT_EQ(child_values.get_element(0), 10);
+    EXPECT_EQ(child_values.get_element(1), 20);
 }
 
 TEST(TableReaderTest, ReopenSplitAfterClose) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_struct_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_struct_schema_evolution.groovy
@@ -95,6 +95,28 @@ suite("test_iceberg_struct_schema_evolution", "p0,external") {
     // Test 8: DISTINCT query on struct fields
     qt_struct_distinct """SELECT DISTINCT element_at(a_struct, 'renamed'), element_at(a_struct, 'added'), element_at(a_struct, 'keep') FROM ${table_name} ORDER BY 1, 2, 3"""
 
+    // Reproduce Spark Iceberg struct child type evolution: old files keep col.a as INT while
+    // current Iceberg schema exposes it as BIGINT. Reading col.a must cast the materialized struct
+    // child without assuming the declared nullable file type matches the actual column nullability.
+    def type_evolution_table_name = "test_struct_child_type_evolution"
+    spark_iceberg_multi """
+        DROP TABLE IF EXISTS demo.test_db.${type_evolution_table_name};
+        CREATE TABLE demo.test_db.${type_evolution_table_name} (
+            id INT,
+            col STRUCT<a: INT, b: INT, c: INT>
+        ) USING iceberg
+        TBLPROPERTIES ('write.format.default' = 'parquet');
+        INSERT INTO demo.test_db.${type_evolution_table_name}
+            SELECT 1, named_struct('a', 10, 'b', 20, 'c', 30);
+        ALTER TABLE demo.test_db.${type_evolution_table_name} ALTER COLUMN col.a TYPE BIGINT;
+    """
+    sql """REFRESH CATALOG ${catalog_name}"""
+    sql """
+        SELECT /*+ SET_VAR(enable_prune_nested_column=true) */ col.a, col.b, col.c
+        FROM ${type_evolution_table_name}
+        ORDER BY id
+    """
+
     // ============================================================
     // Test with ORC format (for completeness)
     // ============================================================


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Reading Iceberg struct fields after Spark schema evolution can materialize a column whose root nullability does not match the declared file type used to prepare the cast expression. The cast wrapper unwraps nullable inputs based on the declared input type, so a nullable declared type with a non-nullable actual column can hit an invalid unwrap path and crash BE instead of returning the cast result. This change aligns the declared cast input root nullability with the actual column shape before executing the cast. It also adds a focused BE unit test and an Iceberg regression case that creates a Spark Iceberg struct, evolves col.a from INT to BIGINT, refreshes the Doris catalog, and queries col.a/col.b/col.c with nested pruning enabled.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran git diff --check for modified files
    - Ran targeted clang-format v16 wrapper for modified BE C++ files
    - Attempted BE unit test: ./run-be-ut.sh --run --filter=TableReaderTest.ComplexRematerializeCastsNonNullableScalarChildWithNullableFileType:TableReaderTest.ComplexRematerializeCastsScalarChildToTableType, blocked because local thirdparty/installed is incomplete (missing bin/protoc and Snappy)
    - Attempted regression test: ./run-regression-test.sh --run -d external_table_p0/iceberg -s test_iceberg_struct_schema_evolution, blocked because local thirdparty/installed is incomplete (missing bin/thrift)
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

