### PR TITLE
branch-4.0: [opt](schema) Optimize tables schema scan status #64933

### DIFF
--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -73,6 +74,7 @@ struct SchemaScannerCommonParam {
     int64_t thread_id;
     const std::string* catalog = nullptr;
     std::set<TNetworkAddress> fe_addr_list;
+    std::set<std::string> required_columns;
 };
 
 // scanner parameter from frontend

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -116,6 +116,7 @@ Status SchemaTablesScanner::_get_new_table() {
     if (nullptr != _param->common_param->table) {
         table_params.__set_table(*(_param->common_param->table));
     }
+    table_params.__set_required_columns(_param->common_param->required_columns);
     if (nullptr != _param->common_param->current_user_ident) {
         table_params.__set_current_user_ident(*(_param->common_param->current_user_ident));
     } else {

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -23,6 +23,7 @@
 
 #include "pipeline/exec/operator.h"
 #include "util/runtime_profile.h"
+#include "util/string_util.h"
 #include "vec/data_types/data_type_factory.hpp"
 
 namespace doris {
@@ -180,6 +181,8 @@ Status SchemaScanOperatorX::prepare(RuntimeState* state) {
         for (; j < columns_desc.size(); ++j) {
             if (boost::iequals(_dest_tuple_desc->slots()[i]->col_name(), columns_desc[j].name)) {
                 _slot_offsets[i] = j;
+                _common_scanner_param->required_columns.insert(
+                        to_upper(_dest_tuple_desc->slots()[i]->col_name()));
                 break;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1839,37 +1839,43 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
 
     @Override
     public long getAvgRowLength() {
-        long rowCount = 0;
-        long dataSize = 0;
-        for (Map.Entry<Long, Partition> entry : idToPartition.entrySet()) {
-            rowCount += entry.getValue().getBaseIndex().getRowCount();
-            dataSize += entry.getValue().getBaseIndex().getDataSize(false, false);
-        }
-        if (rowCount > 0) {
-            return dataSize / rowCount;
-        } else {
-            return 0;
-        }
+        return getTableStatusStats().getAvgRowLength();
     }
 
     @Override
     public long getDataLength() {
-        long dataSize = 0;
-        for (Map.Entry<Long, Partition> entry : idToPartition.entrySet()) {
-            dataSize += entry.getValue().getBaseIndex().getLocalSegmentSize();
-            dataSize += entry.getValue().getBaseIndex().getRemoteSegmentSize();
-        }
-        return dataSize;
+        return getTableStatusStats().getDataLength();
     }
 
     @Override
     public long getIndexLength() {
-        long indexSize = 0;
+        return getTableStatusStats().getIndexLength();
+    }
+
+    @Override
+    public TableStatusStats getTableStatusStats() {
+        long rowCount = 0;
+        long rowCountForAvg = 0;
+        long dataSizeForAvg = 0;
+        long dataLength = 0;
+        long indexLength = 0;
         for (Map.Entry<Long, Partition> entry : idToPartition.entrySet()) {
-            indexSize += entry.getValue().getBaseIndex().getLocalIndexSize();
-            indexSize += entry.getValue().getBaseIndex().getRemoteIndexSize();
+            MaterializedIndex baseIndex = entry.getValue().getBaseIndex();
+            long baseIndexRowCount = baseIndex.getRowCount();
+            rowCount += baseIndexRowCount == UNKNOWN_ROW_COUNT ? 0 : baseIndexRowCount;
+            rowCountForAvg += baseIndexRowCount;
+            for (Tablet tablet : baseIndex.getTablets()) {
+                for (Replica replica : tablet.getReplicas()) {
+                    if (replica.getState() == Replica.ReplicaState.NORMAL) {
+                        dataSizeForAvg += replica.getDataSize();
+                    }
+                    dataLength += replica.getLocalSegmentSize() + replica.getRemoteSegmentSize();
+                    indexLength += replica.getLocalInvertedIndexSize() + replica.getRemoteInvertedIndexSize();
+                }
+            }
         }
-        return indexSize;
+        long avgRowLength = rowCountForAvg > 0 ? dataSizeForAvg / rowCountForAvg : 0;
+        return new TableStatusStats(rowCount, dataLength, avgRowLength, indexLength);
     }
 
     // Get the signature string of this table with specified partitions.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -61,6 +61,36 @@ import java.util.stream.Collectors;
 public interface TableIf {
     Logger LOG = LogManager.getLogger(TableIf.class);
 
+    class TableStatusStats {
+        private final long rows;
+        private final long dataLength;
+        private final long avgRowLength;
+        private final long indexLength;
+
+        public TableStatusStats(long rows, long dataLength, long avgRowLength, long indexLength) {
+            this.rows = rows;
+            this.dataLength = dataLength;
+            this.avgRowLength = avgRowLength;
+            this.indexLength = indexLength;
+        }
+
+        public long getRows() {
+            return rows;
+        }
+
+        public long getDataLength() {
+            return dataLength;
+        }
+
+        public long getAvgRowLength() {
+            return avgRowLength;
+        }
+
+        public long getIndexLength() {
+            return indexLength;
+        }
+    }
+
     long UNKNOWN_ROW_COUNT = -1;
 
     default void readLock() {
@@ -181,6 +211,10 @@ public interface TableIf {
     long getAvgRowLength();
 
     long getIndexLength();
+
+    default TableStatusStats getTableStatusStats() {
+        return new TableStatusStats(getCachedRowCount(), getDataLength(), getAvgRowLength(), getIndexLength());
+    }
 
     long getLastCheckTime();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 
 /**
  * This class represents the olap tablet related metadata.
@@ -487,10 +486,20 @@ public class Tablet extends MetaObject {
     // ATTN: Replica::getDataSize may zero in cloud and non-cloud
     // due to dataSize not write to image
     public long getDataSize(boolean singleReplica, boolean filterSizeZero) {
-        LongStream s = replicas.stream().filter(r -> r.getState() == ReplicaState.NORMAL)
-                .filter(r -> !filterSizeZero || r.getDataSize() > 0)
-                .mapToLong(Replica::getDataSize);
-        return singleReplica ? Double.valueOf(s.average().orElse(0)).longValue() : s.sum();
+        long dataSize = 0;
+        int replicaNum = 0;
+        for (Replica replica : replicas) {
+            if (replica.getState() != ReplicaState.NORMAL) {
+                continue;
+            }
+            long replicaDataSize = replica.getDataSize();
+            if (filterSizeZero && replicaDataSize <= 0) {
+                continue;
+            }
+            dataSize += replicaDataSize;
+            replicaNum++;
+        }
+        return singleReplica && replicaNum > 0 ? dataSize / replicaNum : dataSize;
     }
 
     public long getRemoteDataSize() {
@@ -508,9 +517,16 @@ public class Tablet extends MetaObject {
     }
 
     public long getRowCount(boolean singleReplica) {
-        LongStream s = replicas.stream().filter(r -> r.getState() == ReplicaState.NORMAL)
-                .mapToLong(Replica::getRowCount);
-        return singleReplica ? Double.valueOf(s.average().orElse(0)).longValue() : s.sum();
+        long rowCount = 0;
+        int replicaNum = 0;
+        for (Replica replica : replicas) {
+            if (replica.getState() != ReplicaState.NORMAL) {
+                continue;
+            }
+            rowCount += replica.getRowCount();
+            replicaNum++;
+        }
+        return singleReplica && replicaNum > 0 ? rowCount / replicaNum : rowCount;
     }
 
     // Get the least row count among all valid replicas.

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -330,6 +330,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -638,6 +639,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TListTableStatusResult result = new TListTableStatusResult();
         List<TTableStatus> tablesResult = Lists.newArrayList();
         result.setTables(tablesResult);
+        Set<String> requiredColumns = params.isSetRequiredColumns()
+                ? params.getRequiredColumns().stream()
+                        .map(column -> column.toUpperCase(Locale.ROOT))
+                        .collect(Collectors.toSet())
+                : null;
         PatternMatcher matcher = null;
         String specifiedTable = null;
         if (params.isSetPattern()) {
@@ -717,17 +723,40 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                             TTableStatus status = new TTableStatus();
                             status.setName(table.getName());
                             status.setType(table.getMysqlType());
-                            status.setEngine(table.getEngine());
                             status.setComment(table.getComment());
-                            status.setCreateTime(table.getCreateTime());
-                            status.setLastCheckTime(lastCheckTime / 1000);
-                            status.setUpdateTime(table.getUpdateTime() / 1000);
-                            status.setCheckTime(lastCheckTime / 1000);
-                            status.setCollation("utf-8");
-                            status.setRows(table.getCachedRowCount());
-                            status.setDataLength(table.getDataLength());
-                            status.setAvgRowLength(table.getAvgRowLength());
-                            status.setIndexLength(table.getIndexLength());
+                            if (needTableStatusColumn(requiredColumns, "ENGINE")) {
+                                status.setEngine(table.getEngine());
+                            }
+                            if (needTableStatusColumn(requiredColumns, "CREATE_TIME")) {
+                                status.setCreateTime(table.getCreateTime());
+                            }
+                            if (needTableStatusColumn(requiredColumns, "LAST_CHECK_TIME")
+                                    || needTableStatusColumn(requiredColumns, "CHECK_TIME")) {
+                                status.setLastCheckTime(lastCheckTime / 1000);
+                            }
+                            if (needTableStatusColumn(requiredColumns, "UPDATE_TIME")) {
+                                status.setUpdateTime(table.getUpdateTime() / 1000);
+                            }
+                            if (needTableStatusColumn(requiredColumns, "CHECK_TIME")) {
+                                status.setCheckTime(lastCheckTime / 1000);
+                            }
+                            if (needTableStatusColumn(requiredColumns, "TABLE_COLLATION")) {
+                                status.setCollation("utf-8");
+                            }
+                            TableIf.TableStatusStats tableStatusStats =
+                                    needTableStatusStats(requiredColumns) ? table.getTableStatusStats() : null;
+                            if (needTableStatusColumn(requiredColumns, "TABLE_ROWS")) {
+                                status.setRows(tableStatusStats.getRows());
+                            }
+                            if (needTableStatusColumn(requiredColumns, "DATA_LENGTH")) {
+                                status.setDataLength(tableStatusStats.getDataLength());
+                            }
+                            if (needTableStatusColumn(requiredColumns, "AVG_ROW_LENGTH")) {
+                                status.setAvgRowLength(tableStatusStats.getAvgRowLength());
+                            }
+                            if (needTableStatusColumn(requiredColumns, "INDEX_LENGTH")) {
+                                status.setIndexLength(tableStatusStats.getIndexLength());
+                            }
                             if (table instanceof View) {
                                 status.setDdlSql(((View) table).getInlineViewDef());
                             }
@@ -742,6 +771,17 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         return result;
+    }
+
+    private static boolean needTableStatusColumn(Set<String> requiredColumns, String columnName) {
+        return requiredColumns == null || requiredColumns.contains(columnName);
+    }
+
+    private static boolean needTableStatusStats(Set<String> requiredColumns) {
+        return needTableStatusColumn(requiredColumns, "TABLE_ROWS")
+                || needTableStatusColumn(requiredColumns, "DATA_LENGTH")
+                || needTableStatusColumn(requiredColumns, "AVG_ROW_LENGTH")
+                || needTableStatusColumn(requiredColumns, "INDEX_LENGTH");
     }
 
     public TListTableMetadataNameIdsResult listTableMetadataNameIds(TGetTablesParams params) throws TException {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -56,6 +56,42 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class OlapTableTest {
 
     @Test
+    public void testGetTableStatusStatsUsesSinglePassSemantics() {
+        OlapTable olapTable = new OlapTable();
+        MaterializedIndex index = new MaterializedIndex(10, MaterializedIndex.IndexState.NORMAL);
+        index.setRowCount(20);
+
+        List<Replica> replicas = Lists.newArrayList(
+                mockReplica(Replica.ReplicaState.NORMAL, 10, 100, 1, 20, 2),
+                mockReplica(Replica.ReplicaState.DECOMMISSION, 30, 300, 3, 40, 4),
+                mockReplica(Replica.ReplicaState.NORMAL, 50, 500, 5, 60, 6));
+        Tablet tablet = Mockito.mock(Tablet.class);
+        Mockito.when(tablet.getReplicas()).thenReturn(replicas);
+        index.appendTablets(Lists.newArrayList(tablet));
+
+        Partition partition = new Partition(11, "p1", index, null);
+        olapTable.addPartition(partition);
+
+        TableIf.TableStatusStats stats = olapTable.getTableStatusStats();
+        Assert.assertEquals(20L, stats.getRows());
+        Assert.assertEquals(909L, stats.getDataLength());
+        Assert.assertEquals(3L, stats.getAvgRowLength());
+        Assert.assertEquals(132L, stats.getIndexLength());
+    }
+
+    private Replica mockReplica(Replica.ReplicaState state, long dataSize, long localSegmentSize,
+            long remoteSegmentSize, long localIndexSize, long remoteIndexSize) {
+        Replica replica = Mockito.mock(Replica.class);
+        Mockito.when(replica.getState()).thenReturn(state);
+        Mockito.when(replica.getDataSize()).thenReturn(dataSize);
+        Mockito.when(replica.getLocalSegmentSize()).thenReturn(localSegmentSize);
+        Mockito.when(replica.getRemoteSegmentSize()).thenReturn(remoteSegmentSize);
+        Mockito.when(replica.getLocalInvertedIndexSize()).thenReturn(localIndexSize);
+        Mockito.when(replica.getRemoteInvertedIndexSize()).thenReturn(remoteIndexSize);
+        return replica;
+    }
+
+    @Test
     public void test() throws IOException {
 
         new MockUp<Env>() {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -41,6 +41,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -67,7 +68,7 @@ public class OlapTableTest {
                 mockReplica(Replica.ReplicaState.NORMAL, 50, 500, 5, 60, 6));
         Tablet tablet = Mockito.mock(Tablet.class);
         Mockito.when(tablet.getReplicas()).thenReturn(replicas);
-        index.appendTablets(Lists.newArrayList(tablet));
+        index.addTablet(tablet, null, true);
 
         Partition partition = new Partition(11, "p1", index, null);
         olapTable.addPartition(partition);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletTest.java
@@ -109,6 +109,23 @@ public class TabletTest {
     }
 
     @Test
+    public void testGetReplicaStatsOnlyUsesNormalReplicas() {
+        Tablet statsTablet = new Tablet(2);
+        invertedIndex.addTablet(2, new TabletMeta(10, 20, 30, 40, 1, TStorageMedium.HDD));
+        statsTablet.addReplica(new Replica(11L, 1L, 100L, 0, 10L, 0L, 100L, ReplicaState.NORMAL, 0L, 100L));
+        statsTablet.addReplica(new Replica(12L, 2L, 100L, 0, 20L, 0L, 200L, ReplicaState.NORMAL, 0L, 100L));
+        statsTablet.addReplica(new Replica(13L, 3L, 100L, 0, 0L, 0L, 300L, ReplicaState.NORMAL, 0L, 100L));
+        statsTablet.addReplica(new Replica(14L, 4L, 100L, 0, 40L, 0L, 400L, ReplicaState.DECOMMISSION,
+                0L, 100L));
+
+        Assert.assertEquals(30L, statsTablet.getDataSize(false, false));
+        Assert.assertEquals(10L, statsTablet.getDataSize(true, false));
+        Assert.assertEquals(30L, statsTablet.getDataSize(false, true));
+        Assert.assertEquals(600L, statsTablet.getRowCount(false));
+        Assert.assertEquals(200L, statsTablet.getRowCount(true));
+    }
+
+    @Test
     public void deleteReplicaTest() {
         // delete replica1
         Assert.assertTrue(tablet.deleteReplicaByBackendId(replica1.getBackendIdWithoutException()));

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.cloud.CacheHotspotManager;
 import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.common.Config;
@@ -44,6 +45,7 @@ import org.apache.doris.thrift.TGetTablesParams;
 import org.apache.doris.thrift.TGetTablesResult;
 import org.apache.doris.thrift.TGetTabletReplicaInfosRequest;
 import org.apache.doris.thrift.TGetTabletReplicaInfosResult;
+import org.apache.doris.thrift.TListTableStatusResult;
 import org.apache.doris.thrift.TMetadataTableRequestParams;
 import org.apache.doris.thrift.TMetadataType;
 import org.apache.doris.thrift.TNullableStringLiteral;
@@ -51,8 +53,10 @@ import org.apache.doris.thrift.TSchemaTableName;
 import org.apache.doris.thrift.TShowUserRequest;
 import org.apache.doris.thrift.TShowUserResult;
 import org.apache.doris.thrift.TStatusCode;
+import org.apache.doris.thrift.TTableStatus;
 import org.apache.doris.utframe.UtFrameUtils;
 
+import com.google.common.collect.Sets;
 import mockit.Mocked;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -123,6 +127,178 @@ public class FrontendServiceImplTest {
 
         TGetTablesResult result = impl.getTableNames(params);
         Assert.assertTrue(result.getTables().isEmpty());
+    }
+
+    @Test
+    public void testListTableStatusPrunesUnrequestedExpensiveColumns() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.prune_status_columns(\n"
+                + "    k1 INT,\n"
+                + "    v1 INT\n"
+                + ")\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\" = \"1\");";
+        createTable(createOlapTblStmt);
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("prune_status_columns");
+        OlapTable spyTable = Mockito.spy(table);
+        db.unregisterTable(table.getName());
+        db.registerTable(spyTable);
+        try {
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TGetTablesParams params = new TGetTablesParams();
+            params.setCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
+            params.setDb("test");
+            params.setTable("prune_status_columns");
+            params.setRequiredColumns(Collections.singleton("UPDATE_TIME"));
+            params.setCurrentUserIdent(connectContext.getCurrentUserIdentity().toThrift());
+
+            TListTableStatusResult result = impl.listTableStatus(params);
+
+            Assert.assertEquals(1, result.getTablesSize());
+            TTableStatus status = result.getTables().get(0);
+            Assert.assertTrue(status.isSetUpdateTime());
+            Assert.assertFalse(status.isSetRows());
+            Assert.assertFalse(status.isSetDataLength());
+            Assert.assertFalse(status.isSetAvgRowLength());
+            Assert.assertFalse(status.isSetIndexLength());
+            Mockito.verify(spyTable, Mockito.never()).getCachedRowCount();
+            Mockito.verify(spyTable, Mockito.never()).getDataLength();
+            Mockito.verify(spyTable, Mockito.never()).getAvgRowLength();
+            Mockito.verify(spyTable, Mockito.never()).getIndexLength();
+        } finally {
+            db.unregisterTable(spyTable.getName());
+            db.registerTable(table);
+        }
+    }
+
+    @Test
+    public void testListTableStatusSetsLastCheckTimeForCheckTimeProjection() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.prune_check_time_status_column(\n"
+                + "    k1 INT,\n"
+                + "    v1 INT\n"
+                + ")\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\" = \"1\");";
+        createTable(createOlapTblStmt);
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("prune_check_time_status_column");
+        OlapTable spyTable = Mockito.spy(table);
+        Mockito.doReturn(10_000L).when(spyTable).getLastCheckTime();
+        db.unregisterTable(table.getName());
+        db.registerTable(spyTable);
+        try {
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TGetTablesParams params = new TGetTablesParams();
+            params.setCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
+            params.setDb("test");
+            params.setTable("prune_check_time_status_column");
+            params.setRequiredColumns(Collections.singleton("CHECK_TIME"));
+            params.setCurrentUserIdent(connectContext.getCurrentUserIdentity().toThrift());
+
+            TListTableStatusResult result = impl.listTableStatus(params);
+
+            Assert.assertEquals(1, result.getTablesSize());
+            TTableStatus status = result.getTables().get(0);
+            Assert.assertTrue(status.isSetLastCheckTime());
+            Assert.assertEquals(10L, status.getLastCheckTime());
+            Assert.assertTrue(status.isSetCheckTime());
+            Assert.assertEquals(10L, status.getCheckTime());
+            Assert.assertFalse(status.isSetUpdateTime());
+            Assert.assertFalse(status.isSetRows());
+            Mockito.verify(spyTable, Mockito.never()).getTableStatusStats();
+        } finally {
+            db.unregisterTable(spyTable.getName());
+            db.registerTable(table);
+        }
+    }
+
+    @Test
+    public void testListTableStatusPrunesAllOptionalColumnsWhenRequiredColumnsIsEmpty() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.prune_all_optional_status_columns(\n"
+                + "    k1 INT,\n"
+                + "    v1 INT\n"
+                + ")\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\" = \"1\");";
+        createTable(createOlapTblStmt);
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("prune_all_optional_status_columns");
+        OlapTable spyTable = Mockito.spy(table);
+        db.unregisterTable(table.getName());
+        db.registerTable(spyTable);
+        try {
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TGetTablesParams params = new TGetTablesParams();
+            params.setCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
+            params.setDb("test");
+            params.setTable("prune_all_optional_status_columns");
+            params.setRequiredColumns(Collections.emptySet());
+            params.setCurrentUserIdent(connectContext.getCurrentUserIdentity().toThrift());
+
+            TListTableStatusResult result = impl.listTableStatus(params);
+
+            Assert.assertEquals(1, result.getTablesSize());
+            TTableStatus status = result.getTables().get(0);
+            Assert.assertFalse(status.isSetEngine());
+            Assert.assertFalse(status.isSetUpdateTime());
+            Assert.assertFalse(status.isSetRows());
+            Assert.assertFalse(status.isSetDataLength());
+            Assert.assertFalse(status.isSetAvgRowLength());
+            Assert.assertFalse(status.isSetIndexLength());
+            Mockito.verify(spyTable, Mockito.never()).getTableStatusStats();
+        } finally {
+            db.unregisterTable(spyTable.getName());
+            db.registerTable(table);
+        }
+    }
+
+    @Test
+    public void testListTableStatusUsesCombinedStatsForExpensiveColumns() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.combined_status_stats(\n"
+                + "    k1 INT,\n"
+                + "    v1 INT\n"
+                + ")\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\" = \"1\");";
+        createTable(createOlapTblStmt);
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("combined_status_stats");
+        OlapTable spyTable = Mockito.spy(table);
+        Mockito.doReturn(new TableIf.TableStatusStats(10L, 20L, 2L, 30L))
+                .when(spyTable).getTableStatusStats();
+        db.unregisterTable(table.getName());
+        db.registerTable(spyTable);
+        try {
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TGetTablesParams params = new TGetTablesParams();
+            params.setCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
+            params.setDb("test");
+            params.setTable("combined_status_stats");
+            params.setRequiredColumns(Sets.newHashSet("table_rows", "Data_Length", "avg_row_length",
+                    "INDEX_LENGTH"));
+            params.setCurrentUserIdent(connectContext.getCurrentUserIdentity().toThrift());
+
+            TListTableStatusResult result = impl.listTableStatus(params);
+
+            Assert.assertEquals(1, result.getTablesSize());
+            TTableStatus status = result.getTables().get(0);
+            Assert.assertEquals(10L, status.getRows());
+            Assert.assertEquals(20L, status.getDataLength());
+            Assert.assertEquals(2L, status.getAvgRowLength());
+            Assert.assertEquals(30L, status.getIndexLength());
+            Mockito.verify(spyTable).getTableStatusStats();
+            Mockito.verify(spyTable, Mockito.never()).getCachedRowCount();
+            Mockito.verify(spyTable, Mockito.never()).getDataLength();
+            Mockito.verify(spyTable, Mockito.never()).getAvgRowLength();
+            Mockito.verify(spyTable, Mockito.never()).getIndexLength();
+        } finally {
+            db.unregisterTable(spyTable.getName());
+            db.registerTable(table);
+        }
     }
 
     @Test

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -128,6 +128,9 @@ struct TGetTablesParams {
   // Reserved for downstream field `current_roles` to keep thrift field ids
   // wire-compatible across maintained branches. Do not reuse this id.
   9: optional set<string> reserved_field_9
+  // Columns needed by schema table callers. If unset, the callee returns the
+  // full table status for backward compatibility.
+  10: optional set<string> required_columns
 }
 
 struct TTableStatus {

--- a/regression-test/suites/information_schema_p0/test_tables_status_column_pruning.groovy
+++ b/regression-test/suites/information_schema_p0/test_tables_status_column_pruning.groovy
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_tables_status_column_pruning") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    def assertNoTabletStatusColumns = {
+        notContains "col=TABLE_ROWS"
+        notContains "col=DATA_LENGTH"
+        notContains "col=AVG_ROW_LENGTH"
+        notContains "col=INDEX_LENGTH"
+    }
+
+    explain {
+        verbose true
+        sql """
+            SELECT UPDATE_TIME
+            FROM information_schema.tables
+            WHERE TABLE_SCHEMA = 'information_schema'
+        """
+        contains "TABLE: information_schema.tables"
+        contains "final projections: UPDATE_TIME"
+        contains "col=TABLE_SCHEMA"
+        contains "col=UPDATE_TIME"
+        notContains "col=TABLE_NAME"
+        assertNoTabletStatusColumns.delegate = delegate
+        assertNoTabletStatusColumns.call()
+    }
+
+    explain {
+        verbose true
+        sql """
+            SELECT TABLE_NAME, UPDATE_TIME
+            FROM information_schema.tables
+            WHERE TABLE_SCHEMA = 'information_schema'
+        """
+        contains "TABLE: information_schema.tables"
+        contains "final projections: TABLE_NAME"
+        contains "UPDATE_TIME"
+        contains "col=TABLE_SCHEMA"
+        contains "col=TABLE_NAME"
+        contains "col=UPDATE_TIME"
+        assertNoTabletStatusColumns.delegate = delegate
+        assertNoTabletStatusColumns.call()
+    }
+
+    explain {
+        verbose true
+        sql """
+            SELECT TABLE_NAME, UPDATE_TIME
+            FROM information_schema.tables
+            WHERE TABLE_SCHEMA = 'information_schema'
+              AND TABLE_NAME = 'tables'
+        """
+        contains "TABLE: information_schema.tables"
+        contains "final projections: TABLE_NAME"
+        contains "UPDATE_TIME"
+        contains "col=TABLE_SCHEMA"
+        contains "col=TABLE_NAME"
+        contains "col=UPDATE_TIME"
+        assertNoTabletStatusColumns.delegate = delegate
+        assertNoTabletStatusColumns.call()
+    }
+
+    explain {
+        verbose true
+        sql """
+            SELECT TABLE_NAME, ENGINE, VERSION, ROW_FORMAT, TABLE_ROWS, AVG_ROW_LENGTH,
+                   DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, AUTO_INCREMENT,
+                   CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, CHECKSUM,
+                   CREATE_OPTIONS, TABLE_COMMENT
+            FROM information_schema.tables
+            WHERE TABLE_SCHEMA = 'information_schema'
+              AND TABLE_NAME LIKE 'tables'
+        """
+        contains "TABLE: information_schema.tables"
+        contains "col=TABLE_ROWS"
+        contains "col=DATA_LENGTH"
+        contains "col=AVG_ROW_LENGTH"
+        contains "col=INDEX_LENGTH"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64933

Problem Summary: Backport the `information_schema.tables` column-pruning and single-pass table-status statistics optimization from #64933 to `branch-4.0`.

Source merge commit: `058dfd3794aca46617766173ced5ac5574efff94`.

### Conflict resolution

- Adapted the BE changes to the `branch-4.0` schema scanner layout under `be/src/pipeline/exec` and `be/src/exec/schema_scanner`, retaining the required-column collection and adding the branch-compatible `util/string_util.h` include.
- `branch-4.0` predates the `LocalTablet`/`LocalReplica` split. Kept those classes absent and ported the single-pass normal-replica statistics logic to the existing `Tablet`/`Replica` model, with the corresponding test adapted to `TabletTest`.
- Preserved the branch's JMockit `ExecuteEnv` setup in `FrontendServiceImplTest` and added only the imports and four status-pruning tests required by the source PR.
- Preserved Thrift field id `10` for `required_columns`; field id `9` remains reserved on this maintained branch.

The resulting backport retains the source behavior: lightweight projections skip tablet-derived status work, while full status queries compute row/data/index statistics in one tablet traversal.

### Release note

None

### Check List (For Author)

- Test: No need to test (one-time Agent conflict-resolution workflow; build and test execution were intentionally excluded)
    - `build-support/clang-format.sh`
    - `build-support/check-format.sh`
    - `git diff HEAD^ HEAD --check`
- Behavior changed: No
- Does this need documentation: No
