### PR TITLE
[opt](storage) Add cache-aware scheduling for lazy reads

### DIFF
--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -231,6 +231,34 @@ Status OlapScanLocalState::_init_profile() {
             ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPrefetchRanges", TUnit::UNIT);
     _cache_aware_lazy_read_prefetch_bytes =
             ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPrefetchBytes", TUnit::BYTES);
+    _cache_aware_lazy_read_page_collect_timer =
+            ADD_TIMER(_segment_profile, "CacheAwareLazyReadPageCollectTime");
+    _cache_aware_lazy_read_doris_cache_lookup_timer =
+            ADD_TIMER(_segment_profile, "CacheAwareLazyReadDorisCacheLookupTime");
+    _cache_aware_lazy_read_os_page_cache_probe_timer =
+            ADD_TIMER(_segment_profile, "CacheAwareLazyReadOsPageCacheProbeTime");
+    _cache_aware_lazy_read_preload_timer =
+            ADD_TIMER(_segment_profile, "CacheAwareLazyReadPreloadTime");
+    _cache_aware_lazy_read_range_build_timer =
+            ADD_TIMER(_segment_profile, "CacheAwareLazyReadRangeBuildTime");
+    _cache_aware_lazy_read_readahead_timer =
+            ADD_TIMER(_segment_profile, "CacheAwareLazyReadReadaheadTime");
+    _cache_aware_lazy_read_sampled_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSampledPages", TUnit::UNIT);
+    _cache_aware_lazy_read_enabled_segments =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadEnabledSegments", TUnit::UNIT);
+    _cache_aware_lazy_read_skipped_low_io_segments =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSkippedLowIoSegments", TUnit::UNIT);
+    _cache_aware_lazy_read_skipped_cold_ratio_segments = ADD_COUNTER(
+            _segment_profile, "CacheAwareLazyReadSkippedColdRatioSegments", TUnit::UNIT);
+    _cache_aware_lazy_read_budget_limit_events =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadBudgetLimitEvents", TUnit::UNIT);
+    _cache_aware_lazy_read_skipped_prefetch_ranges =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSkippedPrefetchRanges", TUnit::UNIT);
+    _cache_aware_lazy_read_pinned_bytes =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPinnedBytes", TUnit::BYTES);
+    _cache_aware_lazy_read_preloaded_bytes =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPreloadedBytes", TUnit::BYTES);
 
     _output_col_timer = ADD_TIMER(_segment_profile, "OutputColumnTime");
 

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -245,12 +245,26 @@ Status OlapScanLocalState::_init_profile() {
             ADD_TIMER(_segment_profile, "CacheAwareLazyReadReadaheadTime");
     _cache_aware_lazy_read_sampled_pages =
             ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSampledPages", TUnit::UNIT);
+    _cache_aware_lazy_read_sample_batches =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSampleBatches", TUnit::UNIT);
+    _cache_aware_lazy_read_sample_doris_cache_hit_pages = ADD_COUNTER(
+            _segment_profile, "CacheAwareLazyReadSampleDorisCacheHitPages", TUnit::UNIT);
+    _cache_aware_lazy_read_sample_os_only_resident_pages = ADD_COUNTER(
+            _segment_profile, "CacheAwareLazyReadSampleOsOnlyResidentPages", TUnit::UNIT);
+    _cache_aware_lazy_read_sample_cold_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSampleColdPages", TUnit::UNIT);
     _cache_aware_lazy_read_enabled_segments =
             ADD_COUNTER(_segment_profile, "CacheAwareLazyReadEnabledSegments", TUnit::UNIT);
-    _cache_aware_lazy_read_skipped_low_io_segments =
-            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadSkippedLowIoSegments", TUnit::UNIT);
+    _cache_aware_lazy_read_skipped_insufficient_sample_segments = ADD_COUNTER(
+            _segment_profile, "CacheAwareLazyReadSkippedInsufficientSampleSegments", TUnit::UNIT);
+    _cache_aware_lazy_read_skipped_low_os_resident_segments = ADD_COUNTER(
+            _segment_profile, "CacheAwareLazyReadSkippedLowOsResidentSegments", TUnit::UNIT);
     _cache_aware_lazy_read_skipped_cold_ratio_segments = ADD_COUNTER(
             _segment_profile, "CacheAwareLazyReadSkippedColdRatioSegments", TUnit::UNIT);
+    _cache_aware_lazy_read_cooldown_events =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadCooldownEvents", TUnit::UNIT);
+    _cache_aware_lazy_read_resample_attempts =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadResampleAttempts", TUnit::UNIT);
     _cache_aware_lazy_read_budget_limit_events =
             ADD_COUNTER(_segment_profile, "CacheAwareLazyReadBudgetLimitEvents", TUnit::UNIT);
     _cache_aware_lazy_read_skipped_prefetch_ranges =

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -216,6 +216,21 @@ Status OlapScanLocalState::_init_profile() {
     _lazy_read_timer = ADD_TIMER(_segment_profile, "LazyReadTime");
     _lazy_read_seek_timer = ADD_TIMER(_segment_profile, "LazyReadSeekTime");
     _lazy_read_seek_counter = ADD_COUNTER(_segment_profile, "LazyReadSeekCount", TUnit::UNIT);
+    _cache_aware_lazy_read_timer = ADD_TIMER(_segment_profile, "CacheAwareLazyReadTime");
+    _cache_aware_lazy_read_planned_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPlannedPages", TUnit::UNIT);
+    _cache_aware_lazy_read_doris_cache_hit_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadDorisCacheHitPages", TUnit::UNIT);
+    _cache_aware_lazy_read_os_cache_hit_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadOsCacheHitPages", TUnit::UNIT);
+    _cache_aware_lazy_read_cold_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadColdPages", TUnit::UNIT);
+    _cache_aware_lazy_read_probe_unsupported_pages =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadProbeUnsupportedPages", TUnit::UNIT);
+    _cache_aware_lazy_read_prefetch_ranges =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPrefetchRanges", TUnit::UNIT);
+    _cache_aware_lazy_read_prefetch_bytes =
+            ADD_COUNTER(_segment_profile, "CacheAwareLazyReadPrefetchBytes", TUnit::BYTES);
 
     _output_col_timer = ADD_TIMER(_segment_profile, "OutputColumnTime");
 

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -199,6 +199,14 @@ private:
     RuntimeProfile::Counter* _lazy_read_timer = nullptr;
     RuntimeProfile::Counter* _lazy_read_seek_timer = nullptr;
     RuntimeProfile::Counter* _lazy_read_seek_counter = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_planned_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_doris_cache_hit_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_os_cache_hit_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_cold_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_probe_unsupported_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_prefetch_ranges = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_prefetch_bytes = nullptr;
 
     // total pages read
     // used by segment v2

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -207,6 +207,20 @@ private:
     RuntimeProfile::Counter* _cache_aware_lazy_read_probe_unsupported_pages = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_prefetch_ranges = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_prefetch_bytes = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_page_collect_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_doris_cache_lookup_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_os_page_cache_probe_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_preload_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_range_build_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_readahead_timer = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_sampled_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_enabled_segments = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_low_io_segments = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_cold_ratio_segments = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_budget_limit_events = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_prefetch_ranges = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_pinned_bytes = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_preloaded_bytes = nullptr;
 
     // total pages read
     // used by segment v2

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -214,9 +214,16 @@ private:
     RuntimeProfile::Counter* _cache_aware_lazy_read_range_build_timer = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_readahead_timer = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_sampled_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_sample_batches = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_sample_doris_cache_hit_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_sample_os_only_resident_pages = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_sample_cold_pages = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_enabled_segments = nullptr;
-    RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_low_io_segments = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_insufficient_sample_segments = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_low_os_resident_segments = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_cold_ratio_segments = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_cooldown_events = nullptr;
+    RuntimeProfile::Counter* _cache_aware_lazy_read_resample_attempts = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_budget_limit_events = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_skipped_prefetch_ranges = nullptr;
     RuntimeProfile::Counter* _cache_aware_lazy_read_pinned_bytes = nullptr;

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -728,6 +728,21 @@ void OlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_lazy_read_timer, stats.lazy_read_ns);
     COUNTER_UPDATE(local_state->_lazy_read_seek_timer, stats.block_lazy_read_seek_ns);
     COUNTER_UPDATE(local_state->_lazy_read_seek_counter, stats.block_lazy_read_seek_num);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_timer, stats.cache_aware_lazy_read_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_planned_pages,
+                   stats.cache_aware_lazy_read_planned_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_doris_cache_hit_pages,
+                   stats.cache_aware_lazy_read_doris_cache_hit_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_os_cache_hit_pages,
+                   stats.cache_aware_lazy_read_os_cache_hit_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_cold_pages,
+                   stats.cache_aware_lazy_read_cold_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_probe_unsupported_pages,
+                   stats.cache_aware_lazy_read_probe_unsupported_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_prefetch_ranges,
+                   stats.cache_aware_lazy_read_prefetch_ranges);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_prefetch_bytes,
+                   stats.cache_aware_lazy_read_prefetch_bytes);
     COUNTER_UPDATE(local_state->_output_col_timer, stats.output_col_ns);
     COUNTER_UPDATE(local_state->_rows_vec_cond_filtered_counter, stats.rows_vec_cond_filtered);
     COUNTER_UPDATE(local_state->_rows_short_circuit_cond_filtered_counter,

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -743,6 +743,34 @@ void OlapScanner::_collect_profile_before_close() {
                    stats.cache_aware_lazy_read_prefetch_ranges);
     COUNTER_UPDATE(local_state->_cache_aware_lazy_read_prefetch_bytes,
                    stats.cache_aware_lazy_read_prefetch_bytes);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_page_collect_timer,
+                   stats.cache_aware_lazy_read_page_collect_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_doris_cache_lookup_timer,
+                   stats.cache_aware_lazy_read_doris_cache_lookup_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_os_page_cache_probe_timer,
+                   stats.cache_aware_lazy_read_os_page_cache_probe_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_preload_timer,
+                   stats.cache_aware_lazy_read_preload_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_range_build_timer,
+                   stats.cache_aware_lazy_read_range_build_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_readahead_timer,
+                   stats.cache_aware_lazy_read_readahead_ns);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_sampled_pages,
+                   stats.cache_aware_lazy_read_sampled_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_enabled_segments,
+                   stats.cache_aware_lazy_read_enabled_segments);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_low_io_segments,
+                   stats.cache_aware_lazy_read_skipped_low_io_segments);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_cold_ratio_segments,
+                   stats.cache_aware_lazy_read_skipped_cold_ratio_segments);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_budget_limit_events,
+                   stats.cache_aware_lazy_read_budget_limit_events);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_prefetch_ranges,
+                   stats.cache_aware_lazy_read_skipped_prefetch_ranges);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_pinned_bytes,
+                   stats.cache_aware_lazy_read_pinned_bytes);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_preloaded_bytes,
+                   stats.cache_aware_lazy_read_preloaded_bytes);
     COUNTER_UPDATE(local_state->_output_col_timer, stats.output_col_ns);
     COUNTER_UPDATE(local_state->_rows_vec_cond_filtered_counter, stats.rows_vec_cond_filtered);
     COUNTER_UPDATE(local_state->_rows_short_circuit_cond_filtered_counter,

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -757,12 +757,26 @@ void OlapScanner::_collect_profile_before_close() {
                    stats.cache_aware_lazy_read_readahead_ns);
     COUNTER_UPDATE(local_state->_cache_aware_lazy_read_sampled_pages,
                    stats.cache_aware_lazy_read_sampled_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_sample_batches,
+                   stats.cache_aware_lazy_read_sample_batches);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_sample_doris_cache_hit_pages,
+                   stats.cache_aware_lazy_read_sample_doris_cache_hit_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_sample_os_only_resident_pages,
+                   stats.cache_aware_lazy_read_sample_os_only_resident_pages);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_sample_cold_pages,
+                   stats.cache_aware_lazy_read_sample_cold_pages);
     COUNTER_UPDATE(local_state->_cache_aware_lazy_read_enabled_segments,
                    stats.cache_aware_lazy_read_enabled_segments);
-    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_low_io_segments,
-                   stats.cache_aware_lazy_read_skipped_low_io_segments);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_insufficient_sample_segments,
+                   stats.cache_aware_lazy_read_skipped_insufficient_sample_segments);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_low_os_resident_segments,
+                   stats.cache_aware_lazy_read_skipped_low_os_resident_segments);
     COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_cold_ratio_segments,
                    stats.cache_aware_lazy_read_skipped_cold_ratio_segments);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_cooldown_events,
+                   stats.cache_aware_lazy_read_cooldown_events);
+    COUNTER_UPDATE(local_state->_cache_aware_lazy_read_resample_attempts,
+                   stats.cache_aware_lazy_read_resample_attempts);
     COUNTER_UPDATE(local_state->_cache_aware_lazy_read_budget_limit_events,
                    stats.cache_aware_lazy_read_budget_limit_events);
     COUNTER_UPDATE(local_state->_cache_aware_lazy_read_skipped_prefetch_ranges,

--- a/be/src/io/fs/file_reader.h
+++ b/be/src/io/fs/file_reader.h
@@ -65,6 +65,12 @@ struct FileReaderOptions {
 
 inline const FileReaderOptions FileReaderOptions::DEFAULT;
 
+enum class PageCacheProbeResult {
+    RESIDENT,
+    NON_RESIDENT,
+    UNSUPPORTED,
+};
+
 class FileReader : public doris::ProfileCollector {
 public:
     FileReader() = default;
@@ -92,6 +98,17 @@ public:
 
     // File modification time (seconds since epoch). Default to 0 meaning unknown.
     virtual int64_t mtime() const = 0;
+
+    // Best-effort interfaces used by the local cache-aware lazy-read POC. The probe must not
+    // initiate storage IO. Implementations that cannot provide these semantics return
+    // UNSUPPORTED and the caller falls back to ordinary reads.
+    virtual PageCacheProbeResult probe_page_cache(size_t offset, Slice result) {
+        return PageCacheProbeResult::UNSUPPORTED;
+    }
+
+    virtual bool supports_cache_aware_read() const { return false; }
+
+    virtual bool prefetch(size_t offset, size_t length) { return false; }
 
 protected:
     virtual Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -23,6 +23,9 @@
 #include <errno.h> // IWYU pragma: keep
 #include <fmt/format.h>
 #include <glog/logging.h>
+#ifdef __linux__
+#include <sys/uio.h>
+#endif
 #include <unistd.h>
 
 #include <algorithm>
@@ -192,6 +195,54 @@ Status LocalFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_
     }
     DorisMetrics::instance()->local_bytes_read_total->increment(*bytes_read);
     return Status::OK();
+}
+
+PageCacheProbeResult LocalFileReader::probe_page_cache(size_t offset, Slice result) {
+#ifdef __linux__
+    if (closed() || offset > _file_size || result.size == 0) {
+        return PageCacheProbeResult::UNSUPPORTED;
+    }
+
+    const size_t bytes_req = std::min(result.size, _file_size - offset);
+    iovec iov {.iov_base = result.data, .iov_len = bytes_req};
+    ssize_t res;
+    do {
+        res = ::preadv2(_fd, &iov, 1, static_cast<off_t>(offset), RWF_NOWAIT);
+    } while (res == -1 && errno == EINTR);
+
+    if (res == static_cast<ssize_t>(bytes_req)) {
+        return PageCacheProbeResult::RESIDENT;
+    }
+    if (res >= 0 || errno == EAGAIN) {
+        return PageCacheProbeResult::NON_RESIDENT;
+    }
+    if (errno != EOPNOTSUPP && errno != ENOSYS && errno != EINVAL) {
+        VLOG_DEBUG << "RWF_NOWAIT probe failed for " << _path.native() << ": " << errno_to_str();
+    }
+    return PageCacheProbeResult::UNSUPPORTED;
+#else
+    static_cast<void>(offset);
+    static_cast<void>(result);
+    return PageCacheProbeResult::UNSUPPORTED;
+#endif
+}
+
+bool LocalFileReader::prefetch(size_t offset, size_t length) {
+#ifdef __linux__
+    if (closed() || length == 0 || offset >= _file_size) {
+        return false;
+    }
+    length = std::min(length, _file_size - offset);
+    if (::readahead(_fd, static_cast<off64_t>(offset), length) == 0) {
+        return true;
+    }
+    VLOG_DEBUG << "readahead failed for " << _path.native() << ": " << errno_to_str();
+    return false;
+#else
+    static_cast<void>(offset);
+    static_cast<void>(length);
+    return false;
+#endif
 }
 
 } // namespace io

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -65,6 +65,12 @@ public:
 
     int64_t mtime() const override { return 0; }
 
+    PageCacheProbeResult probe_page_cache(size_t offset, Slice result) override;
+
+    bool supports_cache_aware_read() const override { return true; }
+
+    bool prefetch(size_t offset, size_t length) override;
+
 private:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* io_ctx) override;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -480,6 +480,11 @@ public:
 
     bool enable_page_cache() const;
 
+    bool enable_cache_aware_lazy_read() const {
+        return _query_options.__isset.enable_cache_aware_lazy_read &&
+               _query_options.enable_cache_aware_lazy_read;
+    }
+
     bool enable_prefer_cached_rowset() const {
         return _query_options.__isset.enable_prefer_cached_rowset &&
                _query_options.enable_prefer_cached_rowset;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -372,9 +372,16 @@ struct OlapReaderStatistics {
     int64_t cache_aware_lazy_read_range_build_ns = 0;
     int64_t cache_aware_lazy_read_readahead_ns = 0;
     int64_t cache_aware_lazy_read_sampled_pages = 0;
+    int64_t cache_aware_lazy_read_sample_batches = 0;
+    int64_t cache_aware_lazy_read_sample_doris_cache_hit_pages = 0;
+    int64_t cache_aware_lazy_read_sample_os_only_resident_pages = 0;
+    int64_t cache_aware_lazy_read_sample_cold_pages = 0;
     int64_t cache_aware_lazy_read_enabled_segments = 0;
-    int64_t cache_aware_lazy_read_skipped_low_io_segments = 0;
+    int64_t cache_aware_lazy_read_skipped_insufficient_sample_segments = 0;
+    int64_t cache_aware_lazy_read_skipped_low_os_resident_segments = 0;
     int64_t cache_aware_lazy_read_skipped_cold_ratio_segments = 0;
+    int64_t cache_aware_lazy_read_cooldown_events = 0;
+    int64_t cache_aware_lazy_read_resample_attempts = 0;
     int64_t cache_aware_lazy_read_budget_limit_events = 0;
     int64_t cache_aware_lazy_read_skipped_prefetch_ranges = 0;
     int64_t cache_aware_lazy_read_pinned_bytes = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -365,6 +365,20 @@ struct OlapReaderStatistics {
     int64_t cache_aware_lazy_read_probe_unsupported_pages = 0;
     int64_t cache_aware_lazy_read_prefetch_ranges = 0;
     int64_t cache_aware_lazy_read_prefetch_bytes = 0;
+    int64_t cache_aware_lazy_read_page_collect_ns = 0;
+    int64_t cache_aware_lazy_read_doris_cache_lookup_ns = 0;
+    int64_t cache_aware_lazy_read_os_page_cache_probe_ns = 0;
+    int64_t cache_aware_lazy_read_preload_ns = 0;
+    int64_t cache_aware_lazy_read_range_build_ns = 0;
+    int64_t cache_aware_lazy_read_readahead_ns = 0;
+    int64_t cache_aware_lazy_read_sampled_pages = 0;
+    int64_t cache_aware_lazy_read_enabled_segments = 0;
+    int64_t cache_aware_lazy_read_skipped_low_io_segments = 0;
+    int64_t cache_aware_lazy_read_skipped_cold_ratio_segments = 0;
+    int64_t cache_aware_lazy_read_budget_limit_events = 0;
+    int64_t cache_aware_lazy_read_skipped_prefetch_ranges = 0;
+    int64_t cache_aware_lazy_read_pinned_bytes = 0;
+    int64_t cache_aware_lazy_read_preloaded_bytes = 0;
 
     int64_t rows_inverted_index_filtered = 0;
     int64_t inverted_index_filter_timer = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -357,6 +357,15 @@ struct OlapReaderStatistics {
     int64_t total_pages_num = 0;
     int64_t cached_pages_num = 0;
 
+    int64_t cache_aware_lazy_read_ns = 0;
+    int64_t cache_aware_lazy_read_planned_pages = 0;
+    int64_t cache_aware_lazy_read_doris_cache_hit_pages = 0;
+    int64_t cache_aware_lazy_read_os_cache_hit_pages = 0;
+    int64_t cache_aware_lazy_read_cold_pages = 0;
+    int64_t cache_aware_lazy_read_probe_unsupported_pages = 0;
+    int64_t cache_aware_lazy_read_prefetch_ranges = 0;
+    int64_t cache_aware_lazy_read_prefetch_bytes = 0;
+
     int64_t rows_inverted_index_filtered = 0;
     int64_t inverted_index_filter_timer = 0;
     int64_t inverted_index_query_timer = 0;

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -2021,20 +2021,36 @@ Status FileColumnIterator::_load_next_page(bool* eos) {
 }
 
 Status FileColumnIterator::collect_data_pages_by_rowids(const rowid_t* rowids, size_t count,
-                                                        std::vector<PagePointer>* pages) {
-    if (_reading_flag == ReadingFlag::SKIP_READING || count == 0) {
+                                                        size_t max_pages,
+                                                        std::vector<PagePointer>* pages,
+                                                        bool* limit_reached) {
+    DCHECK(limit_reached != nullptr);
+    *limit_reached = false;
+    if (_reading_flag == ReadingFlag::SKIP_READING || count == 0 || max_pages == 0) {
         return Status::OK();
     }
 
     OrdinalIndexReader* ordinal_index = nullptr;
     RETURN_IF_ERROR(_reader->get_ordinal_index_reader(ordinal_index, _opts.stats));
     int32_t previous_page_index = -1;
+    ordinal_t previous_page_first_ordinal = 0;
+    ordinal_t previous_page_last_ordinal = 0;
     for (size_t i = 0; i < count; ++i) {
+        if (previous_page_index >= 0 && rowids[i] >= previous_page_first_ordinal &&
+            rowids[i] <= previous_page_last_ordinal) {
+            continue;
+        }
         auto iter = ordinal_index->seek_at_or_before(rowids[i]);
         if (!iter.valid()) {
             return Status::NotFound("failed to find data page for ordinal {}", rowids[i]);
         }
+        previous_page_first_ordinal = iter.first_ordinal();
+        previous_page_last_ordinal = iter.last_ordinal();
         if (iter.page_index() != previous_page_index) {
+            if (pages->size() >= max_pages) {
+                *limit_reached = true;
+                return Status::OK();
+            }
             pages->push_back(iter.page());
             previous_page_index = iter.page_index();
         }

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -48,6 +48,7 @@
 #include "core/value/decimalv2_value.h"
 #include "core/value/vdatetime_value.h" //for VecDateTime
 #include "io/fs/file_reader.h"
+#include "storage/cache/page_cache.h"
 #include "storage/index/ann/ann_index_reader.h"
 #include "storage/index/bloom_filter/bloom_filter.h"
 #include "storage/index/bloom_filter/bloom_filter_index_reader.h"
@@ -2017,6 +2018,57 @@ Status FileColumnIterator::_load_next_page(bool* eos) {
     RETURN_IF_ERROR(_seek_to_pos_in_page(&_page, 0));
     *eos = false;
     return Status::OK();
+}
+
+Status FileColumnIterator::collect_data_pages_by_rowids(const rowid_t* rowids, size_t count,
+                                                        std::vector<PagePointer>* pages) {
+    if (_reading_flag == ReadingFlag::SKIP_READING || count == 0) {
+        return Status::OK();
+    }
+
+    OrdinalIndexReader* ordinal_index = nullptr;
+    RETURN_IF_ERROR(_reader->get_ordinal_index_reader(ordinal_index, _opts.stats));
+    int32_t previous_page_index = -1;
+    for (size_t i = 0; i < count; ++i) {
+        auto iter = ordinal_index->seek_at_or_before(rowids[i]);
+        if (!iter.valid()) {
+            return Status::NotFound("failed to find data page for ordinal {}", rowids[i]);
+        }
+        if (iter.page_index() != previous_page_index) {
+            pages->push_back(iter.page());
+            previous_page_index = iter.page_index();
+        }
+    }
+    return Status::OK();
+}
+
+bool FileColumnIterator::try_pin_data_page(const PagePointer& page, PageHandle* handle) {
+    if (!_opts.use_page_cache) {
+        return false;
+    }
+    auto* cache = StoragePageCache::instance();
+    if (cache == nullptr) {
+        return false;
+    }
+
+    PageCacheHandle cache_handle;
+    StoragePageCache::CacheKey cache_key(_opts.file_reader->path().native(),
+                                         _opts.file_reader->size(), page.offset);
+    if (!cache->lookup(cache_key, &cache_handle, PageTypePB::DATA_PAGE)) {
+        return false;
+    }
+    *handle = PageHandle(std::move(cache_handle));
+    return true;
+}
+
+Status FileColumnIterator::preload_data_page(const PagePointer& page, PageHandle* handle,
+                                             OlapReaderStatistics* stats) {
+    auto preload_opts = _opts;
+    preload_opts.stats = stats;
+    preload_opts.type = PageTypePB::DATA_PAGE;
+    Slice page_body;
+    PageFooterPB footer;
+    return _reader->read_page(preload_opts, page, handle, &page_body, &footer, _compress_codec);
 }
 
 Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter) {

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -345,7 +345,10 @@ public:
     // Hooks for the scalar-only cache-aware lazy-read POC. Complex column iterators keep the
     // default no-op implementation so their existing read path is unchanged.
     virtual Status collect_data_pages_by_rowids(const rowid_t* rowids, size_t count,
-                                                std::vector<PagePointer>* pages) {
+                                                size_t max_pages, std::vector<PagePointer>* pages,
+                                                bool* limit_reached) {
+        DCHECK(limit_reached != nullptr);
+        *limit_reached = false;
         return Status::OK();
     }
 
@@ -453,8 +456,9 @@ public:
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
 
-    Status collect_data_pages_by_rowids(const rowid_t* rowids, size_t count,
-                                        std::vector<PagePointer>* pages) override;
+    Status collect_data_pages_by_rowids(const rowid_t* rowids, size_t count, size_t max_pages,
+                                        std::vector<PagePointer>* pages,
+                                        bool* limit_reached) override;
 
     bool try_pin_data_page(const PagePointer& page, PageHandle* handle) override;
 

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -342,6 +342,20 @@ public:
         return Status::NotSupported("read_by_rowids not implement");
     }
 
+    // Hooks for the scalar-only cache-aware lazy-read POC. Complex column iterators keep the
+    // default no-op implementation so their existing read path is unchanged.
+    virtual Status collect_data_pages_by_rowids(const rowid_t* rowids, size_t count,
+                                                std::vector<PagePointer>* pages) {
+        return Status::OK();
+    }
+
+    virtual bool try_pin_data_page(const PagePointer& page, PageHandle* handle) { return false; }
+
+    virtual Status preload_data_page(const PagePointer& page, PageHandle* handle,
+                                     OlapReaderStatistics* stats) {
+        return Status::NotSupported("preload_data_page not implemented");
+    }
+
     virtual ordinal_t get_current_ordinal() const = 0;
 
     virtual Status get_row_ranges_by_zone_map(
@@ -438,6 +452,14 @@ public:
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
+
+    Status collect_data_pages_by_rowids(const rowid_t* rowids, size_t count,
+                                        std::vector<PagePointer>* pages) override;
+
+    bool try_pin_data_page(const PagePointer& page, PageHandle* handle) override;
+
+    Status preload_data_page(const PagePointer& page, PageHandle* handle,
+                             OlapReaderStatistics* stats) override;
 
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2462,6 +2462,125 @@ uint16_t SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_ro
     return selected_size;
 }
 
+Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnId>& read_column_ids,
+                                                       const std::vector<rowid_t>& rowids,
+                                                       std::vector<PageHandle>* pinned_pages) {
+    if (rowids.empty() || _opts.runtime_state == nullptr || !_opts.use_page_cache ||
+        _opts.io_ctx.reader_type != ReaderType::READER_QUERY || _file_reader == nullptr ||
+        !_file_reader->supports_cache_aware_read() ||
+        !_opts.runtime_state->enable_cache_aware_lazy_read()) {
+        return Status::OK();
+    }
+
+    SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_ns);
+    struct PageRequest {
+        ColumnIterator* iterator;
+        PagePointer page;
+    };
+    std::vector<PageRequest> requests;
+    std::set<std::pair<uint64_t, uint32_t>> seen_pages;
+    for (auto cid : read_column_ids) {
+        std::vector<PagePointer> pages;
+        Status st = _column_iterators[cid]->collect_data_pages_by_rowids(rowids.data(),
+                                                                         rowids.size(), &pages);
+        if (!st.ok()) {
+            VLOG_DEBUG << "cache-aware lazy-read page collection failed: " << st;
+            continue;
+        }
+        for (const auto& page : pages) {
+            if (seen_pages.emplace(page.offset, page.size).second) {
+                requests.push_back(PageRequest {_column_iterators[cid].get(), page});
+            }
+        }
+    }
+    _opts.stats->cache_aware_lazy_read_planned_pages += requests.size();
+    if (requests.empty()) {
+        return Status::OK();
+    }
+
+    size_t max_page_size = 0;
+    for (const auto& request : requests) {
+        max_page_size = std::max(max_page_size, static_cast<size_t>(request.page.size));
+    }
+    std::vector<char> probe_buffer(max_page_size);
+    std::vector<PageRequest> cold_pages;
+    cold_pages.reserve(requests.size());
+    pinned_pages->reserve(pinned_pages->size() + requests.size());
+    bool probe_supported = true;
+    OlapReaderStatistics preload_stats;
+
+    for (const auto& request : requests) {
+        PageHandle handle;
+        if (request.iterator->try_pin_data_page(request.page, &handle)) {
+            pinned_pages->push_back(std::move(handle));
+            ++_opts.stats->cache_aware_lazy_read_doris_cache_hit_pages;
+            continue;
+        }
+
+        if (probe_supported) {
+            auto probe_result = _file_reader->probe_page_cache(
+                    request.page.offset, Slice(probe_buffer.data(), request.page.size));
+            if (probe_result == io::PageCacheProbeResult::RESIDENT) {
+                Status st =
+                        request.iterator->preload_data_page(request.page, &handle, &preload_stats);
+                if (st.ok()) {
+                    pinned_pages->push_back(std::move(handle));
+                    ++_opts.stats->cache_aware_lazy_read_os_cache_hit_pages;
+                    continue;
+                }
+                VLOG_DEBUG << "cache-aware lazy-read hot page preload failed: " << st;
+            } else if (probe_result == io::PageCacheProbeResult::UNSUPPORTED) {
+                probe_supported = false;
+            }
+        }
+        if (!probe_supported) {
+            ++_opts.stats->cache_aware_lazy_read_probe_unsupported_pages;
+        }
+        cold_pages.push_back(request);
+    }
+    _opts.stats->cache_aware_lazy_read_cold_pages += cold_pages.size();
+
+    std::sort(cold_pages.begin(), cold_pages.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.page.offset < rhs.page.offset; });
+    struct PrefetchRange {
+        uint64_t offset;
+        uint64_t end;
+        uint64_t requested_bytes;
+    };
+    std::vector<PrefetchRange> ranges;
+    constexpr uint64_t MAX_MERGE_GAP = 64 * 1024;
+    constexpr uint64_t MAX_PREFETCH_RANGE = 1024 * 1024;
+    constexpr uint64_t MAX_READ_AMPLIFICATION_PERCENT = 125;
+    for (const auto& request : cold_pages) {
+        const uint64_t page_end = request.page.offset + request.page.size;
+        if (ranges.empty()) {
+            ranges.push_back(PrefetchRange {request.page.offset, page_end, request.page.size});
+            continue;
+        }
+        auto& range = ranges.back();
+        const uint64_t merged_end = std::max(range.end, page_end);
+        const uint64_t merged_span = merged_end - range.offset;
+        const uint64_t merged_requested = range.requested_bytes + request.page.size;
+        const uint64_t gap = request.page.offset > range.end ? request.page.offset - range.end : 0;
+        if (gap <= MAX_MERGE_GAP && merged_span <= MAX_PREFETCH_RANGE &&
+            merged_span * 100 <= merged_requested * MAX_READ_AMPLIFICATION_PERCENT) {
+            range.end = merged_end;
+            range.requested_bytes = merged_requested;
+        } else {
+            ranges.push_back(PrefetchRange {request.page.offset, page_end, request.page.size});
+        }
+    }
+
+    for (const auto& range : ranges) {
+        const size_t length = range.end - range.offset;
+        if (_file_reader->prefetch(range.offset, length)) {
+            ++_opts.stats->cache_aware_lazy_read_prefetch_ranges;
+            _opts.stats->cache_aware_lazy_read_prefetch_bytes += length;
+        }
+    }
+    return Status::OK();
+}
+
 Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_column_ids,
                                                 std::vector<rowid_t>& rowid_vector,
                                                 uint16_t* sel_rowid_idx, size_t select_size,
@@ -2482,6 +2601,10 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
             rowids[i] = rowid_vector[sel_rowid_idx[i]];
         }
     }
+
+    std::vector<PageHandle> cache_aware_pinned_pages;
+    RETURN_IF_ERROR(
+            _prepare_cache_aware_lazy_read(read_column_ids, rowids, &cache_aware_pinned_pages));
 
     for (auto cid : read_column_ids) {
         auto& colunm = (*mutable_columns)[cid];

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -116,15 +116,15 @@ namespace segment_v2 {
 
 namespace {
 
-constexpr int CACHE_AWARE_BASELINE_BATCHES = 2;
-constexpr int64_t CACHE_AWARE_BASELINE_PAGES = 512;
-constexpr int64_t CACHE_AWARE_MIN_BASELINE_PAGES = 64;
-constexpr int64_t CACHE_AWARE_MIN_BASELINE_IO_NS = 5 * 1000 * 1000;
-constexpr int64_t CACHE_AWARE_MIN_IO_NS_PER_PAGE = 20 * 1000;
-constexpr int64_t CACHE_AWARE_MIN_MISS_PERCENT = 15;
-
-constexpr size_t CACHE_AWARE_SAMPLE_PAGES = 512;
-constexpr size_t CACHE_AWARE_MIN_SAMPLE_PAGES = 32;
+constexpr size_t CACHE_AWARE_SAMPLE_PAGES_PER_BATCH = 128;
+constexpr size_t CACHE_AWARE_MIN_SAMPLE_PAGES = 64;
+constexpr size_t CACHE_AWARE_MAX_SAMPLE_PAGES = 512;
+constexpr int CACHE_AWARE_MAX_SAMPLE_BATCHES = 8;
+constexpr int CACHE_AWARE_COOLDOWN_BATCHES = 16;
+// Cache-aware preload is useful for pages that missed the Doris cache but are still resident in
+// the OS page cache. A high Doris-cache ratio needs no scheduling, while a high cold ratio makes
+// eager probing/prefetching risky.
+constexpr size_t CACHE_AWARE_MIN_OS_RESIDENT_PERCENT = 20;
 constexpr size_t CACHE_AWARE_MAX_PAGES_PER_BATCH = 4096;
 constexpr size_t CACHE_AWARE_MAX_ROWID_COLUMN_LOOKUPS = 1000 * 1000;
 constexpr size_t CACHE_AWARE_MAX_PINNED_BYTES_PER_BATCH = 64 * 1024 * 1024;
@@ -2489,6 +2489,21 @@ uint16_t SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_ro
     return selected_size;
 }
 
+void SegmentIterator::_reset_cache_aware_lazy_read_sample() {
+    _cache_aware_lazy_read_sample_pages = 0;
+    _cache_aware_lazy_read_sample_doris_cache_hit_pages = 0;
+    _cache_aware_lazy_read_sample_os_only_resident_pages = 0;
+    _cache_aware_lazy_read_sample_cold_pages = 0;
+    _cache_aware_lazy_read_sample_batches = 0;
+}
+
+void SegmentIterator::_enter_cache_aware_lazy_read_cooldown() {
+    _cache_aware_lazy_read_state = CacheAwareLazyReadState::COOLDOWN;
+    _cache_aware_lazy_read_cooldown_batches = 0;
+    _reset_cache_aware_lazy_read_sample();
+    ++_opts.stats->cache_aware_lazy_read_cooldown_events;
+}
+
 Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnId>& read_column_ids,
                                                        const std::vector<rowid_t>& rowids,
                                                        std::vector<PageHandle>* pinned_pages) {
@@ -2496,16 +2511,25 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
         _opts.io_ctx.reader_type != ReaderType::READER_QUERY || _file_reader == nullptr ||
         !_file_reader->supports_cache_aware_read() ||
         !_opts.runtime_state->enable_cache_aware_lazy_read() ||
-        _cache_aware_lazy_read_state == CacheAwareLazyReadState::OBSERVING ||
         _cache_aware_lazy_read_state == CacheAwareLazyReadState::DISABLED) {
         return Status::OK();
+    }
+
+    if (_cache_aware_lazy_read_state == CacheAwareLazyReadState::COOLDOWN) {
+        if (++_cache_aware_lazy_read_cooldown_batches < CACHE_AWARE_COOLDOWN_BATCHES) {
+            return Status::OK();
+        }
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::SAMPLING;
+        _cache_aware_lazy_read_cooldown_batches = 0;
+        _reset_cache_aware_lazy_read_sample();
+        ++_opts.stats->cache_aware_lazy_read_resample_attempts;
     }
 
     SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_ns);
     if (!read_column_ids.empty() &&
         rowids.size() > CACHE_AWARE_MAX_ROWID_COLUMN_LOOKUPS / read_column_ids.size()) {
-        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
         ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+        _enter_cache_aware_lazy_read_cooldown();
         return Status::OK();
     }
 
@@ -2514,8 +2538,11 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
         PagePointer page;
     };
     const bool is_sampling = _cache_aware_lazy_read_state == CacheAwareLazyReadState::SAMPLING;
+    const size_t remaining_sample_pages =
+            CACHE_AWARE_MAX_SAMPLE_PAGES - _cache_aware_lazy_read_sample_pages;
     const size_t max_requests =
-            is_sampling ? CACHE_AWARE_SAMPLE_PAGES : CACHE_AWARE_MAX_PAGES_PER_BATCH;
+            is_sampling ? std::min(CACHE_AWARE_SAMPLE_PAGES_PER_BATCH, remaining_sample_pages)
+                        : CACHE_AWARE_MAX_PAGES_PER_BATCH;
     std::vector<PageRequest> requests;
     requests.reserve(max_requests);
     std::set<std::pair<uint64_t, uint32_t>> seen_pages;
@@ -2559,20 +2586,21 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
     _opts.stats->cache_aware_lazy_read_planned_pages += requests.size();
     if (is_sampling) {
         _opts.stats->cache_aware_lazy_read_sampled_pages += requests.size();
+        ++_opts.stats->cache_aware_lazy_read_sample_batches;
+        ++_cache_aware_lazy_read_sample_batches;
     }
-    if (page_budget_reached) {
+    if (page_budget_reached && !is_sampling) {
         ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
     }
     if (requests.empty()) {
-        if (is_sampling) {
-            _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
-            ++_opts.stats->cache_aware_lazy_read_skipped_low_io_segments;
+        if (is_sampling &&
+            _cache_aware_lazy_read_sample_batches >= CACHE_AWARE_MAX_SAMPLE_BATCHES) {
+            if (!_cache_aware_lazy_read_counted_insufficient_sample) {
+                _cache_aware_lazy_read_counted_insufficient_sample = true;
+                ++_opts.stats->cache_aware_lazy_read_skipped_insufficient_sample_segments;
+            }
+            _enter_cache_aware_lazy_read_cooldown();
         }
-        return Status::OK();
-    }
-    if (is_sampling && requests.size() < CACHE_AWARE_MIN_SAMPLE_PAGES && !page_budget_reached) {
-        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
-        ++_opts.stats->cache_aware_lazy_read_skipped_low_io_segments;
         return Status::OK();
     }
 
@@ -2589,6 +2617,7 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
     cold_pages.reserve(requests.size());
     bool probe_supported = true;
     size_t pinned_bytes = 0;
+    size_t doris_cache_hit_pages = 0;
 
     for (const auto& request : requests) {
         PageHandle handle;
@@ -2598,6 +2627,7 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
             doris_cache_hit = request.iterator->try_pin_data_page(request.page, &handle);
         }
         if (doris_cache_hit) {
+            ++doris_cache_hit_pages;
             ++_opts.stats->cache_aware_lazy_read_doris_cache_hit_pages;
             const size_t page_bytes = handle.data().size;
             if (pinned_bytes + page_bytes <= CACHE_AWARE_MAX_PINNED_BYTES_PER_BATCH) {
@@ -2631,17 +2661,71 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
     }
     _opts.stats->cache_aware_lazy_read_cold_pages += cold_pages.size();
 
-    const size_t max_cold_percent =
-            is_sampling ? CACHE_AWARE_SAMPLE_MAX_COLD_PERCENT : CACHE_AWARE_DISABLE_COLD_PERCENT;
-    if (!probe_supported || cold_pages.size() * 100 > requests.size() * max_cold_percent) {
+    if (!probe_supported) {
         _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
-        ++_opts.stats->cache_aware_lazy_read_skipped_cold_ratio_segments;
         return Status::OK();
     }
 
     if (is_sampling) {
+        // Accumulate a bounded D/O/C sample across lazy-read batches. Do not reject a segment
+        // merely because one early batch contains too few pages.
+        _cache_aware_lazy_read_sample_pages += requests.size();
+        _cache_aware_lazy_read_sample_doris_cache_hit_pages += doris_cache_hit_pages;
+        _cache_aware_lazy_read_sample_os_only_resident_pages += os_resident_pages.size();
+        _cache_aware_lazy_read_sample_cold_pages += cold_pages.size();
+        _opts.stats->cache_aware_lazy_read_sample_doris_cache_hit_pages += doris_cache_hit_pages;
+        _opts.stats->cache_aware_lazy_read_sample_os_only_resident_pages +=
+                os_resident_pages.size();
+        _opts.stats->cache_aware_lazy_read_sample_cold_pages += cold_pages.size();
+
+        const bool enough_sample =
+                _cache_aware_lazy_read_sample_pages >= CACHE_AWARE_MIN_SAMPLE_PAGES;
+        const bool sample_exhausted =
+                _cache_aware_lazy_read_sample_pages >= CACHE_AWARE_MAX_SAMPLE_PAGES ||
+                _cache_aware_lazy_read_sample_batches >= CACHE_AWARE_MAX_SAMPLE_BATCHES;
+        if (!enough_sample && !sample_exhausted) {
+            return Status::OK();
+        }
+        if (!enough_sample) {
+            if (!_cache_aware_lazy_read_counted_insufficient_sample) {
+                _cache_aware_lazy_read_counted_insufficient_sample = true;
+                ++_opts.stats->cache_aware_lazy_read_skipped_insufficient_sample_segments;
+            }
+            _enter_cache_aware_lazy_read_cooldown();
+            return Status::OK();
+        }
+
+        if (_cache_aware_lazy_read_sample_cold_pages * 100 >
+            _cache_aware_lazy_read_sample_pages * CACHE_AWARE_SAMPLE_MAX_COLD_PERCENT) {
+            if (!_cache_aware_lazy_read_counted_cold_ratio) {
+                _cache_aware_lazy_read_counted_cold_ratio = true;
+                ++_opts.stats->cache_aware_lazy_read_skipped_cold_ratio_segments;
+            }
+            _enter_cache_aware_lazy_read_cooldown();
+            return Status::OK();
+        }
+        if (_cache_aware_lazy_read_sample_os_only_resident_pages * 100 <
+            _cache_aware_lazy_read_sample_pages * CACHE_AWARE_MIN_OS_RESIDENT_PERCENT) {
+            if (!_cache_aware_lazy_read_counted_low_os_resident) {
+                _cache_aware_lazy_read_counted_low_os_resident = true;
+                ++_opts.stats->cache_aware_lazy_read_skipped_low_os_resident_segments;
+            }
+            _enter_cache_aware_lazy_read_cooldown();
+            return Status::OK();
+        }
+
         _cache_aware_lazy_read_state = CacheAwareLazyReadState::ENABLED;
-        ++_opts.stats->cache_aware_lazy_read_enabled_segments;
+        if (!_cache_aware_lazy_read_ever_enabled) {
+            _cache_aware_lazy_read_ever_enabled = true;
+            ++_opts.stats->cache_aware_lazy_read_enabled_segments;
+        }
+    } else if (cold_pages.size() * 100 > requests.size() * CACHE_AWARE_DISABLE_COLD_PERCENT) {
+        if (!_cache_aware_lazy_read_counted_cold_ratio) {
+            _cache_aware_lazy_read_counted_cold_ratio = true;
+            ++_opts.stats->cache_aware_lazy_read_skipped_cold_ratio_segments;
+        }
+        _enter_cache_aware_lazy_read_cooldown();
+        return Status::OK();
     }
 
     pinned_pages->reserve(pinned_pages->size() + doris_cache_pins.size() +
@@ -2746,43 +2830,6 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
     return Status::OK();
 }
 
-void SegmentIterator::_update_cache_aware_lazy_read_baseline(int64_t io_ns_before,
-                                                             int64_t pages_before,
-                                                             int64_t cached_pages_before) {
-    if (_cache_aware_lazy_read_state != CacheAwareLazyReadState::OBSERVING) {
-        return;
-    }
-
-    const int64_t io_ns = std::max<int64_t>(0, _opts.stats->io_ns - io_ns_before);
-    const int64_t pages = std::max<int64_t>(0, _opts.stats->total_pages_num - pages_before);
-    const int64_t cached_pages =
-            std::max<int64_t>(0, _opts.stats->cached_pages_num - cached_pages_before);
-    _cache_aware_lazy_read_baseline_io_ns += io_ns;
-    _cache_aware_lazy_read_baseline_pages += pages;
-    _cache_aware_lazy_read_baseline_miss_pages += std::max<int64_t>(0, pages - cached_pages);
-    ++_cache_aware_lazy_read_baseline_batches;
-
-    if (_cache_aware_lazy_read_baseline_batches < CACHE_AWARE_BASELINE_BATCHES &&
-        _cache_aware_lazy_read_baseline_pages < CACHE_AWARE_BASELINE_PAGES) {
-        return;
-    }
-
-    const bool enough_pages =
-            _cache_aware_lazy_read_baseline_pages >= CACHE_AWARE_MIN_BASELINE_PAGES;
-    const bool enough_misses = _cache_aware_lazy_read_baseline_miss_pages * 100 >=
-                               _cache_aware_lazy_read_baseline_pages * CACHE_AWARE_MIN_MISS_PERCENT;
-    const bool enough_io =
-            _cache_aware_lazy_read_baseline_io_ns >= CACHE_AWARE_MIN_BASELINE_IO_NS &&
-            _cache_aware_lazy_read_baseline_io_ns >=
-                    _cache_aware_lazy_read_baseline_pages * CACHE_AWARE_MIN_IO_NS_PER_PAGE;
-    if (enough_pages && enough_misses && enough_io) {
-        _cache_aware_lazy_read_state = CacheAwareLazyReadState::SAMPLING;
-    } else {
-        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
-        ++_opts.stats->cache_aware_lazy_read_skipped_low_io_segments;
-    }
-}
-
 Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_column_ids,
                                                 std::vector<rowid_t>& rowid_vector,
                                                 uint16_t* sel_rowid_idx, size_t select_size,
@@ -2803,17 +2850,6 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
             rowids[i] = rowid_vector[sel_rowid_idx[i]];
         }
     }
-
-    const bool observe_cache_aware_baseline =
-            _cache_aware_lazy_read_state == CacheAwareLazyReadState::OBSERVING &&
-            _opts.runtime_state != nullptr && _opts.use_page_cache &&
-            _opts.io_ctx.reader_type == ReaderType::READER_QUERY && _file_reader != nullptr &&
-            _file_reader->supports_cache_aware_read() &&
-            _opts.runtime_state->enable_cache_aware_lazy_read();
-    const int64_t io_ns_before = observe_cache_aware_baseline ? _opts.stats->io_ns : 0;
-    const int64_t pages_before = observe_cache_aware_baseline ? _opts.stats->total_pages_num : 0;
-    const int64_t cached_pages_before =
-            observe_cache_aware_baseline ? _opts.stats->cached_pages_num : 0;
 
     std::vector<PageHandle> cache_aware_pinned_pages;
     RETURN_IF_ERROR(
@@ -2848,10 +2884,6 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
         }
         RETURN_IF_ERROR(_column_iterators[cid]->read_by_rowids(rowids.data(), select_size,
                                                                _current_return_columns[cid]));
-    }
-
-    if (observe_cache_aware_baseline) {
-        _update_cache_aware_lazy_read_baseline(io_ns_before, pages_before, cached_pages_before);
     }
 
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -114,6 +114,33 @@ namespace segment_v2 {
 
 #include "common/compile_check_begin.h"
 
+namespace {
+
+constexpr int CACHE_AWARE_BASELINE_BATCHES = 2;
+constexpr int64_t CACHE_AWARE_BASELINE_PAGES = 512;
+constexpr int64_t CACHE_AWARE_MIN_BASELINE_PAGES = 64;
+constexpr int64_t CACHE_AWARE_MIN_BASELINE_IO_NS = 5 * 1000 * 1000;
+constexpr int64_t CACHE_AWARE_MIN_IO_NS_PER_PAGE = 20 * 1000;
+constexpr int64_t CACHE_AWARE_MIN_MISS_PERCENT = 15;
+
+constexpr size_t CACHE_AWARE_SAMPLE_PAGES = 512;
+constexpr size_t CACHE_AWARE_MIN_SAMPLE_PAGES = 32;
+constexpr size_t CACHE_AWARE_MAX_PAGES_PER_BATCH = 4096;
+constexpr size_t CACHE_AWARE_MAX_ROWID_COLUMN_LOOKUPS = 1000 * 1000;
+constexpr size_t CACHE_AWARE_MAX_PINNED_BYTES_PER_BATCH = 64 * 1024 * 1024;
+constexpr size_t CACHE_AWARE_SAMPLE_MAX_COLD_PERCENT = 8;
+constexpr size_t CACHE_AWARE_DISABLE_COLD_PERCENT = 12;
+
+constexpr uint64_t CACHE_AWARE_MAX_MERGE_GAP = 64 * 1024;
+constexpr uint64_t CACHE_AWARE_MAX_PREFETCH_RANGE = 1024 * 1024;
+constexpr uint64_t CACHE_AWARE_MAX_READ_AMPLIFICATION_PERCENT = 125;
+constexpr size_t CACHE_AWARE_MIN_PREFETCH_PAGES = 4;
+constexpr uint64_t CACHE_AWARE_MIN_PREFETCH_RANGE = 256 * 1024;
+constexpr size_t CACHE_AWARE_MAX_PREFETCH_RANGES_PER_BATCH = 32;
+constexpr uint64_t CACHE_AWARE_MAX_PREFETCH_BYTES_PER_BATCH = 32 * 1024 * 1024;
+
+} // namespace
+
 SegmentIterator::~SegmentIterator() = default;
 
 void SegmentIterator::_init_row_bitmap_by_condition_cache() {
@@ -2468,33 +2495,84 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
     if (rowids.empty() || _opts.runtime_state == nullptr || !_opts.use_page_cache ||
         _opts.io_ctx.reader_type != ReaderType::READER_QUERY || _file_reader == nullptr ||
         !_file_reader->supports_cache_aware_read() ||
-        !_opts.runtime_state->enable_cache_aware_lazy_read()) {
+        !_opts.runtime_state->enable_cache_aware_lazy_read() ||
+        _cache_aware_lazy_read_state == CacheAwareLazyReadState::OBSERVING ||
+        _cache_aware_lazy_read_state == CacheAwareLazyReadState::DISABLED) {
         return Status::OK();
     }
 
     SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_ns);
+    if (!read_column_ids.empty() &&
+        rowids.size() > CACHE_AWARE_MAX_ROWID_COLUMN_LOOKUPS / read_column_ids.size()) {
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
+        ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+        return Status::OK();
+    }
+
     struct PageRequest {
         ColumnIterator* iterator;
         PagePointer page;
     };
+    const bool is_sampling = _cache_aware_lazy_read_state == CacheAwareLazyReadState::SAMPLING;
+    const size_t max_requests =
+            is_sampling ? CACHE_AWARE_SAMPLE_PAGES : CACHE_AWARE_MAX_PAGES_PER_BATCH;
     std::vector<PageRequest> requests;
+    requests.reserve(max_requests);
     std::set<std::pair<uint64_t, uint32_t>> seen_pages;
-    for (auto cid : read_column_ids) {
-        std::vector<PagePointer> pages;
-        Status st = _column_iterators[cid]->collect_data_pages_by_rowids(rowids.data(),
-                                                                         rowids.size(), &pages);
-        if (!st.ok()) {
-            VLOG_DEBUG << "cache-aware lazy-read page collection failed: " << st;
-            continue;
-        }
-        for (const auto& page : pages) {
-            if (seen_pages.emplace(page.offset, page.size).second) {
-                requests.push_back(PageRequest {_column_iterators[cid].get(), page});
+    bool page_budget_reached = false;
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_page_collect_ns);
+        for (auto cid : read_column_ids) {
+            const size_t remaining = max_requests - requests.size();
+            if (remaining == 0) {
+                page_budget_reached = true;
+                break;
+            }
+            const size_t per_column_sample_pages =
+                    (max_requests + read_column_ids.size() - 1) / read_column_ids.size();
+            const size_t column_budget =
+                    is_sampling ? std::min(remaining, per_column_sample_pages) : remaining;
+            std::vector<PagePointer> pages;
+            pages.reserve(column_budget);
+            bool column_limit_reached = false;
+            Status st = _column_iterators[cid]->collect_data_pages_by_rowids(
+                    rowids.data(), rowids.size(), column_budget, &pages, &column_limit_reached);
+            if (!st.ok()) {
+                VLOG_DEBUG << "cache-aware lazy-read page collection failed: " << st;
+                continue;
+            }
+            for (const auto& page : pages) {
+                if (seen_pages.emplace(page.offset, page.size).second) {
+                    requests.push_back(PageRequest {_column_iterators[cid].get(), page});
+                }
+            }
+            if (requests.size() >= max_requests) {
+                page_budget_reached = true;
+                break;
+            }
+            if (column_limit_reached && !is_sampling) {
+                page_budget_reached = true;
+                break;
             }
         }
     }
     _opts.stats->cache_aware_lazy_read_planned_pages += requests.size();
+    if (is_sampling) {
+        _opts.stats->cache_aware_lazy_read_sampled_pages += requests.size();
+    }
+    if (page_budget_reached) {
+        ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+    }
     if (requests.empty()) {
+        if (is_sampling) {
+            _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
+            ++_opts.stats->cache_aware_lazy_read_skipped_low_io_segments;
+        }
+        return Status::OK();
+    }
+    if (is_sampling && requests.size() < CACHE_AWARE_MIN_SAMPLE_PAGES && !page_budget_reached) {
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
+        ++_opts.stats->cache_aware_lazy_read_skipped_low_io_segments;
         return Status::OK();
     }
 
@@ -2503,32 +2581,45 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
         max_page_size = std::max(max_page_size, static_cast<size_t>(request.page.size));
     }
     std::vector<char> probe_buffer(max_page_size);
+    std::vector<PageHandle> doris_cache_pins;
+    doris_cache_pins.reserve(requests.size());
+    std::vector<PageRequest> os_resident_pages;
+    os_resident_pages.reserve(requests.size());
     std::vector<PageRequest> cold_pages;
     cold_pages.reserve(requests.size());
-    pinned_pages->reserve(pinned_pages->size() + requests.size());
     bool probe_supported = true;
-    OlapReaderStatistics preload_stats;
+    size_t pinned_bytes = 0;
 
     for (const auto& request : requests) {
         PageHandle handle;
-        if (request.iterator->try_pin_data_page(request.page, &handle)) {
-            pinned_pages->push_back(std::move(handle));
+        bool doris_cache_hit = false;
+        {
+            SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_doris_cache_lookup_ns);
+            doris_cache_hit = request.iterator->try_pin_data_page(request.page, &handle);
+        }
+        if (doris_cache_hit) {
             ++_opts.stats->cache_aware_lazy_read_doris_cache_hit_pages;
+            const size_t page_bytes = handle.data().size;
+            if (pinned_bytes + page_bytes <= CACHE_AWARE_MAX_PINNED_BYTES_PER_BATCH) {
+                pinned_bytes += page_bytes;
+                doris_cache_pins.push_back(std::move(handle));
+            } else {
+                ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+            }
             continue;
         }
 
         if (probe_supported) {
-            auto probe_result = _file_reader->probe_page_cache(
-                    request.page.offset, Slice(probe_buffer.data(), request.page.size));
+            io::PageCacheProbeResult probe_result;
+            {
+                SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_os_page_cache_probe_ns);
+                probe_result = _file_reader->probe_page_cache(
+                        request.page.offset, Slice(probe_buffer.data(), request.page.size));
+            }
             if (probe_result == io::PageCacheProbeResult::RESIDENT) {
-                Status st =
-                        request.iterator->preload_data_page(request.page, &handle, &preload_stats);
-                if (st.ok()) {
-                    pinned_pages->push_back(std::move(handle));
-                    ++_opts.stats->cache_aware_lazy_read_os_cache_hit_pages;
-                    continue;
-                }
-                VLOG_DEBUG << "cache-aware lazy-read hot page preload failed: " << st;
+                ++_opts.stats->cache_aware_lazy_read_os_cache_hit_pages;
+                os_resident_pages.push_back(request);
+                continue;
             } else if (probe_result == io::PageCacheProbeResult::UNSUPPORTED) {
                 probe_supported = false;
             }
@@ -2540,45 +2631,156 @@ Status SegmentIterator::_prepare_cache_aware_lazy_read(const std::vector<ColumnI
     }
     _opts.stats->cache_aware_lazy_read_cold_pages += cold_pages.size();
 
-    std::sort(cold_pages.begin(), cold_pages.end(),
-              [](const auto& lhs, const auto& rhs) { return lhs.page.offset < rhs.page.offset; });
+    const size_t max_cold_percent =
+            is_sampling ? CACHE_AWARE_SAMPLE_MAX_COLD_PERCENT : CACHE_AWARE_DISABLE_COLD_PERCENT;
+    if (!probe_supported || cold_pages.size() * 100 > requests.size() * max_cold_percent) {
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
+        ++_opts.stats->cache_aware_lazy_read_skipped_cold_ratio_segments;
+        return Status::OK();
+    }
+
+    if (is_sampling) {
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::ENABLED;
+        ++_opts.stats->cache_aware_lazy_read_enabled_segments;
+    }
+
+    pinned_pages->reserve(pinned_pages->size() + doris_cache_pins.size() +
+                          os_resident_pages.size());
+    for (auto& handle : doris_cache_pins) {
+        pinned_pages->push_back(std::move(handle));
+    }
+
+    OlapReaderStatistics preload_stats;
+    int64_t preloaded_bytes = 0;
+    for (const auto& request : os_resident_pages) {
+        if (pinned_bytes + request.page.size > CACHE_AWARE_MAX_PINNED_BYTES_PER_BATCH) {
+            ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+            break;
+        }
+        PageHandle handle;
+        Status st;
+        {
+            SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_preload_ns);
+            st = request.iterator->preload_data_page(request.page, &handle, &preload_stats);
+        }
+        if (!st.ok()) {
+            VLOG_DEBUG << "cache-aware lazy-read hot page preload failed: " << st;
+            continue;
+        }
+        const size_t page_bytes = handle.data().size;
+        if (pinned_bytes + page_bytes > CACHE_AWARE_MAX_PINNED_BYTES_PER_BATCH) {
+            ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+            break;
+        }
+        pinned_bytes += page_bytes;
+        preloaded_bytes += page_bytes;
+        pinned_pages->push_back(std::move(handle));
+    }
+    _opts.stats->cache_aware_lazy_read_pinned_bytes += pinned_bytes;
+    _opts.stats->cache_aware_lazy_read_preloaded_bytes += preloaded_bytes;
+
     struct PrefetchRange {
         uint64_t offset;
         uint64_t end;
         uint64_t requested_bytes;
+        size_t page_count;
     };
     std::vector<PrefetchRange> ranges;
-    constexpr uint64_t MAX_MERGE_GAP = 64 * 1024;
-    constexpr uint64_t MAX_PREFETCH_RANGE = 1024 * 1024;
-    constexpr uint64_t MAX_READ_AMPLIFICATION_PERCENT = 125;
-    for (const auto& request : cold_pages) {
-        const uint64_t page_end = request.page.offset + request.page.size;
-        if (ranges.empty()) {
-            ranges.push_back(PrefetchRange {request.page.offset, page_end, request.page.size});
-            continue;
-        }
-        auto& range = ranges.back();
-        const uint64_t merged_end = std::max(range.end, page_end);
-        const uint64_t merged_span = merged_end - range.offset;
-        const uint64_t merged_requested = range.requested_bytes + request.page.size;
-        const uint64_t gap = request.page.offset > range.end ? request.page.offset - range.end : 0;
-        if (gap <= MAX_MERGE_GAP && merged_span <= MAX_PREFETCH_RANGE &&
-            merged_span * 100 <= merged_requested * MAX_READ_AMPLIFICATION_PERCENT) {
-            range.end = merged_end;
-            range.requested_bytes = merged_requested;
-        } else {
-            ranges.push_back(PrefetchRange {request.page.offset, page_end, request.page.size});
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_range_build_ns);
+        std::sort(cold_pages.begin(), cold_pages.end(), [](const auto& lhs, const auto& rhs) {
+            return lhs.page.offset < rhs.page.offset;
+        });
+        for (const auto& request : cold_pages) {
+            const uint64_t page_end = request.page.offset + request.page.size;
+            if (ranges.empty()) {
+                ranges.push_back(
+                        PrefetchRange {request.page.offset, page_end, request.page.size, 1});
+                continue;
+            }
+            auto& range = ranges.back();
+            const uint64_t merged_end = std::max(range.end, page_end);
+            const uint64_t merged_span = merged_end - range.offset;
+            const uint64_t merged_requested = range.requested_bytes + request.page.size;
+            const uint64_t gap =
+                    request.page.offset > range.end ? request.page.offset - range.end : 0;
+            if (gap <= CACHE_AWARE_MAX_MERGE_GAP && merged_span <= CACHE_AWARE_MAX_PREFETCH_RANGE &&
+                merged_span * 100 <=
+                        merged_requested * CACHE_AWARE_MAX_READ_AMPLIFICATION_PERCENT) {
+                range.end = merged_end;
+                range.requested_bytes = merged_requested;
+                ++range.page_count;
+            } else {
+                ranges.push_back(
+                        PrefetchRange {request.page.offset, page_end, request.page.size, 1});
+            }
         }
     }
 
+    size_t submitted_ranges = 0;
+    uint64_t submitted_bytes = 0;
     for (const auto& range : ranges) {
         const size_t length = range.end - range.offset;
-        if (_file_reader->prefetch(range.offset, length)) {
+        if (range.page_count < CACHE_AWARE_MIN_PREFETCH_PAGES ||
+            length < CACHE_AWARE_MIN_PREFETCH_RANGE) {
+            ++_opts.stats->cache_aware_lazy_read_skipped_prefetch_ranges;
+            continue;
+        }
+        if (submitted_ranges >= CACHE_AWARE_MAX_PREFETCH_RANGES_PER_BATCH ||
+            submitted_bytes + length > CACHE_AWARE_MAX_PREFETCH_BYTES_PER_BATCH) {
+            ++_opts.stats->cache_aware_lazy_read_budget_limit_events;
+            break;
+        }
+        bool prefetched = false;
+        {
+            SCOPED_RAW_TIMER(&_opts.stats->cache_aware_lazy_read_readahead_ns);
+            prefetched = _file_reader->prefetch(range.offset, length);
+        }
+        if (prefetched) {
+            ++submitted_ranges;
+            submitted_bytes += length;
             ++_opts.stats->cache_aware_lazy_read_prefetch_ranges;
             _opts.stats->cache_aware_lazy_read_prefetch_bytes += length;
         }
     }
     return Status::OK();
+}
+
+void SegmentIterator::_update_cache_aware_lazy_read_baseline(int64_t io_ns_before,
+                                                             int64_t pages_before,
+                                                             int64_t cached_pages_before) {
+    if (_cache_aware_lazy_read_state != CacheAwareLazyReadState::OBSERVING) {
+        return;
+    }
+
+    const int64_t io_ns = std::max<int64_t>(0, _opts.stats->io_ns - io_ns_before);
+    const int64_t pages = std::max<int64_t>(0, _opts.stats->total_pages_num - pages_before);
+    const int64_t cached_pages =
+            std::max<int64_t>(0, _opts.stats->cached_pages_num - cached_pages_before);
+    _cache_aware_lazy_read_baseline_io_ns += io_ns;
+    _cache_aware_lazy_read_baseline_pages += pages;
+    _cache_aware_lazy_read_baseline_miss_pages += std::max<int64_t>(0, pages - cached_pages);
+    ++_cache_aware_lazy_read_baseline_batches;
+
+    if (_cache_aware_lazy_read_baseline_batches < CACHE_AWARE_BASELINE_BATCHES &&
+        _cache_aware_lazy_read_baseline_pages < CACHE_AWARE_BASELINE_PAGES) {
+        return;
+    }
+
+    const bool enough_pages =
+            _cache_aware_lazy_read_baseline_pages >= CACHE_AWARE_MIN_BASELINE_PAGES;
+    const bool enough_misses = _cache_aware_lazy_read_baseline_miss_pages * 100 >=
+                               _cache_aware_lazy_read_baseline_pages * CACHE_AWARE_MIN_MISS_PERCENT;
+    const bool enough_io =
+            _cache_aware_lazy_read_baseline_io_ns >= CACHE_AWARE_MIN_BASELINE_IO_NS &&
+            _cache_aware_lazy_read_baseline_io_ns >=
+                    _cache_aware_lazy_read_baseline_pages * CACHE_AWARE_MIN_IO_NS_PER_PAGE;
+    if (enough_pages && enough_misses && enough_io) {
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::SAMPLING;
+    } else {
+        _cache_aware_lazy_read_state = CacheAwareLazyReadState::DISABLED;
+        ++_opts.stats->cache_aware_lazy_read_skipped_low_io_segments;
+    }
 }
 
 Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_column_ids,
@@ -2601,6 +2803,17 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
             rowids[i] = rowid_vector[sel_rowid_idx[i]];
         }
     }
+
+    const bool observe_cache_aware_baseline =
+            _cache_aware_lazy_read_state == CacheAwareLazyReadState::OBSERVING &&
+            _opts.runtime_state != nullptr && _opts.use_page_cache &&
+            _opts.io_ctx.reader_type == ReaderType::READER_QUERY && _file_reader != nullptr &&
+            _file_reader->supports_cache_aware_read() &&
+            _opts.runtime_state->enable_cache_aware_lazy_read();
+    const int64_t io_ns_before = observe_cache_aware_baseline ? _opts.stats->io_ns : 0;
+    const int64_t pages_before = observe_cache_aware_baseline ? _opts.stats->total_pages_num : 0;
+    const int64_t cached_pages_before =
+            observe_cache_aware_baseline ? _opts.stats->cached_pages_num : 0;
 
     std::vector<PageHandle> cache_aware_pinned_pages;
     RETURN_IF_ERROR(
@@ -2635,6 +2848,10 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
         }
         RETURN_IF_ERROR(_column_iterators[cid]->read_by_rowids(rowids.data(), select_size,
                                                                _current_return_columns[cid]));
+    }
+
+    if (observe_cache_aware_baseline) {
+        _update_cache_aware_lazy_read_baseline(io_ns_before, pages_before, cached_pages_before);
     }
 
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -230,8 +230,8 @@ private:
     Status _prepare_cache_aware_lazy_read(const std::vector<ColumnId>& read_column_ids,
                                           const std::vector<rowid_t>& rowids,
                                           std::vector<PageHandle>* pinned_pages);
-    void _update_cache_aware_lazy_read_baseline(int64_t io_ns_before, int64_t pages_before,
-                                                int64_t cached_pages_before);
+    void _reset_cache_aware_lazy_read_sample();
+    void _enter_cache_aware_lazy_read_cooldown();
 
     Status copy_column_data_by_selector(IColumn* input_col_ptr, MutableColumnPtr& output_col,
                                         uint16_t* sel_rowid_idx, uint16_t select_size,
@@ -429,12 +429,18 @@ private:
 
     io::FileReaderSPtr _file_reader;
 
-    enum class CacheAwareLazyReadState : uint8_t { OBSERVING, SAMPLING, ENABLED, DISABLED };
-    CacheAwareLazyReadState _cache_aware_lazy_read_state = CacheAwareLazyReadState::OBSERVING;
-    int64_t _cache_aware_lazy_read_baseline_io_ns = 0;
-    int64_t _cache_aware_lazy_read_baseline_pages = 0;
-    int64_t _cache_aware_lazy_read_baseline_miss_pages = 0;
-    int _cache_aware_lazy_read_baseline_batches = 0;
+    enum class CacheAwareLazyReadState : uint8_t { SAMPLING, ENABLED, COOLDOWN, DISABLED };
+    CacheAwareLazyReadState _cache_aware_lazy_read_state = CacheAwareLazyReadState::SAMPLING;
+    size_t _cache_aware_lazy_read_sample_pages = 0;
+    size_t _cache_aware_lazy_read_sample_doris_cache_hit_pages = 0;
+    size_t _cache_aware_lazy_read_sample_os_only_resident_pages = 0;
+    size_t _cache_aware_lazy_read_sample_cold_pages = 0;
+    int _cache_aware_lazy_read_sample_batches = 0;
+    int _cache_aware_lazy_read_cooldown_batches = 0;
+    bool _cache_aware_lazy_read_ever_enabled = false;
+    bool _cache_aware_lazy_read_counted_insufficient_sample = false;
+    bool _cache_aware_lazy_read_counted_low_os_resident = false;
+    bool _cache_aware_lazy_read_counted_cold_ratio = false;
 
     // used for compaction, record selectd rowids of current batch
     uint16_t _selected_size;

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -54,6 +54,7 @@
 #include "storage/schema.h"
 #include "storage/segment/adaptive_block_size_predictor.h"
 #include "storage/segment/common.h"
+#include "storage/segment/page_handle.h"
 #include "storage/segment/segment.h"
 #include "util/slice.h"
 
@@ -225,6 +226,10 @@ private:
                                                  uint16_t* sel_rowid_idx, size_t select_size,
                                                  MutableColumns* mutable_columns,
                                                  bool init_condition_cache = false);
+
+    Status _prepare_cache_aware_lazy_read(const std::vector<ColumnId>& read_column_ids,
+                                          const std::vector<rowid_t>& rowids,
+                                          std::vector<PageHandle>* pinned_pages);
 
     Status copy_column_data_by_selector(IColumn* input_col_ptr, MutableColumnPtr& output_col,
                                         uint16_t* sel_rowid_idx, uint16_t select_size,

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -230,6 +230,8 @@ private:
     Status _prepare_cache_aware_lazy_read(const std::vector<ColumnId>& read_column_ids,
                                           const std::vector<rowid_t>& rowids,
                                           std::vector<PageHandle>* pinned_pages);
+    void _update_cache_aware_lazy_read_baseline(int64_t io_ns_before, int64_t pages_before,
+                                                int64_t cached_pages_before);
 
     Status copy_column_data_by_selector(IColumn* input_col_ptr, MutableColumnPtr& output_col,
                                         uint16_t* sel_rowid_idx, uint16_t select_size,
@@ -426,6 +428,13 @@ private:
     MutableColumns _seek_block;
 
     io::FileReaderSPtr _file_reader;
+
+    enum class CacheAwareLazyReadState : uint8_t { OBSERVING, SAMPLING, ENABLED, DISABLED };
+    CacheAwareLazyReadState _cache_aware_lazy_read_state = CacheAwareLazyReadState::OBSERVING;
+    int64_t _cache_aware_lazy_read_baseline_io_ns = 0;
+    int64_t _cache_aware_lazy_read_baseline_pages = 0;
+    int64_t _cache_aware_lazy_read_baseline_miss_pages = 0;
+    int _cache_aware_lazy_read_baseline_batches = 0;
 
     // used for compaction, record selectd rowids of current batch
     uint16_t _selected_size;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -543,6 +543,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SHOW_USER_DEFAULT_ROLE = "show_user_default_role";
 
     public static final String ENABLE_PAGE_CACHE = "enable_page_cache";
+    public static final String ENABLE_CACHE_AWARE_LAZY_READ = "enable_cache_aware_lazy_read";
     public static final String ENABLE_PARQUET_FILE_PAGE_CACHE = "enable_parquet_file_page_cache";
 
     public static final String MINIDUMP_PATH = "minidump_path";
@@ -2464,6 +2465,16 @@ public class SessionVariable implements Serializable, Writable {
                     + "The default value is true."},
             needForward = true)
     public boolean enablePageCache = true;
+
+    @VariableMgr.VarAttr(
+            name = ENABLE_CACHE_AWARE_LAZY_READ,
+            description = {"是否启用基于 page cache 驻留状态的本地 lazy read 调度实验。默认为 false。",
+                    "Whether to enable experimental cache-aware scheduling for local lazy reads. "
+                            + "The default value is false."},
+            needForward = true,
+            fuzzy = false,
+            varType = VariableAnnotation.EXPERIMENTAL)
+    public boolean enableCacheAwareLazyRead = false;
 
     @VariableMgr.VarAttr(
             name = ENABLE_PARQUET_FILE_PAGE_CACHE,
@@ -5570,6 +5581,8 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFileCache(enableFileCache);
 
         tResult.setEnablePageCache(enablePageCache);
+
+        tResult.setEnableCacheAwareLazyRead(enableCacheAwareLazyRead);
 
         tResult.setEnableParquetFilePageCache(enableParquetFilePageCache);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -204,6 +204,17 @@ public class VariableMgrTest {
     }
 
     @Test
+    public void testCacheAwareLazyReadSessionVariableToThrift() throws Exception {
+        SessionVariable var = new SessionVariable();
+        Assert.assertFalse(var.toThrift().isEnableCacheAwareLazyRead());
+
+        VariableMgr.setVar(var,
+                new SetVar(SetType.SESSION, SessionVariable.ENABLE_CACHE_AWARE_LAZY_READ,
+                        new StringLiteral("true")));
+        Assert.assertTrue(var.toThrift().isEnableCacheAwareLazyRead());
+    }
+
+    @Test
     public void testAdaptiveBatchSizeSessionVariables() throws Exception {
         SessionVariable var = new SessionVariable();
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -497,6 +497,8 @@ struct TQueryOptions {
   // Candidate row ratio threshold against segment rows. Existing default is 0.3.
   220: optional double ann_index_candidate_rows_percent_threshold = 0.3
   221: optional i64 runtime_filter_tree_publish_max_send_bytes = 268435456
+  // Experimental POC: schedule local scalar lazy reads according to page cache residency.
+  222: optional bool enable_cache_aware_lazy_read = false
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Lazy materialization can turn second-phase rowid reads into many small and fragmented local-file reads. The initial cache-aware POC showed that eagerly planning every lazy read is too aggressive:

- scans with many sparse cold pages can issue almost one `readahead()` per page and amplify cold I/O;
- scans with millions of planned pages but little actual I/O can spend more CPU on page enumeration, cache lookup, probing, and pinning than they save;
- a two-batch I/O baseline can misclassify a segment from its earliest reads and permanently suppress useful scheduling later in the scan.

This PR keeps the feature experimental and default-off, and makes the local scalar lazy-read scheduler adaptive:

- add `experimental_enable_cache_aware_lazy_read` and forward it through `TQueryOptions`;
- start with a bounded D/O/C cache-tier sample instead of gating on early `IOTimer`: D is a Doris page-cache hit, O is a Doris miss that is resident in the OS page cache, and C is OS-cold;
- accumulate up to 128 pages per lazy-read batch, require at least 64 sampled pages, and bound each sampling round to 512 pages / 8 batches;
- enable cache-aware scheduling only when OS-only resident pages are at least 20% and cold pages are at most 8%;
- enter a 16-batch cooldown and resample instead of permanently disabling a segment when a sample is insufficient, has too little OS-resident reuse, is too cold, or exceeds a planning budget;
- leave the enabled state and resample when a later batch exceeds a 12% cold ratio;
- cap rowid-column lookup work, planned pages (4096 per enabled batch), and pinned/preloaded data (64 MiB per batch);
- pin Doris-cache pages and preload OS-resident pages only within that budget;
- sort remaining cold pages by file offset and merge nearby pages with a 64 KiB gap, 1 MiB span, and 1.25x read-amplification limits;
- issue `readahead()` only for merged ranges containing at least four pages and spanning at least 256 KiB, with per-batch limits of 32 ranges and 32 MiB;
- fall back to the original read path when admission fails, cache probing is unsupported, the cold ratio is too high, or a budget is reached;
- expose separate timers for page collection, Doris-cache lookup, OS-cache probing, preload, range building, and readahead;
- expose D/O/C sample pages, sample batches, rejection reasons, cooldowns, resampling, budgets, and pinned/preloaded byte counters in the scan profile.

The POC applies only to local files, query readers, scalar lazy columns, and scans with the Doris page cache enabled. The session variable remains disabled by default, so the off path retains the original lazy-read behavior.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Validation on `opt_perf_4.1` at `2608ff7d5e9`:

```text
./run-fe-ut.sh --run \
  org.apache.doris.qe.VariableMgrTest#testCacheAwareLazyReadSessionVariableToThrift
# Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

ninja -C be/build_Release -j32 \
  src/exec/CMakeFiles/Exec.dir/operator/olap_scan_operator.cpp.o \
  src/exec/CMakeFiles/Exec.dir/scan/olap_scanner.cpp.o \
  src/storage/CMakeFiles/Storage.dir/segment/segment_iterator.cpp.o
# all changed BE translation units compiled successfully

DISABLE_BE_JAVA_EXTENSIONS=ON \
  ./build.sh --fe --be --output <fresh-output> -j 96
# Successfully build Doris
```

- Behavior changed:
    - [ ] No.
    - [x] Yes. Only when `experimental_enable_cache_aware_lazy_read` is explicitly enabled; the default remains off.

- Does this need documentation?
    - [x] No. This is a default-off experimental POC.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
