### PR TITLE
[refactor](catalog) fe-connector: replace fat hive-catalog-shade with a slim HMS metastore-client shade

### DIFF
--- a/fe/fe-connector/fe-connector-hms-hive-shade/pom.xml
+++ b/fe/fe-connector/fe-connector-hms-hive-shade/pom.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.doris</groupId>
+        <artifactId>fe-connector</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>fe-connector-hms-hive-shade</artifactId>
+    <packaging>jar</packaging>
+    <name>Doris FE Connector - HMS Hive Shade</name>
+    <description>
+        Plugin-private slim replacement for the fat org.apache.doris:hive-catalog-shade (122MB)
+        that fe-connector-hms and fe-connector-iceberg used to consume. It shades ONLY the Hive
+        metastore-CLIENT closure (hive-standalone-metastore + hive-common/HiveConf +
+        hive-storage-api + hive-serde + iceberg-hive-metastore's HiveCatalog) plus a pinned
+        libthrift/libfb303 0.9.3, and relocates org.apache.thrift ->
+        shade.doris.hive.org.apache.thrift.
+
+        Why relocate thrift: Doris internal thrift is 0.16.0 (fe/pom.xml manages libthrift there),
+        and the doris-gen stubs (TFileScanRangeParams / TIcebergFileDesc ...) are compiled against
+        it; the Hive 3.1.3 metastore-client stubs are compiled against thrift ~0.9.x (TFramedTransport
+        in .transport, TBase/scheme contracts drifted) and are binary-incompatible. One
+        org.apache.thrift namespace cannot host both versions, so the Hive client gets its own private
+        package. The relocation prefix (shade.doris.hive.org.apache.thrift) is REUSED from the fat
+        hive-catalog-shade on purpose: Doris's vendored patch client
+        (fe-connector-hms/.../org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java) and
+        ThriftHmsClient already import that prefix, so no connector source changes are needed, and the
+        bundled libthrift 0.9.3 is byte-identical to the fat shade's, so the atomic global->slim swap
+        never splits the namespace.
+
+        Why iceberg-hive-metastore rides along here (one shared shade, not two): iceberg's HiveCatalog
+        builds Doris's patch HiveMetaStoreClient BY CLASS NAME, so it must link against the SAME
+        relocated thrift + the SAME metastore-api class identities as the plain-HMS client. Bundling it
+        here means hive/hudi carry ~1MB of iceberg-hive classes they never load (bytes only, no leak),
+        in exchange for a single thrift private namespace.
+
+        See plan-doc/fe-connector-hive-shade-localization/design.md (mirrors the pattern established by
+        fe-connector-paimon-hive-shade / plan-doc/fix-c-hms-thrift-design.md).
+    </description>
+
+    <dependencies>
+        <!-- hive-standalone-metastore 3.1.3 supplies the REAL metastore implementation:
+             org.apache.hadoop.hive.metastore.api.* (ThriftHiveMetastore + ~200 structs),
+             IMetaStoreClient / MetastoreConf / MetaStoreUtils / HadoopThriftAuthBridge / txn.TxnUtils,
+             and the base org.apache.hadoop.hive.metastore.HiveMetaStoreClient that Doris's vendored
+             patch subclass overlays. NOTE: this is standalone-metastore (real impl), NOT
+             hive-metastore:3.1.3 (a 13-class stub -> whole metastore api NoClassDefFound if used).
+             The FE is only ever a metastore CLIENT, so the entire server-side closure is excluded:
+             datanucleus/derby/bonecp/HikariCP/commons-dbcp (JDO + embedded DB), orc, the whole
+             hadoop trio, metrics/dropwizard, sqlline/ant-contrib/antlr/javolution, and the log4j
+             backends (host provides log4j). libthrift/libfb303 are excluded here and pinned inline at
+             0.9.3 below so they can be relocated — our reactor's dependencyManagement pins libthrift to
+             0.16.0, which must NOT be allowed to reach this old-package closure. -->
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-standalone-metastore</artifactId>
+            <version>3.1.3</version>
+            <!-- optional: shaded INTO this jar; must NOT propagate as a transitive dep to the
+                 consuming plugins (whose plugin-zip would otherwise re-bundle the raw jars next to the
+                 shade jar -> child-first duplicate-class hazard). -->
+            <optional>true</optional>
+            <exclusions>
+                <exclusion><groupId>org.apache.orc</groupId><artifactId>orc-core</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></exclusion>
+                <exclusion><groupId>com.github.joshelser</groupId><artifactId>dropwizard-metrics-hadoop-metrics2-reporter</artifactId></exclusion>
+                <exclusion><groupId>com.google.guava</groupId><artifactId>guava</artifactId></exclusion>
+                <exclusion><groupId>com.google.protobuf</groupId><artifactId>protobuf-java</artifactId></exclusion>
+                <exclusion><groupId>com.jolbox</groupId><artifactId>bonecp</artifactId></exclusion>
+                <exclusion><groupId>com.zaxxer</groupId><artifactId>HikariCP</artifactId></exclusion>
+                <exclusion><groupId>commons-dbcp</groupId><artifactId>commons-dbcp</artifactId></exclusion>
+                <exclusion><groupId>io.dropwizard.metrics</groupId><artifactId>metrics-core</artifactId></exclusion>
+                <exclusion><groupId>io.dropwizard.metrics</groupId><artifactId>metrics-jvm</artifactId></exclusion>
+                <exclusion><groupId>io.dropwizard.metrics</groupId><artifactId>metrics-json</artifactId></exclusion>
+                <exclusion><groupId>javolution</groupId><artifactId>javolution</artifactId></exclusion>
+                <exclusion><groupId>org.antlr</groupId><artifactId>antlr-runtime</artifactId></exclusion>
+                <exclusion><groupId>org.apache.derby</groupId><artifactId>derby</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-common</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-distcp</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-hdfs</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-hdfs-client</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-mapreduce-client-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-slf4j-impl</artifactId></exclusion>
+                <exclusion><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-1.2-api</artifactId></exclusion>
+                <exclusion><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.thrift</groupId><artifactId>libthrift</artifactId></exclusion>
+                <exclusion><groupId>org.apache.thrift</groupId><artifactId>libfb303</artifactId></exclusion>
+                <exclusion><groupId>org.datanucleus</groupId><artifactId>datanucleus-api-jdo</artifactId></exclusion>
+                <exclusion><groupId>org.datanucleus</groupId><artifactId>datanucleus-core</artifactId></exclusion>
+                <exclusion><groupId>org.datanucleus</groupId><artifactId>datanucleus-rdbms</artifactId></exclusion>
+                <exclusion><groupId>org.datanucleus</groupId><artifactId>javax.jdo</artifactId></exclusion>
+                <exclusion><groupId>sqlline</groupId><artifactId>sqlline</artifactId></exclusion>
+                <exclusion><groupId>ant-contrib</groupId><artifactId>ant-contrib</artifactId></exclusion>
+                <exclusion><groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- hive-common 3.1.3 supplies org.apache.hadoop.hive.conf.HiveConf (HmsConfHelper.createHiveConf
+             and iceberg's IcebergCatalogFactory build one), and pulls hive-shims transitively (HiveConf
+             static init -> ShimLoader). Pinned at 3.1.3 to match standalone-metastore so HiveConf,
+             HiveMetaStoreClient and the metastore api all sit on one Hive 3.1.x line inside one artifact.
+             The web/CLI/metrics closure (jetty, servlet-api, jline, ant, jpam, dropwizard, tdunning:json)
+             is dead weight for a metastore client and excluded; hadoop + jackson + log4j backends go to
+             the host/plugin. commons-lang (2.x, groupId commons-lang) is intentionally NOT excluded here
+             or in the artifactSet — HiveConf.<clinit> references org.apache.commons.lang.StringUtils and
+             the host runs commons-lang3, so the 2.x copy must live in this shade. -->
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-common</artifactId>
+            <version>3.1.3</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion><groupId>org.apache.orc</groupId><artifactId>orc-core</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-http</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-rewrite</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-server</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-servlet</artifactId></exclusion>
+                <exclusion><groupId>org.eclipse.jetty</groupId><artifactId>jetty-webapp</artifactId></exclusion>
+                <exclusion><groupId>javax.servlet</groupId><artifactId>javax.servlet-api</artifactId></exclusion>
+                <exclusion><groupId>jline</groupId><artifactId>jline</artifactId></exclusion>
+                <exclusion><groupId>org.apache.ant</groupId><artifactId>ant</artifactId></exclusion>
+                <exclusion><groupId>net.sf.jpam</groupId><artifactId>jpam</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-common</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-mapreduce-client-core</artifactId></exclusion>
+                <exclusion><groupId>com.tdunning</groupId><artifactId>json</artifactId></exclusion>
+                <exclusion><groupId>io.dropwizard.metrics</groupId><artifactId>metrics-core</artifactId></exclusion>
+                <exclusion><groupId>io.dropwizard.metrics</groupId><artifactId>metrics-jvm</artifactId></exclusion>
+                <exclusion><groupId>io.dropwizard.metrics</groupId><artifactId>metrics-json</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></exclusion>
+                <exclusion><groupId>com.github.joshelser</groupId><artifactId>dropwizard-metrics-hadoop-metrics2-reporter</artifactId></exclusion>
+                <exclusion><groupId>javolution</groupId><artifactId>javolution</artifactId></exclusion>
+                <exclusion><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-1.2-api</artifactId></exclusion>
+                <exclusion><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-slf4j-impl</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- hive-storage-api 2.7.0 supplies org.apache.hadoop.hive.common.ValidWriteIdList and the ACID
+             write-id types used on the hms txn / write-ACID path; neither hive-common nor
+             standalone-metastore bundle these classes. Declared explicitly (standalone-metastore also
+             pulls it transitively, but declaring it here pins 2.7.0 by nearest-wins and keeps it present
+             even if the transitive edge changes). -->
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-storage-api</artifactId>
+            <version>2.7.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- hive-serde 3.1.3 supplies org.apache.hadoop.hive.serde2.typeinfo.* / objectinspector.* that
+             iceberg's HiveSchemaUtil uses when it builds/commits a table via HiveCatalog (only iceberg
+             needs this; hive/hudi carry the classes unused). Its heavy transitive closure — hive-service-rpc
+             (thrift-gen RPC), arrow-vector, avro, parquet-hadoop-bundle, hadoop, hppc/flatbuffers/opencsv —
+             is not touched by the metastore-client path and is excluded. libthrift is excluded and pinned
+             inline below with the rest so it is relocated, not left original-package. -->
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-serde</artifactId>
+            <version>3.1.3</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion><groupId>org.apache.hive</groupId><artifactId>hive-service-rpc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.arrow</groupId><artifactId>arrow-vector</artifactId></exclusion>
+                <exclusion><groupId>org.apache.avro</groupId><artifactId>avro</artifactId></exclusion>
+                <exclusion><groupId>org.apache.parquet</groupId><artifactId>parquet-hadoop-bundle</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-common</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hadoop</groupId><artifactId>hadoop-mapreduce-client-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.thrift</groupId><artifactId>libthrift</artifactId></exclusion>
+                <exclusion><groupId>com.carrotsearch</groupId><artifactId>hppc</artifactId></exclusion>
+                <exclusion><groupId>com.vlkan</groupId><artifactId>flatbuffers</artifactId></exclusion>
+                <exclusion><groupId>net.sf.opencsv</groupId><artifactId>opencsv</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- iceberg-hive-metastore 1.10.1 supplies org.apache.iceberg.hive.HiveCatalog (the hms flavor);
+             only fe-connector-iceberg loads it. iceberg-core/api/common/bundled-guava + caffeine + slf4j
+             are excluded — the iceberg plugin already ships iceberg-core 1.10.1 (which brings api/common/
+             guava/caffeine) as its own child-first jar, so re-bundling them here would create duplicate
+             classes. Only the org.apache.iceberg.hive.* classes are kept, and the relocation below rewrites
+             their org.apache.thrift refs to the shared private prefix so they link against the same
+             relocated HiveMetaStoreClient + libthrift as the plain-HMS path. -->
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-hive-metastore</artifactId>
+            <version>1.10.1</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion><groupId>org.apache.iceberg</groupId><artifactId>iceberg-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.iceberg</groupId><artifactId>iceberg-api</artifactId></exclusion>
+                <exclusion><groupId>org.apache.iceberg</groupId><artifactId>iceberg-common</artifactId></exclusion>
+                <exclusion><groupId>org.apache.iceberg</groupId><artifactId>iceberg-bundled-guava</artifactId></exclusion>
+                <exclusion><groupId>com.github.ben-manes.caffeine</groupId><artifactId>caffeine</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- libthrift 0.9.3 — the source of the old-package org.apache.thrift.* (TFramedTransport in
+             .transport, the 0.9.x TBase/scheme contract) that the Hive 3.1.3 metastore client + Doris's
+             vendored patch subclass compile against. Pinned INLINE at 0.9.3 (NOT the managed 0.16.0) and
+             relocated to shade.doris.hive.org.apache.thrift so it does not collide with the host 0.16.0
+             doris-gen TBase path. httpcore/httpclient/slf4j go to the host. -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.9.3</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion><groupId>org.apache.httpcomponents</groupId><artifactId>httpcore</artifactId></exclusion>
+                <exclusion><groupId>org.apache.httpcomponents</groupId><artifactId>httpclient</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- libfb303 0.9.3 — ThriftHiveMetastore.{Iface,Client} extend com.facebook.fb303.FacebookService;
+             without it the generated client fails to link. Relocated with the rest (it references
+             org.apache.thrift.*). -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libfb303</artifactId>
+            <version>0.9.3</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- codehaus jackson 1.9.2 (the OLD org.codehaus.jackson.* line, a different package from the
+             host's com.fasterxml.jackson 2.x). hive-standalone-metastore's
+             org.apache.hadoop.hive.metastore.messaging.json.JSONMessageDeserializer uses
+             org.codehaus.jackson.map.ObjectMapper; Doris's HmsEventParser holds a static
+             JSONMessageDeserializer to decode HMS notification-event bodies, so this is a PRODUCTION
+             runtime need, not test-only. jackson-mapper-asl resolves transitively at TEST scope (so
+             maven-shade would not bundle it) — declared here at compile/optional to make it shadeable.
+             The fat hive-catalog-shade bundled these too. NOTE: fe/pom.xml dependencyManagement pins
+             jackson-mapper-asl to <scope>test</scope> (to keep legacy Jackson 1.x off the main FE
+             classpath), so an explicit <scope>compile</scope> is required here to override it, otherwise
+             maven-shade silently skips the test-scoped artifact. optional=true keeps it from propagating
+             to the consuming plugins as a standalone jar (it lives INSIDE this shade). -->
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.2</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>1.9.2</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Pure-shade module (no src/main): under a parallel reactor (build.sh's default -T 1C)
+                 the package-phase shade goal can start before this module's main jar is created and
+                 attached, failing with "Failed to create shaded artifact, project main artifact does
+                 not exist". Pin maven-jar-plugin's default-jar to the package phase and force it to
+                 always (re)create the jar, so the main artifact is guaranteed present before shade.
+                 Mirrors fe-connector-paimon-hive-shade. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <forceCreation>true</forceCreation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <!-- WHITELIST, not blacklist. The fat hive-catalog-shade used a short
+                                 exclude list and tolerated a huge tail of transitive junk (hadoop-yarn,
+                                 curator, jersey, jetty, kerby, ehcache, nimbus-jose, mssql-jdbc, guice,
+                                 jaxb, leveldbjni, dnsjava, fst ...) dragged in mostly by
+                                 hive-shims-0.23 -> hadoop-yarn-server-* — that tail is what made it
+                                 122MB. For a SLIM client shade we bundle ONLY the Hive metastore-client
+                                 closure and let everything else resolve at runtime from the plugin's own
+                                 hadoop-common closure (each consuming plugin bundles hadoop-common, which
+                                 supplies curator/jetty/kerby/etc.) or from the host (guava/slf4j/log4j/
+                                 jackson parent-first). Anything genuinely needed but omitted here surfaces
+                                 in the UT / e2e gate (HiveConf construction, hms read/write), which is far
+                                 safer than an open-ended exclude list. The hive-shims-* CLASSES stay so
+                                 HiveConf's ShimLoader/Utils.getUGI resolve; their heavy hadoop transitives
+                                 do not. commons-lang (2.x) stays for HiveConf.<clinit>. -->
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.hive:hive-standalone-metastore</include>
+                                    <include>org.apache.hive:hive-common</include>
+                                    <include>org.apache.hive:hive-serde</include>
+                                    <include>org.apache.hive:hive-storage-api</include>
+                                    <include>org.apache.hive:hive-classification</include>
+                                    <include>org.apache.hive:hive-shims</include>
+                                    <include>org.apache.hive.shims:hive-shims-common</include>
+                                    <include>org.apache.hive.shims:hive-shims-0.23</include>
+                                    <include>org.apache.hive.shims:hive-shims-scheduler</include>
+                                    <include>org.apache.iceberg:iceberg-hive-metastore</include>
+                                    <include>org.apache.thrift:libthrift</include>
+                                    <include>org.apache.thrift:libfb303</include>
+                                    <include>commons-lang:commons-lang</include>
+                                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
+                                    <include>org.codehaus.jackson:jackson-core-asl</include>
+                                </includes>
+                            </artifactSet>
+                            <!-- MUST be true: the consuming modules (fe-connector-hms, and transitively
+                                 fe-connector-hive/-hudi/-iceberg) depend on this module and their plugin-zip
+                                 pulls its transitive deps into lib/. The reduced pom drops the artifacts that
+                                 were shaded IN (standalone-metastore, hive-common/serde/storage-api,
+                                 iceberg-hive-metastore, libthrift/libfb303) so they are NOT re-bundled as
+                                 standalone jars next to this shade jar — avoiding the child-first
+                                 duplicate-class hazard. -->
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <!-- The single load-bearing action: give the Hive-3.1.3 metastore client its
+                                     own thrift namespace so it never collides with the host doris-gen 0.16.0
+                                     thrift. REUSED prefix -> zero connector source changes (the vendored patch
+                                     client + ThriftHmsClient already import this prefix). -->
+                                <relocation>
+                                    <pattern>org.apache.thrift</pattern>
+                                    <shadedPattern>shade.doris.hive.org.apache.thrift</shadedPattern>
+                                </relocation>
+                                <!-- defensive: hive drags an ancient fastutil via some transitives; relocate
+                                     it so it cannot shadow the modern it.unimi.dsi:fastutil(-core) on the FE
+                                     classpath (NoSuchMethodError). -->
+                                <relocation>
+                                    <pattern>it.unimi.dsi.fastutil</pattern>
+                                    <shadedPattern>shade.doris.hive.it.unimi.dsi.fastutil</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fe/fe-connector/fe-connector-hms/pom.xml
+++ b/fe/fe-connector/fe-connector-hms/pom.xml
@@ -59,10 +59,21 @@ under the License.
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Doris shaded Hive MetaStore client (includes Thrift, DLF, Glue) -->
+        <!-- Slim Hive metastore-client shade — replaces the fat org.apache.doris:hive-catalog-shade
+             (122MB). Bundles hive-standalone-metastore (metastore api + client), HiveConf, hive-serde,
+             hive-storage-api, iceberg-hive-metastore's HiveCatalog and libthrift/libfb303 0.9.3, all with
+             org.apache.thrift relocated to shade.doris.hive.org.apache.thrift so the old-package HMS
+             client does not collide with the host doris-gen thrift 0.16. compile scope (no <scope>):
+             propagates transitively to the plugins that reuse this shared plain-HMS client —
+             fe-connector-hive, fe-connector-hudi, fe-connector-iceberg. The vendored version-aware patch
+             HiveMetaStoreClient stays in THIS module (its bytecode already references the relocated thrift
+             prefix; it overlays the unpatched client inside the shade because fe-connector-hms-*.jar sorts
+             before fe-connector-hms-hive-shade-*.jar in the plugin lib). See
+             plan-doc/fe-connector-hive-shade-localization/design.md. -->
         <dependency>
-            <groupId>org.apache.doris</groupId>
-            <artifactId>hive-catalog-shade</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fe-connector-hms-hive-shade</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Hadoop client for Configuration and auth -->

--- a/fe/fe-connector/fe-connector-hudi/pom.xml
+++ b/fe/fe-connector/fe-connector-hudi/pom.xml
@@ -97,8 +97,9 @@ under the License.
              org.apache.parquet.avro.AvroSchemaConverter for hudi's FE-side schema read: TableSchemaResolver
              reads a data file's parquet footer to resolve the table Avro schema
              (ParquetUtils.readAvroSchema -> readSchema -> ParquetFileReader.readFooter(Configuration, Path),
-             then converts the parquet MessageType to Avro). hudi-common bundles NO parquet, and the
-             hive-catalog-shade jar carries only a RELOCATED (org.apache.paimon.shade.*) parquet — so the
+             then converts the parquet MessageType to Avro). hudi-common bundles NO parquet, and no other
+             jar in this plugin (the fe-connector-hms-hive-shade slim shade carries none either) provides an
+             un-relocated org.apache.parquet.hadoop.* — so the
              un-relocated ParquetFileReader would otherwise resolve from the parent 'app' loader while
              ParquetUtils and Configuration come from the child (org.apache.hadoop is child-first here, from the
              bundled hadoop-common) — readFooter's Configuration parameter then splits across two loaders and the

--- a/fe/fe-connector/fe-connector-iceberg/pom.xml
+++ b/fe/fe-connector/fe-connector-iceberg/pom.xml
@@ -61,8 +61,8 @@ under the License.
         </dependency>
 
         <!-- Shared HMS module: supplies Doris's version-aware org.apache.hadoop.hive.metastore.HiveMetaStoreClient
-             (bundled in fe-connector-hms-*.jar, which sorts before hive-catalog-shade-*.jar in the plugin lib so
-             it shadows the shaded, unpatched client). Required for the hms flavor: without it, iceberg's
+             (bundled in fe-connector-hms-*.jar, which sorts before fe-connector-hms-hive-shade-*.jar in the
+             plugin lib so it shadows the shaded, unpatched client). Required for the hms flavor: without it, iceberg's
              HiveCatalog uses the Hive-3 "@cat#" db-name marker that a Hive-1/2 metastore rejects, so list/get
              database return empty (see HiveMetaStoreClient header). Same module fe-connector-hive reuses. -->
         <dependency>
@@ -127,6 +127,21 @@ under the License.
             <version>2.9.3</version>
         </dependency>
 
+        <!-- iceberg-bundled-guava: needed on the COMPILE classpath for the vendored split-package
+             org.apache.iceberg.DeleteFileIndex (T08), which imports iceberg's relocated guava
+             (org.apache.iceberg.relocated.com.google.common.base/collect). iceberg-core brings this
+             artifact only at RUNTIME scope (so it is in the plugin-zip), and runtime-scoped transitives
+             are not on the compile classpath — the same treatment as caffeine above. Until the fe-connector
+             closure moved off the fat hive-catalog-shade, that shade jar carried these relocated-guava
+             classes at compile scope; the slim fe-connector-hms-hive-shade deliberately excludes
+             iceberg-bundled-guava (iceberg-core already ships it, avoiding a duplicate), so declare it here
+             at compile scope. Same version as iceberg-core, deduped at runtime. -->
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-bundled-guava</artifactId>
+            <version>${iceberg.version}</version>
+        </dependency>
+
         <!-- Iceberg AWS integration: the glue flavor's org.apache.iceberg.aws.glue.GlueCatalog + S3FileIO.
              Needs the AWS SDK v2 modules below at runtime. -->
         <dependency>
@@ -135,18 +150,15 @@ under the License.
             <version>${iceberg.version}</version>
         </dependency>
 
-        <!-- Doris shaded Hive MetaStore client (D-059 Q1: DLF port-now). Supplies the hms flavor's
-             org.apache.iceberg.hive.HiveCatalog AND the dlf flavor's reflectively-loaded
-             com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient, both at their original package wired
-             to a relocated thrift (shade.doris.hive.org.apache.thrift) so the old-package HMS client does
-             NOT collide with the host fe-thrift 0.16. Same dependency fe-connector-hive/hms use; version
-             managed (${doris.hive.catalog.shade.version}). plugin-zip.xml excludes fe-thrift/libthrift so
-             no original-package thrift lands in the plugin (the relocated copy inside the shade is
-             self-contained). -->
-        <dependency>
-            <groupId>org.apache.doris</groupId>
-            <artifactId>hive-catalog-shade</artifactId>
-        </dependency>
+        <!-- The hms-flavor org.apache.iceberg.hive.HiveCatalog is NOT a direct dependency here: it is
+             bundled (with the shared relocated thrift shade.doris.hive.org.apache.thrift) inside
+             fe-connector-hms-hive-shade and reaches this plugin transitively via fe-connector-hms above —
+             the same slim shade that supplies the plain-HMS client, so HiveCatalog and the client link
+             against one identical relocated thrift + metastore-api. The old direct
+             org.apache.doris:hive-catalog-shade dependency (and the dead dlf-flavor ProxyMetaStoreClient
+             it carried) was removed atomically with the hms cutover off the fat shade — see
+             plan-doc/fe-connector-hive-shade-localization/design.md. plugin-zip.xml still excludes
+             fe-thrift/libthrift so no original-package thrift lands in the plugin. -->
 
         <!-- Hadoop for HadoopCatalog and Configuration -->
         <dependency>

--- a/fe/fe-connector/fe-connector-iceberg/src/main/assembly/plugin-zip.xml
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/assembly/plugin-zip.xml
@@ -46,8 +46,9 @@ under the License.
                 <exclude>org.apache.doris:fe-connector-spi</exclude>
                 <exclude>org.apache.doris:fe-extension-spi</exclude>
                 <exclude>org.apache.doris:fe-filesystem-api</exclude>
-                <!-- Host thrift wins: hive-catalog-shade carries its own relocated thrift, so keep
-                     original-package fe-thrift / libthrift out of the plugin (same as fe-connector-hive). -->
+                <!-- Host thrift wins: the fe-connector-hms-hive-shade slim shade carries its own
+                     relocated thrift (shade.doris.hive.org.apache.thrift), so keep original-package
+                     fe-thrift / libthrift out of the plugin (same as fe-connector-hive). -->
                 <exclude>org.apache.doris:fe-thrift</exclude>
                 <exclude>org.apache.thrift:libthrift</exclude>
                 <!-- QUIC natives are unused: netty-bom force-manages the classifier jars to

--- a/fe/fe-connector/pom.xml
+++ b/fe/fe-connector/pom.xml
@@ -52,6 +52,10 @@ under the License.
         <module>fe-connector-trino</module>
         <module>fe-connector-maxcompute</module>
         <module>fe-connector-jdbc</module>
+        <!-- Slim HMS metastore-client shade (relocates org.apache.thrift to
+             shade.doris.hive.org.apache.thrift); MUST build before fe-connector-hms which depends on
+             it. Replaces the fat org.apache.doris:hive-catalog-shade for the fe-connector closure. -->
+        <module>fe-connector-hms-hive-shade</module>
         <module>fe-connector-hms</module>
         <module>fe-connector-hive</module>
         <!-- FIX-C: paimon HMS-thrift shade (relocates org.apache.thrift to a paimon-private

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -843,6 +843,10 @@ under the License.
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- The fat hive-catalog-shade is no longer consumed by any fe/fe-connector module (the plain-HMS
+                 client + iceberg HiveCatalog moved to the slim fe-connector-hms-hive-shade). This version pin
+                 is kept because be-java-extensions (avro-scanner, java-udf) still depend on hive-catalog-shade
+                 — do NOT delete it. -->
             <dependency>
                 <groupId>org.apache.doris</groupId>
                 <artifactId>hive-catalog-shade</artifactId>

--- a/plan-doc/fe-connector-hive-shade-localization/HANDOFF.md
+++ b/plan-doc/fe-connector-hive-shade-localization/HANDOFF.md
@@ -1,0 +1,51 @@
+# 🤝 Session Handoff — `fe/fe-connector` 剥离 `hive-catalog-shade`
+
+> **滚动文档**：每次 session 结束**覆盖式更新**，只保留下一个 session 必须的上下文。
+> 完成明细**不落这里**（在 `git log` + [`progress.md`](./progress.md)）。
+> 空间索引 [`README.md`](./README.md) · 设计 [`design.md`](./design.md) · 清单 [`tasklist.md`](./tasklist.md)
+
+---
+
+# ✅ Phase 0 完成（设计定案 + 用户签字 + 红队 GO） → 🆕 下一个 session = **Phase 1：建承重墙 shade 模块**
+
+> 基线分支 `catalog-spi-hive-shade-12`（== 旧 `catalog-spi-11-hive` 内容）。行号信 HEAD 不信文档。
+
+## 第一件事（按顺序）
+
+1. **读** `progress.md` 末段（Phase 0 结论）+ `design.md §3`（精确 bundle 清单）+ `§4`（决策速查）。
+2. **动码前探并发**（`pgrep -af maven|grep wt-catalog-spi` + 近 90s mtime）；`git add` 白名单严禁 `-A`。
+3. **建 `fe/fe-connector/fe-connector-hms-hive-shade/pom.xml`**（镜像 `fe-connector-paimon-hive-shade/pom.xml`，324 行）。
+
+## 🔑 Phase 0 已定的四件事（照做，别再议）
+
+- **D1=A 共享一个** `fe-connector-hms-hive-shade`：hms 依赖它（compile 传递给 hive/hudi/iceberg），iceberg 复用同一制品。
+- **D2=3.1.3**；**D3=复用前缀 `shade.doris.hive.org.apache.thrift`**（= 补丁客户端现有 import，**零源码改动**，别起新前缀）。
+- **D4=KEEP_IN_HMS**：补丁 `HiveMetaStoreClient.java` 留在 fe-connector-hms 原地，**不搬不改写**（字节码已全是重定位名）。
+
+## 📦 精简 shade 精确 bundle 清单（Phase 0 核实，直接照抄进 pom）
+
+**bundle 进 shade（`<optional>true>` + 重定位 thrift）**：
+- `org.apache.hive:hive-standalone-metastore:3.1.3` ← **⚠️不是 `hive-metastore:3.1.3`（13 类空壳）**
+- `org.apache.thrift:libthrift:0.9.3`（**内联钉**，非 managed 0.16.0）+ `org.apache.thrift:libfb303:0.9.3`
+- `org.apache.hive:hive-common:3.1.3`（带 hive-shims）+ `org.apache.hive:hive-storage-api:2.7.0`
+- `org.apache.hive:hive-serde:3.1.3`（iceberg 用）+ `org.apache.iceberg:iceberg-hive-metastore:1.10.1`（iceberg 用，排除 iceberg-core）
+
+**relocation**：`org.apache.thrift → shade.doris.hive.org.apache.thrift`（**必须此前缀**）；`it.unimi.dsi.fastutil → shade.doris.hive.it.unimi.dsi.fastutil`（防御）。
+**artifactSet exclude**：paimon、完整 hadoop、hive-exec、DLF/aliyun、derby/datanucleus/bonecp/HikariCP/orc、bouncycastle、jersey/jaxb、arrow/parquet/avro、guava/protobuf/jackson/slf4j/log4j/commons、iceberg-core/api/caffeine。
+**META-INF**：过滤 `*.SF/*.DSA/*.RSA`、`META-INF/maven/**`、`META-INF/versions/**`（照 paimon）。
+
+## ⚠️ 两条红队约束（Phase 1/2 必守）
+
+1. **iceberg 摘全局 shade（`fe-connector-iceberg/pom.xml` 现第 ~148 行那条）与接精简 shade 放同一次提交（原子切换）**，别留过渡期两份 `HiveCatalog` 并存（实测 37821B vs 1.10.1 37853B，谁生效随 classpath 序）。顺带订正 iceberg pom:138-145 过期的 "支持 DLF" 注释。
+2. **Phase 1/4 验证**：重部署后类加载冒烟——每插件 `org.apache.hadoop.hive.metastore.api.Table` 与 `shade.doris.hive.org.apache.thrift.TException` **各仅一份**；HMS-on-hive/hudi/iceberg e2e；Kerberos + `MetaStoreFilterHook`/`URIResolverHook` 按名反射路径（D5 TCCL pin 别回归：`ThriftHmsClient.doAs` 钉 plugin loader、`HmsConfHelper.createHiveConf` `setClassLoader`）。
+
+## ⚙️ 构建坑（兄弟任务血泪，全文见 `tasklist.md §构建坑`）
+
+- 测试 **`-Dmaven.build.cache.enabled=false`** + 数 `Running org.apache.doris` 行；**`-am` 必填**；依赖 shade 的模块**跑到 `package`**（`test-compile` 假报 `HiveConf does not exist`）。
+- maven 用**绝对 `-f`** `/mnt/disk1/yy/git/wt-catalog-spi/fe/pom.xml`；`-pl fe-connector-XXX`（reactor 相对名）。
+- `hive-serde` 闭包首次需联网（`servlet-api:2.4` 不在本地仓）→ 首次去 `-o`。
+- shade 模块无 src/main → 照 paimon 钉 `maven-jar-plugin` default-jar 到 package + `forceCreation`（并行 reactor 下 shade 早于 jar 会炸）。
+
+## ✅ 每个 Phase 收尾
+
+commit（英文）+ 覆盖本 HANDOFF + `progress.md` 追加一行 + 勾 `tasklist.md`。

--- a/plan-doc/fe-connector-hive-shade-localization/HANDOFF.md
+++ b/plan-doc/fe-connector-hive-shade-localization/HANDOFF.md
@@ -6,46 +6,33 @@
 
 ---
 
-# ✅ Phase 0 完成（设计定案 + 用户签字 + 红队 GO） → 🆕 下一个 session = **Phase 1：建承重墙 shade 模块**
+# ✅ Phase 1+2+3 完成（建精简 shade + 切 hms/iceberg + 静态&打包闸门全绿） → 🆕 下一个 session = **Phase 4：e2e（唯一真闸门）**
 
-> 基线分支 `catalog-spi-hive-shade-12`（== 旧 `catalog-spi-11-hive` 内容）。行号信 HEAD 不信文档。
+> 分支 `catalog-spi-hive-shade-12`。行号信 HEAD 不信文档。代码改动已 commit（见 git log 最新一条）。
+
+## 现状（一句话）
+`fe/fe-connector/` 已整体脱离 122MB 胖 `hive-catalog-shade`，改用自建 15MB 精简 shade 模块 `fe-connector-hms-hive-shade`（只装 Hive 元数据客户端闭包，重定位 thrift→`shade.doris.hive.org.apache.thrift`）。build+UT（197 测试类全绿）、静态闸门（19 模块 dependency:tree 全空）、打包闸门（三插件 zip 无胖 shade、精简 shade 各 1 份、关键类无重复）、多 agent 对抗 review（零 confirmed）**均已过**。**唯一没做的是 e2e。**
 
 ## 第一件事（按顺序）
+1. **读** `progress.md` 末段（2026-07-16 Phase 1+2+3 结论，含闸门证据 + 两处现补的缺类）+ `design.md §4`（决策速查）。
+2. **动码/跑测前探并发**（`pgrep -af maven|grep wt-catalog-spi` + 近 90s mtime）。
+3. **重新构建部署产物**跑 e2e（精简 shade 需重打包插件重部署；旧部署目录可能还是胖 shade）。
 
-1. **读** `progress.md` 末段（Phase 0 结论）+ `design.md §3`（精确 bundle 清单）+ `§4`（决策速查）。
-2. **动码前探并发**（`pgrep -af maven|grep wt-catalog-spi` + 近 90s mtime）；`git add` 白名单严禁 `-A`。
-3. **建 `fe/fe-connector/fe-connector-hms-hive-shade/pom.xml`**（镜像 `fe-connector-paimon-hive-shade/pom.xml`，324 行）。
+## 🎯 Phase 4 要做的（`tasklist.md` FCL-40/41/42）
+- **异构 HMS docker 套件**：① 普通 hive catalog 读+写；② **iceberg-on-HMS** INSERT/DELETE/MERGE/read，断言与独立 iceberg 目录同表同结果；③ hudi-on-HMS 读。
+- **🔴 TCCL 不回归**（memory `catalog-spi-plugin-tccl-classloader-gotcha` / D5）：`test_string_dict_filter` 类用例 + MetaStoreFilterHook/URIResolverHook 按名反射路径 + kerberos HMS（若环境有）；FE 启动 + 缓存（MetaCache/StatisticsCache/FileSystemCache）冒烟。
+- **专项**：storage-api **2.7.0** 的 write/ACID 路径（本轮从胖 shade 的 2.8.1 换回 3.1.3 原生 2.7.0，review 判无回退但要 e2e 兜底）。
+- 结果（含 CI 编号）追加 `progress.md`。
 
-## 🔑 Phase 0 已定的四件事（照做，别再议）
+## ⚠️ 白名单 shade 的运行时缺类（Phase 4 可能再遇，按此法补）
+精简 shade 用 **白名单 `<includes>`**，只装列出的 hive 客户端闭包；运行时其余靠各插件自带 hadoop-common 闭包/宿主 parent-first 提供。**跑到才暴露的缺类**本轮已补两处（老 Jackson `ObjectMapper`、iceberg `bundled-guava`）；e2e 若再报 `NoClassDefFoundError`（尤其 kerberos/filter-hook 路径），**按同法补**：查是哪个 artifact 的类 → 加进 `fe-connector-hms-hive-shade/pom.xml` 的 `<dependency>`(必要时显式 `<scope>compile</scope>` 覆盖 fe/pom.xml 里的 test-scope 管理) + artifactSet `<include>`。**别退回黑名单 excludes**（那会把 122MB junk 又拉回来）。
 
-- **D1=A 共享一个** `fe-connector-hms-hive-shade`：hms 依赖它（compile 传递给 hive/hudi/iceberg），iceberg 复用同一制品。
-- **D2=3.1.3**；**D3=复用前缀 `shade.doris.hive.org.apache.thrift`**（= 补丁客户端现有 import，**零源码改动**，别起新前缀）。
-- **D4=KEEP_IN_HMS**：补丁 `HiveMetaStoreClient.java` 留在 fe-connector-hms 原地，**不搬不改写**（字节码已全是重定位名）。
-
-## 📦 精简 shade 精确 bundle 清单（Phase 0 核实，直接照抄进 pom）
-
-**bundle 进 shade（`<optional>true>` + 重定位 thrift）**：
-- `org.apache.hive:hive-standalone-metastore:3.1.3` ← **⚠️不是 `hive-metastore:3.1.3`（13 类空壳）**
-- `org.apache.thrift:libthrift:0.9.3`（**内联钉**，非 managed 0.16.0）+ `org.apache.thrift:libfb303:0.9.3`
-- `org.apache.hive:hive-common:3.1.3`（带 hive-shims）+ `org.apache.hive:hive-storage-api:2.7.0`
-- `org.apache.hive:hive-serde:3.1.3`（iceberg 用）+ `org.apache.iceberg:iceberg-hive-metastore:1.10.1`（iceberg 用，排除 iceberg-core）
-
-**relocation**：`org.apache.thrift → shade.doris.hive.org.apache.thrift`（**必须此前缀**）；`it.unimi.dsi.fastutil → shade.doris.hive.it.unimi.dsi.fastutil`（防御）。
-**artifactSet exclude**：paimon、完整 hadoop、hive-exec、DLF/aliyun、derby/datanucleus/bonecp/HikariCP/orc、bouncycastle、jersey/jaxb、arrow/parquet/avro、guava/protobuf/jackson/slf4j/log4j/commons、iceberg-core/api/caffeine。
-**META-INF**：过滤 `*.SF/*.DSA/*.RSA`、`META-INF/maven/**`、`META-INF/versions/**`（照 paimon）。
-
-## ⚠️ 两条红队约束（Phase 1/2 必守）
-
-1. **iceberg 摘全局 shade（`fe-connector-iceberg/pom.xml` 现第 ~148 行那条）与接精简 shade 放同一次提交（原子切换）**，别留过渡期两份 `HiveCatalog` 并存（实测 37821B vs 1.10.1 37853B，谁生效随 classpath 序）。顺带订正 iceberg pom:138-145 过期的 "支持 DLF" 注释。
-2. **Phase 1/4 验证**：重部署后类加载冒烟——每插件 `org.apache.hadoop.hive.metastore.api.Table` 与 `shade.doris.hive.org.apache.thrift.TException` **各仅一份**；HMS-on-hive/hudi/iceberg e2e；Kerberos + `MetaStoreFilterHook`/`URIResolverHook` 按名反射路径（D5 TCCL pin 别回归：`ThriftHmsClient.doAs` 钉 plugin loader、`HmsConfHelper.createHiveConf` `setClassLoader`）。
-
-## ⚙️ 构建坑（兄弟任务血泪，全文见 `tasklist.md §构建坑`）
-
-- 测试 **`-Dmaven.build.cache.enabled=false`** + 数 `Running org.apache.doris` 行；**`-am` 必填**；依赖 shade 的模块**跑到 `package`**（`test-compile` 假报 `HiveConf does not exist`）。
-- maven 用**绝对 `-f`** `/mnt/disk1/yy/git/wt-catalog-spi/fe/pom.xml`；`-pl fe-connector-XXX`（reactor 相对名）。
-- `hive-serde` 闭包首次需联网（`servlet-api:2.4` 不在本地仓）→ 首次去 `-o`。
-- shade 模块无 src/main → 照 paimon 钉 `maven-jar-plugin` default-jar 到 package + `forceCreation`（并行 reactor 下 shade 早于 jar 会炸）。
+## ⚙️ 构建/验证坑（本轮实证，直接复用）
+- `-pl` 选精简 shade 模块用 **`:fe-connector-hms-hive-shade`**（冒号 artifactId 选择器），裸名 maven 报 "Could not find the selected project"。
+- 后台跑 maven **别** `nohup ... &` 套在 `run_in_background` Bash 里 → 脱离 harness 跟踪、误报秒完成；用 `tail --pid=<mvnpid>` 阻塞等真 `BUILD SUCCESS/FAILURE`。
+- 依赖 shade 的模块**跑到 `package`**（`test-compile` 假报缺类）；`-am` 必填；`-Dmaven.build.cache.enabled=false` 且数 `Running org.apache.doris` 行；`mvn|tail` 后 `$?` 是 tail 的（重定向到文件读 BUILD 行）。
+- maven 用绝对 `-f /mnt/disk1/yy/git/wt-catalog-spi/fe/pom.xml`。
+- `git add` 用 path-whitelist，**严禁 `-A`**（工作树大量非本线程 scratch）。
 
 ## ✅ 每个 Phase 收尾
-
 commit（英文）+ 覆盖本 HANDOFF + `progress.md` 追加一行 + 勾 `tasklist.md`。

--- a/plan-doc/fe-connector-hive-shade-localization/design.md
+++ b/plan-doc/fe-connector-hive-shade-localization/design.md
@@ -1,0 +1,151 @@
+# 设计 — `fe/fe-connector` 剥离 `hive-catalog-shade`（迁自带精简局部 shade）
+
+> 稳定参考文档。状态/进度看 `tasklist.md` + `progress.md`；下一步看 `HANDOFF.md`。
+> 基线 2026-07-16，分支 `catalog-spi-11-hive`。所有 `file:line` 以 HEAD `grep` 为准。
+
+---
+
+## 1. 背景：`hive-catalog-shade` 是什么、为什么存在
+
+`org.apache.doris:hive-catalog-shade`（源码库 `doris-shade`）是一个用 `maven-shade-plugin` 把整个 Hive 访问闭包
+（`hive-metastore:3.1.3` + `hive-serde` + `hive-exec:core` + `iceberg-hive-metastore:1.10.1` + `paimon-hive-connector:1.3.1` + DLF）
+打成一个 jar 的胖包，核心动作是**把 `org.apache.thrift` 重定位到 `shade.doris.hive.org.apache.thrift`**。
+
+- **为什么要重定位**：Doris 内部 thrift = **0.16.0**（`fe/pom.xml:295`），doris-gen 桩（`TFileScanRangeParams`/`TIcebergFileDesc` 等）按 0.16.0 编译；而 Hive 3.1.3 的 metastore 客户端桩按 **thrift ~0.9.x** 编译，二进制不兼容（`TFramedTransport` 换包到 `.transport.layered`、`TBase`/scheme 契约漂移）。同一个 `org.apache.thrift` 命名空间容不下两个版本 → 给 Hive 那套单独换私有包。
+- **为什么把 iceberg/paimon 的 hive-metastore 也打进去**：`maven-shade` 只改写它**打进 jar 的类**的字节码；iceberg 的 `HiveCatalog`、paimon 的 `HiveCatalog` 都经 `HiveMetaStoreClient` 访问 HMS、字节码带 `org.apache.thrift.*` 引用，必须一起打进来才会被统一重定位。
+- **为什么胖**：122 MB 里真正为它而存在的（Hive 客户端 4 MB + 重定位 thrift 0.5 MB）不到 1.6%；其余是 paimon-bundle（~94 MB，内部又重打包了 hadoop/guava/fastutil）、完整 hadoop（58 MB）、古董 fastutil 6.5.x（37 MB）、多平台原生库、datanucleus/derby 服务端等——大量**重复**和**无用**。
+
+**这就是要脱离它的动机**：胖、有版本冲突隐患（fastutil 6.5.x child-first 遮蔽）、且插件化后一个插件被迫背另一个连接器的全套依赖。
+
+---
+
+## 2. 现状依赖图（2026-07-16 核实）
+
+`fe/fe-connector/` 下对 `hive-catalog-shade` 的**真实(非注释)直接依赖只有两个**：
+
+```
+hive-catalog-shade  (org.apache.doris, 版本由 fe/pom.xml dependencyManagement 钉)
+      ▲                                   ▲
+      │ 直接 (fe-connector-iceberg:93)    │ 直接 (fe-connector-hms:43, compile 无 scope → 传递)
+      │                                   │
+fe-connector-iceberg               fe-connector-hms   ◄── 共享 plain-HMS 客户端模块
+   (要 iceberg-hive-metastore)             │
+                                           │ compile 传递给
+                          ┌────────────────┼────────────────┐
+                    fe-connector-hive  fe-connector-hudi  fe-connector-iceberg
+                                        (都 depend fe-connector-hms)
+```
+
+- `fe-connector-hms/pom.xml:43` 直接依赖，**无 `<scope>` = compile = 传递**。它是被 hive / hudi / iceberg-on-HMS **共用**的 plain-HMS 客户端。
+- `fe-connector-iceberg/pom.xml:93` 另有一条**直接**依赖，用途是 `iceberg-hive-metastore`（iceberg→HMS 的胶水），外加它链接的重定位 thrift 基座。
+- 结论：**只迁 iceberg 只摘掉它自己那条直接依赖；hms（及经 hms 的 hive/hudi/iceberg）仍被 shade 牵着。要整个 fe/fe-connector 脱钩，必须先迁 `fe-connector-hms`。**
+
+repo 全局(HEAD)真实消费者共 4 个 + 版本钉：`fe-connector-hms`、`fe-connector-iceberg`、`be-java-extensions/avro-scanner`、`be-java-extensions/java-udf`、`fe/pom.xml`（钉）。**后三者不在本任务范围**。
+
+---
+
+## 3. 方案：镜像 `fe-connector-paimon-hive-shade`
+
+paimon 已经走通这条路（`fe/fe-connector/fe-connector-paimon-hive-shade/pom.xml`，324 行；设计 `plan-doc/fix-c-hms-thrift-design.md`）：建一个插件私有 shade 模块，bundle metastore 客户端闭包 + `libthrift`，**重定位 `org.apache.thrift` 到插件私有前缀**（paimon 用 `org.apache.doris.paimon.shaded.thrift`），consumer 换依赖。要点原样照搬：
+
+- **只 shade metastore-client 闭包**，不 shade 连接器主模块（否则会把连接器里对 host 0.16.0 `TSerializer`/`TBase` 的调用也重定位，序列化 doris-gen 结构就断了）。
+- **libthrift 排除出 consumer 插件**（保持 `org.apache.thrift` 对 host 0.16.0 **parent-first**，doris-gen 路径不动），只在 shade 模块里 bundle + 重定位。
+- **artifactSet 排除** host/插件已提供的库：`org.apache.hadoop:*`、guava、protobuf、slf4j、log4j、commons-*、gson、jackson、caffeine（避免 child-first 重复类）。
+- **防御性重定位 fastutil**（`it.unimi.dsi.fastutil` → 私有前缀），躲开 6.5.x 遮蔽。
+- **`org.apache.paimon.* / org.apache.hadoop.*` 绝不重定位**（SPI 发现 + `HiveConf`/`Configuration` 类同一性）。
+- consumer 侧还要在 `plugin-zip.xml` 保留对 `org.apache.thrift:libthrift` 和 `org.apache.doris:fe-thrift` 的 exclude。
+
+目标 jar 体积预估 ≈ **13–15 MB**（对比 122 MB）。**Phase 0 核实的精确 bundle 清单**（`javap` + `jar tf` + 核查 agent 交叉验证，2026-07-16）：
+
+| bundle 进 shade（重定位 thrift） | 版本 | 谁需要 | 为什么 |
+|---|---|---|---|
+| `org.apache.hive:hive-standalone-metastore` | **3.1.3** | 全部 | 提供 `org.apache.hadoop.hive.metastore.api.*`（`ThriftHiveMetastore` + ~200 结构体）+ `IMetaStoreClient`/`MetastoreConf`/`MetaStoreUtils`/`HadoopThriftAuthBridge`/`txn.TxnUtils`。**⚠️ 是 standalone-metastore（真实现），不是 `hive-metastore:3.1.3`（13 类空壳）** |
+| `org.apache.thrift:libthrift` | **0.9.3**（内联钉，非 managed 0.16.0） | 全部 | 补丁客户端直接 import 的 9 个 thrift 类；重定位到 `shade.doris.hive.org.apache.thrift` |
+| `org.apache.thrift:libfb303` | **0.9.3** | 全部 | `ThriftHiveMetastore.{Iface,Client}` 继承 `com.facebook.fb303.FacebookService`，不链接则生成客户端 link 失败 |
+| `org.apache.hive:hive-common` | **3.1.3** | 全部 | `org.apache.hadoop.hive.conf.HiveConf`（`HmsConfHelper.createHiveConf` / iceberg `IcebergCatalogFactory` 用）；带 `hive-shims` |
+| `org.apache.hive:hive-storage-api` | 2.7.0 | 全部 | `ValidWriteIdList` 等（hms txn / write-ACID 路径），hive-common/standalone-metastore 都不含 |
+| `org.apache.hive:hive-serde` | **3.1.3** | 仅 iceberg | iceberg `HiveSchemaUtil` 建表/提交时用 `serde2.typeinfo.*`/`objectinspector.*`（118 处 byte-ref） |
+| `org.apache.iceberg:iceberg-hive-metastore` | 1.10.1 | 仅 iceberg | `org.apache.iceberg.hive.HiveCatalog`（hms flavor）；排除 iceberg-core（插件已直接带 1.10.1） |
+
+**关键 exclude**：`org.apache.paimon:*`（自有 shade）、完整 `org.apache.hadoop:*`（插件自带 child-first）、`it.unimi.dsi:fastutil`（防御性重定位而非 bundle）、`org.apache.hive:hive-exec`（见下）、`com.aliyun:*`/DLF、derby/datanucleus/bonecp/HikariCP/orc、bouncycastle、jersey/jaxb、arrow/parquet/avro（hive-serde 重传递）、guava/protobuf/jackson/slf4j/log4j/commons（host parent-first）、iceberg-core/api/caffeine（插件已带）。
+
+**两处原设计假设已纠正**：
+1. **hive-exec 不进插件**。connector 源码里 `org.apache.hadoop.hive.ql.*` 全是**字符串常量**（ORC/Parquet 格式类名写进 HMS `StorageDescriptor`，FE 从不加载该类；BE 原生读）。`HmsWriteConverter:270-279`、`HiveScanPlanProvider:92`、`HiveConnectorMetadata:139/141`、`HiveTableFormatDetector:43/44` 均为字符串，零 `import`。commit `e7eae85faa4` 的 host `hive-exec:core` 是 CREATE FUNCTION 的 `hive.ql.exec.UDF` 契约，主机侧独立事，与插件无关。
+2. **DLF 已是死代码**，直接不装。`iceberg.catalog.type=dlf` / `metastore.type=dlf` 已在 `IcebergCatalogFactory.resolveCatalogImpl` + `HmsClientConfig.REMOVED_METASTORE_TYPES` 移除并有守卫测试拦截。⚠️ `fe-connector-iceberg/pom.xml:138-145` 那段"支持 DLF / port-now"注释**过期**，动码时顺手订正（别让它误导 shade 的 artifactSet 去保留 DLF）。
+
+---
+
+## 4. 设计决策 —— **已定案（Phase 0，2026-07-16，用户签字）**
+
+> **决策速查**（下方各 D 的详细背景保留；此处为最终结论）：
+> - **D1 = A（共享一个 shade）** ✅ 用户签字。iceberg `HiveCatalog` 按类名建 `HiveMetaStoreClient` → 命中补丁客户端 → 二者须共用同一份重定位 thrift + 元数据 API 类身份 → 必须一个共享 shade。代价：hive/hudi 多背 ~1.1MB 永不加载的 iceberg 类（非泄漏，仅字节）。
+> - **D2 = 3.1.3** ✅ 用户签字。保持与全局 shade 行为一致。
+> - **D3 = 复用 `shade.doris.hive.org.apache.thrift`** ✅ 用户签字。补丁客户端 + `ThriftHmsClient` 本就 import 此前缀 → **零源码改动**；过渡期两包同名同版本（libthrift 0.9.3）字节一致、谁生效都不撕裂（新前缀反而会在过渡期让新旧两份 `HiveCatalog` 绑不同前缀 → 旧份被优先加载即 ClassCastException）。
+> - **D4 = KEEP_IN_HMS**（`javap` 定案）。补丁客户端字节码对 thrift 的全部 48 处引用**已全部是重定位名** `shade.doris.hive.org.apache.thrift.*`，零 raw、零按名反射。故它留在 `fe-connector-hms`、不搬进 shade、不改写，只需精简 shade 在其 classpath 上复现同名 thrift 即可。
+>
+> **配套计划微调（红队条件 1）**：iceberg **摘全局 shade** 与 **接精简 shade** 须放**同一次提交（原子切换）**，消除"过渡期两份 `HiveCatalog` 并存"的不确定（实测全局 37821B vs 精简 1.10.1 37853B，谁生效随 classpath 序 → 顺带把 iceberg.hive 对齐插件自带 iceberg-core 1.10.1）。
+> **验证条件（红队条件 2）**：Phase 1/4 须跑重部署类加载冒烟（每插件 `metastore.api.Table` 与 `shade.doris.hive.org.apache.thrift.TException` **各仅一份**）+ hive/hudi/iceberg-on-HMS e2e + Kerberos/filter-hook 按名反射路径（D5）。
+
+### 4.x 决策原始背景（存档，勿据此再议——结论以上方速查为准）
+
+### D1 — 一个共享 shade 还是两个独立 shade？
+- **选项 A（推荐，共享）**：一个 `fe-connector-hms-hive-shade`，bundle `hive-metastore` + `hive-serde` + `hive-common` + `libthrift`（重定位）**外加 `iceberg-hive-metastore`**。`fe-connector-hms` 和 `fe-connector-iceberg` 都依赖它。iceberg-hive-metastore 随包搭车 → hive/hudi 多背 ~1 MB 用不到的 iceberg 类，但**只需一个 thrift 私有命名空间**、最省事、就是「全局 shade 去肥」版。
+- **选项 B（分开）**：`fe-connector-hms-hive-shade`（客户端+thrift，hive/hudi/iceberg 共用）+ iceberg 的 iceberg-hive-metastore 单独 shade。**难点**：iceberg-hive-metastore 的 `HiveCatalog` 必须和客户端用**同一份**重定位 thrift，而 `libthrift` 不能在两个 shade 各 bundle 一份（child-first 重复类）。要么 iceberg-hive-metastore 进同一个 jar，要么引用 hms shade 的重定位 thrift 而不重打包 → 复杂。
+- **建议**：选 A。Phase 0 交用户签字。
+
+### D2 — bundle 的 hive-metastore 版本？
+全局 shade 用 **3.1.3**；paimon 局部 shade 用 **2.3.7**。plain-HMS 插件当前经全局 shade 跑的是 **3.1.3**。
+**默认取 3.1.3 以保持行为不变**（尤其 vendored 补丁客户端 + `HiveVersionUtil` 对 Hive 版本敏感——见 D4）。Phase 0 确认 vendored 客户端所依赖的版本后签字。
+
+### D3 — thrift 重定位前缀
+新 hms 私有前缀 **`org.apache.doris.hms.shaded.thrift`**（区别于 paimon 的 `org.apache.doris.paimon.shaded.thrift`、全局的 `shade.doris.hive.org.apache.thrift`，三者永不撞）。
+
+### D4 — 🔴 vendored 补丁 `HiveMetaStoreClient.java`（**本任务最大未知**）
+`fe/fe-connector/fe-connector-hms/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java` 是 **Doris 源码写的、版本感知的**补丁客户端（`import org.apache.doris.datasource.hive.HiveVersionUtil`），当前靠 jar 排序 overlay/shadow 掉 shade 里那份未打补丁的同名类（iceberg pom 注释：修 Hive-3 `@cat#` db 标记对 Hive-1/2 metastore 的兼容）。
+
+- **问题**：它编译在 fe-connector-hms 里（**不会被 shade 重定位**）。若它的字节码引用 `org.apache.thrift.transport.*` 等被重定位掉的类，重定位后：shade 里的基类引用 `org.apache.doris.hms.shaded.thrift.*`，而这个补丁子类仍引用原包 `org.apache.thrift.*` → **命名空间撕裂**。paimon **没有**这个问题（它的客户端全来自 SDK jar，可整体 shade）。
+- **Phase 0（FCL-02）必须**：`javap` 出 vendored 客户端对 `org.apache.thrift.*` 的全部引用面；据此决定：
+  - 若它只碰高层 API（不碰 transport/被搬走的类）→ 可能可保留在原包；
+  - 若它碰被重定位的类 → 需把它的**源码也纳入 shade 模块**（在 shade 里编译再重定位），或改写它避免直接触 thrift transport。
+- **这是 Phase 0 的头号交付物**，方案定不下来别进 Phase 1。
+
+### D5 — TCCL classloader pin（**别回归**）
+plain-hive HMS 客户端创建须钉插件 classloader：`ThriftHmsClient.doAs` 钉 plugin loader（非 `getSystemClassLoader()`）、`HmsConfHelper.createHiveConf` 须 `setClassLoader(插件loader)`（否则 `loadFilterHooks` 经 conf 缓存 CL 反射 `MetaStoreFilterHook` split-brain）。
+参考 memory `catalog-spi-plugin-tccl-classloader-gotcha`（TeamCity #991951，commit `92004ef1d0d`；`test_string_dict_filter` 2026-07-11 踩坑）。**重定位不能破坏这套按名反射**——Phase 4 e2e 必须覆盖 filter hook / string dict filter / kerberos 路径。
+
+### D6 — 其它库共存
+mirror paimon 的 artifactSet 排除（hadoop/guava/slf4j/log4j/commons/caffeine），并核对打包后插件 zip 无重复 `HiveConf`/`libthrift`/`hive-metastore`。
+
+---
+
+## 5. 风险清单
+
+| # | 风险 | 触发 | 缓解 |
+|---|---|---|---|
+| R1 | vendored 补丁客户端命名空间撕裂（D4） | 它引用被重定位的 thrift 类 | Phase 0 先 `javap` 定面；必要时把它纳入 shade 编译 |
+| R2 | TCCL 反射回归（D5） | 重定位后 filter hook / doAs 按名反射失效 | e2e 覆盖 string dict filter / filter hook / kerberos |
+| R3 | iceberg-on-HMS 与 hms 客户端 thrift 命名空间不一致 | 分开 shade 各 bundle thrift | 选 D1-A（共享一份重定位 thrift） |
+| R4 | 打包出现两份 `paimon-hive`/`hive-metastore`/`libthrift`（child-first 重复类） | consumer 同时保留旧 raw 依赖 | 照 paimon：raw 依赖 `<optional>true`，plugin-zip exclude，打包后 `unzip -l` 断言唯一 |
+| R5 | hive/hudi 静默受影响（它们经 hms 传递） | 只测 hms、iceberg 漏测 hive/hudi | Phase 1 gate 必须连 hive+hudi build+UT；Phase 4 e2e 三连 |
+| R6 | 行为变更（Caffeine/hive 版本漂移） | 换版本或换传递依赖 | 默认锁 3.1.3；FE 启动 + 缓存冒烟（FCL-41） |
+
+---
+
+## 6. 铁律（继承主线，勿违）
+
+1. **fe-core / fe-connector 源码只出不进**：不为「编译过」把逻辑挪进 fe-core util；shade 模块只装第三方 jar + （必要时）vendored 客户端源码。
+2. **禁 deletion-scaffolding 式搬迁**：遇到「删依赖导致编译不过」，停手重分析真实归属，别就近搬。
+3. **commit / PR 文案全英文**（上游社区看）；plan-doc / 本空间中文。
+4. **每完成一个 Phase 就更新 HANDOFF + commit**（不只阶段边界）。
+5. **大改动用 clean-room 对抗 review**（多 agent 先独立判断、后交叉核对历史结论）。
+6. **iceberg-on-HMS 新能力必须配 e2e**（异构 HMS 目录跑 INSERT/DELETE/MERGE/read 断言与独立 iceberg 目录同结果）。
+
+---
+
+## 7. 参考
+
+- 范式模块：`fe/fe-connector/fe-connector-paimon-hive-shade/pom.xml`
+- 范式设计：`plan-doc/fix-c-hms-thrift-design.md`
+- 兄弟任务：`plan-doc/hive-catalog-shade-removal/`（fe-core 版，已完成阶段 1–5）
+- shade 机制/体积拆解：本 session 分析（见 `progress.md` 开篇「起源」）
+- 相关 memory：`catalog-spi-plugin-tccl-classloader-gotcha`、`fe-core-source-isolation-iron-rules`、`catalog-spi-connector-cache-framework-caffeine-coherence`、`hms-iceberg-delegation-needs-e2e`

--- a/plan-doc/fe-connector-hive-shade-localization/progress.md
+++ b/plan-doc/fe-connector-hive-shade-localization/progress.md
@@ -1,0 +1,60 @@
+# 进度记录 — `fe/fe-connector` 剥离 `hive-catalog-shade`
+
+> **append-only**，只追加不覆盖。每条：日期 · 谁/什么 session · 结论 · 证据(file:line/命令) · 坑。
+> 状态清单看 `tasklist.md`；下一步看 `HANDOFF.md`。
+
+---
+
+## 2026-07-16 · 建档 session（调研，**代码零改动**）
+
+### 起源
+用户先做了一轮 `hive-catalog-shade` 调研（为什么包里有 iceberg/paimon 的 hive-metastore、fe-connector 下是否还需要、StarRocks 怎么不用 shade），据此提出**中期迁移**：把 iceberg 照 paimon 模式迁自带精简局部 shade。追问「只迁 iceberg 是不是整个 fe/fe-connector 就不依赖 hive-catalog-shade 了」→ 核实后**答案是否**，遂建本任务空间。
+
+### 依赖图核实（本 session 实测，2026-07-16 `catalog-spi-11-hive`）
+- **`fe/fe-connector/` 真实(非注释)直接消费者只有 2 个**：`fe-connector-hms/pom.xml:43`（**无 scope = compile = 传递**）、`fe-connector-iceberg/pom.xml:93`。
+  - 验证法：`perl -0777 -pe 's/<!--.*?-->//gs' <pom> | grep -c '<artifactId>hive-catalog-shade</artifactId>'`（剥注释再数）。
+- `fe-connector-hive` / `fe-connector-hudi` / `fe-connector-iceberg` **都 depend `fe-connector-hms`** → 经它传递拿 shade。
+- **repo 全局真实消费者 = 4 + 版本钉**：`fe-connector-hms`、`fe-connector-iceberg`、`be-java-extensions/avro-scanner`、`be-java-extensions/java-udf`、`fe/pom.xml`。**与兄弟任务 `hive-catalog-shade-removal/` HANDOFF 的声明一致。** 后三者不在本任务范围。
+- ⇒ **结论：承重墙是 `fe-connector-hms`。只迁 iceberg 摘不掉。**
+
+### 关键难点（已识别，未解）
+- `fe-connector-hms` 有 vendored 补丁 `src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java`，`import org.apache.doris.datasource.hive.HiveVersionUtil`（**版本感知**），当前靠 jar 排序 overlay 掉 shade 里未打补丁的同名类。重定位后可能命名空间撕裂——**paimon 无此问题**（客户端全来自 SDK jar）。列为 **FCL-02 头号交付物 / D4**。
+
+### shade 机制与体积（本 session 实证，供设计参考）
+- 重定位：`doris-shade/hive-catalog-shade/pom.xml:627` `org.apache.thrift`→`shade.doris.hive.org.apache.thrift`。Doris 内部 thrift 0.16.0（`fe/pom.xml:295`），Hive 3.1.3 客户端桩按 ~0.9.x，二进制不兼容（`TFramedTransport` 换包 `.transport.layered`、`TBase` 契约漂移）。
+- **实测部署 jar** `output/fe/plugins/connector/iceberg/lib/hive-catalog-shade-3.1.1.jar` = **122 MB 压缩 / 300 MB 解压 / 70,030 文件**。占用排行（解压）：paimon-bundle 内部再打包依赖 72.8MB(25%)、完整 hadoop 58.7MB(20%)、fastutil 6.5.x 36.8MB(13%)、多平台原生库 18.6MB(6%)、iceberg 11MB(4%)、datanucleus+derby ~17MB、DLF 7.7MB……**而真正为它存在的 `org.apache.hive` 客户端仅 4MB(1.4%)、重定位 thrift 仅 0.5MB(0.2%)**。⇒ 迁精简 shade 预估目标 **15–25 MB**。
+- 对照 StarRocks：不自维护 shade，用 `io.trino.hive:hive-apache:3.1.2-22`（33MB），单一 libthrift 0.23.0；生成桩只用 thrift「生成代码契约」（跨版本二进制稳定，`readStructBegin` 等 0.14+ 上移到 `TReadProtocol/TWriteProtocol` 接口保签名——本 session 用 classload+link 实测通过）；唯一换包的 `TFramedTransport` 落在手写 transport 层、默认死代码。**「整体换 hive-apache」是可选的更激进终局，本任务不含**（只做「精简局部 shade」中期方案）。
+
+### 建档产出
+- 新任务空间 `plan-doc/fe-connector-hive-shade-localization/`：README + design（D1–D6 + 风险 R1–R6）+ tasklist（FCL-01~50，Phase 0–5）+ HANDOFF + 本文件。
+- **下一步**：Phase 0 从 FCL-02 起（见 HANDOFF）。
+
+### 坑/提醒（留给下一个 session）
+- 剥 XML 注释再判依赖，否则被大量注释里的 `hive-catalog-shade` 字样骗（本 session 第一次 grep 就中招）。
+- 兄弟任务 `hive-catalog-shade-removal/` 已把 shade 从 fe-core/fe-common 摘掉（阶段 1–5），**别重做**；它明确保留 hms/iceberg 两个 fe-connector 消费者——那正是本任务的对象。
+
+---
+
+## 2026-07-16 · Phase 0 完成（侦察+设计定案+用户签字，**代码零改动**；分支 `catalog-spi-hive-shade-12`）
+
+### 头号未知 D4 定案（`javap` 字节码实证）
+- `javap -v -p fe-connector-hms/target/classes/.../HiveMetaStoreClient.class`：对 thrift 全部 **48** 处引用（7 base + 5 protocol + 36 transport）**全部是重定位名** `shade/doris/hive/org/apache/thrift/*`，**零 raw `org.apache.thrift`、零按名反射**。⇒ 补丁客户端**留在 fe-connector-hms、不搬进 shade、不改写**，只需精简 shade 复现同名 thrift。设计原担心的"命名空间撕裂"不成立。
+- 全仓库仅剩**一份** `HiveMetaStoreClient.java`（在 fe-connector-hms）；文件头"be-java-ext/fe-core 有副本"注释**已过期**（那些副本已随迁移删除）。fe-core 已零 hive-catalog-shade 依赖（兄弟任务确认）。
+
+### 精确 bundle 清单（核查 agent + `jar tf` 交叉验证）
+- **装**：`hive-standalone-metastore:3.1.3`（**非** stub `hive-metastore:3.1.3`）、`libthrift:0.9.3`+`libfb303:0.9.3`（重定位）、`hive-common:3.1.3`、`hive-storage-api:2.7.0`、`hive-serde:3.1.3`（iceberg）、`iceberg-hive-metastore:1.10.1`（iceberg）。体积 122MB→**~13-15MB**。清单入 design.md §3。
+- **hive-exec 不进插件**：`hive.ql.*` 全是字符串常量（格式类名写进 HMS SD），零 import；host `hive-exec:core`(e7eae85) 是 CREATE FUNCTION 独立事。
+- **DLF 已死代码**：iceberg dlf flavor 已移除+守卫测试拦截；iceberg pom:138-145 注释过期待订正。standalone 制品存在（`com.aliyun.datalake:metastore-client-hive3:0.2.14` 在 ~/.m2）但用不到。
+
+### 用户签字（D1/D2/D3）
+- **D1=A 共享一个** `fe-connector-hms-hive-shade`；**D2=3.1.3**；**D3=复用 `shade.doris.hive.org.apache.thrift`**（零源码改动）。红队 GO + 两条件：① iceberg 摘全局 shade 与接精简 shade **原子同 commit**（消除过渡期两份 HiveCatalog 并存不确定，实测 37821B vs 37853B）；② Phase 1/4 跑类加载冒烟（每插件 `metastore.api.Table`/`TException` 各一份）+ HMS e2e + Kerberos/filter-hook 路径。
+
+### 证据/命令
+- `javap -v -p .../HiveMetaStoreClient.class | grep thrift`；`jar tf hive-catalog-shade-3.1.1.jar`（roots: paimon 18912 / hadoop 12474 / fastutil 10653 / iceberg 2972 / aliyun-datalake 2266 / hive-ql 6115 / shade-thrift 225）；验证 workflow `.claude/wf-fcl-phase0-verify.js`（4 agent，349k tok）。
+
+### 下一步
+- **Phase 1**：建 `fe-connector-hms-hive-shade` 模块（镜像 paimon-hive-shade），wire fe-connector-hms，gate 连 hive+hudi build+UT。见 HANDOFF。
+
+### 坑/提醒
+- 精简 shade 必装 `hive-**standalone**-metastore`（`hive-metastore:3.1.3` 是 13 类空壳，装错=整个 metastore api NoClassDefFound）。
+- libthrift 必须**内联钉 0.9.3**（managed 默认 0.16.0 是 host doris-gen 路径，别串）。

--- a/plan-doc/fe-connector-hive-shade-localization/progress.md
+++ b/plan-doc/fe-connector-hive-shade-localization/progress.md
@@ -58,3 +58,36 @@
 ### 坑/提醒
 - 精简 shade 必装 `hive-**standalone**-metastore`（`hive-metastore:3.1.3` 是 13 类空壳，装错=整个 metastore api NoClassDefFound）。
 - libthrift 必须**内联钉 0.9.3**（managed 默认 0.16.0 是 host doris-gen 路径，别串）。
+
+---
+
+## 2026-07-16 · Phase 1+2+3 完成（建精简 shade 模块 + 切换 hms/iceberg + 静态&打包闸门，分支 `catalog-spi-hive-shade-12`）
+
+### 本轮做了什么
+把 `fe/fe-connector/` 对 122MB 胖 shade 的依赖，换成一个自建的 **15MB 精简 shade 模块** `fe-connector-hms-hive-shade`（只装 Hive 元数据**客户端**闭包）。
+
+- **新建** `fe/fe-connector/fe-connector-hms-hive-shade/pom.xml`：bundle `hive-standalone-metastore:3.1.3`(元数据 api+客户端) + `hive-common:3.1.3`(HiveConf) + `hive-serde:3.1.3` + `hive-storage-api:2.7.0` + `iceberg-hive-metastore:1.10.1`(HiveCatalog) + `libthrift/libfb303:0.9.3` + `jackson-mapper/core-asl:1.9.2`（HMS 事件解析用的老 Jackson）+ `commons-lang:2.6`（HiveConf 用）。重定位 `org.apache.thrift`→`shade.doris.hive.org.apache.thrift`（**沿用**旧前缀，零源码改动）+ 防御性重定位 fastutil。
+- **共享库改依赖** `fe-connector-hms/pom.xml`：删胖 shade、加精简 shade（compile 传递 → hive/hudi/iceberg 经它拿到）。补丁客户端 `HiveMetaStoreClient.java` **原地不动**（字节码已全是重定位名）。
+- **iceberg** `fe-connector-iceberg/pom.xml`：删掉它自挂的那条胖 shade 直接依赖（改经 hms 传递拿精简 shade），并补 `iceberg-bundled-guava`(compile，供 vendored DeleteFileIndex 编译)、订正过期注释。
+- 与 hms 切换**放在同一次原子提交**（用户拍板），消除 iceberg 过渡期两份 HiveCatalog 并存的红队隐患。
+
+### 关键决策落地方式（与 tasklist 里旧措辞的差异，以此处为准）
+- 重定位前缀用 **`shade.doris.hive.org.apache.thrift`**（非 tasklist FCL-10 旧写的 `org.apache.doris.hms.shaded.thrift`）—— 对齐 design §4 已签字的 D3。
+- 版本**在 shade 模块内联钉**（未动 fe/pom.xml dependencyManagement），libthrift 0.9.3 直接声明胜出 managed 0.16.0。
+- artifactSet 用 **白名单 `<includes>`**（不是黑名单 excludes）：胖 shade 是"厨房水槽"式全打包（122MB 大量 hadoop-yarn/curator/jersey/jetty/kerby/sqlserver junk 由 hive-shims-0.23 拖入），精简版只白名单 hive 客户端闭包，其余运行时由各插件自带的 hadoop-common 闭包/宿主 parent-first 提供。
+
+### 闸门证据（本轮实测）
+- **UT 全绿**：hms/hive/hudi/iceberg build+UT（`-am`，build-cache off，跑到 package）全 SUCCESS，197 个测试类，0 fail/error，checkstyle 0。
+- **两处运行时缺类由闸门抓出并补齐**（白名单方法的预期迭代）：① `HmsEventParser` 静态 `JSONMessageDeserializer` 需老 Jackson `org.codehaus.jackson.map.ObjectMapper`（且 fe/pom.xml 把 jackson-mapper-asl 钉成 test scope，须显式 `<scope>compile</scope>` 覆盖才会被 shade）；② iceberg vendored `DeleteFileIndex` 编译需 `iceberg-bundled-guava`（iceberg-core 只 runtime 带，编译期缺）。
+- **静态闸门 FCL-30**：全部 19 个 fe-connector 模块 `dependency:tree -Dincludes=hive-catalog-shade` 全空。
+- **打包闸门 FCL-31**：hive/hudi/iceberg 三个插件 zip 内——无胖 shade jar、精简 shade jar 各 1 份、无原包 libthrift/fe-thrift；`metastore.api.Table` / `HiveConf` / `iceberg.hive.HiveCatalog` / 重定位 `TException` / 老 Jackson `ObjectMapper` **各仅 1 份**；`HiveMetaStoreClient` 2 份（补丁 `fe-connector-hms-*.jar` + 精简 shade 未补丁，前者字典序在前→补丁生效，与胖 shade 时代同机制）。插件 zip 体积 hive 53M / iceberg 94M / hudi 200M（各比胖 shade 时代少约 107M）。
+- **多 agent 对抗 review（clean-room）**：4 lens × 逐条 adversarial 复核，**零 confirmed/blocker**。要点：精简 shade 里 metastore + iceberg.hive 字节码与胖 shade **md5 逐类相同**；重定位完整（loaded path 上零原包 thrift）；`hive-storage-api 2.7.0` 是 hive-3.1.3 **原生**版本（胖 shade 的 2.8.1 是被 orc/hive-exec 上抬的、精简版已排除二者），非回退；`serde2.dynamic_type` 两个类残留原包 thrift 引用是**死路径+与胖 shade 逐字节相同**，非本次引入。
+
+### 下一步
+- **Phase 4 e2e（唯一真闸门）**：docker 异构 HMS 跑 hive 读写 / iceberg-on-HMS INSERT/DELETE/MERGE(断言与独立 iceberg 目录同结果) / hudi-on-HMS 读；TCCL 不回归（filter hook / string dict filter / kerberos）；FE 启动+缓存冒烟；顺带专项验证 storage-api 2.7.0 的 write/ACID 路径。
+- Phase 5：结项 + PR（引用 tracking issue `apache/doris#65185`）。
+
+### 坑/提醒（留给下一个 session）
+- 白名单 shade 的运行时缺类只有跑到才暴露：**hms UT 抓 Jackson、iceberg 编译抓 bundled-guava** 都是这轮现补的；e2e 可能再暴露 kerberos/filter-hook 路径的缺类，按同法（查缺 → 加 include/显式 dep）补即可，别退回黑名单。
+- `-pl` 选精简 shade 模块要用 **`:fe-connector-hms-hive-shade`**（冒号 artifactId 选择器），裸名 maven 找不到。
+- 后台跑 maven **别** `nohup ... &` 套在 `run_in_background` 里（会脱离 harness 跟踪，误报"完成"）；本轮踩过，改用 `tail --pid` 阻塞等真结果。

--- a/plan-doc/fe-connector-hive-shade-localization/tasklist.md
+++ b/plan-doc/fe-connector-hive-shade-localization/tasklist.md
@@ -24,29 +24,29 @@
 
 ## Phase 1 — `fe-connector-hms` 局部 shade（承重墙）
 
-- [ ] **FCL-10** 新建模块 `fe/fe-connector/fe-connector-hms-hive-shade/pom.xml`（镜像 paimon-hive-shade）：bundle `hive-metastore`(D2 版本) + `hive-serde` + `hive-common` + `libthrift`；重定位 `org.apache.thrift`→`org.apache.doris.hms.shaded.thrift`；防御性重定位 `it.unimi.dsi.fastutil`；artifactSet 排除 hadoop/guava/protobuf/slf4j/log4j/commons-*/gson/jackson/caffeine；META-INF SF/DSA/RSA/maven 过滤。（D1-A 则此处也 bundle `iceberg-hive-metastore`——见 FCL-20。）
-- [ ] **FCL-11** `fe/fe-connector/pom.xml` `<modules>` 注册**在 `fe-connector-hms` 之前**；`fe/pom.xml` dependencyManagement 补 `libthrift`(0.9.x?按 D2 版本对应) + `hive-metastore`(D2) 版本钉（或 shade 模块内联 pin）。
-- [ ] **FCL-12** 🔴 落地 D4：按 FCL-02 结论处理 vendored `HiveMetaStoreClient.java`（纳入 shade 编译 / 保留 / 改写），确保它与重定位后的基类命名空间一致。
-- [ ] **FCL-13** 改 `fe-connector-hms/pom.xml`：删 `hive-catalog-shade` 依赖，加 `fe-connector-hms-hive-shade`。核对 raw hive-metastore/thrift 若有残留改 `<optional>`/exclude；plugin-zip 保留 `libthrift`/`fe-thrift` exclude。
-- [ ] **FCL-14** Gate：`fe-connector-hms` UT（`-am`，`-Dmaven.build.cache.enabled=false`，跑到 `package`）；连带 `fe-connector-hive` + `fe-connector-hudi` build + UT（它们经 hms 传递）。全绿 + checkstyle 0。
-- [ ] **FCL-15** commit（英文）+ 更新 HANDOFF + progress 追加。
+- [x] **FCL-10** 新建模块 `fe/fe-connector/fe-connector-hms-hive-shade/pom.xml`（镜像 paimon-hive-shade）：bundle `hive-metastore`(D2 版本) + `hive-serde` + `hive-common` + `libthrift`；重定位 `org.apache.thrift`→`org.apache.doris.hms.shaded.thrift`；防御性重定位 `it.unimi.dsi.fastutil`；artifactSet 排除 hadoop/guava/protobuf/slf4j/log4j/commons-*/gson/jackson/caffeine；META-INF SF/DSA/RSA/maven 过滤。（D1-A 则此处也 bundle `iceberg-hive-metastore`——见 FCL-20。）
+- [x] **FCL-11** `fe/fe-connector/pom.xml` `<modules>` 注册**在 `fe-connector-hms` 之前**；`fe/pom.xml` dependencyManagement 补 `libthrift`(0.9.x?按 D2 版本对应) + `hive-metastore`(D2) 版本钉（或 shade 模块内联 pin）。
+- [x] **FCL-12** 🔴 落地 D4：按 FCL-02 结论处理 vendored `HiveMetaStoreClient.java`（纳入 shade 编译 / 保留 / 改写），确保它与重定位后的基类命名空间一致。
+- [x] **FCL-13** 改 `fe-connector-hms/pom.xml`：删 `hive-catalog-shade` 依赖，加 `fe-connector-hms-hive-shade`。核对 raw hive-metastore/thrift 若有残留改 `<optional>`/exclude；plugin-zip 保留 `libthrift`/`fe-thrift` exclude。
+- [x] **FCL-14** Gate：`fe-connector-hms` UT（`-am`，`-Dmaven.build.cache.enabled=false`，跑到 `package`）；连带 `fe-connector-hive` + `fe-connector-hudi` build + UT（它们经 hms 传递）。全绿 + checkstyle 0。
+- [x] **FCL-15** commit（英文）+ 更新 HANDOFF + progress 追加。
 
 ---
 
 ## Phase 2 — `fe-connector-iceberg` 迁移
 
-- [ ] **FCL-20** iceberg-hive-metastore 落位：D1-A 则已在 FCL-10 的共享 shade 里（本步仅核对）；D1-B 则单独 shade 且与 hms 共用同一重定位 thrift 命名空间。
-- [ ] **FCL-21** 改 `fe-connector-iceberg/pom.xml`：删 `hive-catalog-shade`（第 93 行那条）直接依赖，改依赖共享/iceberg shade。核对 `fe-connector-hms`（它已带客户端）+ 新 shade 无重复类；更新 plugin-zip exclude。
-- [ ] **FCL-22** Gate：`fe-connector-iceberg` UT（含 `assembleHiveConf` parity 测试等，`-am`，build-cache off，跑到 `package`）；checkstyle 0。
-- [ ] **FCL-23** commit（英文）+ 更新 HANDOFF + progress 追加。
+- [x] **FCL-20** iceberg-hive-metastore 落位：D1-A 则已在 FCL-10 的共享 shade 里（本步仅核对）；D1-B 则单独 shade 且与 hms 共用同一重定位 thrift 命名空间。
+- [x] **FCL-21** 改 `fe-connector-iceberg/pom.xml`：删 `hive-catalog-shade`（第 93 行那条）直接依赖，改依赖共享/iceberg shade。核对 `fe-connector-hms`（它已带客户端）+ 新 shade 无重复类；更新 plugin-zip exclude。
+- [x] **FCL-22** Gate：`fe-connector-iceberg` UT（含 `assembleHiveConf` parity 测试等，`-am`，build-cache off，跑到 `package`）；checkstyle 0。
+- [x] **FCL-23** commit（英文）+ 更新 HANDOFF + progress 追加。
 
 ---
 
 ## Phase 3 — 证明 `fe/fe-connector` 已脱钩（静态闸门）
 
-- [ ] **FCL-30** 对 `fe/fe-connector/` **每个** pom 跑 `dependency:tree -Dincludes=org.apache.doris:hive-catalog-shade` → **全空**（这是总判据）。命中的只应剩 avro-scanner/java-udf/fe-pom（不在范围）。
-- [ ] **FCL-31** `unzip -l` 三个插件 zip（hive/iceberg/hudi）：断言① 无 `hive-catalog-shade-*.jar`；② 无原包 `org/apache/thrift/`（除 host provide）；③ 有 `org/apache/doris/hms/shaded/thrift/`；④ 无重复 `hive-metastore`/`libthrift`/`HiveConf`；⑤ 记录 zip 体积删前/删后差。
-- [ ] **FCL-32** 确认 `fe/pom.xml` 的 hive-catalog-shade 版本钉**仍在**（avro-scanner/java-udf 还要），并加注释说明为何保留。
+- [x] **FCL-30** 对 `fe/fe-connector/` **每个** pom 跑 `dependency:tree -Dincludes=org.apache.doris:hive-catalog-shade` → **全空**（这是总判据）。命中的只应剩 avro-scanner/java-udf/fe-pom（不在范围）。
+- [x] **FCL-31** `unzip -l` 三个插件 zip（hive/iceberg/hudi）：断言① 无 `hive-catalog-shade-*.jar`；② 无原包 `org/apache/thrift/`（除 host provide）；③ 有 `org/apache/doris/hms/shaded/thrift/`；④ 无重复 `hive-metastore`/`libthrift`/`HiveConf`；⑤ 记录 zip 体积删前/删后差。
+- [x] **FCL-32** 确认 `fe/pom.xml` 的 hive-catalog-shade 版本钉**仍在**（avro-scanner/java-udf 还要），并加注释说明为何保留。
 
 ---
 

--- a/plan-doc/fe-connector-hive-shade-localization/tasklist.md
+++ b/plan-doc/fe-connector-hive-shade-localization/tasklist.md
@@ -1,0 +1,78 @@
+# Task list — `fe/fe-connector` 剥离 `hive-catalog-shade`
+
+> 唯一进度清单。每完成一项随 commit 勾 `[x]` 并在 `progress.md` 追加一行。
+> 设计/为什么看 [`design.md`](./design.md)（决策 D1–D6）；下一步看 [`HANDOFF.md`](./HANDOFF.md)。
+> 基线 2026-07-16 `catalog-spi-11-hive`。**行号信 HEAD 不信文档**。
+
+**总成功判据**：对 `fe/fe-connector/` 每个 pom，`dependency:tree -Dincludes=org.apache.doris:hive-catalog-shade` 全空。
+（`fe/pom.xml`、avro-scanner、java-udf 仍命中 = 预期，不算破。）
+
+---
+
+## Phase 0 — 侦察 + 设计定案（**动码前必须做完 + 用户签字 D1/D2**）
+
+- [x] **FCL-01** 枚举完成：补丁客户端 + `ThriftHmsClient` 用重定位 thrift（`shade.doris.hive.*`）；`HiveConnectorTransaction`/`*SchemaUtils` 用 host raw thrift 0.16.0（**不受迁移影响**）。清单入 progress。
+- [x] **FCL-02** 🔴 **定案**：`javap` 出补丁客户端字节码对 thrift 48 处引用**全是重定位名**、零 raw、零按名反射 → **D4=KEEP_IN_HMS**（不搬不改写）。
+- [x] **FCL-03** 版本确认：`hive.version=3.1.3`（fe/pom.xml:341）；补丁客户端头"Copied From release-3.1.3" → **D2=3.1.3**。
+- [x] **FCL-04** **D1=A 共享 + D3=复用 `shade.doris.hive.org.apache.thrift`**（非原设计的新前缀），中文向用户解释并**已签字**。
+- [x] **FCL-05** 确认：iceberg 需 `iceberg-hive-metastore`（HiveCatalog）**与** hms 客户端共用同一重定位 thrift（支撑 D1-A）；DLF 已死代码不计。
+- [x] **FCL-06** design.md §3 补精确 bundle 清单、§4 决策定案留痕。
+
+**Phase 0 出口**：✅ design.md 定案 + 用户签 D1/D2/D3 + FCL-02 定 D4=KEEP_IN_HMS。**红队 GO**（两条件：iceberg 原子切换 + Phase1/4 类加载冒烟&e2e）。
+
+---
+
+## Phase 1 — `fe-connector-hms` 局部 shade（承重墙）
+
+- [ ] **FCL-10** 新建模块 `fe/fe-connector/fe-connector-hms-hive-shade/pom.xml`（镜像 paimon-hive-shade）：bundle `hive-metastore`(D2 版本) + `hive-serde` + `hive-common` + `libthrift`；重定位 `org.apache.thrift`→`org.apache.doris.hms.shaded.thrift`；防御性重定位 `it.unimi.dsi.fastutil`；artifactSet 排除 hadoop/guava/protobuf/slf4j/log4j/commons-*/gson/jackson/caffeine；META-INF SF/DSA/RSA/maven 过滤。（D1-A 则此处也 bundle `iceberg-hive-metastore`——见 FCL-20。）
+- [ ] **FCL-11** `fe/fe-connector/pom.xml` `<modules>` 注册**在 `fe-connector-hms` 之前**；`fe/pom.xml` dependencyManagement 补 `libthrift`(0.9.x?按 D2 版本对应) + `hive-metastore`(D2) 版本钉（或 shade 模块内联 pin）。
+- [ ] **FCL-12** 🔴 落地 D4：按 FCL-02 结论处理 vendored `HiveMetaStoreClient.java`（纳入 shade 编译 / 保留 / 改写），确保它与重定位后的基类命名空间一致。
+- [ ] **FCL-13** 改 `fe-connector-hms/pom.xml`：删 `hive-catalog-shade` 依赖，加 `fe-connector-hms-hive-shade`。核对 raw hive-metastore/thrift 若有残留改 `<optional>`/exclude；plugin-zip 保留 `libthrift`/`fe-thrift` exclude。
+- [ ] **FCL-14** Gate：`fe-connector-hms` UT（`-am`，`-Dmaven.build.cache.enabled=false`，跑到 `package`）；连带 `fe-connector-hive` + `fe-connector-hudi` build + UT（它们经 hms 传递）。全绿 + checkstyle 0。
+- [ ] **FCL-15** commit（英文）+ 更新 HANDOFF + progress 追加。
+
+---
+
+## Phase 2 — `fe-connector-iceberg` 迁移
+
+- [ ] **FCL-20** iceberg-hive-metastore 落位：D1-A 则已在 FCL-10 的共享 shade 里（本步仅核对）；D1-B 则单独 shade 且与 hms 共用同一重定位 thrift 命名空间。
+- [ ] **FCL-21** 改 `fe-connector-iceberg/pom.xml`：删 `hive-catalog-shade`（第 93 行那条）直接依赖，改依赖共享/iceberg shade。核对 `fe-connector-hms`（它已带客户端）+ 新 shade 无重复类；更新 plugin-zip exclude。
+- [ ] **FCL-22** Gate：`fe-connector-iceberg` UT（含 `assembleHiveConf` parity 测试等，`-am`，build-cache off，跑到 `package`）；checkstyle 0。
+- [ ] **FCL-23** commit（英文）+ 更新 HANDOFF + progress 追加。
+
+---
+
+## Phase 3 — 证明 `fe/fe-connector` 已脱钩（静态闸门）
+
+- [ ] **FCL-30** 对 `fe/fe-connector/` **每个** pom 跑 `dependency:tree -Dincludes=org.apache.doris:hive-catalog-shade` → **全空**（这是总判据）。命中的只应剩 avro-scanner/java-udf/fe-pom（不在范围）。
+- [ ] **FCL-31** `unzip -l` 三个插件 zip（hive/iceberg/hudi）：断言① 无 `hive-catalog-shade-*.jar`；② 无原包 `org/apache/thrift/`（除 host provide）；③ 有 `org/apache/doris/hms/shaded/thrift/`；④ 无重复 `hive-metastore`/`libthrift`/`HiveConf`；⑤ 记录 zip 体积删前/删后差。
+- [ ] **FCL-32** 确认 `fe/pom.xml` 的 hive-catalog-shade 版本钉**仍在**（avro-scanner/java-udf 还要），并加注释说明为何保留。
+
+---
+
+## Phase 4 — e2e（异构 HMS，唯一真闸门；memory `hms-iceberg-delegation-needs-e2e`）
+
+- [ ] **FCL-40** docker 外表 HMS 套件：① 普通 hive catalog 读+写；② **iceberg-on-HMS** INSERT/DELETE/MERGE/read，断言与独立 iceberg 目录同表同结果；③ hudi-on-HMS 读。
+- [ ] **FCL-41** 🔴 TCCL 不回归（D5/R2）：`test_string_dict_filter` 类用例 + MetaStoreFilterHook 路径 + kerberos HMS（若环境有）；FE 启动 + 缓存（MetaCache/StatisticsCache/FileSystemCache）冒烟。
+- [ ] **FCL-42** progress 追加 e2e 结果（含 CI 编号）。
+
+---
+
+## Phase 5 — 收尾
+
+- [ ] **FCL-50** `progress.md` 结项段；`../decisions-log.md` 补 `D-NNN`（本任务的 D1–D6 定案）；PR（base `branch-catalog-spi`，squash，英文）。引用 tracking issue `apache/doris#65185`。
+
+---
+
+## 🧰 构建/验证坑（兄弟任务实测，直接复用，别再踩）
+
+1. **maven build cache 会静默跳过 surefire**（`Skipping plugin execution (cached): surefire:test`，BUILD SUCCESS 但 0 测试）→ **必须 `-Dmaven.build.cache.enabled=false`**，并数 `grep -c "^\[INFO\] Running org.apache.doris"`。
+2. **`-am` 必填**：漏了报 `org.apache.doris:fe:pom:${revision}` 无法解析 = **没编译，不是代码错**。
+3. **依赖 shade 模块的模块必须跑到 `package`**：`test-compile`/`test` 会假报 `package org.apache.hadoop.hive.conf does not exist`（不是代码错）；`install` 不行（`fe-type` quirk）。
+4. **`surefire:test` 独立 goal 解析不了 `${revision}`** → 走 `test` 生命周期 + `-am`；无匹配测试加 `-DfailIfNoTests=false`。
+5. **连接器模块路径嵌套**：`-pl fe/fe-connector/fe-connector-XXX` 用相对 reactor 名 `-pl fe-connector-XXX`（在 fe/pom.xml reactor 内）；maven 必须**绝对 `-f`**：`mvn -o -f /mnt/disk1/yy/git/wt-catalog-spi/fe/pom.xml ...`。
+6. **`hive-serde` 闭包首次需联网**（`javax.servlet:servlet-api:2.4` 不在本地仓），`-o` 会失败——首次去 `-o`。
+7. **`mvn ... | tail` 后 `$?` 是 tail 的**：重定向到文件再读 `BUILD SUCCESS/FAILURE` 行。
+8. **变异验证要红在断言上**（不是 checkstyle/编译），变异代码也须合 checkstyle。
+9. **`git add` 用 path-whitelist，严禁 `git add -A`**（工作树有大量非本线程 scratch，含 `regression-conf.groovy` 本就脏）。commit 后看 `git show --stat` 文件数。
+10. **动码前先探并发**（`git log`/`status` + `pgrep maven` 看 `etime` 别误判僵尸 + 近 90s mtime）。


### PR DESCRIPTION
## Proposed changes

Part of the catalog SPI migration umbrella: apache/doris#65185.

The `fe/fe-connector` closure depended on `org.apache.doris:hive-catalog-shade`, a ~122 MB "kitchen-sink" shade whose Hive metastore-client content is under 2% of its bytes (the rest is a full Hadoop, the paimon bundle, an ancient fastutil, DLF, etc.). This PR replaces it, for the fe-connector modules, with a new plugin-private slim shade `fe-connector-hms-hive-shade` (~15 MB) that bundles **only** the Hive metastore-**client** closure and relocates `org.apache.thrift` to `shade.doris.hive.org.apache.thrift`, mirroring the existing `fe-connector-paimon-hive-shade`.

### What changed
- **New module `fe-connector-hms-hive-shade`**: hive-standalone-metastore (api + client), hive-common (`HiveConf`), hive-serde, hive-storage-api, iceberg-hive-metastore (`HiveCatalog`), libthrift/libfb303 0.9.3, codehaus jackson 1.9.2 (HMS JSON event messaging) and commons-lang 2.x (`HiveConf`). It uses an artifactSet `<includes>` **whitelist** so the hadoop-yarn/curator/jersey/kerby tail dragged in by hive-shims stays out; hadoop-common and guava/slf4j/log4j come from each plugin's own deps / the host at runtime. The thrift relocation **reuses** the existing `shade.doris.hive` prefix, so the vendored patch `HiveMetaStoreClient` in `fe-connector-hms` needs no source change.
- **`fe-connector-hms`** now depends on the slim shade (compile, transitive to hive/hudi/iceberg) instead of the fat shade; the patch client stays in place.
- **`fe-connector-iceberg`** drops its direct fat-shade dependency in the **same commit** (the hms-flavor `HiveCatalog` now arrives transitively via the slim shade), so iceberg is never left with two `HiveCatalog` copies; adds `iceberg-bundled-guava` at compile scope for the vendored `DeleteFileIndex`.
- **`fe/pom.xml`** keeps the `hive-catalog-shade` version pin (still used by `be-java-extensions`) with an explanatory comment; stale comments in the iceberg/hudi poms are corrected.

### Size impact
The shade artifact drops **122 MB → 15 MB** (to ~12% of its size). Each of the hive / hudi / iceberg plugins bundles its own copy, so each deployed plugin shrinks by **~107 MB** (~322 MB across the three).

### Verification
- `fe-connector-hms` / `-hive` / `-hudi` / `-iceberg` build + unit tests green (197 test classes, 0 failures, checkstyle 0).
- `dependency:tree` across all 19 fe-connector modules shows no `hive-catalog-shade`.
- The three assembled plugin zips contain the slim shade once, no fat shade, no original-package libthrift, and exactly one copy each of the metastore-api `Table` / `HiveConf` / iceberg `HiveCatalog` / relocated thrift; the metastore and `iceberg.hive` bytecode is md5-identical to the fat shade.
- **Remaining gate**: heterogeneous-HMS e2e (hive read/write, iceberg-on-HMS INSERT/DELETE/MERGE, hudi-on-HMS read; TCCL / filter-hook / kerberos paths) — to be exercised by CI / a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkwFY4c7kZkLKZeazy3UMW
