### PR TITLE
branch-4.1: [fix](packed-file) set tablet_id in CacheContext when writing small file to file cache

### DIFF
--- a/be/src/io/fs/packed_file_manager.cpp
+++ b/be/src/io/fs/packed_file_manager.cpp
@@ -145,6 +145,7 @@ void do_write_to_file_cache(const std::string& small_file_path, const std::strin
     CacheContext ctx;
     ctx.cache_type = expiration_time > 0 ? FileCacheType::TTL : FileCacheType::NORMAL;
     ctx.expiration_time = expiration_time;
+    ctx.tablet_id = tablet_id;
     ReadStatistics stats;
     ctx.stats = &stats;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-27148

When a packed small file is written to the file cache, `do_write_to_file_cache()` did not set `ctx.tablet_id`, so the cache block meta was persisted with `tablet_id=0`. As a result:

1. `information_schema.file_cache_info` shows these blocks under `tablet_id=0`, and they cannot be queried by the real tablet id.
2. TTL blocks are not registered to `BlockFileCacheTtlMgr` (registration is skipped when `context.tablet_id == 0`), so the TTL expiration check cannot evict them by tablet.

This was introduced when picking #59892 to this branch: the pick dropped the `ctx.tablet_id = tablet_id;` line that exists on master. This PR restores it, aligning with master.

Note: existing cache meta already persisted with `tablet_id=0` will not be rewritten automatically; it is corrected only when the block is evicted and cached again.

### Release note

Fix that file cache blocks written via the packed-file path were recorded with tablet_id=0 in information_schema.file_cache_info.

### Check List (For Author)

- Test
    - [x] Manual test (add detailed scripts or steps below)
    - Verified per DORIS-27148: write small segments that go through the packed-file path, then query `information_schema.file_cache_info` by the real tablet ids and confirm blocks are no longer recorded under tablet_id=0.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label