### PR TITLE
[be](serde) support more arrow::Type in read_column_from_arrow

### DIFF
--- a/be/src/core/data_type_serde/arrow_validation.h
+++ b/be/src/core/data_type_serde/arrow_validation.h
@@ -93,6 +93,16 @@ inline std::shared_ptr<arrow::Int32Array> get_int32_offsets_array(const arrow::A
     return offsets;
 }
 
+inline std::shared_ptr<arrow::Int64Array> get_int64_offsets_array(
+        const arrow::LargeListArray& array) {
+    auto offsets_array = array.offsets();
+    auto offsets = std::dynamic_pointer_cast<arrow::Int64Array>(offsets_array);
+    if (UNLIKELY(!offsets)) {
+        throw_invalid_arrow(array, "offsets array is not Int64Array");
+    }
+    return offsets;
+}
+
 } // namespace arrow_validation_detail
 
 inline void check_arrow_no_offset(const arrow::Array& array) {
@@ -207,6 +217,20 @@ inline void check_arrow_value_range(const arrow::Array& array, int64_t offset, i
     }
 }
 
+// Validate two variable-width value offsets before subtracting them. Keeping the endpoints
+// separate avoids signed overflow on malformed int64 offsets.
+inline int64_t check_arrow_value_offsets(const arrow::Array& array, int64_t start_offset,
+                                         int64_t end_offset, size_t buffer_size) {
+    if (UNLIKELY(start_offset < 0 || end_offset < start_offset)) {
+        arrow_validation_detail::throw_invalid_arrow(
+                array, "value offsets are invalid: start_offset={}, end_offset={}", start_offset,
+                end_offset);
+    }
+    const int64_t length = end_offset - start_offset;
+    check_arrow_value_range(array, start_offset, length, buffer_size);
+    return length;
+}
+
 namespace arrow_validation_detail {
 
 // Offsets buffers may come from external Arrow producers through Buffer::Wrap or FFI and are not
@@ -218,23 +242,29 @@ inline int32_t read_int32_offset(const arrow::Int32Array& offsets, int64_t index
     return unaligned_load<int32_t>(data + index * sizeof(int32_t));
 }
 
-inline int64_t check_arrow_offsets_range(const arrow::Int32Array& offsets, int64_t start,
-                                         int64_t end) {
+inline int64_t read_int64_offset(const arrow::Int64Array& offsets, int64_t index) {
+    const auto* data = reinterpret_cast<const uint8_t*>(offsets.raw_values());
+    return unaligned_load<int64_t>(data + index * sizeof(int64_t));
+}
+
+template <typename OffsetArray, typename ReadOffset>
+inline int64_t check_arrow_offsets_range(const OffsetArray& offsets, size_t offset_size,
+                                         ReadOffset&& read_offset, int64_t start, int64_t end) {
     check_arrow_array_range(offsets, 0, offsets.length());
-    check_arrow_fixed_width_buffer(offsets, sizeof(int32_t));
+    check_arrow_fixed_width_buffer(offsets, offset_size);
     if (UNLIKELY(start < 0 || end < start || end >= offsets.length())) {
         arrow_validation_detail::throw_invalid_arrow(
                 offsets, "offsets read range is invalid: start={}, end={}, offsets_length={}",
                 start, end, offsets.length());
     }
 
-    int64_t previous_offset = read_int32_offset(offsets, start);
+    int64_t previous_offset = read_offset(offsets, start);
     if (UNLIKELY(previous_offset < 0)) {
         arrow_validation_detail::throw_invalid_arrow(
                 offsets, "offsets contain negative value: offset[{}]={}", start, previous_offset);
     }
     for (int64_t i = start + 1; i <= end; ++i) {
-        const int64_t current_offset = read_int32_offset(offsets, i);
+        const int64_t current_offset = read_offset(offsets, i);
         if (UNLIKELY(current_offset < previous_offset)) {
             arrow_validation_detail::throw_invalid_arrow(
                     offsets,
@@ -244,6 +274,16 @@ inline int64_t check_arrow_offsets_range(const arrow::Int32Array& offsets, int64
         previous_offset = current_offset;
     }
     return previous_offset;
+}
+
+inline int64_t check_arrow_offsets_range(const arrow::Int32Array& offsets, int64_t start,
+                                         int64_t end) {
+    return check_arrow_offsets_range(offsets, sizeof(int32_t), read_int32_offset, start, end);
+}
+
+inline int64_t check_arrow_offsets_range(const arrow::Int64Array& offsets, int64_t start,
+                                         int64_t end) {
+    return check_arrow_offsets_range(offsets, sizeof(int64_t), read_int64_offset, start, end);
 }
 
 } // namespace arrow_validation_detail
@@ -259,6 +299,47 @@ inline void check_arrow_list_offsets(const arrow::ListArray& array, int64_t star
         arrow_validation_detail::throw_invalid_arrow(
                 array, "offsets exceed values length: last_offset={}, values_length={}",
                 last_offset, values_length);
+    }
+}
+
+// Validate LargeList offsets before reading offsets or recursing into values.
+inline void check_arrow_large_list_offsets(const arrow::LargeListArray& array, int64_t start,
+                                           int64_t end) {
+    check_arrow_array_range(array, start, end);
+    const auto offsets = arrow_validation_detail::get_int64_offsets_array(array);
+    const int64_t last_offset =
+            arrow_validation_detail::check_arrow_offsets_range(*offsets, start, end);
+    const int64_t values_length = array.values() ? array.values()->length() : 0;
+    if (UNLIKELY(last_offset > values_length)) {
+        arrow_validation_detail::throw_invalid_arrow(
+                array, "offsets exceed values length: last_offset={}, values_length={}",
+                last_offset, values_length);
+    }
+}
+
+inline int64_t checked_fixed_size_list_offset(const arrow::FixedSizeListArray& array,
+                                              int64_t index) {
+    const int64_t list_size = array.value_length();
+    if (UNLIKELY(index < 0 || list_size < 0 ||
+                 (list_size != 0 && index > std::numeric_limits<int64_t>::max() / list_size))) {
+        arrow_validation_detail::throw_invalid_arrow(
+                array, "fixed-size list offset overflows: index={}, list_size={}", index,
+                list_size);
+    }
+    return index * list_size;
+}
+
+// Validate FixedSizeList offset arithmetic and its child coverage before recursion.
+inline void check_arrow_fixed_size_list_offsets(const arrow::FixedSizeListArray& array,
+                                                int64_t start, int64_t end) {
+    check_arrow_array_range(array, start, end);
+    static_cast<void>(checked_fixed_size_list_offset(array, start));
+    const int64_t end_offset = checked_fixed_size_list_offset(array, end);
+    const auto& values = array.values();
+    if (UNLIKELY(!values || end_offset > values->length())) {
+        arrow_validation_detail::throw_invalid_arrow(
+                array, "fixed-size list values are too short: end_offset={}, values_length={}",
+                end_offset, values ? values->length() : 0);
     }
 }
 

--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -322,29 +322,59 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
                                                   const cctz::time_zone& ctz) const {
     auto& column_array = static_cast<ColumnArray&>(column);
     auto& offsets_data = column_array.get_offsets();
-    const auto* concrete_array = dynamic_cast<const arrow::ListArray*>(arrow_array);
-    auto arrow_offsets_array = concrete_array->offsets();
-    auto* arrow_offsets = dynamic_cast<arrow::Int32Array*>(arrow_offsets_array.get());
-    if (config::enable_arrow_input_validation) {
-        check_arrow_list_offsets(*concrete_array, start, end);
-    }
-    auto prev_size = offsets_data.back();
-    const auto* base_offsets_ptr = reinterpret_cast<const uint8_t*>(arrow_offsets->raw_values());
-    const size_t offset_element_size = sizeof(int32_t);
-    const uint8_t* start_offset_ptr = base_offsets_ptr + start * offset_element_size;
-    const uint8_t* end_offset_ptr = base_offsets_ptr + end * offset_element_size;
-    auto arrow_nested_start_offset = unaligned_load<int32_t>(start_offset_ptr);
-    auto arrow_nested_end_offset = unaligned_load<int32_t>(end_offset_ptr);
 
-    for (auto i = start + 1; i < end + 1; ++i) {
-        const uint8_t* current_offset_ptr = base_offsets_ptr + i * offset_element_size;
-        auto current_offset = unaligned_load<int32_t>(current_offset_ptr);
-        // convert to doris offset, start from offsets.back()
-        offsets_data.emplace_back(prev_size + current_offset - arrow_nested_start_offset);
+    const auto read_list = [&](const auto* concrete_array) -> Status {
+        const int64_t arrow_nested_start_offset = concrete_array->value_offset(start);
+        const int64_t arrow_nested_end_offset = concrete_array->value_offset(end);
+        const auto prev_size = offsets_data.back();
+        for (int64_t i = start + 1; i <= end; ++i) {
+            // Convert Arrow offsets to Doris offsets, starting at offsets.back().
+            offsets_data.emplace_back(prev_size + concrete_array->value_offset(i) -
+                                      arrow_nested_start_offset);
+        }
+        return nested_serde->read_column_from_arrow(
+                column_array.get_data(), concrete_array->values().get(), arrow_nested_start_offset,
+                arrow_nested_end_offset, ctz);
+    };
+
+    switch (arrow_array->type_id()) {
+    case arrow::Type::LIST: {
+        const auto* concrete_array = dynamic_cast<const arrow::ListArray*>(arrow_array);
+        if (concrete_array == nullptr) {
+            return Status::InvalidArgument("Expected Arrow ListArray, got {}",
+                                           arrow_array->type()->name());
+        }
+        if (config::enable_arrow_input_validation) {
+            check_arrow_list_offsets(*concrete_array, start, end);
+        }
+        return read_list(concrete_array);
     }
-    return nested_serde->read_column_from_arrow(
-            column_array.get_data(), concrete_array->values().get(), arrow_nested_start_offset,
-            arrow_nested_end_offset, ctz);
+    case arrow::Type::LARGE_LIST: {
+        const auto* concrete_array = dynamic_cast<const arrow::LargeListArray*>(arrow_array);
+        if (concrete_array == nullptr) {
+            return Status::InvalidArgument("Expected Arrow LargeListArray, got {}",
+                                           arrow_array->type()->name());
+        }
+        if (config::enable_arrow_input_validation) {
+            check_arrow_array_range(*concrete_array, start, end);
+        }
+        return read_list(concrete_array);
+    }
+    case arrow::Type::FIXED_SIZE_LIST: {
+        const auto* concrete_array = dynamic_cast<const arrow::FixedSizeListArray*>(arrow_array);
+        if (concrete_array == nullptr) {
+            return Status::InvalidArgument("Expected Arrow FixedSizeListArray, got {}",
+                                           arrow_array->type()->name());
+        }
+        if (config::enable_arrow_input_validation) {
+            check_arrow_array_range(*concrete_array, start, end);
+        }
+        return read_list(concrete_array);
+    }
+    default:
+        return Status::InvalidArgument("Unsupported Arrow array type for Doris ARRAY: {}",
+                                       arrow_array->type()->name());
+    }
 }
 
 Status DataTypeArraySerDe::write_column_to_mysql_binary(const IColumn& column,

--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -346,8 +346,8 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
         if (config::enable_arrow_input_validation) {
             check_arrow_list_offsets(*concrete_array, start, end);
         }
-        const auto* offsets =
-                dynamic_cast<const arrow::Int32Array*>(concrete_array->offsets().get());
+        const auto offsets =
+                std::dynamic_pointer_cast<arrow::Int32Array>(concrete_array->offsets());
         if (offsets == nullptr) {
             return Status::InvalidArgument("Expected Arrow Int32Array offsets, got {}",
                                            arrow_array->type()->name());
@@ -367,8 +367,8 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
         if (config::enable_arrow_input_validation) {
             check_arrow_large_list_offsets(*concrete_array, start, end);
         }
-        const auto* offsets =
-                dynamic_cast<const arrow::Int64Array*>(concrete_array->offsets().get());
+        const auto offsets =
+                std::dynamic_pointer_cast<arrow::Int64Array>(concrete_array->offsets());
         if (offsets == nullptr) {
             return Status::InvalidArgument("Expected Arrow Int64Array offsets, got {}",
                                            arrow_array->type()->name());

--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -323,14 +323,13 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
     auto& column_array = static_cast<ColumnArray&>(column);
     auto& offsets_data = column_array.get_offsets();
 
-    const auto read_list = [&](const auto* concrete_array) -> Status {
-        const int64_t arrow_nested_start_offset = concrete_array->value_offset(start);
-        const int64_t arrow_nested_end_offset = concrete_array->value_offset(end);
+    const auto read_list = [&](const auto* concrete_array, const auto& read_offset) -> Status {
+        const int64_t arrow_nested_start_offset = read_offset(start);
+        const int64_t arrow_nested_end_offset = read_offset(end);
         const auto prev_size = offsets_data.back();
         for (int64_t i = start + 1; i <= end; ++i) {
             // Convert Arrow offsets to Doris offsets, starting at offsets.back().
-            offsets_data.emplace_back(prev_size + concrete_array->value_offset(i) -
-                                      arrow_nested_start_offset);
+            offsets_data.emplace_back(prev_size + read_offset(i) - arrow_nested_start_offset);
         }
         return nested_serde->read_column_from_arrow(
                 column_array.get_data(), concrete_array->values().get(), arrow_nested_start_offset,
@@ -347,7 +346,17 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
         if (config::enable_arrow_input_validation) {
             check_arrow_list_offsets(*concrete_array, start, end);
         }
-        return read_list(concrete_array);
+        const auto* offsets =
+                dynamic_cast<const arrow::Int32Array*>(concrete_array->offsets().get());
+        if (offsets == nullptr) {
+            return Status::InvalidArgument("Expected Arrow Int32Array offsets, got {}",
+                                           arrow_array->type()->name());
+        }
+        // External Arrow buffers are not guaranteed to satisfy int32_t alignment.
+        return read_list(concrete_array, [offsets](int64_t index) {
+            return static_cast<int64_t>(
+                    arrow_validation_detail::read_int32_offset(*offsets, index));
+        });
     }
     case arrow::Type::LARGE_LIST: {
         const auto* concrete_array = dynamic_cast<const arrow::LargeListArray*>(arrow_array);
@@ -356,9 +365,18 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
                                            arrow_array->type()->name());
         }
         if (config::enable_arrow_input_validation) {
-            check_arrow_array_range(*concrete_array, start, end);
+            check_arrow_large_list_offsets(*concrete_array, start, end);
         }
-        return read_list(concrete_array);
+        const auto* offsets =
+                dynamic_cast<const arrow::Int64Array*>(concrete_array->offsets().get());
+        if (offsets == nullptr) {
+            return Status::InvalidArgument("Expected Arrow Int64Array offsets, got {}",
+                                           arrow_array->type()->name());
+        }
+        // LargeList offsets have the same alignment requirement as List offsets.
+        return read_list(concrete_array, [offsets](int64_t index) {
+            return arrow_validation_detail::read_int64_offset(*offsets, index);
+        });
     }
     case arrow::Type::FIXED_SIZE_LIST: {
         const auto* concrete_array = dynamic_cast<const arrow::FixedSizeListArray*>(arrow_array);
@@ -367,9 +385,13 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
                                            arrow_array->type()->name());
         }
         if (config::enable_arrow_input_validation) {
-            check_arrow_array_range(*concrete_array, start, end);
+            check_arrow_fixed_size_list_offsets(*concrete_array, start, end);
         }
-        return read_list(concrete_array);
+        // FixedSizeList computes offsets from its fixed value length and does not read an
+        // offset buffer.
+        return read_list(concrete_array, [concrete_array](int64_t index) {
+            return checked_fixed_size_list_offset(*concrete_array, index);
+        });
     }
     default:
         return Status::InvalidArgument("Unsupported Arrow array type for Doris ARRAY: {}",

--- a/be/src/core/data_type_serde/data_type_varbinary_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_varbinary_serde.cpp
@@ -17,8 +17,6 @@
 
 #include "core/data_type_serde/data_type_varbinary_serde.h"
 
-#include <cstring>
-
 #include "core/column/column_varbinary.h"
 #include "core/data_type_serde/parquet_decode_source.h"
 #include "core/data_type_serde/arrow_validation.h"
@@ -192,6 +190,37 @@ Status DataTypeVarbinarySerDe::read_column_from_arrow(IColumn& column,
                                                       int64_t start, int64_t end,
                                                       const cctz::time_zone& ctz) const {
     auto& varbinary_column = assert_cast<ColumnVarbinary&>(column);
+    const auto read_binary = [&](const auto* concrete_array, const auto& read_offset) -> Status {
+        const auto& buffer = concrete_array->value_data();
+        const size_t buffer_size = buffer ? static_cast<size_t>(buffer->size()) : 0;
+        for (int64_t offset_i = start; offset_i < end; ++offset_i) {
+            if (concrete_array->IsNull(offset_i)) {
+                varbinary_column.insert_default();
+                continue;
+            }
+
+            const int64_t start_offset = read_offset(offset_i);
+            const int64_t end_offset = read_offset(offset_i + 1);
+            const int64_t length =
+                    config::enable_arrow_input_validation
+                            ? check_arrow_value_offsets(*concrete_array, start_offset, end_offset,
+                                                        buffer_size)
+                            : end_offset - start_offset;
+            // Arrow may omit an empty values buffer. Do not form a pointer from it for an empty
+            // value, but require a buffer before reading any non-empty value.
+            if (length == 0) {
+                varbinary_column.insert_data("", 0);
+            } else if (!buffer) {
+                return Status::InvalidArgument("Arrow {} values buffer is missing",
+                                               concrete_array->type()->name());
+            } else {
+                varbinary_column.insert_data(
+                        reinterpret_cast<const char*>(buffer->data() + start_offset), length);
+            }
+        }
+        return Status::OK();
+    };
+
     if (arrow_array->type_id() == arrow::Type::STRING ||
         arrow_array->type_id() == arrow::Type::BINARY) {
         const auto* concrete_array = assert_cast<const arrow::BinaryArray*>(arrow_array);
@@ -199,23 +228,16 @@ Status DataTypeVarbinarySerDe::read_column_from_arrow(IColumn& column,
             check_arrow_array_range(*concrete_array, start, end);
             check_arrow_binary_offsets_buffer(*concrete_array);
         }
-        const auto& buffer = concrete_array->value_data();
-        const uint8_t* offsets_data = concrete_array->value_offsets()->data();
-        constexpr size_t offset_size = sizeof(int32_t);
-
-        for (int64_t offset_i = start; offset_i < end; ++offset_i) {
-            if (concrete_array->IsNull(offset_i)) {
-                varbinary_column.insert_default();
-                continue;
-            }
-            int32_t start_offset = 0;
-            int32_t end_offset = 0;
-            memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
-            memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
-            const auto length = end_offset - start_offset;
-            varbinary_column.insert_data(
-                    reinterpret_cast<const char*>(buffer->data() + start_offset), length);
+        const auto& offsets = concrete_array->value_offsets();
+        if (!offsets) {
+            return Status::InvalidArgument("Arrow {} offsets buffer is missing",
+                                           concrete_array->type()->name());
         }
+        const auto* offsets_data = offsets->data();
+        return read_binary(concrete_array, [offsets_data](int64_t index) {
+            return static_cast<int64_t>(
+                    unaligned_load<int32_t>(offsets_data + index * sizeof(int32_t)));
+        });
     } else if (arrow_array->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
         const auto* concrete_array = assert_cast<const arrow::FixedSizeBinaryArray*>(arrow_array);
         if (config::enable_arrow_input_validation) {
@@ -239,17 +261,15 @@ Status DataTypeVarbinarySerDe::read_column_from_arrow(IColumn& column,
             check_arrow_array_range(*concrete_array, start, end);
             check_arrow_binary_offsets_buffer(*concrete_array);
         }
-        const auto& buffer = concrete_array->value_data();
-        for (int64_t offset_i = start; offset_i < end; ++offset_i) {
-            if (concrete_array->IsNull(offset_i)) {
-                varbinary_column.insert_default();
-                continue;
-            }
-            const auto value_offset = concrete_array->value_offset(offset_i);
-            const auto value_length = concrete_array->value_length(offset_i);
-            varbinary_column.insert_data(
-                    reinterpret_cast<const char*>(buffer->data() + value_offset), value_length);
+        const auto& offsets = concrete_array->value_offsets();
+        if (!offsets) {
+            return Status::InvalidArgument("Arrow {} offsets buffer is missing",
+                                           concrete_array->type()->name());
         }
+        const auto* offsets_data = offsets->data();
+        return read_binary(concrete_array, [offsets_data](int64_t index) {
+            return unaligned_load<int64_t>(offsets_data + index * sizeof(int64_t));
+        });
     } else {
         return Status::InvalidArgument("Unsupported Arrow type for VARBINARY column: {}",
                                        arrow_array->type()->name());

--- a/be/src/core/data_type_serde/data_type_varbinary_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_varbinary_serde.cpp
@@ -18,8 +18,8 @@
 #include "core/data_type_serde/data_type_varbinary_serde.h"
 
 #include "core/column/column_varbinary.h"
-#include "core/data_type_serde/parquet_decode_source.h"
 #include "core/data_type_serde/arrow_validation.h"
+#include "core/data_type_serde/parquet_decode_source.h"
 
 namespace doris {
 namespace {

--- a/be/src/core/data_type_serde/data_type_varbinary_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_varbinary_serde.cpp
@@ -17,8 +17,11 @@
 
 #include "core/data_type_serde/data_type_varbinary_serde.h"
 
+#include <cstring>
+
 #include "core/column/column_varbinary.h"
 #include "core/data_type_serde/parquet_decode_source.h"
+#include "core/data_type_serde/arrow_validation.h"
 
 namespace doris {
 namespace {
@@ -180,6 +183,76 @@ Status DataTypeVarbinarySerDe::write_column_to_arrow(const IColumn& column, cons
     } else {
         return Status::InvalidArgument("Unsupported arrow type for varbinary column: {}",
                                        array_builder->type()->name());
+    }
+    return Status::OK();
+}
+
+Status DataTypeVarbinarySerDe::read_column_from_arrow(IColumn& column,
+                                                      const arrow::Array* arrow_array,
+                                                      int64_t start, int64_t end,
+                                                      const cctz::time_zone& ctz) const {
+    auto& varbinary_column = assert_cast<ColumnVarbinary&>(column);
+    if (arrow_array->type_id() == arrow::Type::STRING ||
+        arrow_array->type_id() == arrow::Type::BINARY) {
+        const auto* concrete_array = assert_cast<const arrow::BinaryArray*>(arrow_array);
+        if (config::enable_arrow_input_validation) {
+            check_arrow_array_range(*concrete_array, start, end);
+            check_arrow_binary_offsets_buffer(*concrete_array);
+        }
+        const auto& buffer = concrete_array->value_data();
+        const uint8_t* offsets_data = concrete_array->value_offsets()->data();
+        constexpr size_t offset_size = sizeof(int32_t);
+
+        for (int64_t offset_i = start; offset_i < end; ++offset_i) {
+            if (concrete_array->IsNull(offset_i)) {
+                varbinary_column.insert_default();
+                continue;
+            }
+            int32_t start_offset = 0;
+            int32_t end_offset = 0;
+            memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
+            memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+            const auto length = end_offset - start_offset;
+            varbinary_column.insert_data(
+                    reinterpret_cast<const char*>(buffer->data() + start_offset), length);
+        }
+    } else if (arrow_array->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
+        const auto* concrete_array = assert_cast<const arrow::FixedSizeBinaryArray*>(arrow_array);
+        if (config::enable_arrow_input_validation) {
+            check_arrow_array_range(*concrete_array, start, end);
+            check_arrow_fixed_width_buffer(*concrete_array,
+                                           static_cast<size_t>(concrete_array->byte_width()));
+        }
+        const auto width = concrete_array->byte_width();
+        for (int64_t offset_i = start; offset_i < end; ++offset_i) {
+            if (concrete_array->IsNull(offset_i)) {
+                varbinary_column.insert_default();
+            } else {
+                varbinary_column.insert_data(
+                        reinterpret_cast<const char*>(concrete_array->GetValue(offset_i)), width);
+            }
+        }
+    } else if (arrow_array->type_id() == arrow::Type::LARGE_STRING ||
+               arrow_array->type_id() == arrow::Type::LARGE_BINARY) {
+        const auto* concrete_array = assert_cast<const arrow::LargeBinaryArray*>(arrow_array);
+        if (config::enable_arrow_input_validation) {
+            check_arrow_array_range(*concrete_array, start, end);
+            check_arrow_binary_offsets_buffer(*concrete_array);
+        }
+        const auto& buffer = concrete_array->value_data();
+        for (int64_t offset_i = start; offset_i < end; ++offset_i) {
+            if (concrete_array->IsNull(offset_i)) {
+                varbinary_column.insert_default();
+                continue;
+            }
+            const auto value_offset = concrete_array->value_offset(offset_i);
+            const auto value_length = concrete_array->value_length(offset_i);
+            varbinary_column.insert_data(
+                    reinterpret_cast<const char*>(buffer->data() + value_offset), value_length);
+        }
+    } else {
+        return Status::InvalidArgument("Unsupported Arrow type for VARBINARY column: {}",
+                                       arrow_array->type()->name());
     }
     return Status::OK();
 }

--- a/be/src/core/data_type_serde/data_type_varbinary_serde.h
+++ b/be/src/core/data_type_serde/data_type_varbinary_serde.h
@@ -76,10 +76,7 @@ public:
                                  const cctz::time_zone& ctz) const override;
 
     Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override {
-        return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                             "read_column_from_arrow with type " + column.get_name());
-    }
+                                  int64_t end, const cctz::time_zone& ctz) const override;
 
     Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                     const ParquetDecodeContext& context, size_t num_values,

--- a/be/test/core/data_type_serde/data_type_serde_array_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_array_test.cpp
@@ -15,12 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <arrow/api.h>
+#include <cctz/time_zone.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstring>
+#include <memory>
 
+#include "core/assert_cast.h"
+#include "core/column/column_array.h"
+#include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
+#include "core/data_type_serde/data_type_array_serde.h"
+#include "core/data_type_serde/data_type_nullable_serde.h"
 #include "core/data_type_serde/data_type_number_serde.h"
 #include "core/data_type_serde/data_type_serde.h"
 #include "core/data_type_serde/data_type_string_serde.h"
@@ -173,6 +182,77 @@ TEST_F(DataTypeArraySerDeFieldTest, empty_array_is_null_element_type) {
     DataTypeSerDe::deserialize_binary_to_field(chars.data(), field, info);
     EXPECT_EQ(info.scalar_type_id, PrimitiveType::TYPE_NULL);
     EXPECT_FALSE(info.need_convert);
+}
+
+TEST_F(DataTypeArraySerDeFieldTest, ReadArrowFixedSizeAndLargeList) {
+    auto nested_serde = std::make_shared<DataTypeNullableSerDe>(
+            std::make_shared<DataTypeNumberSerDe<TYPE_FLOAT>>());
+    DataTypeArraySerDe serde(nested_serde);
+    cctz::time_zone tz;
+
+    const auto expect_array = [](const ColumnArray& column,
+                                 const std::vector<ColumnArray::Offset64>& expected_offsets,
+                                 const std::vector<float>& expected_values) {
+        const auto& offsets = column.get_offsets();
+        ASSERT_EQ(expected_offsets.size(), offsets.size());
+        for (size_t i = 0; i < expected_offsets.size(); ++i) {
+            EXPECT_EQ(expected_offsets[i], offsets[i]);
+        }
+        const auto& nullable_values = assert_cast<const ColumnNullable&>(column.get_data());
+        const auto& values =
+                assert_cast<const ColumnFloat32&>(nullable_values.get_nested_column()).get_data();
+        ASSERT_EQ(expected_values.size(), values.size());
+        for (size_t i = 0; i < expected_values.size(); ++i) {
+            EXPECT_EQ(0, nullable_values.get_null_map_data()[i]);
+            EXPECT_FLOAT_EQ(expected_values[i], values[i]);
+        }
+    };
+
+    // Lance vectors are Arrow FixedSizeList: every embedding has exactly three floats.
+    {
+        auto value_builder = std::make_shared<arrow::FloatBuilder>();
+        arrow::FixedSizeListBuilder builder(arrow::default_memory_pool(), value_builder, 3);
+        for (const std::array<float, 3>& embedding :
+             {std::array<float, 3> {0.0F, 0.0F, 0.0F}, std::array<float, 3> {1.0F, 0.0F, 0.0F},
+              std::array<float, 3> {-1.5F, 0.25F, 3.75F}}) {
+            ASSERT_TRUE(builder.Append().ok());
+            for (float value : embedding) {
+                ASSERT_TRUE(value_builder->Append(value).ok());
+            }
+        }
+        std::shared_ptr<arrow::FixedSizeListArray> arrow_array;
+        ASSERT_TRUE(builder.Finish(&arrow_array).ok());
+
+        auto column = ColumnArray::create(
+                ColumnNullable::create(ColumnFloat32::create(), ColumnUInt8::create()),
+                ColumnOffset64::create());
+        ASSERT_TRUE(serde.read_column_from_arrow(*column, arrow_array.get(), 0,
+                                                 arrow_array->length(), tz)
+                            .ok());
+        expect_array(*column, {3, 6, 9}, {0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, -1.5F, 0.25F, 3.75F});
+    }
+
+    // LargeList uses 64-bit Arrow offsets but has the same Doris ARRAY representation.
+    {
+        auto value_builder = std::make_shared<arrow::FloatBuilder>();
+        arrow::LargeListBuilder builder(arrow::default_memory_pool(), value_builder);
+        ASSERT_TRUE(builder.Append().ok());
+        ASSERT_TRUE(value_builder->Append(1.0F).ok());
+        ASSERT_TRUE(value_builder->Append(2.0F).ok());
+        ASSERT_TRUE(builder.Append().ok());
+        ASSERT_TRUE(value_builder->Append(3.0F).ok());
+        ASSERT_TRUE(builder.Append().ok());
+        std::shared_ptr<arrow::LargeListArray> arrow_array;
+        ASSERT_TRUE(builder.Finish(&arrow_array).ok());
+
+        auto column = ColumnArray::create(
+                ColumnNullable::create(ColumnFloat32::create(), ColumnUInt8::create()),
+                ColumnOffset64::create());
+        ASSERT_TRUE(serde.read_column_from_arrow(*column, arrow_array.get(), 0,
+                                                 arrow_array->length(), tz)
+                            .ok());
+        expect_array(*column, {2, 3, 3}, {1.0F, 2.0F, 3.0F});
+    }
 }
 
 } // namespace doris

--- a/be/test/core/data_type_serde/data_type_serde_arrow_validation_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_validation_test.cpp
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -40,6 +42,7 @@
 #include "core/data_type_serde/data_type_nullable_serde.h"
 #include "core/data_type_serde/data_type_number_serde.h"
 #include "core/data_type_serde/data_type_string_serde.h"
+#include "core/data_type_serde/data_type_varbinary_serde.h"
 
 namespace doris {
 namespace {
@@ -71,6 +74,21 @@ void expect_invalid_arrow(Func&& func, std::string_view message) {
 
 std::shared_ptr<arrow::Buffer> wrap_offsets(const std::vector<int32_t>& offsets) {
     return arrow::Buffer::Wrap(offsets);
+}
+
+std::shared_ptr<arrow::Buffer> wrap_large_offsets(const std::vector<int64_t>& offsets) {
+    return arrow::Buffer::Wrap(offsets);
+}
+
+auto make_array_column() {
+    return ColumnArray::create(
+            ColumnNullable::create(ColumnString::create(), ColumnUInt8::create()),
+            ColumnOffset64::create());
+}
+
+DataTypeArraySerDe make_string_array_serde() {
+    return DataTypeArraySerDe(std::make_shared<DataTypeNullableSerDe>(
+            std::make_shared<DataTypeStringSerDe>(TYPE_STRING)));
 }
 
 struct StringArrayHolder {
@@ -247,6 +265,130 @@ TEST(DataTypeSerDeArrowValidationTest, RejectsListOffsetsBeyondValuesLength) {
                                                                cctz::utc_time_zone()));
             },
             "list offsets beyond values length should be rejected");
+}
+
+TEST(DataTypeSerDeArrowValidationTest, RejectsMalformedLargeListOffsets) {
+    ScopedArrowInputValidation validation(true);
+    StringArrayHolder values({0, 1}, "a");
+    DataTypeArraySerDe serde = make_string_array_serde();
+
+    const auto expect_invalid_offsets = [&](const std::vector<int64_t>& offsets,
+                                            std::string_view message) {
+        auto array = std::make_shared<arrow::LargeListArray>(
+                arrow::large_list(arrow::utf8()), 1, wrap_large_offsets(offsets), values.array);
+        auto column = make_array_column();
+        expect_invalid_arrow(
+                [&] {
+                    static_cast<void>(serde.read_column_from_arrow(*column, array.get(), 0, 1,
+                                                                   cctz::utc_time_zone()));
+                },
+                message);
+    };
+
+    expect_invalid_offsets({0}, "short LargeList offsets buffer should be rejected");
+    expect_invalid_offsets({0, -1}, "negative LargeList offsets should be rejected");
+    expect_invalid_offsets({1, 0}, "non-monotonic LargeList offsets should be rejected");
+    expect_invalid_offsets({0, 2}, "LargeList offsets beyond values length should be rejected");
+}
+
+TEST(DataTypeSerDeArrowValidationTest, ReadsLargeListWithUnalignedOffsets) {
+    ScopedArrowInputValidation validation(true);
+
+    std::vector<uint8_t> storage(2 * sizeof(int64_t) + alignof(int64_t));
+    auto* offsets_data = storage.data();
+    while (reinterpret_cast<uintptr_t>(offsets_data) % alignof(int64_t) == 0) {
+        ++offsets_data;
+    }
+    const int64_t offsets[] = {0, 1};
+    memcpy(offsets_data, offsets, sizeof(offsets));
+
+    StringArrayHolder values({0, 1}, "a");
+    auto array = std::make_shared<arrow::LargeListArray>(
+            arrow::large_list(arrow::utf8()), 1, arrow::Buffer::Wrap(offsets_data, sizeof(offsets)),
+            values.array);
+    auto column = make_array_column();
+    DataTypeArraySerDe serde = make_string_array_serde();
+
+    ASSERT_TRUE(
+            serde.read_column_from_arrow(*column, array.get(), 0, 1, cctz::utc_time_zone()).ok());
+    ASSERT_EQ(column->size(), 1);
+    EXPECT_EQ(column->get_offsets()[0], 1);
+}
+
+TEST(DataTypeSerDeArrowValidationTest, RejectsFixedSizeListOffsetOverflow) {
+    ScopedArrowInputValidation validation(true);
+
+    auto values = std::make_shared<arrow::Int32Array>(0, std::shared_ptr<arrow::Buffer>());
+    constexpr int64_t list_size = std::numeric_limits<int32_t>::max();
+    const int64_t overflowing_index = std::numeric_limits<int64_t>::max() / list_size + 1;
+    auto array = std::make_shared<arrow::FixedSizeListArray>(
+            arrow::fixed_size_list(arrow::int32(), list_size), overflowing_index, values);
+    auto column = make_array_column();
+    DataTypeArraySerDe serde = make_string_array_serde();
+
+    expect_invalid_arrow(
+            [&] {
+                static_cast<void>(serde.read_column_from_arrow(*column, array.get(),
+                                                               overflowing_index, overflowing_index,
+                                                               cctz::utc_time_zone()));
+            },
+            "FixedSizeList offset multiplication overflow should be rejected");
+}
+
+TEST(DataTypeSerDeArrowValidationTest, RejectsVarbinaryValueRangeBeyondBuffer) {
+    ScopedArrowInputValidation validation(true);
+
+    std::vector<int32_t> offsets = {0, 8};
+    const std::string values = "a";
+    auto array = std::make_shared<arrow::BinaryArray>(
+            1, wrap_offsets(offsets), arrow::Buffer::Wrap(values.data(), values.size()));
+    auto column = ColumnVarbinary::create();
+    DataTypeVarbinarySerDe serde;
+
+    expect_invalid_arrow(
+            [&] {
+                static_cast<void>(serde.read_column_from_arrow(*column, array.get(), 0, 1,
+                                                               cctz::utc_time_zone()));
+            },
+            "VARBINARY value range beyond data buffer should be rejected");
+}
+
+TEST(DataTypeSerDeArrowValidationTest, ReadsEmptyVarbinaryWithoutValuesBuffer) {
+    ScopedArrowInputValidation validation(true);
+
+    std::vector<int32_t> offsets = {0, 0};
+    auto array = std::make_shared<arrow::BinaryArray>(1, wrap_offsets(offsets),
+                                                      std::shared_ptr<arrow::Buffer>());
+    auto column = ColumnVarbinary::create();
+    DataTypeVarbinarySerDe serde;
+
+    ASSERT_TRUE(
+            serde.read_column_from_arrow(*column, array.get(), 0, 1, cctz::utc_time_zone()).ok());
+    ASSERT_EQ(column->size(), 1);
+    EXPECT_TRUE(column->get_data_at(0).empty());
+}
+
+TEST(DataTypeSerDeArrowValidationTest, ReadsLargeVarbinaryWithUnalignedOffsets) {
+    ScopedArrowInputValidation validation(true);
+
+    std::vector<uint8_t> storage(2 * sizeof(int64_t) + alignof(int64_t));
+    auto* offsets_data = storage.data();
+    while (reinterpret_cast<uintptr_t>(offsets_data) % alignof(int64_t) == 0) {
+        ++offsets_data;
+    }
+    const int64_t offsets[] = {0, 1};
+    memcpy(offsets_data, offsets, sizeof(offsets));
+    const std::string values = "a";
+    auto array = std::make_shared<arrow::LargeBinaryArray>(
+            1, arrow::Buffer::Wrap(offsets_data, sizeof(offsets)),
+            arrow::Buffer::Wrap(values.data(), values.size()));
+    auto column = ColumnVarbinary::create();
+    DataTypeVarbinarySerDe serde;
+
+    ASSERT_TRUE(
+            serde.read_column_from_arrow(*column, array.get(), 0, 1, cctz::utc_time_zone()).ok());
+    ASSERT_EQ(column->size(), 1);
+    EXPECT_EQ(column->get_data_at(0).to_string(), values);
 }
 
 TEST(DataTypeSerDeArrowValidationTest, RejectsMapOffsetsBeyondKeysLength) {

--- a/be/test/core/data_type_serde/data_type_serde_varbinary_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_varbinary_test.cpp
@@ -170,7 +170,7 @@ TEST_F(DataTypeVarbinarySerDeTest, MysqlTextAndBinaryAndConst) {
     }
 }
 
-TEST_F(DataTypeVarbinarySerDeTest, ArrowWriteSupportedReadNotImplemented) {
+TEST_F(DataTypeVarbinarySerDeTest, ArrowBinaryRoundTrip) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
     auto* vb = col.get();
@@ -185,8 +185,11 @@ TEST_F(DataTypeVarbinarySerDeTest, ArrowWriteSupportedReadNotImplemented) {
 
     std::shared_ptr<arrow::Array> arr;
     ASSERT_TRUE(builder->Finish(&arr).ok());
-    st = serde.read_column_from_arrow(*vb, arr.get(), 0, 1, tz);
-    EXPECT_FALSE(st.ok());
+    auto read_column = ColumnVarbinary::create();
+    st = serde.read_column_from_arrow(*read_column, arr.get(), 0, 1, tz);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(1U, read_column->size());
+    EXPECT_EQ(v, read_column->get_data_at(0).to_string());
 
     auto* binary_array = dynamic_cast<arrow::BinaryArray*>(arr.get());
     ASSERT_NE(binary_array, nullptr);
@@ -196,6 +199,49 @@ TEST_F(DataTypeVarbinarySerDeTest, ArrowWriteSupportedReadNotImplemented) {
     EXPECT_EQ(binary_array->value_length(0), static_cast<int>(view.size));
     const uint8_t* raw = binary_array->value_data()->data() + binary_array->value_offset(0);
     EXPECT_EQ(memcmp(raw, view.data, view.size), 0);
+}
+
+TEST_F(DataTypeVarbinarySerDeTest, ArrowReadSupportsLargeAndFixedSizeBinary) {
+    DataTypeVarbinarySerDe serde;
+    cctz::time_zone tz;
+    const auto expect_values = [](const ColumnVarbinary& column,
+                                  const std::vector<std::string>& expected) {
+        ASSERT_EQ(expected.size(), column.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            EXPECT_EQ(expected[i], column.get_data_at(i).to_string());
+        }
+    };
+
+    {
+        arrow::LargeBinaryBuilder builder;
+        ASSERT_TRUE(builder.Append("large").ok());
+        ASSERT_TRUE(builder.AppendNull().ok());
+        ASSERT_TRUE(builder.Append("binary").ok());
+        std::shared_ptr<arrow::Array> arrow_array;
+        ASSERT_TRUE(builder.Finish(&arrow_array).ok());
+
+        auto column = ColumnVarbinary::create();
+        ASSERT_TRUE(serde.read_column_from_arrow(*column, arrow_array.get(), 0,
+                                                 arrow_array->length(), tz)
+                            .ok());
+        expect_values(*column, {"large", "", "binary"});
+    }
+
+    {
+        auto type = arrow::fixed_size_binary(3);
+        arrow::FixedSizeBinaryBuilder builder(type, arrow::default_memory_pool());
+        ASSERT_TRUE(builder.Append("abc").ok());
+        ASSERT_TRUE(builder.AppendNull().ok());
+        ASSERT_TRUE(builder.Append("xyz").ok());
+        std::shared_ptr<arrow::Array> arrow_array;
+        ASSERT_TRUE(builder.Finish(&arrow_array).ok());
+
+        auto column = ColumnVarbinary::create();
+        ASSERT_TRUE(serde.read_column_from_arrow(*column, arrow_array.get(), 0,
+                                                 arrow_array->length(), tz)
+                            .ok());
+        expect_values(*column, {"abc", "", "xyz"});
+    }
 }
 
 TEST_F(DataTypeVarbinarySerDeTest, OrcWriteSupported) {


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
support more arrow::Type like: FIXED_SIZE_LIST and LARGE_LIST .....
FIXED_SIZE_LIST is used by lance vectors.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

