### PR TITLE
[fix](fe) Fix row binlog schema change test metadata

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -900,9 +900,9 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         Column key = new Column("k1", PrimitiveType.INT);
         key.setIsKey(true);
         rowBinlogSchema.add(Column.generateRowBinlogKeyColumn(key));
-        rowBinlogSchema.add(new Column(Column.BINLOG_LSN_COL, PrimitiveType.LARGEINT));
+        rowBinlogSchema.add(new Column(Column.BINLOG_TSO_COL, PrimitiveType.BIGINT));
+        rowBinlogSchema.add(new Column(Column.BINLOG_LSN_COL, PrimitiveType.BIGINT));
         rowBinlogSchema.add(new Column(Column.BINLOG_OPERATION_COL, PrimitiveType.BIGINT));
-        rowBinlogSchema.add(new Column(Column.BINLOG_TIMESTAMP_COL, PrimitiveType.BIGINT));
 
         Column hiddenKey = new Column("__DORIS_TEST_HIDDEN_KEY__", PrimitiveType.BIGINT);
         hiddenKey.setIsKey(true);
@@ -918,7 +918,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         List<String> columnNames = rowBinlogSchema.stream().map(Column::getName).collect(Collectors.toList());
         Assertions.assertEquals(1, columnNames.indexOf("__DORIS_TEST_HIDDEN_KEY__"));
-        Assertions.assertEquals(2, columnNames.indexOf(Column.BINLOG_LSN_COL));
+        Assertions.assertEquals(3, columnNames.indexOf(Column.BINLOG_LSN_COL));
 
         Column hiddenValue = new Column("__DORIS_TEST_HIDDEN_VALUE__", PrimitiveType.INT);
         hiddenValue.setIsKey(false);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableRowBinlogSchemaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableRowBinlogSchemaTest.java
@@ -141,7 +141,8 @@ public class OlapTableRowBinlogSchemaTest {
         Assertions.assertFalse(columnNames.contains("__DORIS_TEST_HIDDEN_VALUE__"));
         Assertions.assertTrue(columnNames.contains(Column.generateBeforeColName("v1")));
         Assertions.assertFalse(columnNames.contains(Column.generateBeforeColName("__DORIS_TEST_HIDDEN_KEY__")));
-        Assertions.assertEquals(4, columnNames.indexOf(Column.BINLOG_LSN_COL));
+        Assertions.assertEquals(4, columnNames.indexOf(Column.BINLOG_TSO_COL));
+        Assertions.assertEquals(5, columnNames.indexOf(Column.BINLOG_LSN_COL));
     }
 
     @Test
@@ -161,6 +162,7 @@ public class OlapTableRowBinlogSchemaTest {
         Assertions.assertEquals("k1", columnNames.get(0));
         Assertions.assertEquals("v1", columnNames.get(1));
         Assertions.assertFalse(columnNames.contains("__DORIS_TEST_HIDDEN_VALUE__"));
-        Assertions.assertEquals(2, columnNames.indexOf(Column.BINLOG_LSN_COL));
+        Assertions.assertEquals(2, columnNames.indexOf(Column.BINLOG_TSO_COL));
+        Assertions.assertEquals(3, columnNames.indexOf(Column.BINLOG_LSN_COL));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65076

Problem Summary:
The master FE test compilation fails because `SchemaChangeHandlerTest`
references the removed `Column.BINLOG_TIMESTAMP_COL` constant. Two
`OlapTableRowBinlogSchemaTest` assertions also expect LSN indexes from the
previous metadata layout.

Root cause: PR #65076 added these tests using the previous row-binlog metadata
schema. PR #64133 subsequently replaced the timestamp column with TSO,
changed the LSN type to `BIGINT`, and ordered the metadata columns as
TSO, LSN, and operation before #65076 was merged.

This change aligns both test fixtures with the current production schema,
updates the expected LSN indexes, and explicitly verifies TSO positions.

| File | Change Description |
|------|-------------------|
| `SchemaChangeHandlerTest.java` | Use the current TSO, LSN, and operation metadata columns and update the expected LSN index |
| `OlapTableRowBinlogSchemaTest.java` | Verify TSO positions and align LSN indexes with the current metadata order |

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `mvn install -DskipTests -Dmaven.build.cache.enabled=false`
        - `./run-fe-ut.sh --run org.apache.doris.catalog.OlapTableRowBinlogSchemaTest,org.apache.doris.alter.SchemaChangeHandlerTest`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label