### PR TITLE
[fix](regression) stabilize DPHyp query85 shape check

### DIFF
--- a/regression-test/suites/shape_check/tpcds_sf1000/dphyper/query85.groovy
+++ b/regression-test/suites/shape_check/tpcds_sf1000/dphyper/query85.groovy
@@ -38,6 +38,7 @@ suite("query85") {
     sql "SET enable_dphyp_optimizer = true"
     sql "set max_table_count_use_cascades_join_reorder = 1"
     sql "set dphyper_limit=2600"
+    sql "set join_reorder_time_limit=10000"
 
     def ds = """select  substr(r_reason_desc,1,20)
        ,avg(ws_quantity)

--- a/regression-test/suites/shape_check/tpcds_sf1000/dphyper/query85.groovy
+++ b/regression-test/suites/shape_check/tpcds_sf1000/dphyper/query85.groovy
@@ -38,7 +38,7 @@ suite("query85") {
     sql "SET enable_dphyp_optimizer = true"
     sql "set max_table_count_use_cascades_join_reorder = 1"
     sql "set dphyper_limit=2600"
-    sql "set join_reorder_time_limit=10000"
+    sql "set join_order_time_limit=10000"
 
     def ds = """select  substr(r_reason_desc,1,20)
        ,avg(ws_quantity)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64559

Problem Summary:

The TPC-DS SF1000 DPHyp query85 case checks an exact physical plan shape. It already pins the enumeration-count budget with `dphyper_limit=2600`, but it leaves the independent wall-clock `join_order_time_limit` at its 1000 ms default.

`PlanReceiver` stops full enumeration when either limit is exceeded. When that happens, `JoinOrderJob` invokes `GraphSimplifier` and re-enumerates a reduced candidate space, which can select a different valid join order and fail the exact shape golden.

The TeamCity timing split matches that boundary:

| Build | Shape result | Time from `Execute tag` to generated output | First differing join |
|---|---|---:|---|
| [991071](http://43.132.222.7:8111/viewLog.html?buildId=991071&buildTypeId=Doris_DorisRegression_P0Regression) | PASS | 864 ms | expected `web_page` join |
| [989238](http://43.132.222.7:8111/viewLog.html?buildId=989238&buildTypeId=Doris_DorisRegression_P0Regression) | FAILURE | 1378 ms | `customer_address` join |
| [989267](http://43.132.222.7:8111/viewLog.html?buildId=989267&buildTypeId=Doris_DorisRegression_P0Regression) | FAILURE | 1351 ms | `cd1` join |
| [989379](http://43.132.222.7:8111/viewLog.html?buildId=989379&buildTypeId=Doris_DorisRegression_P0Regression) | FAILURE | 1444 ms | `customer_address` join |
| [991088](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/991088?buildTab=tests&expandedTest=build%3A%28id%3A991088%29%2Cid%3A2000003392) | FAILURE | 1361 ms | `date_dim` join |

The four genuine join-order failures all crossed the approximately one-second boundary. The current failing PR #65434 changes only file-cache code, so the failure is not caused by its product diff. Separate qualifier-only failures from PRs #65346 and #65264 are not part of this diagnosis.

This PR pins `join_order_time_limit=10000` for query85 only. It keeps `dphyper_limit=2600`, the SQL, and the expected golden unchanged, so the test continues to validate the intended DPHyp plan while avoiding load-dependent fallback.

Validation:

- `git diff --check`
- Verified the patch changes only the query85 session setup.
- Local single-suite execution was not run because no Doris regression environment was allocated for this task.
- `run buildall` and the exact P0 case will provide CI validation on the patched head.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
