### PR TITLE
[fix](be) Initialize JNI split read options in test

### DIFF
--- a/be/test/format_v2/jni/jni_table_reader_test.cpp
+++ b/be/test/format_v2/jni/jni_table_reader_test.cpp
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -175,7 +176,9 @@ TEST(JniTableReaderTest, AdaptiveProbeSetBeforePrepareControlsFirstJniOpen) {
     reader.set_batch_size(32);
     ASSERT_TRUE(reader.prepare_split({
                                              .partition_values = {},
+                                             .conjuncts = std::nullopt,
                                              .partition_prune_conjuncts = {},
+                                             .all_runtime_filters_applied = true,
                                              .cache = nullptr,
                                              .current_range = {},
                                              .current_split_format = FileFormat::JNI,


### PR DESCRIPTION
### What problem does this PR solve?

Fix a BE UT compile failure introduced by the combination of #65500 and #65503.
`SplitReadOptions` now has `conjuncts` and `all_runtime_filters_applied`, while
the new `jni_table_reader_test.cpp` designated initializer did not initialize
them. With `-Werror,-Wmissing-designated-field-initializers`, this fails
compilation.

This PR explicitly initializes the two fields in the test and adds the missing
`<optional>` include for `std::nullopt`.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `./run-be-ut.sh --run --filter=JniTableReaderTest.*` on `gabriel@10.26.20.3`
      in `/mnt/disk3/gabriel/tmp/doris-fix-jni-split-read-options`: 5 tests passed.
- Behavior changed: No
- Does this need documentation: No
