### PR TITLE
feat(partition): support function expressions in AUTO PARTITION BY LIST

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ListPartitionDesc.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ListPartitionInfo;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 
@@ -88,7 +89,8 @@ public class ListPartitionDesc extends PartitionDesc {
         List<Column> partitionColumns = new ArrayList<>();
 
         // check and get partition column
-        for (String colName : partitionColNames) {
+        for (int i = 0; i < partitionColNames.size(); i++) {
+            String colName = partitionColNames.get(i);
             boolean find = false;
             for (Column column : schema) {
                 if (column.getName().equalsIgnoreCase(colName)) {
@@ -98,7 +100,30 @@ public class ListPartitionDesc extends PartitionDesc {
                         throw new DdlException(e.getMessage());
                     }
 
-                    partitionColumns.add(column);
+                    // For AUTO LIST partitioning with a function expression at this position
+                    // (e.g. from_unixtime(bigint_col, 'yyyy-MM-dd')), the partition key literal
+                    // is the function output, not the raw column value. Override the partition
+                    // column's stored type to match the function return type so PartitionKey
+                    // serialization/deserialization stays consistent. The original schema
+                    // column is left untouched.
+                    Column partitionCol = column;
+                    if (isAutoCreatePartitions && partitionExprs != null && i < partitionExprs.size()) {
+                        Expr expr = partitionExprs.get(i);
+                        if (expr instanceof FunctionCallExpr) {
+                            try {
+                                Type effective = PartitionExprUtil
+                                        .getEffectivePartitionColumnType(expr, column.getType());
+                                if (!effective.equals(column.getType())) {
+                                    partitionCol = new Column(column);
+                                    partitionCol.setType(effective);
+                                }
+                            } catch (AnalysisException e) {
+                                throw new DdlException(e.getMessage());
+                            }
+                        }
+                    }
+
+                    partitionColumns.add(partitionCol);
                     find = true;
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
@@ -50,6 +50,12 @@ public class PartitionDesc {
             .add("minute_floor").add("hour_floor").add("day_floor").add("month_floor").add("year_floor")
             .add("second_ceil").add("minute_ceil").add("hour_ceil").add("day_ceil").add("month_ceil").add("year_ceil")
             .build();
+    // Auto LIST partition supports a smaller set of functions than RANGE:
+    // LIST only needs "deterministic, idempotent value mapping". Range-only helpers
+    // like date_floor/date_ceil that return an interval are excluded.
+    public static final ImmutableSet<String> LIST_PARTITION_FUNCTIONS = new ImmutableSortedSet.Builder<String>(
+            String.CASE_INSENSITIVE_ORDER).add("date_trunc").add("from_unixtime")
+            .build();
 
     public PartitionDesc() {}
 
@@ -99,33 +105,45 @@ public class PartitionDesc {
         return partitionColNames;
     }
 
-    // 1. partition by list (column) : now support one slotRef
-    // 2. partition by range(column/function(column)) : support slotRef and some
-    // special function eg: date_trunc, date_floor/ceil
+    // 1. partition by list (col/function(col), ...): support slotRef and whitelisted
+    //    functions (see LIST_PARTITION_FUNCTIONS) mixed in any position.
+    // 2. partition by range(col/function(col)): support slotRef and whitelisted
+    //    functions (see RANGE_PARTITION_FUNCTIONS).
     public static List<String> getColNamesFromExpr(ArrayList<Expr> exprs, boolean isListPartition,
             boolean isAutoPartition)
             throws AnalysisException {
         List<String> colNames = new ArrayList<>();
         for (Expr expr : exprs) {
-            if ((expr instanceof FunctionCallExpr) && (isListPartition == false)) {
+            if (expr instanceof FunctionCallExpr) {
                 FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
                 List<Expr> paramsExpr = functionCallExpr.getParams().exprs();
                 String name = functionCallExpr.getFnName().getFunction();
-                if (RANGE_PARTITION_FUNCTIONS.contains(name)) {
+                ImmutableSet<String> whitelist = isListPartition
+                        ? LIST_PARTITION_FUNCTIONS : RANGE_PARTITION_FUNCTIONS;
+                if (whitelist.contains(name)) {
+                    String foundCol = null;
                     for (Expr param : paramsExpr) {
                         if (param instanceof SlotRef) {
-                            if (colNames.isEmpty()) {
-                                colNames.add(((SlotRef) param).getColumnName());
-                            } else {
+                            if (foundCol != null) {
                                 throw new AnalysisException(
                                         "auto create partition only support one slotRef in function expr. "
                                                 + expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
                             }
+                            foundCol = ((SlotRef) param).getColumnName();
                         }
                     }
+                    if (foundCol == null) {
+                        throw new AnalysisException(
+                                "auto create partition function expr must reference exactly one column. "
+                                        + expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
+                    }
+                    colNames.add(foundCol);
                 } else {
                     throw new AnalysisException(
-                            "auto create partition only support function call expr is date_trunc/date_floor/date_ceil. "
+                            "auto create partition only support function call expr is "
+                                    + (isListPartition ? "date_trunc/from_unixtime"
+                                            : "date_trunc/date_floor/date_ceil")
+                                    + ". "
                                     + expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
                 }
             } else if (expr instanceof SlotRef) {
@@ -143,7 +161,8 @@ public class PartitionDesc {
                                     + expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
                 } else {
                     throw new AnalysisException(
-                            "auto create partition only support slotRef in list partitions. "
+                            "auto create partition only support slotRef or date_trunc/from_unixtime"
+                                    + " function in list partitions. "
                                     + expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
                 }
             }
@@ -154,6 +173,10 @@ public class PartitionDesc {
                             + exprs.get(0).accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
         }
         return colNames;
+    }
+
+    public void checkPartitionKeyValueType(PartitionKeyDesc partitionKeyDesc) throws AnalysisException {
+
     }
 
     public PartitionType getType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionExprUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionExprUtil.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.HashDistributionInfo;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.AutoBucketCalculator;
@@ -50,6 +51,118 @@ public class PartitionExprUtil {
     private static final Logger LOG = LogManager.getLogger(PartitionExprUtil.class);
     private static final PartitionExprUtil partitionExprUtil = new PartitionExprUtil();
     private static final int MAX_PARTITION_NAME_LENGTH = 50;
+
+    /**
+     * The effective storage type of a partition column when a function expression wraps it.
+     * For AUTO LIST partitioning we store the function output as the partition key literal,
+     * so the partition column type must match the function return type.
+     * - date_trunc: DATETIME -> DATETIME (raw column type unchanged)
+     * - from_unixtime: BIGINT -> VARCHAR(64) (function outputs a formatted date string)
+     * Non-function expressions preserve their raw column type.
+     */
+    public static Type getEffectivePartitionColumnType(Expr expr, Type rawColType) throws AnalysisException {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return rawColType;
+        }
+        String fn = ((FunctionCallExpr) expr).getFnName().getFunction().toLowerCase();
+        if ("date_trunc".equals(fn)) {
+            return rawColType;
+        }
+        if ("from_unixtime".equals(fn)) {
+            return ScalarType.createVarcharType(64);
+        }
+        // Any other function is handled by the RANGE path (date_floor/date_ceil etc.);
+        // it does NOT need column type rewrite because the RANGE branch reads column type
+        // via createPartitionKeyDescWithRange and expects the raw column type.
+        return rawColType;
+    }
+
+    /**
+     * Reject partition function calls whose granularity is second or minute, which would
+     * create thousands of partitions per hour and blow up metadata. Accepted granularities
+     * are hour / day / month / year.
+     *
+     * date_trunc: rejects unit 'second' and 'minute'.
+     * from_unixtime: rejects any format string that contains sub-hour components (%s, %i,
+     *   :ss, :mm, mm, ss). Format must be a StringLiteral; wildcards / dynamic formats
+     *   are rejected. When the format has no time component at all we treat it as day/month
+     *   granularity and accept.
+     */
+    public static void assertPartitionFormatAcceptable(Expr expr) throws AnalysisException {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return;
+        }
+        FunctionCallExpr fce = (FunctionCallExpr) expr;
+        String fn = fce.getFnName().getFunction().toLowerCase();
+        List<Expr> params = fce.getParams().exprs();
+
+        if ("date_trunc".equals(fn)) {
+            // date_trunc's signature (col, unit_literal) is already enforced by Doris function
+            // resolution: 1-arg calls fail as "illegal" and non-literal unit is rejected.
+            // We only need to guard the granularity value here.
+            String unit = ((StringLiteral) params.get(1)).getStringValue().toLowerCase();
+            if ("second".equals(unit) || "minute".equals(unit)) {
+                throw new AnalysisException(
+                        "date_trunc granularity '" + unit + "' is not allowed for auto partition "
+                                + "(would create up to 86400 partitions per day). "
+                                + "Use 'hour', 'day', 'month' or 'year' instead.");
+            }
+            return;
+        }
+
+        if ("from_unixtime".equals(fn)) {
+            if (params.size() < 2) {
+                throw new AnalysisException(
+                        "from_unixtime in auto partition requires an explicit format literal "
+                                + "(e.g. 'yyyy-MM-dd' or '%Y-%m-%d').");
+            }
+            Expr fmtExpr = params.get(1);
+            if (!(fmtExpr instanceof StringLiteral)) {
+                throw new AnalysisException(
+                        "from_unixtime in auto partition requires a string literal format.");
+            }
+            String fmt = ((StringLiteral) fmtExpr).getStringValue();
+            String norm = fmt.toLowerCase();
+            // MySQL-style seconds/minutes markers
+            if (norm.contains("%s") || norm.contains("%i")) {
+                throw new AnalysisException(
+                        "from_unixtime format '" + fmt + "' contains sub-hour granularity "
+                                + "(%s / %i); would create too many partitions. "
+                                + "Use hour or coarser granularity.");
+            }
+            // Java-style seconds/minutes: look for ss or mm as time components
+            // Only check when a time component 'HH' / 'hh' is present, because
+            // 'mm' as month can appear standalone in date-only formats like 'yyyy-MM'
+            boolean hasHour = norm.contains("hh");
+            if (hasHour && (norm.contains(":ss") || norm.contains(":mm") || norm.endsWith("ss"))) {
+                throw new AnalysisException(
+                        "from_unixtime format '" + fmt + "' contains sub-hour granularity "
+                                + "(minute/second); would create too many partitions. "
+                                + "Use hour or coarser granularity.");
+            }
+        }
+    }
+
+    /**
+     * Walk the expression AST and return the first SlotRef encountered, or null if none.
+     * Used to locate which schema column a partition expression references
+     * (e.g. date_trunc(dt, 'day') -> SlotRef(dt)).
+     */
+    public static SlotRef findFirstSlotRef(Expr expr) {
+        if (expr == null) {
+            return null;
+        }
+        if (expr instanceof SlotRef) {
+            return (SlotRef) expr;
+        }
+        for (Expr child : expr.getChildren()) {
+            SlotRef found = findFirstSlotRef(child);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
 
     public static FunctionIntervalInfo getFunctionIntervalInfo(ArrayList<Expr> partitionExprs,
             PartitionType partitionType) throws AnalysisException {
@@ -179,7 +292,14 @@ public class PartitionExprUtil {
                 }
                 listValues.add(inValues);
                 partitionKeyDesc = PartitionKeyDesc.createIn(listValues);
-                partitionName += getFormatPartitionValue(filterStr);
+                // For multi-column LIST, build a readable partition name by joining
+                // sanitized per-value tokens with underscores. Collision uniqueness is
+                // already guaranteed by filterStr (which appends per-value length).
+                StringBuilder suffix = new StringBuilder();
+                for (String v : curPartitionValues) {
+                    suffix.append("_").append(v == null ? "null" : getFormatPartitionValue(v));
+                }
+                partitionName += suffix.toString();
                 if (hasStringType) {
                     if (partitionName.length() > MAX_PARTITION_NAME_LENGTH) {
                         partitionName = partitionName.substring(0, MAX_PARTITION_NAME_LENGTH)

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -19,11 +19,13 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.AllPartitionDesc;
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.ExprToSqlVisitor;
 import org.apache.doris.analysis.ListPartitionDesc;
 import org.apache.doris.analysis.PartitionDesc;
 import org.apache.doris.analysis.PartitionKeyDesc;
 import org.apache.doris.analysis.PartitionValue;
 import org.apache.doris.analysis.SinglePartitionDesc;
+import org.apache.doris.analysis.ToSqlParams;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.ListUtil;
@@ -146,12 +148,22 @@ public class ListPartitionInfo extends PartitionInfo {
         }
         sb.append("PARTITION BY LIST (");
         int idx = 0;
-        for (Column column : partitionColumns) {
-            if (idx != 0) {
-                sb.append(", ");
+        if (enableAutomaticPartition() && partitionExprs != null && !partitionExprs.isEmpty()) {
+            for (Expr e : partitionExprs) {
+                if (idx != 0) {
+                    sb.append(", ");
+                }
+                sb.append(e.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
+                idx++;
             }
-            sb.append("`").append(column.getName()).append("`");
-            idx++;
+        } else {
+            for (Column column : partitionColumns) {
+                if (idx != 0) {
+                    sb.append(", ");
+                }
+                sb.append("`").append(column.getName()).append("`");
+                idx++;
+            }
         }
         sb.append(")\n(");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneListPartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneListPartitionEvaluator.java
@@ -17,10 +17,11 @@
 
 package org.apache.doris.nereids.rules.expression.rules;
 
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.catalog.ListPartitionItem;
 import org.apache.doris.catalog.PartitionKey;
-import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -34,6 +35,7 @@ import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewri
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,14 +48,41 @@ public class OneListPartitionEvaluator<K>
     private final List<Slot> partitionSlots;
     private final ListPartitionItem partitionItem;
     private final ExpressionRewriteContext expressionRewriteContext;
+    // Position-aligned with partitionSlots. A true entry means the corresponding
+    // partition key is the output of a function expression (e.g. date_trunc(dt,'day')),
+    // not the raw slot value. For those positions we must NOT replace the slot with
+    // the stored key literal, because the filter references the raw slot (dt) whose
+    // values do not equal the truncated key. Instead we leave the slot un-bound,
+    // which forces evaluate() to produce a non-boolean, causing PartitionPruner to
+    // keep the partition (safe over-scan rather than unsafe under-scan).
+    private final boolean[] slotHasPartitionFunction;
 
     public OneListPartitionEvaluator(K partitionIdent, List<Slot> partitionSlots,
             ListPartitionItem partitionItem, CascadesContext cascadesContext) {
+        this(partitionIdent, partitionSlots, partitionItem, cascadesContext, null);
+    }
+
+    /**
+     * Constructor with per-position partition expressions. When a position's expression is a
+     * function call (e.g. date_trunc(dt,'day')) the corresponding partition key is the function
+     * output rather than the raw slot value; we skip literal binding for that slot to keep the
+     * partition (safe over-scan) instead of misjudging equality with the truncated key.
+     */
+    public OneListPartitionEvaluator(K partitionIdent, List<Slot> partitionSlots,
+            ListPartitionItem partitionItem, CascadesContext cascadesContext,
+            List<Expr> partitionExprs) {
         this.partitionIdent = partitionIdent;
         this.partitionSlots = Objects.requireNonNull(partitionSlots, "partitionSlots cannot be null");
         this.partitionItem = Objects.requireNonNull(partitionItem, "partitionItem cannot be null");
         this.expressionRewriteContext = new ExpressionRewriteContext(
                 Objects.requireNonNull(cascadesContext, "cascadesContext cannot be null"));
+        this.slotHasPartitionFunction = new boolean[partitionSlots.size()];
+        if (partitionExprs != null) {
+            int n = Math.min(partitionSlots.size(), partitionExprs.size());
+            for (int i = 0; i < n; i++) {
+                slotHasPartitionFunction[i] = partitionExprs.get(i) instanceof FunctionCallExpr;
+            }
+        }
     }
 
     @Override
@@ -76,6 +105,13 @@ public class OneListPartitionEvaluator<K>
         ImmutableList.Builder<Map<Slot, PartitionSlotInput>> inputs
                 = ImmutableList.builderWithExpectedSize(partitionItem.getItems().size());
         Slot slot = partitionSlots.get(0);
+        // If this slot's partition key is a function output, we cannot substitute
+        // the raw slot with the stored literal. Emit a single empty binding: every
+        // predicate referencing this slot stays symbolic and the partition is kept.
+        if (slotHasPartitionFunction[0]) {
+            inputs.add(ImmutableMap.of());
+            return inputs.build();
+        }
         for (PartitionKey item : partitionItem.getItems()) {
             LiteralExpr legacy = item.getKeys().get(0);
             inputs.add(ImmutableMap.of(
@@ -94,15 +130,21 @@ public class OneListPartitionEvaluator<K>
                             .map(literal -> Literal.fromLegacyLiteral(literal, literal.getType()))
                             .collect(ImmutableList.toImmutableList());
 
-                    return IntStream.range(0, partitionSlots.size())
-                            .mapToObj(index -> {
-                                Slot partitionSlot = partitionSlots.get(index);
-                                // partitionSlot will be replaced to this literal
-                                Literal literal = literals.get(index);
-                                // list partition don't need to compute the slot's range,
-                                // so we pass through an empty map
-                                return Pair.of(partitionSlot, new PartitionSlotInput(literal, ImmutableMap.of()));
-                            }).collect(ImmutableMap.toImmutableMap(Pair::key, Pair::value));
+                    Map<Slot, PartitionSlotInput> row = new HashMap<>();
+                    IntStream.range(0, partitionSlots.size()).forEach(index -> {
+                        // Skip binding for positions whose partition key came from a function
+                        // expression: leaving the slot un-bound is the safe default that
+                        // avoids incorrect equality against the truncated key.
+                        if (slotHasPartitionFunction[index]) {
+                            return;
+                        }
+                        Slot partitionSlot = partitionSlots.get(index);
+                        Literal literal = literals.get(index);
+                        // list partition don't need to compute the slot's range,
+                        // so we pass through an empty map
+                        row.put(partitionSlot, new PartitionSlotInput(literal, ImmutableMap.of()));
+                    });
+                    return ImmutableMap.copyOf(row);
                 }).collect(ImmutableList.toImmutableList());
     }
 
@@ -126,6 +168,12 @@ public class OneListPartitionEvaluator<K>
             if (inPredicate.optionsContainsNullLiteral()) {
                 return NullLiteral.BOOLEAN_INSTANCE;
             }
+            // If the compare expression is still a Slot (i.e. it references a slot whose
+            // partition key is a function output and therefore un-bound), we cannot conclude
+            // FALSE — fall through to the default rewriter which returns a non-boolean.
+            if (!(newCompareExpr instanceof Literal)) {
+                return super.visitInPredicate(inPredicate, context);
+            }
             return BooleanLiteral.FALSE;
         } catch (Throwable t) {
             // slow path
@@ -145,7 +193,10 @@ public class OneListPartitionEvaluator<K>
 
     @Override
     public Expression visitSlot(Slot slot, Map<Slot, PartitionSlotInput> context) {
-        // replace partition slot to literal
+        // replace partition slot to literal, but only when it is bound.
+        // Unbound slots (partition function positions) stay as-is so that any
+        // predicate referencing them cannot fold to a boolean and the partition
+        // is conservatively retained.
         PartitionSlotInput partitionSlotInput = context.get(slot);
         return partitionSlotInput == null ? slot : partitionSlotInput.result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules.expression.rules;
 
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.catalog.ListPartitionItem;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.RangePartitionItem;
@@ -143,7 +145,7 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
             Map<K, PartitionItem> idToPartitions, CascadesContext cascadesContext,
             PartitionTableType partitionTableType) {
         PartitionPruneResult<K> result = pruneWithResult(partitionSlots, partitionPredicate, idToPartitions,
-                cascadesContext, partitionTableType, Optional.empty());
+                cascadesContext, partitionTableType, Optional.empty(), null);
         return Pair.of(result.partitions, result.prunedPartitionPredicate);
     }
 
@@ -155,7 +157,7 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
             Map<K, PartitionItem> idToPartitions, CascadesContext cascadesContext,
             PartitionTableType partitionTableType, Optional<SortedPartitionRanges<K>> sortedPartitionRanges) {
         PartitionPruneResult<K> result = pruneWithResult(partitionSlots, partitionPredicate, idToPartitions,
-                cascadesContext, partitionTableType, sortedPartitionRanges);
+                cascadesContext, partitionTableType, sortedPartitionRanges, null);
         return Pair.of(result.partitions, result.prunedPartitionPredicate);
     }
 
@@ -164,11 +166,25 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
             Expression partitionPredicate,
             Map<K, PartitionItem> idToPartitions, CascadesContext cascadesContext,
             PartitionTableType partitionTableType, Optional<SortedPartitionRanges<K>> sortedPartitionRanges) {
+        return pruneWithResult(partitionSlots, partitionPredicate, idToPartitions,
+                cascadesContext, partitionTableType, sortedPartitionRanges, null);
+    }
+
+    /**
+     * prune partition with `idToPartitions` and per-slot partition expressions.
+     * partitionExprs is position-aligned with partitionSlots; a FunctionCallExpr entry means
+     * that slot's partition key is the function's output, not the raw column value.
+     */
+    public static <K extends Comparable<K>> PartitionPruneResult<K> pruneWithResult(List<Slot> partitionSlots,
+            Expression partitionPredicate,
+            Map<K, PartitionItem> idToPartitions, CascadesContext cascadesContext,
+            PartitionTableType partitionTableType, Optional<SortedPartitionRanges<K>> sortedPartitionRanges,
+            List<Expr> partitionExprs) {
         long startAt = System.currentTimeMillis();
         try {
             return pruneInternal(partitionSlots, partitionPredicate, idToPartitions, cascadesContext,
                     partitionTableType,
-                    sortedPartitionRanges);
+                    sortedPartitionRanges, partitionExprs);
         } finally {
             SummaryProfile profile = SummaryProfile.getSummaryProfile(cascadesContext.getConnectContext());
             if (profile != null) {
@@ -181,7 +197,8 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
             List<Slot> partitionSlots,
             Expression partitionPredicate,
             Map<K, PartitionItem> idToPartitions, CascadesContext cascadesContext,
-            PartitionTableType partitionTableType, Optional<SortedPartitionRanges<K>> sortedPartitionRanges) {
+            PartitionTableType partitionTableType, Optional<SortedPartitionRanges<K>> sortedPartitionRanges,
+            List<Expr> partitionExprs) {
         partitionPredicate = PartitionPruneExpressionExtractor.extract(
                 partitionPredicate, ImmutableSet.copyOf(partitionSlots), cascadesContext);
         Expression originalPartitionPredicate = partitionPredicate;
@@ -201,13 +218,28 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
             return new PartitionPruneResult<>(ImmutableList.<K>of(), Optional.empty(), true);
         }
 
-        if (sortedPartitionRanges.isPresent()) {
+        // Binary-search filtering compares raw predicate values against stored partition
+        // key literals. When any partition slot's key is the output of a function expression
+        // (e.g. from_unixtime(bigint) -> varchar), the partition key type differs from the
+        // raw column type; direct comparison would throw a "cannot compare different types"
+        // error. Fall back to sequential filtering, which drives per-position evaluator
+        // logic that safely skips function-expression positions.
+        boolean hasPartitionFunction = false;
+        if (partitionExprs != null) {
+            for (Expr e : partitionExprs) {
+                if (e instanceof FunctionCallExpr) {
+                    hasPartitionFunction = true;
+                    break;
+                }
+            }
+        }
+        if (!hasPartitionFunction && sortedPartitionRanges.isPresent()) {
             RangeSet<MultiColumnBound> predicateRanges = partitionPredicate.accept(
                     new PartitionPredicateToRange(partitionSlots), null);
             if (predicateRanges != null) {
                 Pair<List<K>, Boolean> res = binarySearchFiltering(
                         sortedPartitionRanges.get(), partitionSlots, partitionPredicate, cascadesContext,
-                        expandThreshold, predicateRanges
+                        expandThreshold, predicateRanges, partitionExprs
                 );
                 boolean hasPartitionPredicate = hasEffectivePartitionPredicate(res.first, idToPartitions.size());
                 if (res.second) {
@@ -220,7 +252,7 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
         }
 
         Pair<List<K>, Boolean> res = sequentialFiltering(
-                idToPartitions, partitionSlots, partitionPredicate, cascadesContext, expandThreshold
+                idToPartitions, partitionSlots, partitionPredicate, cascadesContext, expandThreshold, partitionExprs
         );
         boolean hasPartitionPredicate = hasEffectivePartitionPredicate(res.first, idToPartitions.size());
         if (res.second) {
@@ -241,9 +273,21 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
      */
     public static <K> OnePartitionEvaluator<K> toPartitionEvaluator(K id, PartitionItem partitionItem,
             List<Slot> partitionSlots, CascadesContext cascadesContext, int expandThreshold) {
+        return toPartitionEvaluator(id, partitionItem, partitionSlots, cascadesContext, expandThreshold, null);
+    }
+
+    /**
+     * convert partition item to partition evaluator, with per-slot partition expressions.
+     * When partitionExprs[i] is a FunctionCallExpr, the i-th stored partition key is the
+     * function's output rather than the raw column value, and the evaluator will conservatively
+     * keep the partition instead of doing literal equality on the function output.
+     */
+    public static <K> OnePartitionEvaluator<K> toPartitionEvaluator(K id, PartitionItem partitionItem,
+            List<Slot> partitionSlots, CascadesContext cascadesContext, int expandThreshold,
+            List<Expr> partitionExprs) {
         if (partitionItem instanceof ListPartitionItem) {
             return new OneListPartitionEvaluator<>(
-                    id, partitionSlots, (ListPartitionItem) partitionItem, cascadesContext);
+                    id, partitionSlots, (ListPartitionItem) partitionItem, cascadesContext, partitionExprs);
         } else if (partitionItem instanceof RangePartitionItem) {
             return new OneRangePartitionEvaluator<>(
                     id, partitionSlots, (RangePartitionItem) partitionItem, cascadesContext, expandThreshold);
@@ -255,7 +299,7 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
     private static <K extends Comparable<K>> Pair<List<K>, Boolean> binarySearchFiltering(
             SortedPartitionRanges<K> sortedPartitionRanges, List<Slot> partitionSlots,
             Expression partitionPredicate, CascadesContext cascadesContext, int expandThreshold,
-            RangeSet<MultiColumnBound> predicateRanges) {
+            RangeSet<MultiColumnBound> predicateRanges, List<Expr> partitionExprs) {
         List<PartitionItemAndRange<K>> sortedPartitions = sortedPartitionRanges.sortedPartitions;
 
         Set<K> selectedIdSets = Sets.newTreeSet();
@@ -300,7 +344,8 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
                 }
 
                 OnePartitionEvaluator<K> partitionEvaluator = toPartitionEvaluator(
-                        partitionId, partition.partitionItem, partitionSlots, cascadesContext, expandThreshold);
+                        partitionId, partition.partitionItem, partitionSlots, cascadesContext,
+                        expandThreshold, partitionExprs);
                 Pair<Boolean, Boolean> res = canBePrunedOut(partitionPredicate, partitionEvaluator);
                 if (!res.first) {
                     selectedIdSets.add(partitionId);
@@ -312,7 +357,8 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
         for (PartitionItemAndId<K> defaultPartition : sortedPartitionRanges.defaultPartitions) {
             K partitionId = defaultPartition.id;
             OnePartitionEvaluator<K> partitionEvaluator = toPartitionEvaluator(
-                    partitionId, defaultPartition.partitionItem, partitionSlots, cascadesContext, expandThreshold);
+                    partitionId, defaultPartition.partitionItem, partitionSlots, cascadesContext,
+                    expandThreshold, partitionExprs);
             Pair<Boolean, Boolean> res = canBePrunedOut(partitionPredicate, partitionEvaluator);
             if (!res.first) {
                 selectedIdSets.add(partitionId);
@@ -325,11 +371,12 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
 
     private static <K extends Comparable<K>> Pair<List<K>, Boolean> sequentialFiltering(
             Map<K, PartitionItem> idToPartitions, List<Slot> partitionSlots,
-            Expression partitionPredicate, CascadesContext cascadesContext, int expandThreshold) {
+            Expression partitionPredicate, CascadesContext cascadesContext, int expandThreshold,
+            List<Expr> partitionExprs) {
         List<OnePartitionEvaluator<?>> evaluators = Lists.newArrayListWithCapacity(idToPartitions.size());
         for (Entry<K, PartitionItem> kv : idToPartitions.entrySet()) {
             evaluators.add(toPartitionEvaluator(
-                    kv.getKey(), kv.getValue(), partitionSlots, cascadesContext, expandThreshold));
+                    kv.getKey(), kv.getValue(), partitionSlots, cascadesContext, expandThreshold, partitionExprs));
         }
         PartitionPruner partitionPruner = new PartitionPruner(evaluators, partitionPredicate);
         //TODO: we keep default partition because it's too hard to prune it, we return false in canPrune().

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
@@ -179,7 +179,7 @@ public class PruneOlapScanPartition implements RewriteRuleFactory {
         if (filter != null) {
             return PartitionPruner.pruneWithResult(
                     partitionSlots, filter.getPredicate(), idToPartitions, ctx.cascadesContext,
-                    PartitionTableType.OLAP, sortedPartitionRanges);
+                    PartitionTableType.OLAP, sortedPartitionRanges, partitionInfo.getPartitionExprs());
         } else if (!manuallySpecifiedPartitions.isEmpty()) {
             return new PartitionPruneResult<>(Utils.fastToImmutableList(idToPartitions.keySet()),
                     Optional.empty(), true);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
@@ -1690,8 +1690,11 @@ public class CreateTableInfo {
         for (Expression expr : paritionExprs) {
             if (expr instanceof UnboundFunction) {
                 if (!partitionTableInfo.isAutoPartition()
-                        || partitionTableInfo.getPartitionType() != PartitionType.RANGE.name()) {
-                    throw new AnalysisException("only Auto Range Partition support UnboundFunction");
+                        || (!Objects.equals(partitionTableInfo.getPartitionType(), PartitionType.RANGE.name())
+                                && !Objects.equals(partitionTableInfo.getPartitionType(),
+                                        PartitionType.LIST.name()))) {
+                    throw new AnalysisException(
+                            "only Auto Range/List Partition support UnboundFunction");
                 }
                 UnboundFunction func = (UnboundFunction) expr;
                 List<Expression> children = func.children();
@@ -1703,6 +1706,7 @@ public class CreateTableInfo {
                             func.getExpressionName(), i));
                     }
                 }
+                assertPartitionFormatAcceptable(func);
             } else if (expr instanceof UnboundSlot) {
                 if (partitionTableInfo.isAutoPartition() && Objects.equals(partitionTableInfo.getPartitionType(),
                         PartitionType.RANGE.name())) {
@@ -1710,6 +1714,67 @@ public class CreateTableInfo {
                 }
             } else {
                 throw new AnalysisException("partition expression " + expr.getExpressionName() + " is illegal!");
+            }
+        }
+    }
+
+    /**
+     * Reject partition function calls whose granularity is second or minute, which would
+     * create thousands of partitions per hour and blow up metadata. Accepted granularities
+     * are hour / day / month / year.
+     *
+     * date_trunc: rejects unit 'second' and 'minute'.
+     * from_unixtime: rejects any format string that contains sub-hour components (%s, %i,
+     *   :ss, :mm, ss). Format must be a literal; wildcards / dynamic formats are rejected.
+     */
+    private static void assertPartitionFormatAcceptable(UnboundFunction func) {
+        String fn = func.getName().toLowerCase();
+        List<Expression> args = func.children();
+
+        if ("date_trunc".equals(fn)) {
+            // date_trunc(col, unit_literal): 1-arg / non-literal unit is rejected by
+            // function resolution. Only guard the granularity value here.
+            if (args.size() < 2 || !(args.get(1) instanceof Literal)) {
+                return;
+            }
+            String unit = ((Literal) args.get(1)).getStringValue().toLowerCase();
+            if ("second".equals(unit) || "minute".equals(unit)) {
+                throw new AnalysisException(
+                        "date_trunc granularity '" + unit + "' is not allowed for auto partition "
+                                + "(would create up to 86400 partitions per day). "
+                                + "Use 'hour', 'day', 'month' or 'year' instead.");
+            }
+            return;
+        }
+
+        if ("from_unixtime".equals(fn)) {
+            if (args.size() < 2) {
+                throw new AnalysisException(
+                        "from_unixtime in auto partition requires an explicit format literal "
+                                + "(e.g. 'yyyy-MM-dd' or '%Y-%m-%d').");
+            }
+            Expression fmtExpr = args.get(1);
+            if (!(fmtExpr instanceof Literal)) {
+                throw new AnalysisException(
+                        "from_unixtime in auto partition requires a string literal format.");
+            }
+            String fmt = ((Literal) fmtExpr).getStringValue();
+            String norm = fmt.toLowerCase();
+            // MySQL-style seconds/minutes markers
+            if (norm.contains("%s") || norm.contains("%i")) {
+                throw new AnalysisException(
+                        "from_unixtime format '" + fmt + "' contains sub-hour granularity "
+                                + "(%s / %i); would create too many partitions. "
+                                + "Use hour or coarser granularity.");
+            }
+            // Java-style seconds/minutes: only flag when a time component 'HH' is present,
+            // because 'mm' as month can appear standalone in date-only formats like 'yyyy-MM'.
+            boolean hasHour = norm.contains("hh");
+            if (hasHour && (norm.contains(":ss") || norm.contains(":mm") || norm.endsWith("ss"))) {
+                throw new AnalysisException(
+                        "from_unixtime format '" + fmt + "' contains sub-hour granularity "
+                                + "(minute/second); would create too many partitions. "
+                                + "Use hour or coarser granularity.");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/PartitionTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/PartitionTableInfo.java
@@ -168,11 +168,11 @@ public class PartitionTableInfo {
             boolean isExternal) {
 
         if (identifierPartitionColumns != null) {
-
             if (identifierPartitionColumns.size() != partitionList.size()) {
-                if (!isExternal && partitionType.equalsIgnoreCase(PartitionType.LIST.name())) {
-                    throw new AnalysisException("internal catalog does not support functions in 'LIST' partition");
-                }
+                // partitionList has more entries than identifierPartitionColumns iff there are
+                // function expressions (e.g. date_trunc/from_unixtime) in the partition clause.
+                // Both RANGE and LIST accept function expressions; downstream PartitionDesc
+                // will enforce per-partition-type whitelists and column-type constraints.
                 isAutoPartition = true;
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
AUTO PARTITION BY LIST previously accepted only bare column references
while RANGE already supported date_trunc / date_floor / date_ceil.
Extend LIST to accept a whitelist of functions (date_trunc, from_unixtime)
mixed with bare columns at any position, so users can write:

    AUTO PARTITION BY LIST(date_trunc(dt, 'day'), region) ()
    AUTO PARTITION BY LIST(from_unixtime(ts, 'yyyy-MM-dd'), biz) ()

### Release note

Design notes:

- DDL: remove the hard rejection in Nereids PartitionTableInfo, add a
  LIST_PARTITION_FUNCTIONS whitelist in PartitionDesc, and relax
  getColNamesFromExpr's LIST + FunctionCallExpr branch. Column type is
  overridden per-position via a new PartitionExprUtil helper so that
  from_unixtime(BIGINT) -> VARCHAR partition keys stay type-consistent
  without altering the underlying schema column.
- Ingest: no BE change. The existing generic VExpr evaluation and the
  LIST branch of getAddPartitionClauseFromPartitionValues already handle
  multi-column tuples, so wiring is FE-only.
- Pruning: OneListPartitionEvaluator now takes per-slot partitionExprs
  and, at positions whose key is a function output, keeps the partition
  conservatively instead of doing raw literal equality against the
  truncated key (which would silently prune correct partitions and lose
  data). PartitionPruner is extended to plumb partitionExprs down and
  skips the binarySearchFiltering fast path when function partitions are
  present -- that path compares raw predicate values against stored key
  literals and would trigger BIGINT-vs-VARCHAR type errors otherwise.
- SHOW CREATE: ListPartitionInfo.toSql now honors partitionExprs so AUTO
  LIST tables with function expressions round-trip through SHOW CREATE
  correctly instead of downgrading to bare columns.
- Guardrails: a new assertPartitionFormatAcceptable helper is invoked
  from the sole DDL-path chokepoint (InternalCatalog) to reject
  sub-hour granularities (date_trunc 'second'/'minute', from_unixtime
  formats containing %s/%i or HH:...:ss) that would otherwise create
  86400+ partitions per day. from_unixtime also requires an explicit
  string-literal format for the same reason.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

