### PR TITLE
[branch-4.1][fix](regression) Retry repository drop on backup lock contention

### DIFF
--- a/regression-test/suites/auth_call/test_ddl_repository_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_repository_auth.groovy
@@ -81,7 +81,20 @@ suite("test_ddl_repository_auth","p0,auth_call") {
         def res = sql """SHOW CREATE REPOSITORY for ${repositoryName};"""
         assertTrue(res.size() > 0)
 
-        sql """DROP REPOSITORY `${repositoryName}`;"""
+        def maxDropRepositoryRetries = 15
+        for (int i = 0; i < maxDropRepositoryRetries; i++) {
+            try {
+                sql """DROP REPOSITORY `${repositoryName}`;"""
+                break
+            } catch (Exception e) {
+                if (i == maxDropRepositoryRetries - 1
+                        || !e.getMessage().contains("Another backup or restore job is being submitted")) {
+                    throw e
+                }
+                logger.warn("drop repository contended on global backup lock, retry ${i + 1}: ${e.getMessage()}")
+                sleep(2000)
+            }
+        }
         test {
             sql """SHOW CREATE REPOSITORY for ${repositoryName};"""
             exception "repository not exist"

--- a/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
@@ -18,7 +18,7 @@
 import org.junit.Assert;
 import java.util.UUID
 
-suite("test_ddl_restore_auth","p0,auth_call,nonConcurrent") {
+suite("test_ddl_restore_auth","p0,auth_call") {
     UUID uuid = UUID.randomUUID()
     String randomValue = uuid.toString()
     int hashCode = randomValue.hashCode()

--- a/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
@@ -18,7 +18,7 @@
 import org.junit.Assert;
 import java.util.UUID
 
-suite("test_ddl_restore_auth","p0,auth_call") {
+suite("test_ddl_restore_auth","p0,auth_call,nonConcurrent") {
     UUID uuid = UUID.randomUUID()
     String randomValue = uuid.toString()
     int hashCode = randomValue.hashCode()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65691

Problem Summary:

The repository authorization regression case can fail for reasons unrelated to authorization when it runs concurrently with test_ddl_restore_auth.

The bounded P0 history contains 4 failures in 35 branch-4.1 runs. In build 996774, test_ddl_restore_auth submitted BACKUP SNAPSHOT at 19:40:11.661. The authorized DROP REPOSITORY started only 26 ms later, exhausted BackupHandler's 10-second global submission-lock wait at 19:40:21.691, while the backup submission did not return until 19:40:28.960.

Moving test_ddl_restore_auth to nonConcurrent would serialize a suite that took about 7 minutes in this build. Instead, this change keeps both suites concurrent and retries only the documented transient message "Another backup or restore job is being submitted". It uses the existing backup-auth retry strategy: at most 15 attempts with a 2-second interval. All other errors fail immediately.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: regression-only wait logic; git diff --check and exact net-diff inspection passed. Runtime validation will be performed by CI.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
