### PR TITLE
[fix](regression) branch-4.1: avoid midnight race in auto recycle case

### DIFF
--- a/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
@@ -114,8 +114,6 @@ suite("test_auto_new_recycle", "nonConcurrent") {
         );
     """
 
-    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BOUNDARY", 20)
-
     def waitPartitionCount = { int expectedCount ->
         Awaitility.await().atMost(1200, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until {
             res = sql "show partitions from auto_recycle"
@@ -176,6 +174,7 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     """
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '600') """
     sleep(8000)
+    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BOUNDARY", 1300)
     sql """
         insert into auto_recycle select date_add(now(), interval number-5 day) from numbers("number" = "8");
     """


### PR DESCRIPTION
### What problem does this PR solve?

Related PRs: #65435, #65375

Problem Summary:

`test_auto_new_recycle` uses `now()` to create historical, current-day, and
future partitions, then waits for asynchronous partition recycling. The
day-boundary guard ran near the start of the case, so it did not protect the
final time-sensitive assertion after the preceding Awaitility waits.

This branch-4.1 backport moves the guard directly before the final `now()`
insert. The 1300-second protected window covers the existing 1200-second
Awaitility timeout plus the insert and assertion overhead. The guard only
sleeps when this final section would otherwise start too close to midnight.

Testing:

- `git diff --check`
- Not run locally because no Doris regression environment was allocated. The
  PR build will run the regression coverage.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
