### PR TITLE
[fix](fe) Reuse Ranger Doris access controller

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/RangerDorisAccessControllerFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/RangerDorisAccessControllerFactoryTest.java
@@ -19,21 +19,25 @@ package org.apache.doris.mysql.privilege;
 
 import org.apache.doris.catalog.authorizer.ranger.doris.RangerDorisAccessController;
 
-import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
-public class RangerDorisAccessControllerFactory implements AccessControllerFactory {
-    private static class SingletonHolder {
-        // Every controller starts a Ranger policy refresher, so all Env instances must share one controller.
-        private static final RangerDorisAccessController INSTANCE = new RangerDorisAccessController("doris");
-    }
+import java.util.Collections;
 
-    @Override
-    public String factoryIdentifier() {
-        return "ranger-doris";
-    }
+public class RangerDorisAccessControllerFactoryTest {
+    @Test
+    public void testCreateAccessControllerReturnsSingleton() {
+        try (MockedConstruction<RangerDorisAccessController> mockedConstruction =
+                Mockito.mockConstruction(RangerDorisAccessController.class)) {
+            RangerDorisAccessController first = new RangerDorisAccessControllerFactory()
+                    .createAccessController(Collections.emptyMap());
+            RangerDorisAccessController second = new RangerDorisAccessControllerFactory()
+                    .createAccessController(Collections.emptyMap());
 
-    @Override
-    public RangerDorisAccessController createAccessController(Map<String, String> prop) {
-        return SingletonHolder.INSTANCE;
+            Assert.assertEquals(1, mockedConstruction.constructed().size());
+            Assert.assertSame(first, second);
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65524

Related PR: #45645

Problem Summary:

When Ranger Doris authorization is enabled, constructing a `RangerDorisAccessController` initializes a Ranger plugin and starts a `PolicyRefresher` background thread. Metadata checkpoints create temporary `Env` instances, and each `Env` previously received a newly constructed Ranger Doris access controller. Destroying the checkpoint `Env` only released the `Env` reference, so the refresher threads remained alive. A successful checkpoint could therefore leak two `PolicyRefresher` threads.

This change uses an initialization-on-demand holder in `RangerDorisAccessControllerFactory` so all `Env` instances in the FE process share one lazily initialized controller and one refresher thread. The unit test verifies that multiple factory instances construct and return only one controller.

### Release note

Fix Ranger PolicyRefresher thread leakage during metadata checkpoints.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.mysql.privilege.RangerDorisAccessControllerFactoryTest,org.apache.doris.mysql.privilege.RangerTest,org.apache.doris.mysql.privilege.AccessControllerManagerTest`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Metadata checkpoints no longer create additional Ranger PolicyRefresher threads.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->