### PR TITLE
[fix](regression) Stabilize sync MV selection in MTMV test

### DIFF
--- a/regression-test/suites/rollup_p0/test_create_mv_and_mtmv.groovy
+++ b/regression-test/suites/rollup_p0/test_create_mv_and_mtmv.groovy
@@ -95,6 +95,14 @@ AND RefreshMode = '${refreshMode}';"""
     wait_mtmv_refresh_finish("COMPLETE")
     qt_mtmv_init """ SELECT * FROM ${mtmvName} ORDER BY dt, advertiser"""
 
+    // Verify that the MTMV definition can build a rewrite cache and produce a rewrite candidate.
+    // The final CBO choice is intentionally not asserted because either valid plan may be cheaper.
+    mv_rewrite_success_without_check_chosen("""
+                SELECT dt, advertiser, count(distinct user_id)
+                FROM ${tableName}
+                GROUP BY dt, advertiser
+            """, mtmvName)
+
     sql """INSERT INTO ${tableName} VALUES("2024-07-03",'b', "2024-07-03", 'b',2);"""
     refreshTime = (int) (System.currentTimeMillis() / 1000L)
     sql """REFRESH MATERIALIZED VIEW ${mtmvName} AUTO;"""

--- a/regression-test/suites/rollup_p0/test_create_mv_and_mtmv.groovy
+++ b/regression-test/suites/rollup_p0/test_create_mv_and_mtmv.groovy
@@ -52,9 +52,10 @@ suite("test_create_mv_and_mtmv") {
                  dt;
 
     """)
+    // The MTMV must read the sync MV to cover partition-column resolution through the rollup.
     explain {
         sql("""
-                    SELECT dt,advertiser,
+                    SELECT /*+ use_mv(${tableName}.${mvName}) */ dt,advertiser,
                           count(DISTINCT user_id)
                     FROM ${tableName}
                     GROUP BY dt,advertiser""")
@@ -68,7 +69,7 @@ suite("test_create_mv_and_mtmv") {
             DISTRIBUTED BY RANDOM BUCKETS 1
             PROPERTIES ('replication_num' = '1') 
             AS 
-            select dt, advertiser, count(distinct user_id)
+            select /*+ use_mv(${tableName}.${mvName}) */ dt, advertiser, count(distinct user_id)
                 from ${tableName}
                 group by dt, advertiser;
     """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #37396

Problem Summary:

`test_create_mv_and_mtmv` verifies that an async MTMV can read a sync rollup MV, resolve the rollup column back to the base-table partition column, and complete full and partial refreshes.

The original case disabled cost-based sync MV selection so both the precondition query and MTMV definition actually read the sync rollup. After that control was removed, `TRY_IN_RBO` could successfully generate the rollup candidate while cost-based planning still selected the base index, causing an intermittent `MaterializedViewRewriteSuccessButNotChose` failure before MTMV creation.

Add `USE_MV` to both queries so the case deterministically exercises the intended sync-rollup path while retaining the existing full and partial refresh assertions.

After the initial complete refresh, call `mv_rewrite_success_without_check_chosen` for the MTMV definition query. This directly verifies that the MTMV rewrite cache can be generated and produce a rewrite candidate, while intentionally accepting either legal final CBO choice.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Parsed the modified Groovy suite with `GroovyShell`.
        - Ran `git diff --check`.
        - Ran the local case-record checker.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
