### PR TITLE
[chore](build) Update ASF GitHub collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -192,12 +192,12 @@ github:
   collaborators:
     - Yukang-Lian
     - Hastyshell
-    - freemandealer
+    - yujun777
     - shuke987
     - wm1581066
     - doris-robot
     - ixzc
-    - deardeng
+    - feiniaofeiafei
     - wyxxxcat
     - linrrzqqq
 notifications:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Update the ASF GitHub collaborator configuration to reflect the current maintainer list.
This change removes `freemandealer` and `deardeng`, and adds `yujun777` and
`feiniaofeiafei`. It only affects repository automation configuration and does
not change Doris runtime behavior.

### Release note

None

### Check List (For Author)

- Test: No need to test (configuration-only change; YAML syntax validation and whitespace check passed)
- Behavior changed: No
- Does this need documentation: No