### PR TITLE
[branch-4.1][fix](regression) Use single bucket for unique key delete compaction cases

### DIFF
--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -62,6 +62,7 @@ suite("test_compaction_uniq_keys_with_delete") {
                 `max_dwell_time` INT DEFAULT "0" COMMENT "用户最大停留时间",
                 `min_dwell_time` INT DEFAULT "99999" COMMENT "用户最小停留时间")
             UNIQUE KEY(`user_id`, `date`, `datev2`, `datetimev2_1`, `datetimev2_2`, `city`, `age`, `sex`) DISTRIBUTED BY HASH(`user_id`)
+            BUCKETS 1
             PROPERTIES ( "replication_num" = "1", "disable_auto_compaction" = "true" );
         """
 

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -64,6 +64,7 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
             UNIQUE KEY(`user_id`, `date`, `datev2`, `datetimev2_1`, `datetimev2_2`, `city`, `age`, `sex`)
             ORDER BY(`sex`, `date`, `cost`)
             DISTRIBUTED BY HASH(`user_id`)
+            BUCKETS 1
             PROPERTIES (
                 "replication_num" = "1",
                 "enable_unique_key_merge_on_write" = "true",


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

pick #65352 to branch-4.1. This keeps the strict `rowCount < 8 * replicaNum` check and fixes the two unique-key-with-delete compaction case tables to a single bucket.

The backport diff only adds `BUCKETS 1` to:

- `test_compaction_uniq_keys_with_delete.groovy`
- `test_compaction_uniq_keys_with_delete_ck.groovy`

### Release note

None. Regression case deflake only.

### Check List (For Author)

- [x] I have checked the final diff is limited to the regression cases.
- [x] I have run `git diff --check origin/branch-4.1..pick-65352-branch-4.1`.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the backport only adds `BUCKETS 1` to the two target cases.
