### PR TITLE
[fix](regression) Disable auto compaction for physical row inspections

### DIFF
--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_publish_conflict_seq.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_publish_conflict_seq.groovy
@@ -32,6 +32,7 @@ suite("test_partial_update_publish_conflict_seq", "nonConcurrent") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/publish/test_auto_inc_replica_consistency.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/publish/test_auto_inc_replica_consistency.groovy
@@ -36,6 +36,7 @@ suite("test_auto_inc_replica_consistency") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/publish/test_f_seq_publish_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/publish/test_f_seq_publish_read_from_old.groovy
@@ -36,6 +36,7 @@ suite("test_f_seq_publish_read_from_old") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/publish/test_fleixble_partial_update_publish_conflict_seq.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/publish/test_fleixble_partial_update_publish_conflict_seq.groovy
@@ -36,6 +36,7 @@ suite("test_flexible_partial_update_publish_conflict_seq") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/test_f_seq_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/test_f_seq_read_from_old.groovy
@@ -39,6 +39,7 @@ suite('test_f_seq_read_from_old') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_delete_sign.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_delete_sign.groovy
@@ -43,6 +43,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -93,6 +94,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -130,6 +132,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -161,6 +164,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -193,6 +197,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -264,6 +269,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -336,6 +342,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_seq_col.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_seq_col.groovy
@@ -287,6 +287,7 @@ suite('test_flexible_partial_update_seq_col') {
             DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES (
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
             "function_column.sequence_col" = "c1");
@@ -321,6 +322,7 @@ suite('test_flexible_partial_update_seq_col') {
             DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES (
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
             "function_column.sequence_col" = "c1");

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_p_seq_publish_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_p_seq_publish_read_from_old.groovy
@@ -35,6 +35,7 @@ suite("test_p_seq_publish_read_from_old") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "function_column.sequence_col" = "v1",

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_seq_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_seq_read_from_old.groovy
@@ -40,6 +40,7 @@ suite('test_partial_update_seq_read_from_old') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65211, #64508

Problem Summary:

Some unique-key MOW regression cases deliberately bypass the delete bitmap and assert historical physical rows, sequence values, skip bitmaps, and rowset versions. These assertions require the pre-compaction rowsets to remain available, but the affected tables leave automatic compaction enabled. Background compaction can therefore merge the expected old rowsets before `qt_inspect` or an equivalent raw-row query runs, while all user-visible SQL results remain correct.

This PR disables table-level automatic compaction only for the tables whose assertions intentionally depend on historical physical layout. It covers nine case files, including publish-conflict, read-from-old, delete-sign, sequence-column, and auto-increment physical-row checks. Golden results and user-visible correctness assertions are unchanged.

The source scan reviewed all master cases that set `skip_delete_bitmap=true` without already disabling automatic compaction. Four remaining files were intentionally excluded because the variable is used only for debug-mode validation, routine-load waiting, insert execution setup, or binlog TVF behavior; they do not assert historical table rowsets.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

  Validation: `test_flexible_partial_update_publish_conflict_seq` passed as one lock-serialized suite on the authorized branch-4.1 test cluster using the patched master case file. The run confirmed the new table property in `SHOW CREATE TABLE` and completed all logical and physical-row assertions with 0 failed suites. `git diff --check origin/master...HEAD` also passed.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
