### PR TITLE
[fix](regression) Avoid midnight race in curdate fold test

### DIFF
--- a/regression-test/suites/datatype_p0/datetimev2/test_curdate_fold.groovy
+++ b/regression-test/suites/datatype_p0/datetimev2/test_curdate_fold.groovy
@@ -18,6 +18,14 @@
 
 suite("test_curdate_fold") {
     def tbName = "test_curdate_fold"
+    def originalTimeZone = sql("SELECT @@session.time_zone")[0][0].toString()
+    onFinish {
+        try_sql "SET time_zone = '${originalTimeZone}'"
+    }
+
+    def utcHour = sql("SELECT HOUR(UTC_TIMESTAMP())")[0][0].toString().toInteger()
+    def safeTimeZone = String.format("%+03d:00", 12 - utcHour)
+    sql "SET time_zone = '${safeTimeZone}'"
 
     sql "DROP TABLE IF EXISTS test_curdate_fold"
     sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`test_curdate_fold` creates rows with `DATE(CURRENT_TIMESTAMP())` and then checks those rows with `CURDATE()` in separate SQL statements. In Cloud P0 build 997105, the inserts ran at 23:59:58 and the first equality check ran just after 00:00:00. The stored dates were therefore from the previous day, so Doris correctly returned an empty result while the static golden expected rows 0 and 1.

This change derives a valid fixed-offset session time zone from `UTC_TIMESTAMP()` so the suite runs around local noon, safely away from the date boundary. The original session time zone is restored through `onFinish`. The table setup, `CURDATE()` predicates, DATETIME precision coverage, and all existing golden results remain unchanged.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test source compilation with `groovyc`
    - [x] Manual validation of all UTC hours 0 through 23; generated offsets stay within `-11:00` through `+12:00`
    - [ ] Exact regression execution (pending a compiled Doris CI environment)
- Behavior changed:
    - [x] No. This only stabilizes test setup time.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
