### PR TITLE
[fix](function) Prevent overflow in array range generation

### DIFF
--- a/be/src/exprs/function/array/function_array_range.cpp
+++ b/be/src/exprs/function/array/function_array_range.cpp
@@ -37,13 +37,13 @@
 #include "core/data_type/data_type_date_or_datetime_v2.h"
 #include "core/data_type/data_type_date_time.h"
 #include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/pod_array_fwd.h"
 #include "core/types.h"
 #include "core/value/vdatetime_value.h"
 #include "exprs/aggregate/aggregate_function.h"
 #include "exprs/function/function.h"
-#include "exprs/function/function_date_or_datetime_computation.h"
 #include "exprs/function/simple_function_factory.h"
 
 namespace doris {
@@ -188,19 +188,21 @@ private:
                     dest_offsets.push_back(dest_offsets.back());
                     continue;
                 } else {
-                    if (idx < end_row && step_row > 0 &&
-                        ((static_cast<__int128_t>(end_row) - static_cast<__int128_t>(idx) - 1) /
-                                 static_cast<__int128_t>(step_row) +
-                         1) > max_array_size_as_field) {
-                        return Status::InvalidArgument("Array size exceeds the limit {}",
-                                                       max_array_size_as_field);
+                    const Int64 start_value = idx;
+                    const Int64 end_value = end_row;
+                    const Int64 step_value = step_row;
+                    if (start_value < end_value) {
+                        const Int64 range_size = (end_value - start_value - 1) / step_value + 1;
+                        if (range_size > static_cast<Int64>(max_array_size_as_field)) {
+                            return Status::InvalidArgument("Array size exceeds the limit {}",
+                                                           max_array_size_as_field);
+                        }
                     }
                     size_t offset = dest_offsets.back();
-                    while (idx < end[row]) {
-                        nested_column.push_back(idx);
+                    for (Int64 current = start_value; current < end_value; current += step_value) {
+                        nested_column.push_back(static_cast<Int32>(current));
                         dest_nested_null_map.push_back(0);
                         offset++;
-                        idx = idx + step_row;
                     }
                     dest_offsets.push_back(offset);
                 }
@@ -222,7 +224,7 @@ private:
                     int move = 0;
                     while (doris::datetime_diff<UNIT::value, DateTimeV2ValueType,
                                                 DateTimeV2ValueType>(idx, end_row) > 0) {
-                        if (move > max_array_size_as_field) {
+                        if (move >= max_array_size_as_field) {
                             return Status::InvalidArgument("Array size exceeds the limit {}",
                                                            max_array_size_as_field);
                         }
@@ -230,8 +232,15 @@ private:
                         dest_nested_null_map.push_back(0);
                         offset++;
                         move++;
-                        idx = doris::date_time_add<UNIT::value, TYPE_DATETIMEV2, Int32>(idx,
-                                                                                        step_row);
+                        auto next = idx;
+                        TimeInterval interval(UNIT::value, step_row, false);
+                        // The current value can be the last element even if advancing it exceeds
+                        // the DateTimeV2 range.
+                        if (!next.template date_add_interval<UNIT::value>(interval)) {
+                            break;
+                        }
+                        DCHECK_NE(next, idx);
+                        idx = next;
                     }
                     dest_offsets.push_back(offset);
                 }

--- a/regression-test/data/nereids_function_p0/scalar_function/Array.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/Array.out
@@ -13425,6 +13425,27 @@ true
 ["2012-03-11 11:10:11", "2014-12-11 11:10:11"]
 ["2012-03-12 12:11:12", "2015-03-12 12:11:12"]
 
+-- !array_range_int32_upper_bound --
+[2147483646]
+
+-- !array_range_int32_upper_bound_multiple_elements --
+[2147483644, 2147483646]
+
+-- !array_range_int32_upper_bound_non_const --
+[2147483646]
+
+-- !array_range_datetime_day_upper_bound --
+["9999-12-30 00:00:00"]
+
+-- !array_range_datetime_second_upper_bound --
+["9999-12-31 23:59:58"]
+
+-- !array_range_datetime_year_upper_bound --
+["9998-12-31 00:00:00"]
+
+-- !array_range_datetime_month_end --
+["2020-01-31 00:00:00", "2020-02-29 00:00:00"]
+
 -- !sequence_int_one_para --
 \N
 [0]
@@ -13470,6 +13491,9 @@ true
 [10, 11, 12]
 [11, 12, 13]
 
+-- !sequence_int32_upper_bound --
+[2147483646]
+
 -- !sequence_datetime_default --
 \N
 []
@@ -13499,6 +13523,9 @@ true
 ["2012-03-10 10:09:10", "2012-03-20 10:09:10"]
 ["2012-03-11 11:10:11", "2012-03-22 11:10:11"]
 ["2012-03-12 12:11:12", "2012-03-24 12:11:12"]
+
+-- !sequence_datetime_upper_bound --
+["9999-12-30 00:00:00"]
 
 -- !sequence_datetime_week --
 \N

--- a/regression-test/suites/nereids_function_p0/scalar_function/Array.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/Array.groovy
@@ -1207,11 +1207,20 @@ suite("nereids_scalar_fn_Array") {
     qt_array_range_datetime1 """select array_range(kdtmv2s1, date_add(kdtmv2s1, interval kint+1 day), interval kint day) from fn_test order by kdtmv2s1;"""
     qt_array_range_datetime2 """select array_range(kdtmv2s1, date_add(kdtmv2s1, interval kint+2 week), interval kint week) from fn_test order by kdtmv2s1;"""
     qt_array_range_datetime3 """select array_range(kdtmv2s1, date_add(kdtmv2s1, interval kint+2 quarter), interval kint quarter) from fn_test order by kdtmv2s1;"""
+    qt_array_range_int32_upper_bound """select array_range(2147483646, 2147483647, 2);"""
+    qt_array_range_int32_upper_bound_multiple_elements """select array_range(2147483644, 2147483647, 2);"""
+    qt_array_range_int32_upper_bound_non_const """select array_range(cast(number + 2147483646 as int), 2147483647, 2) from numbers("number" = "1");"""
+    qt_array_range_datetime_day_upper_bound """select array_range(cast('9999-12-30' as datetimev2), cast('9999-12-31' as datetimev2), interval 2 day);"""
+    qt_array_range_datetime_second_upper_bound """select array_range(cast('9999-12-31 23:59:58' as datetimev2), cast('9999-12-31 23:59:59' as datetimev2), interval 2 second);"""
+    qt_array_range_datetime_year_upper_bound """select array_range(cast('9998-12-31' as datetimev2), cast('9999-12-31' as datetimev2), interval 2 year);"""
+    qt_array_range_datetime_month_end """select array_range(cast('2020-01-31' as datetimev2), cast('2020-03-30' as datetimev2), interval 1 month);"""
     qt_sequence_int_one_para """select sequence(kint) from fn_test order by kint;"""
     qt_sequence_int_two_para """select sequence(kint, kint+2) from fn_test order by kint;"""
     qt_sequence_int_three_para """select sequence(kint-1, kint+2, 1) from fn_test order by kint;"""
+    qt_sequence_int32_upper_bound """select sequence(2147483646, 2147483647, 2);"""
     qt_sequence_datetime_default """select sequence(kdtmv2s1, date_add(kdtmv2s1, interval kint-3 day)) from fn_test order by kdtmv2s1;"""
     qt_sequence_datetime_day """select sequence(kdtmv2s1, date_add(kdtmv2s1, interval kint+1 day), interval kint day) from fn_test order by kdtmv2s1;"""
+    qt_sequence_datetime_upper_bound """select sequence(cast('9999-12-30' as datetimev2), cast('9999-12-31' as datetimev2), interval 2 day);"""
     qt_sequence_datetime_week """select sequence(kdtmv2s1, date_add(kdtmv2s1, interval kint+2 week), interval kint week) from fn_test order by kdtmv2s1;"""
     qt_sequence_datetime_month """select sequence(kdtmv2s1, date_add(kdtmv2s1, interval kint+3 month), interval kint month) from fn_test order by kdtmv2s1;"""
     qt_sequence_datetime_year """select sequence(kdtmv2s1, date_add(kdtmv2s1, interval kint+3 year), interval kint year) from fn_test order by kdtmv2s1;"""
@@ -1229,6 +1238,10 @@ suite("nereids_scalar_fn_Array") {
 
     test {
         sql "select sequence(kdtmv2s1, date_add(kdtmv2s1, interval 5000 year), interval 1 second) from fn_test"
+        exception "Array size exceeds the limit 1000000"
+    }
+    test {
+        sql """select array_range(cast('9999-12-08 20:26:38' as datetimev2), cast('9999-12-31 23:59:59' as datetimev2), interval 2 second)"""
         exception "Array size exceeds the limit 1000000"
     }
     sql "select sequence(kdtmv2s1, date_add(kdtmv2s1, interval 5000 year), interval 500 year) from fn_test"


### PR DESCRIPTION
### What problem does this PR solve?

Integer array ranges can overflow when an Int32 iterator advances near its upper bound. DateTimeV2 ranges can also try to advance past the maximum representable value after emitting the final valid element. This change uses Int64 arithmetic for integer ranges and safely stops DateTimeV2 iteration when the next value is out of range.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

