### PR TITLE
[fix](regression) Drop view before its base tables in test_join5

### DIFF
--- a/regression-test/suites/query_p0/join/test_join5.groovy
+++ b/regression-test/suites/query_p0/join/test_join5.groovy
@@ -101,6 +101,8 @@ suite("test_join5", "query,p0") {
             where f2 = 53;
         """
 
+    // Avoid exposing a dangling view to concurrent information_schema scans.
+    sql "DROP VIEW IF EXISTS ${tbName7};"
     sql "DROP TABLE IF EXISTS ${tbName4};"
     sql "DROP TABLE IF EXISTS ${tbName5};"
     sql "DROP TABLE IF EXISTS ${tbName6};"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-23587

Related PR: None

Problem Summary:

`test_join5` creates the `uqv1` view on top of `uq1`, but drops `uq1` while the view still exists. A concurrent `information_schema.view_dependency` scan can observe this dangling view and fail while resolving its missing base table.

This change drops `uqv1` after its last assertion and before dropping its base tables, so the case does not expose an invalid intermediate state to concurrently running regression suites.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `git diff --check`
        - Parsed `test_join5.groovy` with `GroovyShell`; result: PASS.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
