### PR TITLE
[fix](regression) Stabilize delete bitmap cache metrics test

### DIFF
--- a/regression-test/suites/metrics_p0/test_delete_bitmap_metrics.groovy
+++ b/regression-test/suites/metrics_p0/test_delete_bitmap_metrics.groovy
@@ -17,7 +17,7 @@
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
-suite("test_delete_bitmap_metrics", "p0") {
+suite("test_delete_bitmap_metrics", "p0,nonConcurrent") {
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]
     def backendId_to_params = [string: [:]]
@@ -183,54 +183,68 @@ suite("test_delete_bitmap_metrics", "p0") {
         qt_sql "select * from ${testTable} order by plan_id"
 
 
-        def tablets = sql_return_maparray """ show tablets from ${testTable}; """
-        tablets.sort { lhs, rhs -> lhs.ReplicaId.toLong() <=> rhs.ReplicaId.toLong() }
-        logger.info("tablets: " + tablets)
-        def local_delete_bitmap_count = 0
-        def ms_delete_bitmap_count = 0
-        def local_delete_bitmap_cardinality = 0;
-        def ms_delete_bitmap_cardinality = 0;
-        try {
-            for (int ri = 0; ri < tablets.size(); ri++) {
-                // use_fix_replica selects replicas in ReplicaId order. Populate and
-                // inspect each replica immediately because the agg cache is an LRU.
-                sql "set use_fix_replica=${ri};"
-                sql "select * from ${testTable};"
+        def checkPerReplicaDeleteBitmap = {
+            def tablets = sql_return_maparray """ show tablets from ${testTable}; """
+            tablets.sort { lhs, rhs -> lhs.ReplicaId.toLong() <=> rhs.ReplicaId.toLong() }
+            logger.info("tablets: " + tablets)
+            def local_delete_bitmap_count = 0
+            def ms_delete_bitmap_count = 0
+            def local_delete_bitmap_cardinality = 0;
+            def ms_delete_bitmap_cardinality = 0;
+            try {
+                for (int ri = 0; ri < tablets.size(); ri++) {
+                    // use_fix_replica selects replicas in ReplicaId order. Populate and
+                    // inspect each replica immediately because the agg cache is an LRU.
+                    sql "set use_fix_replica=${ri};"
+                    sql "select * from ${testTable};"
 
-                def tablet = tablets[ri]
-                String tablet_id = tablet.TabletId
-                def tablet_info = sql_return_maparray """ show tablet ${tablet_id}; """
-                logger.info("tablet: " + tablet_info)
-                String trigger_backend_id = tablet.BackendId
+                    def tablet = tablets[ri]
+                    String tablet_id = tablet.TabletId
+                    def tablet_info = sql_return_maparray """ show tablet ${tablet_id}; """
+                    logger.info("tablet: " + tablet_info)
+                    String trigger_backend_id = tablet.BackendId
 
-                // before compaction, delete_bitmap_count is (rowsets num - 1)
-                local_delete_bitmap_count = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
-                local_delete_bitmap_cardinality = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
-                logger.info("local_delete_bitmap_count:" + local_delete_bitmap_count)
-                logger.info("local_delete_bitmap_cardinality:" + local_delete_bitmap_cardinality)
-                assertTrue(local_delete_bitmap_count == 7)
-                assertTrue(local_delete_bitmap_cardinality == 7)
+                    // before compaction, delete_bitmap_count is (rowsets num - 1)
+                    local_delete_bitmap_count = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
+                    local_delete_bitmap_cardinality = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
+                    logger.info("local_delete_bitmap_count:" + local_delete_bitmap_count)
+                    logger.info("local_delete_bitmap_cardinality:" + local_delete_bitmap_cardinality)
+                    assertTrue(local_delete_bitmap_count == 7)
+                    assertTrue(local_delete_bitmap_cardinality == 7)
 
-                if (isCloudMode()) {
-                    ms_delete_bitmap_count = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
-                    ms_delete_bitmap_cardinality = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
-                    logger.info("ms_delete_bitmap_count:" + ms_delete_bitmap_count)
-                    logger.info("ms_delete_bitmap_cardinality:" + ms_delete_bitmap_cardinality)
-                    assertTrue(ms_delete_bitmap_count == 7)
-                    assertTrue(ms_delete_bitmap_cardinality == 7)
+                    if (isCloudMode()) {
+                        ms_delete_bitmap_count = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
+                        ms_delete_bitmap_cardinality = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
+                        logger.info("ms_delete_bitmap_count:" + ms_delete_bitmap_count)
+                        logger.info("ms_delete_bitmap_cardinality:" + ms_delete_bitmap_cardinality)
+                        assertTrue(ms_delete_bitmap_count == 7)
+                        assertTrue(ms_delete_bitmap_cardinality == 7)
+                    }
+
+                    def status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id)
+                    logger.info("agg cache status: ${status}")
+                    assert status.delete_bitmap_count == 8
+                    assert status.cardinality == 7
+                    assert status.size > 0
+
+                    status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id, true)
+                    logger.info("agg cache verbose status: ${status}")
                 }
-
-                def status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id)
-                logger.info("agg cache status: ${status}")
-                assert status.delete_bitmap_count == 8
-                assert status.cardinality == 7
-                assert status.size > 0
-
-                status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id, true)
-                logger.info("agg cache verbose status: ${status}")
+            } finally {
+                sql "set use_fix_replica=-1;"
             }
-        } finally {
-            sql "set use_fix_replica=-1;"
+        }
+
+        if (isCloudMode()) {
+            // Cloud multi-replica can resolve the same logical CloudReplica to a
+            // different physical BE for SHOW TABLETS and the warm-up scan. Disable
+            // it while binding the warm-up and per-BE cache assertion; the helper
+            // restores the original FE config even when an assertion fails.
+            setFeConfigTemporary([enable_cloud_multi_replica: false]) {
+                checkPerReplicaDeleteBitmap()
+            }
+        } else {
+            checkPerReplicaDeleteBitmap()
         }
 
         def tablet_delete_bitmap_count = 0;

--- a/regression-test/suites/metrics_p0/test_delete_bitmap_metrics.groovy
+++ b/regression-test/suites/metrics_p0/test_delete_bitmap_metrics.groovy
@@ -184,79 +184,90 @@ suite("test_delete_bitmap_metrics", "p0") {
 
 
         def tablets = sql_return_maparray """ show tablets from ${testTable}; """
+        tablets.sort { lhs, rhs -> lhs.ReplicaId.toLong() <=> rhs.ReplicaId.toLong() }
         logger.info("tablets: " + tablets)
         def local_delete_bitmap_count = 0
         def ms_delete_bitmap_count = 0
         def local_delete_bitmap_cardinality = 0;
         def ms_delete_bitmap_cardinality = 0;
-        for (def tablet in tablets) {
-            String tablet_id = tablet.TabletId
-            def tablet_info = sql_return_maparray """ show tablet ${tablet_id}; """
-            logger.info("tablet: " + tablet_info)
-            String trigger_backend_id = tablet.BackendId
+        try {
+            for (int ri = 0; ri < tablets.size(); ri++) {
+                // use_fix_replica selects replicas in ReplicaId order. Populate and
+                // inspect each replica immediately because the agg cache is an LRU.
+                sql "set use_fix_replica=${ri};"
+                sql "select * from ${testTable};"
 
-            // before compaction, delete_bitmap_count is (rowsets num - 1)
-            local_delete_bitmap_count = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
-            local_delete_bitmap_cardinality = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
-            logger.info("local_delete_bitmap_count:" + local_delete_bitmap_count)
-            logger.info("local_delete_bitmap_cardinality:" + local_delete_bitmap_cardinality)
-            assertTrue(local_delete_bitmap_count == 7)
-            assertTrue(local_delete_bitmap_cardinality == 7)
+                def tablet = tablets[ri]
+                String tablet_id = tablet.TabletId
+                def tablet_info = sql_return_maparray """ show tablet ${tablet_id}; """
+                logger.info("tablet: " + tablet_info)
+                String trigger_backend_id = tablet.BackendId
 
-            if (isCloudMode()) {
-                ms_delete_bitmap_count = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
-                ms_delete_bitmap_cardinality = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
-                logger.info("ms_delete_bitmap_count:" + ms_delete_bitmap_count)
-                logger.info("ms_delete_bitmap_cardinality:" + ms_delete_bitmap_cardinality)
-                assertTrue(ms_delete_bitmap_count == 7)
-                assertTrue(ms_delete_bitmap_cardinality == 7)
-            }
+                // before compaction, delete_bitmap_count is (rowsets num - 1)
+                local_delete_bitmap_count = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
+                local_delete_bitmap_cardinality = getLocalDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
+                logger.info("local_delete_bitmap_count:" + local_delete_bitmap_count)
+                logger.info("local_delete_bitmap_cardinality:" + local_delete_bitmap_cardinality)
+                assertTrue(local_delete_bitmap_count == 7)
+                assertTrue(local_delete_bitmap_cardinality == 7)
 
-            def status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id)
-            logger.info("agg cache status: ${status}")
-            assert status.delete_bitmap_count == 8
-            assert status.cardinality == 7
-            assert status.size > 0
-
-            status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id, true)
-            logger.info("agg cache verbose status: ${status}")
-
-            def tablet_delete_bitmap_count = 0;
-            def base_rowset_delete_bitmap_count = 0;
-            int retry_time = 0;
-            while (retry_time < 10) {
-                log.info("retry_time: ${retry_time}")
-                getMetricsMethod.call() {
-                    respCode, body ->
-                        logger.info("test get delete bitmap count resp Code {}", "${respCode}".toString())
-                        assertEquals("${respCode}".toString(), "200")
-                        String out = "${body}".toString()
-                        def strs = out.split('\n')
-                        for (String line in strs) {
-                            if (line.startsWith("tablet_max_delete_bitmap_score")) {
-                                logger.info("find: {}", line)
-                                tablet_delete_bitmap_count = line.replaceAll("tablet_max_delete_bitmap_score ", "").toInteger()
-                                break
-                            }
-                        }
-                        for (String line in strs) {
-                            if (line.startsWith("tablet_max_base_rowset_delete_bitmap_score")) {
-                                logger.info("find: {}", line)
-                                base_rowset_delete_bitmap_count = line.replaceAll("tablet_max_base_rowset_delete_bitmap_score ", "").toInteger()
-                                break
-                            }
-                        }
+                if (isCloudMode()) {
+                    ms_delete_bitmap_count = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).delete_bitmap_count
+                    ms_delete_bitmap_cardinality = getMSDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id).cardinality
+                    logger.info("ms_delete_bitmap_count:" + ms_delete_bitmap_count)
+                    logger.info("ms_delete_bitmap_cardinality:" + ms_delete_bitmap_cardinality)
+                    assertTrue(ms_delete_bitmap_count == 7)
+                    assertTrue(ms_delete_bitmap_cardinality == 7)
                 }
-                if (tablet_delete_bitmap_count > 0 && base_rowset_delete_bitmap_count > 0) {
-                    break;
-                } else {
-                    Thread.sleep(10000)
-                    retry_time++;
-                }
+
+                def status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id)
+                logger.info("agg cache status: ${status}")
+                assert status.delete_bitmap_count == 8
+                assert status.cardinality == 7
+                assert status.size > 0
+
+                status = getAggCacheDeleteBitmapStatus(backendId_to_backendIP[trigger_backend_id], backendId_to_backendHttpPort[trigger_backend_id], tablet_id, true)
+                logger.info("agg cache verbose status: ${status}")
             }
-            assertTrue(tablet_delete_bitmap_count > 0)
-            assertTrue(base_rowset_delete_bitmap_count > 0)
+        } finally {
+            sql "set use_fix_replica=-1;"
         }
+
+        def tablet_delete_bitmap_count = 0;
+        def base_rowset_delete_bitmap_count = 0;
+        int retry_time = 0;
+        while (retry_time < 10) {
+            log.info("retry_time: ${retry_time}")
+            getMetricsMethod.call() {
+                respCode, body ->
+                    logger.info("test get delete bitmap count resp Code {}", "${respCode}".toString())
+                    assertEquals("${respCode}".toString(), "200")
+                    String out = "${body}".toString()
+                    def strs = out.split('\n')
+                    for (String line in strs) {
+                        if (line.startsWith("tablet_max_delete_bitmap_score")) {
+                            logger.info("find: {}", line)
+                            tablet_delete_bitmap_count = line.replaceAll("tablet_max_delete_bitmap_score ", "").toInteger()
+                            break
+                        }
+                    }
+                    for (String line in strs) {
+                        if (line.startsWith("tablet_max_base_rowset_delete_bitmap_score")) {
+                            logger.info("find: {}", line)
+                            base_rowset_delete_bitmap_count = line.replaceAll("tablet_max_base_rowset_delete_bitmap_score ", "").toInteger()
+                            break
+                        }
+                    }
+            }
+            if (tablet_delete_bitmap_count > 0 && base_rowset_delete_bitmap_count > 0) {
+                break;
+            } else {
+                Thread.sleep(10000)
+                retry_time++;
+            }
+        }
+        assertTrue(tablet_delete_bitmap_count > 0)
+        assertTrue(base_rowset_delete_bitmap_count > 0)
     } finally {
         reset_be_param("check_tablet_delete_bitmap_interval_seconds")
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #64515

Problem Summary:

`test_delete_bitmap_metrics` verifies each replica's durable delete bitmap and lazy aggregate-cache snapshot. In multi-replica P0 environments, the case warmed cache entries before iteration and fetched the large global `/brpc_metrics` payload inside the per-replica loop. On build 202230, the third replica was inspected about 32 seconds after warm-up; its durable bitmap was still correct (`7/7`) but the capacity-bounded LRU snapshot was empty.

This change sorts tablet rows by `ReplicaId` to match `use_fix_replica` ordering, pins and queries each replica immediately before checking that same replica's cache, restores the session variable in `finally`, and fetches the global metrics payload once after all replica checks.

The patched single case passed 3 consecutive lock-serialized runs on the authorized agent5 test cluster.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
