### PR TITLE
[fix](fe) synchronize HDFS resource property access

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -67,8 +67,13 @@ public class HdfsResource extends Resource {
 
     @Override
     public void modifyProperties(Map<String, String> properties) throws DdlException {
-        for (Map.Entry<String, String> kv : properties.entrySet()) {
-            replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+        writeLock();
+        try {
+            for (Map.Entry<String, String> kv : properties.entrySet()) {
+                replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+            }
+        } finally {
+            writeUnlock();
         }
         super.modifyProperties(properties);
     }
@@ -85,14 +90,24 @@ public class HdfsResource extends Resource {
 
     @Override
     public Map<String, String> getCopiedProperties() {
-        return Maps.newHashMap(properties);
+        readLock();
+        try {
+            return Maps.newHashMap(properties);
+        } finally {
+            readUnlock();
+        }
     }
 
     @Override
     protected void getProcNodeData(BaseProcResult result) {
         String lowerCaseType = type.name().toLowerCase();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+        readLock();
+        try {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+            }
+        } finally {
+            readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -258,13 +258,23 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     @Override
     public String toString() {
-        return GsonUtils.GSON.toJson(this);
+        readLock();
+        try {
+            return GsonUtils.GSON.toJson(this);
+        } finally {
+            readUnlock();
+        }
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
-        Text.writeString(out, json);
+        readLock();
+        try {
+            String json = GsonUtils.GSON.toJson(this);
+            Text.writeString(out, json);
+        } finally {
+            readUnlock();
+        }
     }
 
     public static Resource read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.DropResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.DropResourceOperationLog;
+import org.apache.doris.persist.EditLog.EditLogItem;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
@@ -150,10 +151,22 @@ public class ResourceMgr implements Writable {
         }
 
         Resource resource = nameToResource.get(resourceName);
-        resource.modifyProperties(properties);
+        EditLogItem editLogItem;
+        resource.writeLock();
+        try {
+            resource.modifyProperties(properties);
+            Resource resourceSnapshot = resource.clone();
+            if (resourceSnapshot == null) {
+                throw new IllegalStateException("Failed to snapshot resource " + resourceName);
+            }
+            editLogItem = Env.getCurrentEnv().getEditLog().submitAlterResource(resourceSnapshot);
+        } finally {
+            resource.writeUnlock();
+        }
 
-        // log alter
-        Env.getCurrentEnv().getEditLog().logAlterResource(resource);
+        // Wait outside the resource lock. The detached snapshot was enqueued while holding the lock,
+        // so concurrent ALTER RESOURCE operations preserve journal order without blocking on journal I/O.
+        editLogItem.await();
         LOG.info("Alter resource success. Resource: {}", resource);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -2216,6 +2216,10 @@ public class EditLog {
         logEdit(OperationType.OP_ALTER_RESOURCE, resource);
     }
 
+    public EditLogItem submitAlterResource(Resource resource) {
+        return submitEdit(OperationType.OP_ALTER_RESOURCE, resource);
+    }
+
     public void logAlterWorkloadGroup(WorkloadGroup workloadGroup) {
         logEdit(OperationType.OP_ALTER_WORKLOAD_GROUP, workloadGroup);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/HdfsResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/HdfsResourceTest.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -46,6 +48,17 @@ public class HdfsResourceTest {
     public void testModifyWaitsForCopiedPropertiesRead() throws Exception {
         BlockingReadHdfsResource resource = createResource();
         assertModifyWaitsForRead(resource, resource::getCopiedProperties);
+    }
+
+    @Test
+    public void testModifyWaitsForSerializationRead() throws Exception {
+        BlockingReadHdfsResource resource = createResource();
+        assertModifyWaitsForRead(resource, () -> {
+            try (DataOutputStream out = new DataOutputStream(new ByteArrayOutputStream())) {
+                resource.write(out);
+            }
+            return null;
+        });
     }
 
     private BlockingReadHdfsResource createResource() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/HdfsResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/HdfsResourceTest.java
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.proc.BaseProcResult;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class HdfsResourceTest {
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @Test
+    public void testModifyWaitsForProcNodeRead() throws Exception {
+        BlockingReadHdfsResource resource = createResource();
+        assertModifyWaitsForRead(resource, () -> {
+            resource.getProcNodeData(new BaseProcResult());
+            return null;
+        });
+    }
+
+    @Test
+    public void testModifyWaitsForCopiedPropertiesRead() throws Exception {
+        BlockingReadHdfsResource resource = createResource();
+        assertModifyWaitsForRead(resource, resource::getCopiedProperties);
+    }
+
+    private BlockingReadHdfsResource createResource() throws Exception {
+        BlockingReadHdfsResource resource = new BlockingReadHdfsResource("hdfs_resource");
+        resource.setProperties(ImmutableMap.of(
+                HdfsResource.HADOOP_FS_NAME, "hdfs://namenode:8020",
+                "hadoop.username", "doris"));
+        return resource;
+    }
+
+    private void assertModifyWaitsForRead(BlockingReadHdfsResource resource, Callable<?> readTask)
+            throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch writeCompleted = new CountDownLatch(1);
+        try {
+            Future<?> readFuture = executor.submit(readTask);
+            Assert.assertTrue(resource.readLockEntered.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            Future<?> writeFuture = executor.submit(() -> {
+                try {
+                    resource.modifyProperties(ImmutableMap.of("dfs.replication", "3"));
+                } finally {
+                    writeCompleted.countDown();
+                }
+                return null;
+            });
+
+            Assert.assertTrue(resource.writeLockAttempted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            Assert.assertFalse(writeCompleted.await(100, TimeUnit.MILLISECONDS));
+
+            resource.allowReadToFinish.countDown();
+            readFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            writeFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Assert.assertEquals("3", resource.getCopiedProperties().get("dfs.replication"));
+        } finally {
+            resource.allowReadToFinish.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private static class BlockingReadHdfsResource extends HdfsResource {
+        private final CountDownLatch readLockEntered = new CountDownLatch(1);
+        private final CountDownLatch allowReadToFinish = new CountDownLatch(1);
+        private final CountDownLatch writeLockAttempted = new CountDownLatch(1);
+
+        private BlockingReadHdfsResource(String name) {
+            super(name);
+        }
+
+        @Override
+        public void readLock() {
+            super.readLock();
+            readLockEntered.countDown();
+            try {
+                allowReadToFinish.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void writeLock() {
+            writeLockAttempted.countDown();
+            super.writeLock();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.EditLog.EditLogItem;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableMap;
@@ -34,8 +35,19 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 public class ResourceMgrTest {
     // s3 resource
@@ -128,6 +140,79 @@ public class ResourceMgrTest {
 
             // add again
             mgr.createResource(createResourceCommand);
+        }
+    }
+
+    @Test
+    public void testConcurrentAlterUsesDetachedJournalSnapshots() throws Exception {
+        Env env = Env.getCurrentEnv();
+        EditLog originalEditLog = env.getEditLog();
+        EditLog editLog = Mockito.mock(EditLog.class);
+        CountDownLatch firstSerializationStarted = new CountDownLatch(1);
+        CountDownLatch allowFirstSerialization = new CountDownLatch(1);
+        AtomicInteger submitIndex = new AtomicInteger();
+        AtomicReferenceArray<Resource> persistedResources = new AtomicReferenceArray<>(2);
+
+        Mockito.when(editLog.submitAlterResource(Mockito.any())).thenAnswer(invocation -> {
+            int index = submitIndex.getAndIncrement();
+            Resource snapshot = invocation.getArgument(0);
+            EditLogItem item = Mockito.mock(EditLogItem.class);
+            Mockito.when(item.await()).thenAnswer(awaitInvocation -> {
+                if (index == 0) {
+                    firstSerializationStarted.countDown();
+                    Assert.assertTrue(allowFirstSerialization.await(5, TimeUnit.SECONDS));
+                }
+                persistedResources.set(index, serializeAndRead(snapshot));
+                return (long) index;
+            });
+            return item;
+        });
+
+        HdfsResource resource = new HdfsResource("hdfs_resource");
+        resource.setProperties(ImmutableMap.of(
+                HdfsResource.HADOOP_FS_NAME, "hdfs://namenode:8020",
+                "hadoop.username", "doris"));
+        ResourceMgr mgr = new ResourceMgr();
+        Assert.assertTrue(mgr.createResource(resource, false));
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        env.setEditLog(editLog);
+        try {
+            Future<?> firstAlter = executor.submit(() -> {
+                mgr.alterResource(resource.getName(), ImmutableMap.of("dfs.replication", "1"));
+                return null;
+            });
+            Assert.assertTrue(firstSerializationStarted.await(5, TimeUnit.SECONDS));
+
+            Future<?> secondAlter = executor.submit(() -> {
+                mgr.alterResource(resource.getName(), ImmutableMap.of("dfs.replication", "2"));
+                return null;
+            });
+            secondAlter.get(5, TimeUnit.SECONDS);
+
+            allowFirstSerialization.countDown();
+            firstAlter.get(5, TimeUnit.SECONDS);
+
+            Assert.assertEquals(2, submitIndex.get());
+            Assert.assertEquals("1", ((HdfsResource) persistedResources.get(0))
+                    .getCopiedProperties().get("dfs.replication"));
+            Assert.assertEquals("2", ((HdfsResource) persistedResources.get(1))
+                    .getCopiedProperties().get("dfs.replication"));
+            Assert.assertEquals("2", resource.getCopiedProperties().get("dfs.replication"));
+        } finally {
+            allowFirstSerialization.countDown();
+            executor.shutdownNow();
+            env.setEditLog(originalEditLog);
+        }
+    }
+
+    private Resource serializeAndRead(Resource resource) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            resource.write(out);
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return Resource.read(in);
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

A concurrent `ALTER RESOURCE` and `SHOW RESOURCES` can mutate and iterate an HDFS resource's `properties` HashMap at the same time, causing `ConcurrentModificationException` in FE.

The failure was observed in TeamCity build 991451:
http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/991451?buildTab=tests&expandedTest=build%3A%28id%3A991451%29%2Cid%3A2000001351

The batch edit-log path also queued the same live `Resource` object and serialized it later on the flusher thread. A second ALTER could therefore mutate the map during Gson serialization or make the first journal entry capture the second ALTER's state.

This PR:
- protects HDFS resource property mutation, copying, proc output, and Resource serialization with matching resource locks;
- creates a detached Resource snapshot and submits it to the edit-log queue while holding the resource write lock, preserving ALTER journal order;
- waits for journal flush only after releasing the resource lock.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  `DORIS_THIRDPARTY=/Users/keshu/dudu/doris/thirdparty mvn -q test -pl fe-common,fe-core -am -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest=org.apache.doris.catalog.HdfsResourceTest,org.apache.doris.catalog.ResourceMgrTest`

  Result:
  - `HdfsResourceTest`: 3 tests, 0 failures, 0 errors.
  - `ResourceMgrTest`: 3 tests, 0 failures, 0 errors.
  - FE checkstyle passed.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
