### PR TITLE
[opt](paimon) Optimize PAIMON JNI memory with reuse jni scanner

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -1012,8 +1012,15 @@ void FileScanner::_fill_base_init_context(ReaderInitContext* ctx) {
 Status FileScanner::_get_next_reader() {
     while (true) {
         if (_cur_reader) {
-            _cur_reader->collect_profile_before_close();
-            RETURN_IF_ERROR(_cur_reader->close());
+            if (auto* paimon_jni_reader = dynamic_cast<PaimonJniReader*>(_cur_reader.get());
+                paimon_jni_reader != nullptr) {
+                RETURN_IF_ERROR(paimon_jni_reader->finish_split());
+                DORIS_CHECK(_cached_paimon_jni_reader == nullptr);
+                _cached_paimon_jni_reader = std::move(_cur_reader);
+            } else {
+                _cur_reader->collect_profile_before_close();
+                RETURN_IF_ERROR(_cur_reader->close());
+            }
             _state->update_num_finished_scan_range(1);
         }
         _cur_reader.reset(nullptr);
@@ -1134,11 +1141,29 @@ Status FileScanner::_get_next_reader() {
                             static_cast<GenericReader*>(cpp_reader.get())->init_reader(&jni_ctx);
                     _cur_reader = std::move(cpp_reader);
                 } else {
-                    auto paimon_reader = PaimonJniReader::create_unique(_file_slot_descs, _state,
-                                                                        _profile, range, _params);
-                    init_status =
-                            static_cast<GenericReader*>(paimon_reader.get())->init_reader(&jni_ctx);
-                    _cur_reader = std::move(paimon_reader);
+                    if (_cached_paimon_jni_reader != nullptr) {
+                        auto* cached_reader =
+                                dynamic_cast<PaimonJniReader*>(_cached_paimon_jni_reader.get());
+                        DORIS_CHECK(cached_reader != nullptr);
+                        if (cached_reader->can_reuse_for(range)) {
+                            _cur_reader = std::move(_cached_paimon_jni_reader);
+                            init_status = cached_reader->prepare_split(range, &jni_ctx);
+                        } else {
+                            _cached_paimon_jni_reader->collect_profile_before_close();
+                            RETURN_IF_ERROR(_cached_paimon_jni_reader->close());
+                            _cached_paimon_jni_reader.reset();
+                        }
+                    }
+                    if (_cur_reader == nullptr) {
+                        auto paimon_reader = PaimonJniReader::create_unique(
+                                _file_slot_descs, _state, _profile, range, _params);
+                        init_status = static_cast<GenericReader*>(paimon_reader.get())
+                                              ->init_reader(&jni_ctx);
+                        if (init_status.ok()) {
+                            init_status = paimon_reader->prepare_split(range, &jni_ctx);
+                        }
+                        _cur_reader = std::move(paimon_reader);
+                    }
                 }
             } else if (range.__isset.table_format_params &&
                        range.table_format_params.table_format_type == "hudi") {
@@ -2059,6 +2084,9 @@ Status FileScanner::close(RuntimeState* state) {
     if (_cur_reader) {
         RETURN_IF_ERROR(_cur_reader->close());
     }
+    if (_cached_paimon_jni_reader) {
+        RETURN_IF_ERROR(_cached_paimon_jni_reader->close());
+    }
 
     RETURN_IF_ERROR(Scanner::close(state));
     return Status::OK();
@@ -2144,6 +2172,9 @@ void FileScanner::_collect_profile_before_close() {
 
     if (_cur_reader != nullptr) {
         _cur_reader->collect_profile_before_close();
+    }
+    if (_cached_paimon_jni_reader != nullptr) {
+        _cached_paimon_jni_reader->collect_profile_before_close();
     }
 
     FileScanLocalState* local_state = static_cast<FileScanLocalState*>(_local_state);

--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -1066,6 +1066,10 @@ Status FileScanner::_get_next_reader() {
         Status init_status = Status::OK();
         TFileFormatType::type format_type = _get_current_format_type();
         const bool is_position_deletes_sys_table = is_iceberg_position_deletes_sys_table(range);
+        const bool is_table_level_count = _get_push_down_agg_type() == TPushAggOp::type::COUNT &&
+                                          range.__isset.table_format_params &&
+                                          range.table_format_params.table_level_row_count >= 0;
+        bool count_reader_initialized = false;
         // for compatibility, this logic is deprecated in 3.1
         if (format_type == TFileFormatType::FORMAT_JNI && range.__isset.table_format_params) {
             if (range.table_format_params.table_format_type == "paimon" &&
@@ -1140,6 +1144,13 @@ Status FileScanner::_get_next_reader() {
                     init_status =
                             static_cast<GenericReader*>(cpp_reader.get())->init_reader(&jni_ctx);
                     _cur_reader = std::move(cpp_reader);
+                } else if (is_table_level_count) {
+                    // The FE-provided count is complete, so this split does not need Paimon's
+                    // table-level Java scanner. Keep any scanner cached from an earlier data split
+                    // available for the next data split.
+                    _cur_reader = std::make_unique<CountReader>(
+                            range.table_format_params.table_level_row_count, _state->batch_size());
+                    count_reader_initialized = true;
                 } else {
                     if (_cached_paimon_jni_reader != nullptr) {
                         auto* cached_reader =
@@ -1373,9 +1384,6 @@ Status FileScanner::_get_next_reader() {
         // For table-level COUNT pushdown, offsets are undefined so we must skip
         // _set_fill_or_truncate_columns (it uses [start_offset, end_offset] to
         // filter row groups, which would produce incorrect empty results).
-        bool is_table_level_count = _get_push_down_agg_type() == TPushAggOp::type::COUNT &&
-                                    range.__isset.table_format_params &&
-                                    range.table_format_params.table_level_row_count >= 0;
         if (!is_table_level_count) {
             Status status = _set_fill_or_truncate_columns(need_to_get_parsed_schema);
             if (status.is<END_OF_FILE>()) { // all parquet row groups are filtered
@@ -1388,7 +1396,8 @@ Status FileScanner::_get_next_reader() {
 
         // Unified COUNT(*) pushdown: replace the real reader with CountReader
         // decorator if the reader accepts COUNT and can provide a total row count.
-        if (_cur_reader->get_push_down_agg_type() == TPushAggOp::type::COUNT) {
+        if (!count_reader_initialized &&
+            _cur_reader->get_push_down_agg_type() == TPushAggOp::type::COUNT) {
             int64_t total_rows = -1;
             if (is_table_level_count) {
                 // FE-provided count (may account for table-format deletions)

--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -2081,11 +2081,27 @@ Status FileScanner::close(RuntimeState* state) {
 
     _finalize_reader_condition_cache();
 
-    if (_cur_reader) {
-        RETURN_IF_ERROR(_cur_reader->close());
-    }
-    if (_cached_paimon_jni_reader) {
-        RETURN_IF_ERROR(_cached_paimon_jni_reader->close());
+    Status close_status = Status::OK();
+    auto close_retained_reader = [&close_status](std::unique_ptr<GenericReader>& reader) {
+        if (reader == nullptr) {
+            return;
+        }
+
+        auto status = reader->close();
+        if (status.ok()) {
+            reader.reset();
+        } else if (close_status.ok()) {
+            // Continue closing the other retained reader, but report the first failure.
+            close_status = std::move(status);
+        }
+    };
+    close_retained_reader(_cur_reader);
+    close_retained_reader(_cached_paimon_jni_reader);
+    if (!close_status.ok()) {
+        // _try_close() reserves the close attempt before reader cleanup. Restore the state so a
+        // later close can retry any retained reader whose cleanup failed.
+        _is_closed.store(false);
+        return close_status;
     }
 
     RETURN_IF_ERROR(Scanner::close(state));

--- a/be/src/exec/scan/file_scanner.h
+++ b/be/src/exec/scan/file_scanner.h
@@ -151,6 +151,9 @@ protected:
     TFileRangeDesc _current_range;
 
     std::unique_ptr<GenericReader> _cur_reader;
+    // A Paimon JNI scanner owns table-level Java resources that are independent of one logical
+    // split. Keep it here while native or C++ Paimon splits are processed.
+    std::unique_ptr<GenericReader> _cached_paimon_jni_reader;
     bool _cur_reader_eof = false;
     // File source slot descriptors
     std::vector<SlotDescriptor*> _file_slot_descs;

--- a/be/src/format/jni/jni_reader.cpp
+++ b/be/src/format/jni/jni_reader.cpp
@@ -260,21 +260,41 @@ Status JniReader::get_table_schema(std::string& table_schema_str) {
 // =========================================================================
 
 Status JniReader::close() {
-    if (!_closed) {
-        _closed = true;
-        JNIEnv* env = nullptr;
-        RETURN_IF_ERROR(Jni::Env::Get(&env));
-        if (_scanner_opened) {
-            RETURN_IF_ERROR(_publish_current_split_profile(env));
-
-            // _fill_block may be failed and returned, we should release table in close.
-            // org.apache.doris.common.jni.JniScanner#releaseTable is idempotent
-            RETURN_IF_ERROR(
-                    _jni_scanner_obj.call_void_method(env, _jni_scanner_release_table).call());
-            RETURN_IF_ERROR(_jni_scanner_obj.call_void_method(env, _jni_scanner_close).call());
-        }
+    if (_closed) {
+        return Status::OK();
     }
-    return Status::OK();
+    auto close_status = _close_jni_scanner();
+    if (close_status.ok()) {
+        _closed = true;
+    }
+    return close_status;
+}
+
+Status JniReader::_close_jni_scanner() {
+    if (!_scanner_opened) {
+        return Status::OK();
+    }
+
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    const auto profile_status = _publish_current_split_profile(env);
+    if (!profile_status.ok()) {
+        // Profile collection is best effort and must not prevent Java resource cleanup.
+        LOG(WARNING) << "failed to collect JNI profile during close: " << profile_status;
+    }
+
+    // _fill_block may fail before releasing the current Java table. releaseTable() is idempotent,
+    // and Java close must still run if it fails so connector resources can be released.
+    auto cleanup_status = _jni_scanner_obj.call_void_method(env, _jni_scanner_release_table).call();
+    auto java_close_status = _jni_scanner_obj.call_void_method(env, _jni_scanner_close).call();
+    if (cleanup_status.ok() && !java_close_status.ok()) {
+        cleanup_status = std::move(java_close_status);
+    }
+    if (cleanup_status.ok()) {
+        _scanner_opened = false;
+    }
+    // Keep the Java object and opened state on failure so close() can retry the cleanup.
+    return cleanup_status;
 }
 
 // =========================================================================

--- a/be/src/format/jni/jni_reader.cpp
+++ b/be/src/format/jni/jni_reader.cpp
@@ -322,6 +322,10 @@ Status JniReader::_init_jni_scanner(JNIEnv* env, int batch_size) {
                                                 &_jni_scanner_get_statistics));
     RETURN_IF_ERROR(
             _jni_scanner_cls.get_method(env, "setBatchSize", "(I)V", &_jni_scanner_set_batch_size));
+    RETURN_IF_ERROR(_jni_scanner_cls.get_method(env, "prepareForSplit", "(Ljava/util/Map;)V",
+                                                &_jni_scanner_prepare_for_split));
+    RETURN_IF_ERROR(_jni_scanner_cls.get_method(env, "resetCurrentSplit", "()V",
+                                                &_jni_scanner_reset_current_split));
     return Status::OK();
 }
 

--- a/be/src/format/jni/jni_reader.cpp
+++ b/be/src/format/jni/jni_reader.cpp
@@ -159,6 +159,52 @@ Status JniReader::open(RuntimeState* state, RuntimeProfile* profile) {
     return Status::OK();
 }
 
+Status JniReader::publish_current_split_profile() {
+    if (_profile == nullptr) {
+        return Status::OK();
+    }
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    return _publish_current_split_profile(env);
+}
+
+Status JniReader::_publish_current_split_profile(JNIEnv* env) {
+    DORIS_CHECK(env != nullptr);
+    if (_profile == nullptr) {
+        return Status::OK();
+    }
+
+    COUNTER_UPDATE(_open_scanner_time, _jni_scanner_open_watcher);
+    COUNTER_UPDATE(_fill_block_time, _fill_block_watcher);
+
+    RETURN_ERROR_IF_EXC(env);
+    jlong append_data_time = 0;
+    RETURN_IF_ERROR(_jni_scanner_obj.call_long_method(env, _jni_scanner_get_append_data_time)
+                            .call(&append_data_time));
+    jlong create_vector_table_time = 0;
+    RETURN_IF_ERROR(
+            _jni_scanner_obj.call_long_method(env, _jni_scanner_get_create_vector_table_time)
+                    .call(&create_vector_table_time));
+
+    const auto append_data_time_delta = append_data_time - _java_append_data_time_snapshot;
+    const auto create_vector_table_time_delta =
+            create_vector_table_time - _java_create_vector_table_time_snapshot;
+    COUNTER_UPDATE(_java_append_data_time, append_data_time_delta);
+    COUNTER_UPDATE(_java_create_vector_table_time, create_vector_table_time_delta);
+    COUNTER_UPDATE(_java_scan_time,
+                   _java_scan_watcher - append_data_time_delta - create_vector_table_time_delta);
+    const auto split_time = _jni_scanner_open_watcher + _fill_block_watcher + _java_scan_watcher;
+    if (split_time > 0) {
+        _max_time_split_weight_counter->conditional_update(split_time, _self_split_weight);
+    }
+    _jni_scanner_open_watcher = 0;
+    _java_scan_watcher = 0;
+    _fill_block_watcher = 0;
+    _java_append_data_time_snapshot = append_data_time;
+    _java_create_vector_table_time_snapshot = create_vector_table_time;
+    return Status::OK();
+}
+
 // =========================================================================
 // JniReader::_do_get_next_block  (merged from JniConnector::get_next_block)
 // =========================================================================
@@ -219,34 +265,7 @@ Status JniReader::close() {
         JNIEnv* env = nullptr;
         RETURN_IF_ERROR(Jni::Env::Get(&env));
         if (_scanner_opened) {
-            if (_profile) {
-                COUNTER_UPDATE(_open_scanner_time, _jni_scanner_open_watcher);
-                COUNTER_UPDATE(_fill_block_time, _fill_block_watcher);
-            }
-
-            RETURN_ERROR_IF_EXC(env);
-            jlong _append = 0;
-            RETURN_IF_ERROR(
-                    _jni_scanner_obj.call_long_method(env, _jni_scanner_get_append_data_time)
-                            .call(&_append));
-
-            if (_profile) {
-                COUNTER_UPDATE(_java_append_data_time, _append);
-            }
-
-            jlong _create = 0;
-            RETURN_IF_ERROR(
-                    _jni_scanner_obj
-                            .call_long_method(env, _jni_scanner_get_create_vector_table_time)
-                            .call(&_create));
-
-            if (_profile) {
-                COUNTER_UPDATE(_java_create_vector_table_time, _create);
-                COUNTER_UPDATE(_java_scan_time, _java_scan_watcher - _append - _create);
-                _max_time_split_weight_counter->conditional_update(
-                        _jni_scanner_open_watcher + _fill_block_watcher + _java_scan_watcher,
-                        _self_split_weight);
-            }
+            RETURN_IF_ERROR(_publish_current_split_profile(env));
 
             // _fill_block may be failed and returned, we should release table in close.
             // org.apache.doris.common.jni.JniScanner#releaseTable is idempotent

--- a/be/src/format/jni/jni_reader.h
+++ b/be/src/format/jni/jni_reader.h
@@ -135,6 +135,14 @@ protected:
         _column_names = std::move(column_names);
     }
 
+    Jni::GlobalObject& jni_scanner_obj() { return _jni_scanner_obj; }
+    const Jni::MethodId& jni_scanner_prepare_for_split() const {
+        return _jni_scanner_prepare_for_split;
+    }
+    const Jni::MethodId& jni_scanner_reset_current_split() const {
+        return _jni_scanner_reset_current_split;
+    }
+
     const std::vector<SlotDescriptor*>& _file_slot_descs;
     RuntimeState* _state = nullptr;
     RuntimeProfile* _profile = nullptr;
@@ -182,6 +190,8 @@ private:
     Jni::MethodId _jni_scanner_release_table;
     Jni::MethodId _jni_scanner_get_statistics;
     Jni::MethodId _jni_scanner_set_batch_size;
+    Jni::MethodId _jni_scanner_prepare_for_split;
+    Jni::MethodId _jni_scanner_reset_current_split;
 
     JniDataBridge::TableMetaAddress _table_meta;
     size_t _batch_size = 0;

--- a/be/src/format/jni/jni_reader.h
+++ b/be/src/format/jni/jni_reader.h
@@ -142,6 +142,10 @@ protected:
     const Jni::MethodId& jni_scanner_reset_current_split() const {
         return _jni_scanner_reset_current_split;
     }
+    Status publish_current_split_profile();
+    void set_self_split_weight(int64_t weight) {
+        _self_split_weight = static_cast<int32_t>(weight);
+    }
 
     const std::vector<SlotDescriptor*>& _file_slot_descs;
     RuntimeState* _state = nullptr;
@@ -154,6 +158,7 @@ private:
     Status _init_jni_scanner(JNIEnv* env, int batch_size);
     Status _fill_block(Block* block, size_t num_rows);
     Status _get_statistics(JNIEnv* env, std::map<std::string, std::string>* result);
+    Status _publish_current_split_profile(JNIEnv* env);
 
     std::string _connector_name;
     std::string _connector_class;
@@ -172,6 +177,8 @@ private:
     int64_t _jni_scanner_open_watcher = 0;
     int64_t _java_scan_watcher = 0;
     int64_t _fill_block_watcher = 0;
+    jlong _java_append_data_time_snapshot = 0;
+    jlong _java_create_vector_table_time_snapshot = 0;
 
     size_t _has_read = 0;
 

--- a/be/src/format/jni/jni_reader.h
+++ b/be/src/format/jni/jni_reader.h
@@ -146,6 +146,7 @@ protected:
     void set_self_split_weight(int64_t weight) {
         _self_split_weight = static_cast<int32_t>(weight);
     }
+    virtual Status _close_jni_scanner();
 
     const std::vector<SlotDescriptor*>& _file_slot_descs;
     RuntimeState* _state = nullptr;

--- a/be/src/format/table/paimon_jni_reader.cpp
+++ b/be/src/format/table/paimon_jni_reader.cpp
@@ -149,6 +149,7 @@ Status PaimonJniReader::prepare_split(const TFileRangeDesc& range, ReaderInitCon
         return Status::OK();
     }
 
+    set_self_split_weight(range.__isset.self_split_weight ? range.self_split_weight : -1);
     RETURN_IF_ERROR(prepare_jni_scanner_for_split(range));
     _current_split_prepared = true;
     return Status::OK();
@@ -158,6 +159,7 @@ Status PaimonJniReader::finish_split() {
     if (!_current_split_prepared) {
         return Status::OK();
     }
+    RETURN_IF_ERROR(publish_current_split_profile());
     RETURN_IF_ERROR(reset_jni_scanner_current_split());
     _current_split_prepared = false;
     return Status::OK();

--- a/be/src/format/table/paimon_jni_reader.cpp
+++ b/be/src/format/table/paimon_jni_reader.cpp
@@ -17,6 +17,7 @@
 
 #include "paimon_jni_reader.h"
 
+#include <algorithm>
 #include <map>
 #include <string_view>
 #include <vector>
@@ -51,68 +52,7 @@ PaimonJniReader::PaimonJniReader(const std::vector<SlotDescriptor*>& file_slot_d
                                  const TFileScanRangeParams* range_params)
         : JniReader(
                   file_slot_descs, state, profile, "org/apache/doris/paimon/PaimonJniScanner",
-                  [&]() {
-                      std::vector<std::string> column_names;
-                      std::vector<std::string> column_types;
-                      for (const auto& desc : file_slot_descs) {
-                          column_names.emplace_back(desc->col_name());
-                          column_types.emplace_back(
-                                  JniDataBridge::get_jni_type_with_different_string(desc->type()));
-                      }
-                      const auto& paimon_params = range.table_format_params.paimon_params;
-                      std::map<String, String> params;
-                      params["paimon_split"] = paimon_params.paimon_split;
-                      if (range_params->__isset.paimon_predicate &&
-                          !range_params->paimon_predicate.empty()) {
-                          params["paimon_predicate"] = range_params->paimon_predicate;
-                      } else if (paimon_params.__isset.paimon_predicate) {
-                          params["paimon_predicate"] = paimon_params.paimon_predicate;
-                      }
-                      params["required_fields"] = join(column_names, ",");
-                      params["columns_types"] = join(column_types, "#");
-                      params["time_zone"] = state->timezone();
-                      if (range_params->__isset.serialized_table) {
-                          params["serialized_table"] = range_params->serialized_table;
-                      }
-                      if (range_params->__isset.paimon_options &&
-                          !range_params->paimon_options.empty()) {
-                          for (const auto& kv : range_params->paimon_options) {
-                              params[PAIMON_OPTION_PREFIX + kv.first] = kv.second;
-                          }
-                      } else if (paimon_params.__isset.paimon_options) {
-                          for (const auto& kv : paimon_params.paimon_options) {
-                              params[PAIMON_OPTION_PREFIX + kv.first] = kv.second;
-                          }
-                      }
-                      const std::string enable_io_manager_key =
-                              PAIMON_OPTION_PREFIX + DORIS_ENABLE_JNI_IO_MANAGER;
-                      const std::string io_manager_tmp_dir_key =
-                              PAIMON_OPTION_PREFIX + DORIS_JNI_IO_MANAGER_TMP_DIR;
-                      auto enable_io_manager_it = params.find(enable_io_manager_key);
-                      if (enable_io_manager_it != params.end() &&
-                          iequal(enable_io_manager_it->second, "true") &&
-                          params.find(io_manager_tmp_dir_key) == params.end()) {
-                          std::vector<std::string> tmp_dirs;
-                          for (const auto& store_path : state->exec_env()->store_paths()) {
-                              tmp_dirs.push_back(store_path.path + "/" +
-                                                 std::string(PAIMON_JNI_SCANNER_IO_TMP_DIR));
-                          }
-                          DORIS_CHECK(!tmp_dirs.empty());
-                          // Paimon's IOManager creates and later removes its own paimon-* child
-                          // directory under these Doris storage-root scoped parent directories.
-                          params[io_manager_tmp_dir_key] = join(tmp_dirs, ":");
-                      }
-                      if (range_params->__isset.properties && !range_params->properties.empty()) {
-                          for (const auto& kv : range_params->properties) {
-                              params[HADOOP_OPTION_PREFIX + kv.first] = kv.second;
-                          }
-                      } else if (paimon_params.__isset.hadoop_conf) {
-                          for (const auto& kv : paimon_params.hadoop_conf) {
-                              params[HADOOP_OPTION_PREFIX + kv.first] = kv.second;
-                          }
-                      }
-                      return params;
-                  }(),
+                  build_scanner_params(file_slot_descs, state, range, range_params),
                   [&]() {
                       std::vector<std::string> names;
                       for (const auto& desc : file_slot_descs) {
@@ -120,12 +60,133 @@ PaimonJniReader::PaimonJniReader(const std::vector<SlotDescriptor*>& file_slot_d
                       }
                       return names;
                   }(),
-                  range.__isset.self_split_weight ? range.self_split_weight : -1) {
-    if (range.table_format_params.__isset.table_level_row_count) {
-        _remaining_table_level_row_count = range.table_format_params.table_level_row_count;
-    } else {
-        _remaining_table_level_row_count = -1;
+                  range.__isset.self_split_weight ? range.self_split_weight : -1),
+          _range_params(range_params),
+          _scanner_params_signature(
+                  build_scanner_params(file_slot_descs, state, range, range_params)) {
+    set_remaining_table_level_row_count(range);
+}
+
+std::map<std::string, std::string> PaimonJniReader::build_scanner_params(
+        const std::vector<SlotDescriptor*>& file_slot_descs, RuntimeState* state,
+        const TFileRangeDesc& range, const TFileScanRangeParams* range_params) {
+    DORIS_CHECK(state != nullptr);
+    DORIS_CHECK(range_params != nullptr);
+    std::vector<std::string> column_names;
+    std::vector<std::string> column_types;
+    column_names.reserve(file_slot_descs.size());
+    column_types.reserve(file_slot_descs.size());
+    for (const auto* desc : file_slot_descs) {
+        column_names.emplace_back(desc->col_name());
+        column_types.emplace_back(JniDataBridge::get_jni_type_with_different_string(desc->type()));
     }
+
+    const auto& paimon_params = range.table_format_params.paimon_params;
+    std::map<std::string, std::string> params;
+    if (range_params->__isset.paimon_predicate && !range_params->paimon_predicate.empty()) {
+        params["paimon_predicate"] = range_params->paimon_predicate;
+    } else if (paimon_params.__isset.paimon_predicate) {
+        params["paimon_predicate"] = paimon_params.paimon_predicate;
+    }
+    params["required_fields"] = join(column_names, ",");
+    params["columns_types"] = join(column_types, "#");
+    params["time_zone"] = state->timezone();
+    if (range_params->__isset.serialized_table) {
+        params["serialized_table"] = range_params->serialized_table;
+    }
+    if (range_params->__isset.paimon_options && !range_params->paimon_options.empty()) {
+        for (const auto& kv : range_params->paimon_options) {
+            params[PAIMON_OPTION_PREFIX + kv.first] = kv.second;
+        }
+    } else if (paimon_params.__isset.paimon_options) {
+        for (const auto& kv : paimon_params.paimon_options) {
+            params[PAIMON_OPTION_PREFIX + kv.first] = kv.second;
+        }
+    }
+    const std::string enable_io_manager_key = PAIMON_OPTION_PREFIX + DORIS_ENABLE_JNI_IO_MANAGER;
+    const std::string io_manager_tmp_dir_key = PAIMON_OPTION_PREFIX + DORIS_JNI_IO_MANAGER_TMP_DIR;
+    const auto enable_io_manager_it = params.find(enable_io_manager_key);
+    if (enable_io_manager_it != params.end() && iequal(enable_io_manager_it->second, "true") &&
+        params.find(io_manager_tmp_dir_key) == params.end()) {
+        std::vector<std::string> tmp_dirs;
+        const auto& store_paths = state->exec_env()->store_paths();
+        tmp_dirs.reserve(store_paths.size());
+        for (const auto& store_path : store_paths) {
+            tmp_dirs.push_back(store_path.path + "/" + std::string(PAIMON_JNI_SCANNER_IO_TMP_DIR));
+        }
+        DORIS_CHECK(!tmp_dirs.empty());
+        params[io_manager_tmp_dir_key] = join(tmp_dirs, ":");
+    }
+    if (range_params->__isset.properties && !range_params->properties.empty()) {
+        for (const auto& kv : range_params->properties) {
+            params[HADOOP_OPTION_PREFIX + kv.first] = kv.second;
+        }
+    } else if (paimon_params.__isset.hadoop_conf) {
+        for (const auto& kv : paimon_params.hadoop_conf) {
+            params[HADOOP_OPTION_PREFIX + kv.first] = kv.second;
+        }
+    }
+    return params;
+}
+
+void PaimonJniReader::set_remaining_table_level_row_count(const TFileRangeDesc& range) {
+    _remaining_table_level_row_count = range.table_format_params.__isset.table_level_row_count
+                                               ? range.table_format_params.table_level_row_count
+                                               : -1;
+}
+
+bool PaimonJniReader::can_reuse_for(const TFileRangeDesc& range) const {
+    return _scanner_params_signature ==
+           build_scanner_params(_file_slot_descs, _state, range, _range_params);
+}
+
+Status PaimonJniReader::prepare_split(const TFileRangeDesc& range, ReaderInitContext* ctx) {
+    DORIS_CHECK(ctx != nullptr);
+    DORIS_CHECK(!_current_split_prepared);
+    RETURN_IF_ERROR(on_before_init_reader(ctx));
+    set_remaining_table_level_row_count(range);
+    if (_push_down_agg_type == TPushAggOp::type::COUNT && _remaining_table_level_row_count >= 0) {
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(prepare_jni_scanner_for_split(range));
+    _current_split_prepared = true;
+    return Status::OK();
+}
+
+Status PaimonJniReader::finish_split() {
+    if (!_current_split_prepared) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(reset_jni_scanner_current_split());
+    _current_split_prepared = false;
+    return Status::OK();
+}
+
+Status PaimonJniReader::prepare_jni_scanner_for_split(const TFileRangeDesc& range) {
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+
+    Jni::LocalObject hashmap_object;
+    const auto& paimon_params = range.table_format_params.paimon_params;
+    std::map<std::string, std::string> split_params;
+    split_params["paimon_split"] = paimon_params.paimon_split;
+    RETURN_IF_ERROR(Jni::Util::convert_to_java_map(env, split_params, &hashmap_object));
+    RETURN_IF_ERROR(jni_scanner_obj()
+                            .call_void_method(env, jni_scanner_prepare_for_split())
+                            .with_arg(hashmap_object)
+                            .call());
+    RETURN_ERROR_IF_EXC(env);
+    return Status::OK();
+}
+
+Status PaimonJniReader::reset_jni_scanner_current_split() {
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    RETURN_IF_ERROR(
+            jni_scanner_obj().call_void_method(env, jni_scanner_reset_current_split()).call());
+    RETURN_ERROR_IF_EXC(env);
+    return Status::OK();
 }
 
 Status PaimonJniReader::_do_get_next_block(Block* block, size_t* read_rows, bool* eof) {

--- a/be/src/format/table/paimon_jni_reader.h
+++ b/be/src/format/table/paimon_jni_reader.h
@@ -18,14 +18,12 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "common/status.h"
 #include "format/jni/jni_reader.h"
-#include "storage/olap_scan_common.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -58,12 +56,25 @@ public:
     Status _do_get_next_block(Block* block, size_t* read_rows, bool* eof) override;
 
     Status init_reader();
+    Status prepare_split(const TFileRangeDesc& range, ReaderInitContext* ctx);
+    Status finish_split();
+    bool can_reuse_for(const TFileRangeDesc& range) const;
 
 protected:
     Status _do_init_reader(ReaderInitContext* /*ctx*/) override { return init_reader(); }
 
 private:
+    Status prepare_jni_scanner_for_split(const TFileRangeDesc& range);
+    Status reset_jni_scanner_current_split();
+    static std::map<std::string, std::string> build_scanner_params(
+            const std::vector<SlotDescriptor*>& file_slot_descs, RuntimeState* state,
+            const TFileRangeDesc& range, const TFileScanRangeParams* range_params);
+    void set_remaining_table_level_row_count(const TFileRangeDesc& range);
+
+    const TFileScanRangeParams* _range_params = nullptr;
+    std::map<std::string, std::string> _scanner_params_signature;
     int64_t _remaining_table_level_row_count;
+    bool _current_split_prepared = false;
 };
 
 } // namespace doris

--- a/be/src/format/table/paimon_jni_reader.h
+++ b/be/src/format/table/paimon_jni_reader.h
@@ -60,6 +60,12 @@ public:
     Status finish_split();
     bool can_reuse_for(const TFileRangeDesc& range) const;
 
+#ifdef BE_TEST
+    const std::map<std::string, std::string>& TEST_scanner_params_signature() const {
+        return _scanner_params_signature;
+    }
+#endif
+
 protected:
     Status _do_init_reader(ReaderInitContext* /*ctx*/) override { return init_reader(); }
 

--- a/be/src/format_v2/jni/jni_table_reader.cpp
+++ b/be/src/format_v2/jni/jni_table_reader.cpp
@@ -61,7 +61,6 @@ Status JniTableReader::prepare_split(const SplitReadOptions& options) {
         return Status::OK();
     }
     DORIS_CHECK(!_closed);
-    DORIS_CHECK(!_scanner_opened);
     if (_is_table_level_count_active()) {
         return Status::OK();
     }
@@ -74,7 +73,7 @@ Status JniTableReader::prepare_split(const SplitReadOptions& options) {
     }
     // Subclasses populate split-specific scanner params before calling this method, so the Java
     // scanner can be opened here instead of being lazily opened by the first get_block() call.
-    return _open_jni_scanner();
+    return open_jni_scanner_for_split();
 }
 
 Status JniTableReader::get_block(Block* output_block, bool* eos) {
@@ -110,7 +109,7 @@ Status JniTableReader::get_block(Block* output_block, bool* eos) {
         RETURN_IF_ERROR(_get_next_jni_block(&current_rows, &current_eof));
         if (current_eof) {
             _eof = true;
-            RETURN_IF_ERROR(_close_jni_scanner());
+            RETURN_IF_ERROR(close_jni_scanner_for_split());
             *eos = true;
             return Status::OK();
         }
@@ -384,6 +383,10 @@ Status JniTableReader::close() {
     return close_status;
 }
 
+Status JniTableReader::close_jni_scanner_for_split() {
+    return _close_jni_scanner();
+}
+
 Status JniTableReader::_close_jni_scanner() {
     if (!_scanner_opened) {
         JNIEnv* env = nullptr;
@@ -428,7 +431,12 @@ void JniTableReader::_reset_split_state(JNIEnv* env) {
     _split_profile_published = false;
 }
 
+Status JniTableReader::open_jni_scanner_for_split() {
+    return _open_jni_scanner();
+}
+
 Status JniTableReader::_open_jni_scanner() {
+    DORIS_CHECK(!_scanner_opened);
     // subclasses build map<string,string> _scanner_params to JAVA side
     RETURN_IF_ERROR(build_scanner_params(&_scanner_params));
     // subclasses build _jni_columns info to JAVA side, including column name and column type
@@ -542,6 +550,10 @@ Status JniTableReader::_register_jni_class_functions_once(JNIEnv* env) {
                                                 &_jni_scanner_get_statistics));
     RETURN_IF_ERROR(
             _jni_scanner_cls.get_method(env, "setBatchSize", "(I)V", &_jni_scanner_set_batch_size));
+    RETURN_IF_ERROR(_jni_scanner_cls.get_method(env, "prepareForSplit", "(Ljava/util/Map;)V",
+                                                &_jni_scanner_prepare_for_split));
+    RETURN_IF_ERROR(_jni_scanner_cls.get_method(env, "resetCurrentSplit", "()V",
+                                                &_jni_scanner_reset_current_split));
     return Status::OK();
 }
 

--- a/be/src/format_v2/jni/jni_table_reader.cpp
+++ b/be/src/format_v2/jni/jni_table_reader.cpp
@@ -99,7 +99,6 @@ Status JniTableReader::get_block(Block* output_block, bool* eos) {
         // TableReader cancellation contract so a cancelled query does not drain the whole split.
         if (_io_ctx != nullptr && _io_ctx->should_stop) {
             _eof = true;
-            RETURN_IF_ERROR(_close_jni_scanner());
             *eos = true;
             return Status::OK();
         }
@@ -329,10 +328,18 @@ void JniTableReader::_publish_split_profile(JNIEnv* env) {
         return;
     }
 
-    if (_scanner_profile != nullptr) {
-        COUNTER_UPDATE(_open_scanner_time, _jni_scanner_open_watcher);
-        COUNTER_UPDATE(_fill_block_time, _fill_block_watcher);
+    _publish_jni_scanner_split_timing(env);
+
+    _collect_jni_scanner_profile(env);
+}
+
+void JniTableReader::_publish_jni_scanner_split_timing(JNIEnv* env) {
+    if (_scanner_profile == nullptr) {
+        return;
     }
+
+    COUNTER_UPDATE(_open_scanner_time, _jni_scanner_open_watcher);
+    COUNTER_UPDATE(_fill_block_time, _fill_block_watcher);
 
     jlong append_data_time = 0;
     const auto append_time_status =
@@ -350,16 +357,25 @@ void JniTableReader::_publish_split_profile(JNIEnv* env) {
         LOG(WARNING) << "failed to collect JNI vector-table time during close: "
                      << create_table_time_status;
     }
-    if (_scanner_profile != nullptr && append_time_status.ok() && create_table_time_status.ok()) {
-        COUNTER_UPDATE(_java_append_data_time, append_data_time);
-        COUNTER_UPDATE(_java_create_vector_table_time, create_vector_table_time);
-        COUNTER_UPDATE(_java_scan_time,
-                       _java_scan_watcher - append_data_time - create_vector_table_time);
-        _max_time_split_weight_counter->conditional_update(
-                _jni_scanner_open_watcher + _fill_block_watcher + _java_scan_watcher,
-                self_split_weight());
+    if (append_time_status.ok() && create_table_time_status.ok()) {
+        const auto append_data_time_delta = append_data_time - _java_append_data_time_snapshot;
+        const auto create_vector_table_time_delta =
+                create_vector_table_time - _java_create_vector_table_time_snapshot;
+        COUNTER_UPDATE(_java_append_data_time, append_data_time_delta);
+        COUNTER_UPDATE(_java_create_vector_table_time, create_vector_table_time_delta);
+        COUNTER_UPDATE(_java_scan_time, _java_scan_watcher - append_data_time_delta -
+                                                create_vector_table_time_delta);
+        const auto split_time =
+                _jni_scanner_open_watcher + _fill_block_watcher + _java_scan_watcher;
+        if (split_time > 0) {
+            _max_time_split_weight_counter->conditional_update(split_time, self_split_weight());
+        }
+        _jni_scanner_open_watcher = 0;
+        _java_scan_watcher = 0;
+        _fill_block_watcher = 0;
+        _java_append_data_time_snapshot = append_data_time;
+        _java_create_vector_table_time_snapshot = create_vector_table_time;
     }
-    _collect_jni_scanner_profile(env);
 }
 
 Status JniTableReader::close() {
@@ -428,7 +444,10 @@ void JniTableReader::_reset_split_state(JNIEnv* env) {
     _jni_scanner_open_watcher = 0;
     _java_scan_watcher = 0;
     _fill_block_watcher = 0;
+    _java_append_data_time_snapshot = 0;
+    _java_create_vector_table_time_snapshot = 0;
     _split_profile_published = false;
+    _on_jni_scanner_discarded();
 }
 
 Status JniTableReader::open_jni_scanner_for_split() {

--- a/be/src/format_v2/jni/jni_table_reader.h
+++ b/be/src/format_v2/jni/jni_table_reader.h
@@ -93,6 +93,11 @@ protected:
     virtual Status _set_open_scanner_batch_size(size_t batch_size);
     virtual bool supports_batch_size_update_after_open() const { return true; }
     virtual Status _open_jni_scanner();
+    // A derived reader can retain split-local state after the base reader destroys the global
+    // Java scanner. Clear that state from this hook rather than relying on a particular close
+    // caller to do so.
+    virtual void _on_jni_scanner_discarded() {}
+    void _publish_jni_scanner_split_timing(JNIEnv* env);
     bool _reserve_split_profile_publication();
     const std::vector<JniColumn>& jni_columns() const { return _jni_columns; }
     RuntimeProfile::Counter* connector_total_timer() const { return _connector_total_time; }
@@ -132,6 +137,8 @@ private:
     int64_t _jni_scanner_open_watcher = 0;
     int64_t _java_scan_watcher = 0;
     int64_t _fill_block_watcher = 0;
+    jlong _java_append_data_time_snapshot = 0;
+    jlong _java_create_vector_table_time_snapshot = 0;
 
     Jni::GlobalClass _jni_scanner_cls;
     Jni::GlobalObject _jni_scanner_obj;

--- a/be/src/format_v2/jni/jni_table_reader.h
+++ b/be/src/format_v2/jni/jni_table_reader.h
@@ -75,6 +75,17 @@ protected:
     // Subclasses can override this method when Java transfer types differ from output types.
     virtual Status build_jni_columns(std::vector<JniColumn>* columns) const;
     virtual Status finalize_jni_block(Block* jni_block, Block* output_block, size_t* rows);
+    virtual Status open_jni_scanner_for_split();
+    virtual Status close_jni_scanner_for_split();
+    void reset_jni_eof() { _eof = false; }
+    bool jni_scanner_opened() const { return _scanner_opened; }
+    Jni::GlobalObject& jni_scanner_obj() { return _jni_scanner_obj; }
+    const Jni::MethodId& jni_scanner_prepare_for_split() const {
+        return _jni_scanner_prepare_for_split;
+    }
+    const Jni::MethodId& jni_scanner_reset_current_split() const {
+        return _jni_scanner_reset_current_split;
+    }
     // used for profile
     virtual int64_t self_split_weight() const;
     virtual Status _get_next_jni_block(size_t* rows, bool* eof);
@@ -91,7 +102,6 @@ private:
     // init
     void _init_profile();
     std::string _connector_name() const;
-    // open
     void _reset_split_state(JNIEnv* env);
     void _prepare_jni_scanner_schema();
     Status _register_jni_class_functions_once(JNIEnv* env);
@@ -135,6 +145,8 @@ private:
     Jni::MethodId _jni_scanner_release_table;
     Jni::MethodId _jni_scanner_get_statistics;
     Jni::MethodId _jni_scanner_set_batch_size;
+    Jni::MethodId _jni_scanner_prepare_for_split;
+    Jni::MethodId _jni_scanner_reset_current_split;
 };
 
 } // namespace doris::format

--- a/be/src/format_v2/jni/paimon_jni_reader.cpp
+++ b/be/src/format_v2/jni/paimon_jni_reader.cpp
@@ -18,6 +18,7 @@
 #include "format_v2/jni/paimon_jni_reader.h"
 
 #include <string_view>
+#include <utility>
 
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
@@ -91,7 +92,6 @@ Status PaimonJniReader::build_scanner_params(std::map<std::string, std::string>*
     const auto& paimon_params = _current_range.table_format_params.paimon_params;
     const auto* paimon_predicate = get_paimon_predicate(_scan_params, paimon_params);
     DORIS_CHECK(paimon_predicate != nullptr);
-    (*params)["paimon_split"] = paimon_params.paimon_split;
     (*params)["paimon_predicate"] = *paimon_predicate;
     (*params)["serialized_table"] = _scan_params->serialized_table;
 
@@ -130,6 +130,59 @@ Status PaimonJniReader::build_scanner_params(std::map<std::string, std::string>*
     }
     // TODO: Remove legacy split-level paimon_predicate, paimon_options and hadoop_conf from thrift
     // after the minimum supported FE always sends their scan-level replacements.
+    return Status::OK();
+}
+
+Status PaimonJniReader::open_jni_scanner_for_split() {
+    if (!jni_scanner_opened()) {
+        RETURN_IF_ERROR(JniTableReader::open_jni_scanner_for_split());
+    }
+    return _prepare_for_split();
+}
+
+Status PaimonJniReader::close_jni_scanner_for_split() {
+    return _reset_current_split();
+}
+
+Status PaimonJniReader::_prepare_for_split() {
+    DORIS_CHECK(jni_scanner_opened());
+    DORIS_CHECK(!_current_split_prepared);
+    std::map<std::string, std::string> split_params;
+    split_params["paimon_split"] = _current_range.table_format_params.paimon_params.paimon_split;
+
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    Jni::LocalObject hashmap_object;
+    RETURN_IF_ERROR(Jni::Util::convert_to_java_map(env, split_params, &hashmap_object));
+    RETURN_IF_ERROR(jni_scanner_obj()
+                            .call_void_method(env, jni_scanner_prepare_for_split())
+                            .with_arg(hashmap_object)
+                            .call());
+    RETURN_ERROR_IF_EXC(env);
+    _current_split_prepared = true;
+    reset_jni_eof();
+    return Status::OK();
+}
+
+Status PaimonJniReader::close() {
+    auto reset_status = _reset_current_split();
+    auto close_status = JniTableReader::close();
+    if (reset_status.ok() && !close_status.ok()) {
+        reset_status = std::move(close_status);
+    }
+    return reset_status;
+}
+
+Status PaimonJniReader::_reset_current_split() {
+    if (!_current_split_prepared) {
+        return Status::OK();
+    }
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    RETURN_IF_ERROR(
+            jni_scanner_obj().call_void_method(env, jni_scanner_reset_current_split()).call());
+    RETURN_ERROR_IF_EXC(env);
+    _current_split_prepared = false;
     return Status::OK();
 }
 

--- a/be/src/format_v2/jni/paimon_jni_reader.cpp
+++ b/be/src/format_v2/jni/paimon_jni_reader.cpp
@@ -141,6 +141,12 @@ Status PaimonJniReader::open_jni_scanner_for_split() {
 }
 
 Status PaimonJniReader::close_jni_scanner_for_split() {
+    if (!_current_split_prepared) {
+        return Status::OK();
+    }
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    _publish_jni_scanner_split_timing(env);
     return _reset_current_split();
 }
 

--- a/be/src/format_v2/jni/paimon_jni_reader.h
+++ b/be/src/format_v2/jni/paimon_jni_reader.h
@@ -29,7 +29,7 @@
 
 namespace doris::format::paimon {
 
-class PaimonJniReader final : public format::JniTableReader {
+class PaimonJniReader : public format::JniTableReader {
 public:
     ~PaimonJniReader() override = default;
     Status close() override;
@@ -45,6 +45,8 @@ public:
             const std::vector<StorePath>& store_paths) {
         return build_default_io_manager_tmp_dirs(store_paths);
     }
+    void TEST_set_current_split_prepared(bool prepared) { _current_split_prepared = prepared; }
+    bool TEST_current_split_prepared() const { return _current_split_prepared; }
 #endif
 
 protected:
@@ -54,10 +56,12 @@ protected:
     bool supports_batch_size_update_after_open() const override { return false; }
     Status open_jni_scanner_for_split() override;
     Status close_jni_scanner_for_split() override;
+    void _on_jni_scanner_discarded() override { _current_split_prepared = false; }
+
+    Status _prepare_for_split();
+    virtual Status _reset_current_split();
 
 private:
-    Status _prepare_for_split();
-    Status _reset_current_split();
     static std::string build_default_io_manager_tmp_dirs(const std::vector<StorePath>& store_paths);
 
     bool _current_split_prepared = false;

--- a/be/src/format_v2/jni/paimon_jni_reader.h
+++ b/be/src/format_v2/jni/paimon_jni_reader.h
@@ -32,6 +32,7 @@ namespace doris::format::paimon {
 class PaimonJniReader final : public format::JniTableReader {
 public:
     ~PaimonJniReader() override = default;
+    Status close() override;
 
 #ifdef BE_TEST
     void TEST_set_scan_params(TFileScanRangeParams* params) { _scan_params = params; }
@@ -51,9 +52,15 @@ protected:
     Status validate_scan_range(const TFileRangeDesc& range) const override;
     Status build_scanner_params(std::map<std::string, std::string>* params) const override;
     bool supports_batch_size_update_after_open() const override { return false; }
+    Status open_jni_scanner_for_split() override;
+    Status close_jni_scanner_for_split() override;
 
 private:
+    Status _prepare_for_split();
+    Status _reset_current_split();
     static std::string build_default_io_manager_tmp_dirs(const std::vector<StorePath>& store_paths);
+
+    bool _current_split_prepared = false;
 };
 
 } // namespace doris::format::paimon

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -143,6 +143,45 @@ private:
     std::shared_ptr<RetryableCloseState> _state;
 };
 
+struct RetainedReaderCloseState {
+    int close_calls = 0;
+    std::vector<Status> close_results;
+};
+
+class RetainedReader final : public GenericReader {
+public:
+    explicit RetainedReader(std::shared_ptr<RetainedReaderCloseState> state)
+            : _state(std::move(state)) {}
+
+    Status close() override {
+        ++_state->close_calls;
+        if (static_cast<size_t>(_state->close_calls) <= _state->close_results.size()) {
+            return _state->close_results[_state->close_calls - 1];
+        }
+        return Status::OK();
+    }
+
+protected:
+    Status _do_get_next_block(Block* /*block*/, size_t* /*read_rows*/, bool* /*eof*/) override {
+        return Status::OK();
+    }
+
+private:
+    std::shared_ptr<RetainedReaderCloseState> _state;
+};
+
+class RetainedReaderCloseFileScanner final : public FileScanner {
+public:
+    RetainedReaderCloseFileScanner(RuntimeState* state, RuntimeProfile* profile)
+            : FileScanner(state, profile, nullptr, nullptr, nullptr) {}
+
+    void set_retained_readers(std::unique_ptr<GenericReader> current,
+                              std::unique_ptr<GenericReader> cached) {
+        _cur_reader = std::move(current);
+        _cached_paimon_jni_reader = std::move(cached);
+    }
+};
+
 VExprSPtr slot_ref(int slot_id, int column_id, DataTypePtr type, const std::string& name) {
     return VSlotRef::create_shared(slot_id, column_id, -1, std::move(type), name);
 }
@@ -898,6 +937,50 @@ TEST(FileScannerTest, PartitionPruningStopsAtUnsafePredicate) {
     const auto& partition_conjuncts = scanner.TEST_runtime_filter_partition_prune_ctxs();
     ASSERT_EQ(partition_conjuncts.size(), 1);
     EXPECT_EQ(partition_conjuncts[0], conjuncts[0]);
+}
+
+TEST(FileScannerTest, CloseRetainedReadersAfterCurrentReaderFailure) {
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    RuntimeProfile profile("file_scanner");
+    RetainedReaderCloseFileScanner scanner(&state, &profile);
+
+    auto current_state = std::make_shared<RetainedReaderCloseState>();
+    current_state->close_results = {Status::InternalError("current close failure"), Status::OK()};
+    auto cached_state = std::make_shared<RetainedReaderCloseState>();
+    scanner.set_retained_readers(std::make_unique<RetainedReader>(current_state),
+                                 std::make_unique<RetainedReader>(cached_state));
+
+    const auto first_close = scanner.close(&state);
+    EXPECT_FALSE(first_close.ok());
+    EXPECT_NE(first_close.to_string().find("current close failure"), std::string::npos);
+    EXPECT_EQ(current_state->close_calls, 1);
+    EXPECT_EQ(cached_state->close_calls, 1);
+
+    EXPECT_TRUE(scanner.close(&state).ok());
+    EXPECT_EQ(current_state->close_calls, 2);
+    EXPECT_EQ(cached_state->close_calls, 1);
+}
+
+TEST(FileScannerTest, CloseRetainedReadersAfterCachedReaderFailure) {
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    RuntimeProfile profile("file_scanner");
+    RetainedReaderCloseFileScanner scanner(&state, &profile);
+
+    auto current_state = std::make_shared<RetainedReaderCloseState>();
+    auto cached_state = std::make_shared<RetainedReaderCloseState>();
+    cached_state->close_results = {Status::InternalError("cached close failure"), Status::OK()};
+    scanner.set_retained_readers(std::make_unique<RetainedReader>(current_state),
+                                 std::make_unique<RetainedReader>(cached_state));
+
+    const auto first_close = scanner.close(&state);
+    EXPECT_FALSE(first_close.ok());
+    EXPECT_NE(first_close.to_string().find("cached close failure"), std::string::npos);
+    EXPECT_EQ(current_state->close_calls, 1);
+    EXPECT_EQ(cached_state->close_calls, 1);
+
+    EXPECT_TRUE(scanner.close(&state).ok());
+    EXPECT_EQ(current_state->close_calls, 1);
+    EXPECT_EQ(cached_state->close_calls, 2);
 }
 
 } // namespace doris

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -46,7 +46,9 @@
 #include "exprs/vdirect_in_predicate.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
+#include "format/count_reader.h"
 #include "format_v2/expr/cast.h"
+#include "testutil/desc_tbl_builder.h"
 #include "testutil/mock/mock_runtime_state.h"
 
 namespace doris {
@@ -96,6 +98,16 @@ TFileRangeDesc legacy_paimon_jni_range_without_reader_type() {
     paimon_params.__set_paimon_split("legacy-split");
     paimon_params.__set_paimon_predicate("legacy-predicate");
     range.table_format_params.__set_paimon_params(std::move(paimon_params));
+    return range;
+}
+
+TFileRangeDesc paimon_jni_count_range(std::string split, int64_t row_count) {
+    auto range = range_with_format("paimon", TFileFormatType::FORMAT_JNI);
+    TPaimonFileDesc paimon_params;
+    paimon_params.__set_reader_type(TPaimonReaderType::PAIMON_JNI);
+    paimon_params.__set_paimon_split(std::move(split));
+    range.table_format_params.__set_paimon_params(std::move(paimon_params));
+    range.table_format_params.__set_table_level_row_count(row_count);
     return range;
 }
 
@@ -180,6 +192,47 @@ public:
         _cur_reader = std::move(current);
         _cached_paimon_jni_reader = std::move(cached);
     }
+};
+
+class PaimonCountSplitSource final : public SplitSourceConnector {
+public:
+    PaimonCountSplitSource(TFileScanRangeParams params, std::vector<TFileRangeDesc> ranges)
+            : _params(std::move(params)), _ranges(std::move(ranges)) {}
+
+    Status get_next(bool* has_next, TFileRangeDesc* range) override {
+        *has_next = _next_range < _ranges.size();
+        if (*has_next) {
+            *range = _ranges[_next_range++];
+        }
+        return Status::OK();
+    }
+
+    int num_scan_ranges() override { return static_cast<int>(_ranges.size()); }
+
+    TFileScanRangeParams* get_params() override { return &_params; }
+
+private:
+    TFileScanRangeParams _params;
+    std::vector<TFileRangeDesc> _ranges;
+    size_t _next_range = 0;
+};
+
+class PaimonCountFileScanner final : public FileScanner {
+public:
+    PaimonCountFileScanner(RuntimeState* state, FileScanLocalState* local_state,
+                           std::shared_ptr<SplitSourceConnector> split_source,
+                           RuntimeProfile* profile,
+                           const std::unordered_map<std::string, int>* colname_to_slot_id)
+            : FileScanner(state, local_state, -1, std::move(split_source), profile, nullptr,
+                          colname_to_slot_id) {}
+
+    bool current_count_reader_owns_inner_reader() const {
+        const auto* count_reader = dynamic_cast<const CountReader*>(_cur_reader.get());
+        DORIS_CHECK(count_reader != nullptr);
+        return count_reader->inner_reader() != nullptr;
+    }
+
+    bool has_cached_paimon_reader() const { return _cached_paimon_jni_reader != nullptr; }
 };
 
 VExprSPtr slot_ref(int slot_id, int column_id, DataTypePtr type, const std::string& name) {
@@ -498,6 +551,82 @@ TEST(FileScannerV2Test, JniCompatibilityShapesForceLegacyScanner) {
     EXPECT_FALSE(FileScanLocalState::TEST_should_use_file_scanner_v2(query_options, false, params));
     EXPECT_FALSE(
             FileScannerV2::is_supported(params, legacy_paimon_jni_range_without_reader_type()));
+}
+
+TEST(FileScannerTest, PaimonTableLevelCountSplitsDoNotOpenJniReader) {
+    ObjectPool object_pool;
+    DescriptorTblBuilder descriptor_builder(&object_pool);
+    descriptor_builder.declare_tuple()
+            << std::make_tuple(std::make_shared<DataTypeInt64>(), "count");
+    auto* descriptor_table = descriptor_builder.build();
+
+    TQueryOptions query_options;
+    query_options.__set_batch_size(1024);
+    RuntimeState state(query_options, TQueryGlobals());
+    state.set_desc_tbl(descriptor_table);
+
+    TPlanNode plan_node;
+    plan_node.__set_node_id(0);
+    plan_node.__set_node_type(TPlanNodeType::FILE_SCAN_NODE);
+    plan_node.__set_num_children(0);
+    plan_node.__set_limit(-1);
+    plan_node.__set_row_tuples({0});
+    plan_node.__set_push_down_agg_type_opt(TPushAggOp::type::COUNT);
+    plan_node.__set_push_down_count_slot_ids(std::vector<int32_t> {});
+    TFileScanNode file_scan_node;
+    file_scan_node.__set_tuple_id(0);
+    plan_node.__set_file_scan_node(std::move(file_scan_node));
+
+    auto scan_operator =
+            std::make_shared<FileScanOperatorX>(&object_pool, plan_node, 0, *descriptor_table, 1);
+    scan_operator->_output_tuple_desc = descriptor_table->get_tuple_descriptor(0);
+    ASSERT_TRUE(scan_operator->init(plan_node, &state).ok());
+    ASSERT_TRUE(scan_operator->prepare(&state).ok());
+
+    RuntimeProfile global_profile("paimon_count_file_scanner");
+    auto local_state = FileScanLocalState::create_unique(&state, scan_operator.get());
+    LocalStateInfo local_state_info {.parent_profile = &global_profile,
+                                     .scan_ranges = {},
+                                     .shared_state = nullptr,
+                                     .shared_state_map = {},
+                                     .task_idx = 0};
+    ASSERT_TRUE(local_state->init(&state, local_state_info).ok());
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_src_tuple_id(-1);
+    scan_params.__set_dest_tuple_id(0);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_JNI);
+    auto split_source = std::make_shared<PaimonCountSplitSource>(
+            std::move(scan_params),
+            std::vector<TFileRangeDesc> {paimon_jni_count_range("count-split-a", 3),
+                                         paimon_jni_count_range("count-split-b", 5)});
+    std::unordered_map<std::string, int> colname_to_slot_id;
+    PaimonCountFileScanner scanner(&state, local_state.get(), std::move(split_source),
+                                   local_state->scanner_profile(), &colname_to_slot_id);
+    ASSERT_TRUE(scanner.init(&state, {}).ok());
+
+    Block first_block;
+    bool eof = false;
+    ASSERT_TRUE(scanner.get_block(&state, &first_block, &eof).ok());
+    EXPECT_EQ(first_block.rows(), 3);
+    EXPECT_FALSE(eof);
+    EXPECT_FALSE(scanner.current_count_reader_owns_inner_reader());
+    EXPECT_FALSE(scanner.has_cached_paimon_reader());
+
+    Block second_block;
+    ASSERT_TRUE(scanner.get_block(&state, &second_block, &eof).ok());
+    EXPECT_EQ(second_block.rows(), 5);
+    EXPECT_FALSE(eof);
+    EXPECT_FALSE(scanner.current_count_reader_owns_inner_reader());
+    EXPECT_FALSE(scanner.has_cached_paimon_reader());
+
+    Block final_block;
+    ASSERT_TRUE(scanner.get_block(&state, &final_block, &eof).ok());
+    EXPECT_EQ(final_block.rows(), 0);
+    EXPECT_TRUE(eof);
+
+    EXPECT_TRUE(scanner.close(&state).ok());
+    EXPECT_TRUE(local_state->close(&state).ok());
 }
 
 TEST(FileScannerV2Test, FailedTableReaderCloseCanBeRetriedThroughScanner) {

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -47,6 +47,7 @@
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
 #include "format/count_reader.h"
+#include "format/table/paimon_jni_reader.h"
 #include "format_v2/expr/cast.h"
 #include "testutil/desc_tbl_builder.h"
 #include "testutil/mock/mock_runtime_state.h"
@@ -192,6 +193,35 @@ public:
         _cur_reader = std::move(current);
         _cached_paimon_jni_reader = std::move(cached);
     }
+
+    bool has_current_reader() const { return _cur_reader != nullptr; }
+};
+
+struct RetryablePaimonJniCloseState {
+    int close_calls = 0;
+};
+
+class RetryableClosePaimonJniReader final : public PaimonJniReader {
+public:
+    RetryableClosePaimonJniReader(const std::vector<SlotDescriptor*>& file_slot_descs,
+                                  RuntimeState* state, RuntimeProfile* profile,
+                                  const TFileRangeDesc& range,
+                                  const TFileScanRangeParams* range_params,
+                                  std::shared_ptr<RetryablePaimonJniCloseState> close_state)
+            : PaimonJniReader(file_slot_descs, state, profile, range, range_params),
+              _close_state(std::move(close_state)) {}
+
+protected:
+    Status _close_jni_scanner() override {
+        ++_close_state->close_calls;
+        if (_close_state->close_calls == 1) {
+            return Status::InternalError("injected Paimon JNI close failure");
+        }
+        return Status::OK();
+    }
+
+private:
+    std::shared_ptr<RetryablePaimonJniCloseState> _close_state;
 };
 
 class PaimonCountSplitSource final : public SplitSourceConnector {
@@ -1088,6 +1118,34 @@ TEST(FileScannerTest, CloseRetainedReadersAfterCurrentReaderFailure) {
     EXPECT_TRUE(scanner.close(&state).ok());
     EXPECT_EQ(current_state->close_calls, 2);
     EXPECT_EQ(cached_state->close_calls, 1);
+}
+
+TEST(FileScannerTest, RetriesPaimonJniCleanupAfterInnerCloseFailure) {
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    RuntimeProfile profile("file_scanner");
+    RetainedReaderCloseFileScanner scanner(&state, &profile);
+
+    auto range = paimon_jni_count_range("retry-close", 1);
+    TFileScanRangeParams scan_params;
+    std::vector<SlotDescriptor*> file_slot_descs;
+    auto close_state = std::make_shared<RetryablePaimonJniCloseState>();
+    scanner.set_retained_readers(
+            std::make_unique<RetryableClosePaimonJniReader>(file_slot_descs, &state, &profile,
+                                                            range, &scan_params, close_state),
+            nullptr);
+
+    const auto first_close = scanner.close(&state);
+    EXPECT_FALSE(first_close.ok());
+    EXPECT_NE(first_close.to_string().find("injected Paimon JNI close failure"), std::string::npos);
+    EXPECT_EQ(close_state->close_calls, 1);
+    EXPECT_TRUE(scanner.has_current_reader());
+
+    EXPECT_TRUE(scanner.close(&state).ok());
+    EXPECT_EQ(close_state->close_calls, 2);
+    EXPECT_FALSE(scanner.has_current_reader());
+
+    EXPECT_TRUE(scanner.close(&state).ok());
+    EXPECT_EQ(close_state->close_calls, 2);
 }
 
 TEST(FileScannerTest, CloseRetainedReadersAfterCachedReaderFailure) {

--- a/be/test/format/table/paimon_jni_reader_test.cpp
+++ b/be/test/format/table/paimon_jni_reader_test.cpp
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/table/paimon_jni_reader.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_number.h"
+#include "format/generic_reader.h"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
+
+namespace doris {
+namespace {
+
+TFileRangeDesc make_paimon_jni_range(std::string split) {
+    TFileRangeDesc range;
+    TTableFormatFileDesc table_format_params;
+    table_format_params.__set_table_format_type("paimon");
+    TPaimonFileDesc paimon_params;
+    paimon_params.__set_paimon_split(std::move(split));
+    table_format_params.__set_paimon_params(std::move(paimon_params));
+    range.__set_table_format_params(std::move(table_format_params));
+    return range;
+}
+
+TFileScanRangeParams make_scan_params() {
+    TFileScanRangeParams params;
+    params.__set_serialized_table("serialized-paimon-table");
+    params.__set_paimon_predicate("serialized-paimon-predicate");
+    return params;
+}
+
+class LegacyPaimonJniReaderTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _query_options.__set_batch_size(2);
+        _runtime_state = std::make_unique<RuntimeState>(_query_options, _query_globals);
+    }
+
+    TQueryOptions _query_options;
+    TQueryGlobals _query_globals;
+    std::unique_ptr<RuntimeState> _runtime_state;
+    RuntimeProfile _profile {"paimon_jni_reader_test"};
+    std::vector<SlotDescriptor*> _file_slot_descs;
+};
+
+TEST_F(LegacyPaimonJniReaderTest, ReusesScannerWhenOnlySplitChanges) {
+    auto first_range = make_paimon_jni_range("split-a");
+    auto second_range = make_paimon_jni_range("split-b");
+    const auto scan_params = make_scan_params();
+
+    PaimonJniReader reader(_file_slot_descs, _runtime_state.get(), &_profile, first_range,
+                           &scan_params);
+
+    EXPECT_TRUE(reader.can_reuse_for(second_range));
+    EXPECT_EQ(reader.TEST_scanner_params_signature().at("paimon_predicate"),
+              "serialized-paimon-predicate");
+    EXPECT_EQ(reader.TEST_scanner_params_signature().at("serialized_table"),
+              "serialized-paimon-table");
+}
+
+TEST_F(LegacyPaimonJniReaderTest, RecreatesScannerWhenScannerParametersChange) {
+    auto first_range = make_paimon_jni_range("split-a");
+    first_range.table_format_params.paimon_params.__set_paimon_options(
+            std::map<std::string, std::string> {{"warehouse", "a"}});
+    auto second_range = make_paimon_jni_range("split-b");
+    second_range.table_format_params.paimon_params.__set_paimon_options(
+            std::map<std::string, std::string> {{"warehouse", "b"}});
+    const auto scan_params = make_scan_params();
+
+    PaimonJniReader reader(_file_slot_descs, _runtime_state.get(), &_profile, first_range,
+                           &scan_params);
+
+    EXPECT_FALSE(reader.can_reuse_for(second_range));
+}
+
+TEST_F(LegacyPaimonJniReaderTest, ReturnsTableLevelCountInBatches) {
+    auto range = make_paimon_jni_range("count-split");
+    range.table_format_params.__set_table_level_row_count(5);
+    const auto scan_params = make_scan_params();
+    PaimonJniReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, &scan_params);
+    reader.set_push_down_agg_type(TPushAggOp::type::COUNT);
+
+    Block block;
+    block.insert({ColumnInt32::create(), std::make_shared<DataTypeInt32>(), "count"});
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader._do_get_next_block(&block, &rows, &eof).ok());
+    EXPECT_EQ(rows, 2);
+    EXPECT_EQ(block.rows(), 2);
+    EXPECT_FALSE(eof);
+
+    ASSERT_TRUE(reader._do_get_next_block(&block, &rows, &eof).ok());
+    EXPECT_EQ(rows, 2);
+    EXPECT_FALSE(eof);
+
+    ASSERT_TRUE(reader._do_get_next_block(&block, &rows, &eof).ok());
+    EXPECT_EQ(rows, 1);
+    EXPECT_EQ(block.rows(), 1);
+    EXPECT_TRUE(eof);
+}
+
+TEST_F(LegacyPaimonJniReaderTest, PreparesCountSplitWithoutOpeningAnotherScanner) {
+    auto initial_range = make_paimon_jni_range("first-split");
+    auto count_range = make_paimon_jni_range("second-split");
+    count_range.table_format_params.__set_table_level_row_count(3);
+    const auto scan_params = make_scan_params();
+    PaimonJniReader reader(_file_slot_descs, _runtime_state.get(), &_profile, initial_range,
+                           &scan_params);
+    reader.set_push_down_agg_type(TPushAggOp::type::COUNT);
+
+    ReaderInitContext init_ctx;
+    ASSERT_TRUE(reader.prepare_split(count_range, &init_ctx).ok());
+    ASSERT_TRUE(reader.finish_split().ok());
+
+    Block block;
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader._do_get_next_block(&block, &rows, &eof).ok());
+    EXPECT_EQ(rows, 2);
+    EXPECT_FALSE(eof);
+}
+
+} // namespace
+} // namespace doris

--- a/be/test/format_v2/jni/jni_table_reader_test.cpp
+++ b/be/test/format_v2/jni/jni_table_reader_test.cpp
@@ -121,6 +121,8 @@ TEST(JniTableReaderTest, CancellationStopsBeforeFetchingAnotherJavaBatch) {
     ASSERT_TRUE(reader.get_block(&block, &eos).ok());
     EXPECT_TRUE(eos);
     EXPECT_EQ(reader.get_next_calls, 0);
+    EXPECT_EQ(reader.close_calls, 0);
+    ASSERT_TRUE(reader.close().ok());
     EXPECT_EQ(reader.close_calls, 1);
 }
 

--- a/be/test/format_v2/jni/paimon_jni_reader_test.cpp
+++ b/be/test/format_v2/jni/paimon_jni_reader_test.cpp
@@ -20,11 +20,13 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 
 #include "format_v2/table_reader.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "io/io_common.h"
 
 namespace doris::format::paimon {
 namespace {
@@ -63,6 +65,50 @@ Status build_params(PaimonJniReader* reader, const TFileRangeDesc& range,
                     std::map<std::string, std::string>* params) {
     reader->_current_range = range;
     return reader->build_scanner_params(params);
+}
+
+class LifecyclePaimonJniReader final : public PaimonJniReader {
+public:
+    int global_scanner_close_calls = 0;
+    int reset_current_split_calls = 0;
+    bool fail_next_reset = false;
+
+protected:
+    Status _close_jni_scanner() override {
+        if (!TEST_scanner_opened()) {
+            return Status::OK();
+        }
+        ++global_scanner_close_calls;
+        TEST_set_split_state(false, TEST_eof());
+        _on_jni_scanner_discarded();
+        return Status::OK();
+    }
+
+    Status _reset_current_split() override {
+        if (!TEST_current_split_prepared()) {
+            return Status::OK();
+        }
+        ++reset_current_split_calls;
+        if (fail_next_reset) {
+            fail_next_reset = false;
+            return Status::InternalError("injected reset failure");
+        }
+        TEST_set_current_split_prepared(false);
+        return Status::OK();
+    }
+};
+
+Status init_lifecycle_reader(LifecyclePaimonJniReader* reader,
+                             const std::shared_ptr<io::IOContext>& io_ctx) {
+    return reader->init({
+            .projected_columns = {},
+            .conjuncts = {},
+            .format = FileFormat::JNI,
+            .scan_params = nullptr,
+            .io_ctx = io_ctx,
+            .runtime_state = nullptr,
+            .scanner_profile = nullptr,
+    });
 }
 
 TEST(PaimonJniReaderTest, UsesScanLevelPredicateBeforeLegacySplitPredicate) {
@@ -169,6 +215,43 @@ TEST(PaimonJniReaderTest, KeepsInitialPhysicalBatchSizeAfterOpen) {
     reader.TEST_set_split_state(true, false);
     reader.set_batch_size(1);
     EXPECT_EQ(reader.TEST_batch_size(), 32);
+}
+
+TEST(PaimonJniReaderTest, StopDefersPreparedSplitCleanupUntilClose) {
+    auto io_ctx = std::make_shared<io::IOContext>();
+    LifecyclePaimonJniReader reader;
+    ASSERT_TRUE(init_lifecycle_reader(&reader, io_ctx).ok());
+    reader.TEST_set_split_state(true, false);
+    reader.TEST_set_current_split_prepared(true);
+    io_ctx->should_stop = true;
+
+    Block block;
+    bool eos = false;
+    ASSERT_TRUE(reader.get_block(&block, &eos).ok());
+    EXPECT_TRUE(eos);
+    EXPECT_EQ(reader.global_scanner_close_calls, 0);
+    EXPECT_TRUE(reader.TEST_current_split_prepared());
+
+    ASSERT_TRUE(reader.close().ok());
+    EXPECT_EQ(reader.reset_current_split_calls, 1);
+    EXPECT_EQ(reader.global_scanner_close_calls, 1);
+    EXPECT_FALSE(reader.TEST_current_split_prepared());
+}
+
+TEST(PaimonJniReaderTest, FailedSplitResetDoesNotSurviveSuccessfulGlobalClose) {
+    LifecyclePaimonJniReader reader;
+    ASSERT_TRUE(init_lifecycle_reader(&reader, nullptr).ok());
+    reader.TEST_set_split_state(true, false);
+    reader.TEST_set_current_split_prepared(true);
+    reader.fail_next_reset = true;
+
+    EXPECT_FALSE(reader.close().ok());
+    EXPECT_EQ(reader.reset_current_split_calls, 1);
+    EXPECT_EQ(reader.global_scanner_close_calls, 1);
+    EXPECT_FALSE(reader.TEST_current_split_prepared());
+
+    EXPECT_TRUE(reader.close().ok());
+    EXPECT_EQ(reader.reset_current_split_calls, 1);
 }
 
 } // namespace

--- a/be/test/format_v2/jni/paimon_jni_reader_test.cpp
+++ b/be/test/format_v2/jni/paimon_jni_reader_test.cpp
@@ -205,6 +205,13 @@ TEST(PaimonJniReaderTest, ScanLevelOptionsOverrideLegacySplitFallbacks) {
     EXPECT_EQ(params["hadoop.source"], "scan");
 }
 
+TEST(PaimonJniReaderTest, DefaultIoManagerTmpDirsUseEveryStoreRoot) {
+    EXPECT_EQ(PaimonJniReader::TEST_build_default_io_manager_tmp_dirs(
+                      {StorePath("/data1/doris", -1), StorePath("/data2/doris", -1)}),
+              "/data1/doris/paimon_jni_scanner_io_tmp:"
+              "/data2/doris/paimon_jni_scanner_io_tmp");
+}
+
 TEST(PaimonJniReaderTest, KeepsInitialPhysicalBatchSizeAfterOpen) {
     PaimonJniReader reader;
     reader.set_batch_size(32);

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/JniScanner.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/JniScanner.java
@@ -52,6 +52,14 @@ public abstract class JniScanner {
     // Close JniScanner and release resources
     public abstract void close() throws IOException;
 
+    public void prepareForSplit(Map<String, String> splitParams) throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " does not support split preparation");
+    }
+
+    public void resetCurrentSplit() throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " does not support split reset");
+    }
+
     // Scan data and save as vector table
     protected abstract int getNext() throws IOException;
 

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -74,8 +74,8 @@ public class PaimonJniScanner extends JniScanner {
 
     private final Map<String, String> params;
     private final Map<String, String> hadoopOptionParams;
-    private final String paimonSplit;
     private final String paimonPredicate;
+    private String currentPaimonSplit;
     private Table table;
     private RecordReader<InternalRow> reader;
     private IOManager ioManager;
@@ -83,6 +83,7 @@ public class PaimonJniScanner extends JniScanner {
     private final PaimonColumnValue columnValue = new PaimonColumnValue();
     private List<String> paimonAllFieldNames;
     private List<DataType> paimonDataTypeList;
+    private int[] projected;
     private RecordReader.RecordIterator<InternalRow> recordIterator = null;
     private final ClassLoader classLoader;
     private PreExecutionAuthenticator preExecutionAuthenticator;
@@ -108,7 +109,6 @@ public class PaimonJniScanner extends JniScanner {
         for (int i = 0; i < requiredTypes.length; i++) {
             columnTypes[i] = ColumnType.parseType(requiredFields[i], requiredTypes[i]);
         }
-        paimonSplit = params.get("paimon_split");
         paimonPredicate = params.get("paimon_predicate");
         String timeZone = params.getOrDefault("time_zone", TimeZone.getDefault().getID());
         columnValue.setTimeZone(timeZone);
@@ -133,7 +133,8 @@ public class PaimonJniScanner extends JniScanner {
             preExecutionAuthenticator.execute(() -> {
                 PaimonJdbcDriverUtils.registerDriverIfNeeded(params, classLoader);
                 initTable();
-                initReader();
+                initProjection();
+                initIOManagerIfNeeded();
                 return null;
             });
             resetDatetimeV2Precision();
@@ -151,8 +152,53 @@ public class PaimonJniScanner extends JniScanner {
         }
     }
 
-    private void initReader() throws IOException {
-        ReadBuilder readBuilder = table.newReadBuilder();
+    @Override
+    public void prepareForSplit(Map<String, String> splitParams) throws IOException {
+        Preconditions.checkArgument(splitParams != null, "Paimon split params are required");
+        String paimonSplit = splitParams.get("paimon_split");
+        Preconditions.checkArgument(paimonSplit != null && !paimonSplit.isEmpty(), "paimon_split is required");
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            preExecutionAuthenticator.execute(() -> {
+                resetCurrentSplit();
+                currentPaimonSplit = paimonSplit;
+                initReader();
+                return null;
+            });
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void resetCurrentSplit() throws IOException {
+        IOException exception = null;
+        try {
+            releaseRecordIterator();
+        } catch (RuntimeException e) {
+            exception = new IOException("Failed to release Paimon record iterator", e);
+        }
+        if (reader != null) {
+            try {
+                reader.close();
+                reader = null;
+            } catch (IOException e) {
+                if (exception == null) {
+                    exception = e;
+                } else {
+                    exception.addSuppressed(e);
+                }
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
+        currentPaimonSplit = null;
+    }
+
+    private void initProjection() throws IOException {
         if (this.fields.length > this.paimonAllFieldNames.size()) {
             throw new IOException(
                     String.format(
@@ -160,12 +206,19 @@ public class PaimonJniScanner extends JniScanner {
                                     + " Please refresh table and try again",
                             fields.length, paimonAllFieldNames.size()));
         }
-        int[] projected = getProjected();
+        projected = getProjected();
+        paimonDataTypeList =
+                Arrays.stream(projected).mapToObj(i -> table.rowType().getTypeAt(i)).collect(Collectors.toList());
+    }
+
+    private void initReader() throws IOException {
+        Preconditions.checkState(table != null, "Paimon scanner is not opened");
+        Preconditions.checkState(projected != null, "Paimon scanner projection is not initialized");
+        Preconditions.checkState(currentPaimonSplit != null, "Paimon split is not prepared");
+        ReadBuilder readBuilder = table.newReadBuilder();
         readBuilder.withProjection(projected);
         readBuilder.withFilter(getPredicates());
         reader = newReadWithOptionalIOManager(readBuilder).executeFilter().createReader(getSplit());
-        paimonDataTypeList =
-                Arrays.stream(projected).mapToObj(i -> table.rowType().getTypeAt(i)).collect(Collectors.toList());
     }
 
     private TableRead newReadWithOptionalIOManager(ReadBuilder readBuilder) throws IOException {
@@ -173,11 +226,18 @@ public class PaimonJniScanner extends JniScanner {
         if (!isIOManagerEnabled(params)) {
             return tableRead;
         }
+        Preconditions.checkState(ioManager != null, "Paimon JNI IOManager is not initialized");
+        return tableRead.withIOManager(ioManager);
+    }
+
+    private void initIOManagerIfNeeded() throws IOException {
+        if (!isIOManagerEnabled(params) || ioManager != null) {
+            return;
+        }
         ioManagerTempDirs = getIOManagerTempDirs(params);
         ioManager = createIOManager(ioManagerTempDirs, getIOManagerImplClass(params));
         LOG.info("Enable Paimon JNI IOManager with temp dirs: {}, implementation: {}",
                 ioManagerTempDirs, ioManager.getClass().getName());
-        return tableRead.withIOManager(ioManager);
     }
 
     static boolean isIOManagerEnabled(Map<String, String> params) {
@@ -279,7 +339,8 @@ public class PaimonJniScanner extends JniScanner {
     }
 
     private Split getSplit() {
-        Split split = PaimonUtils.deserialize(paimonSplit);
+        Preconditions.checkState(currentPaimonSplit != null, "Paimon split is not prepared");
+        Split split = PaimonUtils.deserialize(currentPaimonSplit);
         if (LOG.isDebugEnabled()) {
             LOG.debug("split:{}", split);
         }
@@ -306,23 +367,11 @@ public class PaimonJniScanner extends JniScanner {
     public void close() throws IOException {
         IOException exception = null;
         try {
-            try {
-                releaseRecordIterator();
-            } catch (RuntimeException e) {
-                exception = new IOException("Failed to release Paimon record iterator", e);
-            }
-            if (reader != null) {
-                try {
-                    reader.close();
-                    reader = null;
-                } catch (IOException e) {
-                    if (exception == null) {
-                        exception = e;
-                    } else {
-                        exception.addSuppressed(e);
-                    }
-                }
-            }
+            resetCurrentSplit();
+        } catch (IOException e) {
+            exception = e;
+        }
+        try {
             if (ioManager != null) {
                 try {
                     ioManager.close();
@@ -354,6 +403,7 @@ public class PaimonJniScanner extends JniScanner {
     private int readAndProcessNextBatch() throws IOException {
         int rows = 0;
         try {
+            Preconditions.checkState(reader != null, "Paimon split is not prepared");
             if (recordIterator == null) {
                 recordIterator = readBatchWithMetrics();
             }
@@ -388,10 +438,14 @@ public class PaimonJniScanner extends JniScanner {
             }
             rowsRead += rows;
         } catch (Exception e) {
-            close();
             LOG.warn("Failed to get the next batch of paimon. "
                             + "split: {}, requiredFieldNames: {}, paimonAllFieldNames: {}, dataType: {}",
-                    getSplit(), params.get("required_fields"), paimonAllFieldNames, paimonDataTypeList, e);
+                    currentPaimonSplit, params.get("required_fields"), paimonAllFieldNames, paimonDataTypeList, e);
+            try {
+                close();
+            } catch (IOException closeException) {
+                e.addSuppressed(closeException);
+            }
             throw new IOException(e);
         }
         return rows;
@@ -434,7 +488,7 @@ public class PaimonJniScanner extends JniScanner {
         statistics.put("gauge:PaimonJniAsyncReaderThreadCount",
                 String.valueOf(currentAsyncReaderThreadCount()));
         statistics.put("gauge:PaimonJniRequiredFieldCount", String.valueOf(fields.length));
-        statistics.put("counter:PaimonJniSplitEncodedLength", String.valueOf(lengthOfParam("paimon_split")));
+        statistics.put("counter:PaimonJniSplitEncodedLength", String.valueOf(lengthOfCurrentPaimonSplit()));
         statistics.put("counter:PaimonJniPredicateEncodedLength", String.valueOf(lengthOfParam("paimon_predicate")));
         statistics.put("gauge:PaimonJniAsyncThresholdConfigured",
                 hasPaimonOption(FILE_READER_ASYNC_THRESHOLD) ? "1" : "0");
@@ -452,6 +506,10 @@ public class PaimonJniScanner extends JniScanner {
     private int lengthOfParam(String key) {
         String value = params.get(key);
         return value == null ? 0 : value.length();
+    }
+
+    private int lengthOfCurrentPaimonSplit() {
+        return currentPaimonSplit == null ? 0 : currentPaimonSplit.length();
     }
 
     private boolean hasPaimonOption(String key) {

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -93,6 +93,7 @@ public class PaimonJniScanner extends JniScanner {
     private long readBatchCalls;
     private long emptyReadBatchCalls;
     private long rowsRead;
+    private long completedSplitEncodedLength;
 
     public PaimonJniScanner(int batchSize, Map<String, String> params) {
         this.classLoader = this.getClass().getClassLoader();
@@ -195,6 +196,7 @@ public class PaimonJniScanner extends JniScanner {
         if (exception != null) {
             throw exception;
         }
+        completedSplitEncodedLength += lengthOfCurrentPaimonSplit();
         currentPaimonSplit = null;
     }
 
@@ -488,7 +490,8 @@ public class PaimonJniScanner extends JniScanner {
         statistics.put("gauge:PaimonJniAsyncReaderThreadCount",
                 String.valueOf(currentAsyncReaderThreadCount()));
         statistics.put("gauge:PaimonJniRequiredFieldCount", String.valueOf(fields.length));
-        statistics.put("counter:PaimonJniSplitEncodedLength", String.valueOf(lengthOfCurrentPaimonSplit()));
+        statistics.put("counter:PaimonJniSplitEncodedLength",
+                String.valueOf(completedSplitEncodedLength + lengthOfCurrentPaimonSplit()));
         statistics.put("counter:PaimonJniPredicateEncodedLength", String.valueOf(lengthOfParam("paimon_predicate")));
         statistics.put("gauge:PaimonJniAsyncThresholdConfigured",
                 hasPaimonOption(FILE_READER_ASYNC_THRESHOLD) ? "1" : "0");

--- a/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
+++ b/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.AsyncRecordReader;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -184,6 +185,30 @@ public class PaimonJniScannerTest {
     @Test
     public void testFailedCloseRetainsResourcesForRetry() throws Exception {
         PaimonJniScanner scanner = new PaimonJniScanner(128, createBaseParams());
+        CountDownLatch asyncReaderStarted = new CountDownLatch(1);
+        CountDownLatch asyncReaderRelease = new CountDownLatch(1);
+        CountDownLatch asyncReaderStopped = new CountDownLatch(1);
+        RecordReader<InternalRow> asyncReaderDelegate = new RecordReader<InternalRow>() {
+            @Override
+            public RecordIterator<InternalRow> readBatch() {
+                asyncReaderStarted.countDown();
+                try {
+                    asyncReaderRelease.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return null;
+            }
+
+            @Override
+            public void close() {
+                asyncReaderStopped.countDown();
+            }
+        };
+        AsyncRecordReader<InternalRow> asyncRecordReader =
+                new AsyncRecordReader<>(() -> asyncReaderDelegate);
+        Assert.assertTrue(asyncReaderStarted.await(5, TimeUnit.SECONDS));
+
         AtomicInteger iteratorCloseCalls = new AtomicInteger();
         RecordReader.RecordIterator<InternalRow> recordIterator =
                 new RecordReader.RecordIterator<InternalRow>() {
@@ -202,8 +227,8 @@ public class PaimonJniScannerTest {
         AtomicInteger readerCloseCalls = new AtomicInteger();
         RecordReader<InternalRow> reader = new RecordReader<InternalRow>() {
             @Override
-            public RecordIterator<InternalRow> readBatch() {
-                return null;
+            public RecordIterator<InternalRow> readBatch() throws IOException {
+                return asyncRecordReader.readBatch();
             }
 
             @Override
@@ -211,9 +236,16 @@ public class PaimonJniScannerTest {
                 if (readerCloseCalls.incrementAndGet() == 1) {
                     throw new IOException("injected reader close failure");
                 }
+                asyncRecordReader.close();
             }
         };
-        RetryableIOManager ioManager = new RetryableIOManager();
+        File tempDir = temporaryFolder.newFolder("paimon-io-manager-retry");
+        IOManager delegateIOManager = PaimonJniScanner.createIOManager(tempDir.getAbsolutePath());
+        FileIOChannel.ID channel = delegateIOManager.createChannel();
+        File spillFile = channel.getPathFile();
+        Assert.assertTrue(spillFile.createNewFile());
+        File spillDir = spillFile.getParentFile();
+        RetryableIOManager ioManager = new RetryableIOManager(delegateIOManager);
         Field recordIteratorField = PaimonJniScanner.class.getDeclaredField("recordIterator");
         recordIteratorField.setAccessible(true);
         recordIteratorField.set(scanner, recordIterator);
@@ -225,22 +257,32 @@ public class PaimonJniScannerTest {
         ioManagerField.set(scanner, ioManager);
 
         try {
-            scanner.close();
-            Assert.fail("expected the first close to fail");
-        } catch (IOException expected) {
-            Assert.assertEquals("Failed to release Paimon record iterator", expected.getMessage());
-        }
-        Assert.assertSame(recordIterator, recordIteratorField.get(scanner));
-        Assert.assertSame(reader, readerField.get(scanner));
-        Assert.assertSame(ioManager, ioManagerField.get(scanner));
+            try {
+                scanner.close();
+                Assert.fail("expected the first close to fail");
+            } catch (IOException expected) {
+                Assert.assertEquals("Failed to release Paimon record iterator", expected.getMessage());
+            }
+            Assert.assertSame(recordIterator, recordIteratorField.get(scanner));
+            Assert.assertSame(reader, readerField.get(scanner));
+            Assert.assertSame(ioManager, ioManagerField.get(scanner));
+            Assert.assertEquals(1L, asyncReaderStopped.getCount());
+            Assert.assertTrue(spillDir.exists());
 
-        scanner.close();
-        Assert.assertNull(recordIteratorField.get(scanner));
-        Assert.assertNull(readerField.get(scanner));
-        Assert.assertNull(ioManagerField.get(scanner));
-        Assert.assertEquals(2, iteratorCloseCalls.get());
-        Assert.assertEquals(2, readerCloseCalls.get());
-        Assert.assertEquals(2, ioManager.closeCalls.get());
+            scanner.close();
+            Assert.assertNull(recordIteratorField.get(scanner));
+            Assert.assertNull(readerField.get(scanner));
+            Assert.assertNull(ioManagerField.get(scanner));
+            Assert.assertEquals(2, iteratorCloseCalls.get());
+            Assert.assertEquals(2, readerCloseCalls.get());
+            Assert.assertEquals(2, ioManager.closeCalls.get());
+            Assert.assertTrue(asyncReaderStopped.await(5, TimeUnit.SECONDS));
+            Assert.assertFalse(spillDir.exists());
+        } finally {
+            asyncReaderRelease.countDown();
+            asyncRecordReader.close();
+            asyncReaderStopped.await(5, TimeUnit.SECONDS);
+        }
     }
 
     @Test
@@ -359,15 +401,22 @@ public class PaimonJniScannerTest {
 
     public static class RetryableIOManager extends TestIOManager {
         private final AtomicInteger closeCalls = new AtomicInteger();
+        private final IOManager delegate;
 
-        public RetryableIOManager() {
-            super(new String[0]);
+        public RetryableIOManager(IOManager delegate) {
+            super(delegate.tempDirs());
+            this.delegate = delegate;
         }
 
         @Override
         public void close() {
             if (closeCalls.incrementAndGet() == 1) {
                 throw new RuntimeException("injected IO manager close failure");
+            }
+            try {
+                delegate.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
+++ b/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
@@ -107,10 +107,10 @@ public class PaimonJniScannerTest {
     @Test
     public void testStatisticsIncludePaimonDiagnostics() throws Exception {
         Map<String, String> params = createBaseParams();
-        params.put("paimon_split", "encoded-split");
         params.put("paimon_predicate", "encoded-predicate");
         PaimonJniScanner scanner = new PaimonJniScanner(128, params);
         setTableOptions(scanner, Collections.singletonMap("file-reader-async-threshold", "10 MiB"));
+        setCurrentPaimonSplit(scanner, "encoded-split");
 
         Map<String, String> statistics = scanner.getStatistics();
 
@@ -169,18 +169,7 @@ public class PaimonJniScannerTest {
     public void testCloseReleasesActiveRecordIterator() throws Exception {
         PaimonJniScanner scanner = new PaimonJniScanner(128, createBaseParams());
         AtomicBoolean released = new AtomicBoolean(false);
-        RecordReader.RecordIterator<InternalRow> recordIterator =
-                new RecordReader.RecordIterator<InternalRow>() {
-                    @Override
-                    public InternalRow next() {
-                        return null;
-                    }
-
-                    @Override
-                    public void releaseBatch() {
-                        released.set(true);
-                    }
-                };
+        RecordReader.RecordIterator<InternalRow> recordIterator = createRecordIterator(released);
 
         Field recordIteratorField = PaimonJniScanner.class.getDeclaredField("recordIterator");
         recordIteratorField.setAccessible(true);
@@ -225,7 +214,6 @@ public class PaimonJniScannerTest {
             }
         };
         RetryableIOManager ioManager = new RetryableIOManager();
-
         Field recordIteratorField = PaimonJniScanner.class.getDeclaredField("recordIterator");
         recordIteratorField.setAccessible(true);
         recordIteratorField.set(scanner, recordIterator);
@@ -255,11 +243,38 @@ public class PaimonJniScannerTest {
         Assert.assertEquals(2, ioManager.closeCalls.get());
     }
 
+    @Test
+    public void testResetCurrentSplitReleasesActiveRecordIterator() throws Exception {
+        PaimonJniScanner scanner = new PaimonJniScanner(128, createBaseParams());
+        AtomicBoolean released = new AtomicBoolean(false);
+        RecordReader.RecordIterator<InternalRow> recordIterator = createRecordIterator(released);
+
+        Field recordIteratorField = PaimonJniScanner.class.getDeclaredField("recordIterator");
+        recordIteratorField.setAccessible(true);
+        recordIteratorField.set(scanner, recordIterator);
+
+        scanner.resetCurrentSplit();
+
+        Assert.assertTrue(released.get());
+        Assert.assertNull(recordIteratorField.get(scanner));
+    }
+
+    @Test
+    public void testPrepareForSplitRequiresSplitParam() throws Exception {
+        PaimonJniScanner scanner = new PaimonJniScanner(128, createBaseParams());
+
+        try {
+            scanner.prepareForSplit(new HashMap<>());
+            Assert.fail("Expected prepareForSplit to reject missing paimon_split");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("paimon_split"));
+        }
+    }
+
     private Map<String, String> createBaseParams() {
         Map<String, String> params = new HashMap<>();
         params.put("required_fields", "");
         params.put("columns_types", "");
-        params.put("paimon_split", "");
         params.put("paimon_predicate", "");
         return params;
     }
@@ -278,6 +293,26 @@ public class PaimonJniScannerTest {
         Field tableField = PaimonJniScanner.class.getDeclaredField("table");
         tableField.setAccessible(true);
         tableField.set(scanner, table);
+    }
+
+    private void setCurrentPaimonSplit(PaimonJniScanner scanner, String split) throws Exception {
+        Field currentPaimonSplitField = PaimonJniScanner.class.getDeclaredField("currentPaimonSplit");
+        currentPaimonSplitField.setAccessible(true);
+        currentPaimonSplitField.set(scanner, split);
+    }
+
+    private RecordReader.RecordIterator<InternalRow> createRecordIterator(AtomicBoolean released) {
+        return new RecordReader.RecordIterator<InternalRow>() {
+            @Override
+            public InternalRow next() {
+                return null;
+            }
+
+            @Override
+            public void releaseBatch() {
+                released.set(true);
+            }
+        };
     }
 
     public static class TestIOManager implements IOManager {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1170,7 +1170,7 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = ENABLE_FILE_SCANNER_V2, needForward = true, fuzzy = true, description = {
             "开启后 FileScanNode 会在支持的查询场景使用 FileScannerV2，默认开启",
             "When enabled, FileScanNode uses FileScannerV2 for supported query scans. Enabled by default."})
-    public boolean enableFileScannerV2 = true;
+    public boolean enableFileScannerV2 = false;
 
     @VarAttrDef.VarAttr(name = LOCAL_EXCHANGE_FREE_BLOCKS_LIMIT)
     public int localExchangeFreeBlocksLimit = 4;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1170,7 +1170,7 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = ENABLE_FILE_SCANNER_V2, needForward = true, fuzzy = true, description = {
             "开启后 FileScanNode 会在支持的查询场景使用 FileScannerV2，默认开启",
             "When enabled, FileScanNode uses FileScannerV2 for supported query scans. Enabled by default."})
-    public boolean enableFileScannerV2 = false;
+    public boolean enableFileScannerV2 = true;
 
     @VarAttrDef.VarAttr(name = LOCAL_EXCHANGE_FREE_BLOCKS_LIMIT)
     public int localExchangeFreeBlocksLimit = 4;


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
beore the PaimonJniReader handle multi splits one by one: eg:

PaimonJniReader(BE) ---> split1 ----> PaimonJniScanner(FE) -----> open -------> get_next-------->close.

split mapping to PaimonJniScanner, one split will new PaimonJniScanner object and deserialize, open, get_next, close.
so those will make JVM more pressure when have lost of splits.

now add reset logical, eg:
PaimonJniReader hold PaimonJniScanner not close it, when finish first split and reset some state, continue to handle next splits.




### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

