### PR TITLE
[fix](regression) Retry repository drop on backup lock contention

### DIFF
--- a/regression-test/suites/auth_call/test_ddl_repository_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_repository_auth.groovy
@@ -81,7 +81,20 @@ suite("test_ddl_repository_auth","p0,auth_call") {
         def res = sql """SHOW CREATE REPOSITORY for ${repositoryName};"""
         assertTrue(res.size() > 0)
 
-        sql """DROP REPOSITORY `${repositoryName}`;"""
+        def maxDropRepositoryRetries = 15
+        for (int i = 0; i < maxDropRepositoryRetries; i++) {
+            try {
+                sql """DROP REPOSITORY `${repositoryName}`;"""
+                break
+            } catch (Exception e) {
+                if (i == maxDropRepositoryRetries - 1
+                        || !e.getMessage().contains("Another backup or restore job is being submitted")) {
+                    throw e
+                }
+                logger.warn("drop repository contended on global backup lock, retry ${i + 1}: ${e.getMessage()}")
+                sleep(2000)
+            }
+        }
         test {
             sql """SHOW CREATE REPOSITORY for ${repositoryName};"""
             exception "repository not exist"

--- a/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
@@ -17,7 +17,7 @@
 
 import java.util.UUID
 
-suite("test_ddl_restore_auth", "p0,auth_call") {
+suite("test_ddl_restore_auth", "p0,auth_call,nonConcurrent") {
     String label = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 8)
     def syncer = getSyncer()
 

--- a/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
@@ -17,7 +17,7 @@
 
 import java.util.UUID
 
-suite("test_ddl_restore_auth", "p0,auth_call,nonConcurrent") {
+suite("test_ddl_restore_auth", "p0,auth_call") {
     String label = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 8)
     def syncer = getSyncer()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65668, #65669

Problem Summary:

In P0 build 996774, test_ddl_restore_auth submitted BACKUP SNAPSHOT at 19:40:11.661. The authorized DROP REPOSITORY in test_ddl_repository_auth started 26 ms later and exhausted BackupHandler's 10-second global submission-lock wait before the backup submission returned.

The authorized DROP now retries only the documented transient message "Another backup or restore job is being submitted", with at most 15 attempts and a 2-second interval. All other errors fail immediately.

The follow-up keeps test_ddl_restore_auth in the nonConcurrent SINGLE phase. Review of both lock directions showed that moving it back to NORMAL would also require exact transient handling for required fixed-name setup DROPs and expected-success BACKUP/RESTORE statements. Keeping the existing scheduling isolation is the smallest change that fully covers those orderings.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: regression framework package build passed; the actual suite group was deterministically classified as SINGLE; both related Groovy files compiled; git diff --check passed. Runtime validation will be performed by CI.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
