### PR TITLE
[test](fe) Isolate cloud frontend service test

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplCloudTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplCloudTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.service;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.cloud.CacheHotspotManager;
+import org.apache.doris.cloud.catalog.CloudEnv;
+import org.apache.doris.common.Config;
+import org.apache.doris.thrift.TGetTabletReplicaInfosRequest;
+import org.apache.doris.thrift.TGetTabletReplicaInfosResult;
+import org.apache.doris.thrift.TStatusCode;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class FrontendServiceImplCloudTest {
+
+    // Regression test for FrontendServiceImpl.getTabletReplicaInfos NPE:
+    // When a warm-up job has been removed from
+    // CacheHotspotManager.cloudWarmUpJobs (past
+    // history_cloud_warm_up_job_keep_max_second), getCloudWarmUpJob
+    // returns null. The previous code called job.getJobId() inside the
+    // log message, throwing NPE which bubbled up to BE as
+    // "Internal error processing getTabletReplicaInfos".
+    @Test
+    public void testGetTabletReplicaInfosNullJobReturnsCancelledWithoutNpe() {
+        String originalCloudUniqueId = Config.cloud_unique_id;
+        Config.cloud_unique_id = "gettabletreplicainfostest";
+
+        CloudEnv cloudEnv = Mockito.mock(CloudEnv.class);
+        CacheHotspotManager cacheHotspotManager = Mockito.mock(CacheHotspotManager.class);
+        Mockito.when(cloudEnv.getCacheHotspotMgr()).thenReturn(cacheHotspotManager);
+        // Simulate job already removed from cloudWarmUpJobs.
+        Mockito.when(cacheHotspotManager.getCloudWarmUpJob(123456L)).thenReturn(null);
+
+        try (MockedStatic<Env> envMock = Mockito.mockStatic(Env.class)) {
+            envMock.when(Env::getCurrentEnv).thenReturn(cloudEnv);
+
+            FrontendServiceImpl frontendService = new FrontendServiceImpl(Mockito.mock(ExecuteEnv.class));
+            TGetTabletReplicaInfosRequest request = new TGetTabletReplicaInfosRequest();
+            request.setTabletIds(Collections.singletonList(789L));
+            request.setWarmUpJobId(123456L);
+
+            TGetTabletReplicaInfosResult result;
+            try {
+                result = frontendService.getTabletReplicaInfos(request);
+            } catch (NullPointerException e) {
+                throw new AssertionError("getTabletReplicaInfos must not NPE when the "
+                        + "warm-up job has been removed from CacheHotspotManager", e);
+            }
+
+            Assert.assertNotNull("result.status must be set", result.getStatus());
+            Assert.assertEquals("BE must be told to cancel its stale warm-up job entry",
+                    TStatusCode.CANCELLED, result.getStatus().getStatusCode());
+        } finally {
+            Config.cloud_unique_id = originalCloudUniqueId;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -23,8 +23,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.cloud.CacheHotspotManager;
-import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.common.AuthenticationException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -51,8 +49,6 @@ import org.apache.doris.thrift.TGetDbsParams;
 import org.apache.doris.thrift.TGetDbsResult;
 import org.apache.doris.thrift.TGetTablesParams;
 import org.apache.doris.thrift.TGetTablesResult;
-import org.apache.doris.thrift.TGetTabletReplicaInfosRequest;
-import org.apache.doris.thrift.TGetTabletReplicaInfosResult;
 import org.apache.doris.thrift.TListTableStatusResult;
 import org.apache.doris.thrift.TLoadTxnCommitRequest;
 import org.apache.doris.thrift.TLoadTxnRollbackRequest;
@@ -729,50 +725,6 @@ public class FrontendServiceImplTest {
             assertInvalidToken(impl, "rollbackTxnImpl", request);
         } finally {
             closeTransactionValidationMock();
-        }
-    }
-
-    // Regression test for FrontendServiceImpl.getTabletReplicaInfos NPE:
-    // When a warm-up job has been removed from
-    // CacheHotspotManager.cloudWarmUpJobs (past
-    // history_cloud_warm_up_job_keep_max_second), getCloudWarmUpJob
-    // returns null. The previous code called job.getJobId() inside the
-    // log message, throwing NPE which bubbled up to BE as
-    // "Internal error processing getTabletReplicaInfos".
-    @Test
-    public void testGetTabletReplicaInfosNullJobReturnsCancelledWithoutNpe() {
-        String originalCloudUniqueId = Config.cloud_unique_id;
-        Config.cloud_unique_id = "gettabletreplicainfostest";
-
-        CloudEnv cloudEnv = Mockito.mock(CloudEnv.class);
-        CacheHotspotManager cacheHotspotManager = Mockito.mock(CacheHotspotManager.class);
-        Mockito.when(cloudEnv.getCacheHotspotMgr()).thenReturn(cacheHotspotManager);
-        // Simulate job already removed from cloudWarmUpJobs.
-        Mockito.when(cacheHotspotManager.getCloudWarmUpJob(123456L)).thenReturn(null);
-
-        MockedStatic<Env> envMock = Mockito.mockStatic(Env.class);
-        try {
-            envMock.when(Env::getCurrentEnv).thenReturn(cloudEnv);
-
-            FrontendServiceImpl frontendService = new FrontendServiceImpl(exeEnv);
-            TGetTabletReplicaInfosRequest request = new TGetTabletReplicaInfosRequest();
-            request.setTabletIds(Collections.singletonList(789L));
-            request.setWarmUpJobId(123456L);
-
-            TGetTabletReplicaInfosResult result;
-            try {
-                result = frontendService.getTabletReplicaInfos(request);
-            } catch (NullPointerException e) {
-                throw new AssertionError("getTabletReplicaInfos must not NPE when the "
-                        + "warm-up job has been removed from CacheHotspotManager", e);
-            }
-
-            Assert.assertNotNull("result.status must be set", result.getStatus());
-            Assert.assertEquals("BE must be told to cancel its stale warm-up job entry",
-                    TStatusCode.CANCELLED, result.getStatus().getStatusCode());
-        } finally {
-            envMock.close();
-            Config.cloud_unique_id = originalCloudUniqueId;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62805

Problem Summary:

`FrontendServiceImplTest` starts a non-cloud mocked FE and BE for its shared
fixture. However,
`testGetTabletReplicaInfosNullJobReturnsCancelledWithoutNpe` temporarily sets
`Config.cloud_unique_id`, which switches the process-wide environment to cloud
mode.

If the background heartbeat runs during that window,
`Backend.isInStandbyCluster()` takes the cloud path and casts the non-cloud
`SystemInfoService` to `CloudSystemInfoService`, causing a
`ClassCastException`. The heartbeat handler converts the exception into a BAD
heartbeat. Because the unit-test heartbeat failure tolerance is 1, this single
failure immediately marks the shared mock BE not alive.

Restoring `Config.cloud_unique_id` does not synchronously restore the BE state.
Tests executed before the next healthy heartbeat therefore observe zero
available backends and fail intermittently with errors such as
`available backend num is 0`.

Move this cloud-specific test to `FrontendServiceImplCloudTest`, which has no
`MockedFrontend`, mock BE, or background heartbeat fixture. The original
`getTabletReplicaInfos` request and `CANCELLED` assertions remain unchanged, so
the global cloud-mode change can no longer affect the shared non-cloud fixture.

The total test coverage remains unchanged: 19 tests before the change, and 18
tests in `FrontendServiceImplTest` plus the moved test in
`FrontendServiceImplCloudTest` after the change.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  Validation on latest `master`:
  - `./run-fe-ut.sh --run org.apache.doris.service.FrontendServiceImplCloudTest`: 1 test passed
  - `./run-fe-ut.sh --run org.apache.doris.service.FrontendServiceImplTest`: 18 tests passed

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
