### PR TITLE
[fix](regression) retry transient FILE TVF S3 timeout

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1712,10 +1712,14 @@ class Suite implements GroovyInterceptable {
     }
 
     // rowConverter: { row -> convertedRow }
-    void quickRunTest(String tag, Object arg, boolean isOrder = false, Closure rowConverter = null) {
+    // queryExecutor: in verification mode, execute the query after reserving the expected output block
+    void quickRunTest(String tag, Object arg, boolean isOrder = false, Closure rowConverter = null,
+            Closure queryExecutor = null) {
         if (context.config.generateOutputFile || context.config.forceGenerateOutputFile) {
             Tuple2<List<List<Object>>, ResultSetMetaData> tupleResult = null
-            if (arg instanceof PreparedStatement) {
+            if (queryExecutor != null) {
+                tupleResult = queryExecutor.call()
+            } else if (arg instanceof PreparedStatement) {
                 if (tag.contains("hive_docker")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(hivePrefix),  (PreparedStatement) arg)
                 } else if (tag.contains("hive_remote")) {
@@ -1767,7 +1771,9 @@ class Suite implements GroovyInterceptable {
 
             OutputUtils.TagBlockIterator expectCsvResults = context.getOutputIterator().next()
             Tuple2<List<List<Object>>, ResultSetMetaData> tupleResult = null
-            if (arg instanceof PreparedStatement) {
+            if (queryExecutor != null) {
+                tupleResult = queryExecutor.call()
+            } else if (arg instanceof PreparedStatement) {
                 if (tag.contains("hive_docker")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(hivePrefix),  (PreparedStatement) arg)
                 } else if (tag.contains("hive_remote")) {
@@ -1859,8 +1865,7 @@ class Suite implements GroovyInterceptable {
             tupleResult = JdbcUtils.executeToStringList(context.getConnection(), (String) arg)
         }
 
-        def (realResults, meta) = tupleResult
-        return [realResults, meta]
+        return tupleResult
     }
 
     // test results of two sqls are the same
@@ -1885,7 +1890,7 @@ class Suite implements GroovyInterceptable {
         }
     }
 
-    void quickTest(String tag, String sql, boolean isOrder = false) {
+    void quickTest(String tag, String sql, boolean isOrder = false, Closure queryExecutor = null) {
         logger.info("Execute tag: ${tag}, ${isOrder ? "order_" : ""}sql: ${sql}".toString())
         if (tag.contains("hive_docker")) {
             String cleanedSqlStr = sql.replaceAll("\\s*;\\s*\$", "")
@@ -1895,7 +1900,7 @@ class Suite implements GroovyInterceptable {
             String cleanedSqlStr = sql.replaceAll("\\s*;\\s*\$", "")
             sql = cleanedSqlStr
         }
-        quickRunTest(tag, sql, isOrder)
+        quickRunTest(tag, sql, isOrder, null, queryExecutor)
     }
 
     void quickTest(String tag, String sql1, String sql2) {

--- a/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
@@ -82,21 +82,23 @@ suite("test_file_tvf_s3", "p0") {
             "format" = "parquet"
         );
         """
-        for (int attempt = 1; attempt <= 2; attempt++) {
-            try {
-                order_qt_s3_tvf tvfSql
-                return
-            } catch (java.sql.SQLException e) {
-                boolean isS3ConnectTimeout = e.message?.contains("errCode = 202")
-                        && e.message?.contains("Failed to access object storage")
-                        && e.message?.contains("Connect timed out")
-                if (!isS3ConnectTimeout || attempt == 2) {
-                    throw e
+        quickTest("s3_tvf", tvfSql, true, {
+            for (int attempt = 1; attempt <= 2; attempt++) {
+                try {
+                    return executeQueryByTag("s3_tvf", tvfSql)
+                } catch (java.sql.SQLException e) {
+                    boolean isS3ConnectTimeout = e.message?.contains("errCode = 202")
+                            && e.message?.contains("Failed to access object storage")
+                            && e.message?.contains("Connect timed out")
+                    if (!isS3ConnectTimeout || attempt == 2) {
+                        throw e
+                    }
+                    logger.warn("FILE TVF connection to S3 endpoint ${s3_endpoint} timed out, retrying once")
+                    sleep(5000)
                 }
-                logger.warn("FILE TVF connection to S3 endpoint ${s3_endpoint} timed out, retrying once")
-                sleep(5000)
             }
-        }
+            throw new IllegalStateException("Unreachable")
+        })
     }
 
 

--- a/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
@@ -72,7 +72,7 @@ suite("test_file_tvf_s3", "p0") {
 
     def file_s3_tvf = {uri_prefix, endpoint_key, ak_key, sk_key, region_key, is_path_style  ->
         // http schema
-        order_qt_s3_tvf """ SELECT * FROM FILE (
+        def tvfSql = """ SELECT * FROM FILE (
             "uri" = "${uri_prefix}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}0.parquet",
             "${endpoint_key}" = "${s3_endpoint}",
             "${ak_key}"= "${ak}",
@@ -82,6 +82,21 @@ suite("test_file_tvf_s3", "p0") {
             "format" = "parquet"
         );
         """
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            try {
+                order_qt_s3_tvf tvfSql
+                return
+            } catch (java.sql.SQLException e) {
+                boolean isS3ConnectTimeout = e.message?.contains("errCode = 202")
+                        && e.message?.contains("Failed to access object storage")
+                        && e.message?.contains("Connect timed out")
+                if (!isS3ConnectTimeout || attempt == 2) {
+                    throw e
+                }
+                logger.warn("FILE TVF connection to S3 endpoint ${s3_endpoint} timed out, retrying once")
+                sleep(5000)
+            }
+        }
     }
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65454

Problem Summary:

`test_file_tvf_s3` writes and reads data through real S3-compatible services. In P0 build 992758, several Huawei OBS reads succeeded before a path-style `FILE()` request hit the FE endpoint precheck's 10-second connection timeout:

```text
errCode = 202, detailMessage = Failed to access object storage, message=Connect timed out
```

This follow-up retries the same valid `FILE()` query once only for that exact transient signature. Authentication, permission, endpoint whitelist, SSRF, protocol, parsing, assertion, and all other errors still fail immediately, and a second matching timeout is propagated normally.

Unlike #65454, which handles an OUTFILE `PutObject` failure reported as `curlCode: 28`, this failure occurs in the FE `FILE()` TVF endpoint-connectivity precheck.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Manual validation:

- Compiled the modified Groovy suite with `groovyc`.
- Verified the retry predicate with simulated SQL exceptions: one exact connection timeout retries and succeeds; a different `errCode = 202` error is not retried; two consecutive matching timeouts surface the second failure.
- `git diff --check` passed.
- The full suite was not run locally because it requires configured credentials and live COS, OSS, OBS, and AWS-compatible endpoints.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
