### PR TITLE
[fix](search) Reject score() with top-level NESTED queries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckScoreUsage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckScoreUsage.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.SearchExpression;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Score;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
@@ -66,8 +67,30 @@ public class CheckScoreUsage implements RewriteRuleFactory {
                             "score() function cannot be used in aggregate functions. "
                             + "score() requires WHERE clause with MATCH function, "
                             + "ORDER BY and LIMIT for optimization");
+                }).toRule(RuleType.CHECK_SCORE_USAGE),
+
+            any()
+                .when(this::hasNestedSearchAndScore)
+                .then(plan -> {
+                    throw new AnalysisException(
+                            "score() is not supported with a NESTED search clause");
                 }).toRule(RuleType.CHECK_SCORE_USAGE)
         );
+    }
+
+    private boolean hasNestedSearchAndScore(Plan plan) {
+        return containsNestedSearch(plan) && containsScoreFunction(plan);
+    }
+
+    private boolean containsNestedSearch(Plan plan) {
+        return plan.getExpressions().stream().anyMatch(this::containsNestedSearch)
+                || plan.children().stream().anyMatch(this::containsNestedSearch);
+    }
+
+    private boolean containsNestedSearch(Expression expression) {
+        return (expression instanceof SearchExpression
+                && ((SearchExpression) expression).containsNestedQuery())
+                || expression.children().stream().anyMatch(this::containsNestedSearch);
     }
 
     private boolean hasScoreFunction(LogicalProject<?> project) {
@@ -95,6 +118,11 @@ public class CheckScoreUsage implements RewriteRuleFactory {
             return true;
         }
         return expr.children().stream().anyMatch(this::containsScoreFunction);
+    }
+
+    private boolean containsScoreFunction(Plan plan) {
+        return plan.getExpressions().stream().anyMatch(this::containsScoreFunction)
+                || plan.children().stream().anyMatch(this::containsScoreFunction);
     }
 
     private boolean isScoreAlreadyOptimized(LogicalProject<?> project) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SearchExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SearchExpression.java
@@ -49,6 +49,23 @@ public class SearchExpression extends Expression {
         return qsPlan;
     }
 
+    /**
+     * Returns whether this search expression contains a NESTED clause.
+     *
+     * <p>Multi-field expansion can wrap a valid top-level NESTED query in a boolean root, so this
+     * check must inspect the entire parsed tree.</p>
+     */
+    public boolean containsNestedQuery() {
+        return containsNestedQuery(qsPlan.getRoot());
+    }
+
+    private boolean containsNestedQuery(SearchDslParser.QsNode node) {
+        if (node.getType() == SearchDslParser.QsClauseType.NESTED) {
+            return true;
+        }
+        return node.getChildren().stream().anyMatch(this::containsNestedQuery);
+    }
+
     public List<Expression> getSlotChildren() {
         return children();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownScoreTopNIntoOlapScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownScoreTopNIntoOlapScanTest.java
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.analysis.SearchDslParser;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.properties.OrderKey;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.SearchExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Score;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+/**
+ * Tests for score pushdown restrictions.
+ */
+public class PushDownScoreTopNIntoOlapScanTest {
+
+    @Test
+    public void testNestedSearchWithScoreIsRejected() {
+        LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+        Slot idSlot = scan.getOutput().get(0);
+        SearchDslParser.QsNode nestedRoot = new SearchDslParser.QsNode(
+                SearchDslParser.QsClauseType.NESTED, Collections.emptyList());
+        SearchDslParser.QsNode expandedRoot = new SearchDslParser.QsNode(
+                SearchDslParser.QsClauseType.OR, ImmutableList.of(nestedRoot));
+        SearchExpression nestedSearch = new SearchExpression(
+                "NESTED(items, title:hello)",
+                new SearchDslParser.QsPlan(expandedRoot, Collections.emptyList()),
+                Collections.emptyList());
+        LogicalFilter<LogicalOlapScan> filter = new LogicalFilter<>(
+                ImmutableSet.of(nestedSearch), scan);
+        Alias scoreAlias = new Alias(new Score(), "score");
+        LogicalProject<LogicalFilter<LogicalOlapScan>> project = new LogicalProject<>(
+                ImmutableList.of(idSlot, scoreAlias), filter);
+        LogicalTopN<LogicalProject<LogicalFilter<LogicalOlapScan>>> topN = new LogicalTopN<>(
+                ImmutableList.of(new OrderKey(scoreAlias.toSlot(), false, false)), 10, 0, project);
+
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class, () -> PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyTopDown(new CheckScoreUsage())
+                .getPlan());
+        Assertions.assertTrue(exception.getMessage().contains("NESTED"));
+    }
+
+    @Test
+    public void testNestedSearchWithScoreOutsidePushDownShapeIsRejected() {
+        LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+        SearchDslParser.QsNode nestedRoot = new SearchDslParser.QsNode(
+                SearchDslParser.QsClauseType.NESTED, Collections.emptyList());
+        SearchExpression nestedSearch = new SearchExpression(
+                "NESTED(items, title:hello)",
+                new SearchDslParser.QsPlan(nestedRoot, Collections.emptyList()),
+                Collections.emptyList());
+        LogicalFilter<LogicalOlapScan> filter = new LogicalFilter<>(
+                ImmutableSet.of(nestedSearch), scan);
+        LogicalTopN<LogicalFilter<LogicalOlapScan>> topN = new LogicalTopN<>(
+                ImmutableList.of(new OrderKey(new Score(), false, false)), 10, 0, filter);
+
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class, () -> PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyTopDown(new CheckScoreUsage())
+                .getPlan());
+        Assertions.assertTrue(exception.getMessage().contains("NESTED"));
+    }
+
+    @Test
+    public void testScoreOutsidePushDownWithoutNestedIsUnchanged() {
+        LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+        LogicalTopN<LogicalOlapScan> topN = new LogicalTopN<>(
+                ImmutableList.of(new OrderKey(new Score(), false, false)), 10, 0, scan);
+
+        Assertions.assertDoesNotThrow(() -> PlanChecker
+                .from(MemoTestUtils.createConnectContext(), topN)
+                .applyTopDown(new CheckScoreUsage())
+                .getPlan());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SearchExpressionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SearchExpressionTest.java
@@ -76,6 +76,30 @@ public class SearchExpressionTest {
     }
 
     @Test
+    public void testContainsNestedQuery() {
+        SearchDslParser.QsNode nestedRoot = new SearchDslParser.QsNode(
+                SearchDslParser.QsClauseType.NESTED, Collections.emptyList());
+        SearchDslParser.QsPlan nestedPlan = new SearchDslParser.QsPlan(nestedRoot,
+                Collections.emptyList());
+        SearchExpression nestedSearch = new SearchExpression(
+                "NESTED(items, title:hello)", nestedPlan, Collections.emptyList());
+
+        Assertions.assertTrue(nestedSearch.containsNestedQuery());
+
+        SearchDslParser.QsNode wrappedRoot = new SearchDslParser.QsNode(
+                SearchDslParser.QsClauseType.OR, Arrays.asList(nestedRoot));
+        SearchExpression wrappedNestedSearch = new SearchExpression(
+                "NESTED(items, title:hello)",
+                new SearchDslParser.QsPlan(wrappedRoot, Collections.emptyList()),
+                Collections.emptyList());
+        Assertions.assertTrue(wrappedNestedSearch.containsNestedQuery());
+
+        SearchExpression ordinarySearch = new SearchExpression(
+                "title:hello", createTestPlan(), Collections.emptyList());
+        Assertions.assertFalse(ordinarySearch.containsNestedQuery());
+    }
+
+    @Test
     public void testFoldable() {
         String dsl = "title:hello";
         SearchDslParser.QsPlan plan = createTestPlan();

--- a/regression-test/suites/search/test_search_score_cache.groovy
+++ b/regression-test/suites/search/test_search_score_cache.groovy
@@ -84,6 +84,28 @@ suite("test_search_score_cache", "p0") {
     sql """ set enable_common_expr_pushdown = true """
     sql """ set enable_inverted_index_query_cache = true """
 
+    test {
+        sql """
+            SELECT id, score() AS s
+            FROM ${tableName}
+            WHERE search('NESTED(v, host:apple)')
+            ORDER BY s DESC
+            LIMIT 10
+        """
+        exception "score() is not supported with a NESTED search clause"
+    }
+
+    test {
+        sql """
+            SELECT id
+            FROM ${tableName}
+            WHERE search('NESTED(v, host:apple)')
+            ORDER BY score() DESC
+            LIMIT 10
+        """
+        exception "score() is not supported with a NESTED search clause"
+    }
+
     // SEARCH DSL + score() must execute scorers even when the DSL bitmap cache is warm.
     assertStablePositiveScoreQuery(
         "search_dsl_score",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65436

Problem Summary: A top-level NESTED search currently maps matching child elements to parent rows but does not aggregate element scores into CollectionSimilarity. If score() pushdown is allowed, the parent rows can materialize zero scores. Reject top-level NESTED + score() in the FE pushdown rule and add a BE guard until nested score aggregation is implemented.

### Release note

None.

### Check List (For Author)

- [x] Test: FE unit tests
- [x] Test: FE build
- [ ] Test: BE build in progress
- [x] Behavior changed: unsupported top-level NESTED + score() now returns an explicit error
- [x] Does this need documentation: No
