### PR TITLE
[fix](regression) fix index change wait timeout

### DIFF
--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -24,21 +24,25 @@ import java.util.regex.Pattern;
 def delta_time = 1000
 
 Suite.metaClass.wait_for_last_build_index_finish = {table_name, OpTimeout ->
-    def useTime = 0
-    for(int t = delta_time; t <= OpTimeout; t += delta_time){
-        def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
+    def finished = false
+    def alter_res = ""
+    for(int t = 0; t <= OpTimeout; t += delta_time){
+        alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
         alter_res = alter_res.toString()
         if(alter_res.contains("FINISHED")) {
             logger.info(table_name + " latest alter job finished, detail: " + alter_res)
+            finished = true
             break
         } else if (alter_res.contains("CANCELLED")) {
             logger.info(table_name + " latest alter job failed, detail: " + alter_res)
             assertTrue(false)
         }
-        useTime = t
+        if (t >= OpTimeout) {
+            break
+        }
         sleep(delta_time)
     }
-    assertTrue(useTime <= OpTimeout, "wait for last build index finish timeout")
+    assertTrue(finished, "wait for last build index finish timeout, latest result: ${alter_res}")
 }
 
 Suite.metaClass.build_index_on_table = {index_name, table_name ->

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -28,42 +28,10 @@ Suite.metaClass.snapshot_build_index_job_ids = { table_name ->
     return alter_res.collect { it[0].toString() }.toSet()
 }
 
-// Compatibility helper for legacy callers where a build-index job is optional.
-// New explicit build/delete paths must snapshot job ids before the operation and
-// use wait_for_new_build_index_jobs_finish instead.
-Suite.metaClass.wait_for_last_build_index_finish = { table_name, OpTimeout ->
-    def finished = false
-    def alter_res = []
-    for (int t = 0; t <= OpTimeout; t += delta_time) {
-        alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
-                ORDER BY CreateTime DESC LIMIT 1;"""
-        if (alter_res.isEmpty()) {
-            logger.info(table_name + " has no build index job")
-            finished = true
-            break
-        }
-        if (alter_res.any { it[7] == "CANCELLED" }) {
-            logger.info(table_name + " latest build index job failed, detail: " + alter_res)
-            assertTrue(false)
-        }
-        if (alter_res.every { it[7] == "FINISHED" }) {
-            logger.info(table_name + " latest build index job finished, detail: " + alter_res)
-            finished = true
-            break
-        }
-        if (t >= OpTimeout) {
-            break
-        }
-        sleep(delta_time)
-    }
-    assertTrue(finished, "wait for latest build index finish timeout, latest result: ${alter_res}")
-}
-
 Suite.metaClass.wait_for_new_build_index_jobs_finish = { table_name, OpTimeout, previous_job_ids ->
     assertTrue(previous_job_ids != null, "previous build index job ids must be snapshotted before the operation")
     def finished = false
     def alter_res = []
-    def confirmed_finished_job_ids = null
     for (int t = 0; t <= OpTimeout; t += delta_time) {
         def all_jobs = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
                 ORDER BY CreateTime DESC;"""
@@ -71,18 +39,12 @@ Suite.metaClass.wait_for_new_build_index_jobs_finish = { table_name, OpTimeout, 
 
         if (!alter_res.isEmpty() && alter_res.any { it[7] == "CANCELLED" }) {
             logger.info(table_name + " build index job failed, detail: " + alter_res)
-            assertTrue(false)
+            assertTrue(false, "build index job cancelled, result: ${alter_res}")
         }
         if (!alter_res.isEmpty() && alter_res.every { it[7] == "FINISHED" }) {
-            def finished_job_ids = alter_res.collect { it[0].toString() }.toSet()
-            if (finished_job_ids == confirmed_finished_job_ids) {
-                logger.info(table_name + " build index jobs finished, detail: " + alter_res)
-                finished = true
-                break
-            }
-            confirmed_finished_job_ids = finished_job_ids
-        } else {
-            confirmed_finished_job_ids = null
+            logger.info(table_name + " build index jobs finished, detail: " + alter_res)
+            finished = true
+            break
         }
         if (t >= OpTimeout) {
             break
@@ -90,6 +52,15 @@ Suite.metaClass.wait_for_new_build_index_jobs_finish = { table_name, OpTimeout, 
         sleep(delta_time)
     }
     assertTrue(finished, "wait for build index finish timeout, latest result: ${alter_res}")
+}
+
+// Run an operation that must create one or more IndexChangeJobs and wait for
+// every job created by that operation. SHOW BUILD INDEX history is retained, so
+// the pre-operation snapshot is required to isolate the current operation.
+Suite.metaClass.run_index_change_job_and_wait = { table_name, OpTimeout, Closure operation ->
+    def previous_job_ids = snapshot_build_index_job_ids(table_name)
+    operation.call()
+    wait_for_new_build_index_jobs_finish(table_name, OpTimeout, previous_job_ids)
 }
 
 Suite.metaClass.build_index_on_table = {index_name, table_name ->

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -74,16 +74,22 @@ Suite.metaClass.build_index_on_table = {index_name, table_name ->
 
 Suite.metaClass.wait_for_last_col_change_finish = { table_name, OpTimeout ->
     def finished = false
-    def alter_res = ""
+    def alter_res = []
 
     for (int t = 0; t <= OpTimeout; t += delta_time) {
         alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
-        alter_res = alter_res.toString()
-        if (alter_res.contains("FINISHED")) {
-            sleep(3000) // wait change table state to normal
-            logger.info(table_name + " latest alter job finished, detail: " + alter_res)
-            finished = true
-            break
+        if (!alter_res.isEmpty()) {
+            def state = alter_res[0][9].toString()
+            if (state.equalsIgnoreCase("CANCELLED")) {
+                logger.info(table_name + " latest alter job cancelled, detail: " + alter_res)
+                assertTrue(false, "column change job cancelled, result: ${alter_res}")
+            }
+            if (state.equalsIgnoreCase("FINISHED")) {
+                sleep(3000) // wait change table state to normal
+                logger.info(table_name + " latest alter job finished, detail: " + alter_res)
+                finished = true
+                break
+            }
         }
         if (t >= OpTimeout) {
             break

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -42,6 +42,8 @@ Suite.metaClass.wait_for_new_build_index_jobs_finish = { table_name, OpTimeout, 
             assertTrue(false, "build index job cancelled, result: ${alter_res}")
         }
         if (!alter_res.isEmpty() && alter_res.every { it[7] == "FINISHED" }) {
+            // FE registers all sibling jobs before the DDL returns, so the first
+            // nonempty all-FINISHED observation is complete, even at the deadline.
             logger.info(table_name + " build index jobs finished, detail: " + alter_res)
             finished = true
             break

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -25,9 +25,14 @@ def delta_time = 1000
 
 Suite.metaClass.wait_for_last_build_index_finish = {table_name, OpTimeout ->
     def finished = false
-    def alter_res = ""
+    def alter_res = []
     for(int t = 0; t <= OpTimeout; t += delta_time){
         alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
+        if (alter_res.isEmpty()) {
+            logger.info(table_name + " has no build index job to wait for")
+            finished = true
+            break
+        }
         alter_res = alter_res.toString()
         if(alter_res.contains("FINISHED")) {
             logger.info(table_name + " latest alter job finished, detail: " + alter_res)

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -23,31 +23,46 @@ import java.util.regex.Pattern;
 
 def delta_time = 1000
 
-Suite.metaClass.wait_for_last_build_index_finish = {table_name, OpTimeout ->
+Suite.metaClass.get_build_index_job_ids = { table_name ->
+    def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
+    return alter_res.collect { it[0].toString() }.toSet()
+}
+
+Suite.metaClass.wait_for_last_build_index_finish = { table_name, OpTimeout, previous_job_ids = null ->
     def finished = false
     def alter_res = []
-    for(int t = 0; t <= OpTimeout; t += delta_time){
-        alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
-        if (alter_res.isEmpty()) {
-            logger.info(table_name + " has no build index job to wait for")
-            finished = true
-            break
+    def confirmed_finished_job_ids = null
+    for (int t = 0; t <= OpTimeout; t += delta_time) {
+        if (previous_job_ids == null) {
+            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
+                    ORDER BY CreateTime DESC LIMIT 1;"""
+        } else {
+            def all_jobs = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
+                    ORDER BY CreateTime DESC;"""
+            alter_res = all_jobs.findAll { !previous_job_ids.contains(it[0].toString()) }
         }
-        alter_res = alter_res.toString()
-        if(alter_res.contains("FINISHED")) {
-            logger.info(table_name + " latest alter job finished, detail: " + alter_res)
-            finished = true
-            break
-        } else if (alter_res.contains("CANCELLED")) {
-            logger.info(table_name + " latest alter job failed, detail: " + alter_res)
+
+        if (!alter_res.isEmpty() && alter_res.any { it[7] == "CANCELLED" }) {
+            logger.info(table_name + " build index job failed, detail: " + alter_res)
             assertTrue(false)
+        }
+        if (!alter_res.isEmpty() && alter_res.every { it[7] == "FINISHED" }) {
+            def finished_job_ids = alter_res.collect { it[0].toString() }.toSet()
+            if (previous_job_ids == null || finished_job_ids == confirmed_finished_job_ids) {
+                logger.info(table_name + " build index jobs finished, detail: " + alter_res)
+                finished = true
+                break
+            }
+            confirmed_finished_job_ids = finished_job_ids
+        } else {
+            confirmed_finished_job_ids = null
         }
         if (t >= OpTimeout) {
             break
         }
         sleep(delta_time)
     }
-    assertTrue(finished, "wait for last build index finish timeout, latest result: ${alter_res}")
+    assertTrue(finished, "wait for build index finish timeout, latest result: ${alter_res}")
 }
 
 Suite.metaClass.build_index_on_table = {index_name, table_name ->

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -77,7 +77,8 @@ Suite.metaClass.wait_for_last_col_change_finish = { table_name, OpTimeout ->
     def alter_res = []
 
     for (int t = 0; t <= OpTimeout; t += delta_time) {
-        alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
+        alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}"
+                ORDER BY CreateTime DESC, JobId DESC LIMIT 1;"""
         if (!alter_res.isEmpty()) {
             def state = alter_res[0][9].toString()
             if (state.equalsIgnoreCase("CANCELLED")) {

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -77,7 +77,6 @@ Suite.metaClass.wait_for_last_col_change_finish = { table_name, OpTimeout ->
 
 Suite.metaClass.wait_for_last_schema_change_finish = {table_name, OpTimeout ->
     wait_for_last_col_change_finish(table_name, OpTimeout)
-    wait_for_last_build_index_finish(table_name, OpTimeout)
 }
 
 

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -55,20 +55,24 @@ Suite.metaClass.build_index_on_table = {index_name, table_name ->
 }
 
 Suite.metaClass.wait_for_last_col_change_finish = { table_name, OpTimeout ->
-    def useTime = 0
+    def finished = false
+    def alter_res = ""
 
-    for (int t = delta_time; t <= OpTimeout; t += delta_time) {
-        def alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
+    for (int t = 0; t <= OpTimeout; t += delta_time) {
+        alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
         alter_res = alter_res.toString()
         if (alter_res.contains("FINISHED")) {
             sleep(3000) // wait change table state to normal
             logger.info(table_name + " latest alter job finished, detail: " + alter_res)
+            finished = true
             break
         }
-        useTime = t
+        if (t >= OpTimeout) {
+            break
+        }
         sleep(delta_time)
     }
-    assertTrue(useTime <= OpTimeout, "wait_for_last_col_change_finish timeout")
+    assertTrue(finished, "wait_for_last_col_change_finish timeout, latest result: ${alter_res}")
 }
 
 Suite.metaClass.wait_for_last_schema_change_finish = {table_name, OpTimeout ->

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -23,24 +23,51 @@ import java.util.regex.Pattern;
 
 def delta_time = 1000
 
-Suite.metaClass.get_build_index_job_ids = { table_name ->
+Suite.metaClass.snapshot_build_index_job_ids = { table_name ->
     def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
     return alter_res.collect { it[0].toString() }.toSet()
 }
 
-Suite.metaClass.wait_for_last_build_index_finish = { table_name, OpTimeout, previous_job_ids = null ->
+// Compatibility helper for legacy callers where a build-index job is optional.
+// New explicit build/delete paths must snapshot job ids before the operation and
+// use wait_for_new_build_index_jobs_finish instead.
+Suite.metaClass.wait_for_last_build_index_finish = { table_name, OpTimeout ->
+    def finished = false
+    def alter_res = []
+    for (int t = 0; t <= OpTimeout; t += delta_time) {
+        alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
+                ORDER BY CreateTime DESC LIMIT 1;"""
+        if (alter_res.isEmpty()) {
+            logger.info(table_name + " has no build index job")
+            finished = true
+            break
+        }
+        if (alter_res.any { it[7] == "CANCELLED" }) {
+            logger.info(table_name + " latest build index job failed, detail: " + alter_res)
+            assertTrue(false)
+        }
+        if (alter_res.every { it[7] == "FINISHED" }) {
+            logger.info(table_name + " latest build index job finished, detail: " + alter_res)
+            finished = true
+            break
+        }
+        if (t >= OpTimeout) {
+            break
+        }
+        sleep(delta_time)
+    }
+    assertTrue(finished, "wait for latest build index finish timeout, latest result: ${alter_res}")
+}
+
+Suite.metaClass.wait_for_new_build_index_jobs_finish = { table_name, OpTimeout, previous_job_ids ->
+    assertTrue(previous_job_ids != null, "previous build index job ids must be snapshotted before the operation")
     def finished = false
     def alter_res = []
     def confirmed_finished_job_ids = null
     for (int t = 0; t <= OpTimeout; t += delta_time) {
-        if (previous_job_ids == null) {
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
-                    ORDER BY CreateTime DESC LIMIT 1;"""
-        } else {
-            def all_jobs = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
-                    ORDER BY CreateTime DESC;"""
-            alter_res = all_jobs.findAll { !previous_job_ids.contains(it[0].toString()) }
-        }
+        def all_jobs = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}"
+                ORDER BY CreateTime DESC;"""
+        alter_res = all_jobs.findAll { !previous_job_ids.contains(it[0].toString()) }
 
         if (!alter_res.isEmpty() && alter_res.any { it[7] == "CANCELLED" }) {
             logger.info(table_name + " build index job failed, detail: " + alter_res)
@@ -48,7 +75,7 @@ Suite.metaClass.wait_for_last_build_index_finish = { table_name, OpTimeout, prev
         }
         if (!alter_res.isEmpty() && alter_res.every { it[7] == "FINISHED" }) {
             def finished_job_ids = alter_res.collect { it[0].toString() }.toSet()
-            if (previous_job_ids == null || finished_job_ids == confirmed_finished_job_ids) {
+            if (finished_job_ids == confirmed_finished_job_ids) {
                 logger.info(table_name + " build index jobs finished, detail: " + alter_res)
                 finished = true
                 break

--- a/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
+++ b/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
@@ -163,11 +163,11 @@ suite("test_ngram_bloomfilter_index_change") {
     assertTrue(filtered2 != null && filtered2 == 10, "Expected RowsBloomFilterFiltered = 10, but got ${filtered2}")
 
     // Drop index
-    def previousJobIds = isCloudMode() ? get_build_index_job_ids(tableName) : null
+    def previousJobIds = isCloudMode() ? snapshot_build_index_job_ids(tableName) : null
     sql "DROP INDEX idx_ngram_customer_name ON ${tableName};"
     wait_for_last_col_change_finish(tableName, timeout)
     if (isCloudMode()) {
-        wait_for_last_build_index_finish(tableName, timeout, previousJobIds)
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previousJobIds)
     }
 
     // Test after dropping index

--- a/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
+++ b/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
@@ -19,9 +19,6 @@ import groovy.json.JsonSlurper
 suite("test_ngram_bloomfilter_index_change") {
     def tableName = 'test_ngram_bloomfilter_index_change'
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     // Helper functions to fetch profile via HTTP API
     def getProfileList = {
@@ -79,21 +76,6 @@ suite("test_ngram_bloomfilter_index_change") {
             }
         }
         return null
-    }
-
-    def wait_for_latest_op_on_table_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
-            alter_res = alter_res.toString()
-            if(alter_res.contains("FINISHED")) {
-                sleep(3000) // wait change table state to normal
-                logger.info(table_name + " latest alter job finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_op_on_table_finish timeout")
     }
 
     // Function to insert test data batch
@@ -181,9 +163,12 @@ suite("test_ngram_bloomfilter_index_change") {
     assertTrue(filtered2 != null && filtered2 == 10, "Expected RowsBloomFilterFiltered = 10, but got ${filtered2}")
 
     // Drop index
+    def previousJobIds = isCloudMode() ? get_build_index_job_ids(tableName) : null
     sql "DROP INDEX idx_ngram_customer_name ON ${tableName};"
-    wait_for_latest_op_on_table_finish(tableName, timeout)
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_last_col_change_finish(tableName, timeout)
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(tableName, timeout, previousJobIds)
+    }
 
     // Test after dropping index
     def token3 = UUID.randomUUID().toString()
@@ -237,8 +222,7 @@ suite("test_ngram_bloomfilter_index_change") {
 
     // Add NGRAM Bloom Filter index (will trigger schema change in this mode)
     sql "ALTER TABLE ${tableName} ADD INDEX idx_ngram_customer_name(customer_name) USING NGRAM_BF PROPERTIES('bf_size' = '1024', 'gram_size' = '3');"
-    wait_for_latest_op_on_table_finish(tableName, timeout)
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_last_col_change_finish(tableName, timeout)
 
     // Test after adding NGRAM Bloom Filter index (should filter existing data)
     def token5 = UUID.randomUUID().toString()
@@ -263,8 +247,7 @@ suite("test_ngram_bloomfilter_index_change") {
 
     // Drop index
     sql "DROP INDEX idx_ngram_customer_name ON ${tableName};"
-    wait_for_latest_op_on_table_finish(tableName, timeout)
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_last_col_change_finish(tableName, timeout)
 
     // Test after dropping index
     def token7 = UUID.randomUUID().toString()
@@ -306,8 +289,7 @@ suite("test_ngram_bloomfilter_index_change") {
 
     // Add ngram bf index before data insertion
     sql "ALTER TABLE ${tableName} ADD INDEX idx_ngram_customer_name(customer_name) USING NGRAM_BF PROPERTIES('bf_size' = '1024', 'gram_size' = '3');"
-    wait_for_latest_op_on_table_finish(tableName, timeout)
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_last_col_change_finish(tableName, timeout)
 
     // Insert data after index creation
     insertTestData()

--- a/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
+++ b/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
@@ -318,6 +318,10 @@ suite("test_ngram_bloomfilter_index_change") {
     assertTrue(filtered9 != null && filtered9 == 20, "Expected RowsBloomFilterFiltered = 20, but got ${filtered9}")
 
     // Final cleanup
+    previousJobIds = isCloudMode() ? snapshot_build_index_job_ids(tableName) : null
     sql "DROP INDEX idx_ngram_customer_name ON ${tableName};"
-    sleep(2000)
+    wait_for_last_col_change_finish(tableName, timeout)
+    if (isCloudMode()) {
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previousJobIds)
+    }
 }

--- a/regression-test/suites/inverted_index_p0/analyzer/test_custom_analyzer.groovy
+++ b/regression-test/suites/inverted_index_p0/analyzer/test_custom_analyzer.groovy
@@ -462,8 +462,18 @@ suite("test_custom_analyzer", "p0") {
 
     sql """ alter table ${indexTbName1} add index idx_ch_default(`ch`)  using inverted; """
     wait_for_last_col_change_finish("${indexTbName1}", 60000)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(indexTbName1, 60000) {
+            build_index_on_table("idx_ch_default", indexTbName1)
+        }
+    }
     sql """ alter table ${indexTbName1} add index idx_ch(`ch`) using inverted properties("support_phrase" = "true", "analyzer" = "lowercase_delimited"); """
     wait_for_last_col_change_finish("${indexTbName1}", 60000)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(indexTbName1, 60000) {
+            build_index_on_table("idx_ch", indexTbName1)
+        }
+    }
 
     qt_sql """ select * from ${indexTbName1} where ch match_all 'FOO'; """
     qt_sql """ select * from ${indexTbName1} where ch match_all 'BAR'; """

--- a/regression-test/suites/inverted_index_p0/analyzer/test_custom_analyzer.groovy
+++ b/regression-test/suites/inverted_index_p0/analyzer/test_custom_analyzer.groovy
@@ -461,9 +461,9 @@ suite("test_custom_analyzer", "p0") {
     qt_sql """ select tokenize("BAR", '"analyzer"="lowercase_delimited"'); """
 
     sql """ alter table ${indexTbName1} add index idx_ch_default(`ch`)  using inverted; """
-    wait_for_last_build_index_finish("${indexTbName1}", 60000)
+    wait_for_last_col_change_finish("${indexTbName1}", 60000)
     sql """ alter table ${indexTbName1} add index idx_ch(`ch`) using inverted properties("support_phrase" = "true", "analyzer" = "lowercase_delimited"); """
-    wait_for_last_build_index_finish("${indexTbName1}", 60000)
+    wait_for_last_col_change_finish("${indexTbName1}", 60000)
 
     qt_sql """ select * from ${indexTbName1} where ch match_all 'FOO'; """
     qt_sql """ select * from ${indexTbName1} where ch match_all 'BAR'; """

--- a/regression-test/suites/inverted_index_p0/cloud_build_index/test_cloud_build_index_basic.groovy
+++ b/regression-test/suites/inverted_index_p0/cloud_build_index/test_cloud_build_index_basic.groovy
@@ -57,12 +57,14 @@ suite("test_cloud_build_index_basic"){
     sql """create index idx1 on test_cloud_build_index_basic_table(address) using inverted;"""
     check_inverted_index_filter_rows("select * from test_cloud_build_index_basic_table where address='dddd'", 0)
 
-    build_index_on_table("idx1", tabName1)
-    wait_for_last_build_index_finish(tabName1, timeout)
+    run_index_change_job_and_wait(tabName1, timeout) {
+        build_index_on_table("idx1", tabName1)
+    }
     check_inverted_index_filter_rows("select * from test_cloud_build_index_basic_table where address='dddd'", 4)
 
-    sql "drop index idx1 on test_cloud_build_index_basic_table"
-    wait_for_last_build_index_finish(tabName1, timeout)
+    run_index_change_job_and_wait(tabName1, timeout) {
+        sql "drop index idx1 on test_cloud_build_index_basic_table"
+    }
     check_inverted_index_filter_rows("select * from test_cloud_build_index_basic_table where address='dddd'", 0)
 
     // 2 string type, ngram index
@@ -70,12 +72,14 @@ suite("test_cloud_build_index_basic"){
     sql """create index idx2 on test_cloud_build_index_basic_table(address) using ngram_bf properties("gram_size"="3", "bf_size"="256");"""
     check_bf_index_filter_rows("select * from test_cloud_build_index_basic_table where address like '%sdf%'", 0)
 
-    build_index_on_table("idx2", tabName1)
-    wait_for_last_build_index_finish(tabName1, timeout)
+    run_index_change_job_and_wait(tabName1, timeout) {
+        build_index_on_table("idx2", tabName1)
+    }
     check_bf_index_filter_rows("select * from test_cloud_build_index_basic_table where address like '%sdf%'", 5)
 
-    sql "drop index idx2 on test_cloud_build_index_basic_table"
-    wait_for_last_build_index_finish(tabName1, timeout)
+    run_index_change_job_and_wait(tabName1, timeout) {
+        sql "drop index idx2 on test_cloud_build_index_basic_table"
+    }
     check_bf_index_filter_rows("select * from test_cloud_build_index_basic_table where address like '%sdf%'", 0)
 
     // test add column/reset varchar len
@@ -121,16 +125,19 @@ suite("test_cloud_build_index_basic"){
     check_inverted_index_filter_rows("select * from test_cloud_light_sc_table where content='jj1'", 0)
 
     sql """alter table test_cloud_light_sc_table modify column address varchar(400);"""
-    sql """build index on test_cloud_light_sc_table;"""
-    wait_for_last_build_index_finish("test_cloud_light_sc_table", timeout)
+    run_index_change_job_and_wait("test_cloud_light_sc_table", timeout) {
+        sql """build index on test_cloud_light_sc_table;"""
+    }
     check_inverted_index_filter_rows("select * from test_cloud_light_sc_table where address='eeeee'", 4)
     check_inverted_index_filter_rows("select * from test_cloud_light_sc_table where content='jj1'", 4)
 
-    sql """drop index idx1 on test_cloud_light_sc_table;"""
-    wait_for_last_build_index_finish("test_cloud_light_sc_table", timeout)
+    run_index_change_job_and_wait("test_cloud_light_sc_table", timeout) {
+        sql """drop index idx1 on test_cloud_light_sc_table;"""
+    }
     check_inverted_index_filter_rows("select * from test_cloud_light_sc_table where address='eeeee'", 0)
-    sql """drop index idx2 on test_cloud_light_sc_table;"""
-    wait_for_last_build_index_finish("test_cloud_light_sc_table", timeout)
+    run_index_change_job_and_wait("test_cloud_light_sc_table", timeout) {
+        sql """drop index idx2 on test_cloud_light_sc_table;"""
+    }
     check_inverted_index_filter_rows("select * from test_cloud_light_sc_table where content='jj1'", 0)
 
     qt_select_sc_output "select * from test_cloud_light_sc_table order by user_id,username,age,address,content"

--- a/regression-test/suites/inverted_index_p0/cloud_build_index/test_cloud_build_index_update.groovy
+++ b/regression-test/suites/inverted_index_p0/cloud_build_index/test_cloud_build_index_update.groovy
@@ -88,13 +88,15 @@ suite("test_cloud_build_index_update") {
     check_inverted_index_filter_rows("select * from test_cloud_build_idx_uq_table where address='hhhhh'" +
             " order by user_id,username,age,address", 0)
 
-    sql """build index on test_cloud_build_idx_uq_table"""
-    wait_for_last_build_index_finish("test_cloud_build_idx_uq_table", timeout)
+    run_index_change_job_and_wait("test_cloud_build_idx_uq_table", timeout) {
+        sql """build index on test_cloud_build_idx_uq_table"""
+    }
     check_inverted_index_filter_rows("select * from test_cloud_build_idx_uq_table where address='hhhhh'" +
             " order by user_id,username,age,address", 12)
 
-    sql """drop index idx1 on test_cloud_build_idx_uq_table"""
-    wait_for_last_build_index_finish("test_cloud_build_idx_uq_table", timeout)
+    run_index_change_job_and_wait("test_cloud_build_idx_uq_table", timeout) {
+        sql """drop index idx1 on test_cloud_build_idx_uq_table"""
+    }
 
     check_inverted_index_filter_rows("select * from test_cloud_build_idx_uq_table where address='hhhhh'" +
             " order by user_id,username,age,address", 0)
@@ -135,8 +137,9 @@ suite("test_cloud_build_index_update") {
 
     sql """create index idx1 on test_cloud_build_idx_del_tab(address) using inverted;"""
 
-    build_index_on_table("idx1", "test_cloud_build_idx_del_tab")
-    wait_for_last_build_index_finish("test_cloud_build_idx_del_tab", timeout)
+    run_index_change_job_and_wait("test_cloud_build_idx_del_tab", timeout) {
+        build_index_on_table("idx1", "test_cloud_build_idx_del_tab")
+    }
 
     check_inverted_index_filter_rows("select * from test_cloud_build_idx_del_tab" +
             " where address='eeeee' order by user_id,username,age,address", 12)
@@ -144,8 +147,9 @@ suite("test_cloud_build_index_update") {
     qt_select_del_tab_ret3 """select count(1) from test_cloud_build_idx_del_tab where age=23;"""
     qt_select_del_tab_ret4 """select count(1) from test_cloud_build_idx_del_tab where age!=23;"""
 
-    sql """drop index idx1 on test_cloud_build_idx_del_tab;"""
-    wait_for_last_build_index_finish("test_cloud_build_idx_del_tab", timeout)
+    run_index_change_job_and_wait("test_cloud_build_idx_del_tab", timeout) {
+        sql """drop index idx1 on test_cloud_build_idx_del_tab;"""
+    }
 
     check_inverted_index_filter_rows("select * from test_cloud_build_idx_del_tab" +
             " where address='eeeee' order by user_id,username,age,address", 0)

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index.groovy
@@ -143,8 +143,12 @@ suite("test_add_drop_index", "inverted_index"){
     assertEquals(show_result[0][10], "INVERTED")
     logger.info("create index name_idx for " + indexTbName1 + "(`name`) USING INVERTED PROPERTIES(\"parser\"=\"none\")")
     logger.info("show index result: " + show_result)
+    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(indexTbName1) : null
     sql "drop index name_idx on ${indexTbName1}"
     wait_for_last_schema_change_finish(indexTbName1, timeout)
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+    }
 
     // case5：create simple inverted index for char colume
     sql "create index studentInfo_idx on ${indexTbName1}(`studentInfo`) USING INVERTED PROPERTIES(\"parser\"=\"english\")"

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index.groovy
@@ -143,11 +143,11 @@ suite("test_add_drop_index", "inverted_index"){
     assertEquals(show_result[0][10], "INVERTED")
     logger.info("create index name_idx for " + indexTbName1 + "(`name`) USING INVERTED PROPERTIES(\"parser\"=\"none\")")
     logger.info("show index result: " + show_result)
-    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(indexTbName1) : null
+    def previous_job_ids = isCloudMode() ? snapshot_build_index_job_ids(indexTbName1) : null
     sql "drop index name_idx on ${indexTbName1}"
     wait_for_last_schema_change_finish(indexTbName1, timeout)
     if (isCloudMode()) {
-        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(indexTbName1, timeout, previous_job_ids)
     }
 
     // case5：create simple inverted index for char colume

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index.groovy
@@ -47,8 +47,9 @@ suite("test_add_drop_index", "inverted_index"){
     // case1: create index for int colume
     // case1.0 create index
     sql "create index age_idx on ${indexTbName1}(tearchComment) using inverted"
-    build_index_on_table("age_idx", indexTbName1)
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        build_index_on_table("age_idx", indexTbName1)
+    }
 
     def show_result = sql "show index from ${indexTbName1}"
     logger.info("show index from " + indexTbName1 + " result: " + show_result)
@@ -74,8 +75,9 @@ suite("test_add_drop_index", "inverted_index"){
     // case1.3 create duplicate different index for one colume with different name
     sql "create index age_idx_diff on ${indexTbName1}(`tearchComment`) using NGRAM_BF"
     if (isCloudMode()) {
-        build_index_on_table("age_idx_diff", indexTbName1)
-        wait_for_last_build_index_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            build_index_on_table("age_idx_diff", indexTbName1)
+        }
     } else {
         wait_for_last_col_change_finish(indexTbName1, timeout)
     }
@@ -85,13 +87,15 @@ suite("test_add_drop_index", "inverted_index"){
     assertEquals(show_result[1][2], "age_idx_diff")
     
     // case1.4 drop index
-    def drop_result = sql """
-                          ALTER TABLE ${indexTbName1}
-                              drop index age_idx,
-                              drop index age_idx_diff;
-                      """
+    def drop_result
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        drop_result = sql """
+                              ALTER TABLE ${indexTbName1}
+                                  drop index age_idx,
+                                  drop index age_idx_diff;
+                          """
+    }
     logger.info("drop index age_idx and age_idx_diff on " + indexTbName1 + "; result: " + drop_result)
-    wait_for_last_build_index_finish(indexTbName1, timeout)
     show_result = sql "show index from ${indexTbName1}"
     assertEquals(show_result.size(), 0)
     
@@ -107,12 +111,14 @@ suite("test_add_drop_index", "inverted_index"){
 
     // case2: create index for date colume
     sql "create index date_idx on ${indexTbName1}(`registDate`) using inverted"
-    build_index_on_table("date_idx", indexTbName1)
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        build_index_on_table("date_idx", indexTbName1)
+    }
     show_result = sql "show index from ${indexTbName1}"
     assertEquals(show_result.size(), 1)
-    sql "drop index date_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index date_idx on ${indexTbName1}"
+    }
 
     // case3: create string inverted index for int colume
     def create_string_index_on_int_colume_result = "fail"
@@ -127,14 +133,16 @@ suite("test_add_drop_index", "inverted_index"){
 
     // case4: create default inverted index for varchar coulume
     sql "create index name_idx on ${indexTbName1}(`name`) using inverted"
-    build_index_on_table("name_idx", indexTbName1)
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        build_index_on_table("name_idx", indexTbName1)
+    }
     show_result = sql "show index from ${indexTbName1}"
     assertTrue(show_result[0][2] == "name_idx" && show_result[0][10] == "INVERTED")
     logger.info("create index name_idx for " + indexTbName1 + "(`name`)")
     logger.info("show index result: " + show_result)
-    sql "drop index name_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index name_idx on ${indexTbName1}"
+    }
 
     // case5: create none inverted index for char colume
     sql "create index name_idx on ${indexTbName1}(`name`) USING INVERTED PROPERTIES(\"parser\"=\"none\")"
@@ -143,11 +151,9 @@ suite("test_add_drop_index", "inverted_index"){
     assertEquals(show_result[0][10], "INVERTED")
     logger.info("create index name_idx for " + indexTbName1 + "(`name`) USING INVERTED PROPERTIES(\"parser\"=\"none\")")
     logger.info("show index result: " + show_result)
-    def previous_job_ids = isCloudMode() ? snapshot_build_index_job_ids(indexTbName1) : null
-    sql "drop index name_idx on ${indexTbName1}"
-    wait_for_last_schema_change_finish(indexTbName1, timeout)
-    if (isCloudMode()) {
-        wait_for_new_build_index_jobs_finish(indexTbName1, timeout, previous_job_ids)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index name_idx on ${indexTbName1}"
+        wait_for_last_schema_change_finish(indexTbName1, timeout)
     }
 
     // case5：create simple inverted index for char colume
@@ -157,8 +163,9 @@ suite("test_add_drop_index", "inverted_index"){
     assertTrue(show_result[0][2] == "studentInfo_idx" && show_result[0][10] == "INVERTED")
     logger.info("create index studentInfo_idx for " + indexTbName1 + "(`studentInfo`) USING INVERTED PROPERTIES(\"parser\"=\"english\")")
     logger.info("show index result: " + show_result)
-    sql "drop index studentInfo_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index studentInfo_idx on ${indexTbName1}"
+    }
 
     // case6: create standard inverted index for text colume
     sql "create index tearchComment_idx on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")"
@@ -167,8 +174,9 @@ suite("test_add_drop_index", "inverted_index"){
     assertTrue(show_result[0][2] == "tearchComment_idx" && show_result[0][10] == "INVERTED")
     logger.info("create index tearchComment_idx for " + indexTbName1 + "(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")")
     logger.info("show index result: " + show_result)
-    sql "drop index tearchComment_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx on ${indexTbName1}"
+    }
 
     // case7: drop not exist index
     def drop_no_exist_index_result = "fail"
@@ -184,37 +192,43 @@ suite("test_add_drop_index", "inverted_index"){
     // case8.0: create, drop, create same index with same name
     sql "create index tearchComment_idx on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")"
     wait_for_last_col_change_finish(indexTbName1, timeout)
-    sql "drop index tearchComment_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx on ${indexTbName1}"
+    }
     sql "create index tearchComment_idx on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     show_result = sql "show index from ${indexTbName1}"
     assertTrue(show_result[0][2] == "tearchComment_idx" && show_result[0][10] == "INVERTED")
-    sql "drop index tearchComment_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx on ${indexTbName1}"
+    }
 
     // case8.1: create, drop, create other index with same name
     sql "create index tearchComment_idx on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")"
     wait_for_last_col_change_finish(indexTbName1, timeout)
-    sql "drop index tearchComment_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx on ${indexTbName1}"
+    }
     sql "create index tearchComment_idx on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"none\")"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     show_result = sql "show index from ${indexTbName1}"
     assertTrue(show_result[0][2] == "tearchComment_idx" && show_result[0][10] == "INVERTED")
-    sql "drop index tearchComment_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx on ${indexTbName1}"
+    }
 
     // case8.2: create, drop, create same index with other name
     sql "create index tearchComment_idx on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")"
     wait_for_last_col_change_finish(indexTbName1, timeout)
-    sql "drop index tearchComment_idx on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx on ${indexTbName1}"
+    }
     sql "create index tearchComment_idx_2 on ${indexTbName1}(`tearchComment`) USING INVERTED PROPERTIES(\"parser\"=\"standard\")"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     show_result = sql "show index from ${indexTbName1}"
     assertTrue(show_result[0][2] == "tearchComment_idx_2" && show_result[0][10] == "INVERTED")
-    sql "drop index tearchComment_idx_2 on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index tearchComment_idx_2 on ${indexTbName1}"
+    }
 
 }

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_ignore_case_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_ignore_case_column.groovy
@@ -21,30 +21,6 @@ suite("test_add_drop_index_with_ignore_case_column", "inverted_index"){
 
     // prepare test table
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
 
     def indexTbName1 = "test_add_drop_inverted_index4"
 
@@ -113,8 +89,9 @@ suite("test_add_drop_index_with_ignore_case_column", "inverted_index"){
     sql "create index idx_desc on ${indexTbName1}(description) USING INVERTED PROPERTIES(\"parser\"=\"standard\");"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (!isCloudMode()) {
-        sql "build index idx_desc on ${indexTbName1}"
-        wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            sql "build index idx_desc on ${indexTbName1}"
+        }
     }
 
     // show index after add index
@@ -150,8 +127,9 @@ suite("test_add_drop_index_with_ignore_case_column", "inverted_index"){
 
     // drop index
     // add index on column description
-    sql "drop index idx_desc on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index idx_desc on ${indexTbName1}"
+    }
 
     // query rows where description match 'desc' without index
     select_result = sql "select * from ${indexTbName1} where description match 'desc' order by id"
@@ -181,8 +159,9 @@ suite("test_add_drop_index_with_ignore_case_column", "inverted_index"){
     sql "create index idx_desc on ${indexTbName1}(DESCRIPTION) USING INVERTED PROPERTIES(\"parser\"=\"standard\");"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (!isCloudMode()) {
-        sql "build index idx_desc on ${indexTbName1}"
-        wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            sql "build index idx_desc on ${indexTbName1}"
+        }
     }
 
     // query rows where description match 'desc'

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_on_table_with_mv.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_on_table_with_mv.groovy
@@ -21,33 +21,6 @@ suite("test_add_drop_index_on_table_with_mv") {
     sql "set enable_add_index_for_new_data = true"
 
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            logger.info("expected_finished_num: " + expected_finished_num)
-            // check only base table build index job
-            assertEquals(1, expected_finished_num)
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
 
     def getJobState = { table ->
         def jobStateResult = sql """  SHOW ALTER TABLE MATERIALIZED VIEW WHERE TableName='${table}' ORDER BY CreateTime DESC LIMIT 1; """
@@ -114,8 +87,7 @@ suite("test_add_drop_index_on_table_with_mv") {
     assertEquals(show_result.size(), 1)
     assertEquals(show_result[0][2], "idx1")
 
-    // build index
-    build_index_on_table("idx1", tableName)
-        // wait for index build finish
-    wait_for_build_index_on_partition_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        build_index_on_table("idx1", tableName)
+    }
 }

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_repeatly.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_repeatly.groovy
@@ -19,33 +19,6 @@ suite("test_add_drop_index_repeatly"){
     sql "set enable_add_index_for_new_data = true"
 
     def timeout = 300000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
-
-    def wait_for_last_build_index_on_table_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}" ORDER BY JobId """
-
-            if (alter_res.size() == 0) {
-                logger.info(table_name + " last index job finished")
-                return "SKIPPED"
-            }
-            if (alter_res.size() > 0) {
-                def last_job_state = alter_res[alter_res.size()-1][7];
-                if (last_job_state == "FINISHED" || last_job_state == "CANCELLED") {
-                    sleep(10000) // wait change table state to normal
-                    logger.info(table_name + " last index job finished, state: " + last_job_state + ", detail: " + alter_res)
-                    return last_job_state;
-                }
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        logger.info("wait_for_last_build_index_on_table_finish debug: " + alter_res)
-        assertTrue(useTime <= OpTimeout, "wait_for_last_build_index_on_table_finish timeout")
-        return "wait_timeout"
-    }
 
     def tbl = 'test_add_drop_index_repeatly'
     sql """ DROP TABLE IF EXISTS ${tbl} """
@@ -70,11 +43,12 @@ suite("test_add_drop_index_repeatly"){
         sql """ create index idx_k2 on ${tbl}(k2) using inverted """
 
         // build index
-        build_index_on_table("idx_k2", tbl)
-        def state = wait_for_last_build_index_on_table_finish(tbl, timeout)
-        assertEquals(state, "FINISHED")
+        run_index_change_job_and_wait(tbl, timeout) {
+            build_index_on_table("idx_k2", tbl)
+        }
 
-        sql """ drop index idx_k2 on ${tbl} """
-        wait_for_last_build_index_finish(tbl, timeout)
+        run_index_change_job_and_wait(tbl, timeout) {
+            sql """ drop index idx_k2 on ${tbl} """
+        }
     }
 }

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_data.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_data.groovy
@@ -19,32 +19,8 @@
 suite("test_add_drop_index_with_data", "inverted_index"){
     // prepare test table
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
 
     def indexTbName1 = "test_add_drop_inverted_index2"
 
@@ -114,8 +90,9 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     wait_for_last_col_change_finish(indexTbName1, timeout)
 
     if(!isCloudMode()) {
-        build_index_on_table("idx_desc", indexTbName1)
-        wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            build_index_on_table("idx_desc", indexTbName1)
+        }
     }
 
     // show index after add index
@@ -151,8 +128,9 @@ suite("test_add_drop_index_with_data", "inverted_index"){
 
     // drop index
     // add index on column description
-    sql "drop index idx_desc on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index idx_desc on ${indexTbName1}"
+    }
 
     // query rows where description match 'desc', should fail without index
     select_result = sql "select * from ${indexTbName1} where description match 'desc' order by id"
@@ -179,8 +157,9 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     assertEquals(select_result[0][2], "desc 2")
 
     // drop idx_id index
-    sql "drop index idx_id on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index idx_id on ${indexTbName1}"
+    }
 
     // show index of create table
     show_result = sql "show index from ${indexTbName1}"
@@ -203,8 +182,9 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     assertEquals(select_result[0][2], "desc 2")
 
     // drop idx_name index
-    sql "drop index idx_name on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index idx_name on ${indexTbName1}"
+    }
 
     // query rows where name match 'name1' without index
     select_result = sql "select * from ${indexTbName1} where name match 'name1'"
@@ -222,8 +202,9 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     sql "create index idx_desc on ${indexTbName1}(description) USING INVERTED PROPERTIES(\"parser\"=\"standard\");"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (!isCloudMode()) {
-        build_index_on_table("idx_desc", indexTbName1)
-        wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            build_index_on_table("idx_desc", indexTbName1)
+        }
     }
 
     // query rows where description match 'desc'
@@ -261,8 +242,9 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     logger.info("show index from " + indexTbName1 + " result: " + show_result)
     assertEquals(show_result.size(), 3)
 
-    build_index_on_table("idx_name", indexTbName1)
-    wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        build_index_on_table("idx_name", indexTbName1)
+    }
 
     // query rows where name match 'name1'
     select_result = sql "select * from ${indexTbName1} where name match 'name1'"

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_data.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_data.groovy
@@ -262,12 +262,14 @@ suite("test_add_drop_index_with_data", "inverted_index"){
 
 
     // alter table drop multiple index
-    select_result = sql """
-                        ALTER TABLE ${indexTbName1}
-                            DROP INDEX idx_id,
-                            DROP INDEX idx_name,
-                            DROP INDEX idx_desc;
-                    """
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        select_result = sql """
+                            ALTER TABLE ${indexTbName1}
+                                DROP INDEX idx_id,
+                                DROP INDEX idx_name,
+                                DROP INDEX idx_desc;
+                        """
+    }
 
     show_result = sql "show index from ${indexTbName1}"
     logger.info("show index from " + indexTbName1 + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_data.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_data.groovy
@@ -242,9 +242,28 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     logger.info("show index from " + indexTbName1 + " result: " + show_result)
     assertEquals(show_result.size(), 3)
 
-    run_index_change_job_and_wait(indexTbName1, timeout) {
-        build_index_on_table("idx_name", indexTbName1)
+    if (isCloudMode()) {
+        // Cloud BUILD INDEX is table-scoped and builds both newly added indexes.
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            build_index_on_table("idx_name", indexTbName1)
+        }
+    } else {
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            build_index_on_table("idx_id", indexTbName1)
+        }
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            build_index_on_table("idx_name", indexTbName1)
+        }
     }
+
+    def physical_id_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ id
+            FROM ${indexTbName1} WHERE id = 1"""
+    assertEquals(1, physical_id_result.size())
+    assertEquals(1, physical_id_result[0][0])
+    def physical_name_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ id
+            FROM ${indexTbName1} WHERE name MATCH 'name1'"""
+    assertEquals(1, physical_name_result.size())
+    assertEquals(1, physical_name_result[0][0])
 
     // query rows where name match 'name1'
     select_result = sql "select * from ${indexTbName1} where name match 'name1'"

--- a/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_delete_data.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_add_drop_index_with_delete_data.groovy
@@ -19,32 +19,8 @@
 suite("test_add_drop_index_with_delete_data", "inverted_index"){
     // prepare test table
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
 
     def indexTbName1 = "test_add_drop_inverted_index3"
 
@@ -121,8 +97,9 @@ suite("test_add_drop_index_with_delete_data", "inverted_index"){
     wait_for_last_col_change_finish(indexTbName1, timeout)
 
     if (!isCloudMode()) {
-        sql "build index idx_desc on ${indexTbName1}"
-        wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            sql "build index idx_desc on ${indexTbName1}"
+        }
     }
 
     // show index after add index
@@ -185,8 +162,9 @@ suite("test_add_drop_index_with_delete_data", "inverted_index"){
     assertEquals(select_result[1][2], "desc ok world test")
 
     // drop index
-    sql "drop index idx_desc on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    run_index_change_job_and_wait(indexTbName1, timeout) {
+        sql "drop index idx_desc on ${indexTbName1}"
+    }
     // query rows where description match 'desc' without index
     select_result = sql "select * from ${indexTbName1} where description match 'desc' order by id"
     assertEquals(select_result.size(), 4)
@@ -230,8 +208,9 @@ suite("test_add_drop_index_with_delete_data", "inverted_index"){
     wait_for_last_col_change_finish(indexTbName1, timeout)
 
     if (!isCloudMode()) {
-        sql "build index idx_desc on ${indexTbName1}"
-        wait_for_build_index_on_partition_finish(indexTbName1, timeout)
+        run_index_change_job_and_wait(indexTbName1, timeout) {
+            sql "build index idx_desc on ${indexTbName1}"
+        }
     }
 
     // show index after add index

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -45,6 +45,9 @@ suite("test_drop_index_on_partition", "inverted_index") {
     // create inverted index
     sql "CREATE INDEX idx_v2 ON ${tableName1}(v2) USING INVERTED"
     wait_for_last_col_change_finish(tableName1, timeout)
+    run_index_change_job_and_wait(tableName1, timeout) {
+        build_index_on_table("idx_v2", tableName1)
+    }
 
     // verify index exists
     def show_idx = sql "SHOW INDEX FROM ${tableName1}"
@@ -103,6 +106,9 @@ suite("test_drop_index_on_partition", "inverted_index") {
 
     sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName2, timeout)
+    run_index_change_job_and_wait(tableName2, timeout) {
+        build_index_on_table("idx_v1", tableName2)
+    }
 
     previous_job_ids = snapshot_build_index_job_ids(tableName2)
 
@@ -218,6 +224,9 @@ suite("test_drop_index_on_partition", "inverted_index") {
 
     sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName5, timeout)
+    run_index_change_job_and_wait(tableName5, timeout) {
+        build_index_on_table("idx_v1", tableName5)
+    }
 
     previous_job_ids = snapshot_build_index_job_ids(tableName5)
 

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -76,7 +76,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
 
     // create inverted index
     sql "CREATE INDEX idx_v2 ON ${tableName1}(v2) USING INVERTED"
-    wait_for_last_build_index_finish(tableName1, timeout)
+    wait_for_last_col_change_finish(tableName1, timeout)
 
     // verify index exists
     def show_idx = sql "SHOW INDEX FROM ${tableName1}"
@@ -134,7 +134,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "INSERT INTO ${tableName2} VALUES (10, 'hello'), (110, 'world'), (210, 'doris')"
 
     sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
-    wait_for_last_build_index_finish(tableName2, timeout)
+    wait_for_last_col_change_finish(tableName2, timeout)
 
     job_count_before = get_build_index_job_count(tableName2)
 
@@ -171,7 +171,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
     """
     sql "INSERT INTO ${tableName3} VALUES (1, 'test')"
     sql "CREATE INDEX idx_v1 ON ${tableName3}(v1) USING INVERTED"
-    wait_for_last_build_index_finish(tableName3, timeout)
+    wait_for_last_col_change_finish(tableName3, timeout)
 
     test {
         sql "DROP INDEX idx_v1 ON ${tableName3} PARTITION (p1)"
@@ -249,7 +249,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "INSERT INTO ${tableName5} VALUES (10, 'hello world'), (110, 'test data')"
 
     sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
-    wait_for_last_build_index_finish(tableName5, timeout)
+    wait_for_last_col_change_finish(tableName5, timeout)
 
     job_count_before = get_build_index_job_count(tableName5)
 

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -62,10 +62,11 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (p1)"
 
     def job_ids_after = snapshot_build_index_job_ids(tableName1)
-    logger.info("job count after drop: " + job_ids_after.size())
-    assertTrue(job_ids_after.size() > previous_job_ids.size(),
+    def new_job_ids = job_ids_after.findAll { !previous_job_ids.contains(it) }.toSet()
+    logger.info("new job count after drop: " + new_job_ids.size())
+    assertTrue(!new_job_ids.isEmpty(),
             "DROP INDEX ON PARTITION should create new build index jobs, " +
-            "before: ${previous_job_ids.size()}, after: ${job_ids_after.size()}")
+            "previous: ${previous_job_ids}, new: ${new_job_ids}")
 
     wait_for_new_build_index_jobs_finish(tableName1, timeout, previous_job_ids)
 
@@ -116,9 +117,10 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "DROP INDEX idx_v1 ON ${tableName2} PARTITIONS (p1, p2)"
 
     job_ids_after = snapshot_build_index_job_ids(tableName2)
-    logger.info("multi-partition drop: job count before=${previous_job_ids.size()}, after=${job_ids_after.size()}")
-    assertTrue(job_ids_after.size() >= previous_job_ids.size() + 2,
-            "DROP INDEX ON 2 PARTITIONS should create at least 2 new jobs")
+    new_job_ids = job_ids_after.findAll { !previous_job_ids.contains(it) }.toSet()
+    logger.info("multi-partition drop: new job count=${new_job_ids.size()}")
+    assertTrue(new_job_ids.size() >= 2,
+            "DROP INDEX ON 2 PARTITIONS should create at least 2 new jobs, new: ${new_job_ids}")
 
     wait_for_new_build_index_jobs_finish(tableName2, timeout, previous_job_ids)
 
@@ -234,8 +236,9 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "ALTER TABLE ${tableName5} DROP INDEX idx_v1 PARTITION (p1)"
 
     job_ids_after = snapshot_build_index_job_ids(tableName5)
-    assertTrue(job_ids_after.size() > previous_job_ids.size(),
-            "ALTER TABLE DROP INDEX ON PARTITION should create new jobs")
+    new_job_ids = job_ids_after.findAll { !previous_job_ids.contains(it) }.toSet()
+    assertTrue(!new_job_ids.isEmpty(),
+            "ALTER TABLE DROP INDEX ON PARTITION should create new jobs, new: ${new_job_ids}")
 
     wait_for_new_build_index_jobs_finish(tableName5, timeout, previous_job_ids)
 

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -18,33 +18,6 @@
 
 suite("test_drop_index_on_partition", "inverted_index") {
     def timeout = 300000
-    def delta_time = 1000
-
-    def get_build_index_job_count = { table_name ->
-        def res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-        return res.size()
-    }
-
-    def wait_for_build_index_on_partition_finish = { table_name, expected_job_count, OpTimeout ->
-        def finished = false
-        def alter_res = []
-        for (int t = 0; t <= OpTimeout; t += delta_time) {
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            if (alter_res.any { it[7] == "CANCELLED" }) {
-                assertTrue(false, table_name + " build index job cancelled, detail: " + alter_res)
-            }
-            if (alter_res.size() >= expected_job_count && alter_res.every { it[7] == "FINISHED" }) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                finished = true
-                break
-            }
-            if (t >= OpTimeout) {
-                break
-            }
-            sleep(delta_time)
-        }
-        assertTrue(finished, "wait_for_build_index_on_partition_finish timeout, latest result: ${alter_res}")
-    }
 
     // case 1: basic DROP INDEX ON PARTITION with job count verification
     def tableName1 = "test_drop_idx_on_partition_basic"
@@ -79,19 +52,19 @@ suite("test_drop_index_on_partition", "inverted_index") {
     assertTrue(show_idx.toString().contains("idx_v2"))
 
     // record job count before DROP
-    def job_count_before = get_build_index_job_count(tableName1)
-    logger.info("job count before drop: " + job_count_before)
+    def previous_job_ids = get_build_index_job_ids(tableName1)
+    logger.info("job count before drop: " + previous_job_ids.size())
 
     // drop index on partition p1 only — should create new job(s)
     sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (p1)"
 
-    def job_count_after = get_build_index_job_count(tableName1)
-    logger.info("job count after drop: " + job_count_after)
-    assertTrue(job_count_after > job_count_before,
+    def job_ids_after = get_build_index_job_ids(tableName1)
+    logger.info("job count after drop: " + job_ids_after.size())
+    assertTrue(job_ids_after.size() > previous_job_ids.size(),
             "DROP INDEX ON PARTITION should create new build index jobs, " +
-            "before: ${job_count_before}, after: ${job_count_after}")
+            "before: ${previous_job_ids.size()}, after: ${job_ids_after.size()}")
 
-    wait_for_build_index_on_partition_finish(tableName1, job_count_after, timeout)
+    wait_for_last_build_index_finish(tableName1, timeout, previous_job_ids)
 
     // verify index definition still exists in table schema
     show_idx = sql "SHOW INDEX FROM ${tableName1}"
@@ -131,17 +104,17 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName2, timeout)
 
-    job_count_before = get_build_index_job_count(tableName2)
+    previous_job_ids = get_build_index_job_ids(tableName2)
 
     // drop index on p1 and p2 — should create at least 2 new jobs
     sql "DROP INDEX idx_v1 ON ${tableName2} PARTITIONS (p1, p2)"
 
-    job_count_after = get_build_index_job_count(tableName2)
-    logger.info("multi-partition drop: job count before=${job_count_before}, after=${job_count_after}")
-    assertTrue(job_count_after >= job_count_before + 2,
+    job_ids_after = get_build_index_job_ids(tableName2)
+    logger.info("multi-partition drop: job count before=${previous_job_ids.size()}, after=${job_ids_after.size()}")
+    assertTrue(job_ids_after.size() >= previous_job_ids.size() + 2,
             "DROP INDEX ON 2 PARTITIONS should create at least 2 new jobs")
 
-    wait_for_build_index_on_partition_finish(tableName2, job_count_after, timeout)
+    wait_for_last_build_index_finish(tableName2, timeout, previous_job_ids)
 
     // index definition should still exist
     show_idx = sql "SHOW INDEX FROM ${tableName2}"
@@ -246,16 +219,16 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName5, timeout)
 
-    job_count_before = get_build_index_job_count(tableName5)
+    previous_job_ids = get_build_index_job_ids(tableName5)
 
     // use ALTER TABLE form
     sql "ALTER TABLE ${tableName5} DROP INDEX idx_v1 PARTITION (p1)"
 
-    job_count_after = get_build_index_job_count(tableName5)
-    assertTrue(job_count_after > job_count_before,
+    job_ids_after = get_build_index_job_ids(tableName5)
+    assertTrue(job_ids_after.size() > previous_job_ids.size(),
             "ALTER TABLE DROP INDEX ON PARTITION should create new jobs")
 
-    wait_for_build_index_on_partition_finish(tableName5, job_count_after, timeout)
+    wait_for_last_build_index_finish(tableName5, timeout, previous_job_ids)
 
     // index definition should still exist
     show_idx = sql "SHOW INDEX FROM ${tableName5}"

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -45,8 +45,14 @@ suite("test_drop_index_on_partition", "inverted_index") {
     // create inverted index
     sql "CREATE INDEX idx_v2 ON ${tableName1}(v2) USING INVERTED"
     wait_for_last_col_change_finish(tableName1, timeout)
-    run_index_change_job_and_wait(tableName1, timeout) {
-        build_index_on_table("idx_v2", tableName1)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName1, timeout) {
+            build_index_on_table("idx_v2", tableName1)
+        }
+        def physical_index_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */
+                k1 FROM ${tableName1} WHERE v2 MATCH 'foo bar'"""
+        assertEquals(1, physical_index_result.size())
+        assertEquals(10, physical_index_result[0][0])
     }
 
     // verify index exists
@@ -107,8 +113,14 @@ suite("test_drop_index_on_partition", "inverted_index") {
 
     sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName2, timeout)
-    run_index_change_job_and_wait(tableName2, timeout) {
-        build_index_on_table("idx_v1", tableName2)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName2, timeout) {
+            build_index_on_table("idx_v1", tableName2)
+        }
+        def physical_index_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */
+                k1 FROM ${tableName2} WHERE v1 MATCH 'hello'"""
+        assertEquals(1, physical_index_result.size())
+        assertEquals(10, physical_index_result[0][0])
     }
 
     previous_job_ids = snapshot_build_index_job_ids(tableName2)
@@ -226,8 +238,14 @@ suite("test_drop_index_on_partition", "inverted_index") {
 
     sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName5, timeout)
-    run_index_change_job_and_wait(tableName5, timeout) {
-        build_index_on_table("idx_v1", tableName5)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName5, timeout) {
+            build_index_on_table("idx_v1", tableName5)
+        }
+        def physical_index_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */
+                k1 FROM ${tableName5} WHERE v1 MATCH 'hello world'"""
+        assertEquals(1, physical_index_result.size())
+        assertEquals(10, physical_index_result[0][0])
     }
 
     previous_job_ids = snapshot_build_index_job_ids(tableName5)

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -26,29 +26,24 @@ suite("test_drop_index_on_partition", "inverted_index") {
     }
 
     def wait_for_build_index_on_partition_finish = { table_name, expected_job_count, OpTimeout ->
-        def useTime = 0
-        for (int t = delta_time; t <= OpTimeout; t += delta_time) {
-            def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            if (alter_res.size() < expected_job_count) {
-                useTime = t
-                sleep(delta_time)
-                continue
+        def finished = false
+        def alter_res = []
+        for (int t = 0; t <= OpTimeout; t += delta_time) {
+            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
+            if (alter_res.any { it[7] == "CANCELLED" }) {
+                assertTrue(false, table_name + " build index job cancelled, detail: " + alter_res)
             }
-            def finished_num = 0
-            for (int i = 0; i < alter_res.size(); i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + " idx: " + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num
-                }
-            }
-            if (finished_num == alter_res.size()) {
+            if (alter_res.size() >= expected_job_count && alter_res.every { it[7] == "FINISHED" }) {
                 logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
+                finished = true
                 break
             }
-            useTime = t
+            if (t >= OpTimeout) {
+                break
+            }
             sleep(delta_time)
         }
-        assertTrue(useTime <= OpTimeout, "wait_for_build_index_on_partition_finish timeout")
+        assertTrue(finished, "wait_for_build_index_on_partition_finish timeout, latest result: ${alter_res}")
     }
 
     // case 1: basic DROP INDEX ON PARTITION with job count verification

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -52,19 +52,19 @@ suite("test_drop_index_on_partition", "inverted_index") {
     assertTrue(show_idx.toString().contains("idx_v2"))
 
     // record job count before DROP
-    def previous_job_ids = get_build_index_job_ids(tableName1)
+    def previous_job_ids = snapshot_build_index_job_ids(tableName1)
     logger.info("job count before drop: " + previous_job_ids.size())
 
     // drop index on partition p1 only — should create new job(s)
     sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (p1)"
 
-    def job_ids_after = get_build_index_job_ids(tableName1)
+    def job_ids_after = snapshot_build_index_job_ids(tableName1)
     logger.info("job count after drop: " + job_ids_after.size())
     assertTrue(job_ids_after.size() > previous_job_ids.size(),
             "DROP INDEX ON PARTITION should create new build index jobs, " +
             "before: ${previous_job_ids.size()}, after: ${job_ids_after.size()}")
 
-    wait_for_last_build_index_finish(tableName1, timeout, previous_job_ids)
+    wait_for_new_build_index_jobs_finish(tableName1, timeout, previous_job_ids)
 
     // verify index definition still exists in table schema
     show_idx = sql "SHOW INDEX FROM ${tableName1}"
@@ -104,17 +104,17 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName2, timeout)
 
-    previous_job_ids = get_build_index_job_ids(tableName2)
+    previous_job_ids = snapshot_build_index_job_ids(tableName2)
 
     // drop index on p1 and p2 — should create at least 2 new jobs
     sql "DROP INDEX idx_v1 ON ${tableName2} PARTITIONS (p1, p2)"
 
-    job_ids_after = get_build_index_job_ids(tableName2)
+    job_ids_after = snapshot_build_index_job_ids(tableName2)
     logger.info("multi-partition drop: job count before=${previous_job_ids.size()}, after=${job_ids_after.size()}")
     assertTrue(job_ids_after.size() >= previous_job_ids.size() + 2,
             "DROP INDEX ON 2 PARTITIONS should create at least 2 new jobs")
 
-    wait_for_last_build_index_finish(tableName2, timeout, previous_job_ids)
+    wait_for_new_build_index_jobs_finish(tableName2, timeout, previous_job_ids)
 
     // index definition should still exist
     show_idx = sql "SHOW INDEX FROM ${tableName2}"
@@ -219,16 +219,16 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
     wait_for_last_col_change_finish(tableName5, timeout)
 
-    previous_job_ids = get_build_index_job_ids(tableName5)
+    previous_job_ids = snapshot_build_index_job_ids(tableName5)
 
     // use ALTER TABLE form
     sql "ALTER TABLE ${tableName5} DROP INDEX idx_v1 PARTITION (p1)"
 
-    job_ids_after = get_build_index_job_ids(tableName5)
+    job_ids_after = snapshot_build_index_job_ids(tableName5)
     assertTrue(job_ids_after.size() > previous_job_ids.size(),
             "ALTER TABLE DROP INDEX ON PARTITION should create new jobs")
 
-    wait_for_last_build_index_finish(tableName5, timeout, previous_job_ids)
+    wait_for_new_build_index_jobs_finish(tableName5, timeout, previous_job_ids)
 
     // index definition should still exist
     show_idx = sql "SHOW INDEX FROM ${tableName5}"

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_1.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_1.groovy
@@ -67,8 +67,25 @@ suite("test_index_change_1") {
 
     sql """ CREATE INDEX idx_note ON ${tableName}(`note`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_note", tableName)
+        }
+    }
     sql """ CREATE INDEX idx_city ON ${tableName}(`city`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_city", tableName)
+        }
+    }
+
+    def physical_note_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ user_id
+            FROM ${tableName} WHERE note MATCH 'engineer' ORDER BY user_id"""
+    assertEquals(2, physical_note_result.size())
+    def physical_city_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ user_id
+            FROM ${tableName} WHERE city MATCH 'beijing' ORDER BY user_id"""
+    assertEquals(3, physical_city_result.size())
 
     def show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)
@@ -129,8 +146,25 @@ suite("test_index_change_1") {
 
     sql """ CREATE INDEX idx_note ON ${tableName}(`note`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_note", tableName)
+        }
+    }
     sql """ CREATE INDEX idx_city ON ${tableName}(`city`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_city", tableName)
+        }
+    }
+
+    physical_note_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ user_id
+            FROM ${tableName} WHERE note MATCH 'engineer' ORDER BY user_id"""
+    assertEquals(2, physical_note_result.size())
+    physical_city_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ user_id
+            FROM ${tableName} WHERE city MATCH 'beijing' ORDER BY user_id"""
+    assertEquals(3, physical_city_result.size())
 
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_2.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_2.groovy
@@ -19,33 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_index_change_2") {
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                sleep(10000)
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
     
     def tableName = "test_index_change_2"
 
@@ -99,12 +74,22 @@ suite("test_index_change_2") {
     // create inverted index idx_city
     sql """ CREATE INDEX idx_city ON ${tableName}(`city`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_city", tableName)
+        }
+    }
+    def physical_city_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ user_id
+            FROM ${tableName} WHERE city MATCH 'beijing' ORDER BY user_id"""
+    assertEquals(3, physical_city_result.size())
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_build_index_on_partition_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_build_index_on_partition_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_user_id ON ${tableName} """
+    }
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_note ON ${tableName} """
+    }
 
 
     def show_result = sql "show index from ${tableName}"
@@ -170,12 +155,22 @@ suite("test_index_change_2") {
     // create inverted index idx_city
     sql """ CREATE INDEX idx_city ON ${tableName}(`city`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_city", tableName)
+        }
+    }
+    physical_city_result = sql """SELECT /*+ SET_VAR(enable_fallback_on_missing_inverted_index=false) */ user_id
+            FROM ${tableName} WHERE city MATCH 'beijing' ORDER BY user_id"""
+    assertEquals(3, physical_city_result.size())
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_build_index_on_partition_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_build_index_on_partition_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_user_id ON ${tableName} """
+    }
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_note ON ${tableName} """
+    }
 
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_3.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_3.groovy
@@ -75,15 +75,18 @@ suite("test_index_change_3") {
     sql """ CREATE INDEX idx_city ON ${tableName}(`city`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
     if (!isCloudMode()) {
-        build_index_on_table("idx_city", tableName)
-        wait_for_last_build_index_finish(tableName, timeout)
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_city", tableName)
+        }
     }
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_city ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_city ON ${tableName} """
+    }
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_note ON ${tableName} """
+    }
 
     def show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)
@@ -150,15 +153,18 @@ suite("test_index_change_3") {
     wait_for_last_col_change_finish(tableName, timeout)
 
     if (!isCloudMode()) {
-        build_index_on_table("idx_city", tableName)
-        wait_for_last_build_index_finish(tableName, timeout)
+        run_index_change_job_and_wait(tableName, timeout) {
+            build_index_on_table("idx_city", tableName)
+        }
     }
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_city ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_city ON ${tableName} """
+    }
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_note ON ${tableName} """
+    }
 
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
@@ -25,10 +25,10 @@ suite("test_index_change_4") {
     def tableName = "test_index_change_4"
 
     def drop_index_and_wait = { index_name ->
-        def previous_job_ids = get_build_index_job_ids(tableName)
+        def previous_job_ids = snapshot_build_index_job_ids(tableName)
         sql """ DROP INDEX ${index_name} ON ${tableName} """
         wait_for_last_col_change_finish(tableName, timeout)
-        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previous_job_ids)
     }
 
     sql """ DROP TABLE IF EXISTS ${tableName} """
@@ -87,9 +87,9 @@ suite("test_index_change_4") {
     // build index
 
     if (!isCloudMode()) {
-        def previous_job_ids = get_build_index_job_ids(tableName)
+        def previous_job_ids = snapshot_build_index_job_ids(tableName)
         build_index_on_table("idx_note", tableName)
-        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previous_job_ids)
     }
 
     def show_result = sql "show index from ${tableName}"
@@ -160,9 +160,9 @@ suite("test_index_change_4") {
     wait_for_last_col_change_finish(tableName, timeout)
     // build index
     if (!isCloudMode()) {
-        def previous_job_ids = get_build_index_job_ids(tableName)
+        def previous_job_ids = snapshot_build_index_job_ids(tableName)
         build_index_on_table("idx_note", tableName)
-        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previous_job_ids)
     }
 
     show_result = sql "show index from ${tableName}"

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
@@ -20,13 +20,13 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 suite("test_index_change_4") {
     def timeout = 300000
     def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
 
     def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
+        def finished = false
+        def alter_res = []
+        for(int t = 0; t <= OpTimeout; t += delta_time){
             alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
             def expected_finished_num = alter_res.size();
             def finished_num = 0;
@@ -39,12 +39,15 @@ suite("test_index_change_4") {
             if (finished_num == expected_finished_num) {
                 sleep(10000)
                 logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
+                finished = true
                 break
             }
-            useTime = t
+            if (t >= OpTimeout) {
+                break
+            }
             sleep(delta_time)
         }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
+        assertTrue(finished, "wait_for_build_index_on_partition_finish timeout, latest result: ${alter_res}")
     }
     
     def tableName = "test_index_change_4"

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
@@ -19,48 +19,16 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_index_change_4") {
     def timeout = 300000
-    def delta_time = 1000
 
     sql "set enable_add_index_for_new_data = true"
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        def finished = false
-        def alter_res = []
-        for(int t = 0; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (!alter_res.isEmpty() && finished_num == expected_finished_num) {
-                sleep(10000)
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                finished = true
-                break
-            }
-            if (t >= OpTimeout) {
-                break
-            }
-            sleep(delta_time)
-        }
-        assertTrue(finished, "wait_for_build_index_on_partition_finish timeout, latest result: ${alter_res}")
-    }
     
     def tableName = "test_index_change_4"
 
     def drop_index_and_wait = { index_name ->
-        def previous_job_ids = isCloudMode() ? get_build_index_job_ids(tableName) : null
+        def previous_job_ids = get_build_index_job_ids(tableName)
         sql """ DROP INDEX ${index_name} ON ${tableName} """
-        if (isCloudMode()) {
-            wait_for_last_col_change_finish(tableName, timeout)
-            wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
-        } else {
-            wait_for_last_build_index_finish(tableName, timeout)
-        }
+        wait_for_last_col_change_finish(tableName, timeout)
+        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
     }
 
     sql """ DROP TABLE IF EXISTS ${tableName} """
@@ -192,8 +160,9 @@ suite("test_index_change_4") {
     wait_for_last_col_change_finish(tableName, timeout)
     // build index
     if (!isCloudMode()) {
+        def previous_job_ids = get_build_index_job_ids(tableName)
         build_index_on_table("idx_note", tableName)
-        wait_for_build_index_on_partition_finish(tableName, timeout)
+        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
     }
 
     show_result = sql "show index from ${tableName}"

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
@@ -18,7 +18,7 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_index_change_4") {
-    def timeout = 60000
+    def timeout = 300000
     def delta_time = 1000
     def alter_res = "null"
     def useTime = 0

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_4.groovy
@@ -36,7 +36,7 @@ suite("test_index_change_4") {
                     ++finished_num;
                 }
             }
-            if (finished_num == expected_finished_num) {
+            if (!alter_res.isEmpty() && finished_num == expected_finished_num) {
                 sleep(10000)
                 logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
                 finished = true
@@ -51,6 +51,17 @@ suite("test_index_change_4") {
     }
     
     def tableName = "test_index_change_4"
+
+    def drop_index_and_wait = { index_name ->
+        def previous_job_ids = isCloudMode() ? get_build_index_job_ids(tableName) : null
+        sql """ DROP INDEX ${index_name} ON ${tableName} """
+        if (isCloudMode()) {
+            wait_for_last_col_change_finish(tableName, timeout)
+            wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+        } else {
+            wait_for_last_build_index_finish(tableName, timeout)
+        }
+    }
 
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """
@@ -100,18 +111,17 @@ suite("test_index_change_4") {
     qt_select6 """ SELECT * FROM ${tableName} t WHERE note MATCH 'engineer Developer' AND city match_all 'Shanghai China' ORDER BY user_id; """
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    drop_index_and_wait("idx_user_id")
+    drop_index_and_wait("idx_note")
     // create inverted index idx_city
     sql """ CREATE INDEX idx_note ON ${tableName}(`note`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)
     // build index
 
     if (!isCloudMode()) {
+        def previous_job_ids = get_build_index_job_ids(tableName)
         build_index_on_table("idx_note", tableName)
-        wait_for_last_build_index_finish(tableName, timeout)
+        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
     }
 
     def show_result = sql "show index from ${tableName}"
@@ -175,10 +185,8 @@ suite("test_index_change_4") {
     qt_select6_v1 """ SELECT * FROM ${tableName} t WHERE note MATCH 'engineer Developer' AND city match_all 'Shanghai China' ORDER BY user_id; """
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    drop_index_and_wait("idx_user_id")
+    drop_index_and_wait("idx_note")
     // create inverted index idx_city
     sql """ CREATE INDEX idx_note ON ${tableName}(`note`) using inverted properties("support_phrase" = "true", "parser" = "english", "lower_case" = "true") """
     wait_for_last_col_change_finish(tableName, timeout)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_5.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_5.groovy
@@ -72,10 +72,12 @@ suite("test_index_change_5") {
     qt_select6 """ SELECT * FROM ${tableName} t WHERE note MATCH 'engineer Developer' AND city match_all 'Shanghai China' ORDER BY user_id; """
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_user_id ON ${tableName} """
+    }
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_note ON ${tableName} """
+    }
 
     def show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)
@@ -137,10 +139,12 @@ suite("test_index_change_5") {
     qt_select6_v1 """ SELECT * FROM ${tableName} t WHERE note MATCH 'engineer Developer' AND city match_all 'Shanghai China' ORDER BY user_id; """
 
     // drop inverted index idx_user_id, idx_note
-    sql """ DROP INDEX idx_user_id ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
-    sql """ DROP INDEX idx_note ON ${tableName} """
-    wait_for_last_build_index_finish(tableName, timeout)
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_user_id ON ${tableName} """
+    }
+    run_index_change_job_and_wait(tableName, timeout) {
+        sql """ DROP INDEX idx_note ON ${tableName} """
+    }
 
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -25,30 +25,6 @@ suite("test_index_change_on_renamed_column") {
     sql "set enable_add_index_for_new_data = false"
 
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
     
     def tableName = "test_index_change_on_renamed_column"
 
@@ -80,8 +56,9 @@ suite("test_index_change_on_renamed_column") {
 
     // build inverted index on renamed column
     if (!isCloudMode()) {
+        def previous_job_ids = get_build_index_job_ids(tableName)
         build_index_on_table("idx_s", tableName)
-        wait_for_build_index_on_partition_finish(tableName, timeout)
+        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
     }
 
     def show_result = sql "show index from ${tableName}"
@@ -100,12 +77,8 @@ suite("test_index_change_on_renamed_column") {
     check_nested_index_file(ip, port, tablet_id, 3, 1, "V3")
 
     // drop inverted index on renamed column
-    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(tableName) : null
     sql """ alter table ${tableName} drop index idx_s; """
     wait_for_last_col_change_finish(tableName, timeout)
-    if (isCloudMode()) {
-        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
-    }
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)
     assertEquals(show_result.size(), 0)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -100,8 +100,12 @@ suite("test_index_change_on_renamed_column") {
     check_nested_index_file(ip, port, tablet_id, 3, 1, "V3")
 
     // drop inverted index on renamed column
+    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(tableName) : null
     sql """ alter table ${tableName} drop index idx_s; """
-    wait_for_last_build_index_finish(tableName, timeout)
+    wait_for_last_col_change_finish(tableName, timeout)
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+    }
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)
     assertEquals(show_result.size(), 0)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -77,8 +77,12 @@ suite("test_index_change_on_renamed_column") {
     check_nested_index_file(ip, port, tablet_id, 3, 1, "V3")
 
     // drop inverted index on renamed column
+    def previous_job_ids = !isCloudMode() ? get_build_index_job_ids(tableName) : null
     sql """ alter table ${tableName} drop index idx_s; """
     wait_for_last_col_change_finish(tableName, timeout)
+    if (!isCloudMode()) {
+        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+    }
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)
     assertEquals(show_result.size(), 0)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -56,9 +56,9 @@ suite("test_index_change_on_renamed_column") {
 
     // build inverted index on renamed column
     if (!isCloudMode()) {
-        def previous_job_ids = get_build_index_job_ids(tableName)
+        def previous_job_ids = snapshot_build_index_job_ids(tableName)
         build_index_on_table("idx_s", tableName)
-        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previous_job_ids)
     }
 
     def show_result = sql "show index from ${tableName}"
@@ -77,11 +77,11 @@ suite("test_index_change_on_renamed_column") {
     check_nested_index_file(ip, port, tablet_id, 3, 1, "V3")
 
     // drop inverted index on renamed column
-    def previous_job_ids = !isCloudMode() ? get_build_index_job_ids(tableName) : null
+    def previous_job_ids = !isCloudMode() ? snapshot_build_index_job_ids(tableName) : null
     sql """ alter table ${tableName} drop index idx_s; """
     wait_for_last_col_change_finish(tableName, timeout)
     if (!isCloudMode()) {
-        wait_for_last_build_index_finish(tableName, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(tableName, timeout, previous_job_ids)
     }
     show_result = sql "show index from ${tableName}"
     logger.info("show index from " + tableName + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_with_cumulative_compaction.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_with_cumulative_compaction.groovy
@@ -21,32 +21,8 @@ suite("test_index_change_with_cumulative_compaction", "nonConcurrent") {
     def tableName = "index_change_with_cumulative_compaction_dup_keys"
 
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
 
     try {
         //BackendId,Cluster,IP,HeartbeatPort,BePort,HttpPort,BrpcPort,LastStartTime,LastHeartbeat,Alive,SystemDecommissioned,ClusterDecommissioned,TabletNum,DataUsedCapacity,AvailCapacity,TotalCapacity,UsedPct,MaxDiskUsedPct,Tag,ErrMsg,Version,Status
@@ -154,13 +130,22 @@ suite("test_index_change_with_cumulative_compaction", "nonConcurrent") {
         sql """ CREATE INDEX idx_date ON ${tableName}(`date`) USING INVERTED """
         sql """ CREATE INDEX idx_city ON ${tableName}(`city`) USING INVERTED """
 
-        // build index
-        build_index_on_table("idx_user_id", tableName)
-        wait_for_build_index_on_partition_finish(tableName, timeout)
-        build_index_on_table("idx_date", tableName)
-        wait_for_build_index_on_partition_finish(tableName, timeout)
-        build_index_on_table("idx_city", tableName)
-        wait_for_build_index_on_partition_finish(tableName, timeout)
+        // Cloud BUILD INDEX is table-scoped; local BUILD INDEX is index-scoped.
+        if (isCloudMode()) {
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_user_id", tableName)
+            }
+        } else {
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_user_id", tableName)
+            }
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_date", tableName)
+            }
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_city", tableName)
+            }
+        }
 
         // trigger compactions for all tablets in ${tableName}
         trigger_and_wait_compaction(tableName, "cumulative")

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_with_full_compaction.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_with_full_compaction.groovy
@@ -132,12 +132,22 @@ suite("test_index_change_with_full_compaction") {
 
         // build index
 
-        build_index_on_table("idx_user_id", tableName)
-        wait_for_last_build_index_finish(tableName, timeout)
-        build_index_on_table("idx_date", tableName)
-        wait_for_last_build_index_finish(tableName, timeout)
-        build_index_on_table("idx_city", tableName)
-        wait_for_last_build_index_finish(tableName, timeout)
+        if (isCloudMode()) {
+            // Cloud BUILD INDEX works at table scope and builds all indexes.
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_user_id", tableName)
+            }
+        } else {
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_user_id", tableName)
+            }
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_date", tableName)
+            }
+            run_index_change_job_and_wait(tableName, timeout) {
+                build_index_on_table("idx_city", tableName)
+            }
+        }
 
         // trigger compactions for all tablets in ${tableName}
         trigger_and_wait_compaction(tableName, "full")

--- a/regression-test/suites/inverted_index_p0/index_change/test_pk_uk_index_change.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_pk_uk_index_change.groovy
@@ -28,34 +28,8 @@ import java.time.format.DateTimeFormatter;
 
 suite("test_pk_uk_index_change", "inverted_index") {
     def timeout = 60000
-    def delta_time = 1000
-    def alter_res = "null"
-    def useTime = 0
 
     sql "set enable_add_index_for_new_data = true"
-
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
-            alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
-            def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
-                logger.info(table_name + " build index job state: " + alter_res[i][7] + i
-                            + " expected_finished_num=" + expected_finished_num)
-                if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
-                }
-            }
-            if (finished_num == expected_finished_num) {
-                sleep(10000) // wait change table state to normal
-                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
-                break
-            }
-            useTime = t
-            sleep(delta_time)
-        }
-        assertTrue(useTime <= OpTimeout, "wait_for_latest_build_index_on_partition_finish timeout")
-    }
     
     def tableNamePk = "primary_key_pk_uk"
     def tableNameUk = "unique_key_pk_uk"
@@ -228,8 +202,9 @@ suite("test_pk_uk_index_change", "inverted_index") {
             """
 
             // build inverted index
-            build_index_on_table("L_ORDERKEY_idx", tableNamePk)
-            wait_for_build_index_on_partition_finish(tableNamePk, timeout)
+            run_index_change_job_and_wait(tableNamePk, timeout) {
+                build_index_on_table("L_ORDERKEY_idx", tableNamePk)
+            }
         }
 
         sql "sync"
@@ -303,8 +278,8 @@ suite("test_pk_uk_index_change", "inverted_index") {
         }
 
         // drop inverted index
-        sql """ DROP INDEX L_ORDERKEY_idx ON ${tableNamePk}; """
-        wait_for_build_index_on_partition_finish(tableNamePk, timeout)
+        run_index_change_job_and_wait(tableNamePk, timeout) {
+            sql """ DROP INDEX L_ORDERKEY_idx ON ${tableNamePk}; """
+        }
     }
 }
-

--- a/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
+++ b/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
@@ -108,9 +108,13 @@ suite("test_create_index_2", "inverted_index"){
     
     // drop index
     sql "drop index name_idx_1 on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    wait_for_last_col_change_finish(indexTbName1, timeout)
+    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(indexTbName1) : null
     sql "drop index name_idx_2 on ${indexTbName1}"
-    wait_for_last_build_index_finish(indexTbName1, timeout)
+    wait_for_last_col_change_finish(indexTbName1, timeout)
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+    }
     show_result = sql "show index from ${indexTbName1}"
     assertEquals(show_result.size(), 0)
 
@@ -157,12 +161,11 @@ suite("test_create_index_2", "inverted_index"){
         create index name_idx_2 on ${indexTbName1}(name) using ngram_bf properties("gram_size"="3", "bf_size"="256") comment 'name index';
     """
 
-    if (isCloudMode()) {
-        sql "build index on ${indexTbName1}"
-    }
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (isCloudMode()) {
-        wait_for_last_build_index_finish(indexTbName1, timeout)
+        previous_job_ids = get_build_index_job_ids(indexTbName1)
+        sql "build index on ${indexTbName1}"
+        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
     }
 
     show_result = sql "show index from ${indexTbName1}"

--- a/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
+++ b/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
@@ -112,13 +112,11 @@ suite("test_create_index_2", "inverted_index"){
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (isCloudMode()) {
         wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
-        previous_job_ids = get_build_index_job_ids(indexTbName1)
     }
+    previous_job_ids = get_build_index_job_ids(indexTbName1)
     sql "drop index name_idx_2 on ${indexTbName1}"
     wait_for_last_col_change_finish(indexTbName1, timeout)
-    if (isCloudMode()) {
-        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
-    }
+    wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
     show_result = sql "show index from ${indexTbName1}"
     assertEquals(show_result.size(), 0)
 

--- a/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
+++ b/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
@@ -107,9 +107,13 @@ suite("test_create_index_2", "inverted_index"){
     assertEquals(show_result[1][2], "name_idx_2")
     
     // drop index
+    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(indexTbName1) : null
     sql "drop index name_idx_1 on ${indexTbName1}"
     wait_for_last_col_change_finish(indexTbName1, timeout)
-    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(indexTbName1) : null
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+        previous_job_ids = get_build_index_job_ids(indexTbName1)
+    }
     sql "drop index name_idx_2 on ${indexTbName1}"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (isCloudMode()) {

--- a/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
+++ b/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
@@ -160,7 +160,10 @@ suite("test_create_index_2", "inverted_index"){
     if (isCloudMode()) {
         sql "build index on ${indexTbName1}"
     }
-    wait_for_last_schema_change_finish(indexTbName1, timeout)
+    wait_for_last_col_change_finish(indexTbName1, timeout)
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(indexTbName1, timeout)
+    }
 
     show_result = sql "show index from ${indexTbName1}"
     logger.info("show index from " + indexTbName1 + " result: " + show_result)

--- a/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
+++ b/regression-test/suites/inverted_index_p0/test_create_index_2.groovy
@@ -107,16 +107,16 @@ suite("test_create_index_2", "inverted_index"){
     assertEquals(show_result[1][2], "name_idx_2")
     
     // drop index
-    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(indexTbName1) : null
+    def previous_job_ids = isCloudMode() ? snapshot_build_index_job_ids(indexTbName1) : null
     sql "drop index name_idx_1 on ${indexTbName1}"
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (isCloudMode()) {
-        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(indexTbName1, timeout, previous_job_ids)
     }
-    previous_job_ids = get_build_index_job_ids(indexTbName1)
+    previous_job_ids = snapshot_build_index_job_ids(indexTbName1)
     sql "drop index name_idx_2 on ${indexTbName1}"
     wait_for_last_col_change_finish(indexTbName1, timeout)
-    wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+    wait_for_new_build_index_jobs_finish(indexTbName1, timeout, previous_job_ids)
     show_result = sql "show index from ${indexTbName1}"
     assertEquals(show_result.size(), 0)
 
@@ -165,9 +165,9 @@ suite("test_create_index_2", "inverted_index"){
 
     wait_for_last_col_change_finish(indexTbName1, timeout)
     if (isCloudMode()) {
-        previous_job_ids = get_build_index_job_ids(indexTbName1)
+        previous_job_ids = snapshot_build_index_job_ids(indexTbName1)
         sql "build index on ${indexTbName1}"
-        wait_for_last_build_index_finish(indexTbName1, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(indexTbName1, timeout, previous_job_ids)
     }
 
     show_result = sql "show index from ${indexTbName1}"

--- a/regression-test/suites/variant_p0/with_index/load.groovy
+++ b/regression-test/suites/variant_p0/with_index/load.groovy
@@ -44,22 +44,25 @@ suite("regression_test_variant_with_index", "p0"){
     // sql "truncate table ${table_name}"
     sql """insert into var_with_index values(1, '{"a1" : 0, "b1": 3}', 'hello world'), (2, '{"a2" : 123}', 'world'),(3, '{"a3" : 123}', 'hello world')"""
     sql """insert into var_with_index values(4, '{"b1" : 0, "b2": 3}', 'hello world'), (5, '{"b2" : 123}', 'world'),(6, '{"b3" : 123}', 'hello world')"""
+    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(table_name) : null
     def drop_result = sql """
                       ALTER TABLE var_with_index
                           drop index idx
                   """
     logger.info("drop index " + "${table_name}" +  "; result: " + drop_result)
     wait_for_last_schema_change_finish(table_name, timeout)
+    if (isCloudMode()) {
+        wait_for_last_build_index_finish(table_name, timeout, previous_job_ids)
+    }
     def show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 0)
     qt_sql_inv4 """select v["a1"] from ${table_name} where cast(v['a1'] as int) = 0"""
     qt_sql_inv5 """select * from ${table_name} order by k"""
     sql "create index inv_idx on ${table_name}(`inv`) using inverted"
-
-    build_index_on_table("inv_idx", table_name)
-
     wait_for_last_col_change_finish(table_name, timeout)
-    wait_for_last_build_index_finish(table_name, timeout)
+    previous_job_ids = get_build_index_job_ids(table_name)
+    build_index_on_table("inv_idx", table_name)
+    wait_for_last_build_index_finish(table_name, timeout, previous_job_ids)
     show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 1)
     sql """insert into var_with_index values(7, '{"a1" : 0, "b1": 3}', 'hello world'), (8, '{"a2" : 123}', 'world'),(9, '{"a3" : 123}', 'hello world')"""

--- a/regression-test/suites/variant_p0/with_index/load.groovy
+++ b/regression-test/suites/variant_p0/with_index/load.groovy
@@ -58,7 +58,8 @@ suite("regression_test_variant_with_index", "p0"){
 
     build_index_on_table("inv_idx", table_name)
 
-    wait_for_last_schema_change_finish(table_name, timeout)
+    wait_for_last_col_change_finish(table_name, timeout)
+    wait_for_last_build_index_finish(table_name, timeout)
     show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 1)
     sql """insert into var_with_index values(7, '{"a1" : 0, "b1": 3}', 'hello world'), (8, '{"a2" : 123}', 'world'),(9, '{"a3" : 123}', 'hello world')"""

--- a/regression-test/suites/variant_p0/with_index/load.groovy
+++ b/regression-test/suites/variant_p0/with_index/load.groovy
@@ -44,7 +44,7 @@ suite("regression_test_variant_with_index", "p0"){
     // sql "truncate table ${table_name}"
     sql """insert into var_with_index values(1, '{"a1" : 0, "b1": 3}', 'hello world'), (2, '{"a2" : 123}', 'world'),(3, '{"a3" : 123}', 'hello world')"""
     sql """insert into var_with_index values(4, '{"b1" : 0, "b2": 3}', 'hello world'), (5, '{"b2" : 123}', 'world'),(6, '{"b3" : 123}', 'hello world')"""
-    def previous_job_ids = isCloudMode() ? get_build_index_job_ids(table_name) : null
+    def previous_job_ids = isCloudMode() ? snapshot_build_index_job_ids(table_name) : null
     def drop_result = sql """
                       ALTER TABLE var_with_index
                           drop index idx
@@ -52,7 +52,7 @@ suite("regression_test_variant_with_index", "p0"){
     logger.info("drop index " + "${table_name}" +  "; result: " + drop_result)
     wait_for_last_schema_change_finish(table_name, timeout)
     if (isCloudMode()) {
-        wait_for_last_build_index_finish(table_name, timeout, previous_job_ids)
+        wait_for_new_build_index_jobs_finish(table_name, timeout, previous_job_ids)
     }
     def show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 0)
@@ -60,9 +60,9 @@ suite("regression_test_variant_with_index", "p0"){
     qt_sql_inv5 """select * from ${table_name} order by k"""
     sql "create index inv_idx on ${table_name}(`inv`) using inverted"
     wait_for_last_col_change_finish(table_name, timeout)
-    previous_job_ids = get_build_index_job_ids(table_name)
+    previous_job_ids = snapshot_build_index_job_ids(table_name)
     build_index_on_table("inv_idx", table_name)
-    wait_for_last_build_index_finish(table_name, timeout, previous_job_ids)
+    wait_for_new_build_index_jobs_finish(table_name, timeout, previous_job_ids)
     show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 1)
     sql """insert into var_with_index values(7, '{"a1" : 0, "b1": 3}', 'hello world'), (8, '{"a2" : 123}', 'world'),(9, '{"a3" : 123}', 'hello world')"""

--- a/regression-test/suites/variant_p0/with_index/load.groovy
+++ b/regression-test/suites/variant_p0/with_index/load.groovy
@@ -44,25 +44,24 @@ suite("regression_test_variant_with_index", "p0"){
     // sql "truncate table ${table_name}"
     sql """insert into var_with_index values(1, '{"a1" : 0, "b1": 3}', 'hello world'), (2, '{"a2" : 123}', 'world'),(3, '{"a3" : 123}', 'hello world')"""
     sql """insert into var_with_index values(4, '{"b1" : 0, "b2": 3}', 'hello world'), (5, '{"b2" : 123}', 'world'),(6, '{"b3" : 123}', 'hello world')"""
-    def previous_job_ids = isCloudMode() ? snapshot_build_index_job_ids(table_name) : null
-    def drop_result = sql """
-                      ALTER TABLE var_with_index
-                          drop index idx
-                  """
-    logger.info("drop index " + "${table_name}" +  "; result: " + drop_result)
-    wait_for_last_schema_change_finish(table_name, timeout)
-    if (isCloudMode()) {
-        wait_for_new_build_index_jobs_finish(table_name, timeout, previous_job_ids)
+    def drop_result
+    run_index_change_job_and_wait(table_name, timeout) {
+        drop_result = sql """
+                          ALTER TABLE var_with_index
+                              drop index idx
+                      """
+        wait_for_last_schema_change_finish(table_name, timeout)
     }
+    logger.info("drop index " + "${table_name}" +  "; result: " + drop_result)
     def show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 0)
     qt_sql_inv4 """select v["a1"] from ${table_name} where cast(v['a1'] as int) = 0"""
     qt_sql_inv5 """select * from ${table_name} order by k"""
     sql "create index inv_idx on ${table_name}(`inv`) using inverted"
     wait_for_last_col_change_finish(table_name, timeout)
-    previous_job_ids = snapshot_build_index_job_ids(table_name)
-    build_index_on_table("inv_idx", table_name)
-    wait_for_new_build_index_jobs_finish(table_name, timeout, previous_job_ids)
+    run_index_change_job_and_wait(table_name, timeout) {
+        build_index_on_table("inv_idx", table_name)
+    }
     show_result = sql "show index from ${table_name}"
     assertEquals(show_result.size(), 1)
     sql """insert into var_with_index values(7, '{"a1" : 0, "b1": 3}', 'hello world'), (8, '{"a2" : 123}', 'world'),(9, '{"a3" : 123}', 'hello world')"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-24947

Related PR: #65197

Problem Summary:

Cloud P0 `test_index_change_4` can spend the full 60-second timeout waiting for an asynchronous index-change job. The shared `wait_for_last_build_index_finish` helper previously asserted `useTime <= OpTimeout`, which was still true at the timeout boundary even when `FINISHED` had never been observed. The case then submitted a second `DROP INDEX` while the first job was unfinished and failed with `partition test_index_change_4 has been built specified index`.

This change makes the shared build-index and column-change helpers, plus the suite-local V1 partition helper, succeed only after explicitly observing `FINISHED`. The helpers avoid an extra sleep after the deadline and include the latest query result in timeout failures. It also raises the affected case timeout to 300 seconds, matching the Cloud-safe wait used by `test_index_change_6`.

The shared schema-change wrapper now waits only for the column/schema job. Callers that explicitly submit `BUILD INDEX` wait for both the column job and the build-index job, preserving their previous sequencing without making schema-only callers require a nonexistent build-index row.

Schema-only callers now use the column-change wait. Callers that explicitly build or delete index data snapshot the table's existing build-index JobIds before the operation, then wait for a nonempty, stable set of new jobs. Every new partition job must reach `FINISHED`; any new `CANCELLED` job fails immediately, and timeout failures include the latest new-job rows.

The follow-up also removes the same timeout-success behavior from the remaining suite-local partition helper, serializes consecutive Cloud drops with independent JobId snapshots, and avoids waiting for delete jobs in a suite that explicitly disables index construction for new data.

The NGRAM bloom-filter lifecycle suite now follows the same contract: its Cloud three-partition drop snapshots and waits for all new delete jobs, while schema-only and empty-table index changes wait only for the column job. Its duplicate local column helper with the old timeout-success assertion was removed.

The final caller audit scopes partition drops, non-Cloud full-table INVERTED drops, and the V1 explicit build to JobIds created by the current operation. Retained jobs from an earlier table with the same name can no longer satisfy or fail these waits.

The plugin API now makes the two contracts explicit. The legacy two-argument helper remains a compatibility path for callers where a build-index job is optional and observes only the latest row. Strict build/delete paths use `snapshot_build_index_job_ids` before the operation and `wait_for_new_build_index_jobs_finish` afterward, which requires a nonempty stable set of new jobs and checks every new row.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - [x] Groovy syntax conversion passed for the shared plugin and `test_index_change_4`.
        - [x] Mocked shared build-index and column-change helper execution passed for both `RUNNING -> FINISHED` and timeout paths.
        - [x] Mocked schema-only wrapper execution performs only the column/schema wait.
        - [x] Mocked empty build-index results time out instead of returning success.
        - [x] Mocked delayed registration, multiple new partition jobs, stable completion, and new-job cancellation behavior.
        - [x] Groovy syntax compilation passed for the shared plugin and all seven changed suites.
        - [x] Follow-up Groovy compilation passed for all three files changed by the latest review fix.
        - [x] Groovy compilation passed for the NGRAM bloom-filter caller split and the shared helper behavior harness still passed.
        - [x] Groovy compilation passed for all four operation-scoping follow-up suites.
        - [x] Groovy compilation passed for the refactored plugin and every migrated strict caller; compatibility and strict helper harness paths passed.
        - [x] `git diff --check` passed.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg. https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
