### PR TITLE
[branch-4.0][fix](regression) Use single bucket for unique key delete compaction cases

### DIFF
--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -64,6 +64,7 @@ suite("test_compaction_uniq_keys_with_delete") {
                 `max_dwell_time` INT DEFAULT "0" COMMENT "用户最大停留时间",
                 `min_dwell_time` INT DEFAULT "99999" COMMENT "用户最小停留时间")
             UNIQUE KEY(`user_id`, `date`, `datev2`, `datetimev2_1`, `datetimev2_2`, `city`, `age`, `sex`) DISTRIBUTED BY HASH(`user_id`)
+            BUCKETS 1
             PROPERTIES ( "replication_num" = "1" );
         """
 

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -65,7 +65,10 @@ suite("test_compaction_uniq_keys_with_delete") {
                 `min_dwell_time` INT DEFAULT "99999" COMMENT "用户最小停留时间")
             UNIQUE KEY(`user_id`, `date`, `datev2`, `datetimev2_1`, `datetimev2_2`, `city`, `age`, `sex`) DISTRIBUTED BY HASH(`user_id`)
             BUCKETS 1
-            PROPERTIES ( "replication_num" = "1" );
+            PROPERTIES (
+                "replication_num" = "1",
+                "enable_mow_light_delete" = "false"
+            );
         """
 
         sql """ INSERT INTO ${tableName} VALUES

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -121,19 +121,29 @@ suite("test_compaction_uniq_keys_with_delete") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        def isFullyCompacted = { tabletJson ->
+        def isCompactedEnough = { tabletJson ->
             def versionRanges = ((List<String>) tabletJson.rowsets).collect { rowset ->
                 rowset.split(" ")[0]
             }
             logger.info("rowset version ranges after cumulative compaction: " + versionRanges)
-            return versionRanges == ["[0-1]", "[2-11]"]
+            def rangeBounds = versionRanges.collect { range ->
+                def matcher = range =~ /\[(\d+)-(\d+)\]/
+                assert matcher.matches()
+                [Integer.parseInt(matcher[0][1]), Integer.parseInt(matcher[0][2])]
+            }
+            if (rangeBounds.isEmpty() || rangeBounds[0][0] != 0 || rangeBounds[-1][1] != 11) {
+                return false
+            }
+            for (int i = 1; i < rangeBounds.size(); i++) {
+                if (rangeBounds[i][0] != rangeBounds[i - 1][1] + 1) {
+                    return false
+                }
+            }
+            return rangeBounds.size() <= 3
         }
 
-        // BE only picks rowsets whose version is already visible as cumulative
-        // compaction candidates, and the visible version is pushed from FE
-        // asynchronously. Right after a burst of loads it may lag, so a single
-        // cumulative round can merge only the visible prefix of rowsets.
-        // Retry until branch-4.0 reaches the final active rowset shape.
+        // Different environments may finish via cumulative or base compaction, so
+        // accept any compacted layout that continuously covers the final version.
         Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
@@ -143,7 +153,7 @@ suite("test_compaction_uniq_keys_with_delete") {
                 assertEquals(code, 0)
                 def tabletJson = parseJson(out.trim())
                 assert tabletJson.rowsets instanceof List
-                if (!isFullyCompacted(tabletJson)) {
+                if (!isCompactedEnough(tabletJson)) {
                     return false
                 }
             }

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -121,29 +121,35 @@ suite("test_compaction_uniq_keys_with_delete") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        def replicaNum = get_table_replica_num(tableName)
-        logger.info("get table replica num: " + replicaNum)
+        def isFullyCompacted = { tabletJson ->
+            def versionRanges = ((List<String>) tabletJson.rowsets).collect { rowset ->
+                rowset.split(" ")[0]
+            }
+            logger.info("rowset version ranges after cumulative compaction: " + versionRanges)
+            return versionRanges.size() == 2 &&
+                    versionRanges.contains("[0-1]") &&
+                    versionRanges.contains("[2-12]")
+        }
 
         // BE only picks rowsets whose version is already visible as cumulative
         // compaction candidates, and the visible version is pushed from FE
         // asynchronously. Right after a burst of loads it may lag, so a single
-        // cumulative round can merge only the visible prefix of rowsets. Retry
-        // trigger + recount until the rows are fully merged.
+        // cumulative round can merge only the visible prefix of rowsets.
+        // Retry until the final version range [2-12] is compacted.
         Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
-            int rowCount = 0
             for (def tablet in tablets) {
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
                 assertEquals(code, 0)
                 def tabletJson = parseJson(out.trim())
                 assert tabletJson.rowsets instanceof List
-                for (String rowset in (List<String>) tabletJson.rowsets) {
-                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                if (!isFullyCompacted(tabletJson)) {
+                    return false
                 }
             }
-            return rowCount < 8 * replicaNum
+            return true
         })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -126,16 +126,14 @@ suite("test_compaction_uniq_keys_with_delete") {
                 rowset.split(" ")[0]
             }
             logger.info("rowset version ranges after cumulative compaction: " + versionRanges)
-            return versionRanges.size() == 2 &&
-                    versionRanges.contains("[0-1]") &&
-                    versionRanges.contains("[2-12]")
+            return versionRanges == ["[0-1]", "[2-11]"]
         }
 
         // BE only picks rowsets whose version is already visible as cumulative
         // compaction candidates, and the visible version is pushed from FE
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets.
-        // Retry until the final version range [2-12] is compacted.
+        // Retry until branch-4.0 reaches the final active rowset shape.
         Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -138,19 +138,29 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        def isFullyCompacted = { tabletJson ->
+        def isCompactedEnough = { tabletJson ->
             def versionRanges = ((List<String>) tabletJson.rowsets).collect { rowset ->
                 rowset.split(" ")[0]
             }
             logger.info("rowset version ranges after cumulative compaction: " + versionRanges)
-            return versionRanges == ["[0-1]", "[2-9]", "[10-10]", "[11-12]"]
+            def rangeBounds = versionRanges.collect { range ->
+                def matcher = range =~ /\[(\d+)-(\d+)\]/
+                assert matcher.matches()
+                [Integer.parseInt(matcher[0][1]), Integer.parseInt(matcher[0][2])]
+            }
+            if (rangeBounds.isEmpty() || rangeBounds[0][0] != 0 || rangeBounds[-1][1] != 12) {
+                return false
+            }
+            for (int i = 1; i < rangeBounds.size(); i++) {
+                if (rangeBounds[i][0] != rangeBounds[i - 1][1] + 1) {
+                    return false
+                }
+            }
+            return rangeBounds.size() <= 4
         }
 
-        // BE only picks rowsets whose version is already visible as cumulative
-        // compaction candidates, and the visible version is pushed from FE
-        // asynchronously. Right after a burst of loads it may lag, so a single
-        // cumulative round can merge only the visible prefix of rowsets.
-        // Retry until branch-4.0 reaches the final active rowset shape.
+        // Different environments may finish via cumulative or base compaction, so
+        // accept any compacted layout that continuously covers the final version.
         Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
@@ -160,7 +170,7 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
                 assertEquals(code, 0)
                 def tabletJson = parseJson(out.trim())
                 assert tabletJson.rowsets instanceof List
-                if (!isFullyCompacted(tabletJson)) {
+                if (!isCompactedEnough(tabletJson)) {
                     return false
                 }
             }

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -138,29 +138,35 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
         //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
         def tablets = sql_return_maparray """ show tablets from ${tableName}; """
 
-        def replicaNum = get_table_replica_num(tableName)
-        logger.info("get table replica num: " + replicaNum)
+        def isFullyCompacted = { tabletJson ->
+            def versionRanges = ((List<String>) tabletJson.rowsets).collect { rowset ->
+                rowset.split(" ")[0]
+            }
+            logger.info("rowset version ranges after cumulative compaction: " + versionRanges)
+            return versionRanges.size() == 2 &&
+                    versionRanges.contains("[0-1]") &&
+                    versionRanges.contains("[2-12]")
+        }
 
         // BE only picks rowsets whose version is already visible as cumulative
         // compaction candidates, and the visible version is pushed from FE
         // asynchronously. Right after a burst of loads it may lag, so a single
-        // cumulative round can merge only the visible prefix of rowsets. Retry
-        // trigger + recount until the rows are fully merged.
+        // cumulative round can merge only the visible prefix of rowsets.
+        // Retry until the final version range [2-12] is compacted.
         Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")
-            int rowCount = 0
             for (def tablet in tablets) {
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
                 assertEquals(code, 0)
                 def tabletJson = parseJson(out.trim())
                 assert tabletJson.rowsets instanceof List
-                for (String rowset in (List<String>) tabletJson.rowsets) {
-                    rowCount += Integer.parseInt(rowset.split(" ")[1])
+                if (!isFullyCompacted(tabletJson)) {
+                    return false
                 }
             }
-            return rowCount < 8 * replicaNum
+            return true
         })
         qt_select_default3 """ SELECT * FROM ${tableName} t ORDER BY user_id; """
     } finally {

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -66,6 +66,7 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
             UNIQUE KEY(`user_id`, `date`, `datev2`, `datetimev2_1`, `datetimev2_2`, `city`, `age`, `sex`)
             CLUSTER BY(`sex`, `date`, `cost`)
             DISTRIBUTED BY HASH(`user_id`)
+            BUCKETS 1
             PROPERTIES (
                 "replication_num" = "1",
                 "enable_unique_key_merge_on_write" = "true",

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -143,16 +143,14 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
                 rowset.split(" ")[0]
             }
             logger.info("rowset version ranges after cumulative compaction: " + versionRanges)
-            return versionRanges.size() == 2 &&
-                    versionRanges.contains("[0-1]") &&
-                    versionRanges.contains("[2-12]")
+            return versionRanges == ["[0-1]", "[2-9]", "[10-10]", "[11-12]"]
         }
 
         // BE only picks rowsets whose version is already visible as cumulative
         // compaction candidates, and the visible version is pushed from FE
         // asynchronously. Right after a burst of loads it may lag, so a single
         // cumulative round can merge only the visible prefix of rowsets.
-        // Retry until the final version range [2-12] is compacted.
+        // Retry until branch-4.0 reaches the final active rowset shape.
         Awaitility.await().atMost(300, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
             // trigger compactions for all tablets in ${tableName}
             trigger_and_wait_compaction(tableName, "cumulative")


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

pick #65352 to branch-4.0. This keeps the strict compaction-state check and fixes the two unique-key-with-delete compaction case tables to a single bucket.

Conflict resolution:

- Kept branch-4.0's existing table properties.
- Added only `BUCKETS 1` to the two target case tables.

Review / CI follow-up:

- Replaced the old `rowset.split(" ")[1]` segment-count wait predicate.
- Cloud P0 and P0 can finish through different valid compaction paths, so the tests no longer hard-code a single active rowset array.
- Both changed tests now parse active rowset version ranges and wait until they continuously cover the final version and the active rowset count has dropped to the compacted bound.
  - `test_compaction_uniq_keys_with_delete`: cover `[0-11]` with at most 3 active rowsets.
  - `test_compaction_uniq_keys_with_delete_ck`: cover `[0-12]` with at most 4 active rowsets.
- This keeps the check strict while allowing branch-4.0's valid cumulative/base compaction layouts.

### Release note

None. Regression case deflake only.

### Check List (For Author)

- [x] I have checked the final diff is limited to the regression cases.
- [x] I have run `git diff --check origin/branch-4.0...HEAD`.
- [x] I have checked failing Cloud P0 build 997611 and P0 build 997735 and updated the branch-4.0 compaction-state wait.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the backport only updates the two target compaction regression cases.
