### PR TITLE
[fix](stream) Fix stream scan partition prune state propagation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapTableStreamScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapTableStreamScan.java
@@ -276,11 +276,11 @@ public class LogicalOlapTableStreamScan extends LogicalOlapScan {
      */
     @Override
     public LogicalOlapTableStreamScan withSelectedPartitionIds(List<Long> selectedPartitionIds,
-                                                               boolean isPartitionPruned) {
+                                                               boolean hasPartitionPredicate) {
         return AbstractPlan.copyWithSameId(this, () ->
                 new LogicalOlapTableStreamScan(relationId, (Table) table, qualifier,
                         groupExpression, Optional.of(getLogicalProperties()),
-                        selectedPartitionIds, isPartitionPruned, hasPartitionPredicate, selectedTabletIds,
+                        selectedPartitionIds, true, hasPartitionPredicate, selectedTabletIds,
                         selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                         hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                         colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainTableStreamPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainTableStreamPlanTest.java
@@ -501,6 +501,24 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
     }
 
     @Test
+    public void testStreamScanWithSelectedPartitionIdsMarksPartitionPruned() {
+        Plan analyzedPlan = PlanChecker.from(connectContext)
+                .analyze("select * from test_stream.s2 where k1 < 100")
+                .getCascadesContext()
+                .getRewritePlan();
+
+        LogicalOlapTableStreamScan streamScan = findFirstLogicalStreamScan(analyzedPlan);
+        Assertions.assertNotNull(streamScan);
+        Assertions.assertFalse(streamScan.isPartitionPruned());
+
+        LogicalOlapTableStreamScan prunedScan =
+                streamScan.withSelectedPartitionIds(streamScan.getSelectedPartitionIds(), false);
+
+        Assertions.assertTrue(prunedScan.isPartitionPruned());
+        Assertions.assertFalse(prunedScan.hasPartitionPredicate());
+    }
+
+    @Test
     public void testRecordPlanForMvPreRewriteNormalizesStreamScanInsideCte() throws Exception {
         ConnectContext ctx = createDefaultCtx();
         ctx.setDatabase("test_stream");
@@ -570,6 +588,19 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
         }
         for (Plan child : plan.children()) {
             LogicalProject<?> found = findFirstLogicalProject(child);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private LogicalOlapTableStreamScan findFirstLogicalStreamScan(Plan plan) {
+        if (plan instanceof LogicalOlapTableStreamScan) {
+            return (LogicalOlapTableStreamScan) plan;
+        }
+        for (Plan child : plan.children()) {
+            LogicalOlapTableStreamScan found = findFirstLogicalStreamScan(child);
             if (found != null) {
                 return found;
             }


### PR DESCRIPTION
### What problem does this PR solve?

Related Issue: close #65654

`LogicalOlapTableStreamScan.withSelectedPartitionIds(List<Long>, boolean)` diverged from `LogicalOlapScan` and changed the meaning of the second parameter. In `LogicalOlapScan`, the second parameter represents `hasPartitionPredicate`, while the rebuilt scan is always marked as partition-pruned. The stream scan override treated that second parameter as `isPartitionPruned`, which let partition pruning rebuild a stream scan that still looked unpruned and could be matched again by the same rewrite rule.

This PR keeps the stream-scan override consistent with `LogicalOlapScan`: the second parameter remains `hasPartitionPredicate`, and the rebuilt `LogicalOlapTableStreamScan` is marked as already partition-pruned.

