### PR TITLE
[fix](regression) Wait for auto partition recycle

### DIFF
--- a/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
+
 suite("test_auto_new_recycle", "nonConcurrent") {
     sql "drop table if exists auto_recycle"
     test {
@@ -113,6 +116,16 @@ suite("test_auto_new_recycle", "nonConcurrent") {
 
     waitUntilSafeExecutionTime("NOT_CROSS_DAY_BOUNDARY", 20)
 
+    def waitPartitionCount = { int expectedCount ->
+        Awaitility.await().atMost(1200, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until {
+            res = sql "show partitions from auto_recycle"
+            logger.info("partition count: ${res.size()}, expected: ${expectedCount}")
+            res.size() == expectedCount
+        }
+        res = sql "show partitions from auto_recycle"
+        assertEquals(expectedCount, res.size())
+    }
+
     sql """
     insert into auto_recycle select date_add('2020-01-01 00:00:00', interval number day) from numbers("number" = "100");
     """
@@ -124,9 +137,7 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     assertTrue(res[0][1].contains('"partition.retention_count" = "3"'))
 
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
-    sleep(8000)
-    res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 3)
+    waitPartitionCount.call(3)
 
     // before everytime insert data, we should avoid recycle because if they conflict, insert will fail
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '600') """
@@ -135,15 +146,11 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     insert into auto_recycle select date_add('2020-01-01 00:00:00', interval number day) from numbers("number" = "100");
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
-    sleep(8000)
-    res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 3)
+    waitPartitionCount.call(3)
     qt_sql0 "select * from auto_recycle order by k0"
 
     sql "alter table auto_recycle set ('partition.retention_count' = '1')"
-    sleep(5000)
-    res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 1)
+    waitPartitionCount.call(1)
 
     sql "alter table auto_recycle set ('partition.retention_count' = '10')"
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '600') """
@@ -152,9 +159,7 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     insert into auto_recycle select date_add('2022-01-01 00:00:00', interval number day) from numbers("number" = "100");
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
-    sleep(8000)
-    res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 10)
+    waitPartitionCount.call(10)
     qt_sql1 "select * from auto_recycle order by k0"
 
     // verify not consider future partition when do recycle
@@ -175,9 +180,7 @@ suite("test_auto_new_recycle", "nonConcurrent") {
         insert into auto_recycle select date_add(now(), interval number-5 day) from numbers("number" = "8");
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
-    sleep(8000)
-    res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 6) // [-5, -1] -> [-3, -1], [0, 2] -> [0, 2]
+    waitPartitionCount.call(6) // [-5, -1] -> [-3, -1], [0, 2] -> [0, 2]
     res = sql "select * from auto_recycle order by k0"
     assertEquals(res.size(), 6)
 


### PR DESCRIPTION
## Summary

- Fix `test_auto_new_recycle` to wait for auto partition recycle by polling the expected partition count.
- Replace fixed sleeps before retention-count assertions with an Awaitility-based helper.
- Keep the original validation intent: auto partition retention should eventually keep only the latest configured historical partitions.

## Testing

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [ ] Not run locally: no regression environment was allocated for this case.

Failure evidence:

- x64 branch-4.1 NonConcurrent build 201293, occurrence 2000000189.
- Recent same-pipeline history showed repeated line-129 failures mixed with passes, which points to async scheduler timing rather than a deterministic product semantic failure.
