### PR TITLE
[fix](regression) Handle loopback export hosts locally

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/RemoteFileOperator.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/RemoteFileOperator.groovy
@@ -100,7 +100,7 @@ class RemoteFileOperator {
             }
             
             if (execResult.exitCode != 0) {
-                def errorMsg = "Failed to create directory on ${host} (exit code: ${execResult.exitCode}): ${execResult.error}"
+                def errorMsg = "Failed to create directory on ${host} (exit code: ${execResult.exitCode}): ${execResult.stderr}"
                 logger.error(errorMsg)
                 throw new Exception(errorMsg)
             }
@@ -140,7 +140,9 @@ class RemoteFileOperator {
         hosts.each { host ->
             // Step 1: Check if remote directory has files (count regular files only)
             // scp user@host:/tmp/doristest/* will fail if doristest has no files.
-            String countCommand = """ssh -p ${port} ${username}@${host} "find ${escapePath(remoteDir)} -maxdepth 1 -type f | wc -l" """
+            String countCommand = isLocalHost(host)
+                    ? "find ${escapePath(remoteDir)} -maxdepth 1 -type f | wc -l"
+                    : """ssh -p ${port} ${username}@${host} "find ${escapePath(remoteDir)} -maxdepth 1 -type f | wc -l" """
             def countResult = executeLocalCommand(countCommand)
             
             if (countResult.timedOut) {
@@ -150,7 +152,7 @@ class RemoteFileOperator {
             }
             
             if (countResult.exitCode != 0) {
-                def errorMsg = "Failed to check file count on ${host} (exit code: ${countResult.exitCode}): ${countResult.error}"
+                def errorMsg = "Failed to check file count on ${host} (exit code: ${countResult.exitCode}): ${countResult.stderr}"
                 logger.error(errorMsg)
                 throw new Exception(errorMsg)
             }
@@ -163,9 +165,16 @@ class RemoteFileOperator {
             if (fileCount > 0) {
                 logger.info("Downloading ${fileCount} files from ${host}:${remoteDir} to ${localBaseDir}")
 
-                def normalizedRemoteDir = (remoteDir.endsWith('/') ? remoteDir : "${remoteDir}/") + "*"
-                def scpCommand = "scp -P ${port} ${username}@${host}:${escapePath(normalizedRemoteDir)} ${escapePath(localBaseDir)}"
-                def execResult = executeLocalCommand(scpCommand)
+                def copyCommand
+                if (isLocalHost(host)) {
+                    copyCommand = "find ${escapePath(remoteDir)} -maxdepth 1 -type f " +
+                            "-exec cp -f '{}' ${escapePath(localBaseDir)} ';'"
+                } else {
+                    def normalizedRemoteDir = (remoteDir.endsWith('/') ? remoteDir : "${remoteDir}/") + "*"
+                    copyCommand = "scp -P ${port} ${username}@${host}:${escapePath(normalizedRemoteDir)} " +
+                            escapePath(localBaseDir)
+                }
+                def execResult = executeLocalCommand(copyCommand)
 
                 if (execResult.timedOut) {
                     def errorMsg = "Timeout downloading from ${host} (${timeout}ms)"
@@ -174,7 +183,7 @@ class RemoteFileOperator {
                 }
 
                 if (execResult.exitCode != 0) {
-                    def errorMsg = "Failed to download from ${host} (exit code: ${execResult.exitCode}): ${execResult.error}"
+                    def errorMsg = "Failed to download from ${host} (exit code: ${execResult.exitCode}): ${execResult.stderr}"
                     logger.error(errorMsg)
                     throw new Exception(errorMsg)
                 }
@@ -214,7 +223,7 @@ class RemoteFileOperator {
             }
             
             if (execResult.exitCode != 0) {
-                def errorMsg = "Failed to delete directory on ${host} (exit code: ${execResult.exitCode}): ${execResult.error}"
+                def errorMsg = "Failed to delete directory on ${host} (exit code: ${execResult.exitCode}): ${execResult.stderr}"
                 logger.error(errorMsg)
                 throw new Exception(errorMsg)
             }
@@ -224,8 +233,15 @@ class RemoteFileOperator {
     }
 
     private Map executeSshCommand(String host, String command) {
+        if (isLocalHost(host)) {
+            return executeLocalCommand(command)
+        }
         def sshCommand = "ssh -p ${port} ${username}@${host} '${command}'"
         return executeLocalCommand(sshCommand)
+    }
+
+    private boolean isLocalHost(String host) {
+        return host in ["127.0.0.1", "localhost", "::1"]
     }
 
     private Map executeLocalCommand(String command) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`ExportTestHelper` always used SSH and SCP for every backend host, including loopback addresses. In Cloud P0 build 990900, `test_outfile_agg_state` received `127.0.0.1` from `SHOW BACKENDS` and failed before running its product assertions because the helper's SSH directory creation returned exit code 255.

Handle `127.0.0.1`, `localhost`, and `::1` with local filesystem commands while preserving the existing SSH/SCP path for remote backend hosts. Also report the command result's actual `stderr` field so future failures keep their diagnostic message.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Compiled `RemoteFileOperator.groovy` with Groovy 4.0.19.
        - Exercised loopback directory creation, file collection, content verification, and cleanup through `RemoteFileOperator`; result: `PASS: loopback create/copy/delete without SSH`.
        - `git diff --check` passed.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. Product behavior is unchanged; only regression-test file transport for loopback hosts changes.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
