### PR TITLE
[fix](regression) Deflake segcompaction agg keys case

### DIFF
--- a/regression-test/suites/segcompaction_p2/test_segcompaction_agg_keys.groovy
+++ b/regression-test/suites/segcompaction_p2/test_segcompaction_agg_keys.groovy
@@ -89,21 +89,20 @@ suite("test_segcompaction_agg_keys") {
         // Cannot use qt_select_default here: S3 Load parallelizes across multiple BE workers,
         // each creating separate segments with non-deterministic sequence numbers.
         // REPLACE aggregation picks the value from the segment with the highest sequence,
-        // so validate stable invariants instead of pinning a specific duplicate-key winner.
+        // so accept any complete source row instead of pinning one deterministic winner.
         def result = sql """ SELECT * FROM ${tableName} WHERE col_0=47; """
         assertEquals(1, result.size(), "Expected exactly 1 row for col_0=47 after REPLACE aggregation")
         assertEquals(50, result[0].size())
         assertEquals("47", result[0][0].toString())
 
-        def validValues = [
-            "Apple", "Avocado", "Banana", "Blueberry", "Cherry", "Grapes",
-            "Kiwi", "Lemon", "Lychee", "Mango", "Orange", "Peach",
-            "Pineapple", "Plum", "Raspberry", "Strawberry", "Watermelon"
-        ] as Set
-        for (int i = 1; i < result[0].size(); i++) {
-            assertTrue(validValues.contains(result[0][i]),
-                    "unexpected value for col_${i}: ${result[0][i]}")
-        }
+        def sourceRows = new File(context.dataPath, "test_segcompaction_dup_keys.out")
+                .readLines()
+                .findAll { it.startsWith("47\t") }
+                .collect { it.split("\t", -1).toList() }
+        assertEquals(12, sourceRows.size(), "Unexpected col_0=47 source row count")
+        def row = result[0].collect { it?.toString() }
+        assertTrue(sourceRows.contains(row),
+                "Result for col_0=47 is not one complete source row: ${row}")
 
         String[][] tablets = sql """ show tablets from ${tableName}; """
 

--- a/regression-test/suites/segcompaction_p2/test_segcompaction_agg_keys.groovy
+++ b/regression-test/suites/segcompaction_p2/test_segcompaction_agg_keys.groovy
@@ -89,14 +89,21 @@ suite("test_segcompaction_agg_keys") {
         // Cannot use qt_select_default here: S3 Load parallelizes across multiple BE workers,
         // each creating separate segments with non-deterministic sequence numbers.
         // REPLACE aggregation picks the value from the segment with the highest sequence,
-        // so the winner among the 12 source rows with col_0=47 is not guaranteed across runs.
-        def selectResult = sql """ SELECT * FROM ${tableName} WHERE col_0=47; """
-        assertEquals(1, selectResult.size(), "Expected exactly 1 row for col_0=47 after REPLACE aggregation")
-        def row = selectResult[0].collect { it?.toString() }
-        def possibleResult1 = ["47", "Lychee", "Lychee", "Plum", "Banana", "Lychee", "Lychee", "Cherry", "Pineapple", "Banana", "Watermelon", "Mango", "Apple", "Apple", "Peach", "Raspberry", "Grapes", "Raspberry", "Raspberry", "Kiwi", "Orange", "Apple", "Plum", "Blueberry", "Strawberry", "Orange", "Raspberry", "Strawberry", "Lemon", "Orange", "Blueberry", "Apple", "Peach", "Banana", "Kiwi", "Orange", "Banana", "Strawberry", "Lemon", "Mango", "Orange", "Peach", "Avocado", "Pineapple", "Kiwi", "Lemon", "Grapes", "Strawberry", "Grapes", "Lychee"]
-        def possibleResult2 = ["47", "Banana", "Watermelon", "Lychee", "Blueberry", "Raspberry", "Strawberry", "Grapes", "Watermelon", "Lemon", "Lemon", "Pineapple", "Watermelon", "Peach", "Kiwi", "Lychee", "Peach", "Pineapple", "Raspberry", "Grapes", "Lychee", "Raspberry", "Peach", "Kiwi", "Pineapple", "Apple", "Lemon", "Lychee", "Pineapple", "Blueberry", "Blueberry", "Avocado", "Cherry", "Kiwi", "Cherry", "Watermelon", "Plum", "Banana", "Peach", "Pineapple", "Apple", "Strawberry", "Avocado", "Kiwi", "Blueberry", "Mango", "Watermelon", "Orange", "Strawberry", "Banana"]
-        assertTrue(row == possibleResult1 || row == possibleResult2,
-            "Result for col_0=47 does not match either expected outcome.\nGot: ${row}")
+        // so validate stable invariants instead of pinning a specific duplicate-key winner.
+        def result = sql """ SELECT * FROM ${tableName} WHERE col_0=47; """
+        assertEquals(1, result.size(), "Expected exactly 1 row for col_0=47 after REPLACE aggregation")
+        assertEquals(50, result[0].size())
+        assertEquals("47", result[0][0].toString())
+
+        def validValues = [
+            "Apple", "Avocado", "Banana", "Blueberry", "Cherry", "Grapes",
+            "Kiwi", "Lemon", "Lychee", "Mango", "Orange", "Peach",
+            "Pineapple", "Plum", "Raspberry", "Strawberry", "Watermelon"
+        ] as Set
+        for (int i = 1; i < result[0].size(); i++) {
+            assertTrue(validValues.contains(result[0][i]),
+                    "unexpected value for col_${i}: ${result[0][i]}")
+        }
 
         String[][] tablets = sql """ show tablets from ${tableName}; """
 


### PR DESCRIPTION
## Proposed changes

Follow up the existing `test_segcompaction_agg_keys` deflake from #61026.

The current master case already avoids the old golden file by allowing two concrete full-row results for `col_0=47`. This patch keeps the same intent but removes the hard-coded full-row candidates. The case now checks stable invariants instead:

- `col_0=47` returns exactly one aggregate row.
- The row has the expected 50 columns.
- The key is `47`.
- All `REPLACE` value columns belong to the known fruit value domain in the ORC input.

This avoids pinning the test to a specific duplicate-key `REPLACE` winner while still checking that the load and aggregation returned a valid row.

## Why

The ORC input contains multiple rows with `col_0=47`. With `AGGREGATE KEY(col_0)` and `REPLACE` value columns, the case should not require one specific source row to win unless the data/model makes that winner deterministic.

## Validation

Remote branch-4.1 regression environment:

```bash
ssh root@172.20.56.184
cd /deploy/teamcity_agent13/work/a0477ef061788419/case_output/doris
export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
export PATH=$JAVA_HOME/bin:$PATH
./run-regression-test.sh --run -d segcompaction_p2 -s test_segcompaction_agg_keys
```

Result:

```text
Test 1 suites, failed 0 suites, fatal 0 scripts, skipped 0 scripts
```
