### PR TITLE
[enhance](job) Reduce adaptive routine load batch interval

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1234,7 +1234,7 @@ public class Config extends ConfigBase {
      * Minimum batch interval for adaptive routine load tasks when not at EOF.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static int routine_load_adaptive_min_batch_interval_sec = 360;
+    public static int routine_load_adaptive_min_batch_interval_sec = 120;
 
     /**
      * The max number of files store in SmallFileMgr

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
@@ -75,11 +75,11 @@ suite("test_routine_load_adaptive_param","nonConcurrent") {
                 logger.info("---test adaptively increase---")
                 RoutineLoadTestUtils.sendTestDataToKafka(producer, kafkaCsvTpoics)
                 // Drive data each round so an isEof=false task keeps being scheduled. The converged
-                // adaptive timeout (3600) lives on the renewed idle task (txnId == -1), so both checks
+                // adaptive timeout (1200) lives on the renewed idle task (txnId == -1), so both checks
                 // poll by value (task timeout col, and the committed txn's persisted timeout looked up
                 // by task-UUID label) instead of racing a sub-second running task.
-                RoutineLoadTestUtils.checkTaskTimeoutWithData(runSql, producer, kafkaCsvTpoics, job, "3600")
-                RoutineLoadTestUtils.checkTxnTimeoutMatchesTaskTimeout(runSql, producer, kafkaCsvTpoics, job, "3600000")
+                RoutineLoadTestUtils.checkTaskTimeoutWithData(runSql, producer, kafkaCsvTpoics, job, "1200")
+                RoutineLoadTestUtils.checkTxnTimeoutMatchesTaskTimeout(runSql, producer, kafkaCsvTpoics, job, "1200000")
                 RoutineLoadTestUtils.waitForTaskFinish(runSql, job, tableName, 2)
             } finally {
                 GetDebugPoint().disableDebugPointForAllFEs(injection)

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_timeout_value.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_timeout_value.groovy
@@ -215,7 +215,7 @@ suite("test_routine_load_timeout_value","nonConcurrent") {
             sql "stop routine load for ${jobName}"
             sql "DROP TABLE IF EXISTS ${tableName} FORCE"
             // Restore routine_load_adaptive_min_batch_interval_sec to default value
-            sql "ADMIN SET FRONTEND CONFIG ('routine_load_adaptive_min_batch_interval_sec' = '360')"
+            sql "ADMIN SET FRONTEND CONFIG ('routine_load_adaptive_min_batch_interval_sec' = '120')"
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The 360-second minimum adaptive batch interval can delay routine load progress commits and data visibility during backlog without improving throughput for workloads that already sustain their processing rate with shorter batches. This change reduces the default to 120 seconds and aligns the regression expectations with the new adaptive task timeout.

### Release note

Reduce the default `routine_load_adaptive_min_batch_interval_sec` from 360 seconds to 120 seconds.

### Check List (For Author)

- Test: Manual test
    - `mvn -pl fe-common -am -DskipTests -Dskip.doc=true validate`
- Behavior changed: Yes. Backlogged routine load tasks use a 120-second minimum adaptive batch interval by default.
- Does this need documentation: No
