### PR TITLE
[fix](regression) Wait for schema change in rewrite_when_dml

### DIFF
--- a/regression-test/suites/nereids_rules_p0/mv/dml/rewrite/rewrite_when_dml.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dml/rewrite/rewrite_when_dml.groovy
@@ -177,6 +177,9 @@ suite("rewrite_when_dml") {
     """
     order_qt_query1_0_before "${query1_0}"
     sql """ALTER TABLE orders ADD COLUMN new_col INT KEY DEFAULT "0";"""
+    waitForSchemaChangeDone {
+        sql """SHOW ALTER TABLE COLUMN WHERE TableName='orders' ORDER BY CreateTime DESC LIMIT 1"""
+    }
     async_mv_rewrite_success(db, mv1_0, query1_0, "mv1_0")
     order_qt_query1_0_after "${query1_0}"
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv1_0"""
@@ -231,6 +234,9 @@ suite("rewrite_when_dml") {
     """
     waitingMTMVTaskFinishedByMvName("mv2_0")
     sql """ALTER TABLE lineitem DROP COLUMN l_suppkey;"""
+    waitForSchemaChangeDone {
+        sql """SHOW ALTER TABLE COLUMN WHERE TableName='lineitem' ORDER BY CreateTime DESC LIMIT 1"""
+    }
 
     try {
         mv_not_part_in(query2_0, "mv2_0")
@@ -284,6 +290,9 @@ suite("rewrite_when_dml") {
     """
     waitingMTMVTaskFinishedByMvName("mv3_0")
     sql """ALTER TABLE orders DROP COLUMN O_COMMENT;"""
+    waitForSchemaChangeDone {
+        sql """SHOW ALTER TABLE COLUMN WHERE TableName='orders' ORDER BY CreateTime DESC LIMIT 1"""
+    }
     mv_not_part_in(query3_0, "mv3_0")
 
     order_qt_query3_0_after "${query3_0}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

The `rewrite_when_dml` regression case waits for MTMV build tasks, but it did not wait for column schema-change jobs after ALTER statements. On Cloud P0, a later ALTER can run while the table is still in `SCHEMA_CHANGE` and fail with `Table[orders]'s state(SCHEMA_CHANGE) is not NORMAL`.

This patch waits for the latest column schema-change job to finish after each ALTER in this case before continuing with MV rewrite checks.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `git diff --check`
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->