### PR TITLE
[fix](regression) Avoid midnight race in auto recycle case

### DIFF
--- a/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
@@ -111,8 +111,6 @@ suite("test_auto_new_recycle", "nonConcurrent") {
         );
     """
 
-    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BOUNDARY", 20)
-
     sql """
     insert into auto_recycle select date_add('2020-01-01 00:00:00', interval number day) from numbers("number" = "100");
     """
@@ -172,12 +170,15 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '600') """
     sleep(8000)
     sql """
-        insert into auto_recycle select date_add(now(), interval number-5 day) from numbers("number" = "8");
+        insert into auto_recycle
+        select date_add('1900-01-01 00:00:00', interval number day) from numbers("number" = "5")
+        union all
+        select date_add('2900-01-01 00:00:00', interval number day) from numbers("number" = "3");
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
     sleep(8000)
     res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 6) // [-5, -1] -> [-3, -1], [0, 2] -> [0, 2]
+    assertEquals(res.size(), 6) // latest 3 historical partitions and all 3 future partitions
     res = sql "select * from auto_recycle order by k0"
     assertEquals(res.size(), 6)
 

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
@@ -169,16 +169,14 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '600') """
     sleep(8000)
+    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BOUNDARY", 100)
     sql """
-        insert into auto_recycle
-        select date_add('1900-01-01 00:00:00', interval number day) from numbers("number" = "5")
-        union all
-        select date_add('2900-01-01 00:00:00', interval number day) from numbers("number" = "3");
+        insert into auto_recycle select date_add(now(), interval number-5 day) from numbers("number" = "8");
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
     sleep(8000)
     res = sql "show partitions from auto_recycle"
-    assertEquals(res.size(), 6) // latest 3 historical partitions and all 3 future partitions
+    assertEquals(res.size(), 6) // [-5, -1] -> [-3, -1], [0, 2] -> [0, 2]
     res = sql "select * from auto_recycle order by k0"
     assertEquals(res.size(), 6)
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #65375

Problem Summary:

`test_auto_new_recycle` uses `now()` to create five historical partitions, one
current-day partition, and two future partitions, then asserts that retention
leaves six partitions. The day-boundary guard previously ran near the start of
the case and only reserved 20 seconds, while the time-sensitive assertion ran
after multiple fixed sleeps. The case could therefore cross midnight before
the final scheduler pass, changing the correct partition count from six to
five.

This change moves the guard directly before the final time-sensitive insert
and reserves 100 seconds for that section. It preserves coverage for the
current-day partition boundary and future partitions while preventing the
final scheduler pass from crossing midnight.

Testing:

- `git diff --check`
- Not run locally because no Doris regression environment was allocated. The
  PR build will run the regression coverage.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
