### PR TITLE
[fix](regression) Fix agg_sync_mv data path

### DIFF
--- a/regression-test/suites/nereids_syntax_p1/mv/aggregate/agg_sync_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p1/mv/aggregate/agg_sync_mv.groovy
@@ -480,7 +480,7 @@ suite("agg_sync_mv") {
 
     streamLoad {
         table "agg_mv_test"
-        db "regression_test_nereids_syntax_p1_mv"
+        db "regression_test_nereids_syntax_p1_mv_aggregate"
         set 'column_separator', ';'
         set 'columns', '''
             id, kbool, ktint, ksint, kint, kbint, klint, kfloat, kdbl, kdcmls1, kdcmls2, kdcmls3,
@@ -493,7 +493,7 @@ suite("agg_sync_mv") {
             km_tint_bool, km_int_int, km_tint_sint, km_tint_int, km_tint_bint, km_tint_lint, km_tint_float,
             km_tint_dbl, km_tint_dcml, km_tint_chr, km_tint_vchr, km_tint_str, km_tint_date, km_tint_dtm, kjson, kstruct
             '''
-        file "../agg_mv_test.dat"
+        file "agg_mv_test.dat"
     }
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65133, #65336

Problem Summary:

The second `streamLoad` in `nereids_syntax_p1/mv/aggregate/agg_sync_mv.groovy` still uses the database and data-file path from before the case was moved into the `aggregate` directory.

The stale `../agg_mv_test.dat` path does not exist. The stream load therefore returns no response, and the regression framework later reports the misleading `Text must not be null or empty` error while parsing it.

Align the second load with the working initial load by using database `regression_test_nereids_syntax_p1_mv_aggregate` and file `agg_mv_test.dat`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason: test-only path correction; `git diff --check` passes, the corrected data file exists, and the stale parent path does not.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
