### PR TITLE
[branch-4.1][fix](paimon) Fix external regression failures

### DIFF
--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -65,8 +65,11 @@ public class PaimonJniScanner extends JniScanner {
             LOG.debug("params:{}", params);
         }
         this.params = params;
-        String[] requiredFields = params.get("required_fields").split(",");
-        String[] requiredTypes = params.get("columns_types").split("#");
+        String[] requiredFields = splitParam(params.get("required_fields"), ",");
+        String[] requiredTypes = splitParam(params.get("columns_types"), "#");
+        Preconditions.checkArgument(requiredFields.length == requiredTypes.length,
+                "required_fields size %s does not match columns_types size %s",
+                requiredFields.length, requiredTypes.length);
         ColumnType[] columnTypes = new ColumnType[requiredTypes.length];
         for (int i = 0; i < requiredTypes.length; i++) {
             columnTypes[i] = ColumnType.parseType(requiredFields[i], requiredTypes[i]);
@@ -123,7 +126,11 @@ public class PaimonJniScanner extends JniScanner {
     }
 
     private int[] getProjected() {
-        return Arrays.stream(fields).mapToInt(paimonAllFieldNames::indexOf).toArray();
+        return Arrays.stream(fields).mapToInt(fieldName -> {
+            int index = paimonAllFieldNames.indexOf(fieldName);
+            Preconditions.checkArgument(index >= 0, "RequiredField %s not found in schema", fieldName);
+            return index;
+        }).toArray();
     }
 
     private List<Predicate> getPredicates() {
@@ -184,6 +191,9 @@ public class PaimonJniScanner extends JniScanner {
                         appendData(i, columnValue);
                     }
                     if (rows >= batchSize) {
+                        if (fields.length == 0) {
+                            vectorTable.appendVirtualData(rows);
+                        }
                         appendDataTime += System.nanoTime() - startTime;
                         return rows;
                     }
@@ -192,6 +202,9 @@ public class PaimonJniScanner extends JniScanner {
 
                 recordIterator.releaseBatch();
                 recordIterator = reader.readBatch();
+            }
+            if (fields.length == 0 && rows > 0) {
+                vectorTable.appendVirtualData(rows);
             }
         } catch (Exception e) {
             close();
@@ -225,6 +238,13 @@ public class PaimonJniScanner extends JniScanner {
         if (LOG.isDebugEnabled()) {
             LOG.debug("paimonAllFieldNames:{}", paimonAllFieldNames);
         }
+    }
+
+    private static String[] splitParam(String value, String delimiter) {
+        if (value == null || value.isEmpty()) {
+            return new String[0];
+        }
+        return value.split(delimiter);
     }
 
 }

--- a/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
+++ b/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJniScannerTest.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.paimon;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaimonJniScannerTest {
+    @Test
+    public void testConstructorAcceptsEmptyProjection() {
+        Map<String, String> params = new HashMap<>();
+        params.put("required_fields", "");
+        params.put("columns_types", "");
+        params.put("paimon_split", "");
+        params.put("paimon_predicate", "");
+
+        new PaimonJniScanner(128, params);
+    }
+}

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
@@ -231,7 +231,6 @@ suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,externa
 
         try {
             sql """ set time_zone = 'Asia/Shanghai'; """
-            sql """ set enable_file_scanner_v2 = false; """
             sql """ set enable_runtime_filter_partition_prune = false; """
             test_runtime_filter_partition_pruning()
             sql """ set enable_runtime_filter_partition_prune = true; """
@@ -239,7 +238,6 @@ suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,externa
 
         } finally {
             sql """ unset variable time_zone; """
-            sql """ unset variable enable_file_scanner_v2; """
             sql """ set enable_runtime_filter_partition_prune = true; """
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

The branch-4.1 Paimon partition metadata backport makes partition-only scans produce an empty physical-file projection. The JNI scanner parsed empty `required_fields` as one empty field, mapped it to index `-1`, and failed during MTMV `ANALYZE` with `Index -1 out of bounds`.

The runtime-filter regression also set `enable_file_scanner_v2`, which is unavailable on branch-4.1, so the suite failed while setting and unsetting that variable.

### What changed?

- Treat empty Paimon JNI projections as zero-field scans.
- Append virtual row counts so BE can fill partition columns from path metadata.
- Validate required field/type lengths and projection lookup.
- Add empty-projection constructor coverage.
- Remove the unsupported scanner variable from the branch-4.1 regression.

### Validation

- `./build.sh --fe`
- `mvn -pl be-java-extensions/paimon-scanner -am -Dtest=PaimonJniScannerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
