### PR TITLE
[fix](iceberg) Route position deletes to native scanner

### DIFF
--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -334,10 +334,17 @@ TEST(FileScannerV2Test, SupportedFormatMatrix) {
 }
 
 // Scenario: Iceberg position-delete system table splits use FileScannerV2 for both native delete
-// formats and V3 deletion vectors. Avro remains unsupported and is rejected by FE before routing.
+// formats and V3 deletion vectors. A scan-level Avro write default does not make actual Avro ranges
+// supported, but it also must not prevent historical Parquet or ORC ranges from using V2.
 TEST(FileScannerV2Test, IcebergPositionDeletesSupportNativeFormats) {
     TFileScanRangeParams params;
+    // The scan-level value comes from write.delete.format.default. Each range still carries the
+    // actual delete file format, which may differ from this default.
     params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+
+    TQueryOptions query_options;
+    query_options.__set_enable_file_scanner_v2(true);
+    EXPECT_TRUE(FileScanLocalState::TEST_should_use_file_scanner_v2(query_options, false, params));
 
     const auto parquet_position_delete = iceberg_position_deletes_range(
             TFileFormatType::FORMAT_PARQUET, kIcebergPositionDeleteContent);
@@ -348,10 +355,18 @@ TEST(FileScannerV2Test, IcebergPositionDeletesSupportNativeFormats) {
     const auto avro_position_delete = iceberg_position_deletes_range(TFileFormatType::FORMAT_AVRO,
                                                                      kIcebergPositionDeleteContent);
 
+    EXPECT_TRUE(FileScannerV2::is_supported(params, orc_position_delete));
+
+    params.__set_format_type(TFileFormatType::FORMAT_AVRO);
+    EXPECT_TRUE(FileScanLocalState::TEST_should_use_file_scanner_v2(query_options, false, params));
     EXPECT_TRUE(FileScannerV2::is_supported(params, parquet_position_delete));
     EXPECT_TRUE(FileScannerV2::is_supported(params, parquet_deletion_vector));
     EXPECT_TRUE(FileScannerV2::is_supported(params, orc_position_delete));
     EXPECT_FALSE(FileScannerV2::is_supported(params, avro_position_delete));
+
+    params.__set_format_type(TFileFormatType::FORMAT_UNKNOWN);
+    EXPECT_TRUE(FileScanLocalState::TEST_should_use_file_scanner_v2(query_options, false, params));
+    EXPECT_TRUE(FileScannerV2::is_supported(params, parquet_deletion_vector));
 }
 
 // Ready IN/Bloom/MinMax runtime filters all expose their payload through get_digest(). Rebuilding

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -1305,6 +1305,15 @@ public class IcebergUtils {
         return fileFormat;
     }
 
+    public static FileFormat getDefaultDeleteFileFormat(Table icebergTable) {
+        Map<String, String> properties = icebergTable.properties();
+        String deleteFileFormat = properties.get(TableProperties.DELETE_DEFAULT_FILE_FORMAT);
+        if (deleteFileFormat == null) {
+            deleteFileFormat = resolveFileFormatName(icebergTable, properties);
+        }
+        return FileFormat.fromString(deleteFileFormat);
+    }
+
     private static String resolveFileFormatName(Table icebergTable, Map<String, String> properties) {
         // 1. Check "write-format" (nickname in Flink and Spark)
         if (properties.containsKey(WRITE_FORMAT)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -175,6 +175,7 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     private Boolean isBatchMode = null;
     private boolean isSystemTable = false;
+    private TFileFormatType positionDeleteScanFileFormatType;
 
     // ReferencedDataFile path -> List<DeleteFile> / List<TIcebergDeleteFileDesc> (exclude equal delete)
     public Map<String, List<DeleteFile>> deleteFilesByReferencedDataFile = new HashMap<>();
@@ -1365,10 +1366,13 @@ public class IcebergScanNode extends FileQueryScanNode {
     @Override
     public TFileFormatType getFileFormatType() throws UserException {
         if (isSystemTable) {
+            if (isPositionDeletesSystemTable()) {
+                return getPositionDeleteScanFileFormatType();
+            }
             return TFileFormatType.FORMAT_JNI;
         }
-        TFileFormatType type;
         String icebergFormat = source.getFileFormat();
+        TFileFormatType type;
         if (icebergFormat.equalsIgnoreCase("parquet")) {
             type = TFileFormatType.FORMAT_PARQUET;
         } else if (icebergFormat.equalsIgnoreCase("orc")) {
@@ -1377,6 +1381,36 @@ public class IcebergScanNode extends FileQueryScanNode {
             throw new DdlException(String.format("Unsupported format name: %s for iceberg table.", icebergFormat));
         }
         return type;
+    }
+
+    private TFileFormatType getPositionDeleteScanFileFormatType() {
+        if (positionDeleteScanFileFormatType != null) {
+            return positionDeleteScanFileFormatType;
+        }
+        IcebergSysExternalTable systemTable = (IcebergSysExternalTable) source.getTargetTable();
+        Table sourceIcebergTable = systemTable.getSourceTable().getIcebergTable();
+        // This is only the scan-level routing hint. Each range is overwritten with the
+        // actual delete file format in setIcebergPositionDeleteSysTableParams.
+        FileFormat fileFormat = IcebergUtils.getDefaultDeleteFileFormat(sourceIcebergTable);
+        switch (fileFormat) {
+            case PARQUET:
+                positionDeleteScanFileFormatType = TFileFormatType.FORMAT_PARQUET;
+                break;
+            case ORC:
+                positionDeleteScanFileFormatType = TFileFormatType.FORMAT_ORC;
+                break;
+            case AVRO:
+                // This is only a routing hint. Actual Avro position delete files remain unsupported
+                // and are rejected when their ranges are created.
+                positionDeleteScanFileFormatType = TFileFormatType.FORMAT_AVRO;
+                break;
+            default:
+                // write.delete.format.default supports Parquet, Avro, and ORC. Other Iceberg file
+                // formats do not provide a scan-wide physical format, so let each range decide.
+                positionDeleteScanFileFormatType = TFileFormatType.FORMAT_UNKNOWN;
+                break;
+        }
+        return positionDeleteScanFileFormatType;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -22,10 +22,13 @@ import org.apache.doris.analysis.TupleId;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergSysExternalTable;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.system.Backend;
+import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TIcebergDeleteFileDesc;
 
@@ -37,6 +40,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ScanTaskUtil;
@@ -140,6 +144,81 @@ public class IcebergScanNodeTest {
 
         Assert.assertEquals(Collections.singletonMap(7, "AAEC/w=="), defaults);
         Mockito.verify(node, Mockito.never()).createTableScan();
+    }
+
+    @Test
+    public void testPositionDeletesSystemTableUsesPerRangeFileFormat() throws Exception {
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable());
+        IcebergSource source = Mockito.mock(IcebergSource.class);
+        IcebergSysExternalTable systemTable = Mockito.mock(IcebergSysExternalTable.class);
+        IcebergExternalTable sourceTable = Mockito.mock(IcebergExternalTable.class);
+        Table sourceIcebergTable = Mockito.mock(Table.class);
+        Mockito.when(source.getTargetTable()).thenReturn(systemTable);
+        Mockito.when(systemTable.getSourceTable()).thenReturn(sourceTable);
+        Mockito.when(sourceTable.getIcebergTable()).thenReturn(sourceIcebergTable);
+        Mockito.when(sourceIcebergTable.properties()).thenReturn(Collections.singletonMap(
+                TableProperties.DEFAULT_FILE_FORMAT, "parquet"));
+
+        Field sourceField = IcebergScanNode.class.getDeclaredField("source");
+        sourceField.setAccessible(true);
+        sourceField.set(node, source);
+        Field isSystemTableField = IcebergScanNode.class.getDeclaredField("isSystemTable");
+        isSystemTableField.setAccessible(true);
+        isSystemTableField.setBoolean(node, true);
+
+        Mockito.when(systemTable.getSysTableType()).thenReturn("position_deletes");
+        Assert.assertEquals(TFileFormatType.FORMAT_PARQUET, node.getFileFormatType());
+        Assert.assertEquals(TFileFormatType.FORMAT_PARQUET, node.getFileFormatType());
+        Mockito.verify(sourceIcebergTable, Mockito.times(1)).properties();
+        Mockito.verify(source, Mockito.never()).getFileFormat();
+
+        Mockito.when(sourceIcebergTable.properties()).thenReturn(Collections.singletonMap(
+                TableProperties.DELETE_DEFAULT_FILE_FORMAT, "orc"));
+        TestIcebergScanNode orcNode = new TestIcebergScanNode(new SessionVariable());
+        sourceField.set(orcNode, source);
+        isSystemTableField.setBoolean(orcNode, true);
+        Assert.assertEquals(TFileFormatType.FORMAT_ORC, orcNode.getFileFormatType());
+
+        Mockito.when(sourceIcebergTable.properties()).thenReturn(Collections.singletonMap(
+                TableProperties.DELETE_DEFAULT_FILE_FORMAT, "avro"));
+        TestIcebergScanNode avroNode = new TestIcebergScanNode(new SessionVariable());
+        sourceField.set(avroNode, source);
+        isSystemTableField.setBoolean(avroNode, true);
+        Assert.assertEquals(TFileFormatType.FORMAT_AVRO, avroNode.getFileFormatType());
+
+        // Puffin is used for V3 deletion vectors, but it is not a supported
+        // write.delete.format.default value and must not become a scan-wide physical format.
+        Mockito.when(sourceIcebergTable.properties()).thenReturn(Collections.singletonMap(
+                TableProperties.DELETE_DEFAULT_FILE_FORMAT, "puffin"));
+        TestIcebergScanNode puffinNode = new TestIcebergScanNode(new SessionVariable());
+        sourceField.set(puffinNode, source);
+        isSystemTableField.setBoolean(puffinNode, true);
+        Assert.assertEquals(TFileFormatType.FORMAT_UNKNOWN, puffinNode.getFileFormatType());
+
+        Mockito.when(sourceIcebergTable.properties()).thenReturn(Collections.singletonMap(
+                TableProperties.DEFAULT_FILE_FORMAT, "parquet"));
+
+        Mockito.when(systemTable.getSysTableType()).thenReturn("snapshots");
+        Assert.assertEquals(TFileFormatType.FORMAT_JNI, node.getFileFormatType());
+
+        String deletePath = "file:///tmp/position-delete.orc";
+        IcebergSplit split = IcebergSplit.newPositionDeleteSysTableSplit(
+                LocationPath.of(deletePath), 0, 128, 128, Collections.emptyMap(), deletePath);
+        split.setTableFormatType(TableFormatType.ICEBERG);
+        // The table default is Parquet, but this range must still use its actual ORC format.
+        split.setPositionDeleteFileFormat(TFileFormatType.FORMAT_ORC);
+        split.setPositionDeleteOriginalPath(deletePath);
+
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        rangeDesc.setPath(deletePath);
+        Method setIcebergParams = IcebergScanNode.class.getDeclaredMethod(
+                "setIcebergParams", TFileRangeDesc.class, IcebergSplit.class);
+        setIcebergParams.setAccessible(true);
+        setIcebergParams.invoke(node, rangeDesc, split);
+
+        Assert.assertEquals(TFileFormatType.FORMAT_ORC, rangeDesc.getFormatType());
+        Assert.assertEquals(TFileFormatType.FORMAT_ORC, rangeDesc.getTableFormatParams()
+                .getIcebergParams().getDeleteFiles().get(0).getFileFormat());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?
Related PR: #65135
Problem Summary:
Problem Summary: Iceberg position_deletes system table scans used FORMAT_JNI at the scan level, so FileScanLocalState always selected FileScanner V1 before it could inspect range-level formats. Use the source table write.delete.format.default, falling back to its data file format, only as a cached scan-level routing hint. Every range and delete descriptor still uses the actual format recorded in Iceberg metadata, so historical Parquet, ORC, and Puffin deletion-vector splits keep their physical reader. An Avro default can be a routing hint, while actual Avro position delete files remain unsupported.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

