### PR TITLE
[feature](fe) Add query-level BE metrics persistence

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.ColumnNullableType;
 import org.apache.doris.analysis.TypeDef;
 import org.apache.doris.common.UserException;
 import org.apache.doris.plugin.audit.AuditLoader;
+import org.apache.doris.plugin.audit.BeMetricsLoader;
 import org.apache.doris.statistics.StatisticConstants;
 
 import com.google.common.collect.Lists;
@@ -36,6 +37,7 @@ public class InternalSchema {
     public static final List<ColumnDef> PARTITION_STATS_SCHEMA;
     public static final List<ColumnDef> HISTO_STATS_SCHEMA;
     public static final List<ColumnDef> AUDIT_SCHEMA;
+    public static final List<ColumnDef> QUERY_BE_METRICS_SCHEMA;
 
     static {
         // table statistics table
@@ -169,6 +171,31 @@ public class InternalSchema {
                 new ColumnDef("compute_group", TypeDef.create(PrimitiveType.STRING), ColumnNullableType.NULLABLE));
         // Keep stmt as last column. So that in fe.audit.log, it will be easier to get sql string
         AUDIT_SCHEMA.add(new ColumnDef("stmt", TypeDef.create(PrimitiveType.STRING), ColumnNullableType.NULLABLE));
+
+        // query_be_metrics table: per-BE resource consumption breakdown for each query
+        QUERY_BE_METRICS_SCHEMA = new ArrayList<>();
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("query_id", TypeDef.createVarchar(48),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("be_id", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("time", TypeDef.createDatetimeV2(3),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_rows", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_bytes", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("cpu_ms", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("peak_memory_bytes", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("shuffle_send_rows", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("shuffle_send_bytes", TypeDef.create(PrimitiveType.BIGINT),
+            ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_bytes_from_local_storage",
+            TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+        QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_bytes_from_remote_storage",
+            TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
     }
 
     // Get copied schema for statistic table
@@ -187,6 +214,9 @@ public class InternalSchema {
                 break;
             case AuditLoader.AUDIT_LOG_TABLE:
                 schema = AUDIT_SCHEMA;
+                break;
+            case BeMetricsLoader.BE_METRICS_TABLE:
+                schema = QUERY_BE_METRICS_SCHEMA;
                 break;
             default:
                 throw new UserException("Unknown internal table name: " + tblName);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -175,27 +175,27 @@ public class InternalSchema {
         // query_be_metrics table: per-BE resource consumption breakdown for each query
         QUERY_BE_METRICS_SCHEMA = new ArrayList<>();
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("query_id", TypeDef.createVarchar(48),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("be_id", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("time", TypeDef.createDatetimeV2(3),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_rows", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_bytes", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("cpu_ms", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("peak_memory_bytes", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("shuffle_send_rows", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("shuffle_send_bytes", TypeDef.create(PrimitiveType.BIGINT),
-            ColumnNullableType.NULLABLE));
+                ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_bytes_from_local_storage",
-            TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         QUERY_BE_METRICS_SCHEMA.add(new ColumnDef("scan_bytes_from_remote_storage",
-            TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
     }
 
     // Get copied schema for statistic table

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -433,7 +433,7 @@ public class InternalSchemaInitializer extends Thread {
 
         if (LOG.isDebugEnabled()) {
             LOG.info("Audit table schema needs update. Current columns ({}): {}",
-                currentColumnNames.size(), currentColumnNames);
+                    currentColumnNames.size(), currentColumnNames);
             LOG.info("Expected columns ({}): {}", expectedColumnNames.size(), expectedColumnNames);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -45,6 +45,7 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.plugin.audit.AuditLoader;
+import org.apache.doris.plugin.audit.BeMetricsLoader;
 import org.apache.doris.statistics.StatisticConstants;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -108,6 +109,7 @@ public class InternalSchemaInitializer extends Thread {
         modifyTblReplicaCount(database, StatisticConstants.TABLE_STATISTIC_TBL_NAME);
         modifyTblReplicaCount(database, StatisticConstants.PARTITION_STATISTIC_TBL_NAME);
         modifyTblReplicaCount(database, AuditLoader.AUDIT_LOG_TABLE);
+        modifyTblReplicaCount(database, BeMetricsLoader.BE_METRICS_TABLE);
     }
 
     public void modifyColumnStatsTblSchema() {
@@ -254,6 +256,8 @@ public class InternalSchemaInitializer extends Thread {
                     Lists.newArrayList("catalog_id", "db_id", "tbl_id", "idx_id", "part_name", "part_id", "col_id")));
         // audit table
         Env.getCurrentEnv().getInternalCatalog().createTable(buildAuditTblStmt());
+        // be metrics table
+        Env.getCurrentEnv().getInternalCatalog().createTable(buildBeMetricsTblStmt());
     }
 
     @VisibleForTesting
@@ -325,6 +329,39 @@ public class InternalSchemaInitializer extends Thread {
         return createTableStmt;
     }
 
+    private static CreateTableStmt buildBeMetricsTblStmt() throws UserException {
+        TableName tableName = new TableName("",
+                FeConstants.INTERNAL_DB_NAME, BeMetricsLoader.BE_METRICS_TABLE);
+
+        String engineName = "olap";
+        ArrayList<String> dupKeys = Lists.newArrayList("query_id", "be_id", "time");
+        KeysDesc keysDesc = new KeysDesc(KeysType.DUP_KEYS, dupKeys);
+        // partition
+        PartitionDesc partitionDesc = new RangePartitionDesc(Lists.newArrayList("time"), Lists.newArrayList());
+        // distribution
+        int bucketNum = 10;
+        DistributionDesc distributionDesc = new HashDistributionDesc(bucketNum, Lists.newArrayList("query_id"));
+        Map<String, String> properties = new HashMap<String, String>() {
+            {
+                put("dynamic_partition.time_unit", "DAY");
+                put("dynamic_partition.start", "-7");
+                put("dynamic_partition.end", "3");
+                put("dynamic_partition.prefix", "p");
+                put("dynamic_partition.buckets", String.valueOf(bucketNum));
+                put("dynamic_partition.enable", "true");
+                put("replication_num", String.valueOf(Math.max(1,
+                        Config.min_replication_num_per_tablet)));
+            }
+        };
+
+        PropertyAnalyzer.getInstance().rewriteForceProperties(properties);
+        CreateTableStmt createTableStmt = new CreateTableStmt(true, false,
+                tableName, InternalSchema.getCopiedSchema(BeMetricsLoader.BE_METRICS_TABLE),
+                engineName, keysDesc, partitionDesc, distributionDesc,
+                properties, null, "Doris internal be metrics table, DO NOT MODIFY IT", null);
+        StatisticsUtil.analyze(createTableStmt);
+        return createTableStmt;
+    }
 
     private boolean created() {
         // 1. check database exist
@@ -364,11 +401,16 @@ public class InternalSchemaInitializer extends Thread {
         if (!optionalStatsTbl.isPresent()) {
             return false;
         }
-
         // 4. check and update audit table schema
         OlapTable auditTable = (OlapTable) optionalStatsTbl.get();
 
-        // 5. check if we need to add new columns
+        // 5. check be_metrics table
+        optionalStatsTbl = db.getTable(BeMetricsLoader.BE_METRICS_TABLE);
+        if (!optionalStatsTbl.isPresent()) {
+            return false;
+        }
+
+        // 6. check if we need to add new columns
         return alterAuditSchemaIfNeeded(auditTable);
     }
 
@@ -389,6 +431,12 @@ public class InternalSchemaInitializer extends Thread {
             return true;
         }
 
+        if (LOG.isDebugEnabled()) {
+            LOG.info("Audit table schema needs update. Current columns ({}): {}",
+                currentColumnNames.size(), currentColumnNames);
+            LOG.info("Expected columns ({}): {}", expectedColumnNames.size(), expectedColumnNames);
+        }
+
         List<AlterClause> alterClauses = Lists.newArrayList();
         // add new columns
         List<ColumnDef> addColumnsDef = Lists.newArrayList();
@@ -402,7 +450,7 @@ public class InternalSchemaInitializer extends Thread {
             try {
                 addColumnsClause.analyze(null);
             } catch (Exception e) {
-                LOG.warn("Failed to alter audit table schema", e);
+                LOG.warn("Failed to analyze add columns clause", e);
                 return false;
             }
             alterClauses.add(addColumnsClause);
@@ -412,7 +460,8 @@ public class InternalSchemaInitializer extends Thread {
         removedColumnNames.removeAll(expectedColumnNames);
         List<String> newColumnOrders = Lists.newArrayList(expectedColumnNames);
         newColumnOrders.addAll(removedColumnNames);
-        if (!newColumnOrders.isEmpty()) {
+        // Only reorder if the order is different from current
+        if (!newColumnOrders.equals(currentColumnNames)) {
             ReorderColumnsClause reorderColumnsOp = new ReorderColumnsClause(newColumnOrders, null, Maps.newHashMap());
             alterClauses.add(reorderColumnsOp);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -17,9 +17,11 @@
 
 package org.apache.doris.plugin;
 
+import org.apache.doris.resource.workloadschedpolicy.WorkloadRuntimeStatusMgr.BeMetrics;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
 
 /*
  * AuditEvent contains all information about audit log info.
@@ -131,6 +133,11 @@ public class AuditEvent {
     // stmt should be last one
     @AuditField(value = "Stmt", colName = "stmt")
     public String stmt = "";
+
+    // Per-BE resource metrics for drill-down analysis.
+    // Key: backend ID, Value: BeMetrics.
+    // Not annotated with @AuditField — consumed by BeMetricsLoader plugin only.
+    public Map<Long, BeMetrics> beMetricsMap = null;
 
     public long pushToAuditLogQueueTime;
 
@@ -292,6 +299,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setCommandType(String commandType) {
             auditEvent.commandType = commandType;
+            return this;
+        }
+
+        public AuditEventBuilder setBeMetricsMap(Map<Long, BeMetrics> beMetricsMap) {
+            auditEvent.beMetricsMap = beMetricsMap;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginMgr.java
@@ -29,6 +29,7 @@ import org.apache.doris.plugin.PluginInfo.PluginType;
 import org.apache.doris.plugin.PluginLoader.PluginStatus;
 import org.apache.doris.plugin.audit.AuditLoader;
 import org.apache.doris.plugin.audit.AuditLogBuilder;
+import org.apache.doris.plugin.audit.BeMetricsLoader;
 import org.apache.doris.plugin.dialect.HttpDialectConverterPlugin;
 
 import com.google.common.base.Strings;
@@ -63,6 +64,7 @@ public class PluginMgr implements Writable {
 
     // Save this handler for external call
     private AuditLoader auditLoader = null;
+    private BeMetricsLoader beMetricsLoader = null;
 
     public PluginMgr() {
         plugins = new Map[PluginType.MAX_PLUGIN_TYPE_SIZE];
@@ -119,6 +121,12 @@ public class PluginMgr implements Writable {
         this.auditLoader = new AuditLoader();
         if (!registerBuiltinPlugin(auditLoader.getPluginInfo(), auditLoader)) {
             LOG.warn("failed to register audit log builder");
+        }
+
+        // BeMetricsLoader: log per-BE resource metrics to internal table
+        this.beMetricsLoader = new BeMetricsLoader();
+        if (!registerBuiltinPlugin(beMetricsLoader.getPluginInfo(), beMetricsLoader)) {
+            LOG.warn("failed to register be metrics loader");
         }
 
         // sql dialect converter

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsLoader.java
@@ -1,0 +1,242 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.plugin.audit;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.util.DigitalVersion;
+import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.plugin.AuditEvent;
+import org.apache.doris.plugin.AuditPlugin;
+import org.apache.doris.plugin.Plugin;
+import org.apache.doris.plugin.PluginContext;
+import org.apache.doris.plugin.PluginException;
+import org.apache.doris.plugin.PluginInfo;
+import org.apache.doris.plugin.PluginInfo.PluginType;
+import org.apache.doris.plugin.PluginMgr;
+import org.apache.doris.qe.GlobalVariable;
+import org.apache.doris.resource.workloadschedpolicy.WorkloadRuntimeStatusMgr.BeMetrics;
+
+import com.google.common.collect.Queues;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Built-in audit plugin that persists per-BE resource consumption metrics
+ * to the __internal_schema.query_be_metrics table.
+ *
+ * Data flow:
+ *   AuditEvent.beMetricsMap (set by WorkloadRuntimeStatusMgr)
+ *     -> exec() enqueues event
+ *     -> LoadWorker calls assembleRow() to build delimiter-separated rows
+ *     -> loadIfNecessary() triggers BeMetricsStreamLoader HTTP PUT
+ *
+ * Runs in parallel with AuditLoader/AuditLogBuilder via AuditEventProcessor.
+ */
+public class BeMetricsLoader extends Plugin implements AuditPlugin {
+
+    private static final Logger LOG = LogManager.getLogger(BeMetricsLoader.class);
+
+    public static final String BE_METRICS_TABLE = "query_be_metrics";
+
+    public static final char BE_METRICS_COL_SEPARATOR = 0x1F;
+    public static final char BE_METRICS_LINE_DELIMITER = 0x1E;
+    public static final String BE_METRICS_COL_SEPARATOR_STR = "\\x1F";
+    public static final String BE_METRICS_LINE_DELIMITER_STR = "\\x1E";
+
+    private StringBuilder buffer = new StringBuilder();
+    private int bufferedRowCount = 0;
+    private long lastLoadTime = 0;
+    private long discardRowNum = 0;
+
+    private BlockingQueue<AuditEvent> eventQueue;
+    private BeMetricsStreamLoader streamLoader;
+    private Thread loadThread;
+
+    private volatile boolean isClosed = false;
+    private volatile boolean isInit = false;
+
+    private final PluginInfo pluginInfo;
+
+    public BeMetricsLoader() {
+        pluginInfo = new PluginInfo(
+            PluginMgr.BUILTIN_PLUGIN_PREFIX + "BeMetricsLoader",
+            PluginType.AUDIT,
+            "builtin be metrics loader, to load per-BE resource metrics to internal table",
+            DigitalVersion.fromString("2.1.0"),
+            DigitalVersion.fromString("1.8.31"),
+            BeMetricsLoader.class.getName(),
+            null, null);
+    }
+
+    public PluginInfo getPluginInfo() {
+        return pluginInfo;
+    }
+
+    @Override
+    public void init(PluginInfo info, PluginContext ctx) throws PluginException {
+        super.init(info, ctx);
+        synchronized (this) {
+            if (isInit) {
+                return;
+            }
+            this.lastLoadTime = System.currentTimeMillis();
+            this.eventQueue = Queues.newLinkedBlockingDeque(100000);
+            this.streamLoader = new BeMetricsStreamLoader();
+            this.loadThread = new Thread(new LoadWorker(), "be-metrics-loader");
+            this.loadThread.start();
+            isInit = true;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        isClosed = true;
+        if (loadThread != null) {
+            try {
+                loadThread.join();
+            } catch (InterruptedException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("encounter exception when closing the be metrics loader", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean eventFilter(AuditEvent.EventType type) {
+        return type == AuditEvent.EventType.AFTER_QUERY;
+    }
+
+    @Override
+    public void exec(AuditEvent event) {
+        if (!GlobalVariable.enableBeMetricsLoader) {
+            return;
+        }
+        Map<Long, BeMetrics> beMetricsMap = event.beMetricsMap;
+        if (beMetricsMap == null || beMetricsMap.isEmpty()) {
+            return;
+        }
+        try {
+            eventQueue.add(event);
+        } catch (Exception e) {
+            ++discardRowNum;
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("encounter exception when putting be metrics event,"
+                    + " total discard: {}", discardRowNum, e);
+            }
+        }
+    }
+
+    /**
+     * Convert one AuditEvent into N delimiter-separated rows (one per BE).
+     * Column order MUST match InternalSchema.QUERY_BE_METRICS_SCHEMA:
+     *   query_id, be_id, time, scan_rows, scan_bytes, cpu_ms,
+     *   peak_memory_bytes, shuffle_send_rows, shuffle_send_bytes,
+     *   scan_bytes_from_local_storage, scan_bytes_from_remote_storage
+     */
+    private void assembleRow(AuditEvent event) {
+        Map<Long, BeMetrics> beMetricsMap = event.beMetricsMap;
+        if (beMetricsMap == null) {
+            return;
+        }
+        String timeStr = TimeUtils.longToTimeStringWithms(event.timestamp);
+        for (Map.Entry<Long, BeMetrics> entry : beMetricsMap.entrySet()) {
+            Long beId = entry.getKey();
+            BeMetrics m = entry.getValue();
+            buffer.append(event.queryId).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(beId).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(timeStr).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scan_rows).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scan_bytes).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.cpu_ms).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.max_peak_memory_bytes).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.shuffle_send_rows).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.shuffle_send_bytes).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scan_bytes_from_local_storage).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scan_bytes_from_remote_storage).append(BE_METRICS_LINE_DELIMITER);
+            ++bufferedRowCount;
+        }
+    }
+
+    public synchronized void loadIfNecessary(boolean force) {
+        long currentTime = System.currentTimeMillis();
+        if (buffer.length() != 0 && (force
+            || buffer.length() >= GlobalVariable.beMetricsPluginMaxBatchBytes
+            || currentTime - lastLoadTime
+            >= GlobalVariable.beMetricsPluginMaxBatchInternalSec * 1000)) {
+            try {
+                String token = "";
+                try {
+                    token = Env.getCurrentEnv().getTokenManager().acquireToken();
+                } catch (Exception e) {
+                    LOG.warn("BeMetricsLoader failed to get auth token: {}", e.getMessage());
+                    discardRowNum += bufferedRowCount;
+                    return;
+                }
+                BeMetricsStreamLoader.LoadResponse response = streamLoader.loadBatch(buffer, token);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("be metrics loader response: {}", response);
+                }
+            } catch (Exception e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("encounter exception when loading be metrics batch,"
+                        + " discard current batch", e);
+                }
+                discardRowNum += bufferedRowCount;
+            } finally {
+                resetBatch(currentTime);
+                if (discardRowNum > 0) {
+                    LOG.info("num of total discarded be metrics rows: {}", discardRowNum);
+                }
+            }
+        }
+    }
+
+    private void resetBatch(long currentTime) {
+        this.buffer = new StringBuilder();
+        this.lastLoadTime = currentTime;
+        this.bufferedRowCount = 0;
+    }
+
+    private class LoadWorker implements Runnable {
+        @Override
+        public void run() {
+            while (!isClosed) {
+                try {
+                    AuditEvent event = eventQueue.poll(5, TimeUnit.SECONDS);
+                    if (event != null) {
+                        assembleRow(event);
+                    }
+                    loadIfNecessary(false);
+                } catch (InterruptedException ie) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("encounter exception when loading be metrics batch", ie);
+                    }
+                } catch (Exception e) {
+                    LOG.error("run be metrics loader error:", e);
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsLoader.java
@@ -143,7 +143,7 @@ public class BeMetricsLoader extends Plugin implements AuditPlugin {
             ++discardRowNum;
             if (LOG.isDebugEnabled()) {
                 LOG.debug("encounter exception when putting be metrics event,"
-                    + " total discard: {}", discardRowNum, e);
+                        + " total discard: {}", discardRowNum, e);
             }
         }
     }
@@ -167,14 +167,14 @@ public class BeMetricsLoader extends Plugin implements AuditPlugin {
             buffer.append(event.queryId).append(BE_METRICS_COL_SEPARATOR);
             buffer.append(beId).append(BE_METRICS_COL_SEPARATOR);
             buffer.append(timeStr).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.scan_rows).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.scan_bytes).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.cpu_ms).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.max_peak_memory_bytes).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.shuffle_send_rows).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.shuffle_send_bytes).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.scan_bytes_from_local_storage).append(BE_METRICS_COL_SEPARATOR);
-            buffer.append(m.scan_bytes_from_remote_storage).append(BE_METRICS_LINE_DELIMITER);
+            buffer.append(m.scanRows).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scanBytes).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.cpuMs).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.maxPeakMemoryBytes).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.shuffleSendRows).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.shuffleSendBytes).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scanBytesFromLocalStorage).append(BE_METRICS_COL_SEPARATOR);
+            buffer.append(m.scanBytesFromRemoteStorage).append(BE_METRICS_LINE_DELIMITER);
             ++bufferedRowCount;
         }
     }
@@ -182,9 +182,9 @@ public class BeMetricsLoader extends Plugin implements AuditPlugin {
     public synchronized void loadIfNecessary(boolean force) {
         long currentTime = System.currentTimeMillis();
         if (buffer.length() != 0 && (force
-            || buffer.length() >= GlobalVariable.beMetricsPluginMaxBatchBytes
-            || currentTime - lastLoadTime
-            >= GlobalVariable.beMetricsPluginMaxBatchInternalSec * 1000)) {
+                || buffer.length() >= GlobalVariable.beMetricsPluginMaxBatchBytes
+                || currentTime - lastLoadTime
+                >= GlobalVariable.beMetricsPluginMaxBatchInternalSec * 1000)) {
             try {
                 String token = "";
                 try {
@@ -201,7 +201,7 @@ public class BeMetricsLoader extends Plugin implements AuditPlugin {
             } catch (Exception e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("encounter exception when loading be metrics batch,"
-                        + " discard current batch", e);
+                            + " discard current batch", e);
                 }
                 discardRowNum += bufferedRowCount;
             } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsStreamLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsStreamLoader.java
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.plugin.audit;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InternalSchema;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.qe.GlobalVariable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Calendar;
+import java.util.stream.Collectors;
+
+/**
+ * Stream loader for uploading per-BE query metrics to
+ * __internal_schema.query_be_metrics via HTTP PUT.
+ *
+ * Mirrors AuditStreamLoader but targets the query_be_metrics table.
+ */
+public class BeMetricsStreamLoader {
+
+    private static final Logger LOG = LogManager.getLogger(BeMetricsStreamLoader.class);
+    private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load?";
+    private static final int HTTP_TIMEOUT_MS = 10000;
+
+    private final String hostPort;
+    private final String loadUrlStr;
+    private final String feIdentity;
+
+    public BeMetricsStreamLoader() {
+        this.hostPort = "127.0.0.1:" + Config.http_port;
+        this.loadUrlStr = String.format(LOAD_URL_PATTERN, hostPort,
+            FeConstants.INTERNAL_DB_NAME, BeMetricsLoader.BE_METRICS_TABLE);
+        this.feIdentity = Env.getCurrentEnv().getSelfNode().getIdent()
+            .replaceAll("\\.", "_").replaceAll(":", "_");
+    }
+
+    private HttpURLConnection getConnection(String urlStr, String label, String clusterToken)
+        throws IOException {
+        URL url = new URL(urlStr);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setInstanceFollowRedirects(false);
+        conn.setRequestMethod("PUT");
+        conn.setRequestProperty("token", clusterToken);
+        conn.setRequestProperty("Authorization", "Basic YWRtaW46");
+        conn.addRequestProperty("Expect", "100-continue");
+        conn.addRequestProperty("Content-Type", "text/plain; charset=UTF-8");
+        conn.addRequestProperty("label", label);
+        conn.setConnectTimeout(HTTP_TIMEOUT_MS);
+        conn.setReadTimeout(HTTP_TIMEOUT_MS);
+        conn.setRequestProperty("timeout",
+            String.valueOf(GlobalVariable.beMetricsPluginLoadTimeoutS));
+        conn.addRequestProperty("max_filter_ratio", "1.0");
+        conn.addRequestProperty("columns",
+            InternalSchema.QUERY_BE_METRICS_SCHEMA.stream()
+                .map(c -> c.getName())
+                .collect(Collectors.joining(",")));
+        conn.addRequestProperty("redirect-policy", "random-be");
+        conn.addRequestProperty("column_separator",
+            BeMetricsLoader.BE_METRICS_COL_SEPARATOR_STR);
+        conn.addRequestProperty("line_delimiter",
+            BeMetricsLoader.BE_METRICS_LINE_DELIMITER_STR);
+        conn.setDoOutput(true);
+        conn.setDoInput(true);
+        return conn;
+    }
+
+    private String getContent(HttpURLConnection conn) {
+        StringBuilder response = new StringBuilder();
+        try {
+            BufferedReader br;
+            if (100 <= conn.getResponseCode() && conn.getResponseCode() <= 399) {
+                br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                br = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+            String line;
+            while ((line = br.readLine()) != null) {
+                response.append(line);
+            }
+        } catch (IOException e) {
+            LOG.warn("get content error,", e);
+        }
+        return response.toString();
+    }
+
+    public LoadResponse loadBatch(StringBuilder sb, String clusterToken) {
+        String label = genLabel();
+        HttpURLConnection feConn = null;
+        HttpURLConnection beConn = null;
+        try {
+            label = "bemetrics" + label;
+            feConn = getConnection(loadUrlStr, label, clusterToken);
+            int status = feConn.getResponseCode();
+            if (status != 307) {
+                throw new Exception("status is not TEMPORARY_REDIRECT 307, status: "
+                    + status + ", response: " + getContent(feConn));
+            }
+            String location = feConn.getHeaderField("Location");
+            if (location == null) {
+                throw new Exception("redirect location is null");
+            }
+            beConn = getConnection(location, label, clusterToken);
+            try (BufferedOutputStream bos = new BufferedOutputStream(beConn.getOutputStream())) {
+                bos.write(sb.toString().getBytes());
+            }
+            status = beConn.getResponseCode();
+            String respMsg = beConn.getResponseMessage();
+            String response = getContent(beConn);
+            LOG.info("BeMetricsLoader plugin load with label: {}, response code: {},"
+                + " msg: {}, content: {}", label, status, respMsg, response);
+            return new LoadResponse(status, respMsg, response);
+        } catch (Exception e) {
+            String err = "failed to load be metrics via BeMetricsLoader plugin with label: "
+                + label;
+            LOG.warn(err, e);
+            return new LoadResponse(-1, e.getMessage(), err);
+        } finally {
+            if (feConn != null) {
+                feConn.disconnect();
+            }
+            if (beConn != null) {
+                beConn.disconnect();
+            }
+        }
+    }
+
+    private String genLabel() {
+        Calendar calendar = Calendar.getInstance();
+        return String.format("_bemetrics_%s%02d%02d_%02d%02d%02d_%s_%s",
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH) + 1,
+            calendar.get(Calendar.DAY_OF_MONTH),
+            calendar.get(Calendar.HOUR_OF_DAY),
+            calendar.get(Calendar.MINUTE),
+            calendar.get(Calendar.SECOND),
+            calendar.get(Calendar.MILLISECOND),
+            feIdentity);
+    }
+
+    public static class LoadResponse {
+        public int status;
+        public String respMsg;
+        public String respContent;
+
+        public LoadResponse(int status, String respMsg, String respContent) {
+            this.status = status;
+            this.respMsg = respMsg;
+            this.respContent = respContent;
+        }
+
+        @Override
+        public String toString() {
+            return "status: " + status + ", resp msg: " + respMsg
+                + ", resp content: " + respContent;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsStreamLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/BeMetricsStreamLoader.java
@@ -60,7 +60,7 @@ public class BeMetricsStreamLoader {
     }
 
     private HttpURLConnection getConnection(String urlStr, String label, String clusterToken)
-        throws IOException {
+            throws IOException {
         URL url = new URL(urlStr);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setInstanceFollowRedirects(false);
@@ -73,17 +73,17 @@ public class BeMetricsStreamLoader {
         conn.setConnectTimeout(HTTP_TIMEOUT_MS);
         conn.setReadTimeout(HTTP_TIMEOUT_MS);
         conn.setRequestProperty("timeout",
-            String.valueOf(GlobalVariable.beMetricsPluginLoadTimeoutS));
+                String.valueOf(GlobalVariable.beMetricsPluginLoadTimeoutS));
         conn.addRequestProperty("max_filter_ratio", "1.0");
         conn.addRequestProperty("columns",
-            InternalSchema.QUERY_BE_METRICS_SCHEMA.stream()
+                InternalSchema.QUERY_BE_METRICS_SCHEMA.stream()
                 .map(c -> c.getName())
                 .collect(Collectors.joining(",")));
         conn.addRequestProperty("redirect-policy", "random-be");
         conn.addRequestProperty("column_separator",
-            BeMetricsLoader.BE_METRICS_COL_SEPARATOR_STR);
+                BeMetricsLoader.BE_METRICS_COL_SEPARATOR_STR);
         conn.addRequestProperty("line_delimiter",
-            BeMetricsLoader.BE_METRICS_LINE_DELIMITER_STR);
+                BeMetricsLoader.BE_METRICS_LINE_DELIMITER_STR);
         conn.setDoOutput(true);
         conn.setDoInput(true);
         return conn;
@@ -118,7 +118,7 @@ public class BeMetricsStreamLoader {
             int status = feConn.getResponseCode();
             if (status != 307) {
                 throw new Exception("status is not TEMPORARY_REDIRECT 307, status: "
-                    + status + ", response: " + getContent(feConn));
+                        + status + ", response: " + getContent(feConn));
             }
             String location = feConn.getHeaderField("Location");
             if (location == null) {
@@ -132,11 +132,11 @@ public class BeMetricsStreamLoader {
             String respMsg = beConn.getResponseMessage();
             String response = getContent(beConn);
             LOG.info("BeMetricsLoader plugin load with label: {}, response code: {},"
-                + " msg: {}, content: {}", label, status, respMsg, response);
+                    + " msg: {}, content: {}", label, status, respMsg, response);
             return new LoadResponse(status, respMsg, response);
         } catch (Exception e) {
             String err = "failed to load be metrics via BeMetricsLoader plugin with label: "
-                + label;
+                    + label;
             LOG.warn(err, e);
             return new LoadResponse(-1, e.getMessage(), err);
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -67,11 +67,11 @@ public final class GlobalVariable {
     public static final String AUDIT_PLUGIN_LOAD_TIMEOUT = "audit_plugin_load_timeout";
     public static final String ENABLE_BE_METRICS_PLUGIN = "enable_be_metrics_plugin";
     public static final String BE_METRICS_PLUGIN_MAX_BATCH_BYTES =
-        "be_metrics_plugin_max_batch_bytes";
+            "be_metrics_plugin_max_batch_bytes";
     public static final String BE_METRICS_PLUGIN_MAX_BATCH_INTERVAL_SEC =
-        "be_metrics_plugin_max_batch_interval_sec";
+            "be_metrics_plugin_max_batch_interval_sec";
     public static final String BE_METRICS_PLUGIN_LOAD_TIMEOUT =
-        "be_metrics_plugin_load_timeout";
+            "be_metrics_plugin_load_timeout";
 
     public static final String ENABLE_GET_ROW_COUNT_FROM_FILE_LIST = "enable_get_row_count_from_file_list";
     public static final String READ_ONLY = "read_only";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -65,6 +65,13 @@ public final class GlobalVariable {
     public static final String AUDIT_PLUGIN_MAX_SQL_LENGTH = "audit_plugin_max_sql_length";
     public static final String AUDIT_PLUGIN_MAX_INSERT_STMT_LENGTH = "audit_plugin_max_insert_stmt_length";
     public static final String AUDIT_PLUGIN_LOAD_TIMEOUT = "audit_plugin_load_timeout";
+    public static final String ENABLE_BE_METRICS_PLUGIN = "enable_be_metrics_plugin";
+    public static final String BE_METRICS_PLUGIN_MAX_BATCH_BYTES =
+        "be_metrics_plugin_max_batch_bytes";
+    public static final String BE_METRICS_PLUGIN_MAX_BATCH_INTERVAL_SEC =
+        "be_metrics_plugin_max_batch_interval_sec";
+    public static final String BE_METRICS_PLUGIN_LOAD_TIMEOUT =
+        "be_metrics_plugin_load_timeout";
 
     public static final String ENABLE_GET_ROW_COUNT_FROM_FILE_LIST = "enable_get_row_count_from_file_list";
     public static final String READ_ONLY = "read_only";
@@ -163,6 +170,16 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = AUDIT_PLUGIN_LOAD_TIMEOUT, flag = VariableMgr.GLOBAL)
     public static int auditPluginLoadTimeoutS = 600;
+
+    // BE Metrics Loader plugin — default OFF, enable via SET GLOBAL enable_be_metrics_plugin=true
+    @VariableMgr.VarAttr(name = ENABLE_BE_METRICS_PLUGIN, flag = VariableMgr.GLOBAL)
+    public static boolean enableBeMetricsLoader = false;
+    @VariableMgr.VarAttr(name = BE_METRICS_PLUGIN_MAX_BATCH_BYTES, flag = VariableMgr.GLOBAL)
+    public static long beMetricsPluginMaxBatchBytes = 50 * 1024 * 1024;
+    @VariableMgr.VarAttr(name = BE_METRICS_PLUGIN_MAX_BATCH_INTERVAL_SEC, flag = VariableMgr.GLOBAL)
+    public static long beMetricsPluginMaxBatchInternalSec = 60;
+    @VariableMgr.VarAttr(name = BE_METRICS_PLUGIN_LOAD_TIMEOUT, flag = VariableMgr.GLOBAL)
+    public static int beMetricsPluginLoadTimeoutS = 10;
 
     @VariableMgr.VarAttr(name = ENABLE_GET_ROW_COUNT_FROM_FILE_LIST, flag = VariableMgr.GLOBAL,
             description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.plugin.AuditEvent;
+import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.thrift.TQueryStatistics;
 import org.apache.doris.thrift.TReportWorkloadRuntimeStatusParams;
 
@@ -61,6 +62,30 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
         Map<String, Pair<Long, TQueryStatistics>> queryStatsMap = Maps.newConcurrentMap();
     }
 
+    public static class BeMetrics {
+        public long scan_rows = 0;
+        public long scan_bytes = 0;
+        public long cpu_ms = 0;
+        public long max_peak_memory_bytes = 0;
+        public long shuffle_send_rows = 0;
+        public long shuffle_send_bytes = 0;
+        public long scan_bytes_from_local_storage = 0;
+        public long scan_bytes_from_remote_storage = 0;
+
+        public static BeMetrics from(TQueryStatistics src) {
+            BeMetrics m = new BeMetrics();
+            m.scan_rows = src.scan_rows;
+            m.scan_bytes = src.scan_bytes;
+            m.cpu_ms = src.cpu_ms;
+            m.max_peak_memory_bytes = src.max_peak_memory_bytes;
+            m.shuffle_send_rows = src.shuffle_send_rows;
+            m.shuffle_send_bytes = src.shuffle_send_bytes;
+            m.scan_bytes_from_local_storage = src.scan_bytes_from_local_storage;
+            m.scan_bytes_from_remote_storage = src.scan_bytes_from_remote_storage;
+            return m;
+        }
+    }
+
     public WorkloadRuntimeStatusMgr() {
         super("workload-runtime-stats-thread", Config.workload_runtime_status_thread_interval_ms);
     }
@@ -68,7 +93,8 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
     @Override
     protected void runAfterCatalogReady() {
         // 1 merge be query statistics
-        Map<String, TQueryStatistics> queryStatisticsMap = getQueryStatisticsMap();
+        Map<String, Pair<TQueryStatistics, Map<Long, BeMetrics>>> queryStatisticsMap
+            = getQueryStatisticsMap();
 
         // 2 log query audit
         try {
@@ -76,8 +102,10 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
             int missedLogCount = 0;
             int succLogCount = 0;
             for (AuditEvent auditEvent : auditEventList) {
-                TQueryStatistics queryStats = queryStatisticsMap.get(auditEvent.queryId);
-                if (queryStats != null) {
+                Pair<TQueryStatistics, Map<Long, BeMetrics>> queryStatsPair
+                    = queryStatisticsMap.get(auditEvent.queryId);
+                if (queryStatsPair != null) {
+                    TQueryStatistics queryStats = queryStatsPair.first;
                     auditEvent.scanRows = queryStats.scan_rows;
                     auditEvent.scanBytes = queryStats.scan_bytes;
                     auditEvent.scanBytesFromLocalStorage = queryStats.scan_bytes_from_local_storage;
@@ -86,6 +114,10 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
                     auditEvent.cpuTimeMs = queryStats.cpu_ms;
                     auditEvent.shuffleSendBytes = queryStats.shuffle_send_bytes;
                     auditEvent.shuffleSendRows = queryStats.shuffle_send_rows;
+                    // Attach per-BE metrics only when BeMetricsLoader is enabled
+                    if (GlobalVariable.enableBeMetricsLoader) {
+                        auditEvent.beMetricsMap = queryStatsPair.second;
+                    }
                 }
                 boolean ret = Env.getCurrentAuditEventProcessor().handleAuditEvent(auditEvent);
                 if (!ret) {
@@ -111,9 +143,9 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
         try {
             if (queryAuditEventList.size() > Config.audit_event_log_queue_size) {
                 LOG.warn("audit log event queue size {} is full, this may cause audit log missing statistics."
-                                + "you can check whether qps is too high "
-                                + "or reset audit_event_log_queue_size. query id: {}",
-                        queryAuditEventList.size(), event.queryId);
+                        + "you can check whether qps is too high "
+                        + "or reset audit_event_log_queue_size. query id: {}",
+                    queryAuditEventList.size(), event.queryId);
                 Env.getCurrentAuditEventProcessor().handleAuditEvent(event);
                 return;
             }
@@ -195,22 +227,25 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
 
     // NOTE: currently getQueryStatisticsMap must be called before clear beToQueryStatsMap
     // so there is no need lock or null check when visit beToQueryStatsMap
-    public Map<String, TQueryStatistics> getQueryStatisticsMap() {
+    public Map<String, Pair<TQueryStatistics, Map<Long, BeMetrics>>> getQueryStatisticsMap() {
         // 1 merge query stats in all be
         Set<Long> beIdSet = beToQueryStatsMap.keySet();
-        Map<String, TQueryStatistics> resultQueryMap = Maps.newHashMap();
+        Map<String, Pair<TQueryStatistics, Map<Long, BeMetrics>>> resultQueryMap = Maps.newHashMap();
         for (Long beId : beIdSet) {
             BeReportInfo beReportInfo = beToQueryStatsMap.get(beId);
             Set<String> queryIdSet = beReportInfo.queryStatsMap.keySet();
             for (String queryId : queryIdSet) {
                 TQueryStatistics curQueryStats = beReportInfo.queryStatsMap.get(queryId).second;
-
-                TQueryStatistics retQuery = resultQueryMap.get(queryId);
-                if (retQuery == null) {
-                    retQuery = new TQueryStatistics();
-                    resultQueryMap.put(queryId, retQuery);
+                Pair<TQueryStatistics, Map<Long, BeMetrics>> retPair = resultQueryMap.get(queryId);
+                if (retPair == null) {
+                    retPair = Pair.of(new TQueryStatistics(), Maps.newHashMap());
+                    resultQueryMap.put(queryId, retPair);
                 }
-                mergeQueryStatistics(retQuery, curQueryStats);
+                // Merge aggregated stats across all BEs
+                mergeQueryStatistics(retPair.first, curQueryStats);
+                // Per-BE stats: each (beId, queryId) has only one latest snapshot
+                // (updateBeQueryStats uses put(), not merge), so direct construction suffices.
+                retPair.second.put(beId, BeMetrics.from(curQueryStats));
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadRuntimeStatusMgr.java
@@ -63,25 +63,25 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
     }
 
     public static class BeMetrics {
-        public long scan_rows = 0;
-        public long scan_bytes = 0;
-        public long cpu_ms = 0;
-        public long max_peak_memory_bytes = 0;
-        public long shuffle_send_rows = 0;
-        public long shuffle_send_bytes = 0;
-        public long scan_bytes_from_local_storage = 0;
-        public long scan_bytes_from_remote_storage = 0;
+        public long scanRows = 0;
+        public long scanBytes = 0;
+        public long cpuMs = 0;
+        public long maxPeakMemoryBytes = 0;
+        public long shuffleSendRows = 0;
+        public long shuffleSendBytes = 0;
+        public long scanBytesFromLocalStorage = 0;
+        public long scanBytesFromRemoteStorage = 0;
 
         public static BeMetrics from(TQueryStatistics src) {
             BeMetrics m = new BeMetrics();
-            m.scan_rows = src.scan_rows;
-            m.scan_bytes = src.scan_bytes;
-            m.cpu_ms = src.cpu_ms;
-            m.max_peak_memory_bytes = src.max_peak_memory_bytes;
-            m.shuffle_send_rows = src.shuffle_send_rows;
-            m.shuffle_send_bytes = src.shuffle_send_bytes;
-            m.scan_bytes_from_local_storage = src.scan_bytes_from_local_storage;
-            m.scan_bytes_from_remote_storage = src.scan_bytes_from_remote_storage;
+            m.scanRows = src.scan_rows;
+            m.scanBytes = src.scan_bytes;
+            m.cpuMs = src.cpu_ms;
+            m.maxPeakMemoryBytes = src.max_peak_memory_bytes;
+            m.shuffleSendRows = src.shuffle_send_rows;
+            m.shuffleSendBytes = src.shuffle_send_bytes;
+            m.scanBytesFromLocalStorage = src.scan_bytes_from_local_storage;
+            m.scanBytesFromRemoteStorage = src.scan_bytes_from_remote_storage;
             return m;
         }
     }
@@ -94,7 +94,7 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
     protected void runAfterCatalogReady() {
         // 1 merge be query statistics
         Map<String, Pair<TQueryStatistics, Map<Long, BeMetrics>>> queryStatisticsMap
-            = getQueryStatisticsMap();
+                = getQueryStatisticsMap();
 
         // 2 log query audit
         try {
@@ -103,7 +103,7 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
             int succLogCount = 0;
             for (AuditEvent auditEvent : auditEventList) {
                 Pair<TQueryStatistics, Map<Long, BeMetrics>> queryStatsPair
-                    = queryStatisticsMap.get(auditEvent.queryId);
+                        = queryStatisticsMap.get(auditEvent.queryId);
                 if (queryStatsPair != null) {
                     TQueryStatistics queryStats = queryStatsPair.first;
                     auditEvent.scanRows = queryStats.scan_rows;
@@ -145,7 +145,7 @@ public class WorkloadRuntimeStatusMgr extends MasterDaemon {
                 LOG.warn("audit log event queue size {} is full, this may cause audit log missing statistics."
                         + "you can check whether qps is too high "
                         + "or reset audit_event_log_queue_size. query id: {}",
-                    queryAuditEventList.size(), event.queryId);
+                        queryAuditEventList.size(), event.queryId);
                 Env.getCurrentAuditEventProcessor().handleAuditEvent(event);
                 return;
             }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close N/A

Related PR: N/A

Problem Summary: Current version of Doris only records the queryId and its resource consumption information in audit-log. When a BE node experiences a read/write high load failure, it is impossible to directly correlate and analyze which queryId is related from the exposed indicators/logs, and can only vaguely extract, guess and handle the problem


### Release note

Add query-level BE metrics persistence and automatically create the
`query_be_metrics` internal table for historical query analysis.

### Check List (For Author)

- Test
    - Built FE with `sh build.sh --fe` ：Passed
    - No dedicated FE unit tests were added or run for this change.
    - Manually verified automatic creation of the `query_be_metrics` table
    - Manually verified metrics persistence when the feature is enabled
    - Manually verified behavior when the feature is disabled

- Behavior changed:
    - Collects query-level BE runtime metrics.
    - Persists the metrics for subsequent analysis.
    - Create the internal table automatically during initialization.
    - Add configuration options for enabling and controlling persistence.
    - Extend audit events with query-level BE metrics context.

- Does this need documentation?
    - No. This change does not introduce a user-facing interface or require
additional user documentation.


### Target branch

This PR targets `branch-3.0` as requested.


### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

