### PR TITLE
[branch-4.1][fix](fe) Disable expression ZoneMap filtering by default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2580,11 +2580,11 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(
             name = ENABLE_EXPR_ZONEMAP_FILTER,
             fuzzy = true,
-            description = {"控制 scanner 是否启用表达式 ZoneMap 过滤。默认为 true。",
+            description = {"控制 scanner 是否启用表达式 ZoneMap 过滤。默认为 false。",
                     "Controls whether to enable expression ZoneMap filtering in scanners. "
-                            + "The default value is true."},
+                            + "The default value is false."},
             needForward = true)
-    public boolean enableExprZonemapFilter = true;
+    public boolean enableExprZonemapFilter = false;
 
     @VariableMgr.VarAttr(
             name = CHECK_ORC_INIT_SARGS_SUCCESS,
@@ -3663,6 +3663,7 @@ public class SessionVariable implements Serializable, Writable {
         this.enableSharedExchangeSinkBuffer = random.nextBoolean();
         this.useSerialExchange = random.nextBoolean();
         this.enableCommonExpPushDownForInvertedIndex = random.nextBoolean();
+        this.enableExprZonemapFilter = Config.pull_request_id % 2 == 0;
         this.disableStreamPreaggregations = random.nextBoolean();
         this.enableStreamingAggHashJoinForcePassthrough = random.nextBoolean();
         this.enableDistinctStreamingAggForcePassthrough = random.nextBoolean();

--- a/regression-test/suites/query_p0/expr_zonemap/test_expr_zonemap_pruning.groovy
+++ b/regression-test/suites/query_p0/expr_zonemap/test_expr_zonemap_pruning.groovy
@@ -20,6 +20,7 @@ import java.util.regex.Pattern
 import org.apache.doris.regression.action.ProfileAction
 
 suite("test_expr_zonemap_pruning") {
+    sql """ set enable_expr_zonemap_filter = true """
     sql """ set enable_common_expr_pushdown = true """
     sql """ set enable_profile = true """
     sql """ set profile_level = 2 """

--- a/regression-test/suites/query_p1/expr_zonemap/test_expr_zonemap_pruning_p1.groovy
+++ b/regression-test/suites/query_p1/expr_zonemap/test_expr_zonemap_pruning_p1.groovy
@@ -20,6 +20,7 @@ import java.util.regex.Pattern
 import org.apache.doris.regression.action.ProfileAction
 
 suite("test_expr_zonemap_pruning_p1") {
+    sql """ set enable_expr_zonemap_filter = true """
     sql """ set enable_common_expr_pushdown = true """
     sql """ set enable_profile = true """
     sql """ set profile_level = 2 """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65263

Problem Summary:

Expression ZoneMap filtering was enabled by default when it was introduced on branch-4.1. This change disables `enable_expr_zonemap_filter` for regular new sessions and enables it in fuzzy mode when `Config.pull_request_id % 2 == 0`, so the fuzzy setting is deterministic for each PR while covering both enabled and disabled paths across PRs.

The dedicated expression ZoneMap regression suites now enable the session variable explicitly, keeping their profile-counter assertions deterministic regardless of the global default or fuzzy-mode PR parity.

For mixed-version compatibility, the absent Thrift-field behavior remains legacy-enabled. New FE sessions always serialize the session value explicitly through `SessionVariable.toThrift()`.

### Release note

Disable expression ZoneMap filtering by default on branch-4.1 and enable it for fuzzy-mode sessions with even pull request IDs.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason: the fuzzy value follows the existing PR-parity assignment pattern.

Validation:

- `git diff --check` passed.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Expression ZoneMap filtering is disabled by default for new sessions and enabled in fuzzy mode for even pull request IDs.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label