### PR TITLE
[fix](regression) stabilize MTMV SQL cache refresh checks

### DIFF
--- a/regression-test/suites/query_p0/cache/mtmv_with_sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/mtmv_with_sql_cache.groovy
@@ -765,7 +765,14 @@ suite("mtmv_with_sql_cache") {
                             waitingMTMVTaskFinishedByMvName(mv_name1)
                             sleep(10 * 1000)
                             assertNoCache "select * from ${mv_name1}"
-                            assertNoCache mtmv_sql1
+                            // mtmv_sql1 was cached while the MTMV was stale, so the cached plan may
+                            // scan only unchanged base tables and legally survive the MTMV refresh.
+                            // Bypass SQL cache to keep checking that the refreshed MTMV is chosen,
+                            // then compare cached and uncached results for correctness.
+                            sql "set enable_sql_cache=false"
+                            mv_rewrite_success(mtmv_sql1, mv_name1)
+                            sql "set enable_sql_cache=true"
+                            judge_res(mtmv_sql1)
                             assertHasCache "select * from ${nested_mv_name1}"
                             assertNoCache nested_mtmv_sql1
 

--- a/regression-test/suites/query_p0/cache/mtmv_with_sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/mtmv_with_sql_cache.groovy
@@ -767,11 +767,8 @@ suite("mtmv_with_sql_cache") {
                             assertNoCache "select * from ${mv_name1}"
                             // mtmv_sql1 was cached while the MTMV was stale, so the cached plan may
                             // scan only unchanged base tables and legally survive the MTMV refresh.
-                            // Bypass SQL cache to keep checking that the refreshed MTMV is chosen,
-                            // then compare cached and uncached results for correctness.
-                            sql "set enable_sql_cache=false"
-                            mv_rewrite_success(mtmv_sql1, mv_name1)
-                            sql "set enable_sql_cache=true"
+                            // Compare cached and uncached results instead of assuming that the
+                            // cached physical plan depends on the MTMV.
                             judge_res(mtmv_sql1)
                             assertHasCache "select * from ${nested_mv_name1}"
                             assertNoCache nested_mtmv_sql1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #57177

Problem Summary:

`mtmv_with_sql_cache` intermittently required `mtmv_sql1` to miss SQL cache after refreshing `mv_name1`. However, the case rebuilt that cache after `INSERT OVERWRITE` while the MTMV was stale. The cached physical plan could therefore scan only the two base tables. Refreshing the MTMV did not change either recorded base-table version, so retaining that cache entry was valid.

This change removes only that invalid cache-residency assumption while preserving the original test coverage:

- cache entries whose real base-table or MTMV dependencies change still must miss;
- `nested_mtmv_sql1`, which names `mv_name1` directly, still deterministically checks refresh-driven dependency invalidation;
- cached and uncached executions of `mtmv_sql1` must return identical results without requiring a particular CBO rewrite choice.

The failure was observed in P0 build 992833, occurrence 2000001579, with the same original line 768 and base-table `PhysicalSqlCache` plan seen in earlier muted failures.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
        - Runtime rerun is pending; this PR is intentionally opened as draft.
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `git diff --check`
        - Verified `judge_res` compares SQL-cache-enabled and SQL-cache-disabled results.
        - Verified the surrounding base-table, direct-MTMV, and nested-MTMV cache invalidation assertions remain unchanged.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
