### PR TITLE
[fix](regression) support MOW compaction case in both modes

### DIFF
--- a/regression-test/suites/compaction/test_mow_compact_multi_segments.groovy
+++ b/regression-test/suites/compaction/test_mow_compact_multi_segments.groovy
@@ -208,6 +208,7 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
     assertEquals(code, 0)
     def compactJson = parseJson(out.trim())
     logger.info("compact json: " + compactJson)
+    waitForCompaction(tablet)
     // check generate 1 segment
     waitForTabletSegmentNum(tablet, 2, 1)
     sql """ select * from ${tableName} limit 1; """

--- a/regression-test/suites/compaction/test_mow_compact_multi_segments.groovy
+++ b/regression-test/suites/compaction/test_mow_compact_multi_segments.groovy
@@ -23,6 +23,9 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]
     def backendId_to_params = [string: [:]]
+    def pickInputRowsetsDebugPoint = isCloudMode()
+            ? "CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets"
+            : "SizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets"
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort)
 
     def reset_be_param = { paramName ->
@@ -55,7 +58,7 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
         }
     }
 
-    def getTabletStatus = { tablet, rowsetIndex, lastRowsetSegmentNum, enableAssert = false ->
+    def getTabletSegmentNum = { tablet, rowsetIndex ->
         String compactionUrl = tablet["CompactionStatus"]
         def (code, out, err) = curl("GET", compactionUrl)
         logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -69,11 +72,19 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
         int end_index = rowset.indexOf("DATA")
         def segmentNumStr = rowset.substring(start_index + 1, end_index).trim()
         logger.info("segmentNumStr: ${segmentNumStr}")
-        if (enableAssert) {
-            assertEquals(lastRowsetSegmentNum, Integer.parseInt(segmentNumStr))
-        } else {
-            return lastRowsetSegmentNum == Integer.parseInt(segmentNumStr);
+        return Integer.parseInt(segmentNumStr)
+    }
+
+    def waitForTabletSegmentNum = { tablet, rowsetIndex, expectedSegmentNum ->
+        int actualSegmentNum = -1
+        for (int i = 0; i < 20; i++) {
+            actualSegmentNum = getTabletSegmentNum(tablet, rowsetIndex)
+            if (actualSegmentNum == expectedSegmentNum) {
+                return
+            }
+            sleep(100)
         }
+        assertEquals(expectedSegmentNum, actualSegmentNum)
     }
 
     def getLocalDeleteBitmapStatus = { tablet ->
@@ -186,25 +197,19 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
     sql "sync"
     def rowCount1 = sql """ select count() from ${tableName}; """
     logger.info("rowCount1: ${rowCount1}")
-    // check generate 3 segments
-    getTabletStatus(tablet, 2, 3)
+    // check generate multiple segments
+    assertTrue(getTabletSegmentNum(tablet, 2) > 1)
 
     // trigger compaction
-    GetDebugPoint().enableDebugPointForAllBEs("CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets",
+    GetDebugPoint().enableDebugPointForAllBEs(pickInputRowsetsDebugPoint,
             [tablet_id: "${tablet.TabletId}", start_version: 2, end_version: 2])
     def (code, out, err) = be_run_cumulative_compaction(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
     logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
     assertEquals(code, 0)
     def compactJson = parseJson(out.trim())
     logger.info("compact json: " + compactJson)
-    // check generate 1 segments
-    for (int i = 0; i < 20; i++) {
-        if (getTabletStatus(tablet, 2, 1, false)) {
-            break
-        }
-        sleep(100)
-    }
-    getTabletStatus(tablet, 2, 1)
+    // check generate 1 segment
+    waitForTabletSegmentNum(tablet, 2, 1)
     sql """ select * from ${tableName} limit 1; """
 
     // load 2
@@ -228,13 +233,13 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
     sql "sync"
     def rowCount2 = sql """ select count() from ${tableName}; """
     logger.info("rowCount2: ${rowCount2}")
-    // check generate 3 segments
-    getTabletStatus(tablet, 3, 6)
+    // check generate multiple segments
+    assertTrue(getTabletSegmentNum(tablet, 3) > 1)
     def local_dm = getLocalDeleteBitmapStatus(tablet)
     logger.info("local delete bitmap 1: " + local_dm)
 
     // trigger compaction for load 2
-    GetDebugPoint().enableDebugPointForAllBEs("CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets",
+    GetDebugPoint().enableDebugPointForAllBEs(pickInputRowsetsDebugPoint,
             [tablet_id: "${tablet.TabletId}", start_version: 3, end_version: 3])
     (code, out, err) = be_run_cumulative_compaction(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
     logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
@@ -242,14 +247,8 @@ suite("test_mow_compact_multi_segments", "nonConcurrent") {
     compactJson = parseJson(out.trim())
     logger.info("compact json: " + compactJson)
     waitForCompaction(tablet)
-    // check generate 1 segments
-    for (int i = 0; i < 20; i++) {
-        if (getTabletStatus(tablet, 3, 1, false)) {
-            break
-        }
-        sleep(100)
-    }
-    getTabletStatus(tablet, 3, 1)
+    // check generate 1 segment
+    waitForTabletSegmentNum(tablet, 3, 1)
 
     GetDebugPoint().enableDebugPointForAllBEs("DeleteBitmapAction._handle_show_local_delete_bitmap_count.vacuum_stale_rowsets") // cloud
     GetDebugPoint().enableDebugPointForAllBEs("DeleteBitmapAction._handle_show_local_delete_bitmap_count.start_delete_unused_rowset") // local


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-26710

Related PR: #64954

Problem Summary:

`test_mow_compact_multi_segments` always enabled the cloud cumulative-compaction rowset-selection debug point. In local storage mode that hook was ignored, so the updated default policy could legally merge versions 2 and 3. The case then failed because it still expected a separate third rowset.

This patch selects the rowset-selection debug point according to `isCloudMode()`:

- cloud mode uses `CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets`
- local mode uses `SizeBasedCumulativeCompactionPolicy::pick_input_rowsets.set_input_rowsets`

It also replaces stale exact input segment counts with the intended semantic checks: each selected input rowset must contain multiple segments before compaction and exactly one segment afterward. The existing query and stale delete-bitmap cleanup coverage is preserved.

### Release note

None

### Check List (For Author)

- Test:
  - Regression framework compilation passed.
  - The modified suite compiled successfully with Groovy 4.0.19.
  - Target-file `git diff --check` passed.
  - Exact local/cloud runtime regression is pending a confirmed test environment.
- Behavior changed: No
- Does this need documentation: No
