### PR TITLE
[fix](filecache) fix flaky be UT for LRU dump

### DIFF
--- a/be/test/io/cache/block_file_cache_test_meta_store.cpp
+++ b/be/test/io/cache/block_file_cache_test_meta_store.cpp
@@ -277,6 +277,7 @@ TEST_F(BlockFileCacheTest, version3_add_remove_restart) {
         ASSERT_EQ(cache._lru_recorder->_shadow_disposable_queue.get_elements_num_unsafe(), 2);
         EXPECT_EQ(cache.replay_lru_logs_once(), 0);
         EXPECT_EQ(cache._lru_recorder_log_replay_idle_metrics->get_value(), 1);
+        cache.dump_lru_queues(true);
 
         // check the meta store to see the content
         {
@@ -312,8 +313,6 @@ TEST_F(BlockFileCacheTest, version3_add_remove_restart) {
             verify_meta_key(*meta_store, 50, "key4", 300000, FileCacheType::DISPOSABLE, 0, 100000);
             verify_meta_key(*meta_store, 50, "key4", 400000, FileCacheType::DISPOSABLE, 0, 100000);
         }
-        std::this_thread::sleep_for(
-                std::chrono::milliseconds(2 * config::file_cache_background_lru_dump_interval_ms));
     }
 
     { // cache2


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `BlockFileCacheTest.version3_add_remove_restart` relied on sleeping for the background LRU dump thread after replaying remove records. If the background dump did not run before the restart phase, stale LRU tail records could be restored and the restarted cache could report non-empty queues. The test now explicitly dumps LRU queues after replaying the remove logs, so persisted LRU state is synchronized before the restart check without changing file cache runtime code.

### Release note

None

### Check List (For Author)

- Test:
    - Unit Test: `DORIS_TOOLCHAIN=clang DISABLE_BE_JAVA_EXTENSIONS=ON ENABLE_INJECTION_POINT=ON ENABLE_CACHE_LOCK_DEBUG=0 ENABLE_PCH=0 sh run-be-ut.sh --run --filter=BlockFileCacheTest.version3_add_remove_restart`
    - Style check: `git diff --check -- be/test/io/cache/block_file_cache_test_meta_store.cpp`
- Behavior changed: No
- Does this need documentation: No