### PR TITLE
[fix](regression) Make incomplete commit info injection deterministic

### DIFF
--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -1266,14 +1266,12 @@ void VNodeChannel::_add_block_success_callback(const PTabletWriterAddBlockResult
         if (!st.ok()) {
             _cancel_with_msg(st.to_string());
         } else if (ctx._is_last_rpc) {
-            bool skip_tablet_info = false;
-            DBUG_EXECUTE_IF("VNodeChannel.add_block_success_callback.incomplete_commit_info",
-                            { skip_tablet_info = true; });
             for (const auto& tablet : result.tablet_vec()) {
                 DBUG_EXECUTE_IF("VNodeChannel.add_block_success_callback.incomplete_commit_info", {
-                    if (skip_tablet_info) {
-                        LOG(INFO) << "skip tablet info: " << tablet.tablet_id();
-                        skip_tablet_info = false;
+                    auto target_tablet_id = dp->param<int64_t>("tablet_id", -1);
+                    if (tablet.tablet_id() == target_tablet_id) {
+                        LOG(INFO) << "skip tablet info: " << tablet.tablet_id()
+                                  << ", backend_id: " << _node_id;
                         continue;
                     }
                 });

--- a/regression-test/suites/fault_injection_p0/test_incomplete_commit_info.groovy
+++ b/regression-test/suites/fault_injection_p0/test_incomplete_commit_info.groovy
@@ -41,7 +41,23 @@ suite("test_incomplete_commit_info", "nonConcurrent") {
             ) engine=olap
             DISTRIBUTED BY HASH(`k1`) BUCKETS 5 properties("replication_num" = "1")
             """
-        GetDebugPoint().enableDebugPointForAllBEs("VNodeChannel.add_block_success_callback.incomplete_commit_info")
+
+        streamLoad {
+            table "${tableName}"
+            db "regression_test_fault_injection_p0"
+            set 'column_separator', ','
+            file "baseall.txt"
+        }
+
+        def tabletIds = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+                .collect { it.TabletId }
+                .unique()
+        def tabletId = tabletIds.find {
+            sql("SELECT COUNT(*) FROM ${tableName} TABLET(${it})")[0][0].toLong() > 0
+        }
+        GetDebugPoint().enableDebugPointForAllBEs(
+                "VNodeChannel.add_block_success_callback.incomplete_commit_info",
+                [tablet_id: "${tabletId}"])
         streamLoad {
             table "${tableName}"
             db "regression_test_fault_injection_p0"
@@ -55,6 +71,8 @@ suite("test_incomplete_commit_info", "nonConcurrent") {
                 log.info("Stream load result: ${result}".toString())
                 def json = parseJson(result)
                 assertEquals("fail", json.Status.toLowerCase())
+                assertTrue(json.Message.contains("Failed to commit txn"))
+                assertTrue(json.Message.contains("succ replica num 0 < load required replica num 1"))
             }
         }
     } finally {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #53979

Problem Summary:

`test_incomplete_commit_info` expects stream load to fail after the debug point removes tablet commit information. The debug point previously skipped the first tablet independently in every `VNodeChannel`. With multiple buckets, those skipped entries could belong to different tablets, so every tablet could still retain the required replica quorum and the load would legally succeed.

This change makes the injection deterministic:

- the debug point skips commit info only for an explicitly supplied `tablet_id`;
- the regression case keeps its five-bucket layout, performs a successful seed load, then uses tablet-scoped queries to select a tablet that actually received rows;
- the fault-injection load reuses the same input, so hash routing guarantees that the selected tablet participates again;
- the debug log records both the selected tablet and destination backend.

Normal load behavior is unchanged when debug points are disabled. The debug point has only this one in-repository caller, which is updated in the same change.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  Manual check:

  ```bash
  git diff origin/master...HEAD --check
  ```

  The targeted runtime regression test will be run after review because it requires a BE built from this patch.

- Behavior changed:
    - [ ] No.
    - [x] Yes. The test-only debug point now requires an explicit `tablet_id` and no longer skips an arbitrary first tablet.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
