### PR TITLE
[cloud](regression) disable test_scale_num_nulls in cloud mode

### DIFF
--- a/regression-test/suites/statistics/test_scale_num_nulls.groovy
+++ b/regression-test/suites/statistics/test_scale_num_nulls.groovy
@@ -18,6 +18,9 @@
 suite("test_scale_num_nulls") {
     // For an OlapTable, when only a subset of partitions is selected, 
     // the num_nulls value in column statistics needs to be scaled proportionally.
+    if (isCloudMode()) {
+        return
+    }
     sql """
         drop table if exists ptable;
         CREATE TABLE `ptable` (


### PR DESCRIPTION
### What problem does this PR solve?

in cloud mode, row count can not be reported in time. disable this test case in cloud mode.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

