### PR TITLE
[test](fe) Cover binlog config validation routing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
@@ -113,7 +113,9 @@ public class AlterOperations {
         ).anyMatch(clause -> clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE)
             || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL_SECONDS)
             || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_BYTES)
-            || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_HISTORY_NUMS));
+            || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_HISTORY_NUMS)
+            || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_FORMAT)
+            || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_NEED_HISTORICAL_VALUE));
     }
 
     public boolean isBeingSynced(List<AlterOp> alterOps) {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterOperationsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterOperationsTest.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.alter;
+
+import org.apache.doris.common.util.PropertyAnalyzer;
+import org.apache.doris.nereids.trees.plans.commands.info.AlterOp;
+import org.apache.doris.nereids.trees.plans.commands.info.ModifyTablePropertiesOp;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AlterOperationsTest {
+
+    @Test
+    public void testBinlogFormatUsesBinlogConfigChangePath() {
+        Map<String, String> properties = Collections.singletonMap(
+                PropertyAnalyzer.PROPERTIES_BINLOG_FORMAT, "STATEMENT_AND_SNAPSHOT");
+        List<AlterOp> alterOps = Collections.singletonList(new ModifyTablePropertiesOp(properties));
+
+        Assert.assertTrue(new AlterOperations().checkBinlogConfigChange(alterOps));
+    }
+
+    @Test
+    public void testBinlogNeedHistoricalValueUsesBinlogConfigChangePath() {
+        Map<String, String> properties = Collections.singletonMap(
+                PropertyAnalyzer.PROPERTIES_BINLOG_NEED_HISTORICAL_VALUE, "true");
+        List<AlterOp> alterOps = Collections.singletonList(new ModifyTablePropertiesOp(properties));
+
+        Assert.assertTrue(new AlterOperations().checkBinlogConfigChange(alterOps));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.info.ColumnPosition;
 import org.apache.doris.catalog.info.IndexType;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.nereids.StatementContext;
@@ -162,6 +163,43 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             System.out.println(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains(expectedErrorMsg),
                     "Actual error: " + e.getMessage() + "\nExpected: " + expectedErrorMsg);
+        }
+    }
+
+    @Test
+    public void testChangeBinlogFormatReportsBinlogError() throws Exception {
+        boolean originalEnableFeatureBinlog = Config.enable_feature_binlog;
+        try {
+            Config.enable_feature_binlog = true;
+            String tableName = "binlog_format_change";
+            createTable("CREATE TABLE test." + tableName + " (k1 INT NOT NULL) "
+                    + "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 "
+                    + "PROPERTIES('replication_num'='1','binlog.enable'='true','binlog.format'='ROW')");
+
+            expectException("ALTER TABLE test." + tableName
+                            + " SET ('binlog.format'='STATEMENT_AND_SNAPSHOT')",
+                    "not support change binlog format from ROW to STATEMENT_AND_SNAPSHOT");
+        } finally {
+            Config.enable_feature_binlog = originalEnableFeatureBinlog;
+        }
+    }
+
+    @Test
+    public void testChangeBinlogNeedHistoricalValueReportsBinlogError() throws Exception {
+        boolean originalEnableFeatureBinlog = Config.enable_feature_binlog;
+        try {
+            Config.enable_feature_binlog = true;
+            String tableName = "binlog_historical_value_change";
+            createTable("CREATE TABLE test." + tableName + " (k1 INT NOT NULL) "
+                    + "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 "
+                    + "PROPERTIES('replication_num'='1','binlog.enable'='true','binlog.format'='ROW',"
+                    + "'binlog.need_historical_value'='false')");
+
+            expectException("ALTER TABLE test." + tableName
+                            + " SET ('binlog.need_historical_value'='true')",
+                    "not support change binlog.need_historical_value from false to true");
+        } finally {
+            Config.enable_feature_binlog = originalEnableFeatureBinlog;
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -30,6 +30,7 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.info.ColumnPosition;
 import org.apache.doris.catalog.info.IndexType;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.jmockit.Deencapsulation;
@@ -171,6 +172,43 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             System.out.println(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains(expectedErrorMsg),
                     "Actual error: " + e.getMessage() + "\nExpected: " + expectedErrorMsg);
+        }
+    }
+
+    @Test
+    public void testChangeBinlogFormatReportsBinlogError() throws Exception {
+        boolean originalEnableFeatureBinlog = Config.enable_feature_binlog;
+        try {
+            Config.enable_feature_binlog = true;
+            String tableName = "binlog_format_change";
+            createTable("CREATE TABLE test." + tableName + " (k1 INT NOT NULL) "
+                    + "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 "
+                    + "PROPERTIES('replication_num'='1','binlog.enable'='true','binlog.format'='ROW')");
+
+            expectException("ALTER TABLE test." + tableName
+                            + " SET ('binlog.format'='STATEMENT_AND_SNAPSHOT')",
+                    "not support change binlog format from ROW to STATEMENT_AND_SNAPSHOT");
+        } finally {
+            Config.enable_feature_binlog = originalEnableFeatureBinlog;
+        }
+    }
+
+    @Test
+    public void testChangeBinlogNeedHistoricalValueReportsBinlogError() throws Exception {
+        boolean originalEnableFeatureBinlog = Config.enable_feature_binlog;
+        try {
+            Config.enable_feature_binlog = true;
+            String tableName = "binlog_historical_value_change";
+            createTable("CREATE TABLE test." + tableName + " (k1 INT NOT NULL) "
+                    + "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 "
+                    + "PROPERTIES('replication_num'='1','binlog.enable'='true','binlog.format'='ROW',"
+                    + "'binlog.need_historical_value'='false')");
+
+            expectException("ALTER TABLE test." + tableName
+                            + " SET ('binlog.need_historical_value'='true')",
+                    "not support change binlog.need_historical_value from false to true");
+        } finally {
+            Config.enable_feature_binlog = originalEnableFeatureBinlog;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65383

Related PR: #65810

`ALTER TABLE ... SET` changes to `binlog.format` and
`binlog.need_historical_value` must be classified as binlog configuration
updates. Otherwise they can fall through to the generic schema-change path and
report the wrong error instead of the existing immutable-setting validation.

The production routing originally proposed here is now present on `master`
through #65810. That broader row-binlog change did not add focused regression
coverage for #65383, so this rebased PR intentionally drops the duplicate
production diff and keeps only targeted tests for both immutable properties.

### What is covered?

- `AlterOperations` recognizes `binlog.format` as a binlog config change.
- `AlterOperations` recognizes `binlog.need_historical_value` as a binlog
  config change.
- End-to-end `ALTER TABLE` validation reports the specific immutable-format
  error.
- End-to-end `ALTER TABLE` validation reports the specific historical-value
  error.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
        - `AlterOperationsTest` (2 tests)
        - `SchemaChangeHandlerTest` (2 targeted tests)
    - [ ] Manual test
    - [ ] No need to test or manual test.

Local verification on current `master`:

```text
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

- Behavior changed:
    - [x] No. The production behavior is already on `master`; this PR adds
      regression coverage only.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

I used AI-assisted review during development. I verified the current upstream
behavior, rebased diff, and all four focused tests locally.
