### PR TITLE
[fix](be) Skip unsafe predicates in partition pruning

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -352,6 +352,11 @@ void FileScanner::_init_runtime_filter_partition_prune_ctxs() {
         auto impl = conjunct->root()->get_impl();
         // If impl is not null, which means this a conjuncts from runtime filter.
         auto expr = impl ? impl : conjunct->root();
+        // Preserve a safe prefix of the row-level conjunct order. Considering later predicates
+        // after an unsafe one could prune the split before the unsafe predicate is evaluated.
+        if (!expr->is_safe_to_execute_on_selected_rows()) {
+            break;
+        }
         if (_check_partition_prune_expr(expr)) {
             _runtime_filter_partition_prune_ctxs.emplace_back(conjunct);
         }

--- a/be/src/exec/scan/file_scanner.h
+++ b/be/src/exec/scan/file_scanner.h
@@ -68,6 +68,19 @@ public:
     static const std::string FileReadBytesProfile;
     static const std::string FileReadTimeProfile;
 
+#ifdef BE_TEST
+    void TEST_init_runtime_filter_partition_prune_ctxs(
+            const VExprContextSPtrs& conjuncts,
+            const std::unordered_map<SlotId, int>& partition_slot_index_map) {
+        _conjuncts = conjuncts;
+        _partition_slot_index_map = partition_slot_index_map;
+        _init_runtime_filter_partition_prune_ctxs();
+    }
+    const VExprContextSPtrs& TEST_runtime_filter_partition_prune_ctxs() const {
+        return _runtime_filter_partition_prune_ctxs;
+    }
+#endif
+
     FileScanner(RuntimeState* state, FileScanLocalState* parent, int64_t limit,
                 std::shared_ptr<SplitSourceConnector> split_source, RuntimeProfile* profile,
                 ShardedKVCache* kv_cache,

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -803,6 +803,15 @@ Status TableReader::_evaluate_partition_prune_conjuncts(const VExprContextSPtrs&
     for (const auto& conjunct : conjuncts) {
         DORIS_CHECK(conjunct != nullptr);
         DORIS_CHECK(conjunct->root() != nullptr);
+        const auto root = conjunct->root();
+        const auto impl = root->get_impl();
+        const auto predicate = impl != nullptr ? impl : root;
+        // Split pruning evaluates a predicate once before any file rows are read. Reordering
+        // non-deterministic or error-preserving expressions can change their row-level semantics,
+        // even when every referenced slot is a partition column.
+        if (!predicate->is_safe_to_execute_on_selected_rows()) {
+            continue;
+        }
         std::set<GlobalIndex> global_indices;
         collect_global_indices(conjunct->root(), &global_indices);
         if (global_indices.empty()) {

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -803,14 +803,11 @@ Status TableReader::_evaluate_partition_prune_conjuncts(const VExprContextSPtrs&
     for (const auto& conjunct : conjuncts) {
         DORIS_CHECK(conjunct != nullptr);
         DORIS_CHECK(conjunct->root() != nullptr);
-        const auto root = conjunct->root();
-        const auto impl = root->get_impl();
-        const auto predicate = impl != nullptr ? impl : root;
-        // Split pruning evaluates a predicate once before any file rows are read. Reordering
-        // non-deterministic or error-preserving expressions can change their row-level semantics,
-        // even when every referenced slot is a partition column.
-        if (!predicate->is_safe_to_execute_on_selected_rows()) {
-            continue;
+        // Keep only the safe prefix of the original conjunct order. If an unsafe conjunct is
+        // skipped, a later predicate could prune the split before the unsafe one reaches its
+        // normal row-level evaluation point.
+        if (!_is_safe_to_pre_execute(conjunct)) {
+            break;
         }
         std::set<GlobalIndex> global_indices;
         collect_global_indices(conjunct->root(), &global_indices);
@@ -843,6 +840,18 @@ Status TableReader::_evaluate_partition_prune_conjuncts(const VExprContextSPtrs&
     IColumn::Filter result_filter(block.rows(), 1);
     return VExprContext::execute_conjuncts(partition_conjuncts, nullptr, &block, &result_filter,
                                            can_filter_all);
+}
+
+bool TableReader::_is_safe_to_pre_execute(const VExprContextSPtr& conjunct) {
+    DORIS_CHECK(conjunct != nullptr);
+    DORIS_CHECK(conjunct->root() != nullptr);
+    const auto root = conjunct->root();
+    const auto impl = root->get_impl();
+    const auto predicate = impl != nullptr ? impl : root;
+    // Split pruning evaluates a predicate once before any file rows are read. Reordering
+    // non-deterministic or error-preserving expressions can change their row-level semantics,
+    // even when every referenced slot is a partition column or maps to a constant entry.
+    return predicate->is_safe_to_execute_on_selected_rows();
 }
 
 Status TableReader::_build_partition_prune_block(Block* block) const {

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -413,6 +413,7 @@ protected:
     Status _build_table_filters_from_conjuncts();
     Status _evaluate_partition_prune_conjuncts(const VExprContextSPtrs& conjuncts,
                                                bool* can_filter_all);
+    static bool _is_safe_to_pre_execute(const VExprContextSPtr& conjunct);
     Status _build_partition_prune_block(Block* block) const;
     Status _open_local_filter_exprs(const FileScanRequest& file_request);
     Status _init_reader_condition_cache(const FileScanRequest& file_request);
@@ -423,12 +424,20 @@ protected:
         DORIS_CHECK(can_filter_all != nullptr);
         *can_filter_all = false;
         for (const auto& table_filter : _table_filters) {
-            if (table_filter.conjunct == nullptr ||
-                // RuntimeFilterExpr does not implement execute_column_impl(); it is evaluated by
-                // the row-level filter path through execute_filter(). Constant split pruning uses
-                // VExprContext::execute() on a one-row synthetic block, so runtime filters must not
-                // be pre-executed here even when their referenced slot maps to a constant value.
-                table_filter.conjunct->root()->is_rf_wrapper() ||
+            if (table_filter.conjunct == nullptr) {
+                continue;
+            }
+            // Constant pruning must preserve a safe prefix of the row-level conjunct order. Once
+            // an unsafe predicate is reached, evaluating any later constant predicate could hide
+            // its error or other row-level behavior by pruning the split first.
+            if (!_is_safe_to_pre_execute(table_filter.conjunct)) {
+                break;
+            }
+            // RuntimeFilterExpr does not implement execute_column_impl(); it is evaluated by the
+            // row-level filter path through execute_filter(). Constant split pruning uses
+            // VExprContext::execute() on a one-row synthetic block, so runtime filters must not be
+            // pre-executed here even when their referenced slot maps to a constant value.
+            if (table_filter.conjunct->root()->is_rf_wrapper() ||
                 !_table_filter_has_only_constant_entries(table_filter)) {
                 continue;
             }

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -29,9 +29,13 @@
 
 #include "common/consts.h"
 #include "core/assert_cast.h"
+#include "core/block/block.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "exec/operator/file_scan_operator.h"
+#include "exec/scan/file_scanner.h"
+#include "exec/scan/split_source_connector.h"
 #include "exprs/runtime_filter_expr.h"
 #include "exprs/vdirect_in_predicate.h"
 #include "exprs/vslot_ref.h"
@@ -61,6 +65,33 @@ TFileRangeDesc hudi_range_with_delta_logs() {
 
 VExprSPtr slot_ref(int slot_id, int column_id, DataTypePtr type, const std::string& name) {
     return VSlotRef::create_shared(slot_id, column_id, -1, std::move(type), name);
+}
+
+TExprNode bool_in_pred_node();
+
+class UnsafePartitionPredicate final : public VExpr {
+public:
+    UnsafePartitionPredicate() : VExpr(std::make_shared<DataTypeUInt8>(), false) {}
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t count,
+                               ColumnPtr& result_column) const override {
+        auto result = ColumnUInt8::create();
+        result->get_data().resize_fill(count, 1);
+        result_column = std::move(result);
+        return Status::OK();
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+    bool is_safe_to_execute_on_selected_rows() const override { return false; }
+
+private:
+    const std::string _expr_name = "UnsafePartitionPredicate";
+};
+
+VExprContextSPtr runtime_filter_context(VExprSPtr impl, int filter_id) {
+    const auto node = bool_in_pred_node();
+    return VExprContext::create_shared(
+            RuntimeFilterExpr::create_shared(node, std::move(impl), 0.4, false, filter_id));
 }
 
 TExprNode bool_in_pred_node() {
@@ -510,6 +541,26 @@ TEST(FileScannerV2Test, RewriteSlotRefsToGlobalIndexMatrix) {
         EXPECT_EQ(rewritten_child->column_id(), 2);
         EXPECT_EQ(rewritten_child->column_name(), "rf_value");
     }
+}
+
+TEST(FileScannerTest, PartitionPruningStopsAtUnsafePredicate) {
+    const auto bool_type = std::make_shared<DataTypeUInt8>();
+    auto unsafe_predicate = std::make_shared<UnsafePartitionPredicate>();
+    unsafe_predicate->add_child(slot_ref(1, 0, bool_type, "part"));
+    VExprContextSPtrs conjuncts {
+            runtime_filter_context(slot_ref(1, 0, bool_type, "part"), 1),
+            runtime_filter_context(std::move(unsafe_predicate), 2),
+            runtime_filter_context(slot_ref(1, 0, bool_type, "part"), 3),
+    };
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    RuntimeProfile profile("file_scanner");
+    FileScanner scanner(&state, &profile, nullptr, nullptr, nullptr);
+    scanner.TEST_init_runtime_filter_partition_prune_ctxs(conjuncts, {{1, 0}});
+
+    const auto& partition_conjuncts = scanner.TEST_runtime_filter_partition_prune_ctxs();
+    ASSERT_EQ(partition_conjuncts.size(), 1);
+    EXPECT_EQ(partition_conjuncts[0], conjuncts[0]);
 }
 
 } // namespace doris

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -265,6 +265,29 @@ VExprSPtr runtime_filter_wrapper_expr(VExprSPtr impl) {
     return RuntimeFilterExpr::create_shared(node, std::move(impl), 0, false, /*filter_id=*/1);
 }
 
+class NonDeterministicPartitionPredicate final : public VExpr {
+public:
+    explicit NonDeterministicPartitionPredicate(bool* executed)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false), _executed(executed) {}
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t count,
+                               ColumnPtr& result_column) const override {
+        DORIS_CHECK(_executed != nullptr);
+        *_executed = true;
+        auto result = ColumnUInt8::create();
+        result->get_data().resize_fill(count, 0);
+        result_column = std::move(result);
+        return Status::OK();
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+    bool is_deterministic() const override { return false; }
+
+private:
+    bool* const _executed;
+    const std::string _expr_name = "NonDeterministicPartitionPredicate";
+};
+
 class NullableArrayBigintDefaultExpr final : public VExpr {
 public:
     explicit NullableArrayBigintDefaultExpr(DataTypePtr data_type)
@@ -1213,6 +1236,43 @@ TEST(TableReaderTest, PrepareSplitPrunesPartitionRuntimeFilter) {
             runtime_filter_wrapper_expr(table_int32_greater_than_expr(0, 0, 10))));
     ASSERT_TRUE(reader.prepare_split(retained_split).ok());
     EXPECT_FALSE(reader.current_split_pruned());
+}
+
+TEST(TableReaderTest, PrepareSplitDoesNotEvaluateNonDeterministicPartitionPredicate) {
+    std::vector<ColumnDefinition> projected_columns;
+    auto partition_column = make_table_column(0, "part", std::make_shared<DataTypeInt32>());
+    partition_column.is_partition_key = true;
+    projected_columns.push_back(std::move(partition_column));
+    set_name_identifiers(&projected_columns);
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    RuntimeProfile profile("scanner");
+    TableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = &profile,
+                            })
+                        .ok());
+
+    bool predicate_executed = false;
+    auto predicate = std::make_shared<NonDeterministicPartitionPredicate>(&predicate_executed);
+    predicate->add_child(table_int32_slot_ref(0, 0, "part"));
+    SplitReadOptions split;
+    split.current_range.__set_path("unused-nondeterministic-file");
+    split.partition_values.emplace("part", Field::create_field<TYPE_INT>(7));
+    split.partition_prune_conjuncts.push_back(
+            VExprContext::create_shared(runtime_filter_wrapper_expr(std::move(predicate))));
+
+    ASSERT_TRUE(reader.prepare_split(split).ok());
+    EXPECT_FALSE(predicate_executed);
+    EXPECT_FALSE(reader.current_split_pruned());
+    ASSERT_NE(profile.get_counter("RuntimeFilterPartitionPrunedRangeNum"), nullptr);
+    EXPECT_EQ(profile.get_counter("RuntimeFilterPartitionPrunedRangeNum")->value(), 0);
 }
 
 TEST(TableReaderTest, CanUseInjectedFileReaderForStandaloneUnitTest) {

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -283,6 +283,12 @@ public:
     const std::string& expr_name() const override { return _expr_name; }
     bool is_deterministic() const override { return false; }
 
+    Status clone_node(VExprSPtr* cloned_expr) const override {
+        DORIS_CHECK(cloned_expr != nullptr);
+        *cloned_expr = std::make_shared<NonDeterministicPartitionPredicate>(_executed);
+        return Status::OK();
+    }
+
 private:
     bool* const _executed;
     const std::string _expr_name = "NonDeterministicPartitionPredicate";
@@ -1267,12 +1273,59 @@ TEST(TableReaderTest, PrepareSplitDoesNotEvaluateNonDeterministicPartitionPredic
     split.partition_values.emplace("part", Field::create_field<TYPE_INT>(7));
     split.partition_prune_conjuncts.push_back(
             VExprContext::create_shared(runtime_filter_wrapper_expr(std::move(predicate))));
+    split.partition_prune_conjuncts.push_back(VExprContext::create_shared(
+            runtime_filter_wrapper_expr(table_int32_greater_than_expr(0, 0, 10))));
 
     ASSERT_TRUE(reader.prepare_split(split).ok());
     EXPECT_FALSE(predicate_executed);
     EXPECT_FALSE(reader.current_split_pruned());
     ASSERT_NE(profile.get_counter("RuntimeFilterPartitionPrunedRangeNum"), nullptr);
     EXPECT_EQ(profile.get_counter("RuntimeFilterPartitionPrunedRangeNum")->value(), 0);
+}
+
+TEST(TableReaderTest, ConstantPruningStopsAtUnsafePredicate) {
+    std::vector<ColumnDefinition> projected_columns;
+    auto partition_column = make_table_column(0, "part", std::make_shared<DataTypeInt32>());
+    partition_column.is_partition_key = true;
+    projected_columns.push_back(std::move(partition_column));
+    set_name_identifiers(&projected_columns);
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    bool predicate_executed = false;
+    auto unsafe_predicate =
+            std::make_shared<NonDeterministicPartitionPredicate>(&predicate_executed);
+    unsafe_predicate->add_child(table_int32_slot_ref(0, 0, "part"));
+    auto fake_state = std::make_shared<FakeFileReaderState>();
+    FakeTableReader reader({}, fake_state);
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts =
+                                            {
+                                                    prepared_conjunct(&state, unsafe_predicate),
+                                                    prepared_conjunct(&state,
+                                                                      table_int32_greater_than_expr(
+                                                                              0, 0, 10)),
+                                            },
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+
+    SplitReadOptions split;
+    split.current_range.__set_path("fake-table-reader-input");
+    split.partition_values.emplace("part", Field::create_field<TYPE_INT>(7));
+    ASSERT_TRUE(reader.prepare_split(split).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    ASSERT_TRUE(reader.get_block(&block, &eos).ok());
+    EXPECT_FALSE(predicate_executed);
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(fake_state->open_count, 1);
+    ASSERT_TRUE(reader.close().ok());
 }
 
 TEST(TableReaderTest, CanUseInjectedFileReaderForStandaloneUnitTest) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65449

Problem Summary:

FileScannerV2 split-level partition pruning classified predicates only by their referenced slots. A predicate could therefore reference only partition columns while also containing a zero-slot non-deterministic or error-preserving expression. Evaluating such a predicate once before reading the split could change its normal row-level semantics and incorrectly prune the whole file.

This change checks the unwrapped predicate's existing safe-to-reorder contract before evaluating it at split level. Unsafe predicates stay on the normal row-level path. A focused unit test verifies that an unsafe runtime-filter predicate is neither executed nor used to prune a split.

### Release note

Prevent FileScannerV2 partition pruning from pre-evaluating non-deterministic or error-preserving predicates.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `TableReaderTest.PrepareSplit*` (2 tests passed on the remote ASAN_UT build)
        - `build-support/clang-format.sh`
        - `build-support/check-format.sh`
        - `git diff --check`
        - clang-tidy was attempted with the generated compilation database; analysis was blocked by the remote toolchain's missing `stddef.h` and pre-existing diagnostics outside the changed lines.
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Unsafe predicates remain on the normal row-level evaluation path instead of being evaluated once per split.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
