### PR TITLE
[fix](clone) Check temporary partition tablets for colocate tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletChecker.java
@@ -267,6 +267,11 @@ public class TabletChecker extends MasterDaemon {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("table {} is a colocate table, skip tablet checker.", olapTable.getName());
                         }
+                        LoopControlStatus st = handleColocateTempPartitions(db, olapTable, true, aliveBeIds, start,
+                                counter);
+                        if (st == LoopControlStatus.BREAK_OUT) {
+                            break OUT;
+                        }
                         continue;
                     }
                     for (Partition partition : olapTable.getAllPartitions()) {
@@ -311,6 +316,12 @@ public class TabletChecker extends MasterDaemon {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("table {} is a colocate table, skip tablet checker.", table.getName());
                         }
+                        OlapTable tbl = (OlapTable) table;
+                        LoopControlStatus st = handleColocateTempPartitions(db, tbl, false, aliveBeIds, start,
+                                counter);
+                        if (st == LoopControlStatus.BREAK_OUT) {
+                            break OUT;
+                        }
                         continue;
                     }
 
@@ -352,6 +363,20 @@ public class TabletChecker extends MasterDaemon {
                 + "cost: {} ms",
                 counter.unhealthyTabletNum, counter.totalTabletNum, counter.addToSchedulerTabletNum,
                 counter.tabletInScheduler, counter.tabletNotReady, counter.tabletExceedLimit, cost);
+    }
+
+    private LoopControlStatus handleColocateTempPartitions(Database db, OlapTable tbl, boolean onlyPrios,
+            List<Long> aliveBeIds, long startTime, CheckerCounter counter) {
+        for (Partition partition : tbl.getAllTempPartitions()) {
+            if (onlyPrios != isInPrios(db.getId(), tbl.getId(), partition.getId())) {
+                continue;
+            }
+            LoopControlStatus st = handlePartitionTablet(db, tbl, partition, onlyPrios, aliveBeIds, startTime, counter);
+            if (st == LoopControlStatus.BREAK_OUT) {
+                return st;
+            }
+        }
+        return LoopControlStatus.CONTINUE;
     }
 
     private LoopControlStatus handlePartitionTablet(Database db, OlapTable tbl, Partition partition, boolean isInPrios,
@@ -556,7 +581,7 @@ public class TabletChecker extends MasterDaemon {
             tblId = olapTable.getId();
 
             if (partitions == null || partitions.isEmpty()) {
-                partIds = olapTable.getPartitions().stream().map(Partition::getId).collect(Collectors.toList());
+                partIds = olapTable.getAllPartitions().stream().map(Partition::getId).collect(Collectors.toList());
             } else {
                 for (String partName : partitions) {
                     Partition partition = olapTable.getPartition(partName);

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/TabletHealthTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/TabletHealthTest.java
@@ -365,6 +365,49 @@ public class TabletHealthTest extends TestWithFeService {
     }
 
     @Test
+    public void testColocateTemporaryPartitionCheckedByTabletChecker() throws Exception {
+        createTable("CREATE TABLE tbl4 (k INT)"
+                + " PARTITION BY RANGE(k) (PARTITION p1 VALUES LESS THAN (\"10\"))"
+                + " DISTRIBUTED BY HASH(k) BUCKETS 1"
+                + " PROPERTIES ('replication_num' = '3', 'colocate_with' = 'temp_group')");
+        alterTableSync("ALTER TABLE tbl4 ADD TEMPORARY PARTITION tp1 VALUES LESS THAN (\"10\")");
+
+        OlapTable table = (OlapTable) db.getTableOrMetaException("tbl4");
+        Assertions.assertTrue(Env.getCurrentColocateIndex().isColocateTable(table.getId()));
+        Assertions.assertEquals(1, table.getAllTempPartitions().size());
+
+        Partition tempPartition = table.getAllTempPartitions().get(0);
+        Tablet tablet = tempPartition.getMaterializedIndices(IndexExtState.ALL).iterator().next()
+                .getTablets().iterator().next();
+        tempPartition.updateVisibleVersion(10L);
+        tablet.getReplicas().forEach(replica -> replica.updateVersion(10L));
+
+        Backend decommissionBe = Env.getCurrentSystemInfo().getBackend(tablet.getReplicas().get(0).getBackendId());
+        decommissionBe.setDecommissioned(true);
+        Env.getCurrentEnv().getTabletChecker().runAfterCatalogReady();
+
+        Assertions.assertTrue(Env.getCurrentEnv().getTabletScheduler().containsTablet(tablet.getId()));
+        decommissionBe.setDecommissioned(false);
+        dropTable(table.getName(), true);
+    }
+
+    @Test
+    public void testRepairTabletInfoContainsTemporaryPartitions() throws Exception {
+        createTable("CREATE TABLE tbl5 (k INT)"
+                + " PARTITION BY RANGE(k) (PARTITION p1 VALUES LESS THAN (\"10\"))"
+                + " DISTRIBUTED BY HASH(k) BUCKETS 1"
+                + " PROPERTIES ('replication_num' = '3')");
+        alterTableSync("ALTER TABLE tbl5 ADD TEMPORARY PARTITION tp1 VALUES LESS THAN (\"10\")");
+
+        OlapTable table = (OlapTable) db.getTableOrMetaException("tbl5");
+        TabletChecker.RepairTabletInfo repairTabletInfo = TabletChecker.getRepairTabletInfo("test", "tbl5", null);
+
+        Assertions.assertEquals(table.getAllPartitions().stream().map(Partition::getId).collect(Collectors.toSet()),
+                repairTabletInfo.partIds.stream().collect(Collectors.toSet()));
+        dropTable(table.getName(), true);
+    }
+
+    @Test
     public void testAddTabletNoDeadLock() throws Exception {
         Config.max_scheduling_tablets = 1;
         createTable("CREATE TABLE tbl3 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

This PR fixes a tablet scheduler feeder blind spot for temporary partitions of colocate tables.

For colocate tables, `TabletChecker` skips the whole table because normal colocate tablets are expected to be checked by `ColocateTableCheckerAndBalancer`. However, `ColocateTableCheckerAndBalancer` iterates `OlapTable#getPartitions()`, which intentionally excludes temporary partitions. As a result, tablets in temporary partitions of colocate tables are not enqueued by either checker.

Bug type and impact:

- **Bug type**: tablet health-check / repair feeder missing coverage.
- **Affected objects**: tablets that belong to temporary partitions of colocate OLAP tables.
- **Affected branches/versions**: this code path exists in current master and release branches with the same checker split.
- **Root impact**: these tablets are not regularly health-checked and are not added to `TabletScheduler` by the normal feeder paths.

The production symptom that exposed this issue was BE decommission being blocked, but the impact is broader than decommission. Any scenario that depends on the regular tablet health-check feeder for these temporary-partition tablets can be affected, including:

- **BE decommission relocation**: tablets on decommissioning BEs are not scheduled to move away, so decommission can stay blocked with a non-zero tablet count.
- **Replica-missing repair**: missing replicas in colocate temporary partitions may not be automatically repaired.
- **Version-incomplete repair**: stale or incomplete-version replicas may not be scheduled for repair.
- **Bad or unavailable replica handling**: bad/unavailable replicas can remain unnoticed by the regular checker path.
- **Redundant replica cleanup**: redundant replicas may not be cleaned up through the normal repair path.
- **Tag/resource-tag allocation issues**: placement issues detectable by normal tablet health checks can be missed for these tablets.

There is also a manual repair gap: `ADMIN REPAIR TABLE` without explicit partition names used `getPartitions()`, so temporary partitions were not added to the priority repair set by default. Since explicit temporary partition repair is restricted by command validation, users had no convenient way to repair these tablets through the normal admin repair flow.

The executor side is already able to resolve temporary partitions via `OlapTable#getPartition(partitionId)`, so this PR keeps the fix in the feeder layer.

Solution:

- Keep formal partitions of colocate tables handled by `ColocateTableCheckerAndBalancer`.
- Let `TabletChecker` additionally check temporary partitions for colocate tables.
- Include temporary partitions in `ADMIN REPAIR TABLE` when no partition name is specified, so the default repair target set is consistent with all partitions owned by the table.

This PR intentionally keeps the fix minimal. It does not change colocate bucket-sequence or colocate rebalance semantics in `ColocateTableCheckerAndBalancer`; that larger semantic change can be discussed separately if needed.

### Release note

Fix colocate table temporary partition tablets not being checked or scheduled for repair, which could leave repair issues unresolved and block BE decommission.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Tested locally:

```bash
export JAVA_HOME=/opt/work/tools/jdk17 JDK_17=/opt/work/tools/jdk17 PATH=/opt/work/tools/bin:/opt/work/tools/jdk17/bin:/opt/homebrew/opt/bison/bin:/opt/homebrew/bin:$PATH
cd fe
/opt/work/tools/bin/mvn test -Dmaven.repo.local=/opt/work/tools/m2 -pl fe-common,fe-core -am -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest=org.apache.doris.clone.TabletHealthTest
```

Result:

```text
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

- Behavior changed:
    - [ ] No.
    - [x] Yes. Temporary partitions of colocate tables are now covered by `TabletChecker`, and `ADMIN REPAIR TABLE` without explicit partition names includes temporary partitions by default.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label