### PR TITLE
[fix](catalog) Materialize external table remote names during construction

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -117,7 +117,9 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
             TableType type) {
         this.id = id;
         this.name = name;
-        this.remoteName = remoteName;
+        // External tables are rebuilt lazily, so materialize the fallback before publication
+        // instead of relying on a persistence callback that the live reconstruction path does not use.
+        this.remoteName = Strings.isNullOrEmpty(remoteName) ? name : remoteName;
         this.catalog = catalog;
         this.db = db;
         this.dbName = db.getFullName();
@@ -399,9 +401,6 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     @Override
     public void gsonPostProcess() throws IOException {
         objectCreated = false;
-        // Older metadata may not contain remoteName. Materialize the same fallback
-        // used by getRemoteName() so no metadata path can observe a null table name.
-        remoteName = getRemoteName();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -399,6 +399,9 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     @Override
     public void gsonPostProcess() throws IOException {
         objectCreated = false;
+        // Older metadata may not contain remoteName. Materialize the same fallback
+        // used by getRemoteName() so no metadata path can observe a null table name.
+        remoteName = getRemoteName();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/PluginDrivenExternalTableEngineTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/PluginDrivenExternalTableEngineTest.java
@@ -100,6 +100,17 @@ public class PluginDrivenExternalTableEngineTest {
     }
 
     @Test
+    public void testGsonPostProcessRestoresMissingRemoteName() throws Exception {
+        PluginDrivenExternalTable table = createTableWithCatalogType("jdbc");
+        table.setRemoteName(null);
+
+        table.gsonPostProcess();
+
+        Assertions.assertEquals("test_table", table.remoteName,
+                "Deserialized external tables should materialize the effective remote table name");
+    }
+
+    @Test
     public void testInitSchemaReturnsEmptyWhenTableHandleMissing() {
         Connector connector = createMockConnector(false, false);
         PluginDrivenExternalTable table = createTableWithCatalogType("jdbc", connector);

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/PluginDrivenExternalTableEngineTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/PluginDrivenExternalTableEngineTest.java
@@ -100,14 +100,11 @@ public class PluginDrivenExternalTableEngineTest {
     }
 
     @Test
-    public void testGsonPostProcessRestoresMissingRemoteName() throws Exception {
-        PluginDrivenExternalTable table = createTableWithCatalogType("jdbc");
-        table.setRemoteName(null);
-
-        table.gsonPostProcess();
-
+    public void testConstructorMaterializesMissingRemoteName() {
+        PluginDrivenExternalTable table = createTableWithCatalogType(
+                "jdbc", createMockConnector(true, false), null);
         Assertions.assertEquals("test_table", table.remoteName,
-                "Deserialized external tables should materialize the effective remote table name");
+                "New external tables should materialize the effective remote table name");
     }
 
     @Test
@@ -139,13 +136,18 @@ public class PluginDrivenExternalTableEngineTest {
     }
 
     private PluginDrivenExternalTable createTableWithCatalogType(String catalogType, Connector connector) {
+        return createTableWithCatalogType(catalogType, connector, "test_table");
+    }
+
+    private PluginDrivenExternalTable createTableWithCatalogType(
+            String catalogType, Connector connector, String remoteName) {
         TestablePluginCatalog catalog = new TestablePluginCatalog(catalogType, connector);
         ExternalDatabase<PluginDrivenExternalTable> db = mockExternalDatabase();
         Mockito.when(db.getFullName()).thenReturn("test_db");
         Mockito.when(db.getRemoteName()).thenReturn("test_db");
 
         PluginDrivenExternalTable table = new PluginDrivenExternalTable(
-                1L, "test_table", "test_table", catalog, db);
+                1L, "test_table", remoteName, catalog, db);
         return table;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

External tables on current master are rebuilt lazily through live construction paths. They are not restored from persisted table JSON, so a fallback placed in Gson post-processing does not protect production reconstruction.

`getRemoteName()` already treats a null or empty remote name as the local table name, but the underlying field can still remain null when a caller constructs an external table without a remote name. Any metadata path that reads the stored state directly can then observe a value that differs from the public getter.

### How was it fixed?

Materialize the existing fallback in the `ExternalTable` constructor, before the rebuilt object is published. Explicit remote-name mappings remain unchanged.

The regression test now exercises the production construction boundary instead of manually invoking Gson post-processing.

### Release note

Fix external table construction when the remote table name is missing.

### Check List (For Author)

- Test
    - [x] Unit Test: `PluginDrivenExternalTableEngineTest`
- Behavior changed:
    - [x] No. This materializes the fallback already defined by `getRemoteName()`.
- Does this need documentation?
    - [x] No.