### PR TITLE
[test](regression) Target publish debug point on master FE

### DIFF
--- a/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
+++ b/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.util.DebugPoint
+import org.apache.doris.regression.util.NodeType
+
 suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
     if (isCloudMode()) {
         return
@@ -36,10 +39,15 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
         )
     """
 
+    def masterFe = sql_return_maparray("SHOW FRONTENDS").find { it.IsMaster == "true" }
+    assertNotNull(masterFe, "Could not find master FE")
+    def masterFeHost = masterFe.Host as String
+    def masterFeHttpPort = masterFe.HttpPort as int
+
     try {
-        // PublishVersionDaemon only runs on the master FE. Enable the debug point on every FE so the
-        // case does not depend on whether the regression runner is connected to a master or follower FE.
-        GetDebugPoint().enableDebugPointForAllFEs(debugPoint)
+        // PublishVersionDaemon only runs on the master FE. Keep the SQL connection unchanged and
+        // inject the fault directly into the master identified by the same SHOW FRONTENDS snapshot.
+        DebugPoint.enableDebugPoint(masterFeHost, masterFeHttpPort, NodeType.FE, debugPoint)
 
         sql """ SET insert_visible_timeout_ms = 1000 """
 
@@ -55,7 +63,7 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
         }
     } finally {
         try {
-            GetDebugPoint().disableDebugPointForAllFEs(debugPoint)
+            DebugPoint.disableDebugPoint(masterFeHost, masterFeHttpPort, NodeType.FE, debugPoint)
         } catch (Throwable e) {
             logger.warn("Failed to disable debug point ${debugPoint}", e)
         }

--- a/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
+++ b/regression-test/suites/insert_p0/test_insert_visible_timeout_return_mode.groovy
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import org.apache.doris.regression.util.DebugPoint
-import org.apache.doris.regression.util.NodeType
-
 suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
     if (isCloudMode()) {
         return
@@ -25,10 +22,6 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
 
     def tableName = "test_insert_visible_timeout_return_mode_tbl"
     def debugPoint = "PublishVersionDaemon.stop_publish"
-    // Use the configured FE HTTP endpoint so the case also works when SHOW FRONTENDS exposes loopback addresses.
-    def feHttpAddress = context.config.feHttpAddress
-    def feHost = feHttpAddress.split(":")[0]
-    def feHttpPort = Integer.parseInt(feHttpAddress.split(":")[1])
 
     // Prepare a single-replica table so publish blocking deterministically drives the visible timeout path.
     sql """ DROP TABLE IF EXISTS ${tableName} FORCE """
@@ -44,8 +37,9 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
     """
 
     try {
-        // Block FE publish so inserts can commit but remain non-visible until the debug point is removed.
-        DebugPoint.enableDebugPoint(feHost, feHttpPort, NodeType.FE, debugPoint)
+        // PublishVersionDaemon only runs on the master FE. Enable the debug point on every FE so the
+        // case does not depend on whether the regression runner is connected to a master or follower FE.
+        GetDebugPoint().enableDebugPointForAllFEs(debugPoint)
 
         sql """ SET insert_visible_timeout_ms = 1000 """
 
@@ -61,7 +55,7 @@ suite("test_insert_visible_timeout_return_mode", "nonConcurrent") {
         }
     } finally {
         try {
-            DebugPoint.disableDebugPoint(feHost, feHttpPort, NodeType.FE, debugPoint)
+            GetDebugPoint().disableDebugPointForAllFEs(debugPoint)
         } catch (Throwable e) {
             logger.warn("Failed to disable debug point ${debugPoint}", e)
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65340

Problem Summary:

`test_insert_visible_timeout_return_mode` enables `PublishVersionDaemon.stop_publish` to exercise the committed and error return modes after the visible wait times out.

The case currently adds the debug point only to the FE HTTP endpoint configured for the regression runner. In a multi-FE dynamic pipeline, that endpoint can belong to a follower FE, while `PublishVersionDaemon` runs only on the master FE. Publishing then continues normally and the expected timeout error is not returned.

Find the master FE from one `SHOW FRONTENDS` snapshot and enable/disable the debug point only on that FE. Keep the suite JDBC connection unchanged so the case does not depend on a separate runner-facing master JDBC mapping.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `mvn -f regression-test/framework/pom.xml -DskipTests package`
        - Compiled the target Groovy suite with `org.codehaus.groovy.tools.FileSystemCompiler`
        - `git diff --check`
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No. This is a regression-case stabilization and does not change product behavior.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
