### PR TITLE
[bugfix](memory) should update memory more quickly when user changes memory in cgroup directly in serveless mode

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1091,6 +1091,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params,
     query_options.batch_size = params.batch_size;
     query_options.execution_timeout = params.execution_timeout;
     query_options.mem_limit = params.mem_limit;
+    query_options.__isset.mem_limit = params.__isset.mem_limit;
     query_options.query_type = TQueryType::EXTERNAL;
     query_options.be_exec_version = BeExecVersionManager::get_newest_version();
     exec_fragment_params.__set_query_options(query_options);

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -157,33 +157,38 @@ QueryContext::QueryContext(TUniqueId query_id, ExecEnv* exec_env,
 }
 
 void QueryContext::_init_query_mem_tracker() {
+    // If user not set query limit, will use default 1TB memory limit. It is large enough to cover most cases.
+    constexpr int64_t DEFAULT_QUERY_MEM_LIMIT = 1LL << 60;
     bool has_query_mem_limit = _query_options.__isset.mem_limit && (_query_options.mem_limit > 0);
-    int64_t bytes_limit = has_query_mem_limit ? _query_options.mem_limit : -1;
-    if (bytes_limit > MemInfo::mem_limit() || bytes_limit == -1) {
-        VLOG_NOTICE << "Query memory limit " << PrettyPrinter::print(bytes_limit, TUnit::BYTES)
+    int64_t user_set_mem_limit =
+            has_query_mem_limit ? _query_options.mem_limit : DEFAULT_QUERY_MEM_LIMIT;
+    int64_t adjusted_mem_limit = user_set_mem_limit;
+    if (adjusted_mem_limit > MemInfo::mem_limit()) {
+        VLOG_NOTICE << "Query memory limit "
+                    << PrettyPrinter::print(user_set_mem_limit, TUnit::BYTES)
                     << " exceeds process memory limit of "
                     << PrettyPrinter::print(MemInfo::mem_limit(), TUnit::BYTES)
-                    << " OR is -1. Using process memory limit instead.";
-        bytes_limit = MemInfo::mem_limit();
+                    << ". Using process memory limit instead.";
+        adjusted_mem_limit = MemInfo::mem_limit();
     }
     // If the query is a pure load task(streamload, routine load, group commit), then it should not use
     // memlimit per query to limit their memory usage.
     if (is_pure_load_task()) {
-        bytes_limit = MemInfo::mem_limit();
+        adjusted_mem_limit = MemInfo::mem_limit();
     }
     std::shared_ptr<MemTrackerLimiter> query_mem_tracker;
     if (_query_options.query_type == TQueryType::SELECT) {
         query_mem_tracker = MemTrackerLimiter::create_shared(
                 MemTrackerLimiter::Type::QUERY, fmt::format("Query#Id={}", print_id(_query_id)),
-                bytes_limit);
+                adjusted_mem_limit);
     } else if (_query_options.query_type == TQueryType::LOAD) {
         query_mem_tracker = MemTrackerLimiter::create_shared(
                 MemTrackerLimiter::Type::LOAD, fmt::format("Load#Id={}", print_id(_query_id)),
-                bytes_limit);
+                adjusted_mem_limit);
     } else if (_query_options.query_type == TQueryType::EXTERNAL) { // spark/flink/etc..
         query_mem_tracker = MemTrackerLimiter::create_shared(
                 MemTrackerLimiter::Type::QUERY, fmt::format("External#Id={}", print_id(_query_id)),
-                bytes_limit);
+                adjusted_mem_limit);
     } else {
         LOG(FATAL) << "__builtin_unreachable";
         __builtin_unreachable();
@@ -201,6 +206,7 @@ void QueryContext::_init_query_mem_tracker() {
     query_mem_tracker->set_enable_check_limit(!(_query_options.__isset.enable_reserve_memory &&
                                                 _query_options.enable_reserve_memory));
     _resource_ctx->memory_context()->set_mem_tracker(query_mem_tracker);
+    _resource_ctx->memory_context()->set_user_set_mem_limit(user_set_mem_limit);
 }
 
 void QueryContext::_init_resource_context() {

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -155,10 +155,7 @@ void WorkloadGroup::check_and_update(const WorkloadGroupInfo& wg_info) {
         return;
     }
     std::lock_guard<std::shared_mutex> wl {_mutex};
-    // In serverless mode, user may modify cgroup's memory limit directly and workload group's config
-    // is not changed. So that we should update workload group's config ignore version.
-    if (wg_info.version > _version ||
-        (wg_info.version == _version && _memory_limit != wg_info.memory_limit)) {
+    if (wg_info.version > _version) {
         _name = wg_info.name;
         _version = wg_info.version;
         _min_cpu_percent = wg_info.min_cpu_percent;
@@ -184,6 +181,38 @@ void WorkloadGroup::check_and_update(const WorkloadGroupInfo& wg_info) {
 
 // MemtrackerLimiter is not removed during query context release, so that should remove it here.
 int64_t WorkloadGroup::refresh_memory_usage() {
+    {
+        // In serverless mode, user may modify cgroup's memory limit directly and workload group's config
+        // is not changed. So that we should update workload group's config ignore version.
+        std::lock_guard<std::shared_mutex> wl {_mutex};
+        const int max_memory_percent = _max_memory_percent.load(std::memory_order_relaxed);
+        const std::string mem_limit_str = fmt::format("{}%", max_memory_percent);
+        bool is_percent = true;
+        const int64_t new_memory_limit =
+                ParseUtil::parse_mem_spec(mem_limit_str, -1, MemInfo::mem_limit(), &is_percent);
+        DCHECK(is_percent) << "mem_limit_str: " << mem_limit_str;
+        if (new_memory_limit != _memory_limit.load(std::memory_order_relaxed)) {
+            LOG(INFO) << fmt::format(
+                    "Workload group id:{}, name:{}, "
+                    "memory_limit changed from {} to {}",
+                    _id, _name,
+                    PrettyPrinter::print(_memory_limit.load(std::memory_order_relaxed),
+                                         TUnit::BYTES),
+                    PrettyPrinter::print(new_memory_limit, TUnit::BYTES));
+
+            _memory_limit.store(new_memory_limit, std::memory_order_relaxed);
+            if (max_memory_percent == 0) {
+                _min_memory_limit.store(0, std::memory_order_relaxed);
+            } else {
+                const int min_memory_percent = _min_memory_percent.load(std::memory_order_relaxed);
+                const int64_t new_min_memory_limit =
+                        static_cast<int64_t>(static_cast<double>(new_memory_limit) *
+                                             min_memory_percent / max_memory_percent);
+                _min_memory_limit.store(new_min_memory_limit, std::memory_order_relaxed);
+            }
+        }
+    }
+
     int64_t fragment_used_memory = 0;
     {
         std::shared_lock<std::shared_mutex> r_lock(_mutex);

--- a/be/src/runtime/workload_management/memory_context.h
+++ b/be/src/runtime/workload_management/memory_context.h
@@ -83,6 +83,10 @@ public:
         adjusted_mem_limit_ = mem_tracker_->limit();
     }
 
+    void set_user_set_mem_limit(int64_t user_set_mem_limit) {
+        user_set_mem_limit_ = user_set_mem_limit;
+    }
+
     // This method is called by workload group manager to set query's memlimit using slot
     // If user set query limit explicitly, then should use less one
     void set_mem_limit(int64_t new_mem_limit) const { mem_tracker_->set_limit(new_mem_limit); }

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -83,6 +83,11 @@ public:
         DCHECK(_s_initialized);
         return _s_mem_limit.load(std::memory_order_relaxed);
     }
+#ifdef BE_TEST
+    static void set_mem_limit_for_test(int64_t mem_limit) {
+        _s_mem_limit.store(mem_limit, std::memory_order_relaxed);
+    }
+#endif
     static inline std::string mem_limit_str() {
         DCHECK(_s_initialized);
         return PrettyPrinter::print(_s_mem_limit.load(std::memory_order_relaxed), TUnit::BYTES);

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -42,6 +42,7 @@
 #include "storage/olap_define.h"
 #include "testutil/mock/mock_query_task_controller.h"
 #include "util/defer_op.h"
+#include "util/mem_info.h"
 
 namespace doris {
 
@@ -150,6 +151,29 @@ private:
 TEST_F(WorkloadGroupManagerTest, get_or_create_workload_group) {
     auto wg = _wg_manager->get_or_create_workload_group({});
     ASSERT_EQ(wg->id(), 0);
+}
+
+TEST_F(WorkloadGroupManagerTest, refresh_memory_usage_updates_memory_limits) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    const int64_t initial_mem_limit = 1024L * 1024 * 1024;
+    MemInfo::set_mem_limit_for_test(initial_mem_limit);
+
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = initial_mem_limit / 2,
+                               .min_memory_percent = 25,
+                               .max_memory_percent = 50};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+
+    EXPECT_EQ(wg->memory_limit(), initial_mem_limit / 2);
+    EXPECT_EQ(wg->min_memory_limit(), initial_mem_limit / 4);
+
+    const int64_t updated_mem_limit = initial_mem_limit * 2;
+    MemInfo::set_mem_limit_for_test(updated_mem_limit);
+    wg->refresh_memory_usage();
+
+    EXPECT_EQ(wg->memory_limit(), updated_mem_limit / 2);
+    EXPECT_EQ(wg->min_memory_limit(), updated_mem_limit / 4);
 }
 
 TEST_F(WorkloadGroupManagerTest, handle_paused_queries_ignores_empty_workload_group) {
@@ -316,8 +340,13 @@ TEST_F(WorkloadGroupManagerTest, wg_reserve_failed_before_query_limit_and_high_w
 // query limit > workload group limit
 // query's limit will be set to workload group limit
 TEST_F(WorkloadGroupManagerTest, wg_exceed3) {
-    WorkloadGroupInfo wg_info {
-            .id = 1, .memory_limit = 1024L * 1024, .slot_mem_policy = TWgSlotMemoryPolicy::NONE};
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 100);
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = 1024L * 1024,
+                               .max_memory_percent = 1,
+                               .slot_mem_policy = TWgSlotMemoryPolicy::NONE};
     auto wg = _wg_manager->get_or_create_workload_group(wg_info);
     auto query_context = _generate_on_query(wg);
 
@@ -358,6 +387,9 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed3) {
 
 // TWgSlotMemoryPolicy::FIXED
 TEST_F(WorkloadGroupManagerTest, wg_exceed4) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 100);
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 100,
                                .memory_low_watermark = 80,
@@ -395,6 +427,9 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed4) {
 
 // TWgSlotMemoryPolicy::DYNAMIC
 TEST_F(WorkloadGroupManagerTest, wg_exceed5) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 100);
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 100,
                                .min_memory_percent = 10,
@@ -520,6 +555,9 @@ TEST_F(WorkloadGroupManagerTest, query_released) {
 }
 
 TEST_F(WorkloadGroupManagerTest, ProcessMemoryNotEnough) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 1000);
     WorkloadGroupInfo wg1_info {.id = 1,
                                 .memory_limit = 1024L * 1024 * 1000,
                                 .min_memory_percent = 10,
@@ -793,6 +831,9 @@ TEST_F(WorkloadGroupManagerTest, cancelled_query_does_not_block_query_mem_exceed
 }
 
 TEST_F(WorkloadGroupManagerTest, recently_cancelled_query_delays_process_mem_exceeded) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 1000);
     WorkloadGroupInfo wg1_info {.id = 1,
                                 .memory_limit = 1024L * 1024 * 1000,
                                 .min_memory_percent = 10,
@@ -905,6 +946,9 @@ TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_dynamic_pol
 // Test Fix 3: For FIXED policy, limit should be correctly set to slot-weighted value.
 // This already worked before the fix, but verify it still works.
 TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_fixed_policy) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 200);
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 200,
                                .memory_low_watermark = 80,

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -885,6 +885,9 @@ TEST_F(WorkloadGroupManagerTest, recently_cancelled_query_delays_process_mem_exc
 // For NONE policy, the old code never called set_mem_limit during refresh (user_set > user_set
 // is always false), so a limit lowered by handle_paused_queries would never recover.
 TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_none_policy) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 200);
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 200,
                                .slot_mem_policy = TWgSlotMemoryPolicy::NONE};
@@ -916,6 +919,9 @@ TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_none_policy
 // query_weighted_mem_limit = wg_high_water_mark which is typically > user_set_mem_limit.
 // The old code's condition (user_set > query_weighted) would be false, preventing restoration.
 TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_dynamic_policy) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 200);
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 200,
                                .memory_low_watermark = 80,
@@ -978,6 +984,9 @@ TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_fixed_polic
 // Test: When WG concurrency decreases (queries finish), remaining queries should get
 // higher per-query limits in FIXED policy.
 TEST_F(WorkloadGroupManagerTest, limit_increases_when_concurrency_decreases) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 200);
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 200,
                                .memory_low_watermark = 80,

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -251,7 +251,7 @@ TEST_F(WorkloadGroupManagerTest, query_exceed) {
 //                    query_ctx->get_mem_tracker()->consumption() + query_it->reserve_size_)
 TEST_F(WorkloadGroupManagerTest, wg_exceed1) {
     auto wg = _wg_manager->get_or_create_workload_group({});
-    auto query_context = _generate_on_query(wg);
+    auto query_context = _generate_on_query(wg, 1024L * 1024 * 128, true);
 
     query_context->query_mem_tracker()->consume(1024L * 1024 * 1024 * 4);
     _wg_manager->add_paused_query(query_context->resource_ctx(), 1024L,
@@ -509,7 +509,7 @@ TEST_F(WorkloadGroupManagerTest, overcommit) {
     auto wg = _wg_manager->get_or_create_workload_group(wg_info);
     EXPECT_EQ(wg->id(), wg_info.id);
 
-    auto query_context = _generate_on_query(wg);
+    auto query_context = _generate_on_query(wg, 1024L * 1024 * 128, true);
 
     _wg_manager->add_paused_query(query_context->resource_ctx(), 1024L * 1024 * 1024,
                                   Status::Error(ErrorCode::WORKLOAD_GROUP_MEMORY_EXCEEDED, "test"));

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -102,10 +102,12 @@ protected:
 
 private:
     std::shared_ptr<QueryContext> _generate_on_query(std::shared_ptr<WorkloadGroup>& wg,
-                                                     int64_t mem_limit = 1024L * 1024 * 128) {
+                                                     int64_t mem_limit = 1024L * 1024 * 128,
+                                                     bool has_mem_limit = false) {
         TQueryOptions query_options;
         query_options.query_type = TQueryType::SELECT;
         query_options.mem_limit = mem_limit;
+        query_options.__isset.mem_limit = has_mem_limit;
         query_options.query_slot_count = 1;
         TNetworkAddress fe_address;
         fe_address.hostname = "127.0.0.1";
@@ -176,6 +178,7 @@ TEST_F(WorkloadGroupManagerTest, refresh_memory_usage_updates_memory_limits) {
     EXPECT_EQ(wg->min_memory_limit(), updated_mem_limit / 4);
 }
 
+<<<<<<< HEAD
 TEST_F(WorkloadGroupManagerTest, handle_paused_queries_ignores_empty_workload_group) {
     auto wg = _wg_manager->get_or_create_workload_group({});
 
@@ -183,6 +186,36 @@ TEST_F(WorkloadGroupManagerTest, handle_paused_queries_ignores_empty_workload_gr
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
     ASSERT_FALSE(_wg_manager->_paused_queries_list.contains(wg));
+=======
+TEST_F(WorkloadGroupManagerTest, refresh_restores_query_limit_after_cgroup_expands) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
+    const int64_t small_mem_limit = 1024L * 1024 * 20;
+    const int64_t large_mem_limit = 1024L * 1024 * 100;
+    MemInfo::set_mem_limit_for_test(small_mem_limit);
+
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = small_mem_limit,
+                               .max_memory_percent = 100,
+                               .slot_mem_policy = TWgSlotMemoryPolicy::NONE};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+    auto query_context = _generate_on_query(wg, large_mem_limit, true);
+    auto query_without_mem_limit = _generate_on_query(wg);
+
+    ASSERT_EQ(query_context->resource_ctx()->memory_context()->mem_limit(), small_mem_limit);
+    ASSERT_EQ(query_context->resource_ctx()->memory_context()->user_set_mem_limit(),
+              large_mem_limit);
+    ASSERT_EQ(query_without_mem_limit->resource_ctx()->memory_context()->mem_limit(),
+              small_mem_limit);
+
+    MemInfo::set_mem_limit_for_test(large_mem_limit);
+    _wg_manager->refresh_workload_group_memory_state();
+
+    ASSERT_EQ(wg->memory_limit(), large_mem_limit);
+    ASSERT_EQ(query_context->resource_ctx()->memory_context()->mem_limit(), large_mem_limit);
+    ASSERT_EQ(query_without_mem_limit->resource_ctx()->memory_context()->mem_limit(),
+              large_mem_limit);
+>>>>>>> f9f6673b274 (set user origin memlimit as a larger value)
 }
 
 // Query is paused due to query memlimit exceed, after waiting in queue for  spill_in_paused_queue_timeout_ms

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -184,6 +184,7 @@ TEST_F(WorkloadGroupManagerTest, handle_paused_queries_ignores_empty_workload_gr
     _wg_manager->handle_paused_queries();
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+    ASSERT_FALSE(_wg_manager->_paused_queries_list.contains(wg));
 }
 
 TEST_F(WorkloadGroupManagerTest, refresh_restores_query_limit_after_cgroup_expands) {
@@ -205,6 +206,8 @@ TEST_F(WorkloadGroupManagerTest, refresh_restores_query_limit_after_cgroup_expan
               large_mem_limit);
     ASSERT_EQ(query_without_mem_limit->resource_ctx()->memory_context()->mem_limit(),
               small_mem_limit);
+    ASSERT_EQ(query_without_mem_limit->resource_ctx()->memory_context()->user_set_mem_limit(),
+              1LL << 60);
 
     MemInfo::set_mem_limit_for_test(large_mem_limit);
     _wg_manager->refresh_workload_group_memory_state();
@@ -219,6 +222,7 @@ TEST_F(WorkloadGroupManagerTest, refresh_restores_query_limit_after_cgroup_expan
 // it should be resumed
 TEST_F(WorkloadGroupManagerTest, query_exceed) {
     auto wg = _wg_manager->get_or_create_workload_group({});
+    auto query_context = _generate_on_query(wg);
 
     query_context->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
     query_context->query_mem_tracker()->consume(1024 * 4);
@@ -921,7 +925,7 @@ TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_none_policy
                                .memory_limit = 1024L * 1024 * 200,
                                .slot_mem_policy = TWgSlotMemoryPolicy::NONE};
     auto wg = _wg_manager->get_or_create_workload_group(wg_info);
-    auto query_context = _generate_on_query(wg);
+    auto query_context = _generate_on_query(wg, 1024L * 1024 * 128, true);
 
     // user_set_mem_limit is set in QueryContext init = query_options.mem_limit = 128MB
     const int64_t user_set = query_context->resource_ctx()->memory_context()->user_set_mem_limit();
@@ -958,7 +962,7 @@ TEST_F(WorkloadGroupManagerTest, update_queries_limit_restores_limit_dynamic_pol
                                .total_query_slot_count = 5,
                                .slot_mem_policy = TWgSlotMemoryPolicy::DYNAMIC};
     auto wg = _wg_manager->get_or_create_workload_group(wg_info);
-    auto query_context = _generate_on_query(wg);
+    auto query_context = _generate_on_query(wg, 1024L * 1024 * 128, true);
 
     const int64_t user_set = query_context->resource_ctx()->memory_context()->user_set_mem_limit();
     ASSERT_EQ(user_set, 1024L * 1024 * 128);

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -178,22 +178,20 @@ TEST_F(WorkloadGroupManagerTest, refresh_memory_usage_updates_memory_limits) {
     EXPECT_EQ(wg->min_memory_limit(), updated_mem_limit / 4);
 }
 
-<<<<<<< HEAD
 TEST_F(WorkloadGroupManagerTest, handle_paused_queries_ignores_empty_workload_group) {
     auto wg = _wg_manager->get_or_create_workload_group({});
 
     _wg_manager->handle_paused_queries();
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
-    ASSERT_FALSE(_wg_manager->_paused_queries_list.contains(wg));
-=======
+}
+
 TEST_F(WorkloadGroupManagerTest, refresh_restores_query_limit_after_cgroup_expands) {
     const int64_t original_mem_limit = MemInfo::mem_limit();
     Defer restore_mem_limit {[&]() { MemInfo::set_mem_limit_for_test(original_mem_limit); }};
     const int64_t small_mem_limit = 1024L * 1024 * 20;
     const int64_t large_mem_limit = 1024L * 1024 * 100;
     MemInfo::set_mem_limit_for_test(small_mem_limit);
-
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = small_mem_limit,
                                .max_memory_percent = 100,
@@ -215,14 +213,12 @@ TEST_F(WorkloadGroupManagerTest, refresh_restores_query_limit_after_cgroup_expan
     ASSERT_EQ(query_context->resource_ctx()->memory_context()->mem_limit(), large_mem_limit);
     ASSERT_EQ(query_without_mem_limit->resource_ctx()->memory_context()->mem_limit(),
               large_mem_limit);
->>>>>>> f9f6673b274 (set user origin memlimit as a larger value)
 }
 
 // Query is paused due to query memlimit exceed, after waiting in queue for  spill_in_paused_queue_timeout_ms
 // it should be resumed
 TEST_F(WorkloadGroupManagerTest, query_exceed) {
     auto wg = _wg_manager->get_or_create_workload_group({});
-    auto query_context = _generate_on_query(wg);
 
     query_context->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
     query_context->query_mem_tracker()->consume(1024 * 4);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

