### PR TITLE
[fix](cloud) Allow recycler to abort expired or missing compaction jobs for prepared rowsets

### DIFF
--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -946,13 +946,17 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
 
     using namespace std::chrono;
     int64_t now = duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
-    if (recorded_compaction->expiration() > 0 && recorded_compaction->expiration() < now) {
+    if (recorded_compaction->expiration() > 0 && recorded_compaction->expiration() < now &&
+        request->action() != FinishTabletJobRequest::ABORT) {
+        // An expired compaction job can never COMMIT (rejected here), but ABORT
+        // must still be allowed to erase it: the recycler aborts the job of a
+        // PREPARED rowset before recycling, and refusing to abort an expired job
+        // leaves that rowset unrecyclable forever, pinning the recycle_rowset
+        // queue watermark.
         code = MetaServiceCode::JOB_EXPIRED;
         SS << "expired compaction job, tablet_id=" << tablet_id
            << " job=" << proto_to_json(*recorded_compaction);
         msg = ss.str();
-        // FIXME: Just remove or notify to abort?
-        // LOG(INFO) << "remove expired job, tablet_id=" << tablet_id << " key=" << hex(job_key);
         return;
     }
 

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1892,6 +1892,22 @@ int InstanceRecycler::abort_job_for_related_rowset(const RowsetMetaCloudPB& rows
         _finish_tablet_job(&req, &res, instance_id_, txn, txn_kv_.get(),
                            delete_bitmap_lock_white_list_.get(), resource_mgr_.get(), code, msg,
                            ss);
+        if (code == MetaServiceCode::JOB_EXPIRED || code == MetaServiceCode::INVALID_ARGUMENT) {
+            // Nothing left to abort — proceed to recycle. JOB_EXPIRED: an expired
+            // compaction job can never commit (COMMIT is rejected by the same
+            // expiration check), so its prepared rowset data is safe to delete.
+            // INVALID_ARGUMENT: the recorded job no longer matches this rowset's
+            // job (job id already removed, or the job key referenced by the job's
+            // embedded tablet idx is gone). Returning failure here would leave the
+            // rowset unrecyclable forever and pin the recycle_rowset queue
+            // watermark on it.
+            LOG(INFO) << "no abortable job for related rowset, proceed to recycle"
+                      << ", instance_id=" << instance_id_
+                      << " tablet_id=" << tablet_idx.tablet_id()
+                      << " rowset_id=" << rowset_meta.rowset_id_v2() << " code=" << code
+                      << " msg=" << msg;
+            return 0;
+        }
         if (code != MetaServiceCode::OK) {
             LOG(WARNING) << "failed to abort job, instance_id=" << instance_id_
                          << " tablet_id=" << tablet_idx.tablet_id() << " code=" << code

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1902,8 +1902,7 @@ int InstanceRecycler::abort_job_for_related_rowset(const RowsetMetaCloudPB& rows
             // rowset unrecyclable forever and pin the recycle_rowset queue
             // watermark on it.
             LOG(INFO) << "no abortable job for related rowset, proceed to recycle"
-                      << ", instance_id=" << instance_id_
-                      << " tablet_id=" << tablet_idx.tablet_id()
+                      << ", instance_id=" << instance_id_ << " tablet_id=" << tablet_idx.tablet_id()
                       << " rowset_id=" << rowset_meta.rowset_id_v2() << " code=" << code
                       << " msg=" << msg;
             return 0;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When the cloud recycler processes a PREPARED rowset (the output of a compaction job that died mid-flight, e.g. because its BE crashed), `InstanceRecycler::abort_job_for_related_rowset` must first abort the recorded compaction job. Two failure modes make that abort permanently impossible, so the rowset is never recycled and the oldest such entry pins the whole `recycle_rowset` queue watermark forever:

1. **Expired job cannot be aborted.** `process_compaction_job` rejects every action on an expired compaction job with `JOB_EXPIRED` before the action dispatch (the existing `// FIXME: Just remove or notify to abort?` marks exactly this). The recycler needs the ABORT to succeed, but the job expired long ago — circular, and it never self-heals. An expired job can never COMMIT (rejected by this same check), so allowing ABORT to erase it is strictly cleanup and loses nothing.

2. **Job-not-found treated as fatal.** If the recorded job no longer matches the rowset's job when `_finish_tablet_job` re-resolves it (job id already removed, or the job key referenced by the job's embedded tablet idx no longer exists → `INVALID_ARGUMENT` "job not found"), the recycler returns -1 and retries forever. For the recycler's purposes "nothing to abort" means it is safe to proceed with recycling, mirroring the existing early-return when the job key is absent at the recycler's own read ("job not exists ... return 0").

Observed on a production compute-storage-decoupled cluster (4.1): a BE OOM crash loop killed several BASE compactions mid-flight; 7 PREPARED rowsets then failed every recycler pass for 15 days with:

```
recycler.cpp:1848] failed to abort job, ... code=5000 msg=... expired compaction job, tablet_id=... job={...}
recycler.cpp:2058] failed to abort txn or job for related rowset, ...
```

and

```
recycler.cpp:1848] failed to abort job, ... code=1001 msg=... job not found, ... err=KeyNotFound
recycler.cpp:2058] failed to abort txn or job for related rowset, ...
```

pinning the `recycle_rowset` queue watermark at the crash date while every other queue stayed current.

Fix:

- `meta_service_job.cpp`: skip the expiration short-circuit for `ABORT` actions, so aborting an expired compaction job erases it as usual (COMMIT and LEASE behavior unchanged).
- `recycler.cpp`: in `abort_job_for_related_rowset`, treat `JOB_EXPIRED` (older meta-service without the change above) and `INVALID_ARGUMENT` (job/idx mismatch, job already gone) as "nothing left to abort" and proceed with recycling instead of failing the rowset forever.

### Release note

Fix cloud recycler permanently failing to recycle prepared rowsets whose compaction job has expired or no longer exists, which pinned the recycle_rowset queue watermark.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Reproduced on a production 4.1 compute-storage-decoupled cluster: 7 PREPARED rowsets from BE-crash-killed BASE compactions failed `abort_job_for_related_rowset` on every recycler pass for 15 days (both `JOB_EXPIRED` and `INVALID_ARGUMENT`/KeyNotFound flavors), freezing the `recycle_rowset` watermark at the crash timestamp while other queues stayed current. With the fix the abort path resolves and the rowsets recycle.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. ABORT of an expired compaction job now succeeds (erases the recorded job) instead of returning JOB_EXPIRED; the recycler proceeds to recycle a prepared rowset when there is no abortable job left instead of retrying forever.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label