### PR TITLE
[fix](mtmv) Check agg/window partition keys only for tracked partition outputs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionIncrementMaintainer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionIncrementMaintainer.java
@@ -48,6 +48,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalResultSink;
@@ -410,6 +411,9 @@ public class PartitionIncrementMaintainer {
         @Override
         public Void visitLogicalAggregate(LogicalAggregate<? extends Plan> aggregate,
                 PartitionIncrementCheckContext context) {
+            if (!planOutputContainsPartitionColumnToCheck(aggregate, context)) {
+                return super.visitLogicalAggregate(aggregate, context);
+            }
             Set<Expression> groupByExprSet = new HashSet<>(aggregate.getGroupByExpressions());
             if (groupByExprSet.isEmpty()) {
                 context.addFailReason("group by sets is empty, doesn't contain the target partition");
@@ -426,6 +430,9 @@ public class PartitionIncrementMaintainer {
 
         @Override
         public Void visitLogicalWindow(LogicalWindow<? extends Plan> window, PartitionIncrementCheckContext context) {
+            if (!planOutputContainsPartitionColumnToCheck(window, context)) {
+                return super.visitLogicalWindow(window, context);
+            }
             List<NamedExpression> windowExpressions = window.getWindowExpressions();
             if (windowExpressions.isEmpty()) {
                 context.addFailReason("window expression is empty, doesn't contain the target partition");
@@ -445,6 +452,20 @@ public class PartitionIncrementMaintainer {
         }
 
         @Override
+        public Void visitLogicalPartitionTopN(LogicalPartitionTopN<? extends Plan> partitionTopN,
+                PartitionIncrementCheckContext context) {
+            if (!planOutputContainsPartitionColumnToCheck(partitionTopN, context)) {
+                return super.visitLogicalPartitionTopN(partitionTopN, context);
+            }
+            if (!checkPartitionKeysContainPartitionToCheck(partitionTopN.getPartitionKeys(), context)) {
+                context.addFailReason("window partition sets doesn't contain the target partition");
+                context.collectFailedTableSet(partitionTopN);
+                context.setFailFast(true);
+            }
+            return super.visitLogicalPartitionTopN(partitionTopN, context);
+        }
+
+        @Override
         public Void visit(Plan plan, PartitionIncrementCheckContext context) {
             if (plan instanceof LogicalProject
                     || plan instanceof LogicalLimit
@@ -456,6 +477,7 @@ public class PartitionIncrementMaintainer {
                     || plan instanceof LogicalWindow
                     || (plan instanceof LogicalUnion
                     && ((LogicalUnion) plan).getQualifier() == SetOperation.Qualifier.ALL)
+                    || plan instanceof LogicalPartitionTopN
                     || plan instanceof LogicalCTEAnchor
                     || plan instanceof LogicalCTEConsumer
                     || plan instanceof LogicalCTEProducer
@@ -476,23 +498,39 @@ public class PartitionIncrementMaintainer {
                     expression.collectToList(expressionTreeNode -> expressionTreeNode instanceof WindowExpression);
             for (Object windowExpressionObj : windowExpressions) {
                 WindowExpression windowExpression = (WindowExpression) windowExpressionObj;
-                List<Expression> partitionKeys = windowExpression.getPartitionKeys();
-                Set<Column> originalPartitionbyExprSet = new HashSet<>();
-                partitionKeys.forEach(groupExpr -> {
-                    if (groupExpr instanceof SlotReference && groupExpr.isColumnFromTable()) {
-                        originalPartitionbyExprSet.add(((SlotReference) groupExpr).getOriginalColumn().get());
-                    }
-                });
-                Set<SlotReference> contextPartitionColumnSet = getPartitionColumnsToCheck(context);
-                if (contextPartitionColumnSet.isEmpty()) {
-                    return false;
-                }
-                if (contextPartitionColumnSet.stream().noneMatch(
-                        partition -> originalPartitionbyExprSet.contains(partition.getOriginalColumn().get()))) {
+                if (!checkPartitionKeysContainPartitionToCheck(windowExpression.getPartitionKeys(), context)) {
                     return false;
                 }
             }
             return true;
+        }
+
+        private boolean checkPartitionKeysContainPartitionToCheck(List<Expression> partitionKeys,
+                PartitionIncrementCheckContext context) {
+            Set<Column> originalPartitionByExprSet = new HashSet<>();
+            partitionKeys.forEach(partitionKey -> {
+                if (partitionKey instanceof SlotReference && partitionKey.isColumnFromTable()) {
+                    originalPartitionByExprSet.add(((SlotReference) partitionKey).getOriginalColumn().get());
+                }
+            });
+            Set<SlotReference> contextPartitionColumnSet = getPartitionColumnsToCheck(context);
+            if (contextPartitionColumnSet.isEmpty()) {
+                return false;
+            }
+            return contextPartitionColumnSet.stream().anyMatch(
+                    partition -> originalPartitionByExprSet.contains(partition.getOriginalColumn().get()));
+        }
+
+        private boolean planOutputContainsPartitionColumnToCheck(Plan plan, PartitionIncrementCheckContext context) {
+            Set<Slot> outputSet = plan.getOutputSet();
+            for (NamedExpression namedExpression : context.getPartitionAndRefExpressionMap().keySet()) {
+                // Plan outputs are slots, so only tracked partition expressions already resolved
+                // to slots can match here.
+                if (namedExpression instanceof Slot && outputSet.contains(namedExpression)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private Set<SlotReference> getPartitionColumnsToCheck(PartitionIncrementCheckContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionIncrementMaintainer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionIncrementMaintainer.java
@@ -61,6 +61,7 @@ import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanRewriter;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.ImmutableEqualSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -441,7 +442,7 @@ public class PartitionIncrementMaintainer {
                 return visit(window, context);
             }
             for (NamedExpression namedExpression : windowExpressions) {
-                if (!checkWindowPartition(namedExpression, context)) {
+                if (!checkWindowPartition(namedExpression, window, context)) {
                     context.addFailReason("window partition sets doesn't contain the target partition");
                     context.collectFailedTableSet(window);
                     context.setFailFast(true);
@@ -457,7 +458,16 @@ public class PartitionIncrementMaintainer {
             if (!planOutputContainsPartitionColumnToCheck(partitionTopN, context)) {
                 return super.visitLogicalPartitionTopN(partitionTopN, context);
             }
-            if (!checkPartitionKeysContainPartitionToCheck(partitionTopN.getPartitionKeys(), context)) {
+            if (partitionTopN.hasGlobalLimit()) {
+                // A global limit/topN selects the top rows across all partitions rather than within
+                // each partition, so a change in one source partition can move the global winner and
+                // affect multiple MV partitions. That breaks partition-local maintenance, so reject it.
+                context.addFailReason("partition topN has global limit, which is not partition local");
+                context.collectFailedTableSet(partitionTopN);
+                context.setFailFast(true);
+                return super.visitLogicalPartitionTopN(partitionTopN, context);
+            }
+            if (!checkPartitionKeysContainPartitionToCheck(partitionTopN.getPartitionKeys(), partitionTopN, context)) {
                 context.addFailReason("partition topN partition keys doesn't contain the target partition");
                 context.collectFailedTableSet(partitionTopN);
                 context.setFailFast(true);
@@ -493,12 +503,14 @@ public class PartitionIncrementMaintainer {
             return super.visit(plan, context);
         }
 
-        private boolean checkWindowPartition(Expression expression, PartitionIncrementCheckContext context) {
+        private boolean checkWindowPartition(Expression expression, Plan currentPlan,
+                PartitionIncrementCheckContext context) {
             List<Object> windowExpressions =
                     expression.collectToList(expressionTreeNode -> expressionTreeNode instanceof WindowExpression);
             for (Object windowExpressionObj : windowExpressions) {
                 WindowExpression windowExpression = (WindowExpression) windowExpressionObj;
-                if (!checkPartitionKeysContainPartitionToCheck(windowExpression.getPartitionKeys(), context)) {
+                if (!checkPartitionKeysContainPartitionToCheck(windowExpression.getPartitionKeys(),
+                        currentPlan, context)) {
                     return false;
                 }
             }
@@ -506,13 +518,9 @@ public class PartitionIncrementMaintainer {
         }
 
         private boolean checkPartitionKeysContainPartitionToCheck(List<Expression> partitionKeys,
-                PartitionIncrementCheckContext context) {
-            // Match partition keys by slot identity (exprId) instead of the bare catalog Column,
-            // because Column.equals compares column attributes but not the owning table: an unrelated
-            // input column with the same definition (e.g. l.p vs r.p) would otherwise be accepted as
-            // the tracked partition key. The context already carries every slot equal to the MV
-            // partition column via join equal-set propagation, so a slot-level containment check keeps
-            // genuinely unrelated partition keys (no equality to the tracked column) rejected.
+                Plan currentPlan, PartitionIncrementCheckContext context) {
+            // Match by slot exprId, not catalog Column: Column.equals ignores the owning table, so an
+            // unrelated same-schema column (e.g. l.p vs r.p) would be wrongly accepted as the tracked key.
             Set<SlotReference> partitionKeySlotSet = new HashSet<>();
             partitionKeys.forEach(partitionKey -> {
                 if (partitionKey instanceof SlotReference && partitionKey.isColumnFromTable()) {
@@ -523,7 +531,16 @@ public class PartitionIncrementMaintainer {
             if (contextPartitionColumnSet.isEmpty()) {
                 return false;
             }
-            return contextPartitionColumnSet.stream().anyMatch(partitionKeySlotSet::contains);
+            if (contextPartitionColumnSet.stream().anyMatch(partitionKeySlotSet::contains)) {
+                return true;
+            }
+            // Also accept a key that is a different slot but proven equal to the tracked column, e.g.
+            // window over (partition by r.p) on an inner join l.p = r.p, or a forwarding alias p AS p_alias.
+            // currentPlan's DataTrait carries these equalities (bottom-up) even though this top-down check
+            // runs before the join equalities reach the context.
+            ImmutableEqualSet<Slot> equalSet = currentPlan.getLogicalProperties().getTrait().getEqualSet();
+            return contextPartitionColumnSet.stream().anyMatch(contextSlot ->
+                    partitionKeySlotSet.stream().anyMatch(keySlot -> equalSet.isEqual(contextSlot, keySlot)));
         }
 
         private boolean planOutputContainsPartitionColumnToCheck(Plan plan, PartitionIncrementCheckContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionIncrementMaintainer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionIncrementMaintainer.java
@@ -458,7 +458,7 @@ public class PartitionIncrementMaintainer {
                 return super.visitLogicalPartitionTopN(partitionTopN, context);
             }
             if (!checkPartitionKeysContainPartitionToCheck(partitionTopN.getPartitionKeys(), context)) {
-                context.addFailReason("window partition sets doesn't contain the target partition");
+                context.addFailReason("partition topN partition keys doesn't contain the target partition");
                 context.collectFailedTableSet(partitionTopN);
                 context.setFailFast(true);
             }
@@ -507,18 +507,23 @@ public class PartitionIncrementMaintainer {
 
         private boolean checkPartitionKeysContainPartitionToCheck(List<Expression> partitionKeys,
                 PartitionIncrementCheckContext context) {
-            Set<Column> originalPartitionByExprSet = new HashSet<>();
+            // Match partition keys by slot identity (exprId) instead of the bare catalog Column,
+            // because Column.equals compares column attributes but not the owning table: an unrelated
+            // input column with the same definition (e.g. l.p vs r.p) would otherwise be accepted as
+            // the tracked partition key. The context already carries every slot equal to the MV
+            // partition column via join equal-set propagation, so a slot-level containment check keeps
+            // genuinely unrelated partition keys (no equality to the tracked column) rejected.
+            Set<SlotReference> partitionKeySlotSet = new HashSet<>();
             partitionKeys.forEach(partitionKey -> {
                 if (partitionKey instanceof SlotReference && partitionKey.isColumnFromTable()) {
-                    originalPartitionByExprSet.add(((SlotReference) partitionKey).getOriginalColumn().get());
+                    partitionKeySlotSet.add((SlotReference) partitionKey);
                 }
             });
             Set<SlotReference> contextPartitionColumnSet = getPartitionColumnsToCheck(context);
             if (contextPartitionColumnSet.isEmpty()) {
                 return false;
             }
-            return contextPartitionColumnSet.stream().anyMatch(
-                    partition -> originalPartitionByExprSet.contains(partition.getOriginalColumn().get()));
+            return contextPartitionColumnSet.stream().anyMatch(partitionKeySlotSet::contains);
         }
 
         private boolean planOutputContainsPartitionColumnToCheck(Plan plan, PartitionIncrementCheckContext context) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
@@ -638,6 +638,54 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
     }
 
     @Test
+    public void getRelatedTableInfoTestWithUnrelatedRightWindowTest() {
+        PlanChecker.from(connectContext)
+                .checkExplain("SELECT l.L_SHIPDATE, l.L_ORDERKEY, o.O_ORDERDATE "
+                                + "FROM lineitem as l "
+                                + "LEFT JOIN ("
+                                + "SELECT O_ORDERKEY, O_ORDERDATE, "
+                                + "ROW_NUMBER() OVER (PARTITION BY O_ORDERKEY ORDER BY O_ORDERDATE DESC) AS rn "
+                                + "FROM orders"
+                                + ") as o "
+                                + "ON l.L_ORDERKEY = o.O_ORDERKEY AND o.rn = 1",
+                        nereidsPlanner -> {
+                            Plan rewrittenPlan = nereidsPlanner.getRewrittenPlan();
+                            RelatedTableInfo relatedTableInfo =
+                                    MaterializedViewUtils.getRelatedTableInfo("L_SHIPDATE", null,
+                                            rewrittenPlan, nereidsPlanner.getCascadesContext());
+                            Assertions.assertTrue(relatedTableInfo.isPctPossible(), relatedTableInfo.getFailReason());
+                            checkRelatedTableInfo(relatedTableInfo,
+                                    "lineitem",
+                                    "L_SHIPDATE",
+                                    true);
+                        });
+    }
+
+    @Test
+    public void getRelatedTableInfoTestWithUnrelatedRightAggregateTest() {
+        PlanChecker.from(connectContext)
+                .checkExplain("SELECT l.L_SHIPDATE, l.L_ORDERKEY, o.max_orderdate "
+                                + "FROM lineitem as l "
+                                + "LEFT JOIN ("
+                                + "SELECT O_ORDERKEY, max(O_ORDERDATE) AS max_orderdate "
+                                + "FROM orders "
+                                + "GROUP BY O_ORDERKEY"
+                                + ") as o "
+                                + "ON l.L_ORDERKEY = o.O_ORDERKEY",
+                        nereidsPlanner -> {
+                            Plan rewrittenPlan = nereidsPlanner.getRewrittenPlan();
+                            RelatedTableInfo relatedTableInfo =
+                                    MaterializedViewUtils.getRelatedTableInfo("L_SHIPDATE", null,
+                                            rewrittenPlan, nereidsPlanner.getCascadesContext());
+                            Assertions.assertTrue(relatedTableInfo.isPctPossible(), relatedTableInfo.getFailReason());
+                            checkRelatedTableInfo(relatedTableInfo,
+                                    "lineitem",
+                                    "L_SHIPDATE",
+                                    true);
+                        });
+    }
+
+    @Test
     public void getRelatedTableInfoTestWithLimitTest() {
         PlanChecker.from(connectContext)
                 .checkExplain("SELECT l.L_SHIPDATE, l.L_ORDERKEY "
@@ -875,9 +923,11 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                             RelatedTableInfo relatedTableInfo =
                                     MaterializedViewUtils.getRelatedTableInfo("upgrade_day", null,
                                             rewrittenPlan, nereidsPlanner.getCascadesContext());
-                            Assertions.assertTrue(relatedTableInfo.getFailReason().contains(
-                                    "partition column is not in group by or window partition by"));
-                            Assertions.assertFalse(relatedTableInfo.isPctPossible());
+                            Assertions.assertTrue(relatedTableInfo.isPctPossible(), relatedTableInfo.getFailReason());
+                            checkRelatedTableInfo(relatedTableInfo,
+                                    "test1",
+                                    "upgrade_day",
+                                    true);
                         });
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
@@ -662,6 +662,32 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
     }
 
     @Test
+    public void getRelatedTableInfoTestWithUnrelatedSameSchemaWindowTest() {
+        // t1 and t2 come from the same table, so t1.L_SHIPDATE and t2.L_SHIPDATE share an identical
+        // catalog Column definition but belong to different table instances. The MV partitions by
+        // t1.L_SHIPDATE while the row_number() partitions by the unrelated t2.L_SHIPDATE, and the join
+        // condition is on L_ORDERKEY so the two shipdate slots are NOT in the same equal set. Partition
+        // tracking must reject this: matching by bare Column would wrongly treat t2.L_SHIPDATE as the
+        // tracked partition key and allow stale rows after a partition-only refresh.
+        PlanChecker.from(connectContext)
+                .checkExplain("SELECT t1.L_SHIPDATE, t1.L_ORDERKEY "
+                                + "FROM lineitem t1 "
+                                + "LEFT JOIN ("
+                                + "SELECT L_ORDERKEY, L_SHIPDATE, "
+                                + "ROW_NUMBER() OVER (PARTITION BY L_SHIPDATE ORDER BY L_PARTKEY DESC) AS rn "
+                                + "FROM lineitem"
+                                + ") as t2 "
+                                + "ON t1.L_ORDERKEY = t2.L_ORDERKEY AND t2.rn = 1",
+                        nereidsPlanner -> {
+                            Plan rewrittenPlan = nereidsPlanner.getRewrittenPlan();
+                            RelatedTableInfo relatedTableInfo =
+                                    MaterializedViewUtils.getRelatedTableInfo("L_SHIPDATE", null,
+                                            rewrittenPlan, nereidsPlanner.getCascadesContext());
+                            Assertions.assertFalse(relatedTableInfo.isPctPossible());
+                        });
+    }
+
+    @Test
     public void getRelatedTableInfoTestWithUnrelatedRightAggregateTest() {
         PlanChecker.from(connectContext)
                 .checkExplain("SELECT l.L_SHIPDATE, l.L_ORDERKEY, o.max_orderdate "

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_list_str_increment_create.groovy
@@ -345,12 +345,12 @@ suite("cross_join_list_str_increment_create", "increment_create") {
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
                         mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -375,9 +375,9 @@ suite("cross_join_list_str_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list, partition_by_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on left table with no partition col

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_date_increment_create.groovy
@@ -336,12 +336,12 @@ suite("cross_join_range_date_increment_create", "increment_create") {
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12,
                         mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -366,9 +366,9 @@ suite("cross_join_range_date_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_date_increment_create.groovy
@@ -175,17 +175,23 @@ suite("cross_join_range_date_increment_create", "increment_create") {
         assert (refresh_info[0][5] == "100.00% (6/6)")
     }
 
+    // use a fresh l_orderkey each call so the change is a new group, not a group-by-folded duplicate
+    def primary_change_counter = 100
     def primary_tb_change = {
         sql """
-        insert into lineitem_cross_2 values 
-        (2, 3, 2, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17');
+        insert into lineitem_cross_2 values
+        (${primary_change_counter}, 3, 2, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17');
         """
+        primary_change_counter++
     }
+    // use a fresh o_orderkey each call so the change is a new group, not a group-by-folded duplicate
+    def slave_change_counter = 100
     def slave_tb_change = {
         sql"""
-        insert into orders_cross_2 values 
-        (2, 5, 'ok', 99.5, 'a', 'b', 1, 'yy', '2023-10-17'); 
+        insert into orders_cross_2 values
+        (${slave_change_counter}, 5, 'ok', 99.5, 'a', 'b', 1, 'yy', '2023-10-17');
         """
+        slave_change_counter++
     }
 
     // no window func + on partition col
@@ -392,5 +398,120 @@ suite("cross_join_range_date_increment_create", "increment_create") {
                       mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_not_part_col_right, slave_tb_change, is_complete_change)
+
+    // Focused cases the cross-join matrix above cannot express: identity/equality-class partition-key
+    // matching and the global-limit guard. Dedicated tables keep them isolated from the matrix state.
+    sql "drop table if exists identity_left"
+    sql "drop table if exists identity_right"
+    sql """CREATE TABLE identity_left (
+      id BIGINT NULL,
+      score BIGINT NULL,
+      p DATE NOT NULL
+    ) ENGINE=OLAP DUPLICATE KEY(id)
+    auto partition by range (date_trunc(`p`, 'day')) ()
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES ("replication_allocation" = "tag.location.default: 1");"""
+    // identity_right is defined identically to identity_left so only slot/exprId identity, not
+    // catalog Column.equals, can distinguish identity_left.p from identity_right.p
+    sql """CREATE TABLE identity_right (
+      id BIGINT NULL,
+      score BIGINT NULL,
+      p DATE NOT NULL
+    ) ENGINE=OLAP DUPLICATE KEY(id)
+    auto partition by range (date_trunc(`p`, 'day')) ()
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES ("replication_allocation" = "tag.location.default: 1");"""
+    sql """insert into identity_left values (1,10,'2023-10-17'),(2,20,'2023-10-18');"""
+    sql """insert into identity_right values (1,5,'2023-10-17'),(2,50,'2023-10-18');"""
+    sql """analyze table identity_left with sync;"""
+    sql """analyze table identity_right with sync;"""
+
+    def identity_mv = "mv_identity_focus"
+    def drop_identity_mv = {
+        sql """DROP MATERIALIZED VIEW IF EXISTS ${identity_mv};"""
+        sql """DROP TABLE IF EXISTS ${identity_mv};"""
+    }
+
+    // negative: unrelated same-schema column (window partition by identity_right.p, no equality) must be rejected
+    drop_identity_mv()
+    test {
+        sql """
+        CREATE MATERIALIZED VIEW ${identity_mv}
+        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+        partition by(p)
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
+        AS
+        select identity_left.p, identity_left.id,
+        count(identity_right.score) over (partition by identity_right.p order by identity_right.id) as wc
+        from identity_left cross join identity_right
+        """
+        exception "Unable to find a suitable base table for partitioning"
+    }
+
+    // negative: global-limit PartitionTopN (order by rn limit N over a window) is not partition-local
+    drop_identity_mv()
+    test {
+        sql """
+        CREATE MATERIALIZED VIEW ${identity_mv}
+        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+        partition by(p)
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
+        AS
+        select p, id, rn from (
+          select identity_left.p as p, identity_left.id as id,
+          row_number() over (partition by identity_left.p order by identity_left.score desc) as rn
+          from identity_left
+        ) v order by rn limit 5
+        """
+        exception "Unable to find a suitable base table for partitioning"
+    }
+
+    // positive: inner-join equality identity_left.p = identity_right.p accepts window partition by identity_right.p; expect PARTIAL refresh
+    drop_identity_mv()
+    sql """
+    CREATE MATERIALIZED VIEW ${identity_mv}
+    BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+    partition by(p)
+    DISTRIBUTED BY RANDOM BUCKETS 2
+    PROPERTIES ('replication_num' = '1')
+    AS
+    select identity_left.p, identity_left.id,
+    count(identity_right.score) over (partition by identity_right.p order by identity_right.id) as wc
+    from identity_left inner join identity_right on identity_left.p = identity_right.p
+    """
+    def identity_job = getJobName(db, identity_mv)
+    waitingMTMVTaskFinishedWithoutAnalyze(identity_job)
+    sql """insert into identity_left values (100, 999, '2023-10-17');"""
+    sql """refresh MATERIALIZED VIEW ${identity_mv} AUTO"""
+    waitingMTMVTaskFinishedWithoutAnalyze(identity_job)
+    def identity_refresh = sql """select Status, RefreshMode, NeedRefreshPartitions, Progress
+        from tasks("type"="mv") where JobName="${identity_job}" order by CreateTime desc limit 1;"""
+    assert (identity_refresh[0][0] == "SUCCESS")
+    assert (identity_refresh[0][1] == "PARTIAL")
+    assert (identity_refresh[0][2] == "[\"p_20231017_20231018\"]")
+    assert (identity_refresh[0][3] == "100.00% (1/1)")
+
+    // positive: forwarding alias p_alias equals the window key identity_left.p despite a different ExprId
+    drop_identity_mv()
+    sql """
+    CREATE MATERIALIZED VIEW ${identity_mv}
+    BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+    partition by(p_alias)
+    DISTRIBUTED BY RANDOM BUCKETS 2
+    PROPERTIES ('replication_num' = '1')
+    AS
+    select p_alias, id, wc from (
+      select identity_left.p as p_alias, identity_left.id as id,
+      count(identity_left.score) over (partition by identity_left.p order by identity_left.id) as wc
+      from identity_left
+    ) v
+    """
+    def alias_job = getJobName(db, identity_mv)
+    waitingMTMVTaskFinishedWithoutAnalyze(alias_job)
+    def alias_built = sql """select Status from tasks("type"="mv") where JobName="${alias_job}" order by CreateTime desc limit 1;"""
+    assert (alias_built[0][0] == "SUCCESS")
+    drop_identity_mv()
 
 }

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/cross_join_range_number_increment_create.groovy
@@ -351,7 +351,7 @@ suite("cross_join_range_number_increment_create", "increment_create") {
 
     // change left table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -376,9 +376,9 @@ suite("cross_join_range_number_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_list_str_increment_create.groovy
@@ -370,7 +370,7 @@ suite("inner_join_list_str_increment_create", "increment_create") {
 
     // change left table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -382,7 +382,7 @@ suite("inner_join_list_str_increment_create", "increment_create") {
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = [mv_sql_1, mv_sql_3]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
@@ -396,7 +396,7 @@ suite("inner_join_list_str_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = [mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     sql_complete_list = [mv_sql_1, mv_sql_3]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
@@ -411,7 +411,7 @@ suite("inner_join_list_str_increment_create", "increment_create") {
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_date_increment_create.groovy
@@ -361,7 +361,7 @@ suite("inner_join_range_date_increment_create", "increment_create") {
 
     // change left table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -386,9 +386,9 @@ suite("inner_join_range_date_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
     sql_increment_list = [mv_sql_1, mv_sql_3]
-    sql_complete_list = [mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_13]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/inner_join_range_number_increment_create.groovy
@@ -371,7 +371,7 @@ suite("inner_join_range_number_increment_create", "increment_create") {
 
     // change left table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -382,7 +382,7 @@ suite("inner_join_range_number_increment_create", "increment_create") {
             partition_by_not_part_col, primary_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = []
     sql_complete_list = [mv_sql_1, mv_sql_3]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
@@ -396,7 +396,7 @@ suite("inner_join_range_number_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_17, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = [mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_14]
     sql_complete_list = [mv_sql_1, mv_sql_3]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
@@ -411,7 +411,7 @@ suite("inner_join_range_number_increment_create", "increment_create") {
             partition_by_not_part_col, slave_tb_change, is_complete_change)
 
     // create mv base on right table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_14, mv_sql_15, mv_sql_16, mv_sql_18]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12, mv_sql_13, mv_sql_15, mv_sql_16, mv_sql_18]
     sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_11, mv_sql_17]
     sql_complete_list = []
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_list_str_increment_create.groovy
@@ -302,12 +302,12 @@ suite("left_anti_join_list_str_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -328,9 +328,9 @@ suite("left_anti_join_list_str_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_date_increment_create.groovy
@@ -298,7 +298,7 @@ suite("left_anti_join_range_date_increment_create", "increment_create") {
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -319,9 +319,9 @@ suite("left_anti_join_range_date_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_anti_join_range_number_increment_create.groovy
@@ -301,13 +301,13 @@ suite("left_anti_join_range_number_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
     def sql_error_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -328,9 +328,9 @@ suite("left_anti_join_range_number_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_list_str_increment_create.groovy
@@ -302,12 +302,12 @@ suite("left_join_list_str_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -328,9 +328,9 @@ suite("left_join_list_str_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_date_increment_create.groovy
@@ -293,12 +293,12 @@ suite("left_join_range_date_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -319,9 +319,9 @@ suite("left_join_range_date_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_join_range_number_increment_create.groovy
@@ -306,7 +306,7 @@ suite("left_join_range_number_increment_create", "increment_create") {
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -327,9 +327,9 @@ suite("left_join_range_number_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_list_str_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_list_str_increment_create.groovy
@@ -302,12 +302,12 @@ suite("left_semi_join_list_str_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -328,9 +328,9 @@ suite("left_semi_join_list_str_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_date_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_date_increment_create.groovy
@@ -293,12 +293,12 @@ suite("left_semi_join_range_date_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     def sql_complete_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    def sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -319,9 +319,9 @@ suite("left_semi_join_range_date_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_8, mv_sql_9, mv_sql_11, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_10]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 

--- a/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_number_increment_create.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/increment_create/left_semi_join_range_number_increment_create.groovy
@@ -301,13 +301,13 @@ suite("left_semi_join_range_number_increment_create", "increment_create") {
     }
 
     def sql_all_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_7, mv_sql_8, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
-    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    def sql_increment_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     def sql_complete_list = []
     def sql_error_list = []
 
     // change left table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, primary_tb_change, is_complete_change)
 
@@ -328,9 +328,9 @@ suite("left_semi_join_range_number_increment_create", "increment_create") {
 
     // change right table data
     // create mv base on left table with partition col
-    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_11, mv_sql_12]
+    sql_error_list = [mv_sql_7, mv_sql_9, mv_sql_10, mv_sql_12]
     sql_increment_list = []
-    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8]
+    sql_complete_list = [mv_sql_1, mv_sql_3, mv_sql_4, mv_sql_6, mv_sql_8, mv_sql_11]
     list_judgement(sql_all_list, sql_increment_list, sql_complete_list, sql_error_list,
             partition_by_part_col, slave_tb_change, is_complete_change)
 


### PR DESCRIPTION
Problem Summary:
MV partition tracking could reject valid partitioned MVs when an aggregate, window, or rewritten PartitionTopN exists on a branch that does not carry the MV partition column. A typical case is a left join where the MV partitions by the left table column, while the right subquery has row_number() or group by on unrelated keys.

Solution:
Gate aggregate/window/partition-topn partition-key validation by whether the current plan output contains a tracked MV partition slot. Add LogicalPartitionTopN handling for rewritten row_number ... rn = 1