### PR TITLE
[fix](test) stabilize file cache statistics case

### DIFF
--- a/regression-test/suites/external_table_p0/cache/test_file_cache_statistics.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_statistics.groovy
@@ -45,6 +45,12 @@ suite("test_file_cache_statistics", "p0,external,nonConcurrent") {
 
     sql """set enable_file_cache=true"""
     sql """set disable_file_cache=false"""
+    // This case validates BlockFileCache counters. Keep upper-layer caches and scan scheduling
+    // from serving or cancelling the repeated read before it reaches BlockFileCache.
+    sql """set enable_sql_cache=false"""
+    sql """set enable_hive_sql_cache=false"""
+    sql """set enable_parquet_file_page_cache=false"""
+    sql """set parallel_pipeline_task_num=1"""
 
     // Check backend configuration prerequisites
     // Note: This test case assumes a single backend scenario. Testing with single backend is logically equivalent 
@@ -82,8 +88,10 @@ suite("test_file_cache_statistics", "p0,external,nonConcurrent") {
 
     sql """switch ${catalog_name}"""
 
+    // Pin the query to one partition file instead of racing all six file scan ranges under LIMIT 1.
     String querySql = """select * from ${catalog_name}.${ex_db_name}.parquet_partition_table
-            where l_orderkey=1 and l_partkey=1534 limit 1;"""
+            where nation='cn' and city='beijing'
+            and l_orderkey=1 and l_partkey=1534 limit 1;"""
 
     // load the table into file cache
     sql querySql


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65261

Problem Summary:

`test_file_cache_statistics` verifies that a repeated Hive Parquet read reaches
BlockFileCache and increments both `total_hit_counts` and
`total_read_counts`.

PR #65261 made the suite `nonConcurrent`, aggregated counters across cache
paths, and polled asynchronous metrics. However, the final counter assertion can
still pass or fail with identical relevant code:

- External Regression 995803: PASS, counters `7503/8945 -> 7504/8946`
- External Regression 996006: muted FAIL, the two-counter condition timed out
- External Regression 996177: PASS, counters `7506/8947 -> 7507/8948`

`nonConcurrent` only prevents other suites from running concurrently. It does
not serialize file scan ranges inside one SQL statement. The original query
scans a six-file partitioned table without partition predicates, uses automatic
pipeline parallelism, and stops at `LIMIT 1`. Which scan ranges perform reads
before cancellation therefore depends on scheduling.

Parquet file page cache is also enabled by default. It can serve cached page
headers and payloads before the underlying file reader reaches BlockFileCache.
Its admission is selective and uses shared BE cache state. As a result, the
third query may either touch one BlockFileCache block or be completed from the
upper page cache, while both behaviors return the correct query result.

This is a test isolation issue: a case that asserts BlockFileCache counter
deltas must make the read path deterministic and isolate the cache layer under
test.

This PR:

- explicitly disables SQL cache, Hive SQL cache, and Parquet file page cache for
  this BlockFileCache statistics case;
- sets `parallel_pipeline_task_num=1` to remove internal scan-instance races;
- adds `nation='cn' and city='beijing'` predicates so the query scans the
  single partition file containing the existing expected row.

The output oracle and all file-cache metric assertions are unchanged.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Validation completed:

- `git diff --check`
- standalone Groovy compilation of
  `test_file_cache_statistics.groovy` with Awaitility on the classpath
- verified the fixed `cn/beijing` partition returns the existing golden-output
  row, so no expected-output change is required

The full case was not run locally because it depends on the External Regression
Hive environment. Exact fix-bearing CI validation is pending.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
