### PR TITLE
[fix](test) Scope publish debug point in partial update case

### DIFF
--- a/be/src/service/http/action/debug_point_action.cpp
+++ b/be/src/service/http/action/debug_point_action.cpp
@@ -21,7 +21,6 @@
 #include "service/http/http_channel.h"
 #include "service/http/http_status.h"
 #include "util/debug_points.h"
-#include "util/easy_json.h"
 #include "util/time.h"
 
 namespace doris {
@@ -93,29 +92,6 @@ Status ClearDebugPointsAction::_handle(HttpRequest* req) {
     DebugPoints::instance()->clear();
 
     return Status::OK();
-}
-
-void GetDebugPointStatusAction::handle(HttpRequest* req) {
-    if (!config::enable_debug_points) {
-        auto status = Status::InternalError(
-                "Disable debug points. please check config::enable_debug_points");
-        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, status.to_json());
-        return;
-    }
-
-    auto name = req->param("debug_point");
-    if (name.empty()) {
-        auto status = Status::InternalError("Empty debug point name");
-        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, status.to_json());
-        return;
-    }
-
-    auto debug_point = DebugPoints::instance()->peek_debug_point(name);
-    EasyJson result;
-    result["status"] = "OK";
-    result["exists"] = debug_point != nullptr;
-    result["execute_num"] = debug_point ? debug_point->execute_num.load() : 0;
-    HttpChannel::send_reply(req, HttpStatus::OK, result.ToString());
 }
 
 } // namespace doris

--- a/be/src/service/http/action/debug_point_action.cpp
+++ b/be/src/service/http/action/debug_point_action.cpp
@@ -21,6 +21,7 @@
 #include "service/http/http_channel.h"
 #include "service/http/http_status.h"
 #include "util/debug_points.h"
+#include "util/easy_json.h"
 #include "util/time.h"
 
 namespace doris {
@@ -92,6 +93,29 @@ Status ClearDebugPointsAction::_handle(HttpRequest* req) {
     DebugPoints::instance()->clear();
 
     return Status::OK();
+}
+
+void GetDebugPointStatusAction::handle(HttpRequest* req) {
+    if (!config::enable_debug_points) {
+        auto status = Status::InternalError(
+                "Disable debug points. please check config::enable_debug_points");
+        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, status.to_json());
+        return;
+    }
+
+    auto name = req->param("debug_point");
+    if (name.empty()) {
+        auto status = Status::InternalError("Empty debug point name");
+        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, status.to_json());
+        return;
+    }
+
+    auto debug_point = DebugPoints::instance()->peek_debug_point(name);
+    EasyJson result;
+    result["status"] = "OK";
+    result["exists"] = debug_point != nullptr;
+    result["execute_num"] = debug_point ? debug_point->execute_num.load() : 0;
+    HttpChannel::send_reply(req, HttpStatus::OK, result.ToString());
 }
 
 } // namespace doris

--- a/be/src/service/http/action/debug_point_action.h
+++ b/be/src/service/http/action/debug_point_action.h
@@ -56,10 +56,4 @@ private:
     Status _handle(HttpRequest* req) override;
 };
 
-class GetDebugPointStatusAction : public HttpHandlerWithAuth {
-public:
-    using HttpHandlerWithAuth::HttpHandlerWithAuth;
-    void handle(HttpRequest* req) override;
-};
-
 } // namespace doris

--- a/be/src/service/http/action/debug_point_action.h
+++ b/be/src/service/http/action/debug_point_action.h
@@ -56,4 +56,10 @@ private:
     Status _handle(HttpRequest* req) override;
 };
 
+class GetDebugPointStatusAction : public HttpHandlerWithAuth {
+public:
+    using HttpHandlerWithAuth::HttpHandlerWithAuth;
+    void handle(HttpRequest* req) override;
+};
+
 } // namespace doris

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -315,11 +315,6 @@ void HttpService::register_debug_point_handler() {
             new ClearDebugPointsAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/debug_point/clear",
                                       clear_debug_points_action);
-
-    GetDebugPointStatusAction* get_debug_point_status_action = _pool.add(
-            new GetDebugPointStatusAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
-    _ev_http_server->register_handler(HttpMethod::GET, "/api/debug_point/status/{debug_point}",
-                                      get_debug_point_status_action);
 }
 
 // NOLINTBEGIN(readability-function-size)

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -315,6 +315,11 @@ void HttpService::register_debug_point_handler() {
             new ClearDebugPointsAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/debug_point/clear",
                                       clear_debug_points_action);
+
+    GetDebugPointStatusAction* get_debug_point_status_action = _pool.add(
+            new GetDebugPointStatusAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/debug_point/status/{debug_point}",
+                                      get_debug_point_status_action);
 }
 
 // NOLINTBEGIN(readability-function-size)

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -116,17 +116,30 @@ Status EnginePublishVersionTask::execute() {
         }
     });
     DBUG_EXECUTE_IF("EnginePublishVersionTask::execute.enable_spin_wait", {
-        auto token = dp->param<std::string>("token", "invalid_token");
-        while (DebugPoints::instance()->is_enable("EnginePublishVersionTask::execute.block")) {
-            auto block_dp = DebugPoints::instance()->get_debug_point(
-                    "EnginePublishVersionTask::execute.block");
-            if (block_dp) {
-                auto pass_token = block_dp->param<std::string>("pass_token", "");
-                if (pass_token == token) {
-                    break;
-                }
+        // Scope the fault injection to one partition when requested so unrelated publish tasks
+        // are not blocked by the same process-wide debug point.
+        auto target_partition_id = dp->param<int64_t>("partition_id", -1);
+        bool should_spin_wait = target_partition_id < 0;
+        for (const auto& partition_info : _publish_version_req.partition_version_infos) {
+            if (partition_info.partition_id == target_partition_id) {
+                should_spin_wait = true;
+                break;
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        if (should_spin_wait) {
+            auto token = dp->param<std::string>("token", "invalid_token");
+            while (DebugPoints::instance()->is_enable(
+                    "EnginePublishVersionTask::execute.block")) {
+                auto block_dp = DebugPoints::instance()->get_debug_point(
+                        "EnginePublishVersionTask::execute.block");
+                if (block_dp) {
+                    auto pass_token = block_dp->param<std::string>("pass_token", "");
+                    if (pass_token == token) {
+                        break;
+                    }
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
         }
     });
     std::unique_ptr<ThreadPoolToken> token = _engine.tablet_publish_txn_thread_pool()->new_token(

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -128,8 +128,7 @@ Status EnginePublishVersionTask::execute() {
         }
         if (should_spin_wait) {
             auto token = dp->param<std::string>("token", "invalid_token");
-            while (DebugPoints::instance()->is_enable(
-                    "EnginePublishVersionTask::execute.block")) {
+            while (DebugPoints::instance()->is_enable("EnginePublishVersionTask::execute.block")) {
                 auto block_dp = DebugPoints::instance()->get_debug_point(
                         "EnginePublishVersionTask::execute.block");
                 if (block_dp) {

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -115,18 +115,24 @@ Status EnginePublishVersionTask::execute() {
             std::this_thread::sleep_for(std::chrono::milliseconds(wait));
         }
     });
-    DBUG_EXECUTE_IF("EnginePublishVersionTask::execute.enable_spin_wait", {
-        // Scope the fault injection to one partition when requested so unrelated publish tasks
-        // are not blocked by the same process-wide debug point.
-        auto target_partition_id = dp->param<int64_t>("partition_id", -1);
-        bool should_spin_wait = target_partition_id < 0;
-        for (const auto& partition_info : _publish_version_req.partition_version_infos) {
-            if (partition_info.partition_id == target_partition_id) {
-                should_spin_wait = true;
-                break;
-            }
-        }
-        if (should_spin_wait) {
+    if (UNLIKELY(config::enable_debug_points)) {
+        auto dp = DebugPoints::instance()->get_debug_point_if(
+                "EnginePublishVersionTask::execute.enable_spin_wait",
+                [&](const DebugPoint& debug_point) {
+                    auto target_partition_id = debug_point.param<int64_t>("partition_id", -1);
+                    if (target_partition_id < 0) {
+                        return true;
+                    }
+                    for (const auto& partition_info :
+                         _publish_version_req.partition_version_infos) {
+                        if (partition_info.partition_id == target_partition_id) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+        if (dp) {
+            // The execute limit is consumed only after the partition predicate matches.
             auto token = dp->param<std::string>("token", "invalid_token");
             while (DebugPoints::instance()->is_enable("EnginePublishVersionTask::execute.block")) {
                 auto block_dp = DebugPoints::instance()->get_debug_point(
@@ -140,7 +146,7 @@ Status EnginePublishVersionTask::execute() {
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
             }
         }
-    });
+    }
     std::unique_ptr<ThreadPoolToken> token = _engine.tablet_publish_txn_thread_pool()->new_token(
             ThreadPool::ExecutionMode::CONCURRENT);
     std::unordered_map<int64_t, int64_t> tablet_id_to_num_delta_rows;

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -134,16 +134,16 @@ Status EnginePublishVersionTask::execute() {
         if (dp) {
             // The execute limit is consumed only after the partition predicate matches.
             auto token = dp->param<std::string>("token", "invalid_token");
-            auto block_dp = DebugPoints::instance()->get_debug_point(
-                    "EnginePublishVersionTask::execute.block");
-            while (block_dp) {
-                auto pass_token = block_dp->param<std::string>("pass_token", "");
-                if (pass_token == token) {
-                    break;
+            while (DebugPoints::instance()->is_enable("EnginePublishVersionTask::execute.block")) {
+                auto block_dp = DebugPoints::instance()->get_debug_point(
+                        "EnginePublishVersionTask::execute.block");
+                if (block_dp) {
+                    auto pass_token = block_dp->param<std::string>("pass_token", "");
+                    if (pass_token == token) {
+                        break;
+                    }
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                block_dp = DebugPoints::instance()->peek_debug_point(
-                        "EnginePublishVersionTask::execute.block");
             }
         }
     }

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -134,16 +134,16 @@ Status EnginePublishVersionTask::execute() {
         if (dp) {
             // The execute limit is consumed only after the partition predicate matches.
             auto token = dp->param<std::string>("token", "invalid_token");
-            while (DebugPoints::instance()->is_enable("EnginePublishVersionTask::execute.block")) {
-                auto block_dp = DebugPoints::instance()->get_debug_point(
-                        "EnginePublishVersionTask::execute.block");
-                if (block_dp) {
-                    auto pass_token = block_dp->param<std::string>("pass_token", "");
-                    if (pass_token == token) {
-                        break;
-                    }
+            auto block_dp = DebugPoints::instance()->get_debug_point(
+                    "EnginePublishVersionTask::execute.block");
+            while (block_dp) {
+                auto pass_token = block_dp->param<std::string>("pass_token", "");
+                if (pass_token == token) {
+                    break;
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                block_dp = DebugPoints::instance()->peek_debug_point(
+                        "EnginePublishVersionTask::execute.block");
             }
         }
     }

--- a/be/src/util/debug_points.cpp
+++ b/be/src/util/debug_points.cpp
@@ -34,6 +34,16 @@ bool DebugPoints::is_enable(const std::string& name) {
 }
 
 std::shared_ptr<DebugPoint> DebugPoints::get_debug_point(const std::string& name) {
+    return get_debug_point_impl(name, nullptr);
+}
+
+std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_if(
+        const std::string& name, const DebugPointPredicate& predicate) {
+    return get_debug_point_impl(name, &predicate);
+}
+
+std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_impl(
+        const std::string& name, const DebugPointPredicate* predicate) {
     if (!config::enable_debug_points) {
         return nullptr;
     }
@@ -44,10 +54,16 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point(const std::string& name
     }
 
     auto debug_point = it->second;
-    if ((debug_point->expire_ms > 0 && MonotonicMillis() >= debug_point->expire_ms) ||
-        (debug_point->execute_limit > 0 &&
-         debug_point->execute_num.fetch_add(1, std::memory_order_relaxed) >=
-                 debug_point->execute_limit)) {
+    if (debug_point->expire_ms > 0 && MonotonicMillis() >= debug_point->expire_ms) {
+        remove(name);
+        return nullptr;
+    }
+    if (predicate != nullptr && !(*predicate)(*debug_point)) {
+        return nullptr;
+    }
+    if (debug_point->execute_limit > 0 &&
+        debug_point->execute_num.fetch_add(1, std::memory_order_relaxed) >=
+                debug_point->execute_limit) {
         remove(name);
         return nullptr;
     }

--- a/be/src/util/debug_points.cpp
+++ b/be/src/util/debug_points.cpp
@@ -37,6 +37,24 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point(const std::string& name
     return get_debug_point_impl(name, nullptr);
 }
 
+std::shared_ptr<DebugPoint> DebugPoints::peek_debug_point(const std::string& name) {
+    if (!config::enable_debug_points) {
+        return nullptr;
+    }
+    auto map_ptr = _debug_points.load();
+    auto it = map_ptr->find(name);
+    if (it == map_ptr->end()) {
+        return nullptr;
+    }
+
+    auto debug_point = it->second;
+    if (debug_point->expire_ms > 0 && MonotonicMillis() >= debug_point->expire_ms) {
+        remove(name);
+        return nullptr;
+    }
+    return debug_point;
+}
+
 std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_if(const std::string& name,
                                                             const DebugPointPredicate& predicate) {
     return get_debug_point_impl(name, &predicate);

--- a/be/src/util/debug_points.cpp
+++ b/be/src/util/debug_points.cpp
@@ -37,8 +37,8 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point(const std::string& name
     return get_debug_point_impl(name, nullptr);
 }
 
-std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_if(
-        const std::string& name, const DebugPointPredicate& predicate) {
+std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_if(const std::string& name,
+                                                            const DebugPointPredicate& predicate) {
     return get_debug_point_impl(name, &predicate);
 }
 

--- a/be/src/util/debug_points.cpp
+++ b/be/src/util/debug_points.cpp
@@ -37,24 +37,6 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point(const std::string& name
     return get_debug_point_impl(name, nullptr);
 }
 
-std::shared_ptr<DebugPoint> DebugPoints::peek_debug_point(const std::string& name) {
-    if (!config::enable_debug_points) {
-        return nullptr;
-    }
-    auto map_ptr = _debug_points.load();
-    auto it = map_ptr->find(name);
-    if (it == map_ptr->end()) {
-        return nullptr;
-    }
-
-    auto debug_point = it->second;
-    if (debug_point->expire_ms > 0 && MonotonicMillis() >= debug_point->expire_ms) {
-        remove(name);
-        return nullptr;
-    }
-    return debug_point;
-}
-
 std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_if(const std::string& name,
                                                             const DebugPointPredicate& predicate) {
     return get_debug_point_impl(name, &predicate);

--- a/be/src/util/debug_points.cpp
+++ b/be/src/util/debug_points.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_impl(
 
     auto debug_point = it->second;
     if (debug_point->expire_ms > 0 && MonotonicMillis() >= debug_point->expire_ms) {
-        remove(name);
+        remove_if_same(name, debug_point);
         return nullptr;
     }
     if (predicate != nullptr && !(*predicate)(*debug_point)) {
@@ -64,7 +64,7 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_impl(
     if (debug_point->execute_limit > 0 &&
         debug_point->execute_num.fetch_add(1, std::memory_order_relaxed) >=
                 debug_point->execute_limit) {
-        remove(name);
+        remove_if_same(name, debug_point);
         return nullptr;
     }
 
@@ -89,6 +89,21 @@ void DebugPoints::remove(const std::string& name) {
     update([&](DebugPointMap& new_points) { exists = new_points.erase(name) > 0; });
 
     LOG(INFO) << "remove debug point: name=" << name << ", exists=" << exists;
+}
+
+void DebugPoints::remove_if_same(const std::string& name,
+                                 const std::shared_ptr<DebugPoint>& expected_debug_point) {
+    bool removed = false;
+    update([&](DebugPointMap& new_points) {
+        removed = false;
+        auto it = new_points.find(name);
+        if (it != new_points.end() && it->second == expected_debug_point) {
+            new_points.erase(it);
+            removed = true;
+        }
+    });
+
+    LOG(INFO) << "remove debug point if same: name=" << name << ", removed=" << removed;
 }
 
 void DebugPoints::update(std::function<void(DebugPointMap&)>&& handler) {

--- a/be/src/util/debug_points.cpp
+++ b/be/src/util/debug_points.cpp
@@ -37,6 +37,24 @@ std::shared_ptr<DebugPoint> DebugPoints::get_debug_point(const std::string& name
     return get_debug_point_impl(name, nullptr);
 }
 
+std::shared_ptr<DebugPoint> DebugPoints::peek_debug_point(const std::string& name) {
+    if (!config::enable_debug_points) {
+        return nullptr;
+    }
+    auto map_ptr = _debug_points.load();
+    auto it = map_ptr->find(name);
+    if (it == map_ptr->end()) {
+        return nullptr;
+    }
+
+    auto debug_point = it->second;
+    if (debug_point->expire_ms > 0 && MonotonicMillis() >= debug_point->expire_ms) {
+        remove_if_same(name, debug_point);
+        return nullptr;
+    }
+    return debug_point;
+}
+
 std::shared_ptr<DebugPoint> DebugPoints::get_debug_point_if(const std::string& name,
                                                             const DebugPointPredicate& predicate) {
     return get_debug_point_impl(name, &predicate);

--- a/be/src/util/debug_points.h
+++ b/be/src/util/debug_points.h
@@ -141,8 +141,6 @@ public:
 
     bool is_enable(const std::string& name);
     std::shared_ptr<DebugPoint> get_debug_point(const std::string& name);
-    // Inspect a debug point without consuming its execute limit.
-    std::shared_ptr<DebugPoint> peek_debug_point(const std::string& name);
     // A nonmatching access does not consume the debug point's execute limit.
     std::shared_ptr<DebugPoint> get_debug_point_if(const std::string& name,
                                                    const DebugPointPredicate& predicate);

--- a/be/src/util/debug_points.h
+++ b/be/src/util/debug_points.h
@@ -141,6 +141,8 @@ public:
 
     bool is_enable(const std::string& name);
     std::shared_ptr<DebugPoint> get_debug_point(const std::string& name);
+    // Inspect a debug point without consuming its execute limit.
+    std::shared_ptr<DebugPoint> peek_debug_point(const std::string& name);
     // A nonmatching access does not consume the debug point's execute limit.
     std::shared_ptr<DebugPoint> get_debug_point_if(const std::string& name,
                                                    const DebugPointPredicate& predicate);

--- a/be/src/util/debug_points.h
+++ b/be/src/util/debug_points.h
@@ -193,6 +193,8 @@ private:
 
     std::shared_ptr<DebugPoint> get_debug_point_impl(const std::string& name,
                                                      const DebugPointPredicate* predicate);
+    void remove_if_same(const std::string& name,
+                        const std::shared_ptr<DebugPoint>& expected_debug_point);
 
     // handler(new_debug_points)
     void update(std::function<void(DebugPointMap&)>&& handler);

--- a/be/src/util/debug_points.h
+++ b/be/src/util/debug_points.h
@@ -101,7 +101,7 @@ struct DebugPoint {
     std::any callback;
 
     template <typename T>
-    T param(const std::string& key, T default_value = T()) {
+    T param(const std::string& key, T default_value = T()) const {
         auto it = params.find(key);
         if (it == params.end()) {
             return default_value;
@@ -137,8 +137,13 @@ struct DebugPoint {
 
 class DebugPoints {
 public:
+    using DebugPointPredicate = std::function<bool(const DebugPoint&)>;
+
     bool is_enable(const std::string& name);
     std::shared_ptr<DebugPoint> get_debug_point(const std::string& name);
+    // A nonmatching access does not consume the debug point's execute limit.
+    std::shared_ptr<DebugPoint> get_debug_point_if(const std::string& name,
+                                                   const DebugPointPredicate& predicate);
     void remove(const std::string& name);
     void clear();
 
@@ -185,6 +190,9 @@ private:
     DebugPoints();
 
     using DebugPointMap = std::map<std::string, std::shared_ptr<DebugPoint>>;
+
+    std::shared_ptr<DebugPoint> get_debug_point_impl(const std::string& name,
+                                                     const DebugPointPredicate* predicate);
 
     // handler(new_debug_points)
     void update(std::function<void(DebugPointMap&)>&& handler);

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -121,6 +121,29 @@ TEST(DebugPointsTest, PredicateDoesNotConsumeExecuteLimit) {
     EXPECT_FALSE(DebugPoints::instance()->is_enable("conditional"));
 }
 
+TEST(DebugPointsTest, PeekDoesNotConsumeExecuteLimit) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->clear();
+
+    auto debug_point = std::make_shared<DebugPoint>();
+    debug_point->execute_limit = 1;
+    DebugPoints::instance()->add("peek", debug_point);
+
+    EXPECT_NE(nullptr, DebugPoints::instance()->get_debug_point("peek"));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+    EXPECT_EQ(debug_point, DebugPoints::instance()->peek_debug_point("peek"));
+    EXPECT_EQ(debug_point, DebugPoints::instance()->peek_debug_point("peek"));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+
+    std::string response;
+    HttpClient client;
+    ASSERT_TRUE(client.init(global_test_http_host + "/api/debug_point/status/peek").ok());
+    ASSERT_TRUE(client.execute(&response).ok());
+    EXPECT_NE(std::string::npos, response.find("\"exists\":true"));
+    EXPECT_NE(std::string::npos, response.find("\"execute_num\":1"));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+}
+
 void demo_callback() {
     int a = 0;
 

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -108,8 +108,7 @@ TEST(DebugPointsTest, PredicateDoesNotConsumeExecuteLimit) {
     auto does_not_match = [](const DebugPoint& point) {
         return point.param<int64_t>("partition_id") == 456;
     };
-    EXPECT_EQ(nullptr,
-              DebugPoints::instance()->get_debug_point_if("conditional", does_not_match));
+    EXPECT_EQ(nullptr, DebugPoints::instance()->get_debug_point_if("conditional", does_not_match));
     EXPECT_EQ(0, debug_point->execute_num.load());
 
     auto matches = [](const DebugPoint& point) {

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -152,6 +152,29 @@ TEST(DebugPointsTest, ConcurrentReplacementSurvivesExhaustedLookup) {
     EXPECT_EQ(replacement_point, DebugPoints::instance()->get_debug_point("conditional"));
 }
 
+TEST(DebugPointsTest, PeekDoesNotConsumeExecuteLimit) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->clear();
+
+    auto debug_point = std::make_shared<DebugPoint>();
+    debug_point->execute_limit = 1;
+    DebugPoints::instance()->add("peek", debug_point);
+
+    EXPECT_NE(nullptr, DebugPoints::instance()->get_debug_point("peek"));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+    EXPECT_EQ(debug_point, DebugPoints::instance()->peek_debug_point("peek"));
+    EXPECT_EQ(debug_point, DebugPoints::instance()->peek_debug_point("peek"));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+
+    std::string response;
+    HttpClient client;
+    ASSERT_TRUE(client.init(global_test_http_host + "/api/debug_point/status/peek").ok());
+    ASSERT_TRUE(client.execute(&response).ok());
+    EXPECT_NE(std::string::npos, response.find("\"exists\":true"));
+    EXPECT_NE(std::string::npos, response.find("\"execute_num\":1"));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+}
+
 void demo_callback() {
     int a = 0;
 

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -96,6 +96,32 @@ TEST(DebugPointsTest, AddTest) {
               DebugPoints::instance()->get_debug_param_or_default<std::string>("dbug4", ""));
 }
 
+TEST(DebugPointsTest, PredicateDoesNotConsumeExecuteLimit) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->clear();
+
+    auto debug_point = std::make_shared<DebugPoint>();
+    debug_point->execute_limit = 1;
+    debug_point->params["partition_id"] = "123";
+    DebugPoints::instance()->add("conditional", debug_point);
+
+    auto does_not_match = [](const DebugPoint& point) {
+        return point.param<int64_t>("partition_id") == 456;
+    };
+    EXPECT_EQ(nullptr,
+              DebugPoints::instance()->get_debug_point_if("conditional", does_not_match));
+    EXPECT_EQ(0, debug_point->execute_num.load());
+
+    auto matches = [](const DebugPoint& point) {
+        return point.param<int64_t>("partition_id") == 123;
+    };
+    EXPECT_NE(nullptr, DebugPoints::instance()->get_debug_point_if("conditional", matches));
+    EXPECT_EQ(1, debug_point->execute_num.load());
+    EXPECT_EQ(nullptr, DebugPoints::instance()->get_debug_point_if("conditional", matches));
+    EXPECT_EQ(2, debug_point->execute_num.load());
+    EXPECT_FALSE(DebugPoints::instance()->is_enable("conditional"));
+}
+
 void demo_callback() {
     int a = 0;
 

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -121,29 +121,6 @@ TEST(DebugPointsTest, PredicateDoesNotConsumeExecuteLimit) {
     EXPECT_FALSE(DebugPoints::instance()->is_enable("conditional"));
 }
 
-TEST(DebugPointsTest, PeekDoesNotConsumeExecuteLimit) {
-    config::enable_debug_points = true;
-    DebugPoints::instance()->clear();
-
-    auto debug_point = std::make_shared<DebugPoint>();
-    debug_point->execute_limit = 1;
-    DebugPoints::instance()->add("peek", debug_point);
-
-    EXPECT_NE(nullptr, DebugPoints::instance()->get_debug_point("peek"));
-    EXPECT_EQ(1, debug_point->execute_num.load());
-    EXPECT_EQ(debug_point, DebugPoints::instance()->peek_debug_point("peek"));
-    EXPECT_EQ(debug_point, DebugPoints::instance()->peek_debug_point("peek"));
-    EXPECT_EQ(1, debug_point->execute_num.load());
-
-    std::string response;
-    HttpClient client;
-    ASSERT_TRUE(client.init(global_test_http_host + "/api/debug_point/status/peek").ok());
-    ASSERT_TRUE(client.execute(&response).ok());
-    EXPECT_NE(std::string::npos, response.find("\"exists\":true"));
-    EXPECT_NE(std::string::npos, response.find("\"execute_num\":1"));
-    EXPECT_EQ(1, debug_point->execute_num.load());
-}
-
 void demo_callback() {
     int a = 0;
 

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 
+#include <barrier>
 #include <chrono>
 #include <thread>
 
@@ -119,6 +120,36 @@ TEST(DebugPointsTest, PredicateDoesNotConsumeExecuteLimit) {
     EXPECT_EQ(nullptr, DebugPoints::instance()->get_debug_point_if("conditional", matches));
     EXPECT_EQ(2, debug_point->execute_num.load());
     EXPECT_FALSE(DebugPoints::instance()->is_enable("conditional"));
+}
+
+TEST(DebugPointsTest, ConcurrentReplacementSurvivesExhaustedLookup) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->clear();
+
+    auto exhausted_point = std::make_shared<DebugPoint>();
+    exhausted_point->execute_limit = 1;
+    exhausted_point->execute_num.store(1);
+    DebugPoints::instance()->add("conditional", exhausted_point);
+
+    std::barrier sync_point(2);
+    std::shared_ptr<DebugPoint> lookup_result;
+    std::thread lookup_thread([&] {
+        lookup_result = DebugPoints::instance()->get_debug_point_if(
+                "conditional", [&](const DebugPoint&) {
+                    sync_point.arrive_and_wait();
+                    sync_point.arrive_and_wait();
+                    return true;
+                });
+    });
+
+    sync_point.arrive_and_wait();
+    auto replacement_point = std::make_shared<DebugPoint>();
+    DebugPoints::instance()->add("conditional", replacement_point);
+    sync_point.arrive_and_wait();
+    lookup_thread.join();
+
+    EXPECT_EQ(nullptr, lookup_result);
+    EXPECT_EQ(replacement_point, DebugPoints::instance()->get_debug_point("conditional"));
 }
 
 void demo_callback() {

--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -134,8 +134,8 @@ TEST(DebugPointsTest, ConcurrentReplacementSurvivesExhaustedLookup) {
     std::barrier sync_point(2);
     std::shared_ptr<DebugPoint> lookup_result;
     std::thread lookup_thread([&] {
-        lookup_result = DebugPoints::instance()->get_debug_point_if(
-                "conditional", [&](const DebugPoint&) {
+        lookup_result =
+                DebugPoints::instance()->get_debug_point_if("conditional", [&](const DebugPoint&) {
                     sync_point.arrive_and_wait();
                     sync_point.arrive_and_wait();
                     return true;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
@@ -112,22 +112,6 @@ public class DebugPointUtil {
         return debugPoint;
     }
 
-    public static DebugPoint peekDebugPoint(String debugPointName) {
-        if (!Config.enable_debug_points) {
-            return null;
-        }
-
-        DebugPoint debugPoint = debugPoints.get(debugPointName);
-        if (debugPoint == null) {
-            return null;
-        }
-        if (debugPoint.expireTime > 0 && System.currentTimeMillis() >= debugPoint.expireTime) {
-            debugPoints.remove(debugPointName);
-            return null;
-        }
-        return debugPoint;
-    }
-
     // if not enable debug point or its params not contains `key`, then return `defaultValue`
     // url: /api/debug_point/add/name?k1=v1&k2=v2&...
     public static <E> E getDebugParamOrDefault(String debugPointName, String key, E defaultValue) {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
@@ -112,6 +112,22 @@ public class DebugPointUtil {
         return debugPoint;
     }
 
+    public static DebugPoint peekDebugPoint(String debugPointName) {
+        if (!Config.enable_debug_points) {
+            return null;
+        }
+
+        DebugPoint debugPoint = debugPoints.get(debugPointName);
+        if (debugPoint == null) {
+            return null;
+        }
+        if (debugPoint.expireTime > 0 && System.currentTimeMillis() >= debugPoint.expireTime) {
+            debugPoints.remove(debugPointName);
+            return null;
+        }
+        return debugPoint;
+    }
+
     // if not enable debug point or its params not contains `key`, then return `defaultValue`
     // url: /api/debug_point/add/name?k1=v1&k2=v2&...
     public static <E> E getDebugParamOrDefault(String debugPointName, String key, E defaultValue) {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
@@ -112,6 +112,22 @@ public class DebugPointUtil {
         return debugPoint;
     }
 
+    public static DebugPoint peekDebugPoint(String debugPointName) {
+        if (!Config.enable_debug_points) {
+            return null;
+        }
+
+        DebugPoint debugPoint = debugPoints.get(debugPointName);
+        if (debugPoint == null) {
+            return null;
+        }
+        if (debugPoint.expireTime > 0 && System.currentTimeMillis() >= debugPoint.expireTime) {
+            debugPoints.remove(debugPointName, debugPoint);
+            return null;
+        }
+        return debugPoint;
+    }
+
     // if not enable debug point or its params not contains `key`, then return `defaultValue`
     // url: /api/debug_point/add/name?k1=v1&k2=v2&...
     public static <E> E getDebugParamOrDefault(String debugPointName, String key, E defaultValue) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -1157,14 +1157,14 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 LOG.info("error ", e);
             }
         }
-        DebugPoint spinWaitDebugPoint = DebugPointUtil.getDebugPoint(
-                "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
-        if (spinWaitDebugPoint != null) {
+        if (DebugPointUtil.isEnable("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")) {
             LOG.info("debug point: block at CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
-            String token = spinWaitDebugPoint.param("token", "invalid_token");
-            DebugPoint blockDebugPoint = DebugPointUtil.getDebugPoint(
-                    "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block");
-            while (blockDebugPoint != null) {
+            DebugPoint debugPoint = DebugPointUtil.getDebugPoint(
+                    "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
+            String token = debugPoint.param("token", "invalid_token");
+            while (DebugPointUtil.isEnable("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")) {
+                DebugPoint blockDebugPoint = DebugPointUtil.getDebugPoint(
+                        "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block");
                 String passToken = blockDebugPoint.param("pass_token", "");
                 if (token.equals(passToken)) {
                     break;
@@ -1174,8 +1174,6 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 } catch (InterruptedException e) {
                     LOG.info("error ", e);
                 }
-                blockDebugPoint = DebugPointUtil.peekDebugPoint(
-                        "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block");
             }
             LOG.info("debug point: leave CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -1157,14 +1157,14 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 LOG.info("error ", e);
             }
         }
-        if (DebugPointUtil.isEnable("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")) {
+        DebugPoint spinWaitDebugPoint = DebugPointUtil.getDebugPoint(
+                "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
+        if (spinWaitDebugPoint != null) {
             LOG.info("debug point: block at CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
-            DebugPoint debugPoint = DebugPointUtil.getDebugPoint(
-                    "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
-            String token = debugPoint.param("token", "invalid_token");
-            while (DebugPointUtil.isEnable("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")) {
-                DebugPoint blockDebugPoint = DebugPointUtil.getDebugPoint(
-                        "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block");
+            String token = spinWaitDebugPoint.param("token", "invalid_token");
+            DebugPoint blockDebugPoint = DebugPointUtil.getDebugPoint(
+                    "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block");
+            while (blockDebugPoint != null) {
                 String passToken = blockDebugPoint.param("pass_token", "");
                 if (token.equals(passToken)) {
                     break;
@@ -1174,6 +1174,8 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 } catch (InterruptedException e) {
                     LOG.info("error ", e);
                 }
+                blockDebugPoint = DebugPointUtil.peekDebugPoint(
+                        "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block");
             }
             LOG.info("debug point: leave CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/DebugPointAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/DebugPointAction.java
@@ -24,6 +24,7 @@ import org.apache.doris.httpv2.controller.BaseController.ActionAuthorizationInfo
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,6 +38,25 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class DebugPointAction extends RestBaseController {
+
+    @RequestMapping(path = "/api/debug_point/status/{debugPoint}", method = RequestMethod.GET)
+    protected Object getDebugPointStatus(@PathVariable("debugPoint") String name,
+            HttpServletRequest request, HttpServletResponse response) {
+        if (!Config.enable_debug_points) {
+            return ResponseEntityBuilder.internalError(
+                    "Disable debug points. please check Config.enable_debug_points");
+        }
+        ActionAuthorizationInfo authInfo = executeCheckPassword(request, response);
+        checkAdminAuth(authInfo.userIdentity);
+        if (Strings.isNullOrEmpty(name)) {
+            return ResponseEntityBuilder.badRequest("Empty debug point name.");
+        }
+
+        DebugPoint debugPoint = DebugPointUtil.peekDebugPoint(name);
+        return ResponseEntityBuilder.ok(ImmutableMap.of(
+                "exists", debugPoint != null,
+                "execute_num", debugPoint == null ? 0 : debugPoint.executeNum.get()));
+    }
 
     @RequestMapping(path = "/api/debug_point/add/{debugPoint}", method = RequestMethod.POST)
     protected Object addDebugPoint(@PathVariable("debugPoint") String name,

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/DebugPointAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/DebugPointAction.java
@@ -24,7 +24,6 @@ import org.apache.doris.httpv2.controller.BaseController.ActionAuthorizationInfo
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,25 +37,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class DebugPointAction extends RestBaseController {
-
-    @RequestMapping(path = "/api/debug_point/status/{debugPoint}", method = RequestMethod.GET)
-    protected Object getDebugPointStatus(@PathVariable("debugPoint") String name,
-            HttpServletRequest request, HttpServletResponse response) {
-        if (!Config.enable_debug_points) {
-            return ResponseEntityBuilder.internalError(
-                    "Disable debug points. please check Config.enable_debug_points");
-        }
-        ActionAuthorizationInfo authInfo = executeCheckPassword(request, response);
-        checkAdminAuth(authInfo.userIdentity);
-        if (Strings.isNullOrEmpty(name)) {
-            return ResponseEntityBuilder.badRequest("Empty debug point name.");
-        }
-
-        DebugPoint debugPoint = DebugPointUtil.peekDebugPoint(name);
-        return ResponseEntityBuilder.ok(ImmutableMap.of(
-                "exists", debugPoint != null,
-                "execute_num", debugPoint == null ? 0 : debugPoint.executeNum.get()));
-    }
 
     @RequestMapping(path = "/api/debug_point/add/{debugPoint}", method = RequestMethod.POST)
     protected Object addDebugPoint(@PathVariable("debugPoint") String name,

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugPointUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugPointUtilTest.java
@@ -72,6 +72,18 @@ public class DebugPointUtilTest extends DorisHttpTestCase {
 
         sendRequest("/api/debug_point/add/dbug6?value=100");
         Assert.assertEquals(100, (int) DebugPointUtil.getDebugParamOrDefault("dbug6", 0));
+
+        sendRequest("/api/debug_point/add/dbug7?execute=1");
+        DebugPoint executeLimited = DebugPointUtil.getDebugPoint("dbug7");
+        Assert.assertNotNull(executeLimited);
+        Assert.assertEquals(1, executeLimited.executeNum.get());
+        Assert.assertSame(executeLimited, DebugPointUtil.peekDebugPoint("dbug7"));
+        Assert.assertSame(executeLimited, DebugPointUtil.peekDebugPoint("dbug7"));
+        Assert.assertEquals(1, executeLimited.executeNum.get());
+        String status = sendGetRequest("/api/debug_point/status/dbug7");
+        Assert.assertTrue(status.contains("\"exists\":true"));
+        Assert.assertTrue(status.contains("\"execute_num\":1"));
+        Assert.assertEquals(1, executeLimited.executeNum.get());
     }
 
     private void sendRequest(String uri) throws Exception {
@@ -84,5 +96,18 @@ public class DebugPointUtilTest extends DorisHttpTestCase {
         Response response = networkClient.newCall(request).execute();
         Assert.assertNotNull(response.body());
         Assert.assertEquals(200, response.code());
+    }
+
+    private String sendGetRequest(String uri) throws Exception {
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url("http://localhost:" + HTTP_PORT + uri)
+                .build();
+
+        Response response = networkClient.newCall(request).execute();
+        Assert.assertNotNull(response.body());
+        Assert.assertEquals(200, response.code());
+        return response.body().string();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugPointUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugPointUtilTest.java
@@ -72,18 +72,6 @@ public class DebugPointUtilTest extends DorisHttpTestCase {
 
         sendRequest("/api/debug_point/add/dbug6?value=100");
         Assert.assertEquals(100, (int) DebugPointUtil.getDebugParamOrDefault("dbug6", 0));
-
-        sendRequest("/api/debug_point/add/dbug7?execute=1");
-        DebugPoint executeLimited = DebugPointUtil.getDebugPoint("dbug7");
-        Assert.assertNotNull(executeLimited);
-        Assert.assertEquals(1, executeLimited.executeNum.get());
-        Assert.assertSame(executeLimited, DebugPointUtil.peekDebugPoint("dbug7"));
-        Assert.assertSame(executeLimited, DebugPointUtil.peekDebugPoint("dbug7"));
-        Assert.assertEquals(1, executeLimited.executeNum.get());
-        String status = sendGetRequest("/api/debug_point/status/dbug7");
-        Assert.assertTrue(status.contains("\"exists\":true"));
-        Assert.assertTrue(status.contains("\"execute_num\":1"));
-        Assert.assertEquals(1, executeLimited.executeNum.get());
     }
 
     private void sendRequest(String uri) throws Exception {
@@ -96,18 +84,5 @@ public class DebugPointUtilTest extends DorisHttpTestCase {
         Response response = networkClient.newCall(request).execute();
         Assert.assertNotNull(response.body());
         Assert.assertEquals(200, response.code());
-    }
-
-    private String sendGetRequest(String uri) throws Exception {
-        Request request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .url("http://localhost:" + HTTP_PORT + uri)
-                .build();
-
-        Response response = networkClient.newCall(request).execute();
-        Assert.assertNotNull(response.body());
-        Assert.assertEquals(200, response.code());
-        return response.body().string();
     }
 }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/DebugPoint.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/DebugPoint.groovy
@@ -81,6 +81,14 @@ class DebugPoint {
         Http.checkHttpResult(result, type)
     }
 
+    static boolean isDebugPointHit(String host, int httpPort, NodeType type, String name) {
+        def url = 'http://' + host + ':' + httpPort + '/api/debug_point/status/' + name
+        def result = Http.GET(url, true, false)
+        Http.checkHttpResult(result, type)
+        def status = type == NodeType.FE ? result.data : result
+        return status.exists && (status.execute_num as long) > 0
+    }
+
     def operateDebugPointForAllFEs(Closure closure) {
         getFEHostAndHTTPPort().each { httpAddr ->
             def pos = httpAddr.indexOf(':')
@@ -164,6 +172,15 @@ class DebugPoint {
         return suite.getFrontendIpHttpPort()
     }
 
+    boolean isDebugPointHitOnAnyFE(String name) {
+        return getFEHostAndHTTPPort().any { httpAddr ->
+            def pos = httpAddr.indexOf(':')
+            def ip = httpAddr.substring(0, pos)
+            def port = httpAddr.substring(pos + 1) as int
+            port != -1 && isDebugPointHit(ip, port, NodeType.FE, name)
+        }
+    }
+
     def enableDebugPointForAllFEs(String name, Map<String, String> params = null) {
         operateDebugPointForAllFEs({ host, port ->
             logger.info("enable debug point ${name} with params ${params} for FE $host:$port")
@@ -197,4 +214,3 @@ class DebugPoint {
         }
     }
 }
-

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/DebugPoint.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/DebugPoint.groovy
@@ -81,14 +81,6 @@ class DebugPoint {
         Http.checkHttpResult(result, type)
     }
 
-    static boolean isDebugPointHit(String host, int httpPort, NodeType type, String name) {
-        def url = 'http://' + host + ':' + httpPort + '/api/debug_point/status/' + name
-        def result = Http.GET(url, true, false)
-        Http.checkHttpResult(result, type)
-        def status = type == NodeType.FE ? result.data : result
-        return status.exists && (status.execute_num as long) > 0
-    }
-
     def operateDebugPointForAllFEs(Closure closure) {
         getFEHostAndHTTPPort().each { httpAddr ->
             def pos = httpAddr.indexOf(':')
@@ -172,15 +164,6 @@ class DebugPoint {
         return suite.getFrontendIpHttpPort()
     }
 
-    boolean isDebugPointHitOnAnyFE(String name) {
-        return getFEHostAndHTTPPort().any { httpAddr ->
-            def pos = httpAddr.indexOf(':')
-            def ip = httpAddr.substring(0, pos)
-            def port = httpAddr.substring(pos + 1) as int
-            port != -1 && isDebugPointHit(ip, port, NodeType.FE, name)
-        }
-    }
-
     def enableDebugPointForAllFEs(String name, Map<String, String> params = null) {
         operateDebugPointForAllFEs({ host, port ->
             logger.info("enable debug point ${name} with params ${params} for FE $host:$port")
@@ -214,3 +197,4 @@ class DebugPoint {
         }
     }
 }
+

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -24,6 +24,10 @@ import org.apache.doris.regression.util.NodeType
 suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def table1 = "test_partial_update_skip_compaction"
+    def cloudSpinWaitPoint = "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait"
+    def cloudBlockPoint = "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block"
+    def beSpinWaitPoint = "EnginePublishVersionTask::execute.enable_spin_wait"
+    def beBlockPoint = "EnginePublishVersionTask::execute.block"
     sql "DROP TABLE IF EXISTS ${table1} FORCE;"
     sql """ CREATE TABLE IF NOT EXISTS ${table1} (
             `k1` int NOT NULL,
@@ -97,38 +101,50 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def enable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
+            GetDebugPoint().enableDebugPointForAllFEs(cloudSpinWaitPoint, [execute: "1"])
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.enable_spin_wait", [partition_id: "${partitionId}"])
+                    beSpinWaitPoint, [partition_id: "${partitionId}", execute: "1"])
         }
     }
 
     def disable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
+            GetDebugPoint().disableDebugPointForAllFEs(cloudSpinWaitPoint)
         } else {
             DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.enable_spin_wait")
+                    beSpinWaitPoint)
         }
     }
 
     def enable_block_in_publish = {
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
+            GetDebugPoint().enableDebugPointForAllFEs(cloudBlockPoint, [execute: "1"])
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.block")
+                    beBlockPoint, [execute: "1"])
         }
     }
 
     def disable_block_in_publish = {
         if (isCloudMode()) {
-            GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
+            GetDebugPoint().disableDebugPointForAllFEs(cloudBlockPoint)
         } else {
             DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.block")
+                    beBlockPoint)
         }
+    }
+
+    def wait_publish_block_hit = {
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+            {
+                if (isCloudMode()) {
+                    return GetDebugPoint().isDebugPointHitOnAnyFE(cloudBlockPoint)
+                }
+                return DebugPoint.isDebugPointHit(tabletBackend.Host, tabletBackend.HttpPort as int,
+                        NodeType.BE, beBlockPoint)
+            }
+        )
     }
 
     try {
@@ -144,7 +160,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
             sql "insert into ${table1}(k1,c1,c2) values(1,999,999),(2,888,888),(3,777,777);"
         }
 
-        Thread.sleep(500)
+        // Do not start compaction until the load has reached and is blocked in the publish hook.
+        wait_publish_block_hit()
 
         // trigger full compaction on tablet
         logger.info("trigger compaction on another BE ${tabletBackend.Host} with backendId=${tabletBackend.BackendId}")

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -18,6 +18,8 @@
 import org.junit.Assert
 import java.util.concurrent.TimeUnit
 import org.awaitility.Awaitility
+import org.apache.doris.regression.util.DebugPoint
+import org.apache.doris.regression.util.NodeType
 
 suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
@@ -45,6 +47,7 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
     def tabletStat = sql_return_maparray("show tablets from ${table1};").get(0)
     def tabletBackendId = tabletStat.BackendId
     def tabletId = tabletStat.TabletId
+    def partitionId = tabletStat.PartitionId
     def tabletBackend;
     for (def be : beNodes) {
         if (be.BackendId == tabletBackendId) {
@@ -92,7 +95,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         if (isCloudMode()) {
             GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
         } else {
-            GetDebugPoint().enableDebugPointForAllBEs("EnginePublishVersionTask::execute.enable_spin_wait")
+            DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
+                    "EnginePublishVersionTask::execute.enable_spin_wait", [partition_id: "${partitionId}"])
         }
     }
 
@@ -100,7 +104,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         if (isCloudMode()) {
             GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
         } else {
-            GetDebugPoint().disableDebugPointForAllBEs("EnginePublishVersionTask::execute.enable_spin_wait")
+            DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
+                    "EnginePublishVersionTask::execute.enable_spin_wait")
         }
     }
 
@@ -108,7 +113,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         if (isCloudMode()) {
             GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
         } else {
-            GetDebugPoint().enableDebugPointForAllBEs("EnginePublishVersionTask::execute.block")
+            DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
+                    "EnginePublishVersionTask::execute.block")
         }
     }
 
@@ -116,7 +122,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         if (isCloudMode()) {
             GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
         } else {
-            GetDebugPoint().disableDebugPointForAllBEs("EnginePublishVersionTask::execute.block")
+            DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
+                    "EnginePublishVersionTask::execute.block")
         }
     }
 
@@ -166,7 +173,18 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
         // let the partial update load publish
         disable_block_in_publish()
+        disable_publish_spin_wait()
         t1.join()
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+            {
+                def updatedRows = sql """ select count(*) from ${table1}
+                        where (k1 = 1 and c1 = 999 and c2 = 999 and c3 = 1 and c4 = 1)
+                           or (k1 = 2 and c1 = 888 and c2 = 888 and c3 = 2 and c4 = 2)
+                           or (k1 = 3 and c1 = 777 and c2 = 777 and c3 = 3 and c4 = 3); """
+                return (updatedRows[0][0] as int) == 3
+            }
+        )
 
         order_qt_sql "select * from ${table1};"
 

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -24,10 +24,6 @@ import org.apache.doris.regression.util.NodeType
 suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def table1 = "test_partial_update_skip_compaction"
-    def cloudSpinWaitPoint = "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait"
-    def cloudBlockPoint = "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block"
-    def beSpinWaitPoint = "EnginePublishVersionTask::execute.enable_spin_wait"
-    def beBlockPoint = "EnginePublishVersionTask::execute.block"
     sql "DROP TABLE IF EXISTS ${table1} FORCE;"
     sql """ CREATE TABLE IF NOT EXISTS ${table1} (
             `k1` int NOT NULL,
@@ -101,50 +97,38 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def enable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs(cloudSpinWaitPoint, [execute: "1"])
+            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    beSpinWaitPoint, [partition_id: "${partitionId}", execute: "1"])
+                    "EnginePublishVersionTask::execute.enable_spin_wait", [partition_id: "${partitionId}"])
         }
     }
 
     def disable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().disableDebugPointForAllFEs(cloudSpinWaitPoint)
+            GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
         } else {
             DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    beSpinWaitPoint)
+                    "EnginePublishVersionTask::execute.enable_spin_wait")
         }
     }
 
     def enable_block_in_publish = {
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs(cloudBlockPoint, [execute: "1"])
+            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    beBlockPoint, [execute: "1"])
+                    "EnginePublishVersionTask::execute.block")
         }
     }
 
     def disable_block_in_publish = {
         if (isCloudMode()) {
-            GetDebugPoint().disableDebugPointForAllFEs(cloudBlockPoint)
+            GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
         } else {
             DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    beBlockPoint)
+                    "EnginePublishVersionTask::execute.block")
         }
-    }
-
-    def wait_publish_block_hit = {
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
-            {
-                if (isCloudMode()) {
-                    return GetDebugPoint().isDebugPointHitOnAnyFE(cloudBlockPoint)
-                }
-                return DebugPoint.isDebugPointHit(tabletBackend.Host, tabletBackend.HttpPort as int,
-                        NodeType.BE, beBlockPoint)
-            }
-        )
     }
 
     try {
@@ -160,8 +144,7 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
             sql "insert into ${table1}(k1,c1,c2) values(1,999,999),(2,888,888),(3,777,777);"
         }
 
-        // Do not start compaction until the load has reached and is blocked in the publish hook.
-        wait_publish_block_hit()
+        Thread.sleep(500)
 
         // trigger full compaction on tablet
         logger.info("trigger compaction on another BE ${tabletBackend.Host} with backendId=${tabletBackend.BackendId}")

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -177,8 +177,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
         // let the partial update load publish
         disable_block_in_publish()
-        disable_publish_spin_wait()
         t1.join()
+        disable_publish_spin_wait()
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
             {

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -24,6 +24,10 @@ import org.apache.doris.regression.util.NodeType
 suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def table1 = "test_partial_update_skip_compaction"
+    def cloudSpinWaitPoint = "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait"
+    def cloudBlockPoint = "CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block"
+    def beSpinWaitPoint = "EnginePublishVersionTask::execute.enable_spin_wait"
+    def beBlockPoint = "EnginePublishVersionTask::execute.block"
     sql "DROP TABLE IF EXISTS ${table1} FORCE;"
     sql """ CREATE TABLE IF NOT EXISTS ${table1} (
             `k1` int NOT NULL,
@@ -98,41 +102,53 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def enable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait",
-                    [token: "${publishToken}"])
+            GetDebugPoint().enableDebugPointForAllFEs(cloudSpinWaitPoint,
+                    [token: "${publishToken}", execute: "1"])
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.enable_spin_wait",
-                    [partition_id: "${partitionId}", token: "${publishToken}"])
+                    beSpinWaitPoint,
+                    [partition_id: "${partitionId}", token: "${publishToken}", execute: "1"])
         }
     }
 
     def disable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
+            GetDebugPoint().disableDebugPointForAllFEs(cloudSpinWaitPoint)
         } else {
             DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.enable_spin_wait")
+                    beSpinWaitPoint)
         }
     }
 
     def enable_block_in_publish = { passToken ->
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block",
+            GetDebugPoint().enableDebugPointForAllFEs(cloudBlockPoint,
                     [pass_token: "${passToken}"])
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.block", [pass_token: "${passToken}"])
+                    beBlockPoint, [pass_token: "${passToken}"])
         }
     }
 
     def disable_block_in_publish = {
         if (isCloudMode()) {
-            GetDebugPoint().disableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
+            GetDebugPoint().disableDebugPointForAllFEs(cloudBlockPoint)
         } else {
             DebugPoint.disableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.block")
+                    beBlockPoint)
         }
+    }
+
+    def wait_publish_spin_hit = {
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+            {
+                if (isCloudMode()) {
+                    return GetDebugPoint().isDebugPointHitOnAnyFE(cloudSpinWaitPoint)
+                }
+                return DebugPoint.isDebugPointHit(tabletBackend.Host, tabletBackend.HttpPort as int,
+                        NodeType.BE, beSpinWaitPoint)
+            }
+        )
     }
 
     try {
@@ -148,7 +164,8 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
             sql "insert into ${table1}(k1,c1,c2) values(1,999,999),(2,888,888),(3,777,777);"
         }
 
-        Thread.sleep(500)
+        // Do not start compaction until the target publish has entered the spin wait.
+        wait_publish_spin_hit()
 
         // trigger full compaction on tablet
         logger.info("trigger compaction on another BE ${tabletBackend.Host} with backendId=${tabletBackend.BackendId}")

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -52,6 +52,7 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
     Assert.assertNotNull("SHOW PARTITIONS must return PartitionId", partitionIdText)
     Assert.assertTrue("PartitionId must be numeric", partitionIdText ==~ /[0-9]+/)
     def partitionId = Long.parseLong(partitionIdText)
+    def publishToken = "test_partial_update_skip_compaction"
     def tabletBackend;
     for (def be : beNodes) {
         if (be.BackendId == tabletBackendId) {
@@ -97,10 +98,12 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
     def enable_publish_spin_wait = {
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait")
+            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.enable_spin_wait",
+                    [token: "${publishToken}"])
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.enable_spin_wait", [partition_id: "${partitionId}"])
+                    "EnginePublishVersionTask::execute.enable_spin_wait",
+                    [partition_id: "${partitionId}", token: "${publishToken}"])
         }
     }
 
@@ -113,12 +116,13 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         }
     }
 
-    def enable_block_in_publish = {
+    def enable_block_in_publish = { passToken ->
         if (isCloudMode()) {
-            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block")
+            GetDebugPoint().enableDebugPointForAllFEs("CloudGlobalTransactionMgr.getDeleteBitmapUpdateLock.block",
+                    [pass_token: "${passToken}"])
         } else {
             DebugPoint.enableDebugPoint(tabletBackend.Host, tabletBackend.HttpPort as int, NodeType.BE,
-                    "EnginePublishVersionTask::execute.block")
+                    "EnginePublishVersionTask::execute.block", [pass_token: "${passToken}"])
         }
     }
 
@@ -137,7 +141,7 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
 
         // block the partial update in publish phase
         enable_publish_spin_wait()
-        enable_block_in_publish()
+        enable_block_in_publish("blocked")
         def t1 = Thread.start {
             sql "set enable_unique_key_partial_update=true;"
             sql "sync;"
@@ -176,9 +180,10 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         })
 
         // let the partial update load publish
-        disable_block_in_publish()
+        enable_block_in_publish(publishToken)
         t1.join()
         disable_publish_spin_wait()
+        disable_block_in_publish()
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
             {

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -47,7 +47,11 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
     def tabletStat = sql_return_maparray("show tablets from ${table1};").get(0)
     def tabletBackendId = tabletStat.BackendId
     def tabletId = tabletStat.TabletId
-    def partitionId = tabletStat.PartitionId
+    def partitionStat = sql_return_maparray("show partitions from ${table1};").get(0)
+    def partitionIdText = partitionStat.PartitionId?.toString()
+    Assert.assertNotNull("SHOW PARTITIONS must return PartitionId", partitionIdText)
+    Assert.assertTrue("PartitionId must be numeric", partitionIdText ==~ /[0-9]+/)
+    def partitionId = Long.parseLong(partitionIdText)
     def tabletBackend;
     for (def be : beNodes) {
         if (be.BackendId == tabletBackendId) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Scope the partial-update publish fault injection, deterministically prove the target publish is blocked before compaction, and release/clean up the debug points without lookup races.

Issue Number: N/A

Related PR: #55606

#### Review boundary

This PR is intentionally limited to the failure mechanism and the three synchronization/cleanup requirements raised on this case:

1. An unrelated `__internal_schema.audit_log` publish entered the process-wide BE wait and delayed debug-point cleanup for about 152 seconds.
2. The final SQL read the old rows immediately before the intended partial-update transaction became visible.
3. A fixed pre-compaction sleep did not prove that the target BE or Cloud publish had entered its spin wait, and Cloud's split check/get sequence could race point removal.

The acceptance boundary of this PR is therefore:

- unrelated partitions on the selected BE cannot enter or consume the scoped publish injection;
- both non-Cloud and Cloud branches must observe `execute_num > 0` on the target spin point before starting compaction;
- automatic cleanup of an exhausted or expired point cannot erase a newer same-name replacement;
- the case releases the Cloud FE loop by replacing the block point with a non-null matching-token point, then removes both points only after the load thread joins;
- after releasing the injection, the final assertion waits for the exact expected rows;
- existing unscoped debug-point callers retain their old semantics.

The following remain explicit non-goals:

- adding a general event/latch framework, debug-point history, or arbitrary hit-count waiting API;
- changing normal publish, compaction, transaction, or delete-bitmap behavior when debug points are disabled;
- claiming a Cloud runtime execution result before an explicit Cloud NonConcurrent run is available.

The read-only status endpoint is the smallest shared mechanism that can prove the same named hook was consumed on both BE and FE. It exposes only `exists` and `execute_num`, is protected by the existing debug-point admin authentication, and does not consume the point. The 13-file boundary is limited to the two status implementations, their tests, the framework query helper, the Cloud atomic lookup fix, the scoped BE hook, and this case; no unrelated observability infrastructure is included.

#### Root cause

`test_partial_update_skip_compaction` is intended to pause one partial-update publish, run full compaction while that publish is blocked, then release publish and check the final rows and rowset versions. The previous fixed 500 ms delay did not establish that overlap: a slow load could reach publish only after compaction had already completed.

The non-cloud case previously enabled these process-wide debug points on every BE:

- `EnginePublishVersionTask::execute.enable_spin_wait`
- `EnginePublishVersionTask::execute.block`

They were not tied to the table, partition, tablet, or transaction under test. An unrelated `__internal_schema.audit_log` publish could therefore enter the same wait. In the observed failures, an audit-log publish occupied the path for about 151–152 seconds, delaying cleanup and making the final assertion depend on unrelated publish scheduling.

After cleanup, joining the client-side load thread was also not a sufficient visibility barrier for the following query. The historical failure queried the old rows milliseconds before the target transaction became visible.

In Cloud mode, the debug-point path used separate `isEnable()` and `getDebugPoint()` calls for both the outer spin point and inner block point. A concurrent removal could make the second lookup null; an execute-limited handshake point could also be consumed twice before the loop began.

#### What changes

##### 1. Scope the non-cloud injection to one BE and one partition

The case now:

1. Selects the single-replica tablet BE from `SHOW TABLETS`.
2. Reads and validates `PartitionId` from `SHOW PARTITIONS`.
3. Enables both publish debug points only on the selected BE.
4. Passes `partition_id` to the spin point.

The BE publish hook applies the point only when the request contains that partition. Unrelated audit-log and user publish tasks continue normally.

##### 2. Preserve `execute` semantics and add a deterministic hit handshake

`DebugPoints` adds `get_debug_point_if(name, predicate)`. Its lookup order is:

1. Find the point and apply the existing expiration check.
2. Evaluate the optional predicate.
3. Consume/check the existing `execute` limit only when the predicate matches.

This prevents an unrelated publish from consuming a scoped `execute=1` point before the target partition arrives. Existing `get_debug_point(name)` callers keep their previous behavior, and omitting `partition_id` preserves the previous process-global publish-hook behavior.

When an expired or exhausted point needs automatic cleanup, the removal is now conditional on the map still containing the same `DebugPoint` instance that was loaded. This closes the review-found replacement race: an older lookup cannot erase a newer same-name point installed concurrently. A barrier-based unit test fixes the T1/T2 ordering and verifies that the replacement survives.

BE and FE now expose an authenticated `GET /api/debug_point/status/{name}` response with only `exists` and `execute_num`. The underlying `peek` lookup checks expiry but does not consume `execute`. The regression helper uses this endpoint to poll:

- the selected tablet BE in non-Cloud mode;
- all configured FEs in Cloud mode, succeeding when the FE handling the load reports the hit.

The case installs the spin point with `execute=1` and waits up to 30 seconds for `execute_num > 0` before triggering compaction. This replaces `Thread.sleep(500)` and fails closed if the target publish hook is never reached.

##### 3. Make case cleanup and final visibility explicit

The Cloud path now obtains the outer spin point once and refreshes the inner block point with the non-consuming lookup, removing both split check/get windows. The spin point carries an explicit token. The initial block point carries a different `pass_token`; to release the wait, the case replaces that point with a non-null same-name point whose `pass_token` matches the spin token.

The case then joins the load thread while both points remain installed and removes the spin and block points only after the join. This also prevents removal between Cloud FE's outer `isEnable(spin)` and `getDebugPoint(spin)` calls. The all-node `finally` cleanup remains for failures.

After release, the case polls for the three exact expected partial-update rows for at most 30 seconds, then retains the original ordered golden query and non-cloud rowset assertions.

#### Scope and risk

- The effective diff is limited to 13 files required for the scoped hook, BE/FE non-consuming status query and tests, framework helper, Cloud atomic lookup, and this case.
- The status API is read-only, admin-authenticated, debug-point-only, and returns no production transaction or storage state.
- Cloud mode keeps the same named FE injection and token/pass-token protocol; the change makes lookup/release atomic and observable for this case.
- The fixed pre-compaction sleep is removed; compaction starts only after the hit handshake succeeds.
- Production publish behavior is unchanged unless this debug point is enabled.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - Added `DebugPointsTest.PredicateDoesNotConsumeExecuteLimit` for predicate mismatch, first matching access, and execute-limit exhaustion.
        - Added `DebugPointsTest.ConcurrentReplacementSurvivesExhaustedLookup` with a barrier-controlled replacement race.
        - Added BE/FE coverage proving status/peek does not consume an execute-limited point.
        - `DebugPointUtilTest`: passed on JDK 17 (`tests=1`, `failures=0`, `errors=0`).
        - Local BE UT configuration remains blocked before source compilation because AppleClang cannot find `omp.h`.
    - [x] Manual test
        - `mvn -DskipTests package` in `regression-test/framework`: passed; 467 Groovy files compiled.
        - Standalone Groovy compilation of `test_partial_update_skip_compaction.groovy`: passed.
        - `git diff --check`: passed.
        - New HEAD: `5ba16fcbab6`; formatter, BE UT, compile, and review checks have been retriggered for this head.
        - Patched runtime regression remains pending because it requires a BE built from this change.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. When `partition_id` is present, only a matching publish consumes `execute` and enters the wait; unscoped behavior is unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
