### PR TITLE
[fix](be) Stop stream load recorder before HTTP service

### DIFF
--- a/be/src/load/stream_load/stream_load_recorder_manager.cpp
+++ b/be/src/load/stream_load/stream_load_recorder_manager.cpp
@@ -89,7 +89,9 @@ void StreamLoadRecorderManager::stop() {
 void StreamLoadRecorderManager::_worker_thread_func() {
     SCOPED_ATTACH_TASK(_mem_tracker);
     while (!_stop) {
-        _fetch_and_buffer_records();
+        if (!_has_pending_batch()) {
+            _fetch_and_buffer_records();
+        }
         _load_if_necessary();
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
@@ -232,17 +234,31 @@ std::string StreamLoadRecorderManager::_parse_and_format_record(const std::strin
 
 void StreamLoadRecorderManager::_load_if_necessary() {
     int64_t current_time = UnixMillis();
-    bool should_load = _buffer.size() >= config::stream_load_record_batch_bytes ||
+    bool should_load = _has_pending_batch() ||
+                       _buffer.size() >= config::stream_load_record_batch_bytes ||
                        (current_time - _last_load_time) >=
                                config::stream_load_record_batch_interval_secs * 1000;
     if (!should_load || _buffer.size() == 0) {
         return;
     }
 
-    Status st = _send_stream_load(_buffer.ToString());
+    if (!_has_pending_batch()) {
+        _pending_label = _generate_label();
+    }
+
+    Status st;
+#ifdef BE_TEST
+    if (_stream_load_sender_for_test) {
+        st = _stream_load_sender_for_test(_buffer.ToString(), _pending_label);
+    } else {
+        st = _send_stream_load(_buffer.ToString(), _pending_label);
+    }
+#else
+    st = _send_stream_load(_buffer.ToString(), _pending_label);
+#endif
     if (!st.ok()) {
         LOG(WARNING) << "Failed to load stream load records to audit log table: " << st
-                     << ", keep current batch for retry";
+                     << ", keep pending batch with label " << _pending_label << " for retry";
         return;
     }
 
@@ -251,12 +267,12 @@ void StreamLoadRecorderManager::_load_if_necessary() {
     _reset_batch(current_time);
 }
 
-Status StreamLoadRecorderManager::_send_stream_load(const std::string& data) {
+Status StreamLoadRecorderManager::_send_stream_load(const std::string& data,
+                                                    const std::string& label) {
     std::string url = _generate_url();
     if (url.empty()) {
         return Status::InternalError("FE address is not available yet");
     }
-    std::string label = _generate_label();
 
     HttpClient client;
     Status st = client.init(url);
@@ -288,17 +304,33 @@ Status StreamLoadRecorderManager::_send_stream_load(const std::string& data) {
         return Status::InternalError("Stream load failed with HTTP status {}: {}", http_status,
                                      response);
     }
+    return _parse_stream_load_response(response);
+}
+
+Status StreamLoadRecorderManager::_parse_stream_load_response(const std::string& response) {
     rapidjson::Document doc;
-    if (!doc.Parse(response.data(), response.length()).HasParseError()) {
-        if (doc.HasMember("Status") && doc["Status"].IsString()) {
-            std::string status = doc["Status"].GetString();
-            if (status != "Success") {
-                return Status::InternalError("Stream load status is not Success: {}", response);
-            }
-        }
+    if (doc.Parse(response.data(), response.length()).HasParseError() || !doc.IsObject()) {
+        return Status::InternalError("Failed to parse stream load response: {}", response);
+    }
+    if (!doc.HasMember("Status") || !doc["Status"].IsString()) {
+        return Status::InternalError("Stream load response has no valid Status: {}", response);
     }
 
-    return Status::OK();
+    std::string status = doc["Status"].GetString();
+    // PUBLISH_TIMEOUT means the transaction was committed but did not become visible before the
+    // response timeout. The stream load path does not roll it back.
+    if (status == "Success" || status == "Publish Timeout") {
+        return Status::OK();
+    }
+    // A retry after an unknown HTTP outcome reuses the pending label. FINISHED means the original
+    // transaction is already COMMITTED or VISIBLE, so the batch must not be submitted again.
+    if (status == "Label Already Exists" && doc.HasMember("ExistingJobStatus") &&
+        doc["ExistingJobStatus"].IsString() &&
+        std::string(doc["ExistingJobStatus"].GetString()) == "FINISHED") {
+        return Status::OK();
+    }
+
+    return Status::InternalError("Stream load batch is not accepted: {}", response);
 }
 
 std::string StreamLoadRecorderManager::_generate_label() {
@@ -322,6 +354,7 @@ void StreamLoadRecorderManager::_reset_batch(int64_t current_time) {
     _buffer.clear();
     _last_load_time = current_time;
     _record_num = 0;
+    _pending_label.clear();
 }
 
 } // namespace doris

--- a/be/src/load/stream_load/stream_load_recorder_manager.cpp
+++ b/be/src/load/stream_load/stream_load_recorder_manager.cpp
@@ -242,7 +242,8 @@ void StreamLoadRecorderManager::_load_if_necessary() {
     Status st = _send_stream_load(_buffer.ToString());
     if (!st.ok()) {
         LOG(WARNING) << "Failed to load stream load records to audit log table: " << st
-                     << ", discard current batch";
+                     << ", keep current batch for retry";
+        return;
     }
 
     _save_last_fetch_key();

--- a/be/src/load/stream_load/stream_load_recorder_manager.h
+++ b/be/src/load/stream_load/stream_load_recorder_manager.h
@@ -19,9 +19,11 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "util/faststring.h"
 
@@ -59,6 +61,15 @@ public:
 
     void stop();
 
+#ifdef BE_TEST
+    using StreamLoadSender =
+            std::function<Status(const std::string& data, const std::string& label)>;
+
+    void set_stream_load_sender_for_test(StreamLoadSender sender) {
+        _stream_load_sender_for_test = std::move(sender);
+    }
+#endif
+
 private:
     void _load_last_fetch_key();
 
@@ -72,7 +83,11 @@ private:
 
     void _load_if_necessary();
 
-    Status _send_stream_load(const std::string& data);
+    Status _send_stream_load(const std::string& data, const std::string& label);
+
+    static Status _parse_stream_load_response(const std::string& response);
+
+    bool _has_pending_batch() const { return !_pending_label.empty(); }
 
     std::string _generate_label();
 
@@ -93,6 +108,11 @@ private:
     int64_t _record_num;
 
     std::string _last_fetch_key;
+    std::string _pending_label;
+
+#ifdef BE_TEST
+    StreamLoadSender _stream_load_sender_for_test;
+#endif
 };
 
 } // namespace doris

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -163,6 +163,10 @@ public:
     // Stop all threads and delete resources.
     void destroy();
 
+    // StreamLoadRecorderManager sends records through the BE HTTP service, so it must stop before
+    // the HTTP service is shut down.
+    void stop_stream_load_recorder_manager();
+
     /// Returns the first created exec env instance. In a normal doris, this is
     /// the only instance. In test setups with multiple ExecEnv's per process,
     /// we return the most recently created instance.

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -852,6 +852,10 @@ void ExecEnv::clear_wal_mgr() {
 #endif
 // TODO(zhiqiang): Need refactor all thread pool. Each thread pool must have a Stop method.
 // We need to stop all threads before releasing resource.
+void ExecEnv::stop_stream_load_recorder_manager() {
+    SAFE_STOP(_stream_load_recorder_manager);
+}
+
 void ExecEnv::destroy() {
     //Only destroy once after init
     if (!ready()) {
@@ -869,7 +873,7 @@ void ExecEnv::destroy() {
     SAFE_STOP(_group_commit_mgr);
     // _routine_load_task_executor should be stopped before _new_load_stream_mgr.
     SAFE_STOP(_routine_load_task_executor);
-    SAFE_STOP(_stream_load_recorder_manager);
+    stop_stream_load_recorder_manager();
     // stop workload scheduler
     SAFE_STOP(_workload_sched_mgr);
     // Stop workload group execution threads before FragmentMgr. Running pipeline tasks can still

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -724,6 +724,10 @@ int main(int argc, char** argv) {
         _exit(0); // Do not call exit(0), it will wait for all objects de-constructed normally
         return 0;
     }
+    // StreamLoadRecorderManager may be sending audit records through the local HTTP service.
+    // Stop it before shutting down HTTP so its worker cannot wait for an unavailable endpoint.
+    exec_env->stop_stream_load_recorder_manager();
+    LOG(INFO) << "Stream load recorder manager stopped";
     daemon.stop();
     flight_starter->stop();
     flight_starter->join();

--- a/be/test/load/stream_load_recorder_manager_test.cpp
+++ b/be/test/load/stream_load_recorder_manager_test.cpp
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "load/stream_load/stream_load_recorder_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/status.h"
+
+namespace doris {
+
+TEST(StreamLoadRecorderManagerTest, ParseAcceptedStreamLoadResponses) {
+    EXPECT_TRUE(
+            StreamLoadRecorderManager::_parse_stream_load_response(R"({"Status":"Success"})").ok());
+    EXPECT_TRUE(StreamLoadRecorderManager::_parse_stream_load_response(
+                        R"({"Status":"Publish Timeout"})")
+                        .ok());
+    EXPECT_TRUE(StreamLoadRecorderManager::_parse_stream_load_response(
+                        R"({"Status":"Label Already Exists","ExistingJobStatus":"FINISHED"})")
+                        .ok());
+
+    EXPECT_FALSE(StreamLoadRecorderManager::_parse_stream_load_response(
+                         R"({"Status":"Label Already Exists","ExistingJobStatus":"RUNNING"})")
+                         .ok());
+    EXPECT_FALSE(
+            StreamLoadRecorderManager::_parse_stream_load_response(R"({"Status":"Fail"})").ok());
+    EXPECT_FALSE(StreamLoadRecorderManager::_parse_stream_load_response("not json").ok());
+}
+
+TEST(StreamLoadRecorderManagerTest, RetryKeepsBoundedBatchAndStableLabel) {
+    StreamLoadRecorderManager manager;
+    manager._buffer.append("record");
+    manager._record_num = 1;
+    manager._last_fetch_key = "1000_source_label";
+    manager._last_load_time = 0;
+
+    std::vector<std::pair<std::string, std::string>> attempts;
+    manager.set_stream_load_sender_for_test(
+            [&attempts](const std::string& data, const std::string& label) {
+                attempts.emplace_back(data, label);
+                if (attempts.size() == 1) {
+                    return Status::InternalError("injected retryable failure");
+                }
+                return Status::OK();
+            });
+
+    manager._load_if_necessary();
+    ASSERT_EQ(attempts.size(), 1);
+    EXPECT_TRUE(manager._has_pending_batch());
+    EXPECT_EQ(manager._buffer.ToString(), "record");
+    EXPECT_EQ(manager._record_num, 1);
+
+    manager._load_if_necessary();
+    ASSERT_EQ(attempts.size(), 2);
+    EXPECT_EQ(attempts[0], attempts[1]);
+    EXPECT_FALSE(manager._has_pending_batch());
+    EXPECT_TRUE(manager._buffer.empty());
+    EXPECT_EQ(manager._record_num, 0);
+}
+
+TEST(StreamLoadRecorderManagerTest, StopIsIdempotent) {
+    StreamLoadRecorderManager manager;
+    manager._worker_thread = std::thread([] {});
+
+    ASSERT_TRUE(manager._worker_thread.joinable());
+    manager.stop();
+    EXPECT_FALSE(manager._worker_thread.joinable());
+
+    manager.stop();
+    EXPECT_FALSE(manager._worker_thread.joinable());
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related TeamCity build: http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_NonConcurrentRegression/993633

Problem Summary:

During graceful BE shutdown, `doris_main` stopped and joined the HTTP service before `ExecEnv::destroy()` stopped `StreamLoadRecorderManager`. The recorder worker sends audit records through the local BE HTTP stream-load endpoint and uses a 600-second request timeout.

In build 993633, shutdown reached `Http service stopped`, then stopped `GroupCommitMgr`, and remained blocked until the external ten-minute grace timeout sent SIGABRT. The captured main-thread stack is:

```text
std::thread::join()
doris::ExecEnv::destroy()
main
```

In the corresponding destroy order, `StreamLoadRecorderManager::stop()` is the next direct `std::thread` join after GroupCommitMgr/routine-load shutdown. The triggering PR #65463 changes only regression Groovy code and is path-unrelated to this lifecycle issue.

This PR adds an explicit, idempotent recorder-manager stop entrypoint and invokes it before any server teardown. The existing call from `ExecEnv::destroy()` remains as a fallback. This keeps the local HTTP endpoint and the rest of the load path available while the recorder worker finishes.

If the audit stream load still fails while the BE is being removed from load planning, the recorder freezes the current batch as a bounded retry unit and does not fetch more records until that batch is accepted. Every retry reuses the same label and payload, so an unknown HTTP outcome cannot create a second audit transaction under a new label. `Publish Timeout` is treated as accepted because the transaction was committed, and a same-label `Label Already Exists` response is accepted only when `ExistingJobStatus` is `FINISHED`. Other outcomes keep the same pending batch for retry.

The cursor is persisted and the pending batch is cleared only after an accepted outcome. Within a running BE this gives bounded, idempotent retry behavior; after a restart, the last successfully persisted cursor still provides at-least-once replay.

The exact worker-side curl frame was not captured because the failure artifact contains only the signal-thread stack; the conclusion is based on the direct join site, shutdown order, local HTTP dependency, and matching timeout.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - Added focused coverage for stream-load response classification, stable payload/label retry, bounded pending state, and idempotent stop.
        - The local targeted BE UT runner was blocked during first-time third-party submodule setup before compilation; GitHub BE UT/buildall is the authoritative run.
    - [x] Manual test
        - `git diff --check`
        - clang-format 15 `--dry-run --Werror` for the three changed recorder files.
        - Verified current `origin/master` lifecycle order and build 993633 BE logs/stack.
        - Verified pending state gates `get_batch()`, reuses one label, and only advances the persisted cursor after an accepted result.
        - TeamCity buildall and graceful-stop runtime validation are pending.
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes.
        - Previous behavior: full graceful teardown stopped HTTP before joining the audit stream-load recorder worker.
        - New behavior: the recorder worker is stopped and joined while HTTP and its load dependencies are still available.
        - Impact: the full graceful-exit path stops the recorder earlier; failed audit loads are retried as one bounded, stable-label batch instead of being discarded or resubmitted under new labels. Normal batching thresholds and stream-load timeouts are unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
