### PR TITLE
[fix](regression) retry transient S3 outfile timeout

### DIFF
--- a/regression-test/suites/export_p0/outfile/s3/test_outfile_with_different_s3.groovy
+++ b/regression-test/suites/export_p0/outfile/s3/test_outfile_with_different_s3.groovy
@@ -22,7 +22,7 @@ suite("test_outfile_with_different_s3", "p0") {
     def outfile_to_S3 = {bucket, s3_endpoint, region, ak, sk  ->
         def outFilePath = "${bucket}/outfile_different_s3/exp_"
         // select ... into outfile ...
-        def res = sql """
+        def outfileSql = """
             SELECT * FROM ${export_table_name} t ORDER BY user_id
             INTO OUTFILE "s3://${outFilePath}"
             FORMAT AS parquet
@@ -33,7 +33,21 @@ suite("test_outfile_with_different_s3", "p0") {
                 "s3.access_key" = "${ak}"
             );
         """
-        return res[0][3]
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            try {
+                def res = sql outfileSql
+                return res[0][3]
+            } catch (java.sql.SQLException e) {
+                boolean isS3Timeout = e.message?.contains("curlCode: 28")
+                        && e.message?.contains("Timeout was reached")
+                if (!isS3Timeout || attempt == 2) {
+                    throw e
+                }
+                logger.warn("OUTFILE to S3 endpoint ${s3_endpoint} timed out, retrying once")
+                sleep(5000)
+            }
+        }
+        throw new IllegalStateException("Unreachable")
     }
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

`test_outfile_with_different_s3` writes and reads data through real S3-compatible services. Recent Cloud P0 failures across unrelated PRs consistently exhausted the Tencent COS `PutObject` transport path with `curlCode: 28, Timeout was reached`.

This change retries the valid OUTFILE operation once only for that exact libcurl timeout signature. Authentication, permission, protocol, assertion, and all other SQL errors still fail immediately, and a second timeout is propagated normally.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Manual validation:

- Compiled the modified Groovy suite with `groovyc`.
- Verified the retry predicate with simulated SQL exceptions: one transient timeout retries and succeeds; `InvalidAccessKeyId` is not retried; two consecutive timeouts surface the second failure.
- `git diff --check` passed.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
