### PR TITLE
[chore](deps) Upgrade vulnerable FE dependencies

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -522,7 +522,7 @@ under the License.
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
+            <version>${postgresql.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -264,7 +264,7 @@ under the License.
         <cglib.version>2.2</cglib.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-filerupload.version>1.6.0</commons-filerupload.version>
-        <commons-configuration2.version>2.11.0</commons-configuration2.version>
+        <commons-configuration2.version>2.15.1</commons-configuration2.version>
         <commons-codec.version>1.13</commons-codec.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
         <commons-net.version>3.13.0</commons-net.version>
@@ -304,7 +304,7 @@ under the License.
         <!--Need to ensure that the version is the same as in arrow/java/pom.xml or compatible with it.-->
         <grpc.version>1.65.1</grpc.version>
         <check.freamework.version>3.53.0</check.freamework.version>
-        <cel.version>0.12.0</cel.version>
+        <cel.version>0.13.1</cel.version>
         <!-- FE-only Arrow 19 startup POC: align protobuf runtime with Arrow Java 19's protobuf BOM. -->
         <protobuf.version>4.33.4</protobuf.version>
         <!-- we use protoc-jar-maven-plugin to generate protobuf generated code -->
@@ -360,6 +360,7 @@ under the License.
         <httpcore.version>4.4.15</httpcore.version>
         <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
         <mariadb-java-client.version>3.0.9</mariadb-java-client.version>
+        <postgresql.version>42.7.13</postgresql.version>
         <hadoop.version>3.4.2</hadoop.version>
         <re2j.version>1.8</re2j.version>
         <hadoop.thirdparty.guava.version>1.2.0</hadoop.thirdparty.guava.version>
@@ -403,6 +404,9 @@ under the License.
         <asm.version>9.4</asm.version>
         <airlift.concurrent.version>202</airlift.concurrent.version>
         <azure.sdk.version>1.3.7</azure.sdk.version>
+        <azure.core.version>1.58.1</azure.core.version>
+        <azure.core.http.netty.version>1.16.5</azure.core.http.netty.version>
+        <azure.identity.version>1.18.4</azure.identity.version>
         <azure.sdk.batch.version>12.22.0</azure.sdk.batch.version>
         <msal4j.version>1.25.0</msal4j.version>
         <azure.keyvault.core.version>1.2.6</azure.keyvault.core.version>
@@ -1834,6 +1838,22 @@ under the License.
                 <version>${azure.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Patch the latest Azure BOM with newer stable component releases. -->
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-core</artifactId>
+                <version>${azure.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-core-http-netty</artifactId>
+                <version>${azure.core.http.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-identity</artifactId>
+                <version>${azure.identity.version}</version>
             </dependency>
             <!-- Pulled in by azure-identity and msal4j-persistence-extension. -->
             <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -270,7 +270,7 @@ under the License.
         <commons-net.version>3.13.0</commons-net.version>
         <commons-pool2.version>2.2</commons-pool2.version>
         <commons-pool.version>1.5.1</commons-pool.version>
-        <commons-text.version>1.10.0</commons-text.version>
+        <commons-text.version>1.15.0</commons-text.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-validator.version>1.9.0</commons-validator.version>
         <gson.version>2.10.1</gson.version>
@@ -304,7 +304,7 @@ under the License.
         <!--Need to ensure that the version is the same as in arrow/java/pom.xml or compatible with it.-->
         <grpc.version>1.65.1</grpc.version>
         <check.freamework.version>3.53.0</check.freamework.version>
-        <cel.version>0.13.1</cel.version>
+        <cel.version>0.12.0</cel.version>
         <!-- FE-only Arrow 19 startup POC: align protobuf runtime with Arrow Java 19's protobuf BOM. -->
         <protobuf.version>4.33.4</protobuf.version>
         <!-- we use protoc-jar-maven-plugin to generate protobuf generated code -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -404,9 +404,6 @@ under the License.
         <asm.version>9.4</asm.version>
         <airlift.concurrent.version>202</airlift.concurrent.version>
         <azure.sdk.version>1.3.7</azure.sdk.version>
-        <azure.core.version>1.58.1</azure.core.version>
-        <azure.core.http.netty.version>1.16.5</azure.core.http.netty.version>
-        <azure.identity.version>1.18.4</azure.identity.version>
         <azure.sdk.batch.version>12.22.0</azure.sdk.batch.version>
         <msal4j.version>1.25.0</msal4j.version>
         <azure.keyvault.core.version>1.2.6</azure.keyvault.core.version>
@@ -1838,22 +1835,6 @@ under the License.
                 <version>${azure.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <!-- Patch the latest Azure BOM with newer stable component releases. -->
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-core</artifactId>
-                <version>${azure.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-core-http-netty</artifactId>
-                <version>${azure.core.http.netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-identity</artifactId>
-                <version>${azure.identity.version}</version>
             </dependency>
             <!-- Pulled in by azure-identity and msal4j-persistence-extension. -->
             <dependency>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:
This PR upgrades FE dependencies that are directly controlled by the Maven POMs and were reported with CVEs by dependency-check on the `rich/master` baseline.

Upgraded because dependency-check reported CVEs:
- `commons-configuration2` `2.11.0` -> `2.15.1` (CVE-2026-45205, MEDIUM)
- `postgresql` `42.7.3` -> `42.7.13` (CVE-2026-42198, HIGH)

Required companion upgrade (not a CVE fix):
- `commons-text` `1.10.0` -> `1.15.0`

  `commons-configuration2:2.15.1` is compiled against `commons-text:1.15.0` and its
  `org.apache.commons.configuration2.interpol.StringLookupAdapter` calls
  `StringLookup.apply(String)`. That method only exists once `StringLookup` extends
  `UnaryOperator` (1.15.0); `commons-text:1.10.0` declares `lookup(String)` only.
  Leaving Text pinned at 1.10.0 would therefore make any interpolation path that goes
  through `StringLookupAdapter` (e.g. Hadoop `MetricsConfig` resolving `${sys:user.home}`)
  fail with `NoSuchMethodError` at runtime. 1.15.0 still contains the Text4Shell
  (CVE-2022-42889) fix that 1.10.0 was originally pinned for, so this is not a CVE regression.

Notable upstream behavior change (documented, no Doris code change):
- `commons-configuration2:2.15.1` adds a URL-scheme allow-list to file/URL location loading.
  `AbstractFileLocationStrategy` now defaults `DEFAULT_SCHEMES` to `file,jar` and rejects any
  other scheme with `ConfigurationDeniedException` (complete overridable set: `file,http,https,jar`).
  This is an upstream security hardening (mitigates loading configuration from arbitrary remote
  URLs). A configuration that pulls a remote include over `http`/`https` -- e.g. a Hadoop
  `hadoop-metrics2*.properties` with `include = https://...` -- will now fail to load by default.
  Doris does not ship such a configuration, so there is no expected impact; a deployment that
  genuinely relied on remote includes can restore the old behavior with the system property
  `-Dorg.apache.commons.configuration2.io.FileLocationStrategy.schemes=file,http,https,jar`.
  We deliberately do not re-open `http`/`https` by default, as that would undo the upstream fix.

Deliberately NOT changed:
- `dev.cel` stays at `0.12.0`. An earlier revision of this PR bumped it to `0.13.1`, but
  dependency-check reports **zero** vulnerabilities for `cel-0.12.0.jar` (no suppressions), and
  there is no published CVE/GHSA for `dev.cel` / `cel-java`. The bump carried real risk for no
  security benefit: `0.13.1` ships a new `dev.cel.runtime.planner` evaluation engine and can
  broaden the accepted CEL dialect, which matters because `RoleMappingMgr` validates a mapping
  only on the creating FE and journals the source expression, while replay stores it without
  compiling and `DefinitionBackedRoleMappingEvaluator` recompiles it lazily at authentication
  time. During a mixed-version rollout that could turn into an authentication failure on a
  not-yet-upgraded FE. Reverting the bump removes that exposure entirely.
- Azure SDK components are left at the versions managed by `azure-sdk-bom` `1.3.7`. An earlier
  revision overrode `azure-core`/`azure-core-http-netty`/`azure-identity` to newer patch levels,
  but BOM `1.3.7` already manages `azure-core 1.58.0`, `azure-identity 1.18.3` and
  `azure-security-keyvault-keys 4.10.7` -- all at or above their fixed versions -- and no FE
  module declares `azure-security-keyvault-keys` (the artifact CVE-2026-33117 affects). The
  overrides therefore remediated no shipped vulnerable coordinate and only added BOM skew, so
  they were dropped.

The refreshed dependency-check JSON no longer contains the old direct vulnerable coordinates
`commons-configuration2@2.11.0` or `postgresql@42.7.3`. Some remaining findings are still
reported for shaded/bundled dependencies or CPE matches that are not safely removable through
a small POM-only change.

### Release note

None

### Check List (For Author)

- Test:
    - `env DORIS_THIRDPARTY=/mnt/disk1/gq/idea/thirdparty mvn -pl fe-core -am install -DskipTests -Dskip.doc=true -Dmaven.build.cache.enabled=false`
    - `mvn org.owasp:dependency-check-maven:12.2.0:aggregate -Dformat=ALL -DfailBuildOnCVSS=11 -DfailOnError=false -DnvdApiServerId=nvd-api-key -DnvdValidForHours=2160 -Dmaven.build.cache.enabled=false -DyarnAuditAnalyzerEnabled=false -DretireJsAnalyzerEnabled=false -DassemblyAnalyzerEnabled=false -DnugetconfAnalyzerEnabled=false -DnuspecAnalyzerEnabled=false -DskipTests`
- Behavior changed: Only an upstream commons-configuration2 URL-scheme allow-list (documented above); no Doris-side behavior change and no default configuration ships a remote include.
- Does this need documentation: No
