### PR TITLE
[branch-4.1][fix](profile) guard execution profile access

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -198,7 +198,12 @@ public class ProfileManager extends MasterDaemon {
     }
 
     public ExecutionProfile getExecutionProfile(TUniqueId queryId) {
-        return this.queryIdToExecutionProfiles.get(queryId);
+        readLock.lock();
+        try {
+            return this.queryIdToExecutionProfiles.get(queryId);
+        } finally {
+            readLock.unlock();
+        }
     }
 
     public void pushProfile(Profile profile) {
@@ -1116,4 +1121,3 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 }
-


### PR DESCRIPTION
### What

Backport the `ProfileManager.getExecutionProfile()` read-lock fix from
apache/doris#65353 to `branch-4.1`.

### Why

`queryIdToExecutionProfiles` is updated and removed under the profile manager's
write lock. Reads should use the corresponding read lock to keep access
consistent with the map's lock discipline.

### Backport Notes

The master PR also marks `query_profile/dml_profile_safe.groovy` as
`nonConcurrent`, because that master-only suite runs `clean all profile`.
`branch-4.1` does not contain `dml_profile_safe.groovy`, and no query_profile
suite on this branch uses `clean all profile`, so that part is intentionally not
backported.

### Validation

- `git diff --check`

Local FE build/regression was not run in this manual pick pass.
