### PR TITLE
[fix](iceberg) Preserve nested struct field name case

### DIFF
--- a/be/src/format/table/table_schema_change_helper.cpp
+++ b/be/src/format/table/table_schema_change_helper.cpp
@@ -67,14 +67,20 @@ bool find_file_field_idx_by_name_mapping(
         return true;
     };
 
+    // When the table defines schema.name-mapping.default, field resolution for files without field
+    // ids must go strictly through the mapping. A field that is not covered by the mapping (empty
+    // name_mapping) or whose mapped names are absent from the file must resolve to NULL, never fall
+    // back to physical-name matching.
     if (table_field.__isset.name_mapping) {
         for (const auto& mapped_name : table_field.name_mapping) {
             if (try_match(mapped_name)) {
                 return true;
             }
         }
+        return false;
     }
 
+    // No name mapping defined for the table: keep legacy physical-name matching.
     return table_field.__isset.name && try_match(table_field.name);
 }
 

--- a/be/src/format_v2/column_data.h
+++ b/be/src/format_v2/column_data.h
@@ -248,6 +248,11 @@ struct ColumnDefinition {
     // Historical or external names for the same logical field. Table formats such as Iceberg can
     // use this to resolve partition path keys after column rename.
     std::vector<std::string> name_mapping {};
+    // True when the table defines schema.name-mapping.default and FE sent this field's mapping
+    // (possibly an empty list for a field the mapping does not cover). When set, name-based
+    // resolution must go strictly through name_mapping and must not fall back to the field's own
+    // physical name; an uncovered field then resolves to no match (NULL).
+    bool has_name_mapping = false;
     DataTypePtr type;
     // Semantic nested children for this schema node.
     //

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -81,6 +81,14 @@ bool column_has_name(const ColumnDefinition& column, const std::string& name) {
 }
 
 bool column_names_match(const ColumnDefinition& lhs, const ColumnDefinition& rhs) {
+    if (lhs.has_name_mapping) {
+        // The table defines schema.name-mapping.default: resolve strictly through the mapping
+        // aliases. A field the mapping does not cover (empty name_mapping) matches nothing (-> NULL)
+        // instead of falling back to its own physical name (Iceberg name-mapping semantics).
+        return std::ranges::any_of(lhs.name_mapping, [&](const std::string& alias) {
+            return column_has_name(rhs, alias);
+        });
+    }
     if (column_has_name(rhs, lhs.name)) {
         return true;
     }

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -144,13 +144,15 @@ const schema::external::TField* get_field_ptr(const schema::external::TFieldPtr&
 }
 
 bool external_field_matches_name(const schema::external::TField& field, const std::string& name) {
-    if (field.__isset.name && to_lower(field.name) == to_lower(name)) {
-        return true;
+    if (field.__isset.name_mapping) {
+        // The table defines schema.name-mapping.default: match strictly via the mapping aliases.
+        // A field the mapping does not cover (empty name_mapping) matches nothing instead of falling
+        // back to its own physical name.
+        return std::ranges::any_of(field.name_mapping, [&](const std::string& alias) {
+            return to_lower(alias) == to_lower(name);
+        });
     }
-    return field.__isset.name_mapping &&
-           std::ranges::any_of(field.name_mapping, [&](const std::string& alias) {
-               return to_lower(alias) == to_lower(name);
-           });
+    return field.__isset.name && to_lower(field.name) == to_lower(name);
 }
 
 DataTypePtr find_struct_child_type_by_external_field(const DataTypeStruct& struct_type,
@@ -189,6 +191,7 @@ ColumnDefinition build_schema_column_from_external_field(const schema::external:
             .name = field.__isset.name ? field.name : "",
             .name_mapping =
                     field.__isset.name_mapping ? field.name_mapping : std::vector<std::string> {},
+            .has_name_mapping = field.__isset.name_mapping,
             .type = std::move(type),
             .children = {},
             .default_expr = nullptr,
@@ -488,6 +491,7 @@ Status TableReader::annotate_projected_column(const TFileScanSlotInfo& slot_info
     context->schema_column = build_schema_column_from_external_field(*schema_field, column->type);
     column->identifier = context->schema_column->identifier;
     column->name_mapping = context->schema_column->name_mapping;
+    column->has_name_mapping = context->schema_column->has_name_mapping;
     return Status::OK();
 }
 

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -143,16 +143,19 @@ const schema::external::TField* get_field_ptr(const schema::external::TFieldPtr&
     return field_ptr.field_ptr.get();
 }
 
+// Associates a projected column with its current-schema field (by current name, then aliases).
+// This is the current-schema association phase, NOT legacy-file matching: it must match the field
+// by its own current name so annotate_projected_column can copy the field id / aliases / mapping
+// marker. Strict name-mapping resolution (no physical-name fallback) belongs only to the id-less
+// file matching path in column_mapper (column_names_match), not here.
 bool external_field_matches_name(const schema::external::TField& field, const std::string& name) {
-    if (field.__isset.name_mapping) {
-        // The table defines schema.name-mapping.default: match strictly via the mapping aliases.
-        // A field the mapping does not cover (empty name_mapping) matches nothing instead of falling
-        // back to its own physical name.
-        return std::ranges::any_of(field.name_mapping, [&](const std::string& alias) {
-            return to_lower(alias) == to_lower(name);
-        });
+    if (field.__isset.name && to_lower(field.name) == to_lower(name)) {
+        return true;
     }
-    return field.__isset.name && to_lower(field.name) == to_lower(name);
+    return field.__isset.name_mapping &&
+           std::ranges::any_of(field.name_mapping, [&](const std::string& alias) {
+               return to_lower(alias) == to_lower(name);
+           });
 }
 
 DataTypePtr find_struct_child_type_by_external_field(const DataTypeStruct& struct_type,

--- a/be/test/format/table/table_schema_change_helper_test.cpp
+++ b/be/test/format/table/table_schema_change_helper_test.cpp
@@ -663,10 +663,10 @@ TEST(MockTableSchemaChangeHelper, IcebergOrcPartialNameMappingReturnsNull) {
     std::unique_ptr<orc::Type> orc_type(orc::Type::buildTypeFromString("struct<a:int,b:int>"));
 
     std::shared_ptr<TableSchemaChangeHelper::Node> ans_node = nullptr;
-    ASSERT_TRUE(TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_field_id_with_name_mapping(
-                        root_field, orc_type.get(), IcebergOrcReader::ICEBERG_ORC_ATTRIBUTE,
-                        ans_node)
-                        .ok());
+    ASSERT_TRUE(
+            TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_field_id_with_name_mapping(
+                    root_field, orc_type.get(), IcebergOrcReader::ICEBERG_ORC_ATTRIBUTE, ans_node)
+                    .ok());
 
     ASSERT_EQ(TableSchemaChangeHelper::debug(ans_node),
               "StructNode\n"

--- a/be/test/format/table/table_schema_change_helper_test.cpp
+++ b/be/test/format/table/table_schema_change_helper_test.cpp
@@ -425,6 +425,102 @@ TEST(MockTableSchemaChangeHelper, IcebergParquetNameMappingFallback) {
               "    ScalarNode\n");
 }
 
+TEST(MockTableSchemaChangeHelper, IcebergParquetPartialNameMappingReturnsNull) {
+    // Table defines schema.name-mapping.default that covers `a` but not `b`. The migrated legacy
+    // parquet file (no field ids) physically contains both `a` and `b`. `b` is uncovered by the
+    // mapping (empty name_mapping list, as FE now emits), so it must resolve to NULL rather than
+    // fall back to the physical column `b`. Mirrors testMigratedDataWithPartialNameMapping ([1, null]).
+    TColumnType int_type;
+    int_type.type = TPrimitiveType::INT;
+
+    schema::external::TStructField root_field;
+    {
+        auto a_field = std::make_shared<schema::external::TField>();
+        a_field->name = "a";
+        a_field->id = 1;
+        a_field->type = int_type;
+        a_field->__set_name_mapping(std::vector<std::string> {"a"});
+        schema::external::TFieldPtr a_ptr;
+        a_ptr.field_ptr = a_field;
+        root_field.fields.emplace_back(a_ptr);
+    }
+    {
+        auto b_field = std::make_shared<schema::external::TField>();
+        b_field->name = "b";
+        b_field->id = 2;
+        b_field->type = int_type;
+        // Uncovered field: FE sets an empty name mapping so BE must not fall back to physical name.
+        b_field->__set_name_mapping(std::vector<std::string> {});
+        schema::external::TFieldPtr b_ptr;
+        b_ptr.field_ptr = b_field;
+        root_field.fields.emplace_back(b_ptr);
+    }
+
+    FieldDescriptor parquet_field;
+    {
+        FieldSchema a_file;
+        a_file.name = "a";
+        a_file.data_type =
+                DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true);
+        a_file.field_id = -1;
+        parquet_field._fields.emplace_back(a_file);
+    }
+    {
+        FieldSchema b_file;
+        b_file.name = "b";
+        b_file.data_type =
+                DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true);
+        b_file.field_id = -1;
+        parquet_field._fields.emplace_back(b_file);
+    }
+
+    std::shared_ptr<TableSchemaChangeHelper::Node> ans_node = nullptr;
+    ASSERT_TRUE(TableSchemaChangeHelper::BuildTableInfoUtil::by_parquet_field_id_with_name_mapping(
+                        root_field, parquet_field, ans_node)
+                        .ok());
+
+    ASSERT_EQ(TableSchemaChangeHelper::debug(ans_node),
+              "StructNode\n"
+              "  a (file: a)\n"
+              "    ScalarNode\n"
+              "  b (not exists)\n");
+}
+
+TEST(MockTableSchemaChangeHelper, IcebergParquetNameMappingNoPhysicalFallback) {
+    // A field covered by the mapping whose mapped names are absent from the file must resolve to
+    // NULL, even when the field's own physical name exists in the file. This is the lenient
+    // physical-name fallback that was removed for name-mapped tables.
+    TColumnType int_type;
+    int_type.type = TPrimitiveType::INT;
+
+    schema::external::TStructField root_field;
+    auto renamed_field = std::make_shared<schema::external::TField>();
+    renamed_field->name = "col1_new";
+    renamed_field->id = 1;
+    renamed_field->type = int_type;
+    renamed_field->__set_name_mapping(std::vector<std::string> {"absent_old_name"});
+    schema::external::TFieldPtr renamed_ptr;
+    renamed_ptr.field_ptr = renamed_field;
+    root_field.fields.emplace_back(renamed_ptr);
+
+    FieldDescriptor parquet_field;
+    FieldSchema file_col;
+    file_col.name = "col1_new"; // matches the table field's physical name, but not the mapped name
+    file_col.data_type =
+            DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true);
+    file_col.field_id = -1;
+    parquet_field._fields.emplace_back(file_col);
+
+    std::shared_ptr<TableSchemaChangeHelper::Node> ans_node = nullptr;
+    ASSERT_TRUE(TableSchemaChangeHelper::BuildTableInfoUtil::by_parquet_field_id_with_name_mapping(
+                        root_field, parquet_field, ans_node)
+                        .ok());
+
+    ASSERT_EQ(TableSchemaChangeHelper::debug(ans_node),
+              "StructNode\n"
+              "  col1_new (not exists)\n");
+}
+
 TEST(MockTableSchemaChangeHelper, IcebergOrcSchemaChange) {
     schema::external::TField test_field;
     TColumnType struct_type;
@@ -534,6 +630,49 @@ TEST(MockTableSchemaChangeHelper, IcebergOrcNameMappingFallback) {
               "StructNode\n"
               "  col1_new (file: col1_old)\n"
               "    ScalarNode\n");
+}
+
+TEST(MockTableSchemaChangeHelper, IcebergOrcPartialNameMappingReturnsNull) {
+    // ORC counterpart of IcebergParquetPartialNameMappingReturnsNull: `a` is covered by the mapping,
+    // `b` is uncovered (empty name_mapping) and must resolve to NULL, not fall back to physical `b`.
+    TColumnType int_type;
+    int_type.type = TPrimitiveType::INT;
+
+    schema::external::TStructField root_field;
+    {
+        auto a_field = std::make_shared<schema::external::TField>();
+        a_field->name = "a";
+        a_field->id = 1;
+        a_field->type = int_type;
+        a_field->__set_name_mapping(std::vector<std::string> {"a"});
+        schema::external::TFieldPtr a_ptr;
+        a_ptr.field_ptr = a_field;
+        root_field.fields.emplace_back(a_ptr);
+    }
+    {
+        auto b_field = std::make_shared<schema::external::TField>();
+        b_field->name = "b";
+        b_field->id = 2;
+        b_field->type = int_type;
+        b_field->__set_name_mapping(std::vector<std::string> {});
+        schema::external::TFieldPtr b_ptr;
+        b_ptr.field_ptr = b_field;
+        root_field.fields.emplace_back(b_ptr);
+    }
+
+    std::unique_ptr<orc::Type> orc_type(orc::Type::buildTypeFromString("struct<a:int,b:int>"));
+
+    std::shared_ptr<TableSchemaChangeHelper::Node> ans_node = nullptr;
+    ASSERT_TRUE(TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_field_id_with_name_mapping(
+                        root_field, orc_type.get(), IcebergOrcReader::ICEBERG_ORC_ATTRIBUTE,
+                        ans_node)
+                        .ok());
+
+    ASSERT_EQ(TableSchemaChangeHelper::debug(ans_node),
+              "StructNode\n"
+              "  a (file: a)\n"
+              "    ScalarNode\n"
+              "  b (not exists)\n");
 }
 
 TEST(MockTableSchemaChangeHelper, NestedMapArrayStruct) {

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -179,6 +179,39 @@ std::vector<int32_t> projection_ids(const std::vector<LocalColumnIndex>& project
     return ids;
 }
 
+// When a table column carries schema.name-mapping.default (has_name_mapping), BY_NAME resolution
+// must go strictly through the mapping aliases and must not fall back to the column's own physical
+// name. This is the default-scanner (format_v2) counterpart of the legacy-helper name-mapping tests.
+TEST(ColumnMapperNameMappingTest, StrictNameMappingSkipsPhysicalNameFallback) {
+    std::vector<ColumnDefinition> file_schema;
+    file_schema.push_back(name_col("a", i32()));
+    file_schema.push_back(name_col("b", i32()));
+
+    // Covered by the mapping: resolves via the alias.
+    ColumnDefinition covered = name_col("a", i32());
+    covered.has_name_mapping = true;
+    covered.name_mapping = {"a"};
+    const ColumnDefinition* covered_match = find_column_by_name(covered, file_schema);
+    ASSERT_NE(covered_match, nullptr);
+    EXPECT_EQ(covered_match->name, "a");
+
+    // Not covered by the mapping (empty aliases): must not fall back to the physical column `b`.
+    ColumnDefinition uncovered = name_col("b", i32());
+    uncovered.has_name_mapping = true;
+    uncovered.name_mapping = {};
+    EXPECT_EQ(find_column_by_name(uncovered, file_schema), nullptr);
+
+    // Covered, but the mapped name is absent from the file: also resolves to no match.
+    ColumnDefinition renamed = name_col("b", i32());
+    renamed.has_name_mapping = true;
+    renamed.name_mapping = {"absent_old_name"};
+    EXPECT_EQ(find_column_by_name(renamed, file_schema), nullptr);
+
+    // No name mapping at all: legacy physical-name matching still applies.
+    ColumnDefinition legacy = name_col("b", i32());
+    EXPECT_NE(find_column_by_name(legacy, file_schema), nullptr);
+}
+
 TEST(ColumnMapperDebugTest, CoversDebugStringEnumAndNestedBranches) {
     ColumnDefinition child = field_id_col("child", 2, str(), 3);
     child.name_mapping = {"legacy_child"};

--- a/fe/fe-catalog/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -269,8 +269,10 @@ public abstract class ColumnType {
 
     private static void validateStructFieldCompatibility(StructField originalField, StructField newField,
             boolean allowDecimalPrecisionPromotion) throws DdlException {
-        // check field name
-        if (!originalField.getName().equals(newField.getName())) {
+        // check field name. Compare case-insensitively: Doris identifiers are case-insensitive, and
+        // the existing (external) type may carry the original field-name case (e.g. Iceberg struct
+        // fields) while the new type from DDL is lowercased, so a case-only difference is not a rename.
+        if (!originalField.getName().equalsIgnoreCase(newField.getName())) {
             throw new DdlException(
                     "Cannot rename struct field from '" + originalField.getName() + "' to '" + newField.getName()
                             + "'");
@@ -319,14 +321,16 @@ public abstract class ColumnType {
                 StructField newField = newFields.get(i);
 
                 validateStructFieldCompatibility(originalField, newField, allowDecimalPrecisionPromotion);
-                existingNames.add(originalField.getName());
+                // Case-insensitive: identifiers are case-insensitive and the existing type may keep
+                // the original field-name case (e.g. Iceberg), so conflicts must ignore case.
+                existingNames.add(originalField.getName().toLowerCase());
             }
 
             // check new field name is not conflict with old field name
             for (int i = originalFields.size(); i < otherStructType.getFields().size(); i++) {
                 // to check new field name is not conflict with old field name
                 String newFieldName = otherStructType.getFields().get(i).getName();
-                if (existingNames.contains(newFieldName)) {
+                if (existingNames.contains(newFieldName.toLowerCase())) {
                     throw new DdlException("Added struct field '" + newFieldName + "' conflicts with existing field");
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalUtil.java
@@ -178,9 +178,13 @@ public class ExternalUtil {
             root.setInitialDefaultValue(dorisColumn.getDefaultValue());
         }
 
-        if (nameMapping != null && nameMapping.containsKey(dorisColumn.getUniqueId())) {
-            // for iceberg set name mapping.
-            root.setNameMapping(new ArrayList<>(nameMapping.get(dorisColumn.getUniqueId())));
+        if (nameMapping != null) {
+            // The table defines schema.name-mapping.default, so field resolution for files without
+            // field ids must go strictly through the mapping. Set the mapped names when this field
+            // is covered, otherwise an empty list so BE resolves it to NULL rather than falling back
+            // to physical-name matching (Iceberg name-mapping semantics).
+            List<String> mappedNames = nameMapping.get(dorisColumn.getUniqueId());
+            root.setNameMapping(mappedNames != null ? new ArrayList<>(mappedNames) : new ArrayList<>());
         }
 
         TNestedField nestedField = new TNestedField();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/DorisTypeToIcebergType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/DorisTypeToIcebergType.java
@@ -73,7 +73,12 @@ public class DorisTypeToIcebergType extends DorisTypeVisitor<Type> {
             Type type = types.get(i);
 
             int id = isRoot ? i : getNextId();
-            String fieldName = isRoot && !rootFieldNames.isEmpty() ? rootFieldNames.get(i) : field.getName();
+            // Top-level names come from rootFieldNames (#65094, case-preserved from the DDL columns);
+            // nested struct field names use the case-preserved originalName so a Doris-created/altered
+            // Iceberg table keeps cross-engine-faithful nested names. Internal tables are unaffected
+            // (only this Iceberg-scoped visitor reads getOriginalName()).
+            String fieldName = isRoot && !rootFieldNames.isEmpty()
+                    ? rootFieldNames.get(i) : field.getOriginalName();
             if (field.getContainsNull()) {
                 newFields.add(Types.NestedField.optional(id, fieldName, type, field.getComment()));
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -1064,7 +1064,10 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
             }
             org.apache.iceberg.types.Type newFieldIcebergType =
                     IcebergUtils.dorisTypeToIcebergType(newField.getType());
-            updateSchema.addColumn(path, newField.getName(), newFieldIcebergType, newField.getComment());
+            // Use the original, case-preserved name for the appended nested field. The catalog
+            // StructField name is lowercased, and this immediate child name bypasses the Iceberg
+            // type visitor, so getName() would commit e.g. STRUCT<..., CamelName: ...> as camelname.
+            updateSchema.addColumn(path, newField.getOriginalName(), newFieldIcebergType, newField.getComment());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -700,8 +700,12 @@ public class IcebergUtils {
                         icebergTypeToDorisType(map.valueType(), enableMappingVarbinary, enableMappingTimestampTz));
             case STRUCT:
                 Types.StructType struct = (Types.StructType) type;
+                // Preserve the original nested field-name case so DESCRIBE stays consistent with the
+                // top-level columns (already case-preserved) and faithful to the Iceberg schema
+                // (Spark/Trino compatibility). Field lookups remain case-insensitive because
+                // StructType lowercases its map keys.
                 ArrayList<StructField> nestedTypes = struct.fields().stream().map(
-                        x -> new StructField(x.name(),
+                        x -> StructField.createPreservingCase(x.name(),
                                 icebergTypeToDorisType(x.type(), enableMappingVarbinary, enableMappingTimestampTz)))
                         .collect(Collectors.toCollection(ArrayList::new));
                 return new StructType(nestedTypes);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -270,20 +270,25 @@ public class IcebergScanNode extends FileQueryScanNode {
      * Returns a map from field ID to list of mapped names.
      */
     private Map<Integer, List<String>> extractNameMapping() {
+        String nameMappingJson = icebergTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
+        if (nameMappingJson == null || nameMappingJson.isEmpty()) {
+            // Table does not define a name mapping: return null so callers can distinguish
+            // "table uses name mapping" (missing entries must resolve to NULL) from "no name mapping
+            // at all" (legacy physical-name matching is allowed). A non-null result may still be empty.
+            return null;
+        }
         Map<Integer, List<String>> result = new HashMap<>();
         try {
-            String nameMappingJson = icebergTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
-            if (nameMappingJson != null && !nameMappingJson.isEmpty()) {
-                NameMapping mapping = NameMappingParser.fromJson(nameMappingJson);
-                if (mapping != null) {
-                    // Extract mappings from NameMapping
-                    // NameMapping contains field mappings, we need to convert them to our format
-                    extractMappingsFromNameMapping(mapping.asMappedFields(), result);
-                }
+            NameMapping mapping = NameMappingParser.fromJson(nameMappingJson);
+            if (mapping != null) {
+                // Extract mappings from NameMapping
+                // NameMapping contains field mappings, we need to convert them to our format
+                extractMappingsFromNameMapping(mapping.asMappedFields(), result);
             }
         } catch (Exception e) {
-            // If name mapping parsing fails, continue without it
+            // If name mapping parsing fails, fall back to legacy behavior to avoid all-NULL reads.
             LOG.warn("Failed to parse name mapping from Iceberg table properties", e);
+            return null;
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StructField.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StructField.java
@@ -32,6 +32,10 @@ public class StructField {
     private final DataType dataType;
     private final boolean nullable;
     private final String comment;
+    // Original, case-preserved name (before lowercasing). Carried through type rewrites so the
+    // Iceberg write path (DorisTypeToIcebergType) can emit cross-engine-faithful nested field names.
+    // Internal behavior is unaffected: `name` stays lowercased and equals/hashCode use `name`.
+    private final String originalName;
 
     /**
      * StructField Constructor
@@ -40,7 +44,8 @@ public class StructField {
      *  @param nullable Indicates if values of this field can be `null` values
      */
     public StructField(String name, DataType dataType, boolean nullable, String comment) {
-        this.name = Objects.requireNonNull(name, "name should not be null").toLowerCase();
+        this.originalName = Objects.requireNonNull(name, "name should not be null");
+        this.name = this.originalName.toLowerCase();
         this.dataType = Objects.requireNonNull(dataType, "dataType should not be null");
         this.nullable = nullable;
         this.comment = Objects.requireNonNull(comment, "comment should not be null");
@@ -48,6 +53,11 @@ public class StructField {
 
     public String getName() {
         return name;
+    }
+
+    /** The original, case-preserved name. Used only by the Iceberg type converter. */
+    public String getOriginalName() {
+        return originalName;
     }
 
     public DataType getDataType() {
@@ -70,16 +80,16 @@ public class StructField {
     }
 
     public StructField withDataType(DataType dataType) {
-        return new StructField(name, dataType, nullable, comment);
+        return new StructField(originalName, dataType, nullable, comment);
     }
 
     public StructField withDataTypeAndNullable(DataType dataType, boolean nullable) {
-        return new StructField(name, dataType, nullable, comment);
+        return new StructField(originalName, dataType, nullable, comment);
     }
 
     public org.apache.doris.catalog.StructField toCatalogDataType() {
         return new org.apache.doris.catalog.StructField(
-                name, dataType.toCatalogDataType(), comment, nullable);
+                originalName, dataType.toCatalogDataType(), comment, nullable);
     }
 
     public String toSql() {

--- a/fe/fe-type/src/main/java/org/apache/doris/catalog/StructField.java
+++ b/fe/fe-type/src/main/java/org/apache/doris/catalog/StructField.java
@@ -40,13 +40,41 @@ public class StructField {
     @SerializedName(value = "containsNull")
     private final boolean containsNull; // Now always true (nullable field)
 
+    // Original, case-preserved field name. Only consulted by the Iceberg type converter
+    // (DorisTypeToIcebergType) so a Doris-created Iceberg table keeps cross-engine-faithful nested
+    // field names. Transient and unannotated: it is never persisted, and getOriginalName() falls
+    // back to `name` after metadata replay. Internal OLAP tables never read it, so their behavior
+    // (lowercased `name`, serialized form) is unchanged.
+    private final transient String originalName;
+
     public static final String DEFAULT_FIELD_NAME = "col";
 
     public StructField(String name, Type type, String comment, boolean containsNull) {
-        this.name = name.toLowerCase();
+        this(name, type, comment, containsNull, false);
+    }
+
+    /**
+     * When {@code preserveCase} is true the original field-name case is kept in {@link #name},
+     * which the external/Iceberg read path relies on so DESCRIBE shows cross-engine-faithful names.
+     * Internal tables MUST use {@code preserveCase == false} so struct field names stay lowercased,
+     * matching long-standing behavior. Either way {@link #originalName} keeps the original case for
+     * the Iceberg write path.
+     */
+    private StructField(String name, Type type, String comment, boolean containsNull, boolean preserveCase) {
+        this.originalName = name;
+        this.name = preserveCase ? name : name.toLowerCase();
         this.type = type;
         this.comment = comment;
         this.containsNull = containsNull;
+    }
+
+    /**
+     * Builds a field that keeps the original name case, for external schemas (e.g. Iceberg) that
+     * require cross-engine name fidelity. Field lookups stay case-insensitive because
+     * {@link StructType} lowercases its map keys.
+     */
+    public static StructField createPreservingCase(String name, Type type) {
+        return new StructField(name, type, null, true, true);
     }
 
     public StructField(String name, Type type) {
@@ -67,6 +95,14 @@ public class StructField {
 
     public String getName() {
         return name;
+    }
+
+    /**
+     * The original, case-preserved field name (falls back to {@link #name} after metadata replay,
+     * where the transient original name is not restored). Used only by the Iceberg type converter.
+     */
+    public String getOriginalName() {
+        return originalName != null ? originalName : name;
     }
 
     public Type getType() {


### PR DESCRIPTION
Doris lowercased nested struct field names when reading and creating Iceberg tables, so cross-engine (Spark/Trino) schemas lost the original case. Top-level column case is already preserved (#65094); this extends the same behavior to nested struct fields.

- catalog/StructField and nereids/StructField carry an originalName companion (transient, not persisted; `name` stays lowercased so internal OLAP tables and metadata serialization are unchanged).
- DorisTypeToIcebergType emits originalName for nested fields on write (top-level still uses rootFieldNames from #65094).
- IcebergUtils.icebergTypeToDorisType builds nested read fields with StructField.createPreservingCase; lookups stay case-insensitive because StructType lowercases its map keys.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

