### PR TITLE
[enhance](cloud) Increase get version timeout to 30 seconds

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3071,7 +3071,7 @@ public class Config extends ConfigBase {
     public static int drop_rpc_retry_num = 200;
 
     @ConfField
-    public static int default_get_version_from_ms_timeout_second = 3;
+    public static int default_get_version_from_ms_timeout_second = 30;
 
     @ConfField(mutable = true)
     public static boolean enable_cloud_multi_replica = false;


### PR DESCRIPTION
### What problem does this PR solve?

The default timeout for FE get_version requests to MetaService is 3 seconds, which is too short when MetaService responds slowly. Increase the default timeout to 30 seconds to reduce premature request failures.

### Release note

Increase the default FE get_version timeout from 3 seconds to 30 seconds.

### Check List (For Author)

- Test: Manual test (fe-common compilation and Checkstyle passed during FE build)
- Behavior changed: Yes (the default get_version timeout increases to 30 seconds)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

