### PR TITLE
[fix](fe) Protect HDFS resource snapshots from concurrent ALTER

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,6 +46,7 @@ import java.util.Optional;
 
 public class AzureResource extends Resource {
     private static final Logger LOG = LogManager.getLogger(AzureResource.class);
+    @SerializedName(value = "properties")
     private Map<String, String> properties = Maps.newHashMap();
 
     public AzureResource() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -67,8 +67,13 @@ public class HdfsResource extends Resource {
 
     @Override
     public void modifyProperties(Map<String, String> properties) throws DdlException {
-        for (Map.Entry<String, String> kv : properties.entrySet()) {
-            replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+        writeLock();
+        try {
+            for (Map.Entry<String, String> kv : properties.entrySet()) {
+                replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
+            }
+        } finally {
+            writeUnlock();
         }
         super.modifyProperties(properties);
     }
@@ -85,14 +90,24 @@ public class HdfsResource extends Resource {
 
     @Override
     public Map<String, String> getCopiedProperties() {
-        return Maps.newHashMap(properties);
+        readLock();
+        try {
+            return Maps.newHashMap(properties);
+        } finally {
+            readUnlock();
+        }
     }
 
     @Override
     protected void getProcNodeData(BaseProcResult result) {
         String lowerCaseType = type.name().toLowerCase();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+        readLock();
+        try {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
+            }
+        } finally {
+            readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -100,6 +100,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     protected long version = -1;
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+    private final Object alterLock = new Object();
 
     public void writeLock() {
         lock.writeLock().lock();
@@ -115,6 +116,10 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     public void readUnlock() {
         lock.readLock().unlock();
+    }
+
+    Object getAlterLock() {
+        return alterLock;
     }
 
     // https://programmerr47.medium.com/gson-unsafe-problem-d1ff29d4696f
@@ -243,9 +248,11 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     public abstract Map<String, String> getCopiedProperties();
 
     public void dropResource() throws DdlException {
-        if (!references.isEmpty()) {
-            String msg = String.join(", ", references.keySet());
-            throw new DdlException(String.format("Resource %s is used by: %s", name, msg));
+        synchronized (this) {
+            if (!references.isEmpty()) {
+                String msg = String.join(", ", references.keySet());
+                throw new DdlException(String.format("Resource %s is used by: %s", name, msg));
+            }
         }
     }
 
@@ -258,13 +265,12 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     @Override
     public String toString() {
-        return GsonUtils.GSON.toJson(this);
+        return toJson();
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
-        Text.writeString(out, json);
+        Text.writeString(out, toJson());
     }
 
     public static Resource read(DataInput in) throws IOException {
@@ -350,12 +356,31 @@ public abstract class Resource implements Writable, GsonPostProcessable {
         return copied;
     }
 
-    private void notifyUpdate(Map<String, String> properties) {
-        references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {
-            if (type == ReferenceType.CATALOG) {
-                // No longer support resource in Catalog.
+    final Resource getCopiedResourceSnapshot() {
+        return GsonUtils.GSON.fromJson(toJson(), Resource.class);
+    }
+
+    private String toJson() {
+        synchronized (alterLock) {
+            readLock();
+            try {
+                synchronized (this) {
+                    return GsonUtils.GSON.toJson(this);
+                }
+            } finally {
+                readUnlock();
             }
-        });
+        }
+    }
+
+    private void notifyUpdate(Map<String, String> properties) {
+        synchronized (this) {
+            references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {
+                if (type == ReferenceType.CATALOG) {
+                    // No longer support resource in Catalog.
+                }
+            });
+        }
     }
 
     public void applyDefaultProperties() {}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -265,12 +265,13 @@ public abstract class Resource implements Writable, GsonPostProcessable {
 
     @Override
     public String toString() {
-        return toJson();
+        return GsonUtils.GSON.toJson(this);
     }
 
     @Override
     public void write(DataOutput out) throws IOException {
-        Text.writeString(out, toJson());
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
     }
 
     public static Resource read(DataInput in) throws IOException {
@@ -357,20 +358,16 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     }
 
     final Resource getCopiedResourceSnapshot() {
-        return GsonUtils.GSON.fromJson(toJson(), Resource.class);
-    }
-
-    private String toJson() {
-        synchronized (alterLock) {
-            readLock();
-            try {
-                synchronized (this) {
-                    return GsonUtils.GSON.toJson(this);
-                }
-            } finally {
-                readUnlock();
+        String json;
+        readLock();
+        try {
+            synchronized (this) {
+                json = GsonUtils.GSON.toJson(this);
             }
+        } finally {
+            readUnlock();
         }
+        return GsonUtils.GSON.fromJson(json, Resource.class);
     }
 
     private void notifyUpdate(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -370,6 +370,25 @@ public abstract class Resource implements Writable, GsonPostProcessable {
         return GsonUtils.GSON.fromJson(json, Resource.class);
     }
 
+    final Resource getAlterLogResourceSnapshot() {
+        Resource copied = getCopiedResourceSnapshot();
+        // Reference changes are persisted by their owners (for example, storage policy journals).
+        synchronized (copied) {
+            copied.references.clear();
+        }
+        return copied;
+    }
+
+    final void copyReferencesFrom(Resource resource) {
+        Map<String, ReferenceType> copiedReferences;
+        synchronized (resource) {
+            copiedReferences = Maps.newHashMap(resource.references);
+        }
+        synchronized (this) {
+            references = copiedReferences;
+        }
+    }
+
     private void notifyUpdate(Map<String, String> properties) {
         synchronized (this) {
             references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -84,23 +84,38 @@ public class ResourceMgr implements Writable {
                     "Only support SPARK, ODBC_CATALOG, JDBC, S3_COOLDOWN, S3, HDFS(JFS/JUICEFS), and HMS resource.");
         }
         Resource resource = Resource.fromCommand(command);
-        if (createResource(resource, info.isIfNotExists())) {
-            Env.getCurrentEnv().getEditLog().logCreateResource(resource);
-            LOG.info("Create resource success. Resource: {}", resource.getName());
+        Resource logResource;
+        EditLog.EditLogItem logItem;
+        synchronized (nameToResource) {
+            if (nameToResource.containsKey(resource.getName())) {
+                if (info.isIfNotExists()) {
+                    return;
+                }
+                throw new DdlException("Resource(" + resource.getName() + ") already exist");
+            }
+            logResource = getCreateLogResource(resource);
+            // Queue CREATE before publishing the live object so dependent operations cannot journal first.
+            logItem = Env.getCurrentEnv().getEditLog()
+                    .submitEdit(OperationType.OP_CREATE_RESOURCE, logResource);
+            nameToResource.put(resource.getName(), resource);
         }
+        logItem.await();
+        LOG.info("Create resource success. Resource: {}", logResource.getName());
     }
 
     // Return true if the resource is truly added,
     // otherwise, return false or throw exception.
     public boolean createResource(Resource resource, boolean ifNotExists) throws DdlException {
         String resourceName = resource.getName();
-        if (nameToResource.putIfAbsent(resourceName, resource) != null) {
-            if (ifNotExists) {
-                return false;
+        synchronized (nameToResource) {
+            if (nameToResource.putIfAbsent(resourceName, resource) != null) {
+                if (ifNotExists) {
+                    return false;
+                }
+                throw new DdlException("Resource(" + resourceName + ") already exist");
             }
-            throw new DdlException("Resource(" + resourceName + ") already exist");
+            return true;
         }
-        return true;
     }
 
     public void replayCreateResource(Resource resource) {
@@ -110,35 +125,54 @@ public class ResourceMgr implements Writable {
 
     public void dropResource(DropResourceCommand dropResourceCommand) throws DdlException {
         String resourceName = dropResourceCommand.getResourceName();
-        if (!nameToResource.containsKey(resourceName)) {
+        Resource resource = nameToResource.get(resourceName);
+        if (resource == null) {
             if (dropResourceCommand.isIfExists()) {
                 return;
             }
             throw new DdlException("Resource(" + resourceName + ") does not exist");
         }
 
-        Resource resource = nameToResource.get(resourceName);
-        resource.dropResource();
+        EditLog.EditLogItem logItem;
+        synchronized (resource.getAlterLock()) {
+            if (nameToResource.get(resourceName) != resource) {
+                if (dropResourceCommand.isIfExists() && !nameToResource.containsKey(resourceName)) {
+                    return;
+                }
+                throw new DdlException("Resource(" + resourceName + ") changed concurrently");
+            }
 
-        // Check whether the resource is in use before deleting it, except spark resource
-        StoragePolicy checkedStoragePolicy = StoragePolicy.ofCheck(null);
-        checkedStoragePolicy.setStorageResource(resourceName);
-        if (Env.getCurrentEnv().getPolicyMgr().existPolicy(checkedStoragePolicy)) {
-            Policy policy = Env.getCurrentEnv().getPolicyMgr().getPolicy(checkedStoragePolicy);
-            LOG.warn("Can not drop resource, since it's used in policy {}", policy.getPolicyName());
-            throw new DdlException("Can not drop resource, since it's used in policy " + policy.getPolicyName());
+            resource.dropResource();
+
+            // Check whether the resource is in use before deleting it, except spark resource
+            StoragePolicy checkedStoragePolicy = StoragePolicy.ofCheck(null);
+            checkedStoragePolicy.setStorageResource(resourceName);
+            if (Env.getCurrentEnv().getPolicyMgr().existPolicy(checkedStoragePolicy)) {
+                Policy policy = Env.getCurrentEnv().getPolicyMgr().getPolicy(checkedStoragePolicy);
+                LOG.warn("Can not drop resource, since it's used in policy {}", policy.getPolicyName());
+                throw new DdlException("Can not drop resource, since it's used in policy " + policy.getPolicyName());
+            }
+
+            logItem = Env.getCurrentEnv().getEditLog().submitEdit(
+                    OperationType.OP_DROP_RESOURCE, new DropResourceOperationLog(resourceName));
+            if (!nameToResource.remove(resourceName, resource)) {
+                LOG.error("Fatal Error: failed to remove resource {} after submitting its drop log", resourceName);
+                System.exit(-1);
+                throw new IllegalStateException("failed to remove resource " + resourceName);
+            }
         }
-        nameToResource.remove(resourceName);
-        // log drop
-        Env.getCurrentEnv().getEditLog().logDropResource(new DropResourceOperationLog(resourceName));
+
+        logItem.await();
         LOG.info("Drop resource success. Resource resourceName: {}", resourceName);
     }
 
     // Drop resource whether successful or not
     public void dropResource(Resource resource) {
         String name = resource.getName();
-        if (nameToResource.remove(name) == null) {
-            LOG.info("resource " + name + " does not exists.");
+        synchronized (resource.getAlterLock()) {
+            if (!nameToResource.remove(name, resource)) {
+                LOG.info("resource " + name + " does not exists.");
+            }
         }
     }
 
@@ -155,6 +189,9 @@ public class ResourceMgr implements Writable {
         Resource logResource;
         EditLog.EditLogItem logItem;
         synchronized (resource.getAlterLock()) {
+            if (nameToResource.get(resourceName) != resource) {
+                throw new DdlException("Resource(" + resourceName + ") changed concurrently");
+            }
             resource.modifyProperties(properties);
             // Keep mutation, snapshot, and submission ordered without holding the resource state lock.
             logResource = getAlterLogResource(resource);
@@ -166,7 +203,18 @@ public class ResourceMgr implements Writable {
     }
 
     public void replayAlterResource(Resource resource) {
-        nameToResource.put(resource.getName(), resource);
+        Resource replayed = nameToResource.computeIfPresent(resource.getName(), (name, currentResource) -> {
+            if (resource.getId() != currentResource.getId()) {
+                LOG.warn("Ignore alter log for replaced resource {} with id {}, current id is {}",
+                        name, resource.getId(), currentResource.getId());
+                return currentResource;
+            }
+            resource.copyReferencesFrom(currentResource);
+            return resource;
+        });
+        if (replayed == null) {
+            LOG.warn("Ignore alter log for non-existent resource {}", resource.getName());
+        }
     }
 
     public boolean containsResource(String name) {
@@ -239,13 +287,33 @@ public class ResourceMgr implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
+        String json = GsonUtils.GSON.toJson(getCopiedResourceMgr());
         Text.writeString(out, json);
+    }
+
+    private ResourceMgr getCopiedResourceMgr() throws IOException {
+        ResourceMgr copied = new ResourceMgr();
+        try {
+            for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
+                copied.nameToResource.put(entry.getKey(), entry.getValue().getCopiedResourceSnapshot());
+            }
+        } catch (RuntimeException e) {
+            throw new IOException("failed to snapshot resources for image", e);
+        }
+        return copied;
+    }
+
+    private Resource getCreateLogResource(Resource resource) throws DdlException {
+        try {
+            return resource.getCopiedResourceSnapshot();
+        } catch (RuntimeException e) {
+            throw new DdlException("failed to copy created resource " + resource.getName(), e);
+        }
     }
 
     private Resource getAlterLogResource(Resource resource) {
         try {
-            return resource.getCopiedResourceSnapshot();
+            return resource.getAlterLogResourceSnapshot();
         } catch (Throwable t) {
             LOG.error("Fatal Error: failed to copy altered resource {}", resource.getName(), t);
             System.exit(-1);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -156,7 +156,7 @@ public class ResourceMgr implements Writable {
         EditLog.EditLogItem logItem;
         synchronized (resource.getAlterLock()) {
             resource.modifyProperties(properties);
-            // Snapshot and enqueue under the same lock to preserve concurrent ALTER order.
+            // Keep mutation, snapshot, and submission ordered without holding the resource state lock.
             logResource = getAlterLogResource(resource);
             logItem = Env.getCurrentEnv().getEditLog().submitEdit(OperationType.OP_ALTER_RESOURCE, logResource);
         }
@@ -239,7 +239,7 @@ public class ResourceMgr implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(getCopiedResourceMgr());
+        String json = GsonUtils.GSON.toJson(this);
         Text.writeString(out, json);
     }
 
@@ -251,14 +251,6 @@ public class ResourceMgr implements Writable {
             System.exit(-1);
             throw new IllegalStateException(t);
         }
-    }
-
-    private ResourceMgr getCopiedResourceMgr() {
-        ResourceMgr copied = new ResourceMgr();
-        for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
-            copied.nameToResource.put(entry.getKey(), entry.getValue().getCopiedResourceSnapshot());
-        }
-        return copied;
     }
 
     public static ResourceMgr read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -31,6 +31,8 @@ import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.DropResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.DropResourceOperationLog;
+import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.OperationType;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
@@ -145,16 +147,22 @@ public class ResourceMgr implements Writable {
     }
 
     public void alterResource(String resourceName, Map<String, String> properties) throws DdlException {
-        if (!nameToResource.containsKey(resourceName)) {
+        Resource resource = nameToResource.get(resourceName);
+        if (resource == null) {
             throw new DdlException("Resource(" + resourceName + ") dose not exist.");
         }
 
-        Resource resource = nameToResource.get(resourceName);
-        resource.modifyProperties(properties);
+        Resource logResource;
+        EditLog.EditLogItem logItem;
+        synchronized (resource.getAlterLock()) {
+            resource.modifyProperties(properties);
+            // Snapshot and enqueue under the same lock to preserve concurrent ALTER order.
+            logResource = getAlterLogResource(resource);
+            logItem = Env.getCurrentEnv().getEditLog().submitEdit(OperationType.OP_ALTER_RESOURCE, logResource);
+        }
 
-        // log alter
-        Env.getCurrentEnv().getEditLog().logAlterResource(resource);
-        LOG.info("Alter resource success. Resource: {}", resource);
+        logItem.await();
+        LOG.info("Alter resource success. Resource: {}", logResource);
     }
 
     public void replayAlterResource(Resource resource) {
@@ -231,8 +239,26 @@ public class ResourceMgr implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String json = GsonUtils.GSON.toJson(this);
+        String json = GsonUtils.GSON.toJson(getCopiedResourceMgr());
         Text.writeString(out, json);
+    }
+
+    private Resource getAlterLogResource(Resource resource) {
+        try {
+            return resource.getCopiedResourceSnapshot();
+        } catch (Throwable t) {
+            LOG.error("Fatal Error: failed to copy altered resource {}", resource.getName(), t);
+            System.exit(-1);
+            throw new IllegalStateException(t);
+        }
+    }
+
+    private ResourceMgr getCopiedResourceMgr() {
+        ResourceMgr copied = new ResourceMgr();
+        for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
+            copied.nameToResource.put(entry.getKey(), entry.getValue().getCopiedResourceSnapshot());
+        }
+        return copied;
     }
 
     public static ResourceMgr read(DataInput in) throws IOException {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -38,6 +38,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -206,7 +211,7 @@ public class ResourceMgrTest {
     }
 
     @Test
-    public void testConcurrentAlterResourceLogsOrderedDetachedSnapshots() throws Exception {
+    public void testSynchronousAlterSubmitLogsOrderedDetachedSnapshots() throws Exception {
         Env env = Mockito.mock(Env.class);
         EditLog editLog = Mockito.mock(EditLog.class);
         EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
@@ -219,9 +224,11 @@ public class ResourceMgrTest {
         CountDownLatch firstSubmitEntered = new CountDownLatch(1);
         CountDownLatch releaseFirstSubmit = new CountDownLatch(1);
         AtomicInteger submitCount = new AtomicInteger();
+        List<Resource> synchronouslySerializedResources = new ArrayList<>();
         Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
                 .thenAnswer(invocation -> {
                     Assert.assertTrue(Thread.holdsLock(resource.getAlterLock()));
+                    synchronouslySerializedResources.add(copyResource(invocation.getArgument(1)));
                     if (submitCount.getAndIncrement() == 0) {
                         firstSubmitEntered.countDown();
                         Assert.assertTrue(releaseFirstSubmit.await(5, TimeUnit.SECONDS));
@@ -265,6 +272,74 @@ public class ResourceMgrTest {
                 loggedResources.get(0).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
         Assert.assertEquals("hdfs://second",
                 loggedResources.get(1).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        Assert.assertEquals("hdfs://first",
+                synchronouslySerializedResources.get(0).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        Assert.assertEquals("hdfs://second",
+                synchronouslySerializedResources.get(1).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testBatchAlterSerializesQueuedSnapshotsAfterLaterAlter() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        EditLog.EditLogItem firstLogItem = Mockito.mock(EditLog.EditLogItem.class);
+        EditLog.EditLogItem secondLogItem = Mockito.mock(EditLog.EditLogItem.class);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+
+        ResourceMgr mgr = new ResourceMgr();
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://initial");
+        mgr.createResource(resource, false);
+
+        List<Resource> queuedResources = new ArrayList<>();
+        Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
+                .thenAnswer(invocation -> {
+                    Assert.assertTrue(Thread.holdsLock(resource.getAlterLock()));
+                    queuedResources.add(invocation.getArgument(1));
+                    return queuedResources.size() == 1 ? firstLogItem : secondLogItem;
+                });
+
+        CountDownLatch firstAwaitEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstAwait = new CountDownLatch(1);
+        Mockito.when(firstLogItem.await()).thenAnswer(invocation -> {
+            Assert.assertFalse(Thread.holdsLock(resource.getAlterLock()));
+            firstAwaitEntered.countDown();
+            Assert.assertTrue(releaseFirstAwait.await(5, TimeUnit.SECONDS));
+            return 1L;
+        });
+        Mockito.when(secondLogItem.await()).thenAnswer(invocation -> {
+            Assert.assertFalse(Thread.holdsLock(resource.getAlterLock()));
+            return 2L;
+        });
+
+        Future<Void> firstAlter = submitAndWaitUntilStarted(() -> {
+            alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://first"));
+            return null;
+        });
+        Assert.assertTrue(firstAwaitEntered.await(5, TimeUnit.SECONDS));
+
+        Future<Void> secondAlter = submitAndWaitUntilStarted(() -> {
+            alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://second"));
+            return null;
+        });
+        try {
+            secondAlter.get(1, TimeUnit.SECONDS);
+            Assert.assertEquals(2, queuedResources.size());
+            Assert.assertNotSame(resource, queuedResources.get(0));
+            Assert.assertNotSame(queuedResources.get(0), queuedResources.get(1));
+
+            Resource firstSerialized = copyResource(queuedResources.get(0));
+            Resource secondSerialized = copyResource(queuedResources.get(1));
+            Assert.assertEquals("hdfs://first",
+                    firstSerialized.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+            Assert.assertEquals("hdfs://second",
+                    secondSerialized.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        } finally {
+            releaseFirstAwait.countDown();
+        }
+        firstAlter.get(5, TimeUnit.SECONDS);
+
+        Mockito.verify(firstLogItem).await();
+        Mockito.verify(secondLogItem).await();
     }
 
     @Test
@@ -357,6 +432,16 @@ public class ResourceMgrTest {
         try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
             mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
             mgr.alterResource(resourceName, properties);
+        }
+    }
+
+    private Resource copyResource(Resource resource) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            resource.write(out);
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return Resource.read(in);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -23,11 +23,15 @@ import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
+import org.apache.doris.nereids.trees.plans.commands.DropResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
+import org.apache.doris.persist.DropResourceOperationLog;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.persist.OperationType;
+import org.apache.doris.policy.PolicyMgr;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.junit.After;
@@ -104,10 +108,13 @@ public class ResourceMgrTest {
         try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
             Env env = Mockito.mock(Env.class);
             EditLog editLog = Mockito.mock(EditLog.class);
+            EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
             AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
             mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
             Mockito.when(env.getEditLog()).thenReturn(editLog);
             Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(editLog.submitEdit(
+                    Mockito.eq(OperationType.OP_CREATE_RESOURCE), Mockito.any(Resource.class))).thenReturn(logItem);
             Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
                     .thenReturn(true);
 
@@ -135,10 +142,13 @@ public class ResourceMgrTest {
         try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
             Env env = Mockito.mock(Env.class);
             EditLog editLog = Mockito.mock(EditLog.class);
+            EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
             AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
             mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
             Mockito.when(env.getEditLog()).thenReturn(editLog);
             Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(editLog.submitEdit(
+                    Mockito.eq(OperationType.OP_CREATE_RESOURCE), Mockito.any(Resource.class))).thenReturn(logItem);
             Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
                     .thenReturn(true);
 
@@ -208,6 +218,203 @@ public class ResourceMgrTest {
         }
         modifyFuture.get(5, TimeUnit.SECONDS);
         Assert.assertEquals("hdfs://second", resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testCreateJournalUsesDetachedSnapshotBeforeAlter() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        EditLog.EditLogItem createLogItem = Mockito.mock(EditLog.EditLogItem.class);
+        EditLog.EditLogItem alterLogItem = Mockito.mock(EditLog.EditLogItem.class);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+
+        ResourceMgr mgr = new ResourceMgr();
+        CreateResourceCommand command = createHdfsResourceCommand("hdfs0", "hdfs://initial");
+        CountDownLatch createSubmitEntered = new CountDownLatch(1);
+        CountDownLatch releaseCreateSubmit = new CountDownLatch(1);
+        List<Short> submittedOps = new ArrayList<>();
+        List<Resource> submittedResources = new ArrayList<>();
+        Mockito.when(editLog.submitEdit(Mockito.anyShort(), Mockito.any())).thenAnswer(invocation -> {
+            short op = invocation.getArgument(0);
+            Resource submitted = invocation.getArgument(1);
+            submittedOps.add(op);
+            submittedResources.add(submitted);
+            if (op == OperationType.OP_CREATE_RESOURCE) {
+                Assert.assertNull(mgr.getResource("hdfs0"));
+                createSubmitEntered.countDown();
+                Assert.assertTrue(releaseCreateSubmit.await(5, TimeUnit.SECONDS));
+                return createLogItem;
+            }
+            Resource liveResource = mgr.getResource("hdfs0");
+            Assert.assertNotNull(liveResource);
+            Assert.assertTrue(Thread.holdsLock(liveResource.getAlterLock()));
+            return alterLogItem;
+        });
+
+        Future<Void> createFuture = submitAndWaitUntilStarted(() -> {
+            createResourceWithEnv(mgr, env, command);
+            return null;
+        });
+        Assert.assertTrue(createSubmitEntered.await(5, TimeUnit.SECONDS));
+        try {
+            Assert.assertNull(mgr.getResource("hdfs0"));
+        } finally {
+            releaseCreateSubmit.countDown();
+        }
+        createFuture.get(5, TimeUnit.SECONDS);
+
+        Resource liveResource = mgr.getResource("hdfs0");
+        Assert.assertNotNull(liveResource);
+        Future<Void> alterFuture = submitAndWaitUntilStarted(() -> {
+            alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://altered"));
+            return null;
+        });
+        alterFuture.get(5, TimeUnit.SECONDS);
+
+        Assert.assertEquals(ImmutableList.of(OperationType.OP_CREATE_RESOURCE, OperationType.OP_ALTER_RESOURCE),
+                submittedOps);
+        Assert.assertNotSame(liveResource, submittedResources.get(0));
+        Assert.assertEquals("hdfs://initial",
+                submittedResources.get(0).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        Assert.assertEquals("hdfs://altered",
+                submittedResources.get(1).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testAlterLogDoesNotOwnReferencesOnReplay() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(editLog.submitEdit(
+                Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class))).thenReturn(logItem);
+
+        ResourceMgr mgr = new ResourceMgr();
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://initial");
+        resource.addReference("policy", Resource.ReferenceType.POLICY);
+        mgr.createResource(resource, false);
+
+        alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://altered"));
+
+        ArgumentCaptor<Resource> captor = ArgumentCaptor.forClass(Resource.class);
+        Mockito.verify(editLog).submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), captor.capture());
+        Resource logResource = captor.getValue();
+        logResource.dropResource();
+
+        mgr.replayAlterResource(logResource);
+        Resource replayed = mgr.getResource("hdfs0");
+        Assert.assertEquals("hdfs://altered",
+                replayed.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        try {
+            replayed.dropResource();
+            Assert.fail("replay should preserve policy-owned references");
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("policy"));
+        }
+    }
+
+    @Test
+    public void testResourceMgrWriteUsesResourceSnapshots() throws Exception {
+        ResourceMgr mgr = new ResourceMgr();
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://initial");
+        mgr.createResource(resource, false);
+
+        resource.writeLock();
+        Future<ResourceMgr> copiedMgrFuture = null;
+        try {
+            copiedMgrFuture = submitAndWaitUntilStarted(() -> copyResourceMgr(mgr));
+            assertFutureBlocked(copiedMgrFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+
+        ResourceMgr copiedMgr = copiedMgrFuture.get(5, TimeUnit.SECONDS);
+        resource.modifyProperties(hdfsProperties("hdfs://altered"));
+        Assert.assertEquals("hdfs://initial",
+                copiedMgr.getResource("hdfs0").getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        Assert.assertEquals("hdfs://altered",
+                resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testDropWaitsForAlterSubmissionAndDoesNotResurrectResource() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        EditLog.EditLogItem alterLogItem = Mockito.mock(EditLog.EditLogItem.class);
+        EditLog.EditLogItem dropLogItem = Mockito.mock(EditLog.EditLogItem.class);
+        PolicyMgr policyMgr = Mockito.mock(PolicyMgr.class);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(env.getPolicyMgr()).thenReturn(policyMgr);
+
+        ResourceMgr mgr = new ResourceMgr();
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://initial");
+        resource.id = 1;
+        mgr.createResource(resource, false);
+
+        CountDownLatch alterSubmitEntered = new CountDownLatch(1);
+        CountDownLatch releaseAlterSubmit = new CountDownLatch(1);
+        List<Short> submittedOps = new ArrayList<>();
+        List<Object> submittedLogs = new ArrayList<>();
+        Mockito.when(editLog.submitEdit(Mockito.anyShort(), Mockito.any())).thenAnswer(invocation -> {
+            short op = invocation.getArgument(0);
+            Assert.assertTrue(Thread.holdsLock(resource.getAlterLock()));
+            submittedOps.add(op);
+            submittedLogs.add(invocation.getArgument(1));
+            if (op == OperationType.OP_ALTER_RESOURCE) {
+                alterSubmitEntered.countDown();
+                Assert.assertTrue(releaseAlterSubmit.await(5, TimeUnit.SECONDS));
+                return alterLogItem;
+            }
+            Assert.assertTrue(mgr.containsResource("hdfs0"));
+            return dropLogItem;
+        });
+        Mockito.when(alterLogItem.await()).thenAnswer(invocation -> {
+            Assert.assertFalse(Thread.holdsLock(resource.getAlterLock()));
+            return 1L;
+        });
+        Mockito.when(dropLogItem.await()).thenAnswer(invocation -> {
+            Assert.assertFalse(Thread.holdsLock(resource.getAlterLock()));
+            return 2L;
+        });
+
+        Future<Void> alterFuture = submitAndWaitUntilStarted(() -> {
+            alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://altered"));
+            return null;
+        });
+        Assert.assertTrue(alterSubmitEntered.await(5, TimeUnit.SECONDS));
+
+        Future<Void> dropFuture = submitAndWaitUntilStarted(() -> {
+            dropResourceWithEnv(mgr, env, new DropResourceCommand(false, "hdfs0"));
+            return null;
+        });
+        try {
+            assertFutureBlocked(dropFuture);
+            Assert.assertTrue(mgr.containsResource("hdfs0"));
+        } finally {
+            releaseAlterSubmit.countDown();
+        }
+        alterFuture.get(5, TimeUnit.SECONDS);
+        dropFuture.get(5, TimeUnit.SECONDS);
+
+        Assert.assertEquals(ImmutableList.of(OperationType.OP_ALTER_RESOURCE, OperationType.OP_DROP_RESOURCE),
+                submittedOps);
+        Assert.assertFalse(mgr.containsResource("hdfs0"));
+
+        ResourceMgr replayMgr = new ResourceMgr();
+        HdfsResource replayInitial = createHdfsResource("hdfs0", "hdfs://initial");
+        replayInitial.id = 1;
+        replayMgr.createResource(replayInitial, false);
+        replayMgr.replayAlterResource((Resource) submittedLogs.get(0));
+        replayMgr.replayDropResource((DropResourceOperationLog) submittedLogs.get(1));
+        Assert.assertFalse(replayMgr.containsResource("hdfs0"));
+
+        HdfsResource replacement = createHdfsResource("hdfs0", "hdfs://replacement");
+        replacement.id = 2;
+        replayMgr.createResource(replacement, false);
+        replayMgr.replayAlterResource((Resource) submittedLogs.get(0));
+        Assert.assertSame(replacement, replayMgr.getResource("hdfs0"));
+        Assert.assertEquals("hdfs://replacement",
+                replacement.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
     }
 
     @Test
@@ -374,16 +581,10 @@ public class ResourceMgrTest {
         });
         Assert.assertTrue(pingEntered.await(5, TimeUnit.SECONDS));
 
-        Future<Void> readerFuture = submitAndWaitUntilStarted(() -> {
-            resource.readLock();
-            try {
-                return null;
-            } finally {
-                resource.readUnlock();
-            }
-        });
+        Future<ResourceMgr> imageFuture = submitAndWaitUntilStarted(() -> copyResourceMgr(mgr));
         try {
-            readerFuture.get(1, TimeUnit.SECONDS);
+            ResourceMgr copiedMgr = imageFuture.get(1, TimeUnit.SECONDS);
+            Assert.assertNotNull(copiedMgr.getResource("s30"));
         } finally {
             releasePing.countDown();
         }
@@ -421,6 +622,14 @@ public class ResourceMgrTest {
         return resource;
     }
 
+    private CreateResourceCommand createHdfsResourceCommand(String name, String fsName) throws UserException {
+        Map<String, String> properties = hdfsProperties(fsName);
+        properties.put("type", "hdfs");
+        CreateResourceInfo info = new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(properties));
+        info.analyzeResourceType();
+        return new CreateResourceCommand(info);
+    }
+
     private Map<String, String> hdfsProperties(String fsName) {
         Map<String, String> properties = Maps.newHashMap();
         properties.put(HdfsResource.HADOOP_FS_NAME, fsName);
@@ -435,6 +644,20 @@ public class ResourceMgrTest {
         }
     }
 
+    private void createResourceWithEnv(ResourceMgr mgr, Env env, CreateResourceCommand command) throws DdlException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            mgr.createResource(command);
+        }
+    }
+
+    private void dropResourceWithEnv(ResourceMgr mgr, Env env, DropResourceCommand command) throws DdlException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            mgr.dropResource(command);
+        }
+    }
+
     private Resource copyResource(Resource resource) throws Exception {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (DataOutputStream out = new DataOutputStream(bytes)) {
@@ -442,6 +665,16 @@ public class ResourceMgrTest {
         }
         try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
             return Resource.read(in);
+        }
+    }
+
+    private ResourceMgr copyResourceMgr(ResourceMgr mgr) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            mgr.write(out);
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return ResourceMgr.read(in);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -38,10 +38,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ResourceMgrTest {
     // s3 resource
@@ -89,7 +86,7 @@ public class ResourceMgrTest {
         s3Properties.put("AWS_SECRET_KEY", s3SecretKey);
         s3Properties.put("AWS_BUCKET", "test-bucket");
         s3Properties.put("s3_validity_check", "false");
-        executor = Executors.newSingleThreadExecutor();
+        executor = Executors.newFixedThreadPool(2);
     }
 
     @After
@@ -182,6 +179,17 @@ public class ResourceMgrTest {
         }
         procFuture.get(5, TimeUnit.SECONDS);
 
+        resource.writeLock();
+        Future<Resource> snapshotFuture = null;
+        try {
+            snapshotFuture = submitAndWaitUntilStarted(resource::getCopiedResourceSnapshot);
+            assertFutureBlocked(snapshotFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+        Assert.assertEquals("hdfs://first",
+                snapshotFuture.get(5, TimeUnit.SECONDS).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+
         resource.readLock();
         Future<Void> modifyFuture = null;
         try {
@@ -198,74 +206,137 @@ public class ResourceMgrTest {
     }
 
     @Test
-    public void testAlterResourceLogsDetachedSnapshots() throws Exception {
-        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
-            Env env = Mockito.mock(Env.class);
-            EditLog editLog = Mockito.mock(EditLog.class);
-            EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
-            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
-            Mockito.when(env.getEditLog()).thenReturn(editLog);
-            Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
-                    .thenReturn(logItem);
+    public void testConcurrentAlterResourceLogsOrderedDetachedSnapshots() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-            ResourceMgr mgr = new ResourceMgr();
-            mgr.createResource(createHdfsResource("hdfs0", "hdfs://initial"), false);
-            mgr.alterResource("hdfs0", hdfsProperties("hdfs://first"));
-            mgr.alterResource("hdfs0", hdfsProperties("hdfs://second"));
-
-            ArgumentCaptor<Resource> logResourceCaptor = ArgumentCaptor.forClass(Resource.class);
-            Mockito.verify(editLog, Mockito.times(2)).submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE),
-                    logResourceCaptor.capture());
-            Mockito.verify(logItem, Mockito.times(2)).await();
-            List<Resource> loggedResources = logResourceCaptor.getAllValues();
-
-            Assert.assertNotSame(mgr.getResource("hdfs0"), loggedResources.get(0));
-            Assert.assertNotSame(loggedResources.get(0), loggedResources.get(1));
-            Assert.assertEquals("hdfs://first",
-                    loggedResources.get(0).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
-            Assert.assertEquals("hdfs://second",
-                    loggedResources.get(1).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
-        }
-    }
-
-    @Test
-    public void testResourceMgrWriteUsesDetachedResourceSnapshots() throws Exception {
         ResourceMgr mgr = new ResourceMgr();
-        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://initial");
         mgr.createResource(resource, false);
 
-        resource.writeLock();
-        Future<ResourceMgr> copiedMgrFuture = null;
+        CountDownLatch firstSubmitEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstSubmit = new CountDownLatch(1);
+        AtomicInteger submitCount = new AtomicInteger();
+        Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
+                .thenAnswer(invocation -> {
+                    Assert.assertTrue(Thread.holdsLock(resource.getAlterLock()));
+                    if (submitCount.getAndIncrement() == 0) {
+                        firstSubmitEntered.countDown();
+                        Assert.assertTrue(releaseFirstSubmit.await(5, TimeUnit.SECONDS));
+                    }
+                    return logItem;
+                });
+        Mockito.when(logItem.await()).thenAnswer(invocation -> {
+            Assert.assertFalse(Thread.holdsLock(resource.getAlterLock()));
+            return 0L;
+        });
+
+        Future<Void> firstAlter = submitAndWaitUntilStarted(() -> {
+            alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://first"));
+            return null;
+        });
+        Assert.assertTrue(firstSubmitEntered.await(5, TimeUnit.SECONDS));
+
+        Future<Void> secondAlter = submitAndWaitUntilStarted(() -> {
+            alterResourceWithEnv(mgr, env, "hdfs0", hdfsProperties("hdfs://second"));
+            return null;
+        });
         try {
-            copiedMgrFuture = submitAndWaitUntilStarted(() -> copyResourceMgr(mgr));
-            assertFutureBlocked(copiedMgrFuture);
+            assertFutureBlocked(secondAlter);
+            Assert.assertEquals("hdfs://first",
+                    resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
         } finally {
-            resource.writeUnlock();
+            releaseFirstSubmit.countDown();
         }
+        firstAlter.get(5, TimeUnit.SECONDS);
+        secondAlter.get(5, TimeUnit.SECONDS);
 
-        ResourceMgr copiedMgr = copiedMgrFuture.get(5, TimeUnit.SECONDS);
-        resource.modifyProperties(hdfsProperties("hdfs://second"));
+        ArgumentCaptor<Resource> logResourceCaptor = ArgumentCaptor.forClass(Resource.class);
+        Mockito.verify(editLog, Mockito.times(2)).submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE),
+                logResourceCaptor.capture());
+        Mockito.verify(logItem, Mockito.times(2)).await();
+        List<Resource> loggedResources = logResourceCaptor.getAllValues();
 
+        Assert.assertNotSame(resource, loggedResources.get(0));
+        Assert.assertNotSame(loggedResources.get(0), loggedResources.get(1));
         Assert.assertEquals("hdfs://first",
-                copiedMgr.getResource("hdfs0").getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+                loggedResources.get(0).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
         Assert.assertEquals("hdfs://second",
-                resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+                loggedResources.get(1).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
     }
 
     @Test
-    public void testCopiedResourceKeepsReferenceSnapshot() throws Exception {
-        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
-        resource.addReference("tbl", Resource.ReferenceType.POLICY);
+    public void testS3ValidityCheckDoesNotHoldResourceStateLock() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
+                .thenReturn(logItem);
 
-        Resource copied = resource.getCopiedResourceSnapshot();
-        resource.removeReference("tbl", Resource.ReferenceType.POLICY);
+        ResourceMgr mgr = new ResourceMgr();
+        S3Resource resource = new S3Resource("s30");
+        resource.setProperties(ImmutableMap.copyOf(s3Properties));
+        mgr.createResource(resource, false);
+
+        CountDownLatch pingEntered = new CountDownLatch(1);
+        CountDownLatch releasePing = new CountDownLatch(1);
+        Future<Void> alterFuture = submitAndWaitUntilStarted(() -> {
+            try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class);
+                    MockedStatic<S3Resource> mockedS3 = Mockito.mockStatic(S3Resource.class, Mockito.CALLS_REAL_METHODS)) {
+                mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+                mockedS3.when(() -> S3Resource.pingS3(
+                        Mockito.anyString(), Mockito.anyString(), Mockito.anyMap())).thenAnswer(invocation -> {
+                            pingEntered.countDown();
+                            Assert.assertTrue(releasePing.await(5, TimeUnit.SECONDS));
+                            return null;
+                        });
+                mgr.alterResource("s30", Maps.newHashMap(ImmutableMap.of("s3_validity_check", "true")));
+            }
+            return null;
+        });
+        Assert.assertTrue(pingEntered.await(5, TimeUnit.SECONDS));
+
+        Future<Void> readerFuture = submitAndWaitUntilStarted(() -> {
+            resource.readLock();
+            try {
+                return null;
+            } finally {
+                resource.readUnlock();
+            }
+        });
+        try {
+            readerFuture.get(1, TimeUnit.SECONDS);
+        } finally {
+            releasePing.countDown();
+        }
+        alterFuture.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testResourceSnapshotCoordinatesReferenceUpdates() throws Exception {
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+        resource.addReference("first", Resource.ReferenceType.POLICY);
+
+        Future<Resource> copiedFuture;
+        synchronized (resource) {
+            copiedFuture = submitAndWaitUntilStarted(resource::getCopiedResourceSnapshot);
+            assertFutureBlocked(copiedFuture);
+            resource.removeReference("first", Resource.ReferenceType.POLICY);
+            resource.addReference("second", Resource.ReferenceType.POLICY);
+        }
+        Resource copied = copiedFuture.get(5, TimeUnit.SECONDS);
 
         try {
             copied.dropResource();
-            Assert.fail("copied resource should keep the original reference");
+            Assert.fail("copied resource should contain a complete reference snapshot");
         } catch (DdlException e) {
-            Assert.assertTrue(e.getMessage().contains("tbl"));
+            Assert.assertFalse(e.getMessage().contains("first"));
+            Assert.assertTrue(e.getMessage().contains("second"));
         }
+        resource.removeReference("second", Resource.ReferenceType.POLICY);
         resource.dropResource();
     }
 
@@ -281,14 +352,11 @@ public class ResourceMgrTest {
         return properties;
     }
 
-    private ResourceMgr copyResourceMgr(ResourceMgr mgr) throws Exception {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        try (DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
-            mgr.write(dataOutputStream);
-        }
-        try (DataInputStream dataInputStream = new DataInputStream(
-                new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))) {
-            return ResourceMgr.read(dataInputStream);
+    private void alterResourceWithEnv(ResourceMgr mgr, Env env, String resourceName,
+            Map<String, String> properties) throws DdlException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            mgr.alterResource(resourceName, properties);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -19,23 +19,39 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.OperationType;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class ResourceMgrTest {
     // s3 resource
@@ -50,6 +66,7 @@ public class ResourceMgrTest {
     private String s3ReqTimeoutMs;
     private String s3ConnTimeoutMs;
     private Map<String, String> s3Properties;
+    private ExecutorService executor;
 
     @Before
     public void setUp() {
@@ -72,6 +89,12 @@ public class ResourceMgrTest {
         s3Properties.put("AWS_SECRET_KEY", s3SecretKey);
         s3Properties.put("AWS_BUCKET", "test-bucket");
         s3Properties.put("s3_validity_check", "false");
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
     }
 
     @Test
@@ -128,6 +151,163 @@ public class ResourceMgrTest {
 
             // add again
             mgr.createResource(createResourceCommand);
+        }
+    }
+
+    @Test
+    public void testHdfsResourceUsesReadWriteLockForPropertyAccess() throws Exception {
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+
+        resource.writeLock();
+        Future<Map<String, String>> copiedPropertiesFuture = null;
+        try {
+            copiedPropertiesFuture = submitAndWaitUntilStarted(resource::getCopiedProperties);
+            assertFutureBlocked(copiedPropertiesFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+        Assert.assertEquals("hdfs://first",
+                copiedPropertiesFuture.get(5, TimeUnit.SECONDS).get(HdfsResource.HADOOP_FS_NAME));
+
+        resource.writeLock();
+        Future<Void> procFuture = null;
+        try {
+            procFuture = submitAndWaitUntilStarted(() -> {
+                resource.getProcNodeData(new BaseProcResult());
+                return null;
+            });
+            assertFutureBlocked(procFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+        procFuture.get(5, TimeUnit.SECONDS);
+
+        resource.readLock();
+        Future<Void> modifyFuture = null;
+        try {
+            modifyFuture = submitAndWaitUntilStarted(() -> {
+                resource.modifyProperties(hdfsProperties("hdfs://second"));
+                return null;
+            });
+            assertFutureBlocked(modifyFuture);
+        } finally {
+            resource.readUnlock();
+        }
+        modifyFuture.get(5, TimeUnit.SECONDS);
+        Assert.assertEquals("hdfs://second", resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testAlterResourceLogsDetachedSnapshots() throws Exception {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            EditLog.EditLogItem logItem = Mockito.mock(EditLog.EditLogItem.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(editLog.submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE), Mockito.any(Resource.class)))
+                    .thenReturn(logItem);
+
+            ResourceMgr mgr = new ResourceMgr();
+            mgr.createResource(createHdfsResource("hdfs0", "hdfs://initial"), false);
+            mgr.alterResource("hdfs0", hdfsProperties("hdfs://first"));
+            mgr.alterResource("hdfs0", hdfsProperties("hdfs://second"));
+
+            ArgumentCaptor<Resource> logResourceCaptor = ArgumentCaptor.forClass(Resource.class);
+            Mockito.verify(editLog, Mockito.times(2)).submitEdit(Mockito.eq(OperationType.OP_ALTER_RESOURCE),
+                    logResourceCaptor.capture());
+            Mockito.verify(logItem, Mockito.times(2)).await();
+            List<Resource> loggedResources = logResourceCaptor.getAllValues();
+
+            Assert.assertNotSame(mgr.getResource("hdfs0"), loggedResources.get(0));
+            Assert.assertNotSame(loggedResources.get(0), loggedResources.get(1));
+            Assert.assertEquals("hdfs://first",
+                    loggedResources.get(0).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+            Assert.assertEquals("hdfs://second",
+                    loggedResources.get(1).getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        }
+    }
+
+    @Test
+    public void testResourceMgrWriteUsesDetachedResourceSnapshots() throws Exception {
+        ResourceMgr mgr = new ResourceMgr();
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+        mgr.createResource(resource, false);
+
+        resource.writeLock();
+        Future<ResourceMgr> copiedMgrFuture = null;
+        try {
+            copiedMgrFuture = submitAndWaitUntilStarted(() -> copyResourceMgr(mgr));
+            assertFutureBlocked(copiedMgrFuture);
+        } finally {
+            resource.writeUnlock();
+        }
+
+        ResourceMgr copiedMgr = copiedMgrFuture.get(5, TimeUnit.SECONDS);
+        resource.modifyProperties(hdfsProperties("hdfs://second"));
+
+        Assert.assertEquals("hdfs://first",
+                copiedMgr.getResource("hdfs0").getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+        Assert.assertEquals("hdfs://second",
+                resource.getCopiedProperties().get(HdfsResource.HADOOP_FS_NAME));
+    }
+
+    @Test
+    public void testCopiedResourceKeepsReferenceSnapshot() throws Exception {
+        HdfsResource resource = createHdfsResource("hdfs0", "hdfs://first");
+        resource.addReference("tbl", Resource.ReferenceType.POLICY);
+
+        Resource copied = resource.getCopiedResourceSnapshot();
+        resource.removeReference("tbl", Resource.ReferenceType.POLICY);
+
+        try {
+            copied.dropResource();
+            Assert.fail("copied resource should keep the original reference");
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("tbl"));
+        }
+        resource.dropResource();
+    }
+
+    private HdfsResource createHdfsResource(String name, String fsName) throws DdlException {
+        HdfsResource resource = new HdfsResource(name);
+        resource.modifyProperties(hdfsProperties(fsName));
+        return resource;
+    }
+
+    private Map<String, String> hdfsProperties(String fsName) {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(HdfsResource.HADOOP_FS_NAME, fsName);
+        return properties;
+    }
+
+    private ResourceMgr copyResourceMgr(ResourceMgr mgr) throws Exception {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
+            mgr.write(dataOutputStream);
+        }
+        try (DataInputStream dataInputStream = new DataInputStream(
+                new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))) {
+            return ResourceMgr.read(dataInputStream);
+        }
+    }
+
+    private <T> Future<T> submitAndWaitUntilStarted(Callable<T> task) throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        Future<T> future = executor.submit(() -> {
+            started.countDown();
+            return task.call();
+        });
+        Assert.assertTrue(started.await(5, TimeUnit.SECONDS));
+        return future;
+    }
+
+    private void assertFutureBlocked(Future<?> future) throws Exception {
+        try {
+            future.get(100, TimeUnit.MILLISECONDS);
+            Assert.fail("future should be blocked by the resource lock");
+        } catch (TimeoutException e) {
+            // The caller releases the lock before waiting for completion.
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/ResourcePersistTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/ResourcePersistTest.java
@@ -22,7 +22,9 @@ import org.apache.doris.catalog.Resource;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.catalog.S3Resource;
 import org.apache.doris.common.io.Text;
+import org.apache.doris.datasource.property.storage.S3Properties;
 
+import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,6 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Map;
 
 public class ResourcePersistTest {
     @Test
@@ -43,14 +46,19 @@ public class ResourcePersistTest {
     }
 
     @Test
-    public void testAzureResourcePersist() throws IOException {
+    public void testAzureResourcePersist() throws Exception {
         Resource resource = new AzureResource("azure_resource");
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(S3Properties.REGION, "test-region");
+        properties.put(S3Properties.VALIDITY_CHECK, "false");
+        resource.modifyProperties(properties);
         Assert.assertTrue(resource.toString().contains("\"clazz\":\"AzureResource\""));
 
         Resource readResource = readWrittenResource(resource);
         Assert.assertTrue(readResource instanceof AzureResource);
         Assert.assertEquals("azure_resource", readResource.getName());
         Assert.assertEquals(Resource.ResourceType.AZURE, readResource.getType());
+        Assert.assertEquals("test-region", readResource.getCopiedProperties().get(S3Properties.REGION));
         readResource.readLock();
         readResource.readUnlock();
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65665

Problem Summary:

Concurrent `ALTER RESOURCE` could mutate a live HDFS property map while `SHOW RESOURCES`, image serialization, or delayed edit-log serialization iterated the same resource. Besides `ConcurrentModificationException`, asynchronous journaling could serialize a later state into an earlier CREATE/ALTER entry. Review also identified lifecycle and replay gaps around ALTER/DROP ordering, policy-owned references, and Azure snapshot fields.

This change:

- protects HDFS mutation, copied properties, and proc output with the resource state read/write lock;
- submits detached CREATE state before publishing the live resource;
- orders same-resource ALTER and DROP submission with a per-resource lock while keeping edit-log `await()` outside it;
- submits detached ALTER snapshots that exclude policy-owned references, preserves current references on replay, and ignores stale ALTER entries for missing or replaced resource IDs;
- serializes `ResourceMgr` images from per-resource detached snapshots;
- includes Azure properties in Gson persistence;
- keeps S3/Azure external validation outside the resource state lock.

Compared with #65665, this keeps the existing `Resource.clone()` behavior and uses targeted state and lifecycle locks. Generic `Resource.toString()` and `Resource.write()` remain unchanged; the live image path is handled at `ResourceMgr.write()`.

### Release note

None

### Check List (For Author)

- Test:
    - Isolated `JUnitCore` run for `ResourceMgrTest` and `ResourcePersistTest`: 15 tests passed
    - Deterministic coverage for CREATE visibility/journal order, batch and synchronous ALTER submission, ALTER/DROP ordering and stale replay, policy-reference ownership, live image snapshots, non-empty Azure persistence, HDFS readers, and blocked S3 validation
    - `mvn -pl fe-core -am validate -Dskip.doc=true`: passed
    - `git diff --check`: passed
    - `sh build.sh --fe`: FE main compilation passed; test compilation is blocked by an unrelated current-master error in `SchemaChangeHandlerTest` for missing `Column.BINLOG_TIMESTAMP_COL`
    - `sh run-fe-ut.sh --run org.apache.doris.catalog.ResourceMgrTest`: blocked by the same unrelated current-master test-compilation error
- Behavior changed: Yes, resource reads, lifecycle journals, replay, and live image writes now observe stable ordered snapshots
- Does this need documentation: No