### PR TITLE
[fix](backup) clean up FE backup staging directories

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1639,6 +1639,20 @@ public class Config extends ConfigBase {
     public static int max_backup_restore_job_num_per_db = 10;
 
     /**
+     * Keep an unreferenced backup staging directory for this many seconds before deleting it.
+     * Orphan cleanup is disabled when this value is not positive.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static int backup_orphan_dir_keep_max_second = 2 * 24 * 3600;
+
+    /**
+     * Scan for orphan backup staging directories at this interval in seconds.
+     * Orphan cleanup is disabled when this value is not positive.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static long backup_orphan_dir_cleanup_interval_second = 3600;
+
+    /**
      * A internal config, to reduce the restore job size during serialization by compress.
      *
      * WARNING: Once this option is enabled and a restore is performed, the FE version cannot be rolled back.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/GZIPUtils.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/GZIPUtils.java
@@ -23,8 +23,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -43,10 +45,22 @@ public class GZIPUtils {
     }
 
     public static byte[] compress(File file) throws IOException {
+        return compress(file, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Stream-compress {@code file} with an 8KB read buffer.
+     * Fails fast if the compressed output would exceed {@code maxCompressedSize}
+     * so callers can avoid unbounded FE heap growth.
+     */
+    public static byte[] compress(File file, int maxCompressedSize) throws IOException {
+        if (maxCompressedSize <= 0) {
+            throw new IOException("maxCompressedSize must be positive, got " + maxCompressedSize);
+        }
         ByteArrayOutputStream bytesStream = new ByteArrayOutputStream();
         try (FileInputStream fileInputStream = new FileInputStream(file);
-                GZIPOutputStream gzipStream = new GZIPOutputStream(bytesStream)) {
-
+                GZIPOutputStream gzipStream = new GZIPOutputStream(
+                        new BoundedSizeOutputStream(bytesStream, maxCompressedSize))) {
             byte[] buffer = new byte[8192]; // 8KB buffer
             int bytesRead;
             while ((bytesRead = fileInputStream.read(buffer)) != -1) {
@@ -65,5 +79,40 @@ public class GZIPUtils {
 
     public static InputStream lazyDecompress(byte[] data) throws IOException {
         return new GZIPInputStream(new ByteArrayInputStream(data));
+    }
+
+    /**
+     * Counts written bytes and rejects writes that would exceed {@code maxSize}.
+     * Used so gzip can fail during streaming instead of after a multi-GB buffer is filled.
+     */
+    private static final class BoundedSizeOutputStream extends FilterOutputStream {
+        private final int maxSize;
+        private int written;
+
+        BoundedSizeOutputStream(OutputStream out, int maxSize) {
+            super(out);
+            this.maxSize = maxSize;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            ensureCapacity(1);
+            out.write(b);
+            written++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ensureCapacity(len);
+            out.write(b, off, len);
+            written += len;
+        }
+
+        private void ensureCapacity(int len) throws IOException {
+            if (len < 0 || (long) written + len > maxSize) {
+                throw new IOException(
+                        String.format("compressed size exceeds limit %d bytes", maxSize));
+            }
+        }
     }
 }

--- a/fe/fe-common/src/test/java/org/apache/doris/common/GZIPUtilsTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/GZIPUtilsTest.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Random;
+
+public class GZIPUtilsTest {
+    @Test
+    public void testCompressFileRespectsMaxCompressedSize() throws IOException {
+        File file = File.createTempFile("gzip_utils_bound_", ".bin");
+        file.deleteOnExit();
+        // Low-compressibility payload so compressed size stays close to input size.
+        byte[] payload = new byte[64 * 1024];
+        new Random(0).nextBytes(payload);
+        Files.write(file.toPath(), payload);
+
+        byte[] compressed = GZIPUtils.compress(file, Integer.MAX_VALUE);
+        Assert.assertTrue(GZIPUtils.isGZIPCompressed(compressed));
+        Assert.assertArrayEquals(payload, GZIPUtils.decompress(compressed));
+
+        try {
+            GZIPUtils.compress(file, 32);
+            Assert.fail("expected IOException when compressed size exceeds limit");
+        } catch (IOException e) {
+            Assert.assertTrue(e.getMessage().contains("compressed size exceeds limit"));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -65,6 +65,8 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Deque;
@@ -79,6 +81,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class BackupHandler extends MasterDaemon implements Writable {
     private static final Logger LOG = LogManager.getLogger(BackupHandler.class);
@@ -96,6 +99,11 @@ public class BackupHandler extends MasterDaemon implements Writable {
     // If the last job is finished, user can get the job info from repository. If the last job is cancelled,
     // user can get the error message before submitting the next one.
     private final Map<Long, Deque<AbstractJob>> dbIdToBackupOrRestoreJobs = new HashMap<>();
+    // Evicted terminal jobs remain here until their staging directories are cleaned.
+    // Protected by jobLock and not persisted.
+    private final Deque<BackupJob> pendingCleanupJobs = new LinkedList<>();
+    // Accessed only by the backup handler daemon thread.
+    private long lastOrphanJobDirCleanupTimeMs = 0;
 
     // this lock is used for handling one backup or restore request at a time.
     private ReentrantLock seqlock = new ReentrantLock();
@@ -195,6 +203,13 @@ public class BackupHandler extends MasterDaemon implements Writable {
             job.setEnv(env);
             job.run();
         }
+        long nowMs = System.currentTimeMillis();
+        long cleanupStartNanos = System.nanoTime();
+        CleanupStats currentJobStats = cleanupBackupJobLocalJobDirs(nowMs);
+        CleanupStats pendingJobStats = cleanupPendingBackupJobLocalJobDirs();
+        CleanupStats orphanStats = cleanupOrphanBackupJobLocalJobDirsIfNecessary(nowMs);
+        long cleanupElapsedMs = elapsedMillis(cleanupStartNanos);
+        logCleanupStats(currentJobStats, pendingJobStats, orphanStats, cleanupElapsedMs);
     }
 
     // handle create repository command
@@ -651,14 +666,14 @@ public class BackupHandler extends MasterDaemon implements Writable {
             return;
         }
 
-        List<String> removedLabels = Lists.newArrayList();
+        List<BackupJob> removedBackupJobs = Lists.newArrayList();
         jobLock.lock();
         try {
             Deque<AbstractJob> jobs = dbIdToBackupOrRestoreJobs.computeIfAbsent(dbId, k -> Lists.newLinkedList());
             while (jobs.size() >= Config.max_backup_restore_job_num_per_db) {
                 AbstractJob removedJob = jobs.removeFirst();
-                if (removedJob instanceof BackupJob && ((BackupJob) removedJob).isLocalSnapshot()) {
-                    removedLabels.add(removedJob.getLabel());
+                if (removedJob instanceof BackupJob) {
+                    removedBackupJobs.add((BackupJob) removedJob);
                 }
             }
             AbstractJob lastJob = jobs.peekLast();
@@ -669,6 +684,14 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 jobs.removeLast();
             }
             jobs.addLast(job);
+
+            if (!Env.isCheckpointThread()) {
+                for (BackupJob removedBackupJob : removedBackupJobs) {
+                    if (removedBackupJob.isDone()) {
+                        pendingCleanupJobs.addLast(removedBackupJob);
+                    }
+                }
+            }
         } finally {
             jobLock.unlock();
         }
@@ -680,8 +703,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 addSnapshot(backupJob.getLabel(), backupJob);
             }
         }
-        for (String label : removedLabels) {
-            removeSnapshot(label);
+        for (BackupJob removedBackupJob : removedBackupJobs) {
+            if (removedBackupJob.isLocalSnapshot()) {
+                removeSnapshot(removedBackupJob.getLabel());
+            }
         }
     }
 
@@ -692,6 +717,273 @@ public class BackupHandler extends MasterDaemon implements Writable {
                     .map(Deque::getLast).collect(Collectors.toList());
         } finally {
             jobLock.unlock();
+        }
+    }
+
+    private List<AbstractJob> getAllJobs() {
+        jobLock.lock();
+        try {
+            return dbIdToBackupOrRestoreJobs.values().stream().flatMap(Deque::stream).collect(Collectors.toList());
+        } finally {
+            jobLock.unlock();
+        }
+    }
+
+    private CleanupStats cleanupBackupJobLocalJobDirs(long nowMs) {
+        long startNanos = System.nanoTime();
+        CleanupStats stats = new CleanupStats(true);
+        for (AbstractJob job : getAllJobs()) {
+            if (job instanceof BackupJob) {
+                stats.itemsScanned++;
+                BackupJob backupJob = (BackupJob) job;
+                stats.recordKnownJobResult(backupJob.cleanupLocalJobDirIfNecessary(nowMs));
+            }
+        }
+        stats.elapsedMs = elapsedMillis(startNanos);
+        return stats;
+    }
+
+    private CleanupStats cleanupPendingBackupJobLocalJobDirs() {
+        long startNanos = System.nanoTime();
+        CleanupStats stats = new CleanupStats(true);
+        List<BackupJob> pendingJobs;
+        jobLock.lock();
+        try {
+            pendingJobs = Lists.newArrayList(pendingCleanupJobs);
+        } finally {
+            jobLock.unlock();
+        }
+
+        for (BackupJob pendingJob : pendingJobs) {
+            stats.itemsScanned++;
+            BackupJob.LocalJobDirCleanupResult result = pendingJob.cleanupLocalJobDirAfterRemoved();
+            stats.recordKnownJobResult(result);
+            if (result.isCompleted()) {
+                jobLock.lock();
+                try {
+                    pendingCleanupJobs.removeFirstOccurrence(pendingJob);
+                } finally {
+                    jobLock.unlock();
+                }
+            }
+        }
+        jobLock.lock();
+        try {
+            stats.remainingItems = pendingCleanupJobs.size();
+        } finally {
+            jobLock.unlock();
+        }
+        stats.elapsedMs = elapsedMillis(startNanos);
+        return stats;
+    }
+
+    private CleanupStats cleanupOrphanBackupJobLocalJobDirsIfNecessary(long nowMs) {
+        long cleanupIntervalSecond = Config.backup_orphan_dir_cleanup_interval_second;
+        if (cleanupIntervalSecond <= 0) {
+            return CleanupStats.notRun();
+        }
+        long cleanupIntervalMs = TimeUnit.SECONDS.toMillis(cleanupIntervalSecond);
+        if (lastOrphanJobDirCleanupTimeMs != 0
+                && nowMs >= lastOrphanJobDirCleanupTimeMs
+                && nowMs - lastOrphanJobDirCleanupTimeMs < cleanupIntervalMs) {
+            return CleanupStats.notRun();
+        }
+        lastOrphanJobDirCleanupTimeMs = nowMs;
+        return cleanupOrphanBackupJobLocalJobDirs(nowMs);
+    }
+
+    private CleanupStats cleanupOrphanBackupJobLocalJobDirs(long nowMs) {
+        long startNanos = System.nanoTime();
+        CleanupStats stats = new CleanupStats(true);
+        Path backupRootDir = BACKUP_ROOT_DIR.toAbsolutePath().normalize();
+        if (!Files.isDirectory(backupRootDir, LinkOption.NOFOLLOW_LINKS)) {
+            stats.elapsedMs = elapsedMillis(startNanos);
+            return stats;
+        }
+        if (Config.backup_orphan_dir_keep_max_second <= 0) {
+            LOG.warn("skip orphan backup staging directory cleanup because "
+                    + "backup_orphan_dir_keep_max_second is not positive: {}",
+                    Config.backup_orphan_dir_keep_max_second);
+            stats.elapsedMs = elapsedMillis(startNanos);
+            return stats;
+        }
+
+        Set<Path> referencedJobDirs = getReferencedBackupJobDirs(backupRootDir);
+        long orphanExpireBeforeMs = nowMs
+                - TimeUnit.SECONDS.toMillis(Config.backup_orphan_dir_keep_max_second);
+        try {
+            for (Path repoDir : listChildDirectories(backupRootDir)) {
+                if (!repoDir.getFileName().toString().startsWith("repo__")) {
+                    continue;
+                }
+                stats.containersScanned++;
+                cleanupOrphanJobDirsInRepo(repoDir, referencedJobDirs, orphanExpireBeforeMs, stats);
+            }
+        } catch (IOException e) {
+            stats.failures++;
+            LOG.warn("failed to scan backup root dir for orphan staging directories: {}", backupRootDir, e);
+        }
+        stats.elapsedMs = elapsedMillis(startNanos);
+        return stats;
+    }
+
+    private Set<Path> getReferencedBackupJobDirs(Path backupRootDir) {
+        List<BackupJob> backupJobs = Lists.newArrayList();
+        jobLock.lock();
+        try {
+            for (Deque<AbstractJob> jobs : dbIdToBackupOrRestoreJobs.values()) {
+                for (AbstractJob job : jobs) {
+                    if (job instanceof BackupJob) {
+                        backupJobs.add((BackupJob) job);
+                    }
+                }
+            }
+            backupJobs.addAll(pendingCleanupJobs);
+        } finally {
+            jobLock.unlock();
+        }
+
+        Set<Path> referencedJobDirs = Sets.newHashSet();
+        for (BackupJob backupJob : backupJobs) {
+            Path jobDir = backupJob.getLocalJobDirPath();
+            if (jobDir != null && jobDir.startsWith(backupRootDir) && !jobDir.equals(backupRootDir)) {
+                referencedJobDirs.add(jobDir);
+            }
+        }
+        return referencedJobDirs;
+    }
+
+    private void cleanupOrphanJobDirsInRepo(Path repoDir, Set<Path> referencedJobDirs,
+                                            long orphanExpireBeforeMs, CleanupStats stats) {
+        List<Path> jobDirs;
+        try {
+            jobDirs = listChildDirectories(repoDir);
+        } catch (IOException e) {
+            stats.failures++;
+            LOG.warn("failed to scan backup repo dir for orphan staging directories: {}", repoDir, e);
+            return;
+        }
+
+        for (Path jobDir : jobDirs) {
+            stats.itemsScanned++;
+            long cleanupStartNanos = System.nanoTime();
+            try {
+                Path normalizedJobDir = jobDir.toAbsolutePath().normalize();
+                if (referencedJobDirs.contains(normalizedJobDir)
+                        || Files.getLastModifiedTime(normalizedJobDir, LinkOption.NOFOLLOW_LINKS).toMillis()
+                                > orphanExpireBeforeMs) {
+                    continue;
+                }
+                BackupJob.deleteLocalJobDirRecursively(normalizedJobDir);
+                stats.directoriesCleaned++;
+                LOG.info("cleaned orphan backup job dir: {}, elapsed_ms={}", normalizedJobDir,
+                        elapsedMillis(cleanupStartNanos));
+            } catch (IOException e) {
+                stats.failures++;
+                LOG.warn("failed to clean orphan backup job dir: {}, elapsed_ms={}", jobDir,
+                        elapsedMillis(cleanupStartNanos), e);
+            }
+        }
+    }
+
+    private void logCleanupStats(CleanupStats currentJobStats, CleanupStats pendingJobStats,
+                                 CleanupStats orphanStats, long totalElapsedMs) {
+        String message = "backup staging cleanup cycle finished: current_jobs_scanned={}, "
+                + "current_dirs_deleted={}, current_dirs_already_absent={}, current_jobs_deferred={}, "
+                + "current_failures={}, current_not_due={}, current_already_cleaned={}, "
+                + "current_invalid_paths={}, current_elapsed_ms={}, pending_jobs_scanned={}, "
+                + "pending_dirs_deleted={}, pending_dirs_already_absent={}, pending_jobs_deferred={}, "
+                + "pending_failures={}, pending_not_due={}, pending_already_cleaned={}, "
+                + "pending_invalid_paths={}, pending_jobs_remaining={}, pending_elapsed_ms={}, orphan_ran={}, "
+                + "orphan_repo_dirs_scanned={}, orphan_job_dirs_scanned={}, orphan_dirs_cleaned={}, "
+                + "orphan_failures={}, orphan_elapsed_ms={}, total_elapsed_ms={}, daemon_interval_ms={}";
+        Object[] params = new Object[] {
+                currentJobStats.itemsScanned, currentJobStats.directoriesDeleted,
+                currentJobStats.directoriesAlreadyAbsent, currentJobStats.jobsDeferred,
+                currentJobStats.failures, currentJobStats.notDue, currentJobStats.alreadyCleaned,
+                currentJobStats.invalidPaths, currentJobStats.elapsedMs,
+                pendingJobStats.itemsScanned, pendingJobStats.directoriesDeleted,
+                pendingJobStats.directoriesAlreadyAbsent, pendingJobStats.jobsDeferred,
+                pendingJobStats.failures, pendingJobStats.notDue, pendingJobStats.alreadyCleaned,
+                pendingJobStats.invalidPaths, pendingJobStats.remainingItems, pendingJobStats.elapsedMs,
+                orphanStats.ran, orphanStats.containersScanned, orphanStats.itemsScanned,
+                orphanStats.directoriesCleaned, orphanStats.failures, orphanStats.elapsedMs, totalElapsedMs,
+                Config.backup_handler_update_interval_millis
+        };
+        if (totalElapsedMs >= Config.backup_handler_update_interval_millis) {
+            LOG.warn(message, params);
+        } else if (currentJobStats.hasCleanupActivity() || pendingJobStats.itemsScanned > 0 || orphanStats.ran) {
+            LOG.info(message, params);
+        } else {
+            LOG.debug(message, params);
+        }
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    private static class CleanupStats {
+        private final boolean ran;
+        private int containersScanned;
+        private int itemsScanned;
+        private int directoriesCleaned;
+        private int directoriesDeleted;
+        private int directoriesAlreadyAbsent;
+        private int jobsDeferred;
+        private int failures;
+        private int notDue;
+        private int alreadyCleaned;
+        private int invalidPaths;
+        private int remainingItems;
+        private long elapsedMs;
+
+        private CleanupStats(boolean ran) {
+            this.ran = ran;
+        }
+
+        private static CleanupStats notRun() {
+            return new CleanupStats(false);
+        }
+
+        private void recordKnownJobResult(BackupJob.LocalJobDirCleanupResult result) {
+            switch (result) {
+                case NOT_DUE:
+                    notDue++;
+                    break;
+                case ALREADY_CLEANED:
+                    alreadyCleaned++;
+                    break;
+                case DELETED:
+                    directoriesDeleted++;
+                    break;
+                case ALREADY_ABSENT:
+                    directoriesAlreadyAbsent++;
+                    break;
+                case DEFERRED:
+                    jobsDeferred++;
+                    break;
+                case FAILED:
+                    failures++;
+                    break;
+                case INVALID_PATH:
+                    invalidPaths++;
+                    break;
+                default:
+                    throw new IllegalStateException("unknown local job dir cleanup result: " + result);
+            }
+        }
+
+        private boolean hasCleanupActivity() {
+            return directoriesDeleted > 0 || directoriesAlreadyAbsent > 0 || jobsDeferred > 0
+                    || failures > 0 || invalidPaths > 0;
+        }
+    }
+
+    private List<Path> listChildDirectories(Path parentDir) throws IOException {
+        try (Stream<Path> paths = Files.list(parentDir)) {
+            return paths.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+                    .collect(Collectors.toList());
         }
     }
 
@@ -960,7 +1252,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
     }
 
-    public Snapshot getSnapshot(String labelName) {
+    public Snapshot getSnapshot(String labelName, boolean enableCompress) throws IOException {
         BackupJob backupJob;
         localSnapshotsLock.readLock().lock();
         try {
@@ -973,7 +1265,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
             return null;
         }
 
-        return backupJob.getSnapshot();
+        return backupJob.getSnapshot(enableCompress);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -32,6 +32,7 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.GZIPUtils;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.TimeUtils;
@@ -78,7 +79,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public class BackupJob extends AbstractJob implements GsonPostProcessable {
@@ -95,6 +98,26 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         UPLOAD_INFO, // Upload meta and job info file to repository. When finished, transfer to FINISHED
         FINISHED, // Job is finished.
         CANCELLED // Job is cancelled.
+    }
+
+    enum LocalJobDirCleanupResult {
+        NOT_DUE(false),
+        ALREADY_CLEANED(true),
+        DELETED(true),
+        ALREADY_ABSENT(true),
+        DEFERRED(false),
+        FAILED(false),
+        INVALID_PATH(true);
+
+        private final boolean completed;
+
+        LocalJobDirCleanupResult(boolean completed) {
+            this.completed = completed;
+        }
+
+        boolean isCompleted() {
+            return completed;
+        }
     }
 
     // all objects which need backup
@@ -128,6 +151,13 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     private String localMetaInfoFilePath = null;
     @SerializedName("jifp")
     private String localJobInfoFilePath = null;
+    /**
+     * Coordinates local staging-dir lifetime with getSnapshot materialization.
+     * Separate from the job state monitor so heavy IO does not block BackupJob.run().
+     */
+    private final Object localJobDirLock = new Object();
+    private int localJobDirReaders = 0;
+    private boolean localJobDirCleaned = false;
     // backup properties && table commit seq with table id
     @SerializedName("prop")
     private Map<String, String> properties = Maps.newHashMap();
@@ -400,7 +430,9 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     @Override
     public synchronized void replayRun() {
-        if (state == BackupJobState.SAVE_META) {
+        // Checkpoint replay only reconstructs state for the image. Writing staging files
+        // here recreates directories that were already cleaned by the serving FE.
+        if (state == BackupJobState.SAVE_META && !Env.isCheckpointThread()) {
             saveMetaInfo(true);
         }
     }
@@ -1038,6 +1070,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             env.getBackupHandler().addSnapshot(label, this);
             return;
         }
+
     }
 
     private boolean uploadFile(String localFilePath, String remoteFilePath) {
@@ -1100,19 +1133,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 break;
         }
 
-        // clean the backup job dir
-        if (localJobDirPath != null) {
-            try {
-                File jobDir = new File(localJobDirPath.toString());
-                if (jobDir.exists()) {
-                    Files.walk(localJobDirPath, FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder())
-                            .map(Path::toFile).forEach(File::delete);
-                }
-            } catch (Exception e) {
-                LOG.warn("failed to clean the backup job dir: " + localJobDirPath.toString());
-            }
-        }
-
         // meta info and job info not need save in log when cancel, we need to clean them here
         backupMeta = null;
         jobInfo = null;
@@ -1136,21 +1156,237 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         return commitSeq;
     }
 
-    // read meta and job info bytes from disk, and return the snapshot
-    public synchronized Snapshot getSnapshot() {
-        if (state != BackupJobState.FINISHED || repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
-            return null;
+    /**
+     * Materialize a local snapshot for getSnapshot RPC.
+     *
+     * <p>Job state is checked under the job monitor only briefly. File lifetime is
+     * protected by a separate reader refcount so heavy IO/compression does not block
+     * {@link #run()} / other jobs on the backup daemon. Uncompressed payloads that
+     * exceed the thrift ~2GB limit are rejected before reading content. Compressed
+     * payloads are stream-compressed with an output size bound. IO failures propagate
+     * as {@link IOException} (not "snapshot not exist").
+     */
+    public Snapshot getSnapshot(boolean enableCompress) throws IOException {
+        String metaPathStr = null;
+        String jobInfoPathStr = null;
+        long expiredAt = 0;
+        long commitSeqSnapshot = 0;
+        String snapshotLabel = null;
+        Snapshot expiredSnapshot = null;
+        boolean pinned = false;
+
+        synchronized (this) {
+            if (state != BackupJobState.FINISHED || repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
+                return null;
+            }
+
+            // Avoid loading expired meta.
+            expiredAt = createTime + timeoutMs;
+            if (System.currentTimeMillis() >= expiredAt) {
+                expiredSnapshot = new Snapshot(label, null, null, 0, 0, false, expiredAt, commitSeq);
+            } else {
+                metaPathStr = localMetaInfoFilePath;
+                jobInfoPathStr = localJobInfoFilePath;
+                if (metaPathStr == null || jobInfoPathStr == null) {
+                    return null;
+                }
+                if (!acquireLocalJobDirRead()) {
+                    // Dir already cleaned or never created.
+                    return null;
+                }
+                pinned = true;
+                commitSeqSnapshot = commitSeq;
+                snapshotLabel = label;
+            }
         }
 
-        // Avoid loading expired meta.
-        long expiredAt = createTime + timeoutMs;
-        if (System.currentTimeMillis() >= expiredAt) {
-            return new Snapshot(label, null, null, expiredAt, commitSeq);
+        if (expiredSnapshot != null) {
+            return expiredSnapshot;
         }
 
-        File metaInfoFile = new File(localMetaInfoFilePath);
-        File jobInfoFile = new File(localJobInfoFilePath);
-        return new Snapshot(label, metaInfoFile, jobInfoFile, expiredAt, commitSeq);
+        try {
+            Path metaPath = Paths.get(metaPathStr);
+            Path jobInfoPath = Paths.get(jobInfoPathStr);
+            long metaSize = Files.size(metaPath);
+            long jobInfoSize = Files.size(jobInfoPath);
+
+            // Uncompressed thrift payload cannot exceed Integer.MAX_VALUE (~2GB).
+            // Reject before reading so FE heap is not blown by large local snapshots.
+            if (!enableCompress && metaSize + jobInfoSize >= Integer.MAX_VALUE) {
+                return new Snapshot(snapshotLabel, null, null, metaSize, jobInfoSize, false, expiredAt,
+                        commitSeqSnapshot);
+            }
+
+            byte[] meta;
+            byte[] jobInfo;
+            if (enableCompress) {
+                // Stream compress with a hard cap so low-compressibility data cannot
+                // grow an unbounded ByteArrayOutputStream on the FE heap.
+                meta = GZIPUtils.compress(metaPath.toFile(), Integer.MAX_VALUE);
+                int remaining = Integer.MAX_VALUE - meta.length;
+                if (remaining <= 0) {
+                    throw new IOException(String.format(
+                            "Compressed snapshot meta alone is too large (%d bytes >= 2GB).", meta.length));
+                }
+                jobInfo = GZIPUtils.compress(jobInfoPath.toFile(), remaining);
+                if ((long) meta.length + jobInfo.length >= Integer.MAX_VALUE) {
+                    throw new IOException(String.format(
+                            "Compressed snapshot is too large (%d bytes >= 2GB).",
+                            (long) meta.length + jobInfo.length));
+                }
+            } else {
+                meta = Files.readAllBytes(metaPath);
+                jobInfo = Files.readAllBytes(jobInfoPath);
+            }
+            return new Snapshot(snapshotLabel, meta, jobInfo, metaSize, jobInfoSize, enableCompress, expiredAt,
+                    commitSeqSnapshot);
+        } finally {
+            if (pinned) {
+                releaseLocalJobDirRead();
+            }
+        }
+    }
+
+    /**
+     * Cancelled and remote finished jobs have no staging value, while a local finished
+     * snapshot must remain available until its configured expiration time.
+     */
+    LocalJobDirCleanupResult cleanupLocalJobDirIfNecessary(long nowMs) {
+        boolean shouldCleanup;
+        synchronized (this) {
+            shouldCleanup = isCancelled() || (isFinished() && (repoId != Repository.KEEP_ON_LOCAL_REPO_ID
+                    || nowMs >= createTime + timeoutMs));
+        }
+        if (shouldCleanup) {
+            return cleanupLocalJobDir();
+        }
+        return LocalJobDirCleanupResult.NOT_DUE;
+    }
+
+    /**
+     * Clean up local staging dir after this job is evicted from the per-db deque.
+     * Local snapshot lifetime is bounded by both {@link #timeoutMs} and
+     * {@code max_backup_restore_job_num_per_db} queue eviction.
+     */
+    LocalJobDirCleanupResult cleanupLocalJobDirAfterRemoved() {
+        boolean shouldCleanup;
+        synchronized (this) {
+            shouldCleanup = isDone();
+        }
+        if (shouldCleanup) {
+            return cleanupLocalJobDir();
+        }
+        return LocalJobDirCleanupResult.NOT_DUE;
+    }
+
+    /**
+     * Delete local staging dir when no getSnapshot reader is active; otherwise defer
+     * until a later backup handler cleanup cycle after the last reader releases.
+     * Deletion uses {@link #localJobDirLock} only and never runs while holding the job
+     * monitor or on the getSnapshot RPC thread.
+     */
+    private LocalJobDirCleanupResult cleanupLocalJobDir() {
+        synchronized (localJobDirLock) {
+            if (localJobDirCleaned) {
+                return LocalJobDirCleanupResult.ALREADY_CLEANED;
+            }
+            if (localJobDirReaders > 0) {
+                return LocalJobDirCleanupResult.DEFERRED;
+            }
+            return cleanupLocalJobDirUnderLock();
+        }
+    }
+
+    private boolean acquireLocalJobDirRead() {
+        synchronized (localJobDirLock) {
+            if (localJobDirCleaned) {
+                return false;
+            }
+            if (getLocalJobDirPathForCleanup() == null) {
+                return false;
+            }
+            localJobDirReaders++;
+            return true;
+        }
+    }
+
+    private void releaseLocalJobDirRead() {
+        synchronized (localJobDirLock) {
+            localJobDirReaders--;
+        }
+    }
+
+    /** Caller must hold {@link #localJobDirLock}. */
+    private LocalJobDirCleanupResult cleanupLocalJobDirUnderLock() {
+        Path jobDirPath = getLocalJobDirPathForCleanup();
+        if (jobDirPath == null) {
+            localJobDirCleaned = true;
+            return LocalJobDirCleanupResult.ALREADY_CLEANED;
+        }
+        Path normalizedJobDirPath = jobDirPath.toAbsolutePath().normalize();
+        if (!isValidLocalJobDirForCleanup(normalizedJobDirPath)) {
+            LOG.warn("skip cleaning invalid backup job dir: {}. {}", normalizedJobDirPath, this);
+            localJobDirCleaned = true;
+            return LocalJobDirCleanupResult.INVALID_PATH;
+        }
+        long cleanupStartNanos = System.nanoTime();
+        try {
+            File jobDir = normalizedJobDirPath.toFile();
+            LocalJobDirCleanupResult result = LocalJobDirCleanupResult.ALREADY_ABSENT;
+            if (jobDir.exists()) {
+                deleteLocalJobDir(normalizedJobDirPath);
+                result = LocalJobDirCleanupResult.DELETED;
+                LOG.info("cleaned backup job dir: {}, elapsed_ms={}. {}", normalizedJobDirPath,
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - cleanupStartNanos), this);
+            }
+            localJobDirPath = null;
+            localMetaInfoFilePath = null;
+            localJobInfoFilePath = null;
+            localJobDirCleaned = true;
+            return result;
+        } catch (Exception e) {
+            LOG.warn("failed to clean the backup job dir: {}, elapsed_ms={}. {}", normalizedJobDirPath,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - cleanupStartNanos), this, e);
+            return LocalJobDirCleanupResult.FAILED;
+        }
+    }
+
+    Path getLocalJobDirPath() {
+        synchronized (localJobDirLock) {
+            Path jobDirPath = getLocalJobDirPathForCleanup();
+            return jobDirPath == null ? null : jobDirPath.toAbsolutePath().normalize();
+        }
+    }
+
+    void deleteLocalJobDir(Path jobDirPath) throws IOException {
+        deleteLocalJobDirRecursively(jobDirPath);
+    }
+
+    static void deleteLocalJobDirRecursively(Path jobDirPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(jobDirPath)) {
+            List<Path> pathsToDelete = paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+            for (Path path : pathsToDelete) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+
+    private Path getLocalJobDirPathForCleanup() {
+        if (localJobDirPath != null) {
+            return localJobDirPath;
+        }
+        if (localMetaInfoFilePath != null) {
+            return Paths.get(localMetaInfoFilePath).getParent();
+        }
+        if (localJobInfoFilePath != null) {
+            return Paths.get(localJobInfoFilePath).getParent();
+        }
+        return null;
+    }
+
+    private boolean isValidLocalJobDirForCleanup(Path jobDirPath) {
+        Path backupRootDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize();
+        return jobDirPath.startsWith(backupRootDir) && !jobDirPath.equals(backupRootDir);
     }
 
     public synchronized List<String> getInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
@@ -22,17 +22,28 @@ import org.apache.doris.common.Pair;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
+/**
+ * Materialized local backup snapshot for getSnapshot RPC.
+ *
+ * <p>meta/jobInfo hold the response payload (raw or already gzip-compressed).
+ * metaSize/jobInfoSize are the original on-disk sizes used by the 2GB RPC guard
+ * and logging. After construction, callers must not access the original files.
+ */
 public class Snapshot {
     @SerializedName(value = "label")
     private String label = null;
 
-    private File meta = null;
+    private byte[] meta = null;
 
-    private File jobInfo = null;
+    private byte[] jobInfo = null;
+
+    private long metaSize = 0;
+
+    private long jobInfoSize = 0;
+
+    private boolean compressed = false;
 
     @SerializedName(value = "expired_at")
     private long expiredAt = 0;
@@ -43,10 +54,14 @@ public class Snapshot {
     public Snapshot() {
     }
 
-    public Snapshot(String label, File meta, File jobInfo, long expiredAt, long commitSeq) {
+    public Snapshot(String label, byte[] meta, byte[] jobInfo, long metaSize, long jobInfoSize,
+            boolean compressed, long expiredAt, long commitSeq) {
         this.label = label;
         this.meta = meta;
         this.jobInfo = jobInfo;
+        this.metaSize = metaSize;
+        this.jobInfoSize = jobInfoSize;
+        this.compressed = compressed;
         this.expiredAt = expiredAt;
         this.commitSeq = commitSeq;
     }
@@ -68,28 +83,32 @@ public class Snapshot {
         return GZIPUtils.isGZIPCompressed(jobInfo) || GZIPUtils.isGZIPCompressed(meta);
     }
 
+    /**
+     * Original on-disk meta size, not necessarily {@code meta.length}.
+     * Used by the uncompressed 2GB RPC guard before any content is returned.
+     */
     public long getMetaSize() {
-        return meta != null ? meta.length() : 0;
+        return metaSize;
     }
 
+    /**
+     * Original on-disk job info size, not necessarily {@code jobInfo.length}.
+     * Used by the uncompressed 2GB RPC guard before any content is returned.
+     */
     public long getJobInfoSize() {
-        return jobInfo != null ? jobInfo.length() : 0;
+        return jobInfoSize;
     }
 
-    public byte[] getCompressedMeta() throws IOException {
-        return GZIPUtils.compress(meta);
+    public byte[] getMeta() {
+        return meta;
     }
 
-    public byte[] getCompressedJobInfo() throws IOException {
-        return GZIPUtils.compress(jobInfo);
+    public byte[] getJobInfo() {
+        return jobInfo;
     }
 
-    public byte[] getMeta() throws IOException {
-        return Files.readAllBytes(meta.toPath());
-    }
-
-    public byte[] getJobInfo() throws IOException {
-        return Files.readAllBytes(jobInfo.toPath());
+    public boolean isCompressed() {
+        return compressed;
     }
 
     public long getExpiredAt() {
@@ -97,7 +116,7 @@ public class Snapshot {
     }
 
     public boolean isExpired() {
-        return System.currentTimeMillis() > expiredAt;
+        return System.currentTimeMillis() >= expiredAt;
     }
 
     public long getCommitSeq() {
@@ -108,6 +127,9 @@ public class Snapshot {
     public String toString() {
         return "Snapshot{"
                 + "label='" + label + '\''
+                + ", metaSize=" + metaSize
+                + ", jobInfoSize=" + jobInfoSize
+                + ", compressed=" + compressed
                 + ", expiredAt=" + expiredAt
                 + ", commitSeq=" + commitSeq
                 + '}';

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -4053,7 +4053,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         String label = request.getLabelName();
         TGetSnapshotResult result = new TGetSnapshotResult();
         result.setStatus(new TStatus(TStatusCode.OK));
-        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label);
+        boolean enableCompress = request.isEnableCompress();
+        // Materialize (or size-check) with file refcount; IOException propagates as INTERNAL_ERROR.
+        // Do not re-read files after return.
+        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label, enableCompress);
         if (snapshot == null) {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_NOT_EXIST);
             result.getStatus().addToErrorMsgs(String.format("snapshot %s not exist", label));
@@ -4061,10 +4064,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_EXPIRED);
             result.getStatus().addToErrorMsgs(String.format("snapshot %s is expired", label));
         } else {
+            // Original on-disk sizes. For uncompressed oversized snapshots, BackupJob returns
+            // sizes only (meta/jobInfo are null) so the guard runs without loading content.
             long metaSize = snapshot.getMetaSize();
             long jobInfoSize = snapshot.getJobInfoSize();
-            long snapshotSize = snapshot.getMetaSize() + snapshot.getJobInfoSize();
-            if (metaSize + jobInfoSize >= Integer.MAX_VALUE && !request.isEnableCompress()) {
+            long snapshotSize = metaSize + jobInfoSize;
+            if (snapshotSize >= Integer.MAX_VALUE && !enableCompress) {
                 String msg = String.format(
                         "Snapshot %s is too large (%d bytes > 2GB). Please enable compression to continue.",
                         label, snapshotSize);
@@ -4078,20 +4083,18 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             long commitSeq = snapshot.getCommitSeq();
 
             LOG.info("get snapshot info, snapshot: {}, meta size: {}, job info size: {}, "
-                    + "expired at: {}, commit seq: {}", label, metaSize, jobInfoSize, expiredAt, commitSeq);
-            if (request.isEnableCompress()) {
-                byte[] meta = snapshot.getCompressedMeta();
-                byte[] jobInfo = snapshot.getCompressedJobInfo();
-                result.setMeta(meta);
-                result.setJobInfo(jobInfo);
+                    + "expired at: {}, commit seq: {}, compressed: {}",
+                    label, metaSize, jobInfoSize, expiredAt, commitSeq, snapshot.isCompressed());
+            byte[] meta = snapshot.getMeta();
+            byte[] jobInfo = snapshot.getJobInfo();
+            result.setMeta(meta);
+            result.setJobInfo(jobInfo);
+            if (snapshot.isCompressed()) {
                 result.setCompressed(true);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("get snapshot info with compress, snapshot: {}, compressed meta "
                             + "size {}, compressed job info size {}", label, meta.length, jobInfo.length);
                 }
-            } else {
-                result.setMeta(snapshot.getMeta());
-                result.setJobInfo(snapshot.getJobInfo());
             }
             result.setExpiredAt(expiredAt);
             result.setCommitSeq(commitSeq);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.backup;
 
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.backup.BackupJob.BackupJobState;
+import org.apache.doris.backup.BackupJob.LocalJobDirCleanupResult;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DynamicPartitionProperty;
 import org.apache.doris.catalog.Env;
@@ -30,7 +31,9 @@ import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.GZIPUtils;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
@@ -66,13 +69,18 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class BackupJobTest {
@@ -324,6 +332,7 @@ public class BackupJobTest {
         Assert.assertTrue(metaInfo.exists());
         File jobInfo = new File(job.getLocalJobInfoFilePath());
         Assert.assertTrue(jobInfo.exists());
+        File localJobDir = jobInfo.getParentFile();
 
         BackupMeta restoreMetaInfo = null;
         BackupJobInfo restoreJobInfo = null;
@@ -353,6 +362,12 @@ public class BackupJobTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.FINISHED, job.getState());
+        Assert.assertTrue(localJobDir.exists());
+
+        BackupHandler handler = new BackupHandler(env);
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, job);
+        Deencapsulation.invoke(handler, "cleanupBackupJobLocalJobDirs", System.currentTimeMillis());
+        Assert.assertFalse(localJobDir.exists());
     }
 
     @Test
@@ -379,6 +394,514 @@ public class BackupJobTest {
         Assert.assertNotNull(copied);
         Assert.assertFalse(copied.dynamicPartitionExists());
         Assert.assertTrue(copied.getTableProperty().hasInvalidDynamicPartition());
+    }
+
+    @Test
+    public void testCleanupFinishedRemoteBackupJobDirFromPersistedFilePaths() throws IOException {
+        JobDirFixture fixture = createJobDirFixture(job, "remote_cleanup", BackupJobState.FINISHED);
+
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED,
+                job.cleanupLocalJobDirIfNecessary(System.currentTimeMillis()));
+
+        Assert.assertFalse(fixture.jobDir.exists());
+    }
+
+    @Test
+    public void testCleanupLocalSnapshotJobDirOnlyAfterExpired() throws IOException {
+        JobDirFixture fixture = createLocalJobDirFixture(
+                "local_snapshot_cleanup", 1000, BackupJobState.FINISHED);
+
+        Assert.assertEquals(LocalJobDirCleanupResult.NOT_DUE,
+                fixture.job.cleanupLocalJobDirIfNecessary(fixture.createTime + 999));
+        Assert.assertTrue(fixture.jobDir.exists());
+
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED,
+                fixture.job.cleanupLocalJobDirIfNecessary(fixture.createTime + 1000));
+        Assert.assertFalse(fixture.jobDir.exists());
+    }
+
+    @Test
+    public void testLocalSnapshotDataRemainsReadableAfterJobDirCleanup() throws IOException {
+        byte[] metaBytes = new byte[] {1, 2, 3};
+        byte[] jobInfoBytes = new byte[] {4, 5, 6};
+        JobDirFixture fixture = createLocalJobDirFixture("local_snapshot_read_cleanup", 1000,
+                BackupJobState.FINISHED, metaBytes, jobInfoBytes);
+
+        Snapshot snapshot = fixture.job.getSnapshot(false);
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED, fixture.job.cleanupLocalJobDirAfterRemoved());
+
+        Assert.assertFalse(fixture.jobDir.exists());
+        Assert.assertFalse(snapshot.isCompressed());
+        Assert.assertEquals(metaBytes.length, snapshot.getMetaSize());
+        Assert.assertEquals(jobInfoBytes.length, snapshot.getJobInfoSize());
+        Assert.assertArrayEquals(metaBytes, snapshot.getMeta());
+        Assert.assertArrayEquals(jobInfoBytes, snapshot.getJobInfo());
+    }
+
+    /**
+     * Oversized local snapshot must not be fully read into FE heap when compression is off.
+     * Sparse files provide a logical size &gt;= Integer.MAX_VALUE without allocating disk/RAM.
+     */
+    @Test
+    public void testLocalSnapshotOversizedWithoutCompressDoesNotReadFiles() throws IOException {
+        JobDirFixture fixture = createLocalJobDirFixture(
+                "local_snapshot_oversized", 3600 * 1000, BackupJobState.FINISHED);
+
+        long metaLogicalSize = (long) Integer.MAX_VALUE - 100L;
+        long jobInfoLogicalSize = 100L;
+        createSparseFile(fixture.metaInfo, metaLogicalSize);
+        createSparseFile(fixture.jobInfo, jobInfoLogicalSize);
+        Assert.assertEquals(metaLogicalSize, fixture.metaInfo.length());
+        Assert.assertEquals(jobInfoLogicalSize, fixture.jobInfo.length());
+
+        Snapshot snapshot = fixture.job.getSnapshot(false);
+
+        Assert.assertNotNull(snapshot);
+        Assert.assertFalse(snapshot.isExpired());
+        Assert.assertFalse(snapshot.isCompressed());
+        Assert.assertEquals(metaLogicalSize, snapshot.getMetaSize());
+        Assert.assertEquals(jobInfoLogicalSize, snapshot.getJobInfoSize());
+        Assert.assertTrue(snapshot.getMetaSize() + snapshot.getJobInfoSize() >= Integer.MAX_VALUE);
+        // Content must not be materialized for oversized uncompressed responses.
+        Assert.assertNull(snapshot.getMeta());
+        Assert.assertNull(snapshot.getJobInfo());
+        // Job dir must still exist; size guard rejected before any cleanup side-effect.
+        Assert.assertTrue(fixture.jobDir.exists());
+    }
+
+    @Test
+    public void testLocalSnapshotCompressStreamsFilesAndSurvivesCleanup() throws IOException {
+        // Slightly compressible payload; enough bytes to exercise streaming path.
+        byte[] metaBytes = new byte[64 * 1024];
+        byte[] jobInfoBytes = new byte[32 * 1024];
+        for (int i = 0; i < metaBytes.length; i++) {
+            metaBytes[i] = (byte) (i % 7);
+        }
+        for (int i = 0; i < jobInfoBytes.length; i++) {
+            jobInfoBytes[i] = (byte) (i % 11);
+        }
+        JobDirFixture fixture = createLocalJobDirFixture("local_snapshot_compress", 3600 * 1000,
+                BackupJobState.FINISHED, metaBytes, jobInfoBytes);
+
+        Snapshot snapshot = fixture.job.getSnapshot(true);
+        Assert.assertNotNull(snapshot);
+        Assert.assertTrue(snapshot.isCompressed());
+        Assert.assertEquals(metaBytes.length, snapshot.getMetaSize());
+        Assert.assertEquals(jobInfoBytes.length, snapshot.getJobInfoSize());
+        Assert.assertTrue(GZIPUtils.isGZIPCompressed(snapshot.getMeta()));
+        Assert.assertTrue(GZIPUtils.isGZIPCompressed(snapshot.getJobInfo()));
+        Assert.assertArrayEquals(metaBytes, GZIPUtils.decompress(snapshot.getMeta()));
+        Assert.assertArrayEquals(jobInfoBytes, GZIPUtils.decompress(snapshot.getJobInfo()));
+
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED, fixture.job.cleanupLocalJobDirAfterRemoved());
+        Assert.assertFalse(fixture.jobDir.exists());
+        // Materialized compressed payload remains usable after job dir is deleted.
+        Assert.assertArrayEquals(metaBytes, GZIPUtils.decompress(snapshot.getMeta()));
+        Assert.assertArrayEquals(jobInfoBytes, GZIPUtils.decompress(snapshot.getJobInfo()));
+    }
+
+    /**
+     * Active getSnapshot readers pin the staging dir via refcount; cleanup is deferred
+     * to a later handler cleanup cycle after the last reader releases, so neither
+     * mid-read deletion nor directory IO on the RPC thread can occur.
+     */
+    @Test
+    public void testLocalSnapshotCleanupDefersWhileGetSnapshotReaderPinned() throws Exception {
+        byte[] metaBytes = new byte[] {10, 20, 30, 40};
+        byte[] jobInfoBytes = new byte[] {50, 60, 70};
+        JobDirFixture fixture = createLocalJobDirFixture("local_snapshot_lock", 3600 * 1000,
+                BackupJobState.FINISHED, metaBytes, jobInfoBytes);
+
+        // Simulate an in-flight getSnapshot reader pin.
+        Deencapsulation.setField(fixture.job, "localJobDirReaders", 1);
+        Assert.assertEquals(LocalJobDirCleanupResult.DEFERRED, fixture.job.cleanupLocalJobDirAfterRemoved());
+        Assert.assertTrue("cleanup must defer while a reader is pinned", fixture.jobDir.exists());
+
+        // Release the pin (readers 1 -> 0); the RPC reader must not run directory IO.
+        Deencapsulation.invoke(fixture.job, "releaseLocalJobDirRead");
+        Assert.assertTrue(fixture.jobDir.exists());
+        Assert.assertFalse(Deencapsulation.getField(fixture.job, "localJobDirCleaned"));
+
+        // A later backup handler cleanup cycle performs the deferred deletion.
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED, fixture.job.cleanupLocalJobDirAfterRemoved());
+        Assert.assertFalse(fixture.jobDir.exists());
+        Assert.assertTrue(Deencapsulation.getField(fixture.job, "localJobDirCleaned"));
+    }
+
+    @Test
+    public void testCleanupRetriesAfterDeleteFailure() throws IOException {
+        boolean[] failDelete = {true};
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0) {
+            @Override
+            void deleteLocalJobDir(Path jobDirPath) throws IOException {
+                if (failDelete[0]) {
+                    failDelete[0] = false;
+                    throw new IOException("injected delete failure");
+                }
+                super.deleteLocalJobDir(jobDirPath);
+            }
+        };
+        JobDirFixture fixture = createJobDirFixture(
+                localSnapshotJob, "local_snapshot_delete_retry", BackupJobState.CANCELLED);
+
+        Assert.assertEquals(LocalJobDirCleanupResult.FAILED,
+                localSnapshotJob.cleanupLocalJobDirIfNecessary(fixture.createTime));
+        Assert.assertTrue(fixture.jobDir.exists());
+        Assert.assertFalse(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED,
+                localSnapshotJob.cleanupLocalJobDirIfNecessary(fixture.createTime));
+        Assert.assertFalse(fixture.jobDir.exists());
+        Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+    }
+
+    @Test
+    public void testLocalSnapshotIoFailurePropagatesAsIOException() throws IOException {
+        JobDirFixture fixture = createLocalJobDirFixture(
+                "local_snapshot_io_fail", 3600 * 1000, BackupJobState.FINISHED);
+
+        Assert.assertTrue(fixture.metaInfo.delete());
+        try {
+            fixture.job.getSnapshot(false);
+            Assert.fail("expected IOException when meta file is missing");
+        } catch (IOException e) {
+            // Must not be swallowed as null / SNAPSHOT_NOT_EXIST.
+            Assert.assertNotNull(e.getMessage());
+        }
+        // Failed materialization still releases the pin so later cleanup can proceed.
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED, fixture.job.cleanupLocalJobDirAfterRemoved());
+        Assert.assertFalse(fixture.jobDir.exists());
+    }
+
+    @Test
+    public void testGetSnapshotReturnsNullWhenUnavailable() throws IOException {
+        Assert.assertNull(job.getSnapshot(false));
+
+        JobDirFixture remoteFixture = createJobDirFixture(
+                job, "remote_snapshot_unavailable", BackupJobState.FINISHED);
+        Assert.assertNull(remoteFixture.job.getSnapshot(false));
+
+        JobDirFixture missingPathFixture = createLocalJobDirFixture(
+                "local_snapshot_missing_path", 3600 * 1000, BackupJobState.FINISHED);
+        Deencapsulation.setField(missingPathFixture.job, "localMetaInfoFilePath", null);
+        Assert.assertNull(missingPathFixture.job.getSnapshot(false));
+
+        JobDirFixture cleanedFixture = createLocalJobDirFixture(
+                "local_snapshot_cleaned", 3600 * 1000, BackupJobState.FINISHED);
+        Deencapsulation.setField(cleanedFixture.job, "localJobDirCleaned", true);
+        Assert.assertNull(cleanedFixture.job.getSnapshot(false));
+
+        BackupJob pathWithoutParentJob = new BackupJob("path_without_parent", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(pathWithoutParentJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(pathWithoutParentJob, "localMetaInfoFilePath", Repository.FILE_META_INFO);
+        Deencapsulation.setField(pathWithoutParentJob, "localJobInfoFilePath", Repository.PREFIX_JOB_INFO + "test");
+        Assert.assertNull(pathWithoutParentJob.getSnapshot(false));
+    }
+
+    @Test
+    public void testCleanupHandlesMissingPersistedAndInvalidPaths() throws IOException {
+        BackupJob pendingJob = new BackupJob("pending_cleanup", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Assert.assertEquals(LocalJobDirCleanupResult.NOT_DUE, pendingJob.cleanupLocalJobDirAfterRemoved());
+
+        BackupJob missingPathJob = new BackupJob("missing_cleanup_path", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(missingPathJob, "state", BackupJobState.FINISHED);
+        Assert.assertEquals(LocalJobDirCleanupResult.ALREADY_CLEANED,
+                missingPathJob.cleanupLocalJobDirAfterRemoved());
+        Assert.assertEquals(LocalJobDirCleanupResult.ALREADY_CLEANED,
+                missingPathJob.cleanupLocalJobDirAfterRemoved());
+
+        Path invalidJobDir = Files.createTempDirectory("invalid_backup_job_dir");
+        try {
+            BackupJob invalidPathJob = new BackupJob("invalid_cleanup_path", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL,
+                    env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+            Deencapsulation.setField(invalidPathJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(invalidPathJob, "localJobDirPath", invalidJobDir);
+
+            Assert.assertEquals(LocalJobDirCleanupResult.INVALID_PATH,
+                    invalidPathJob.cleanupLocalJobDirAfterRemoved());
+            Assert.assertTrue(Files.exists(invalidJobDir));
+        } finally {
+            Files.deleteIfExists(invalidJobDir);
+        }
+
+        File persistedJobDir = createLocalJobDir("job_info_only_cleanup");
+        File persistedJobInfo = new File(persistedJobDir, Repository.PREFIX_JOB_INFO + "persisted");
+        Files.write(persistedJobInfo.toPath(), new byte[0]);
+        BackupJob jobInfoOnlyJob = new BackupJob("job_info_only", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(jobInfoOnlyJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(jobInfoOnlyJob, "localJobInfoFilePath", persistedJobInfo.getAbsolutePath());
+
+        Assert.assertEquals(LocalJobDirCleanupResult.DELETED, jobInfoOnlyJob.cleanupLocalJobDirAfterRemoved());
+        Assert.assertFalse(persistedJobDir.exists());
+    }
+
+    @Test
+    public void testCleanupStatsDistinguishKnownJobResults() throws Exception {
+        BackupHandler handler = new BackupHandler(env);
+
+        BackupJob deletedJob = new BackupJob("deleted", dbId + 10, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+        createJobDirFixture(deletedJob, "stats_deleted", BackupJobState.FINISHED);
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId + 10, deletedJob);
+
+        BackupJob absentJob = new BackupJob("absent", dbId + 11, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+        JobDirFixture absentFixture = createJobDirFixture(absentJob, "stats_absent", BackupJobState.FINISHED);
+        Files.delete(absentFixture.metaInfo.toPath());
+        Files.delete(absentFixture.jobInfo.toPath());
+        Files.delete(absentFixture.jobDir.toPath());
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId + 11, absentJob);
+
+        BackupJob deferredJob = new BackupJob("deferred", dbId + 12, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+        createJobDirFixture(deferredJob, "stats_deferred", BackupJobState.FINISHED);
+        Deencapsulation.setField(deferredJob, "localJobDirReaders", 1);
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId + 12, deferredJob);
+
+        BackupJob failedJob = new BackupJob("failed", dbId + 13, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0) {
+            @Override
+            void deleteLocalJobDir(Path jobDirPath) throws IOException {
+                throw new IOException("injected delete failure");
+            }
+        };
+        createJobDirFixture(failedJob, "stats_failed", BackupJobState.FINISHED);
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId + 13, failedJob);
+
+        BackupJob notDueJob = new BackupJob("not_due", dbId + 14, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId + 14, notDueJob);
+
+        Object stats = Deencapsulation.invoke(handler, "cleanupBackupJobLocalJobDirs",
+                System.currentTimeMillis());
+        Assert.assertEquals(5, (int) Deencapsulation.getField(stats, "itemsScanned"));
+        Assert.assertEquals(1, (int) Deencapsulation.getField(stats, "directoriesDeleted"));
+        Assert.assertEquals(1, (int) Deencapsulation.getField(stats, "directoriesAlreadyAbsent"));
+        Assert.assertEquals(1, (int) Deencapsulation.getField(stats, "jobsDeferred"));
+        Assert.assertEquals(1, (int) Deencapsulation.getField(stats, "failures"));
+        Assert.assertEquals(1, (int) Deencapsulation.getField(stats, "notDue"));
+    }
+
+    @Test
+    public void testCleanupCancelledLocalSnapshotJobDirFromPersistedFilePaths() throws IOException {
+        JobDirFixture fixture = createLocalJobDirFixture(
+                "local_cancel_cleanup", 1000, BackupJobState.CANCELLED);
+
+        fixture.job.cleanupLocalJobDirIfNecessary(fixture.createTime);
+        Assert.assertFalse(fixture.jobDir.exists());
+    }
+
+    @Test
+    public void testExpiredGetSnapshotDoesNotDeleteJobDir() throws IOException {
+        JobDirFixture fixture = createLocalJobDirFixture(
+                "expired_snapshot_rpc", 1000, BackupJobState.FINISHED);
+        long expiredCreateTime = fixture.createTime - 1000;
+        Deencapsulation.setField(fixture.job, "createTime", expiredCreateTime);
+
+        Snapshot snapshot = fixture.job.getSnapshot(false);
+        Assert.assertTrue(snapshot.isExpired());
+        Assert.assertTrue(fixture.jobDir.exists());
+
+        fixture.job.cleanupLocalJobDirIfNecessary(expiredCreateTime + 1000);
+        Assert.assertFalse(fixture.jobDir.exists());
+    }
+
+    @Test
+    public void testEvictedJobCleanupWaitsForPinnedReader() throws Exception {
+        int oldMaxJobNum = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 1;
+        try {
+            BackupHandler handler = new BackupHandler(env);
+            BackupJob evictedJob = new BackupJob("evicted_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+            JobDirFixture fixture = createJobDirFixture(
+                    evictedJob, "evicted_snapshot", BackupJobState.FINISHED);
+            Deencapsulation.setField(evictedJob, "localJobDirReaders", 1);
+
+            BackupJob replacementJob = new BackupJob("replacement_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, evictedJob);
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, replacementJob);
+
+            Deque<BackupJob> pendingCleanupJobs = Deencapsulation.getField(handler, "pendingCleanupJobs");
+            Assert.assertEquals(1, pendingCleanupJobs.size());
+            Deencapsulation.invoke(handler, "cleanupPendingBackupJobLocalJobDirs");
+            Assert.assertTrue(fixture.jobDir.exists());
+            Assert.assertEquals(1, pendingCleanupJobs.size());
+
+            Deencapsulation.invoke(evictedJob, "releaseLocalJobDirRead");
+            Assert.assertTrue(fixture.jobDir.exists());
+            Deencapsulation.invoke(handler, "cleanupPendingBackupJobLocalJobDirs");
+            Assert.assertFalse(fixture.jobDir.exists());
+            Assert.assertTrue(pendingCleanupJobs.isEmpty());
+        } finally {
+            Config.max_backup_restore_job_num_per_db = oldMaxJobNum;
+        }
+    }
+
+    @Test
+    public void testEvictedLocalSnapshotIsRemovedAndCleaned() throws Exception {
+        int oldMaxJobNum = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 1;
+        try {
+            BackupHandler handler = new BackupHandler(env);
+            JobDirFixture fixture = createLocalJobDirFixture(
+                    "evicted_local_snapshot", 3600 * 1000, BackupJobState.FINISHED,
+                    new byte[] {1, 2}, new byte[] {3, 4});
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, fixture.job);
+
+            Assert.assertNotNull(handler.getSnapshot(fixture.job.getLabel(), false));
+
+            BackupJob replacementJob = new BackupJob("replacement_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 3600 * 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, replacementJob);
+
+            Assert.assertNull(handler.getSnapshot(fixture.job.getLabel(), false));
+            Assert.assertTrue(fixture.jobDir.exists());
+
+            Deencapsulation.invoke(handler, "cleanupPendingBackupJobLocalJobDirs");
+            Assert.assertFalse(fixture.jobDir.exists());
+        } finally {
+            Config.max_backup_restore_job_num_per_db = oldMaxJobNum;
+        }
+    }
+
+    @Test
+    public void testCheckpointReplayAndEvictionDoNotTouchJobDirs() throws Exception {
+        int oldMaxJobNum = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 1;
+        mockedEnvStatic.when(Env::isCheckpointThread).thenReturn(true);
+        try {
+            Deencapsulation.setField(job, "state", BackupJobState.SAVE_META);
+            job.replayRun();
+            Assert.assertNull(job.getLocalMetaInfoFilePath());
+            Assert.assertNull(job.getLocalJobInfoFilePath());
+
+            BackupHandler handler = new BackupHandler(env);
+            BackupJob finishedJob = new BackupJob("checkpoint_finished", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+            File localJobDir = createLocalJobDir("checkpoint_eviction");
+            Deencapsulation.setField(finishedJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(finishedJob, "localJobDirPath", localJobDir.toPath());
+            BackupJob replacementJob = new BackupJob("checkpoint_replacement", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupCommand.BackupContent.ALL, env, repoId, 0);
+
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, finishedJob);
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, replacementJob);
+
+            Deque<BackupJob> pendingCleanupJobs = Deencapsulation.getField(handler, "pendingCleanupJobs");
+            Assert.assertTrue(pendingCleanupJobs.isEmpty());
+            Assert.assertTrue(localJobDir.exists());
+        } finally {
+            Config.max_backup_restore_job_num_per_db = oldMaxJobNum;
+            mockedEnvStatic.when(Env::isCheckpointThread).thenReturn(false);
+        }
+    }
+
+    @Test
+    public void testOrphanJobDirCleanupUsesReferencesAndGracePeriod() throws Exception {
+        int oldOrphanKeepSecond = Config.backup_orphan_dir_keep_max_second;
+        Config.backup_orphan_dir_keep_max_second = 2 * 24 * 3600;
+        Path externalDir = Files.createTempDirectory("backup_orphan_external");
+        Path symlink = null;
+        try {
+            long nowMs = System.currentTimeMillis();
+            File referencedDir = createRepoJobDir(repoId, "referenced");
+            File oldOrphanDir = createRepoJobDir(repoId, "old_orphan");
+            File newOrphanDir = createRepoJobDir(repoId, "new_orphan");
+            Files.setLastModifiedTime(referencedDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Files.setLastModifiedTime(oldOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+
+            BackupHandler handler = new BackupHandler(env);
+            BackupJob referencedJob = new BackupJob("referenced_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), TimeUnit.DAYS.toMillis(7), BackupCommand.BackupContent.ALL,
+                    env, repoId, 0);
+            Deencapsulation.setField(referencedJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(referencedJob, "localJobDirPath", referencedDir.toPath());
+            Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, referencedJob);
+
+            Path repoDir = referencedDir.toPath().getParent();
+            symlink = repoDir.resolve("orphan_symlink_" + id.getAndIncrement());
+            Files.createSymbolicLink(symlink, externalDir);
+
+            Deencapsulation.invoke(handler, "cleanupOrphanBackupJobLocalJobDirs", nowMs);
+
+            Assert.assertTrue(referencedDir.exists());
+            Assert.assertFalse(oldOrphanDir.exists());
+            Assert.assertTrue(newOrphanDir.exists());
+            Assert.assertTrue(Files.exists(symlink, LinkOption.NOFOLLOW_LINKS));
+            Assert.assertTrue(Files.exists(externalDir));
+
+            File disabledCleanupOrphanDir = createRepoJobDir(repoId, "disabled_cleanup_orphan");
+            Files.setLastModifiedTime(disabledCleanupOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Config.backup_orphan_dir_keep_max_second = 0;
+            Deencapsulation.invoke(handler, "cleanupOrphanBackupJobLocalJobDirs", nowMs);
+            Assert.assertTrue(disabledCleanupOrphanDir.exists());
+        } finally {
+            if (symlink != null) {
+                Files.deleteIfExists(symlink);
+            }
+            Files.deleteIfExists(externalDir);
+            Config.backup_orphan_dir_keep_max_second = oldOrphanKeepSecond;
+        }
+    }
+
+    @Test
+    public void testOrphanJobDirCleanupUsesIndependentInterval() throws Exception {
+        long oldCleanupIntervalSecond = Config.backup_orphan_dir_cleanup_interval_second;
+        Config.backup_orphan_dir_cleanup_interval_second = 3600;
+        try {
+            long nowMs = System.currentTimeMillis();
+            BackupHandler handler = new BackupHandler(env);
+
+            File firstOldOrphanDir = createRepoJobDir(repoId, "first_interval_orphan");
+            Files.setLastModifiedTime(firstOldOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Deencapsulation.invoke(handler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary", nowMs);
+            Assert.assertFalse(firstOldOrphanDir.exists());
+
+            File secondOldOrphanDir = createRepoJobDir(repoId, "second_interval_orphan");
+            Files.setLastModifiedTime(secondOldOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Deencapsulation.invoke(handler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary",
+                    nowMs + Config.backup_handler_update_interval_millis);
+            Assert.assertTrue(secondOldOrphanDir.exists());
+
+            Deencapsulation.invoke(handler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary",
+                    nowMs + TimeUnit.HOURS.toMillis(1));
+            Assert.assertFalse(secondOldOrphanDir.exists());
+        } finally {
+            Config.backup_orphan_dir_cleanup_interval_second = oldCleanupIntervalSecond;
+        }
+    }
+
+    @Test
+    public void testOrphanJobDirCleanupCanBeDisabled() throws Exception {
+        long oldCleanupIntervalSecond = Config.backup_orphan_dir_cleanup_interval_second;
+        Config.backup_orphan_dir_cleanup_interval_second = 0;
+        try {
+            BackupHandler handler = new BackupHandler(env);
+            Deencapsulation.invoke(handler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary",
+                    System.currentTimeMillis());
+            long lastCleanupTimeMs = Deencapsulation.getField(handler, "lastOrphanJobDirCleanupTimeMs");
+            Assert.assertEquals(0L, lastCleanupTimeMs);
+        } finally {
+            Config.backup_orphan_dir_cleanup_interval_second = oldCleanupIntervalSecond;
+        }
     }
 
     /**
@@ -656,5 +1179,77 @@ public class BackupJobTest {
         // 3. delete files
         in.close();
         Files.delete(path);
+    }
+
+    private File createLocalJobDir(String name) throws IOException {
+        Path jobDirPath = BackupHandler.BACKUP_ROOT_DIR.resolve(name + "_" + id.getAndIncrement());
+        Files.createDirectories(jobDirPath);
+        return jobDirPath.toFile();
+    }
+
+    private File createRepoJobDir(long jobRepoId, String name) throws IOException {
+        Path jobDirPath = BackupHandler.BACKUP_ROOT_DIR.resolve("repo__" + jobRepoId)
+                .resolve(name + "_" + id.getAndIncrement());
+        Files.createDirectories(jobDirPath);
+        return jobDirPath.toFile();
+    }
+
+    private JobDirFixture createLocalJobDirFixture(
+            String name, long timeoutMs, BackupJobState state) throws IOException {
+        return createLocalJobDirFixture(name, timeoutMs, state, new byte[0], new byte[0]);
+    }
+
+    private JobDirFixture createLocalJobDirFixture(
+            String name, long timeoutMs, BackupJobState state, byte[] metaBytes, byte[] jobInfoBytes)
+            throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), timeoutMs, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        return createJobDirFixture(localSnapshotJob, name, state, metaBytes, jobInfoBytes);
+    }
+
+    private JobDirFixture createJobDirFixture(
+            BackupJob targetJob, String name, BackupJobState state) throws IOException {
+        return createJobDirFixture(targetJob, name, state, new byte[0], new byte[0]);
+    }
+
+    private JobDirFixture createJobDirFixture(
+            BackupJob targetJob, String name, BackupJobState state, byte[] metaBytes, byte[] jobInfoBytes)
+            throws IOException {
+        File jobDir = createLocalJobDir(name);
+        File metaInfo = new File(jobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(jobDir, Repository.PREFIX_JOB_INFO + "test");
+        Files.write(metaInfo.toPath(), metaBytes);
+        Files.write(jobInfo.toPath(), jobInfoBytes);
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(targetJob, "state", state);
+        Deencapsulation.setField(targetJob, "createTime", createTime);
+        Deencapsulation.setField(targetJob, "localJobDirPath", null);
+        Deencapsulation.setField(targetJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(targetJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+        return new JobDirFixture(targetJob, jobDir, metaInfo, jobInfo, createTime);
+    }
+
+    private void createSparseFile(File file, long logicalSize) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.setLength(logicalSize);
+        }
+    }
+
+    private static class JobDirFixture {
+        private final BackupJob job;
+        private final File jobDir;
+        private final File metaInfo;
+        private final File jobInfo;
+        private final long createTime;
+
+        private JobDirFixture(BackupJob job, File jobDir, File metaInfo, File jobInfo, long createTime) {
+            this.job = job;
+            this.jobDir = jobDir;
+            this.metaInfo = metaInfo;
+            this.jobInfo = jobInfo;
+            this.createTime = createTime;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -18,6 +18,8 @@
 package org.apache.doris.service;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.backup.BackupHandler;
+import org.apache.doris.backup.Snapshot;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
@@ -49,6 +51,8 @@ import org.apache.doris.thrift.TFetchSchemaTableDataRequest;
 import org.apache.doris.thrift.TFetchSchemaTableDataResult;
 import org.apache.doris.thrift.TGetDbsParams;
 import org.apache.doris.thrift.TGetDbsResult;
+import org.apache.doris.thrift.TGetSnapshotRequest;
+import org.apache.doris.thrift.TGetSnapshotResult;
 import org.apache.doris.thrift.TGetTablesParams;
 import org.apache.doris.thrift.TGetTablesResult;
 import org.apache.doris.thrift.TGetTabletReplicaInfosRequest;
@@ -66,6 +70,7 @@ import org.apache.doris.thrift.TSchemaTableName;
 import org.apache.doris.thrift.TSchemaTableRequestParams;
 import org.apache.doris.thrift.TShowUserRequest;
 import org.apache.doris.thrift.TShowUserResult;
+import org.apache.doris.thrift.TSnapshotType;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTableStatus;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
@@ -149,6 +154,74 @@ public class FrontendServiceImplTest {
         Field field = target.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(target, value);
+    }
+
+    private static TGetSnapshotRequest createGetSnapshotRequest(boolean enableCompress) {
+        TGetSnapshotRequest request = new TGetSnapshotRequest();
+        request.setUser("root");
+        request.setPasswd("");
+        request.setDb("test");
+        request.setLabelName("local_snapshot");
+        request.setSnapshotName("local_snapshot");
+        request.setSnapshotType(TSnapshotType.LOCAL);
+        request.setToken("test-token");
+        request.setEnableCompress(enableCompress);
+        return request;
+    }
+
+    private static TGetSnapshotResult invokeGetSnapshotImpl(
+            FrontendServiceImpl impl, TGetSnapshotRequest request) throws Exception {
+        Method method = FrontendServiceImpl.class.getDeclaredMethod(
+                "getSnapshotImpl", TGetSnapshotRequest.class, String.class);
+        method.setAccessible(true);
+        return (TGetSnapshotResult) method.invoke(impl, request, "127.0.0.1");
+    }
+
+    @Test
+    public void testGetSnapshotReturnsCompressedPayload() throws Exception {
+        Env mockedEnv = Mockito.mock(Env.class);
+        BackupHandler backupHandler = Mockito.mock(BackupHandler.class);
+        byte[] meta = new byte[] {1, 2, 3};
+        byte[] jobInfo = new byte[] {4, 5};
+        long expiredAt = System.currentTimeMillis() + 60_000;
+        Snapshot snapshot = new Snapshot("local_snapshot", meta, jobInfo, 10, 20,
+                true, expiredAt, 99);
+        Mockito.when(mockedEnv.getBackupHandler()).thenReturn(backupHandler);
+        Mockito.when(backupHandler.getSnapshot("local_snapshot", true)).thenReturn(snapshot);
+
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class)) {
+            mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(mockedEnv);
+            TGetSnapshotResult result = invokeGetSnapshotImpl(
+                    new FrontendServiceImpl(exeEnv), createGetSnapshotRequest(true));
+
+            Assert.assertEquals(TStatusCode.OK, result.getStatus().getStatusCode());
+            Assert.assertArrayEquals(meta, result.getMeta());
+            Assert.assertArrayEquals(jobInfo, result.getJobInfo());
+            Assert.assertTrue(result.isCompressed());
+            Assert.assertEquals(expiredAt, result.getExpiredAt());
+            Assert.assertEquals(99, result.getCommitSeq());
+        }
+    }
+
+    @Test
+    public void testGetSnapshotRejectsOversizedUncompressedPayload() throws Exception {
+        Env mockedEnv = Mockito.mock(Env.class);
+        BackupHandler backupHandler = Mockito.mock(BackupHandler.class);
+        Snapshot snapshot = new Snapshot("local_snapshot", null, null,
+                Integer.MAX_VALUE - 1L, 1, false, System.currentTimeMillis() + 60_000, 99);
+        Mockito.when(mockedEnv.getBackupHandler()).thenReturn(backupHandler);
+        Mockito.when(backupHandler.getSnapshot("local_snapshot", false)).thenReturn(snapshot);
+
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class)) {
+            mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(mockedEnv);
+            TGetSnapshotResult result = invokeGetSnapshotImpl(
+                    new FrontendServiceImpl(exeEnv), createGetSnapshotRequest(false));
+
+            Assert.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatusCode());
+            Assert.assertFalse(result.isSetMeta());
+            Assert.assertFalse(result.isSetJobInfo());
+            Assert.assertTrue(result.getStatus().getErrorMsgs().get(0).contains("enable compression"));
+        }
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #65632 

Related PR: None

Problem Summary: 
FE writes backup metadata and job information to staging directories under `tmp_dir`, but these directories do not have a complete lifecycle management mechanism.

Staging directories may remain after remote backups finish, local snapshots expire or are evicted, journal replay creates files on another FE, or a previous deletion attempt fails. These stale directories can accumulate independently on each FE and consume disk space.

This PR centralizes staging directory cleanup in `BackupHandler`:

- Clean remote backup staging directories after the job reaches `FINISHED` or `CANCELLED`.
- Clean local backup staging directories immediately after `CANCELLED`.
- Keep finished local snapshots until expiration or history eviction.
- Retry cleanup when a snapshot reader is active or directory deletion fails.
- Perform directory deletion outside the `BackupJob` monitor and snapshot RPC reader thread.
- Avoid writing staging files from checkpoint replay.
- Periodically remove orphan staging directories using an independent, configurable scan interval.

The local snapshot materialization path also pins the staging directory while reading, rejects oversized uncompressed snapshots before loading them into memory, and applies a bounded compressed-output size.

The orphan cleanup is controlled by:

- `backup_orphan_dir_keep_max_second`: minimum orphan retention period, default 2 days.
- `backup_orphan_dir_cleanup_interval_second`: full orphan scan interval, default 1 hour.

This PR does not change the backup staging path format, persisted `BackupJob` fields, journal/image format, Thrift protocol, or local snapshot indexing semantics.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

