### PR TITLE
[fix](fe) Snapshot altered resources before journaling

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -67,8 +67,13 @@ public class HdfsResource extends Resource {
 
     @Override
     public void modifyProperties(Map<String, String> properties) throws DdlException {
-        for (Map.Entry<String, String> kv : properties.entrySet()) {
-            replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+        writeLock();
+        try {
+            for (Map.Entry<String, String> kv : properties.entrySet()) {
+                replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+            }
+        } finally {
+            writeUnlock();
         }
         super.modifyProperties(properties);
     }
@@ -85,14 +90,24 @@ public class HdfsResource extends Resource {
 
     @Override
     public Map<String, String> getCopiedProperties() {
-        return Maps.newHashMap(properties);
+        readLock();
+        try {
+            return Maps.newHashMap(properties);
+        } finally {
+            readUnlock();
+        }
     }
 
     @Override
     protected void getProcNodeData(BaseProcResult result) {
         String lowerCaseType = type.name().toLowerCase();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+        readLock();
+        try {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+            }
+        } finally {
+            readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -19,8 +19,6 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.io.DeepCopy;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.proc.BaseProcResult;
@@ -100,6 +98,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     protected long version = -1;
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+    private final Object alterLock = new Object();
 
     public void writeLock() {
         lock.writeLock().lock();
@@ -115,6 +114,10 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     public void readUnlock() {
         lock.readLock().unlock();
+    }
+
+    Object getAlterLock() {
+        return alterLock;
     }
 
     // https://programmerr47.medium.com/gson-unsafe-problem-d1ff29d4696f
@@ -243,9 +246,11 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     public abstract Map<String, String> getCopiedProperties();
 
     public void dropResource() throws DdlException {
-        if (!references.isEmpty()) {
-            String msg = String.join(", ", references.keySet());
-            throw new DdlException(String.format("Resource %s is used by: %s", name, msg));
+        synchronized (this) {
+            if (!references.isEmpty()) {
+                String msg = String.join(", ", references.keySet());
+                throw new DdlException(String.format("Resource %s is used by: %s", name, msg));
+            }
         }
     }
 
@@ -258,13 +263,12 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     @Override
     public String toString() {
-        return GsonUtils.GSON.toJson(this);
+        return toJson();
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
-        Text.writeString(out, json);
+        Text.writeString(out, toJson());
     }
 
     public static Resource read(DataInput in) throws IOException {
@@ -342,7 +346,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     @Override
     public Resource clone() {
-        Resource copied = DeepCopy.copy(this, Resource.class, FeConstants.meta_version);
+        Resource copied = getCopiedResourceSnapshot();
         if (copied == null) {
             LOG.warn("failed to clone odbc resource: " + getName());
             return null;
@@ -350,12 +354,38 @@ public abstract class Resource implements Writable, GsonPostProcessable {
         return copied;
     }
 
-    private void notifyUpdate(Map<String, String> properties) {
-        references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {
-            if (type == ReferenceType.CATALOG) {
-                // No longer support resource in Catalog.
+    final Resource getCopiedResourceSnapshot() {
+        readLock();
+        try {
+            String json;
+            synchronized (this) {
+                json = GsonUtils.GSON.toJson(this);
             }
-        });
+            return GsonUtils.GSON.fromJson(json, Resource.class);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    private String toJson() {
+        readLock();
+        try {
+            synchronized (this) {
+                return GsonUtils.GSON.toJson(this);
+            }
+        } finally {
+            readUnlock();
+        }
+    }
+
+    private void notifyUpdate(Map<String, String> properties) {
+        synchronized (this) {
+            references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {
+                if (type == ReferenceType.CATALOG) {
+                    // No longer support resource in Catalog.
+                }
+            });
+        }
     }
 
     public void applyDefaultProperties() {}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -31,6 +31,8 @@ import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.DropResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.DropResourceOperationLog;
+import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.OperationType;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
@@ -145,16 +147,22 @@ public class ResourceMgr implements Writable {
     }
 
     public void alterResource(String resourceName, Map<String, String> properties) throws DdlException {
-        if (!nameToResource.containsKey(resourceName)) {
+        Resource resource = nameToResource.get(resourceName);
+        if (resource == null) {
             throw new DdlException("Resource(" + resourceName + ") dose not exist.");
         }
 
-        Resource resource = nameToResource.get(resourceName);
-        resource.modifyProperties(properties);
+        EditLog.EditLogItem logItem;
+        Resource logResource;
+        synchronized (resource.getAlterLock()) {
+            resource.modifyProperties(properties);
+            // Keep the journal entry detached and ordered with the in-memory ALTER.
+            logResource = getAlterLogResource(resource);
+            logItem = Env.getCurrentEnv().getEditLog().submitEdit(OperationType.OP_ALTER_RESOURCE, logResource);
+        }
 
-        // log alter
-        Env.getCurrentEnv().getEditLog().logAlterResource(resource);
-        LOG.info("Alter resource success. Resource: {}", resource);
+        logItem.await();
+        LOG.info("Alter resource success. Resource: {}", logResource);
     }
 
     public void replayAlterResource(Resource resource) {
@@ -231,8 +239,30 @@ public class ResourceMgr implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
+        String json = GsonUtils.GSON.toJson(getCopiedResourceMgr());
         Text.writeString(out, json);
+    }
+
+    private Resource getAlterLogResource(Resource resource) {
+        try {
+            return resource.getCopiedResourceSnapshot();
+        } catch (Throwable t) {
+            LOG.error("Fatal Error : failed to copy altered resource {}", resource.getName(), t);
+            System.exit(-1);
+            throw new IllegalStateException(t);
+        }
+    }
+
+    private ResourceMgr getCopiedResourceMgr() {
+        ResourceMgr copied = new ResourceMgr();
+        for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
+            Resource resource = entry.getValue();
+            synchronized (resource.getAlterLock()) {
+                // Checkpoint serialization must not walk a live resource while ALTER mutates it.
+                copied.nameToResource.put(entry.getKey(), resource.getCopiedResourceSnapshot());
+            }
+        }
+        return copied;
     }
 
     public static ResourceMgr read(DataInput in) throws IOException {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -18,24 +18,33 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.OperationType;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class ResourceMgrTest {
     // s3 resource
@@ -50,6 +59,7 @@ public class ResourceMgrTest {
     private String s3ReqTimeoutMs;
     private String s3ConnTimeoutMs;
     private Map<String, String> s3Properties;
+    private ExecutorService executor;
 
     @Before
     public void setUp() {
@@ -72,6 +82,14 @@ public class ResourceMgrTest {
         s3Properties.put("AWS_SECRET_KEY", s3SecretKey);
         s3Properties.put("AWS_BUCKET", "test-bucket");
         s3Properties.put("s3_validity_check", "false");
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
     }
 
     @Test
@@ -128,6 +146,117 @@ public class ResourceMgrTest {
 
             // add again
             mgr.createResource(createResourceCommand);
+        }
+    }
+
+    @Test
+    public void testHdfsResourceUsesReadWriteLockForPropertyAccess() throws Exception {
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+
+        resource.writeLock();
+        Future<Map<String, String>> copiedPropertiesFuture = null;
+        try {
+            copiedPropertiesFuture = executor.submit(resource::getCopiedProperties);
+            assertFutureBlocked(copiedPropertiesFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+        Assert.assertEquals("hdfs://first",
+                copiedPropertiesFuture.get(5, TimeUnit.SECONDS).get(HdfsResource.HADOOP_FS_NAME));
+
+        resource.writeLock();
+        Future<Void> procFuture = null;
+        try {
+            procFuture = executor.submit(() -> {
+                resource.getProcNodeData(new BaseProcResult());
+                return null;
+            });
+            assertFutureBlocked(procFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+        procFuture.get(5, TimeUnit.SECONDS);
+
+        resource.readLock();
+        Future<Void> modifyFuture = null;
+        try {
+            modifyFuture = executor.submit(() -> {
+                resource.modifyProperties(hdfsProperties("hdfs://second"));
+                return null;
+            });
+            assertFutureBlocked(modifyFuture);
+        } finally {
+            resource.readUnlock();
+        }
+        modifyFuture.get(5, TimeUnit.SECONDS);
+        Assert.assertEquals("hdfs://second", resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testAlterResourceLogsDetachedSnapshot() throws Exception {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
+                    .thenReturn(logItem);
+
+            ResourceMgr mgr = new ResourceMgr();
+            mgr.createResource(createHdfsResource("hdfs0", "hdfs://initial"), false);
+            mgr.alterResource("hdfs0", hdfsProperties("hdfs://first"));
+
+            ArgumentCaptor<Resource> logResourceCaptor = ArgumentCaptor.forClass(Resource.class);
+            Mockito.verify(editLog).submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE),
+                    logResourceCaptor.capture());
+            Resource firstLogResource = logResourceCaptor.getValue();
+
+            mgr.alterResource("hdfs0", hdfsProperties("hdfs://second"));
+
+            Assert.assertNotSame(mgr.getResource("hdfs0"), firstLogResource);
+            Assert.assertEquals("hdfs://first",
+                    firstLogResource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+            Assert.assertEquals("hdfs://second",
+                    mgr.getResource("hdfs0").getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        }
+    }
+
+    @Test
+    public void testCopiedResourceKeepsReferenceSnapshot() throws Exception {
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+        resource.addReference("tbl", Resource.ReferenceType.POLICY);
+
+        Resource copied = resource.getCopiedResourceSnapshot();
+        resource.removeReference("tbl", Resource.ReferenceType.POLICY);
+
+        try {
+            copied.dropResource();
+            Assert.fail("copied resource should keep the original reference");
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("tbl"));
+        }
+        resource.dropResource();
+    }
+
+    private HdfsResource createHdfsResource(String name, String fsName) throws DdlException {
+        HdfsResource resource = new HdfsResource(name);
+        resource.modifyProperties(hdfsProperties(fsName));
+        return resource;
+    }
+
+    private Map<String, String> hdfsProperties(String fsName) {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(HdfsResource.HADOOP_FS_NAME, fsName);
+        return properties;
+    }
+
+    private void assertFutureBlocked(Future<?> future) throws Exception {
+        try {
+            future.get(100, TimeUnit.MILLISECONDS);
+            Assert.fail("future should be blocked by the resource lock");
+        } catch (TimeoutException e) {
+            // Expected. The caller releases the lock and then waits for completion.
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:
ALTER RESOURCE mutates resource objects in place, while SHOW RESOURCE, checkpoint image serialization, and edit-log flush can read those same objects asynchronously. For HDFS resources this can expose concurrent property-map iteration and can let a later ALTER change the object serialized by an earlier journal entry.

This change:
- protects HDFS resource property mutation and property/proc reads with the resource read/write lock
- journals ALTER RESOURCE with a detached resource snapshot, preserving per-resource ALTER order
- snapshots resources before checkpoint image serialization
- adds regression coverage for HDFS property locking, detached journal snapshots, and reference snapshot copying

### Release note

None

### Check List

- Test:
    - `git diff --check`
    - `./run-fe-ut.sh --run org.apache.doris.catalog.ResourceMgrTest` (blocked by an existing upstream `fe-core` testCompile failure: `SchemaChangeHandlerTest.java:905` references missing `Column.BINLOG_TIMESTAMP_COL`; FE main sources compile before this failure)
    - `./build.sh --fe` (blocked by the same upstream `fe-core` testCompile failure after FE main sources compile)
