### PR TITLE
[fix](dictionary) stabilize insert target during database drop

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -18,6 +18,7 @@
 package org.apache.doris.dictionary;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
@@ -27,6 +28,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.dictionary.Dictionary.DictionaryStatus;
 import org.apache.doris.job.extensions.insert.InsertTask;
@@ -267,6 +269,7 @@ public class DictionaryManager extends MasterDaemon implements Writable {
             // Log the drop operation
             if (dbDictIds != null) {
                 for (Map.Entry<String, Long> entry : dbDictIds.entrySet()) {
+                    idToDictionary.remove(entry.getValue());
                     Env.getCurrentEnv().getEditLog().logDropDictionary(dbName, entry.getKey());
                 }
                 // also drop all name mapping records.
@@ -280,6 +283,37 @@ public class DictionaryManager extends MasterDaemon implements Writable {
     private boolean hasDictionaryWithoutLock(String dbName, String dictName) {
         Map<String, Long> dbDictIds = dictionaryIds.get(dbName);
         return dbDictIds != null && dbDictIds.containsKey(dictName);
+    }
+
+    public boolean isCurrentDictionary(Database database, Dictionary dictionary) {
+        lockRead();
+        try {
+            return isCurrentDictionaryWithoutLock(database, dictionary);
+        } finally {
+            unlockRead();
+        }
+    }
+
+    private boolean isCurrentDictionaryWithoutLock(Database database, Dictionary dictionary) {
+        Map<String, Long> dbDictIds = dictionaryIds.get(dictionary.getDbName());
+        Long dictionaryId = dbDictIds == null ? null : dbDictIds.get(dictionary.getName());
+        return Env.getCurrentInternalCatalog().getDbNullable(database.getId()) == database
+                && dictionaryId != null
+                && dictionaryId == dictionary.getId()
+                && idToDictionary.get(dictionary.getId()) == dictionary;
+    }
+
+    private Database getCurrentDatabase(Dictionary dictionary) throws AnalysisException {
+        lockRead();
+        try {
+            Database database = Env.getCurrentInternalCatalog().getDbNullable(dictionary.getDbName());
+            if (database == null || !isCurrentDictionaryWithoutLock(database, dictionary)) {
+                throw new AnalysisException("Dictionary " + dictionary.getName() + " has been dropped");
+            }
+            return database;
+        } finally {
+            unlockRead();
+        }
     }
 
     public Map<String, Dictionary> getDictionaries(String dbName) {
@@ -406,10 +440,17 @@ public class DictionaryManager extends MasterDaemon implements Writable {
             LOG.info("skip adaptive dataLoad of dictionary " + dictionary.getName() + ". maybe last load finished.");
             return;
         }
+        // Resolve first so every LOADING refresh carries one exact owner generation.
+        Database database = getCurrentDatabase(dictionary);
+
         // use atomic status as a lock.
         if (!dictionary.trySetStatus(Dictionary.DictionaryStatus.LOADING)) {
             throw new AnalysisException("Dictionary " + dictionary.getName() + " cannot load now, status is "
                     + dictionary.getStatus().name());
+        }
+
+        while (DebugPointUtil.isEnable("DictionaryManager.dataLoad.blockBeforePlan")) {
+            Thread.sleep(10);
         }
 
         if (ctx == null) { // for run with scheduler, not by command.
@@ -433,7 +474,8 @@ public class DictionaryManager extends MasterDaemon implements Writable {
             baseCommand.setJobId(DICTIONARY_JOB_ID);
         }
 
-        InsertIntoDictionaryCommand command = new InsertIntoDictionaryCommand(baseCommand, dictionary, adaptiveLoad);
+        InsertIntoDictionaryCommand command = new InsertIntoDictionaryCommand(
+                baseCommand, database, dictionary, adaptiveLoad);
 
         // run with sync by status.
         try {
@@ -464,8 +506,7 @@ public class DictionaryManager extends MasterDaemon implements Writable {
         lockRead();
         boolean unlocked = false;
         try {
-            if (!dictionaryIds.containsKey(dictionary.getDbName())
-                    || !dictionaryIds.get(dictionary.getDbName()).containsKey(dictionary.getName())) {
+            if (!isCurrentDictionaryWithoutLock(database, dictionary)) {
                 unlockRead();
                 unlocked = true;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundDictionarySink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundDictionarySink.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.analyzer;
 
+import org.apache.doris.catalog.Database;
 import org.apache.doris.dictionary.Dictionary;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.memo.GroupExpression;
@@ -45,15 +46,16 @@ import java.util.Optional;
 public class UnboundDictionarySink<CHILD_TYPE extends Plan> extends UnboundLogicalSink<CHILD_TYPE>
         implements Unbound, Sink, BlockFuncDepsPropagation {
 
+    private final Database database;
     private final Dictionary dictionary;
     private final boolean allowAdaptiveLoad;
 
     /**
      * create unbound sink for dictionary sink
      */
-    public UnboundDictionarySink(Dictionary dictionary, CHILD_TYPE child, boolean adaptiveLoad) {
+    public UnboundDictionarySink(Database database, Dictionary dictionary, CHILD_TYPE child, boolean adaptiveLoad) {
         // all the empty arguments is like UnboundTableSink
-        super(ImmutableList.copyOf(dictionary.getNameWithFullQualifiers().split("\\.")), // nameParts
+        super(ImmutableList.of(database.getCatalog().getName(), database.getFullName(), dictionary.getName()),
                 PlanType.LOGICAL_UNBOUND_DICTIONARY_SINK, // type
                 ImmutableList.of(), // outputExprs
                 Optional.empty(), // groupExpression
@@ -61,8 +63,13 @@ public class UnboundDictionarySink<CHILD_TYPE extends Plan> extends UnboundLogic
                 dictionary.getColumnNames(), // colNames from dictionary
                 DMLCommandType.INSERT, // dmlCommandType
                 child);
+        this.database = database;
         this.dictionary = dictionary;
         this.allowAdaptiveLoad = adaptiveLoad;
+    }
+
+    public Database getDatabase() {
+        return database;
     }
 
     public Dictionary getDictionary() {
@@ -76,7 +83,7 @@ public class UnboundDictionarySink<CHILD_TYPE extends Plan> extends UnboundLogic
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "UnboundDictionarySink only accepts one child");
-        return new UnboundDictionarySink<>(dictionary, children.get(0), allowAdaptiveLoad);
+        return new UnboundDictionarySink<>(database, dictionary, children.get(0), allowAdaptiveLoad);
     }
 
     @Override
@@ -91,13 +98,13 @@ public class UnboundDictionarySink<CHILD_TYPE extends Plan> extends UnboundLogic
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new UnboundDictionarySink<>(dictionary, child(), allowAdaptiveLoad);
+        return new UnboundDictionarySink<>(database, dictionary, child(), allowAdaptiveLoad);
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new UnboundDictionarySink<>(dictionary, children.get(0), allowAdaptiveLoad);
+        return new UnboundDictionarySink<>(database, dictionary, children.get(0), allowAdaptiveLoad);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTableSinkCreator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTableSinkCreator.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.analyzer;
 
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogIf;
@@ -161,8 +162,8 @@ public class UnboundTableSinkCreator {
     /**
      * create unbound sink for dictionary sink
      */
-    public static UnboundDictionarySink<? extends Plan> createUnboundDictionarySink(Dictionary dictionary,
-            LogicalPlan child, boolean adaptiveLoad) {
-        return new UnboundDictionarySink<>(dictionary, child, adaptiveLoad);
+    public static UnboundDictionarySink<? extends Plan> createUnboundDictionarySink(Database database,
+            Dictionary dictionary, LogicalPlan child, boolean adaptiveLoad) {
+        return new UnboundDictionarySink<>(database, dictionary, child, adaptiveLoad);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -990,9 +990,8 @@ public class BindSink implements AnalysisRuleFactory {
 
     private Plan bindDictionarySink(MatchingContext<UnboundDictionarySink<Plan>> ctx) {
         UnboundDictionarySink<?> sink = ctx.root;
-        Pair<Database, Dictionary> pair = bind(ctx.cascadesContext, sink);
-        Database database = pair.first;
-        Dictionary dictionary = pair.second;
+        Database database = sink.getDatabase();
+        Dictionary dictionary = sink.getDictionary();
         LogicalPlan child = ((LogicalPlan) sink.child());
 
         // 1. bind target columns: from sink's column names to target tables' Columns
@@ -1116,19 +1115,6 @@ public class BindSink implements AnalysisRuleFactory {
             return Pair.of(((ExternalDatabase) pair.first), (PluginDrivenExternalTable) pair.second);
         }
         throw new AnalysisException("the target table of insert into is not a plugin-driven connector table");
-    }
-
-    private Pair<Database, Dictionary> bind(CascadesContext cascadesContext,
-            UnboundDictionarySink<? extends Plan> sink) {
-        Dictionary dictionary = sink.getDictionary();
-        Database db;
-        try {
-            db = cascadesContext.getConnectContext().getEnv().getInternalCatalog()
-                    .getDbOrAnalysisException(dictionary.getDatabase().getName());
-        } catch (org.apache.doris.common.AnalysisException e) {
-            throw new AnalysisException(e.getMessage());
-        }
-        return Pair.of(db, dictionary);
     }
 
     private List<Long> bindPartitionIds(OlapTable table, List<String> partitions, boolean temp) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -107,8 +108,17 @@ public abstract class AbstractInsertExecutor {
      */
     public AbstractInsertExecutor(ConnectContext ctx, TableIf table, String labelName, NereidsPlanner planner,
             Optional<InsertCommandContext> insertCtx, boolean emptyInsert, long jobId, boolean needRegister) {
+        this(ctx, table.getDatabase(), table, labelName, planner, insertCtx, emptyInsert, jobId, needRegister);
+    }
+
+    /**
+     * Dictionary loads must retain the owner resolved before a concurrent database drop.
+     */
+    public AbstractInsertExecutor(ConnectContext ctx, DatabaseIf<?> database, TableIf table, String labelName,
+            NereidsPlanner planner, Optional<InsertCommandContext> insertCtx, boolean emptyInsert, long jobId,
+            boolean needRegister) {
         this.ctx = ctx;
-        this.database = table.getDatabase();
+        this.database = Objects.requireNonNull(database, "database should not be null");
         this.insertLoadJob = new InsertLoadJob(database.getId(), labelName, jobId);
         if (needRegister) {
             ctx.getEnv().getLoadManager().addLoadJob(insertLoadJob);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/DictionaryInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/DictionaryInsertExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
@@ -42,9 +43,10 @@ public class DictionaryInsertExecutor extends AbstractInsertExecutor {
     /**
      * constructor
      */
-    public DictionaryInsertExecutor(ConnectContext ctx, Dictionary dictionary, String labelName, NereidsPlanner planner,
-            Optional<InsertCommandContext> insertCtx, boolean emptyInsert, long jobId) {
-        super(ctx, dictionary, labelName, planner, insertCtx, emptyInsert, jobId);
+    public DictionaryInsertExecutor(ConnectContext ctx, DatabaseIf<?> database, Dictionary dictionary,
+            String labelName, NereidsPlanner planner, Optional<InsertCommandContext> insertCtx, boolean emptyInsert,
+            long jobId) {
+        super(ctx, database, dictionary, labelName, planner, insertCtx, emptyInsert, jobId, false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoDictionaryCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoDictionaryCommand.java
@@ -18,6 +18,8 @@
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
 import org.apache.doris.analysis.RedirectStatus;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.dictionary.Dictionary;
 import org.apache.doris.nereids.analyzer.UnboundDictionarySink;
@@ -35,19 +37,22 @@ import java.util.List;
  * logic of InsertIntoTableCommand to maximize code reuse.
  */
 public class InsertIntoDictionaryCommand extends InsertIntoTableCommand {
+    private final Database database;
     private final Dictionary dictionary;
 
     /**
      * Constructor for InsertIntoDictionaryCommand.
      *
      * @param baseCommand The base InsertIntoTableCommand to copy from
+     * @param database The retained owner of the target dictionary
      * @param dictionary The target dictionary to insert into
      * @param adaptiveLoad see DictionaryManager.submitDataLoad
      * @throws AnalysisException if the logical query is not a valid sink
      */
-    public InsertIntoDictionaryCommand(InsertIntoTableCommand baseCommand, Dictionary dictionary,
+    public InsertIntoDictionaryCommand(InsertIntoTableCommand baseCommand, Database database, Dictionary dictionary,
             boolean adaptiveLoad) {
         super(baseCommand, PlanType.INSERT_INTO_DICTIONARY_COMMAND);
+        this.database = database;
         this.dictionary = dictionary;
 
         // Change sink type from olap table(need check) to dictionary
@@ -57,7 +62,7 @@ public class InsertIntoDictionaryCommand extends InsertIntoTableCommand {
         }
 
         UnboundTableSink<?> sink = (UnboundTableSink<?>) logicalQuery;
-        UnboundDictionarySink<?> newSink = UnboundTableSinkCreator.createUnboundDictionarySink(dictionary,
+        UnboundDictionarySink<?> newSink = UnboundTableSinkCreator.createUnboundDictionarySink(database, dictionary,
                 (LogicalPlan) sink.child(0), adaptiveLoad);
         setLogicalQuery(newSink);
         setOriginLogicalQuery(newSink);
@@ -71,7 +76,15 @@ public class InsertIntoDictionaryCommand extends InsertIntoTableCommand {
 
     @Override
     protected TableIf getTargetTableIf(ConnectContext ctx, List<String> qualifiedTargetTableName) {
+        if (!ctx.getEnv().getDictionaryManager().isCurrentDictionary(database, dictionary)) {
+            throw new AnalysisException("Dictionary " + dictionary.getName() + " has been dropped");
+        }
         return dictionary;
+    }
+
+    @Override
+    protected DatabaseIf<?> getTargetDatabase(TableIf targetTable) {
+        return database;
     }
 
     public Dictionary getDictionary() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands.insert;
 
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.StmtType;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
@@ -240,6 +241,10 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
         return RelationUtil.getTable(qualifiedTargetTableName, ctx.getEnv(), Optional.empty());
     }
 
+    protected DatabaseIf<?> getTargetDatabase(TableIf targetTable) {
+        return targetTable.getDatabase();
+    }
+
     public AbstractInsertExecutor initPlan(ConnectContext ctx, StmtExecutor executor) throws Exception {
         return initPlan(ctx, executor, true);
     }
@@ -261,14 +266,15 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
         ctx.getStatementContext().setIsInsert(true);
         while (++retryTimes < Math.max(ctx.getSessionVariable().dmlPlanRetryTimes, 3)) {
             TableIf targetTableIf = getTargetTableIf(ctx, qualifiedTargetTableName);
+            DatabaseIf<?> targetDatabase = getTargetDatabase(targetTableIf);
             // check auth
             if (needAuthCheck(targetTableIf) && !Env.getCurrentEnv().getAccessManager()
-                    .checkTblPriv(ConnectContext.get(), targetTableIf.getDatabase().getCatalog().getName(),
-                            targetTableIf.getDatabase().getFullName(), targetTableIf.getName(),
+                    .checkTblPriv(ConnectContext.get(), targetDatabase.getCatalog().getName(),
+                            targetDatabase.getFullName(), targetTableIf.getName(),
                             PrivPredicate.LOAD)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
                         ConnectContext.get().getQualifiedUser(), ConnectContext.get().getRemoteIP(),
-                        targetTableIf.getDatabase().getFullName()
+                        targetDatabase.getFullName()
                                 + "." + Util.getTempTableDisplayName(targetTableIf.getName()));
             }
             BuildInsertExecutorResult buildResult;
@@ -577,10 +583,11 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
             } else if (physicalSink instanceof PhysicalDictionarySink) {
                 boolean emptyInsert = childIsEmptyRelation(physicalSink);
                 Dictionary dictionary = (Dictionary) targetTableIf;
+                DatabaseIf<?> database = getTargetDatabase(dictionary);
                 // insertCtx is not useful for dictionary. so keep it empty is ok.
                 return ExecutorFactory.from(planner, dataSink, physicalSink,
                         () -> new DictionaryInsertExecutor(
-                                ctx, dictionary, label, planner, insertCtx, emptyInsert, jobId));
+                                ctx, database, dictionary, label, planner, insertCtx, emptyInsert, jobId));
             } else if (physicalSink instanceof PhysicalBlackholeSink) {
                 boolean emptyInsert = childIsEmptyRelation(physicalSink);
                 // insertCtx is not useful for blackhole. so keep it empty is ok.

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/DictionaryInsertTargetDropRaceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/DictionaryInsertTargetDropRaceTest.java
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.common.util.DebugPointUtil.DebugPoint;
+import org.apache.doris.dictionary.Dictionary;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.OriginStatement;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+class DictionaryInsertTargetDropRaceTest extends TestWithFeService {
+    private static final String BLOCK_BEFORE_PLAN = "DictionaryManager.dataLoad.blockBeforePlan";
+
+    private boolean debugPointsEnabled;
+
+    @BeforeEach
+    void saveDebugPointConfig() {
+        debugPointsEnabled = Config.enable_debug_points;
+    }
+
+    @AfterEach
+    void clearDebugPoints() {
+        DebugPointUtil.clearDebugPoints();
+        Config.enable_debug_points = debugPointsEnabled;
+    }
+
+    @Test
+    void rejectsDroppedDictionaryAfterResolvingItsOwner() throws Exception {
+        Config.enable_debug_points = true;
+        DebugPoint blockPoint = new DebugPoint();
+        blockPoint.executeLimit = Integer.MAX_VALUE;
+        DebugPointUtil.addDebugPoint(BLOCK_BEFORE_PLAN, blockPoint);
+
+        String sourceDbName = "dictionary_insert_drop_race_source";
+        createDatabaseAndUse(sourceDbName);
+        createSourceTable();
+
+        String dbName = "dictionary_insert_drop_race";
+        createDatabaseAndUse(dbName);
+        executeNereidsSql("CREATE DICTIONARY dic1 USING internal." + sourceDbName
+                + ".source_table (city KEY, id VALUE) "
+                + "LAYOUT(HASH_MAP) PROPERTIES ('data_lifetime' = '600')");
+
+        Dictionary dictionary = Env.getCurrentEnv().getDictionaryManager().getDictionary(dbName, "dic1");
+        Database database = Env.getCurrentInternalCatalog().getDbOrDdlException(dbName);
+        String sql = "INSERT INTO " + dbName + ".dic1 SELECT * FROM "
+                + dictionary.getSourceCtlName() + "." + dictionary.getSourceDbName() + "."
+                + dictionary.getSourceTableName();
+        InsertIntoTableCommand baseCommand = (InsertIntoTableCommand) new NereidsParser().parseSingle(sql);
+        CountDownLatch targetValidated = new CountDownLatch(1);
+        CountDownLatch resumePlanning = new CountDownLatch(1);
+        AtomicBoolean blockOnce = new AtomicBoolean(true);
+        InsertIntoDictionaryCommand command = new InsertIntoDictionaryCommand(
+                baseCommand, database, dictionary, false) {
+            @Override
+            protected TableIf getTargetTableIf(ConnectContext ctx, List<String> qualifiedTargetTableName) {
+                TableIf target = super.getTargetTableIf(ctx, qualifiedTargetTableName);
+                if (blockOnce.compareAndSet(true, false)) {
+                    targetValidated.countDown();
+                    await(resumePlanning);
+                }
+                return target;
+            }
+        };
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            await(() -> blockPoint.executeNum.get() > 0);
+            Future<Throwable> result = executorService.submit(() -> runInitPlan(command, sql, dbName));
+            Assertions.assertTrue(targetValidated.await(10, TimeUnit.SECONDS));
+            Env.getCurrentInternalCatalog().dropDb(dbName, false, true);
+            resumePlanning.countDown();
+
+            Throwable failure = result.get(10, TimeUnit.SECONDS);
+            Assertions.assertNotNull(failure);
+            Assertions.assertTrue(hasCause(failure, org.apache.doris.nereids.exceptions.AnalysisException.class),
+                    failure.toString());
+            Assertions.assertTrue(failure.toString().contains("Dictionary dic1 has been dropped"),
+                    failure.toString());
+            Assertions.assertFalse(hasCause(failure, NullPointerException.class), failure.toString());
+            Assertions.assertNull(Env.getCurrentEnv().getDictionaryManager().getDictionary(dictionary.getId()));
+
+            createDatabaseAndUse(dbName);
+            executeNereidsSql("CREATE DICTIONARY dic1 USING internal." + sourceDbName
+                    + ".source_table (city KEY, id VALUE) "
+                    + "LAYOUT(HASH_MAP) PROPERTIES ('data_lifetime' = '600')");
+            Dictionary replacement = Env.getCurrentEnv().getDictionaryManager().getDictionary(dbName, "dic1");
+            Assertions.assertNotEquals(dictionary.getId(), replacement.getId());
+        } finally {
+            resumePlanning.countDown();
+            DebugPointUtil.removeDebugPoint(BLOCK_BEFORE_PLAN);
+            executorService.shutdownNow();
+        }
+
+        await(() -> !dictionary.getLastUpdateResult().isEmpty());
+        Assertions.assertTrue(dictionary.getLastUpdateResult().contains("has been dropped"),
+                dictionary.getLastUpdateResult());
+        Assertions.assertFalse(dictionary.getLastUpdateResult().contains("Cannot invoke"),
+                dictionary.getLastUpdateResult());
+        Env.getCurrentInternalCatalog().dropDb(dbName, false, true);
+        Env.getCurrentInternalCatalog().dropDb(sourceDbName, false, true);
+    }
+
+    private void createSourceTable() throws Exception {
+        createTable("CREATE TABLE source_table (id INT NOT NULL, city VARCHAR(32) NOT NULL) "
+                + "DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+    }
+
+    private Throwable runInitPlan(InsertIntoDictionaryCommand command, String sql, String dbName) {
+        try {
+            ConnectContext ctx = createCtx(UserIdentity.ROOT, "127.0.0.1");
+            ctx.setDatabase(dbName);
+            ctx.setQueryId(new TUniqueId(1, 2));
+            ctx.setStatementContext(new StatementContext(ctx, new OriginStatement(sql, 0)));
+            command.initPlan(ctx, new StmtExecutor(ctx, sql));
+            return null;
+        } catch (Throwable t) {
+            return t;
+        }
+    }
+
+    private static boolean hasCause(Throwable throwable, Class<? extends Throwable> causeClass) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (causeClass.isInstance(cause)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting to resume dictionary planning");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void await(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        Assertions.assertTrue(condition.getAsBoolean());
+    }
+}

--- a/regression-test/suites/dictionary_p0/test_create_drop_sync.groovy
+++ b/regression-test/suites/dictionary_p0/test_create_drop_sync.groovy
@@ -15,7 +15,7 @@
  // specific language governing permissions and limitations
  // under the License.
 
-suite('test_create_drop_sync') {
+suite('test_create_drop_sync', 'nonConcurrent') {
     sql "DROP DATABASE IF EXISTS test_create_drop_sync"
     sql "CREATE DATABASE test_create_drop_sync"
     sql "USE test_create_drop_sync"
@@ -37,6 +37,7 @@ suite('test_create_drop_sync') {
         DISTRIBUTED BY HASH(id) BUCKETS 1
         PROPERTIES("replication_num" = "1")
     """
+    sql "INSERT INTO source_table VALUES (1, 'beijing', '001')"
 
     // create dictionary
     sql """
@@ -81,8 +82,35 @@ suite('test_create_drop_sync') {
         properties('data_lifetime'='600');
     """
 
-    // drop and recreate the database. check dic1 is dropped.
-    sql "DROP DATABASE test_create_drop_sync"
+    waitAllDictionariesReady()
+
+    def refreshFuture
+    try {
+        GetDebugPoint().enableDebugPointForAllFEs('DictionaryManager.dataLoad.blockBeforePlan')
+        refreshFuture = thread {
+            sql "REFRESH DICTIONARY test_create_drop_sync.dic1"
+        }
+        awaitUntil(10) {
+            def dictionaries = sql "SHOW DICTIONARIES"
+            dictionaries.size() == 1 && dictionaries[0][4] == "LOADING"
+        }
+        sql "DROP DATABASE test_create_drop_sync"
+    } finally {
+        GetDebugPoint().disableDebugPointForAllFEs('DictionaryManager.dataLoad.blockBeforePlan')
+    }
+
+    Exception refreshFailure = null
+    assertNotNull(refreshFuture)
+    try {
+        refreshFuture.get()
+    } catch (Exception e) {
+        refreshFailure = e
+    }
+    assertNotNull(refreshFailure)
+    assertTrue(refreshFailure.toString().contains("Dictionary dic1 has been dropped"), refreshFailure.toString())
+    assertFalse(refreshFailure.toString().contains("Cannot invoke"), refreshFailure.toString())
+
+    // Recreate the database and verify that the dropped dictionary is not retained.
     sql "CREATE DATABASE test_create_drop_sync"
     sql "USE test_create_drop_sync"
     dict_res = sql "SHOW DICTIONARIES"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

A dictionary refresh can retain a `Dictionary` object while `DROP DATABASE` removes its owner database. The old path repeatedly recovered the database through `dictionary.getDatabase()` and checked existence by database/name, so it could either dereference a null database or accept a newly created dictionary with the same name.

This change establishes one insert-target invariant: resolve the database and table/dictionary together, then carry that exact pair through authorization, sink binding, retry validation, and executor construction. Dictionary loads additionally validate canonical dictionary identity by ID before planning and after execution. Database drop now removes dictionary IDs from the canonical map, matching replay behavior and preventing same-name ABA.

Ordinary internal-table inserts keep their existing table read-lock/write-lock and transaction ordering. The paired target only closes the pre-lock metadata lookup window and adds database ID to retry validation.

### Release note

Fix concurrent dictionary refresh and database drop returning an internal null-pointer error or accepting stale dictionary metadata.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (targeted isolated FE/BE cluster race)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Concurrent target removal now returns a deterministic analysis error instead of an internal null-pointer error; same-name recreation is treated as a different dictionary generation.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.
