### PR TITLE
[fix](case) lower cold compaction threshold in fault injection test

### DIFF
--- a/be/src/storage/compaction/cold_data_compaction.cpp
+++ b/be/src/storage/compaction/cold_data_compaction.cpp
@@ -20,9 +20,11 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -38,6 +40,7 @@
 #include "storage/storage_policy.h"
 #include "storage/tablet/tablet.h"
 #include "storage/tablet/tablet_meta.h"
+#include "util/debug_points.h"
 #include "util/thread.h"
 #include "util/trace.h"
 #include "util/uid_util.h"
@@ -93,6 +96,19 @@ Status ColdDataCompaction::pick_rowsets_to_compact() {
 }
 
 Status ColdDataCompaction::modify_rowsets() {
+    DBUG_EXECUTE_IF("ColdDataCompaction::modify_rowsets.block", {
+        const auto target_tablet_id = dp->param<int64_t>("tablet_id", -1);
+        if (target_tablet_id == _tablet->tablet_id()) {
+            LOG(INFO) << "start debug block ColdDataCompaction::modify_rowsets.block"
+                      << ", tablet_id=" << target_tablet_id;
+            while (DebugPoints::instance()->is_enable("ColdDataCompaction::modify_rowsets.block")) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            }
+            LOG(INFO) << "end debug block ColdDataCompaction::modify_rowsets.block"
+                      << ", tablet_id=" << target_tablet_id;
+        }
+    })
+
     UniqueId cooldown_meta_id = UniqueId::gen_uid();
     {
         std::lock_guard wlock(_tablet->get_header_lock());

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -3563,7 +3563,7 @@ class Suite implements GroovyInterceptable {
             def beIp = ipList.get(id)
             def bePort = portList.get(id)
             logger.info("set be_id ${id} ${paramName} to ${paramValue}".toString())
-            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s", beIp, bePort, paramName, paramValue))
+            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s&persist=false", beIp, bePort, paramName, paramValue))
             assertTrue(out.contains("OK"))
         }
     }
@@ -3577,7 +3577,7 @@ class Suite implements GroovyInterceptable {
             def bePort = portList.get(id)
             def paramValue = backendId_to_params.get(id)
             logger.info("set be_id ${id} ${paramName} to ${paramValue}".toString())
-            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s", beIp, bePort, paramName, paramValue))
+            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s&persist=false", beIp, bePort, paramName, paramValue))
             assertTrue(out.contains("OK"))
         }
     }

--- a/regression-test/suites/fault_injection_p0/test_cold_data_compaction_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_cold_data_compaction_fault_injection.groovy
@@ -38,6 +38,19 @@ suite("test_cold_data_compaction_fault_injection", "nonConcurrent") {
         }
     }
     def tabletName = "test_cold_data_compaction_fault_injection"
+    def cumulativeScoreDebugPoint = "Tablet._calc_cumulative_compaction_score.return"
+    def coldDataOutputDebugPoint = "ColdDataCompaction::modify_rowsets.block"
+
+    def getRowsetCount = {
+        def tablets = sql_return_maparray("show tablets from ${tabletName}")
+        assertEquals(1, tablets.size())
+        def (code, out, err) = curl("GET", tablets[0].CompactionStatus)
+        logger.info("Show tablet status: code=${code}, out=${out}, err=${err}")
+        assertEquals(0, code)
+        def tabletJson = parseJson(out.trim())
+        assert tabletJson.rowsets instanceof List
+        return ((List<String>) tabletJson.rowsets).size()
+    }
 
     def customBeConfig = [
         cold_data_compaction_score_threshold : 4
@@ -116,25 +129,41 @@ suite("test_cold_data_compaction_fault_injection", "nonConcurrent") {
 
     // 5 RowSets + 1 meta
     assertEquals(6, filesBeforeCompaction.size())
+    def rowsetCountBeforeCompaction = getRowsetCount()
+    // 1 empty base RowSet + 5 inserted RowSets.
+    assertEquals(6, rowsetCountBeforeCompaction)
 
     try {
         GetDebugPoint().clearDebugPointsForAllBEs()
-        GetDebugPoint().enableDebugPointForAllBEs("Tablet._calc_cumulative_compaction_score.return")
+        GetDebugPoint().enableDebugPointForAllBEs(cumulativeScoreDebugPoint)
+        GetDebugPoint().enableDebugPointForAllBEs(coldDataOutputDebugPoint,
+                [tablet_id: tabletId])
         // trigger cold data compaction
         sql """alter table ${tabletName} set ("disable_auto_compaction" = "false")"""
 
-        // wait until compaction finish
+        // Cold-data compaction has written its output rowset, but the injected block prevents
+        // it from replacing the input rowsets in tablet metadata.
         retryUntilTimeout(900, {
             def filesAfterCompaction = getS3Client().listObjects(
                     new ListObjectsRequest().withBucketName(getS3BucketName()).withPrefix(s3Prefix+ "/data/${tabletId}")).getObjectSummaries()
-            logger.info("${tabletName}'s remote file number is ${filesAfterCompaction.size()}")
-            // 1 RowSet + 1 meta
-            return filesAfterCompaction.size() == 7
+            def rowsetCount = getRowsetCount()
+            logger.info("${tabletName}'s remote file number is ${filesAfterCompaction.size()}, rowset count is ${rowsetCount}")
+            // 5 input data files + 1 output data file + 1 meta, while tablet metadata still
+            // references the original 6 RowSets (including the empty base RowSet).
+            return filesAfterCompaction.size() == 7 && rowsetCount == rowsetCountBeforeCompaction
+        })
+
+        GetDebugPoint().disableDebugPointForAllBEs(coldDataOutputDebugPoint)
+        retryUntilTimeout(900, {
+            def rowsetCount = getRowsetCount()
+            logger.info("${tabletName}'s rowset count after releasing cold-data compaction is ${rowsetCount}")
+            return rowsetCount == 1
         })
 
         sql "drop table ${tabletName} force"
     } finally {
-        GetDebugPoint().disableDebugPointForAllBEs("Tablet._calc_cumulative_compaction_score.return")
+        GetDebugPoint().disableDebugPointForAllBEs(coldDataOutputDebugPoint)
+        GetDebugPoint().disableDebugPointForAllBEs(cumulativeScoreDebugPoint)
         GetDebugPoint().clearDebugPointsForAllBEs()
     }
     }

--- a/regression-test/suites/fault_injection_p0/test_cold_data_compaction_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_cold_data_compaction_fault_injection.groovy
@@ -39,6 +39,11 @@ suite("test_cold_data_compaction_fault_injection", "nonConcurrent") {
     }
     def tabletName = "test_cold_data_compaction_fault_injection"
 
+    def customBeConfig = [
+        cold_data_compaction_score_threshold : 4
+    ]
+
+    setBeConfigTemporary(customBeConfig) {
     String suffix = UUID.randomUUID().hashCode().abs().toString()
     String s3Prefix = "regression/cold_data_compaction/${suffix}"
     multi_sql """
@@ -131,5 +136,6 @@ suite("test_cold_data_compaction_fault_injection", "nonConcurrent") {
     } finally {
         GetDebugPoint().disableDebugPointForAllBEs("Tablet._calc_cumulative_compaction_score.return")
         GetDebugPoint().clearDebugPointsForAllBEs()
+    }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #55333

Problem Summary:

`test_cold_data_compaction_fault_injection` creates five remote rowsets, but the current default `cold_data_compaction_score_threshold` is 100. The tablet's cold-data compaction score is 5, so the producer keeps skipping it and the case times out while the remote object count stays at 6.

Temporarily set `cold_data_compaction_score_threshold` to 4 for this case, matching the existing `cold_heat_separation/cold_data_compaction.groovy` coverage. `setBeConfigTemporary` restores the original value after the case.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

  Manual validation:
  - Branch-4.1 test cluster single-case run: PASS 1/1.
  - Remote object count changed from 6 to 7 after one 60-second producer interval.
  - All four BE thresholds were restored from the temporary value 4 to 100.
  - Debug-point cleanup completed.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
