### PR TITLE
[fix](regression) Select compaction profile BE by tablet replica

### DIFF
--- a/regression-test/suites/compaction/test_compaction_profile_action.groovy
+++ b/regression-test/suites/compaction/test_compaction_profile_action.groovy
@@ -25,11 +25,6 @@ suite("test_compaction_profile_action", "p0") {
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort)
 
-    String backend_id = backendId_to_backendIP.keySet()[0]
-    def beHost = backendId_to_backendIP[backend_id]
-    def beHttpPort = backendId_to_backendHttpPort[backend_id]
-    def baseUrl = "http://${beHost}:${beHttpPort}/api/compaction/profile"
-
     try {
         // Step 2: Create table, insert data, trigger compaction, wait for completion
         sql """ DROP TABLE IF EXISTS ${tableName} """
@@ -64,6 +59,10 @@ suite("test_compaction_profile_action", "p0") {
         assertTrue(tablets.size() > 0)
         def tablet = tablets[0]
         String tablet_id = tablet.TabletId
+        String backend_id = tablet.BackendId
+        def beHost = backendId_to_backendIP[backend_id]
+        def beHttpPort = backendId_to_backendHttpPort[backend_id]
+        def baseUrl = "http://${beHost}:${beHttpPort}/api/compaction/profile"
 
         // Trigger compaction and wait for completion
         trigger_and_wait_compaction(tableName, "cumulative")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #63886

Problem Summary:

`test_compaction_profile_action` queried `/api/compaction/profile` on the first backend returned by `SHOW BACKENDS`, independently of the target tablet placement. The profile API reads the selected BE's process-local compaction tracker, so the tablet filter returned an empty list whenever that backend was the one BE outside the target tablet's three-replica set.

The branch-4.1 P0 history shows 13 failures in 32 runs. In every failure, the queried first backend was outside the target replica set; in every passing run, it hosted a target replica.

This change derives the profile endpoint from the `BackendId` in the same `SHOW TABLETS` row as the selected `TabletId`. The case therefore queries a replica that participates in `trigger_and_wait_compaction` while preserving all existing API assertions.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `mvn package -DskipTests -Dmaven.javadoc.skip=true` in `regression-test/framework`.
        - Verified the shaded regression-test jar with `ZipFile.testzip()`.
        - Parsed the updated suite with `GroovyShell.parse()`.
        - Runtime single-case validation is pending because the authorized test host timed out on SSH twice; no runtime pass is claimed here.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. The product API behavior is unchanged; this only routes the regression assertion to a target-tablet replica.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
