### PR TITLE
[test](pipeline) inject empty blocks at operator boundaries

### DIFF
--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -348,6 +348,13 @@ protected:
     bool _closed = false;
     std::atomic<bool> _terminated = false;
     Block _origin_block;
+#ifndef NDEBUG
+    // The original block is returned one call after its empty clone so every operator boundary
+    // sees an empty block before processing data.
+    Block _debug_pending_block;
+    bool _debug_has_pending_block = false;
+    bool _debug_pending_eos = false;
+#endif
 };
 
 template <typename SharedStateArg = FakeSharedState>
@@ -618,6 +625,11 @@ public:
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_no_column_string64());
         RETURN_IF_ERROR(block->check_type_and_column());
+#ifndef NDEBUG
+        auto empty_block = block->clone_empty();
+        // The injected empty block must not finish the sink before the original block is consumed.
+        RETURN_IF_ERROR(sink_impl(state, &empty_block, false));
+#endif
         return sink_impl(state, block, eos);
     }
 
@@ -877,7 +889,23 @@ public:
 
     Status terminate(RuntimeState* state) override;
     [[nodiscard]] Status get_block(RuntimeState* state, Block* block, bool* eos) {
+#ifndef NDEBUG
+        auto* local_state = state->get_local_state(operator_id());
+        if (local_state->_debug_has_pending_block) {
+            *block = std::move(local_state->_debug_pending_block);
+            *eos = local_state->_debug_pending_eos;
+            local_state->_debug_has_pending_block = false;
+        } else {
+            RETURN_IF_ERROR(get_block_impl(state, block, eos));
+            local_state->_debug_pending_block = std::move(*block);
+            *block = local_state->_debug_pending_block.clone_empty();
+            local_state->_debug_pending_eos = *eos;
+            local_state->_debug_has_pending_block = true;
+            *eos = false;
+        }
+#else
         RETURN_IF_ERROR(get_block_impl(state, block, eos));
+#endif
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
         RETURN_IF_ERROR(block->check_no_column_string64());
         RETURN_IF_ERROR(block->check_type_and_column());

--- a/be/test/exec/operator/operator_empty_block_test.cpp
+++ b/be/test/exec/operator/operator_empty_block_test.cpp
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "exec/operator/operator.h"
+#include "testutil/column_helper.h"
+#include "testutil/mock/mock_runtime_state.h"
+
+namespace doris {
+
+#ifndef NDEBUG
+
+class EmptyBlockMockSourceOperator final : public OperatorX<DummyOperatorLocalState> {
+public:
+    explicit EmptyBlockMockSourceOperator(Block block)
+            : OperatorX<DummyOperatorLocalState>(nullptr, 0, 0), _block(std::move(block)) {}
+
+    Status get_block_impl(RuntimeState* /*state*/, Block* block, bool* eos) override {
+        ++get_block_impl_calls;
+        *block = _block;
+        *eos = true;
+        return Status::OK();
+    }
+
+    int get_block_impl_calls = 0;
+
+private:
+    Block _block;
+};
+
+class EmptyBlockMockSinkOperator final : public DataSinkOperatorX<DummySinkLocalState> {
+public:
+    EmptyBlockMockSinkOperator() : DataSinkOperatorX<DummySinkLocalState>(0, 0, 0) {}
+
+    Status sink_impl(RuntimeState* /*state*/, Block* block, bool eos) override {
+        input_rows.push_back(block->rows());
+        input_eos.push_back(eos);
+        if (fail_on_empty_block && block->empty()) {
+            return Status::InternalError("failed to process empty block");
+        }
+        return Status::OK();
+    }
+
+    std::vector<size_t> input_rows;
+    std::vector<bool> input_eos;
+    bool fail_on_empty_block = false;
+};
+
+TEST(OperatorEmptyBlockTest, GetBlockReturnsEmptyBlockBeforeOriginalBlock) {
+    MockRuntimeState state;
+    RuntimeProfile profile("test");
+    auto original_block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3});
+    EmptyBlockMockSourceOperator source(original_block);
+
+    auto local_state = DummyOperatorLocalState::create_unique(&state, &source);
+    LocalStateInfo info {.parent_profile = &profile,
+                         .scan_ranges = {},
+                         .shared_state = nullptr,
+                         .shared_state_map = {},
+                         .task_idx = 0};
+    ASSERT_TRUE(local_state->init(&state, info).ok());
+    state.resize_op_id_to_local_state(-1);
+    state.emplace_local_state(source.operator_id(), std::move(local_state));
+
+    Block output_block;
+    bool eos = true;
+    ASSERT_TRUE(source.get_block(&state, &output_block, &eos).ok());
+    EXPECT_EQ(output_block.columns(), original_block.columns());
+    EXPECT_EQ(output_block.rows(), 0);
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(source.get_block_impl_calls, 1);
+
+    ASSERT_TRUE(source.get_block(&state, &output_block, &eos).ok());
+    EXPECT_TRUE(ColumnHelper::block_equal(output_block, original_block));
+    EXPECT_TRUE(eos);
+    EXPECT_EQ(source.get_block_impl_calls, 1);
+}
+
+TEST(OperatorEmptyBlockTest, SinkReceivesEmptyBlockBeforeOriginalBlock) {
+    MockRuntimeState state;
+    EmptyBlockMockSinkOperator sink;
+    auto original_block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3});
+
+    ASSERT_TRUE(sink.sink(&state, &original_block, true).ok());
+    EXPECT_EQ(sink.input_rows, std::vector<size_t>({0, 3}));
+    EXPECT_EQ(sink.input_eos, std::vector<bool>({false, true}));
+    EXPECT_EQ(original_block.rows(), 3);
+}
+
+TEST(OperatorEmptyBlockTest, SinkPropagatesEmptyBlockError) {
+    MockRuntimeState state;
+    EmptyBlockMockSinkOperator sink;
+    sink.fail_on_empty_block = true;
+    auto original_block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3});
+
+    EXPECT_FALSE(sink.sink(&state, &original_block, true).ok());
+    EXPECT_EQ(sink.input_rows, std::vector<size_t>({0}));
+    EXPECT_EQ(sink.input_eos, std::vector<bool>({false}));
+    EXPECT_EQ(original_block.rows(), 3);
+}
+
+#endif
+
+} // namespace doris


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Debug builds did not systematically exercise operators with schema-valid empty blocks. This change injects an empty clone before each source output and sink input while preserving the original block and EOS state, and adds focused BE unit tests.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

