### PR TITLE
[fix](regression) Restore time zone after test_tz_load

### DIFF
--- a/regression-test/suites/datatype_p0/datetimev2/test_tz_load.groovy
+++ b/regression-test/suites/datatype_p0/datetimev2/test_tz_load.groovy
@@ -22,6 +22,9 @@ suite("test_tz_load", "nonConcurrent") {
     def s3Region = getS3Region()
     def ak = getS3AK()
     def sk = getS3SK()
+    def originGlobalTimeZone = sql("select @@global.time_zone")[0][0]
+
+    try {
     
     sql "drop table if exists ${table1}"
 
@@ -226,4 +229,8 @@ suite("test_tz_load", "nonConcurrent") {
     }
     sql "sync"
     qt_global_offset "select * from ${table1} order by id"
+    } finally {
+        sql "SET GLOBAL time_zone = '${originGlobalTimeZone}'"
+        try_sql("drop table if exists ${table1}")
+    }
 }


### PR DESCRIPTION
## Summary
- restore the original global time_zone after test_tz_load changes it during the suite
- clean up the temporary global_timezone_test table in the finally block
- prevent later nonConcurrent suites from inheriting UTC global time zone

## Evidence
- branch-4.0 has the same test_tz_load pattern: it sets GLOBAL time_zone to UTC and previously did not restore it before suite exit
- test_json_load contains a timezone-sensitive from_unixtime assertion that can be affected by the leaked global time zone
- same branch-4.1 fix was submitted in #65385

## Testing
- [x] git diff --check HEAD~1..HEAD
- [x] Cherry-picked the branch-4.1 fix cleanly onto latest origin/branch-4.0
- [x] Equivalent fix was validated on 172.20.56.184 by running test_tz_load and then test_json_load with Asia/Shanghai restored after the runs
- [ ] Not run on a branch-4.0-specific regression environment
- [ ] Buildall skipped