### PR TITLE
[fix](filecache) Support memory file cache resource management

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -26,6 +26,7 @@
 #include <exception>
 #include <fstream>
 #include <unordered_set>
+#include <utility>
 
 #include "common/status.h"
 #include "cpp/sync_point.h"
@@ -537,7 +538,8 @@ Status BlockFileCache::initialize() {
 Status BlockFileCache::initialize_unlocked(std::lock_guard<std::mutex>& cache_lock) {
     DCHECK(!_is_initialized);
     _is_initialized = true;
-    if (config::file_cache_background_lru_dump_tail_record_num > 0) {
+    const bool memory_storage = is_memory_storage();
+    if (!memory_storage && config::file_cache_background_lru_dump_tail_record_num > 0) {
         // requirements:
         // 1. restored data should not overwrite the last dump
         // 2. restore should happen before load and async load
@@ -547,6 +549,9 @@ Status BlockFileCache::initialize_unlocked(std::lock_guard<std::mutex>& cache_lo
         restore_lru_queues_from_disk(cache_lock);
     }
     RETURN_IF_ERROR(_storage->init(this));
+    if (memory_storage) {
+        LOG(INFO) << "Skip LRU dump and restore for memory storage, path=" << _cache_base_path;
+    }
 
     if (auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(_storage.get())) {
         if (auto* meta_store = fs_storage->get_meta_store()) {
@@ -561,10 +566,13 @@ Status BlockFileCache::initialize_unlocked(std::lock_guard<std::mutex>& cache_lo
     _cache_background_block_lru_update_thread =
             std::thread(&BlockFileCache::run_background_block_lru_update, this);
 
-    // Initialize LRU dump thread and restore queues
-    _cache_background_lru_dump_thread = std::thread(&BlockFileCache::run_background_lru_dump, this);
-    _cache_background_lru_log_replay_thread =
-            std::thread(&BlockFileCache::run_background_lru_log_replay, this);
+    if (!memory_storage) {
+        // Initialize LRU dump thread and restore queues
+        _cache_background_lru_dump_thread =
+                std::thread(&BlockFileCache::run_background_lru_dump, this);
+        _cache_background_lru_log_replay_thread =
+                std::thread(&BlockFileCache::run_background_lru_log_replay, this);
+    }
 
     return Status::OK();
 }
@@ -1263,19 +1271,22 @@ bool BlockFileCache::try_reserve(const UInt128Wrapper& hash, const CacheContext&
     }
     // use this strategy in scenarios where there is insufficient disk capacity or insufficient number of inodes remaining
     // directly eliminate 5 times the size of the space
-    if (_disk_resource_limit_mode) {
-        size = 5 * size;
-    }
+    const bool disk_resource_limit_mode = _disk_resource_limit_mode.load(std::memory_order_relaxed);
+    const size_t eviction_size = disk_resource_limit_mode ? 5 * size : size;
 
     auto query_context = config::enable_file_cache_query_limit &&
                                          (context.query_id.hi != 0 || context.query_id.lo != 0)
                                  ? get_query_context(context.query_id, cache_lock)
                                  : nullptr;
     if (!query_context) {
-        return try_reserve_for_lru(hash, nullptr, context, offset, size, cache_lock);
+        return try_reserve_for_lru(hash, nullptr, context, offset, eviction_size, cache_lock);
     } else if (query_context->get_cache_size(cache_lock) + size <=
                query_context->get_max_cache_size()) {
-        return try_reserve_for_lru(hash, query_context, context, offset, size, cache_lock);
+        if (!try_reserve_for_lru(hash, nullptr, context, offset, eviction_size, cache_lock)) {
+            return false;
+        }
+        query_context->reserve(hash, offset, size, cache_lock);
+        return true;
     }
     int64_t cur_time = std::chrono::duration_cast<std::chrono::seconds>(
                                std::chrono::steady_clock::now().time_since_epoch())
@@ -1292,12 +1303,12 @@ bool BlockFileCache::try_reserve(const UInt128Wrapper& hash, const CacheContext&
 
     size_t max_size = queue.get_max_size();
     auto is_overflow = [&] {
-        return _disk_resource_limit_mode ? removed_size < size
-                                         : cur_cache_size + size - removed_size > _capacity ||
-                                                   (queue_size + size - removed_size > max_size) ||
-                                                   (query_context_cache_size + size -
-                                                            (removed_size + ghost_remove_size) >
-                                                    query_context->get_max_cache_size());
+        return disk_resource_limit_mode ? removed_size < eviction_size
+                                        : cur_cache_size + size - removed_size > _capacity ||
+                                                  (queue_size + size - removed_size > max_size) ||
+                                                  (query_context_cache_size + size -
+                                                           (removed_size + ghost_remove_size) >
+                                                   query_context->get_max_cache_size());
     };
 
     /// Select the cache from the LRU queue held by query for expulsion.
@@ -1344,7 +1355,7 @@ bool BlockFileCache::try_reserve(const UInt128Wrapper& hash, const CacheContext&
     std::for_each(to_evict.begin(), to_evict.end(), remove_file_block_if);
 
     if (is_overflow() &&
-        !try_reserve_from_other_queue(context.cache_type, size, cur_time, cache_lock)) {
+        !try_reserve_from_other_queue(context.cache_type, eviction_size, cur_time, cache_lock)) {
         return false;
     }
     query_context->reserve(hash, offset, size, cache_lock);
@@ -1522,7 +1533,7 @@ bool BlockFileCache::is_overflow(size_t removed_size, size_t need_size, size_t c
         ret = (removed_size < need_size);
         return ret;
     }
-    if (_disk_resource_limit_mode) {
+    if (_disk_resource_limit_mode.load(std::memory_order_relaxed)) {
         ret = (removed_size < need_size);
     } else {
         ret = (cur_cache_size + need_size - removed_size > _capacity);
@@ -1681,7 +1692,9 @@ void BlockFileCache::remove(FileBlockSPtr file_block, T& cache_lock, U& block_lo
         key.meta.type = type;
         key.meta.expiration_time = expiration_time;
         key.meta.tablet_id = tablet_id;
-        if (sync) {
+        // Memory payloads are replaced in place by key, so a stale key-only async delete could
+        // erase a newer payload downloaded after this block's metadata is removed.
+        if (sync || is_memory_storage()) {
             int64_t duration_ns = 0;
             Status st;
             {
@@ -1980,13 +1993,41 @@ int disk_used_percentage(const std::string& path, std::pair<int, int>* percent) 
     return 0;
 }
 
+namespace {
+
+const char* file_cache_storage_type_to_string(FileCacheStorageType type) {
+    switch (type) {
+    case FileCacheStorageType::DISK:
+        return "disk";
+    case FileCacheStorageType::MEMORY:
+        return "memory";
+    }
+    DORIS_CHECK(false) << "Unknown file cache storage type: " << type;
+    __builtin_unreachable();
+}
+
+} // namespace
+
+bool BlockFileCache::is_memory_storage() const {
+    return _storage->get_type() == FileCacheStorageType::MEMORY;
+}
+
+size_t BlockFileCache::calc_size_percentage_unlocked(std::lock_guard<std::mutex>&) const {
+    if (_capacity == 0) {
+        return 0;
+    }
+    return static_cast<size_t>(static_cast<double>(_cur_cache_size) /
+                               static_cast<double>(_capacity) * 100);
+}
+
 std::string BlockFileCache::reset_capacity(size_t new_capacity) {
     using namespace std::chrono;
     int64_t space_released = 0;
     size_t old_capacity = 0;
+    size_t size_percentage = 0;
     std::stringstream ss;
     ss << "finish reset_capacity, path=" << _cache_base_path;
-    auto adjust_start_time = steady_clock::time_point();
+    auto adjust_start_time = steady_clock::now();
     {
         SCOPED_CACHE_LOCK(_mutex, this);
         if (new_capacity < _capacity && new_capacity < _cur_cache_size) {
@@ -1998,14 +2039,20 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
                     if (need_remove_size <= 0) {
                         break;
                     }
+                    auto* cell = get_cell(entry_key, entry_offset, cache_lock);
+                    if (!cell->releasable()) {
+                        TEST_SYNC_POINT_CALLBACK(
+                                "BlockFileCache::reset_capacity::before_lock_busy_block");
+                        std::lock_guard block_lock(cell->file_block->_mutex);
+                        // The last holder can release the block before this lock is acquired.
+                        if (!cell->releasable()) {
+                            cell->file_block->set_deleting();
+                            continue;
+                        }
+                    }
                     need_remove_size -= entry_size;
                     space_released += entry_size;
                     queue_released += entry_size;
-                    auto* cell = get_cell(entry_key, entry_offset, cache_lock);
-                    if (!cell->releasable()) {
-                        cell->file_block->set_deleting();
-                        continue;
-                    }
                     to_evict.push_back(cell);
                 }
                 for (auto& cell : to_evict) {
@@ -2023,17 +2070,22 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
             ss << " index_queue released " << queue_released;
             queue_released = remove_blocks(_ttl_queue);
             ss << " ttl_queue released " << queue_released;
-
-            _disk_resource_limit_mode = true;
-            _disk_limit_mode_metrics->set_value(1);
             ss << " total_space_released=" << space_released;
         }
         old_capacity = _capacity;
         _capacity = new_capacity;
+        size_percentage = calc_size_percentage_unlocked(cache_lock);
         _cache_capacity_metrics->set_value(_capacity);
+        _cur_cache_size_metrics->set_value(_cur_cache_size);
+        _disk_limit_mode_metrics->set_value(
+                _disk_resource_limit_mode.load(std::memory_order_relaxed));
+        _need_evict_cache_in_advance_metrics->set_value(
+                _need_evict_cache_in_advance.load(std::memory_order_relaxed));
     }
-    auto use_time = duration_cast<milliseconds>(steady_clock::time_point() - adjust_start_time);
+    auto use_time = duration_cast<milliseconds>(steady_clock::now() - adjust_start_time);
     LOG(INFO) << "Finish tag deleted block. path=" << _cache_base_path
+              << " storage_type=" << file_cache_storage_type_to_string(_storage->get_type())
+              << " size_percent=" << size_percentage
               << " use_time=" << cast_set<int64_t>(use_time.count());
     ss << " old_capacity=" << old_capacity << " new_capacity=" << new_capacity;
     LOG(INFO) << ss.str();
@@ -2041,13 +2093,48 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
 }
 
 void BlockFileCache::check_disk_resource_limit() {
-    if (_storage->get_type() != FileCacheStorageType::DISK) {
+    // ATTN: due to that can be changed dynamically, set it to default value if it's invalid
+    // FIXME: reject with config validator
+    if (config::file_cache_enter_disk_resource_limit_mode_percent <=
+        config::file_cache_exit_disk_resource_limit_mode_percent) {
+        LOG_WARNING("config error, set to default value")
+                .tag("enter", config::file_cache_enter_disk_resource_limit_mode_percent)
+                .tag("exit", config::file_cache_exit_disk_resource_limit_mode_percent);
+        config::file_cache_enter_disk_resource_limit_mode_percent = 88;
+        config::file_cache_exit_disk_resource_limit_mode_percent = 80;
+    }
+    size_t size_percentage = 0;
+    {
+        SCOPED_CACHE_LOCK(_mutex, this);
+        size_percentage = calc_size_percentage_unlocked(cache_lock);
+    }
+    auto is_insufficient = [](size_t percentage) {
+        return std::cmp_greater_equal(percentage,
+                                      config::file_cache_enter_disk_resource_limit_mode_percent);
+    };
+    const bool previous_mode = _disk_resource_limit_mode.load(std::memory_order_relaxed);
+    bool current_mode = previous_mode;
+    if (is_memory_storage()) {
+        bool is_size_insufficient = is_insufficient(size_percentage);
+        if (is_size_insufficient) {
+            current_mode = true;
+        } else if (current_mode &&
+                   size_percentage < config::file_cache_exit_disk_resource_limit_mode_percent) {
+            current_mode = false;
+        }
+        _disk_resource_limit_mode.store(current_mode, std::memory_order_relaxed);
+        _disk_limit_mode_metrics->set_value(current_mode);
+        if (previous_mode != current_mode) {
+            LOG(INFO) << "Memory file cache resource limit mode changed: file_cache="
+                      << get_base_path() << " enabled=" << current_mode
+                      << " size_percent=" << size_percentage;
+        }
         return;
     }
 
-    bool previous_mode = _disk_resource_limit_mode;
     if (_capacity > _cur_cache_size) {
-        _disk_resource_limit_mode = false;
+        current_mode = false;
+        _disk_resource_limit_mode.store(current_mode, std::memory_order_relaxed);
         _disk_limit_mode_metrics->set_value(0);
     }
     std::pair<int, int> percent;
@@ -2057,37 +2144,24 @@ void BlockFileCache::check_disk_resource_limit() {
         return;
     }
     auto [space_percentage, inode_percentage] = percent;
-    auto is_insufficient = [](const int& percentage) {
-        return percentage >= config::file_cache_enter_disk_resource_limit_mode_percent;
-    };
     DCHECK_GE(space_percentage, 0);
     DCHECK_LE(space_percentage, 100);
     DCHECK_GE(inode_percentage, 0);
     DCHECK_LE(inode_percentage, 100);
-    // ATTN: due to that can be changed dynamically, set it to default value if it's invalid
-    // FIXME: reject with config validator
-    if (config::file_cache_enter_disk_resource_limit_mode_percent <
-        config::file_cache_exit_disk_resource_limit_mode_percent) {
-        LOG_WARNING("config error, set to default value")
-                .tag("enter", config::file_cache_enter_disk_resource_limit_mode_percent)
-                .tag("exit", config::file_cache_exit_disk_resource_limit_mode_percent);
-        config::file_cache_enter_disk_resource_limit_mode_percent = 88;
-        config::file_cache_exit_disk_resource_limit_mode_percent = 80;
-    }
     bool is_space_insufficient = is_insufficient(space_percentage);
     bool is_inode_insufficient = is_insufficient(inode_percentage);
     if (is_space_insufficient || is_inode_insufficient) {
-        _disk_resource_limit_mode = true;
-        _disk_limit_mode_metrics->set_value(1);
-    } else if (_disk_resource_limit_mode &&
+        current_mode = true;
+    } else if (current_mode &&
                (space_percentage < config::file_cache_exit_disk_resource_limit_mode_percent) &&
                (inode_percentage < config::file_cache_exit_disk_resource_limit_mode_percent)) {
-        _disk_resource_limit_mode = false;
-        _disk_limit_mode_metrics->set_value(0);
+        current_mode = false;
     }
-    if (previous_mode != _disk_resource_limit_mode) {
+    _disk_resource_limit_mode.store(current_mode, std::memory_order_relaxed);
+    _disk_limit_mode_metrics->set_value(current_mode);
+    if (previous_mode != current_mode) {
         // add log for disk resource limit mode switching
-        if (_disk_resource_limit_mode) {
+        if (current_mode) {
             LOG(WARNING) << "Entering disk resource limit mode: file_cache=" << get_base_path()
                          << " space_percent=" << space_percentage
                          << " inode_percent=" << inode_percentage
@@ -2101,7 +2175,7 @@ void BlockFileCache::check_disk_resource_limit() {
                       << " inode_percent=" << inode_percentage << " exit threshold="
                       << config::file_cache_exit_disk_resource_limit_mode_percent;
         }
-    } else if (_disk_resource_limit_mode) {
+    } else if (current_mode) {
         // print log for disk resource limit mode running, but less frequently
         LOG_EVERY_N(WARNING, 10) << "file_cache=" << get_base_path()
                                  << " space_percent=" << space_percentage
@@ -2113,25 +2187,6 @@ void BlockFileCache::check_disk_resource_limit() {
 }
 
 void BlockFileCache::check_need_evict_cache_in_advance() {
-    if (_storage->get_type() != FileCacheStorageType::DISK) {
-        return;
-    }
-
-    std::pair<int, int> percent;
-    int ret = disk_used_percentage(_cache_base_path, &percent);
-    if (ret != 0) {
-        LOG_ERROR("").tag("file cache path", _cache_base_path).tag("error", strerror(errno));
-        return;
-    }
-    auto [space_percentage, inode_percentage] = percent;
-    int size_percentage = static_cast<int>(_cur_cache_size * 100 / _capacity);
-    auto is_insufficient = [](const int& percentage) {
-        return percentage >= config::file_cache_enter_need_evict_cache_in_advance_percent;
-    };
-    DCHECK_GE(space_percentage, 0);
-    DCHECK_LE(space_percentage, 100);
-    DCHECK_GE(inode_percentage, 0);
-    DCHECK_LE(inode_percentage, 100);
     // ATTN: due to that can be changed dynamically, set it to default value if it's invalid
     // FIXME: reject with config validator
     if (config::file_cache_enter_need_evict_cache_in_advance_percent <=
@@ -2142,23 +2197,62 @@ void BlockFileCache::check_need_evict_cache_in_advance() {
         config::file_cache_enter_need_evict_cache_in_advance_percent = 78;
         config::file_cache_exit_need_evict_cache_in_advance_percent = 75;
     }
-    bool previous_mode = _need_evict_cache_in_advance;
+    size_t size_percentage = 0;
+    {
+        SCOPED_CACHE_LOCK(_mutex, this);
+        size_percentage = calc_size_percentage_unlocked(cache_lock);
+    }
+    auto is_insufficient = [](size_t percentage) {
+        return std::cmp_greater_equal(percentage,
+                                      config::file_cache_enter_need_evict_cache_in_advance_percent);
+    };
+    const bool previous_mode = _need_evict_cache_in_advance.load(std::memory_order_relaxed);
+    bool current_mode = previous_mode;
+    if (is_memory_storage()) {
+        bool is_size_insufficient = is_insufficient(size_percentage);
+        if (is_size_insufficient) {
+            current_mode = true;
+        } else if (current_mode &&
+                   size_percentage < config::file_cache_exit_need_evict_cache_in_advance_percent) {
+            current_mode = false;
+        }
+        _need_evict_cache_in_advance.store(current_mode, std::memory_order_relaxed);
+        _need_evict_cache_in_advance_metrics->set_value(current_mode);
+        if (previous_mode != current_mode) {
+            LOG(INFO) << "Memory file cache evict-in-advance mode changed: file_cache="
+                      << get_base_path() << " enabled=" << current_mode
+                      << " size_percent=" << size_percentage;
+        }
+        return;
+    }
+
+    std::pair<int, int> percent;
+    int ret = disk_used_percentage(_cache_base_path, &percent);
+    if (ret != 0) {
+        LOG_ERROR("").tag("file cache path", _cache_base_path).tag("error", strerror(errno));
+        return;
+    }
+    auto [space_percentage, inode_percentage] = percent;
+    DCHECK_GE(space_percentage, 0);
+    DCHECK_LE(space_percentage, 100);
+    DCHECK_GE(inode_percentage, 0);
+    DCHECK_LE(inode_percentage, 100);
     bool is_space_insufficient = is_insufficient(space_percentage);
     bool is_inode_insufficient = is_insufficient(inode_percentage);
     bool is_size_insufficient = is_insufficient(size_percentage);
     if (is_space_insufficient || is_inode_insufficient || is_size_insufficient) {
-        _need_evict_cache_in_advance = true;
-        _need_evict_cache_in_advance_metrics->set_value(1);
-    } else if (_need_evict_cache_in_advance &&
+        current_mode = true;
+    } else if (current_mode &&
                (space_percentage < config::file_cache_exit_need_evict_cache_in_advance_percent) &&
                (inode_percentage < config::file_cache_exit_need_evict_cache_in_advance_percent) &&
                (size_percentage < config::file_cache_exit_need_evict_cache_in_advance_percent)) {
-        _need_evict_cache_in_advance = false;
-        _need_evict_cache_in_advance_metrics->set_value(0);
+        current_mode = false;
     }
-    if (previous_mode != _need_evict_cache_in_advance) {
+    _need_evict_cache_in_advance.store(current_mode, std::memory_order_relaxed);
+    _need_evict_cache_in_advance_metrics->set_value(current_mode);
+    if (previous_mode != current_mode) {
         // add log for evict cache in advance mode switching
-        if (_need_evict_cache_in_advance) {
+        if (current_mode) {
             LOG(WARNING) << "Entering evict cache in advance mode: "
                          << "file_cache=" << get_base_path()
                          << " space_percent=" << space_percentage
@@ -2175,7 +2269,7 @@ void BlockFileCache::check_need_evict_cache_in_advance() {
                       << " size_percent=" << size_percentage << " exit threshold="
                       << config::file_cache_exit_need_evict_cache_in_advance_percent;
         }
-    } else if (_need_evict_cache_in_advance) {
+    } else if (current_mode) {
         // print log for evict cache in advance mode running, but less frequently
         LOG_EVERY_N(WARNING, 10) << "file_cache=" << get_base_path()
                                  << " space_percent=" << space_percentage
@@ -2197,7 +2291,7 @@ void BlockFileCache::run_background_monitor() {
         if (config::enable_evict_file_cache_in_advance) {
             check_need_evict_cache_in_advance();
         } else {
-            _need_evict_cache_in_advance = false;
+            _need_evict_cache_in_advance.store(false, std::memory_order_relaxed);
             _need_evict_cache_in_advance_metrics->set_value(0);
         }
 
@@ -2327,7 +2421,7 @@ void BlockFileCache::run_background_evict_in_advance() {
         batch = config::file_cache_evict_in_advance_batch_bytes;
 
         // Skip if eviction not needed or too many pending recycles
-        if (!_need_evict_cache_in_advance ||
+        if (!_need_evict_cache_in_advance.load(std::memory_order_relaxed) ||
             _recycle_keys.size_approx() >=
                     config::file_cache_evict_in_advance_recycle_keys_num_threshold) {
             continue;
@@ -2415,7 +2509,8 @@ bool BlockFileCache::try_reserve_during_async_load(size_t size,
     std::vector<FileBlockCell*> to_evict;
     auto collect_eliminate_fragments = [&](LRUQueue& queue) {
         for (const auto& [entry_key, entry_offset, entry_size] : queue) {
-            if (!_disk_resource_limit_mode || removed_size >= size) {
+            if (!_disk_resource_limit_mode.load(std::memory_order_relaxed) ||
+                removed_size >= size) {
                 break;
             }
             auto* cell = get_cell(entry_key, entry_offset, cache_lock);
@@ -2448,7 +2543,7 @@ bool BlockFileCache::try_reserve_during_async_load(size_t size,
     std::string reason = "async load";
     remove_file_blocks(to_evict, cache_lock, true, reason);
 
-    return !_disk_resource_limit_mode || removed_size >= size;
+    return !_disk_resource_limit_mode.load(std::memory_order_relaxed) || removed_size >= size;
 }
 
 void BlockFileCache::clear_need_update_lru_blocks() {
@@ -2516,6 +2611,9 @@ size_t BlockFileCache::replay_lru_logs_once() {
 }
 
 void BlockFileCache::dump_lru_queues(bool force) {
+    if (is_memory_storage()) {
+        return;
+    }
     std::unique_lock dump_lock(_dump_lru_queues_mtx);
     if (config::file_cache_background_lru_dump_tail_record_num > 0 &&
         !ExecEnv::GetInstance()->get_is_upgrading()) {
@@ -2552,6 +2650,11 @@ void BlockFileCache::restore_lru_queues_from_disk(std::lock_guard<std::mutex>& c
 
 std::map<std::string, double> BlockFileCache::get_stats() {
     std::map<std::string, double> stats;
+    size_t size_percentage = 0;
+    {
+        SCOPED_CACHE_LOCK(_mutex, this);
+        size_percentage = calc_size_percentage_unlocked(cache_lock);
+    }
     stats["hits_ratio"] = (double)_hit_ratio->get_value();
     stats["hits_ratio_5m"] = (double)_hit_ratio_5m->get_value();
     stats["hits_ratio_1h"] = (double)_hit_ratio_1h->get_value();
@@ -2594,8 +2697,12 @@ std::map<std::string, double> BlockFileCache::get_stats() {
             (double)_lru_recorder_shadow_queue_element_count_metrics[FileCacheType::DISPOSABLE]
                     ->get_value();
 
-    stats["need_evict_cache_in_advance"] = (double)_need_evict_cache_in_advance;
-    stats["disk_resource_limit_mode"] = (double)_disk_resource_limit_mode;
+    stats["need_evict_cache_in_advance"] =
+            (double)_need_evict_cache_in_advance.load(std::memory_order_relaxed);
+    stats["disk_resource_limit_mode"] =
+            (double)_disk_resource_limit_mode.load(std::memory_order_relaxed);
+    stats["size_percentage"] = (double)size_percentage;
+    stats["storage_type"] = (double)_storage->get_type();
 
     stats["total_removed_counts"] = (double)_num_removed_blocks->get_value();
     stats["total_hit_counts"] = (double)_num_hit_blocks->get_value();
@@ -2647,8 +2754,14 @@ std::map<std::string, double> BlockFileCache::get_stats_unsafe() {
             (double)_lru_recorder_shadow_queue_element_count_metrics[FileCacheType::DISPOSABLE]
                     ->get_value();
 
-    stats["need_evict_cache_in_advance"] = (double)_need_evict_cache_in_advance;
-    stats["disk_resource_limit_mode"] = (double)_disk_resource_limit_mode;
+    stats["need_evict_cache_in_advance"] =
+            (double)_need_evict_cache_in_advance.load(std::memory_order_relaxed);
+    stats["disk_resource_limit_mode"] =
+            (double)_disk_resource_limit_mode.load(std::memory_order_relaxed);
+    stats["size_percentage"] = _capacity == 0 ? 0
+                                              : static_cast<double>(_cur_cache_size) /
+                                                        static_cast<double>(_capacity) * 100;
+    stats["storage_type"] = (double)_storage->get_type();
 
     stats["total_removed_counts"] = (double)_num_removed_blocks->get_value();
     stats["total_hit_counts"] = (double)_num_hit_blocks->get_value();

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -467,6 +467,9 @@ private:
     size_t get_used_cache_size_unlocked(FileCacheType type,
                                         std::lock_guard<std::mutex>& cache_lock) const;
 
+    bool is_memory_storage() const;
+    size_t calc_size_percentage_unlocked(std::lock_guard<std::mutex>&) const;
+
     void check_disk_resource_limit();
     void check_need_evict_cache_in_advance();
 
@@ -539,8 +542,8 @@ private:
     std::thread _cache_background_block_lru_update_thread;
     std::atomic_bool _async_open_done {false};
     // disk space or inode is less than the specified value
-    bool _disk_resource_limit_mode {false};
-    bool _need_evict_cache_in_advance {false};
+    std::atomic_bool _disk_resource_limit_mode {false};
+    std::atomic_bool _need_evict_cache_in_advance {false};
     bool _is_initialized {false};
 
     // strategy

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -36,6 +36,7 @@
 #include <ostream>
 #include <utility>
 
+#include "common/cast_set.h"
 #include "common/config.h"
 #include "core/block/block.h"
 #include "information_schema/schema_scanner_helper.h"
@@ -312,8 +313,8 @@ std::vector<std::string> FileCacheFactory::get_base_paths() {
     return paths;
 }
 
-std::string validate_capacity(const std::string& path, int64_t new_capacity,
-                              int64_t& valid_capacity) {
+std::string validate_disk_capacity(const std::string& path, int64_t new_capacity,
+                                   int64_t& valid_capacity) {
     struct statfs stat;
     if (statfs(path.c_str(), &stat) < 0) {
         auto ret = fmt::format("reset capacity {} statfs error {}. ", path, strerror(errno));
@@ -340,16 +341,35 @@ std::string validate_capacity(const std::string& path, int64_t new_capacity,
     return "";
 }
 
+std::string validate_capacity(BlockFileCache* cache, int64_t new_capacity,
+                              int64_t& valid_capacity) {
+    if (cache->get_storage()->get_type() == FileCacheStorageType::MEMORY) {
+        valid_capacity = new_capacity;
+        if (valid_capacity <= 0) {
+            return fmt::format("The memory cache {} capacity must be greater than zero. ",
+                               cache->get_base_path());
+        }
+        return "";
+    }
+    return validate_disk_capacity(cache->get_base_path(), new_capacity, valid_capacity);
+}
+
 std::string FileCacheFactory::reset_capacity(const std::string& path, int64_t new_capacity) {
     std::stringstream ss;
     size_t total_capacity = 0;
     if (path.empty()) {
-        for (auto& [p, cache] : _path_to_cache) {
+        std::vector<std::pair<BlockFileCache*, size_t>> reset_targets;
+        reset_targets.reserve(_path_to_cache.size());
+        for (auto& entry : _path_to_cache) {
+            auto* cache = entry.second;
             int64_t valid_capacity = 0;
-            ss << validate_capacity(p, new_capacity, valid_capacity);
+            ss << validate_capacity(cache, new_capacity, valid_capacity);
             if (valid_capacity <= 0) {
                 return ss.str();
             }
+            reset_targets.emplace_back(cache, cast_set<size_t>(valid_capacity));
+        }
+        for (auto& [cache, valid_capacity] : reset_targets) {
             ss << cache->reset_capacity(valid_capacity);
             total_capacity += cache->capacity();
         }
@@ -358,11 +378,11 @@ std::string FileCacheFactory::reset_capacity(const std::string& path, int64_t ne
     } else {
         if (auto iter = _path_to_cache.find(path); iter != _path_to_cache.end()) {
             int64_t valid_capacity = 0;
-            ss << validate_capacity(path, new_capacity, valid_capacity);
+            ss << validate_capacity(iter->second, new_capacity, valid_capacity);
             if (valid_capacity <= 0) {
                 return ss.str();
             }
-            ss << iter->second->reset_capacity(valid_capacity);
+            ss << iter->second->reset_capacity(cast_set<size_t>(valid_capacity));
 
             for (auto& [p, cache] : _path_to_cache) {
                 total_capacity += cache->capacity();

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -346,6 +346,15 @@ FileBlocksHolder::~FileBlocksHolder() {
                      file_block->state_unlock(block_lock) == FileBlock::State::EMPTY)) {
                     should_remove = true;
                 }
+                // Serialize the holder release with deletion marks. Otherwise RESET can mark the
+                // block after the check above but before the holder drops its cache-external
+                // reference, leaving nobody to remove the block.
+                if (!should_remove && file_block->cell != nullptr) {
+                    TEST_SYNC_POINT_CALLBACK(
+                            "FileBlocksHolder::~FileBlocksHolder::before_cached_block_release");
+                    file_block_it = file_blocks.erase(current_file_block_it);
+                    continue;
+                }
             }
             if (should_remove) {
                 SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);

--- a/be/src/io/cache/lru_queue_recorder.cpp
+++ b/be/src/io/cache/lru_queue_recorder.cpp
@@ -35,6 +35,9 @@ size_t file_cache_type_index(FileCacheType type) {
 void LRUQueueRecorder::record_queue_event(FileCacheType type, CacheLRULogType log_type,
                                           const UInt128Wrapper hash, const size_t offset,
                                           const size_t size) {
+    if (_mgr->is_memory_storage()) {
+        return;
+    }
     if (config::file_cache_background_lru_dump_tail_record_num <= 0) {
         return;
     }

--- a/be/test/io/cache/block_file_cache_mem_storage_mode_test.cpp
+++ b/be/test/io/cache/block_file_cache_mem_storage_mode_test.cpp
@@ -1,0 +1,672 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <condition_variable>
+#include <functional>
+#include <limits>
+#include <mutex>
+#include <thread>
+
+#include "io/cache/block_file_cache_factory.h"
+#include "io/cache/block_file_cache_test_common.h"
+
+namespace doris::io {
+
+class BlockFileCacheMemModeTest : public BlockFileCacheTest {
+public:
+    void SetUp() override {
+        const auto* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+        _cache_path = caches_dir / test_info->name() / "";
+        fs::remove_all(_cache_path);
+        fs::create_directories(_cache_path);
+
+        _origin_enter_need_evict = config::file_cache_enter_need_evict_cache_in_advance_percent;
+        _origin_exit_need_evict = config::file_cache_exit_need_evict_cache_in_advance_percent;
+        _origin_enter_disk_limit = config::file_cache_enter_disk_resource_limit_mode_percent;
+        _origin_exit_disk_limit = config::file_cache_exit_disk_resource_limit_mode_percent;
+        _origin_enable_evict_in_advance = config::enable_evict_file_cache_in_advance;
+        _origin_enable_query_limit = config::enable_file_cache_query_limit;
+        _origin_lru_dump_tail_record_num = config::file_cache_background_lru_dump_tail_record_num;
+    }
+
+    void TearDown() override {
+        config::file_cache_enter_need_evict_cache_in_advance_percent = _origin_enter_need_evict;
+        config::file_cache_exit_need_evict_cache_in_advance_percent = _origin_exit_need_evict;
+        config::file_cache_enter_disk_resource_limit_mode_percent = _origin_enter_disk_limit;
+        config::file_cache_exit_disk_resource_limit_mode_percent = _origin_exit_disk_limit;
+        config::enable_evict_file_cache_in_advance = _origin_enable_evict_in_advance;
+        config::enable_file_cache_query_limit = _origin_enable_query_limit;
+        config::file_cache_background_lru_dump_tail_record_num = _origin_lru_dump_tail_record_num;
+
+        auto* sync_point = SyncPoint::get_instance();
+        sync_point->disable_processing();
+        sync_point->clear_all_call_backs();
+
+        fs::remove_all(_cache_path);
+    }
+
+protected:
+    FileCacheSettings make_settings(const std::string& storage = "memory") const {
+        FileCacheSettings settings;
+        settings.storage = storage;
+        settings.capacity = 100_mb;
+        settings.max_file_block_size = 10_mb;
+        settings.max_query_cache_size = 100_mb;
+        settings.query_queue_size = 100_mb;
+        settings.query_queue_elements = 16;
+        settings.index_queue_size = 30_mb;
+        settings.index_queue_elements = 8;
+        settings.disposable_queue_size = 30_mb;
+        settings.disposable_queue_elements = 8;
+        settings.ttl_queue_size = 30_mb;
+        settings.ttl_queue_elements = 8;
+        return settings;
+    }
+
+    void wait_async_open(BlockFileCache& cache) const {
+        for (int i = 0; i < 100; ++i) {
+            if (cache.get_async_open_success()) {
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        FAIL() << "cache async open did not finish";
+    }
+
+    bool wait_until(const std::function<bool()>& predicate, int64_t timeout_ms = 2000) const {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (predicate()) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return predicate();
+    }
+
+    void fill_memory_cache(BlockFileCache& cache, size_t total_size) const {
+        TUniqueId query_id;
+        query_id.hi = 1;
+        query_id.lo = 1;
+        CacheContext context;
+        ReadStatistics rstats;
+        context.stats = &rstats;
+        context.cache_type = FileCacheType::NORMAL;
+        context.query_id = query_id;
+        auto key = BlockFileCache::hash("mem-mode-key");
+
+        for (size_t offset = 0; offset < total_size; offset += 10_mb) {
+            auto holder = cache.get_or_set(key, offset, 10_mb, context);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == FileBlock::get_caller_id());
+            download_into_memory(blocks[0]);
+        }
+    }
+
+    void fill_cache(BlockFileCache& cache, const UInt128Wrapper& key, size_t total_size,
+                    bool use_memory_download) const {
+        TUniqueId query_id;
+        query_id.hi = 11;
+        query_id.lo = 11;
+        CacheContext context;
+        ReadStatistics rstats;
+        context.stats = &rstats;
+        context.cache_type = FileCacheType::NORMAL;
+        context.query_id = query_id;
+
+        for (size_t offset = 0; offset < total_size; offset += 10_mb) {
+            auto holder = cache.get_or_set(key, offset, 10_mb, context);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == FileBlock::get_caller_id());
+            if (use_memory_download) {
+                download_into_memory(blocks[0]);
+            } else {
+                download(blocks[0]);
+            }
+        }
+    }
+
+    void download_memory_block(const FileBlockSPtr& block, char value) const {
+        std::string data(block->range().size(), value);
+        ASSERT_TRUE(block->append(Slice(data.data(), data.size())).ok());
+        ASSERT_TRUE(block->finalize().ok());
+    }
+
+    fs::path _cache_path;
+    int64_t _origin_enter_need_evict = 0;
+    int64_t _origin_exit_need_evict = 0;
+    int64_t _origin_enter_disk_limit = 0;
+    int64_t _origin_exit_disk_limit = 0;
+    bool _origin_enable_evict_in_advance = false;
+    bool _origin_enable_query_limit = false;
+    int64_t _origin_lru_dump_tail_record_num = 0;
+};
+
+TEST_F(BlockFileCacheMemModeTest, check_need_evict_memory_enter_exit) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+
+    config::file_cache_enter_need_evict_cache_in_advance_percent = 70;
+    config::file_cache_exit_need_evict_cache_in_advance_percent = 65;
+
+    cache._cur_cache_size = 80_mb;
+    cache.check_need_evict_cache_in_advance();
+    ASSERT_TRUE(cache._need_evict_cache_in_advance);
+
+    cache._cur_cache_size = 60_mb;
+    cache.check_need_evict_cache_in_advance();
+    ASSERT_FALSE(cache._need_evict_cache_in_advance);
+}
+
+TEST_F(BlockFileCacheMemModeTest, zero_capacity_memory_should_keep_monitor_and_stats_available) {
+    auto settings = make_settings();
+    settings.capacity = 0;
+    BlockFileCache cache(_cache_path.string(), settings);
+
+    cache.check_disk_resource_limit();
+    cache.check_need_evict_cache_in_advance();
+    EXPECT_FALSE(cache._disk_resource_limit_mode.load(std::memory_order_relaxed));
+    EXPECT_FALSE(cache._need_evict_cache_in_advance.load(std::memory_order_relaxed));
+    EXPECT_EQ(cache.get_stats().at("size_percentage"), 0);
+    EXPECT_EQ(cache.get_stats_unsafe().at("size_percentage"), 0);
+
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+    EXPECT_EQ(cache.get_stats().at("size_percentage"), 0);
+}
+
+TEST_F(BlockFileCacheMemModeTest,
+       tiny_reset_with_held_blocks_should_keep_pressure_checks_available) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = FileCacheType::NORMAL;
+    auto key = BlockFileCache::hash("mem-held-tiny-reset-key");
+    auto holder = cache.get_or_set(key, 0, 30_mb, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 3);
+    for (const auto& block : blocks) {
+        ASSERT_TRUE(block->get_or_set_downloader() == FileBlock::get_caller_id());
+        download_into_memory(block);
+    }
+
+    auto message = cache.reset_capacity(1);
+    ASSERT_FALSE(message.empty());
+    ASSERT_EQ(cache._cur_cache_size, 30_mb);
+    {
+        std::lock_guard cache_lock(cache._mutex);
+        ASSERT_GT(cache.calc_size_percentage_unlocked(cache_lock), std::numeric_limits<int>::max());
+    }
+
+    cache.check_disk_resource_limit();
+    cache.check_need_evict_cache_in_advance();
+    EXPECT_TRUE(cache._disk_resource_limit_mode.load(std::memory_order_relaxed));
+    EXPECT_TRUE(cache._need_evict_cache_in_advance.load(std::memory_order_relaxed));
+}
+
+TEST_F(BlockFileCacheMemModeTest, pressure_mode_should_account_query_by_actual_block_size) {
+    auto settings = make_settings();
+    config::enable_file_cache_query_limit = false;
+    config::file_cache_enter_disk_resource_limit_mode_percent = 90;
+    config::file_cache_exit_disk_resource_limit_mode_percent = 80;
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    fill_memory_cache(cache, 100_mb);
+    cache.clear_need_update_lru_blocks();
+    {
+        std::lock_guard cache_lock(cache._mutex);
+        // Keep the prefilled blocks cold regardless of the CI worker's uptime.
+        for (auto& file : cache._files) {
+            for (auto& offset_cell : file.second) {
+                offset_cell.second.atime = std::numeric_limits<int64_t>::min();
+            }
+        }
+    }
+    cache.check_disk_resource_limit();
+    ASSERT_TRUE(cache._disk_resource_limit_mode.load(std::memory_order_relaxed));
+
+    config::enable_file_cache_query_limit = true;
+    TUniqueId query_id;
+    query_id.hi = 19;
+    query_id.lo = 19;
+    auto query_context_holder = cache.get_query_context_holder(query_id, 10);
+    ASSERT_NE(query_context_holder, nullptr);
+    ASSERT_NE(query_context_holder->context, nullptr);
+
+    CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = FileCacheType::DISPOSABLE;
+    context.query_id = query_id;
+    auto admit_block = [&](const std::string& key_name) {
+        auto key = BlockFileCache::hash(key_name);
+        auto holder = cache.get_or_set(key, 0, 10_mb, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == FileBlock::get_caller_id());
+        download_into_memory(blocks[0]);
+    };
+
+    admit_block("query-pressure-key-1");
+    cache.clear_need_update_lru_blocks();
+    {
+        std::lock_guard cache_lock(cache._mutex);
+        EXPECT_EQ(query_context_holder->context->get_cache_size(cache_lock), 10_mb);
+    }
+
+    admit_block("query-pressure-key-2");
+    cache.clear_need_update_lru_blocks();
+    {
+        std::lock_guard cache_lock(cache._mutex);
+        EXPECT_EQ(query_context_holder->context->get_cache_size(cache_lock), 10_mb);
+    }
+}
+
+TEST_F(BlockFileCacheMemModeTest, check_need_evict_memory_config_fallback) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+
+    config::file_cache_enter_need_evict_cache_in_advance_percent = 70;
+    config::file_cache_exit_need_evict_cache_in_advance_percent = 75;
+
+    cache._cur_cache_size = 80_mb;
+    cache.check_need_evict_cache_in_advance();
+
+    ASSERT_EQ(config::file_cache_enter_need_evict_cache_in_advance_percent, 78);
+    ASSERT_EQ(config::file_cache_exit_need_evict_cache_in_advance_percent, 75);
+    ASSERT_TRUE(cache._need_evict_cache_in_advance);
+}
+
+TEST_F(BlockFileCacheMemModeTest, check_disk_mode_memory_enter_exit) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+
+    config::file_cache_enter_disk_resource_limit_mode_percent = 90;
+    config::file_cache_exit_disk_resource_limit_mode_percent = 80;
+
+    cache._cur_cache_size = 95_mb;
+    cache.check_disk_resource_limit();
+    ASSERT_TRUE(cache._disk_resource_limit_mode);
+
+    cache._cur_cache_size = 70_mb;
+    cache.check_disk_resource_limit();
+    ASSERT_FALSE(cache._disk_resource_limit_mode);
+}
+
+TEST_F(BlockFileCacheMemModeTest, check_disk_mode_disk_compat) {
+    auto settings = make_settings("disk");
+    BlockFileCache cache(_cache_path.string(), settings);
+
+    config::file_cache_enter_disk_resource_limit_mode_percent = 90;
+    config::file_cache_exit_disk_resource_limit_mode_percent = 80;
+
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->set_call_back("BlockFileCache::disk_used_percentage:1",
+                              [](std::vector<std::any>&& values) {
+                                  auto* percent = try_any_cast<std::pair<int, int>*>(values.back());
+                                  percent->first = 95;
+                                  percent->second = 70;
+                              });
+    sync_point->enable_processing();
+    cache.check_disk_resource_limit();
+    ASSERT_TRUE(cache._disk_resource_limit_mode);
+
+    sync_point->clear_all_call_backs();
+    sync_point->set_call_back("BlockFileCache::disk_used_percentage:1",
+                              [](std::vector<std::any>&& values) {
+                                  auto* percent = try_any_cast<std::pair<int, int>*>(values.back());
+                                  percent->first = 70;
+                                  percent->second = 70;
+                              });
+    cache.check_disk_resource_limit();
+    ASSERT_FALSE(cache._disk_resource_limit_mode);
+}
+
+TEST_F(BlockFileCacheMemModeTest, reset_capacity_memory_should_work_and_mode_converge) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    fill_memory_cache(cache, 60_mb);
+    ASSERT_EQ(cache._cur_cache_size, 60_mb);
+
+    cache._disk_resource_limit_mode = false;
+    cache._disk_limit_mode_metrics->set_value(0);
+
+    auto message = cache.reset_capacity(30_mb);
+    ASSERT_FALSE(message.empty());
+    ASSERT_LE(cache._cur_cache_size, 30_mb);
+    ASSERT_FALSE(cache._disk_resource_limit_mode);
+
+    config::file_cache_enter_disk_resource_limit_mode_percent = 90;
+    config::file_cache_exit_disk_resource_limit_mode_percent = 80;
+    cache.check_disk_resource_limit();
+    ASSERT_TRUE(cache._disk_resource_limit_mode);
+}
+
+TEST_F(BlockFileCacheMemModeTest, reset_capacity_memory_should_not_overcount_unreleasable_blocks) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    TUniqueId query_id;
+    query_id.hi = 7;
+    query_id.lo = 7;
+    CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = FileCacheType::NORMAL;
+    context.query_id = query_id;
+    auto key = BlockFileCache::hash("mem-held-key");
+
+    auto holder = cache.get_or_set(key, 0, 10_mb, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_TRUE(blocks[0]->get_or_set_downloader() == FileBlock::get_caller_id());
+    download_into_memory(blocks[0]);
+
+    fill_memory_cache(cache, 30_mb);
+    ASSERT_EQ(cache._cur_cache_size, 40_mb);
+
+    auto message = cache.reset_capacity(15_mb);
+    ASSERT_FALSE(message.empty());
+    ASSERT_LE(cache._cur_cache_size, 15_mb);
+    ASSERT_EQ(cache._cur_cache_size, 10_mb);
+
+    blocks.clear();
+    holder.file_blocks.clear();
+}
+
+TEST_F(BlockFileCacheMemModeTest, reset_capacity_should_not_miss_last_holder_release) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = FileCacheType::NORMAL;
+    auto key = BlockFileCache::hash("mem-reset-last-holder-key");
+
+    auto holder = std::make_unique<FileBlocksHolder>(cache.get_or_set(key, 0, 1_mb, context));
+    auto blocks = fromHolder(*holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_EQ(blocks[0]->get_or_set_downloader(), FileBlock::get_caller_id());
+    download_memory_block(blocks[0], '0');
+    blocks.clear();
+
+    std::mutex barrier_mutex;
+    std::condition_variable barrier_cv;
+    bool holder_before_release = false;
+    bool reset_before_block_lock = false;
+    bool release_holder = false;
+
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->set_call_back("FileBlocksHolder::~FileBlocksHolder::before_cached_block_release",
+                              [&](auto&&) {
+                                  std::unique_lock lock(barrier_mutex);
+                                  holder_before_release = true;
+                                  barrier_cv.notify_all();
+                                  barrier_cv.wait(lock, [&] { return release_holder; });
+                              });
+    sync_point->set_call_back("BlockFileCache::reset_capacity::before_lock_busy_block",
+                              [&](auto&&) {
+                                  std::lock_guard lock(barrier_mutex);
+                                  reset_before_block_lock = true;
+                                  barrier_cv.notify_all();
+                              });
+    sync_point->enable_processing();
+
+    std::thread holder_thread([&] { holder.reset(); });
+    {
+        std::unique_lock lock(barrier_mutex);
+        barrier_cv.wait(lock, [&] { return holder_before_release; });
+    }
+
+    std::thread reset_thread([&] { cache.reset_capacity(1); });
+    {
+        std::unique_lock lock(barrier_mutex);
+        barrier_cv.wait(lock, [&] { return reset_before_block_lock; });
+        release_holder = true;
+        barrier_cv.notify_all();
+    }
+
+    holder_thread.join();
+    reset_thread.join();
+
+    EXPECT_EQ(cache._cur_cache_size, 0);
+    EXPECT_EQ(cache.get_file_blocks_num(FileCacheType::NORMAL), 0);
+}
+
+TEST_F(BlockFileCacheMemModeTest, reset_holder_cleanup_should_not_remove_redownloaded_block) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = FileCacheType::NORMAL;
+    auto key = BlockFileCache::hash("mem-reset-holder-redownload-key");
+
+    auto old_holder = std::make_unique<FileBlocksHolder>(cache.get_or_set(key, 0, 1_mb, context));
+    auto old_blocks = fromHolder(*old_holder);
+    ASSERT_EQ(old_blocks.size(), 1);
+    ASSERT_EQ(old_blocks[0]->get_or_set_downloader(), FileBlock::get_caller_id());
+    download_memory_block(old_blocks[0], '0');
+    old_blocks.clear();
+
+    std::unique_lock gc_pause(cache._close_mtx);
+    ASSERT_FALSE(cache.reset_capacity(1).empty());
+    old_holder.reset();
+
+    ASSERT_FALSE(cache.reset_capacity(100_mb).empty());
+    auto new_holder = std::make_unique<FileBlocksHolder>(cache.get_or_set(key, 0, 1_mb, context));
+    auto new_blocks = fromHolder(*new_holder);
+    ASSERT_EQ(new_blocks.size(), 1);
+    ASSERT_EQ(new_blocks[0]->get_or_set_downloader(), FileBlock::get_caller_id());
+    download_memory_block(new_blocks[0], '1');
+
+    gc_pause.unlock();
+    ASSERT_TRUE(wait_until([&cache] { return cache._recycle_keys.size_approx() == 0; }));
+
+    std::string actual(1_mb, '\0');
+    ASSERT_TRUE(new_blocks[0]->read(Slice(actual.data(), actual.size()), 0).ok());
+    EXPECT_EQ(actual, std::string(1_mb, '1'));
+}
+
+TEST_F(BlockFileCacheMemModeTest, run_background_monitor_memory_mode_flip) {
+    auto settings = make_settings();
+    config::enable_evict_file_cache_in_advance = true;
+    config::file_cache_enter_need_evict_cache_in_advance_percent = 70;
+    config::file_cache_exit_need_evict_cache_in_advance_percent = 65;
+    config::file_cache_enter_disk_resource_limit_mode_percent = 90;
+    config::file_cache_exit_disk_resource_limit_mode_percent = 80;
+
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->set_call_back("BlockFileCache::set_sleep_time",
+                              [](auto&& args) { *try_any_cast<int64_t*>(args[0]) = 10; });
+    sync_point->enable_processing();
+
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    {
+        std::lock_guard lock(cache._mutex);
+        cache._cur_cache_size = 95_mb;
+    }
+    ASSERT_TRUE(wait_until([&cache] {
+        return cache._need_evict_cache_in_advance && cache._disk_resource_limit_mode;
+    }));
+
+    {
+        std::lock_guard lock(cache._mutex);
+        cache._cur_cache_size = 60_mb;
+    }
+    ASSERT_TRUE(wait_until([&cache] {
+        return !cache._need_evict_cache_in_advance && !cache._disk_resource_limit_mode;
+    }));
+}
+
+TEST_F(BlockFileCacheMemModeTest, stats_memory_contains_storage_type_and_size_percentage) {
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+
+    cache._cur_cache_size = 25_mb;
+    cache._cur_cache_size_metrics->set_value(cache._cur_cache_size);
+
+    auto stats = cache.get_stats();
+    ASSERT_TRUE(stats.contains("size_percentage"));
+    ASSERT_TRUE(stats.contains("storage_type"));
+    ASSERT_EQ(stats["size_percentage"], 25);
+    ASSERT_EQ(stats["storage_type"], FileCacheStorageType::MEMORY);
+}
+
+TEST_F(BlockFileCacheMemModeTest, memory_storage_should_skip_lru_restore_and_dump) {
+    config::file_cache_background_lru_dump_tail_record_num = 100;
+    auto settings = make_settings();
+    auto key = BlockFileCache::hash("memory-lru-restore-key");
+    auto memory_dump_dir = fs::current_path() / "memory";
+    fs::remove_all(memory_dump_dir);
+    fs::create_directories(memory_dump_dir);
+
+    {
+        BlockFileCache cache(_cache_path.string(), settings);
+        ASSERT_TRUE(cache.initialize().ok());
+        wait_async_open(cache);
+
+        fill_cache(cache, key, 20_mb, true);
+        ASSERT_EQ(cache._cur_cache_size, 20_mb);
+        cache.dump_lru_queues(true);
+    }
+
+    auto dump_file = memory_dump_dir / "lru_dump_normal.tail";
+    ASSERT_FALSE(fs::exists(dump_file));
+
+    std::ofstream(dump_file, std::ios::binary) << "stale-memory-dump";
+    ASSERT_TRUE(fs::exists(dump_file));
+
+    BlockFileCache cache2(_cache_path.string(), settings);
+    ASSERT_TRUE(cache2.initialize().ok());
+    wait_async_open(cache2);
+
+    ASSERT_EQ(cache2._cur_cache_size, 0);
+    ASSERT_EQ(cache2._normal_queue.get_elements_num_unsafe(), 0);
+    ASSERT_TRUE(cache2.get_blocks_by_key(key).empty());
+
+    fs::remove_all(memory_dump_dir);
+}
+
+TEST_F(BlockFileCacheMemModeTest, memory_storage_should_skip_lru_queue_recorder) {
+    config::file_cache_background_lru_dump_tail_record_num = 100;
+    auto settings = make_settings();
+    BlockFileCache cache(_cache_path.string(), settings);
+    ASSERT_TRUE(cache.initialize().ok());
+    wait_async_open(cache);
+
+    auto key = BlockFileCache::hash("memory-storage-skip-lru-recorder");
+    fill_cache(cache, key, 10_mb, true);
+
+    EXPECT_EQ(cache._lru_recorder->get_lru_queue_update_cnt_from_last_dump(FileCacheType::NORMAL),
+              0);
+}
+
+TEST_F(BlockFileCacheMemModeTest, disk_storage_should_keep_lru_restore) {
+    config::file_cache_background_lru_dump_tail_record_num = 100;
+    auto settings = make_settings("disk");
+    auto key = BlockFileCache::hash("disk-lru-restore-key");
+    auto origin_cache_base_path = cache_base_path;
+    cache_base_path = _cache_path.string();
+
+    {
+        BlockFileCache cache(_cache_path.string(), settings);
+        ASSERT_TRUE(cache.initialize().ok());
+        wait_async_open(cache);
+
+        fill_cache(cache, key, 10_mb, false);
+        cache.dump_lru_queues(true);
+    }
+
+    BlockFileCache cache2(_cache_path.string(), settings);
+    ASSERT_TRUE(cache2.initialize().ok());
+    wait_async_open(cache2);
+
+    ASSERT_EQ(cache2._cur_cache_size, 10_mb);
+    ASSERT_EQ(cache2._normal_queue.get_elements_num_unsafe(), 1);
+    auto blocks = cache2.get_blocks_by_key(key);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_TRUE(blocks.contains(0));
+
+    cache_base_path = origin_cache_base_path;
+}
+
+TEST_F(BlockFileCacheMemModeTest, factory_should_reset_memory_without_disk_validation) {
+    FileCacheFactory factory;
+    auto memory_settings = make_settings();
+    auto disk_settings = make_settings("disk");
+    auto disk_path = (_cache_path / "disk").string();
+
+    ASSERT_TRUE(factory.create_file_cache("memory", memory_settings).ok());
+    ASSERT_TRUE(factory.create_file_cache(disk_path, disk_settings).ok());
+    ASSERT_EQ(factory.get_capacity(), 200_mb);
+
+    auto message = factory.reset_capacity("memory", 60_mb);
+    EXPECT_FALSE(message.empty());
+    EXPECT_EQ(factory.get_by_path("memory")->capacity(), 60_mb);
+    EXPECT_EQ(factory.get_capacity(), 160_mb);
+
+    message = factory.reset_capacity("", 40_mb);
+    EXPECT_FALSE(message.empty());
+    EXPECT_EQ(factory.get_by_path("memory")->capacity(), 40_mb);
+    EXPECT_EQ(factory.get_by_path(disk_path)->capacity(), 40_mb);
+    EXPECT_EQ(factory.get_capacity(), 80_mb);
+}
+
+TEST_F(BlockFileCacheMemModeTest, factory_should_prevalidate_all_resets_before_mutation) {
+    FileCacheFactory factory;
+    auto settings = make_settings("disk");
+    auto disk_path_a = (_cache_path / "disk_a").string();
+    auto disk_path_b = (_cache_path / "disk_b").string();
+
+    ASSERT_TRUE(factory.create_file_cache(disk_path_a, settings).ok());
+    ASSERT_TRUE(factory.create_file_cache(disk_path_b, settings).ok());
+    auto paths = factory.get_base_paths();
+    ASSERT_EQ(paths.size(), 2);
+    fs::remove_all(paths.back());
+
+    auto message = factory.reset_capacity("", 60_mb);
+    EXPECT_NE(message.find("statfs error"), std::string::npos);
+    EXPECT_EQ(factory.get_by_path(disk_path_a)->capacity(), 100_mb);
+    EXPECT_EQ(factory.get_by_path(disk_path_b)->capacity(), 100_mb);
+    EXPECT_EQ(factory.get_capacity(), 200_mb);
+}
+
+} // namespace doris::io

--- a/be/test/service/http/file_cache_action_test.cpp
+++ b/be/test/service/http/file_cache_action_test.cpp
@@ -242,4 +242,31 @@ TEST_F(FileCacheActionTest, clear_value_uses_async_remove) {
     EXPECT_TRUE(_cache->get_blocks_by_key(hash).empty());
 }
 
+TEST_F(FileCacheActionTest, reset_memory_capacity_without_memory_directory) {
+    reset_file_cache_factory();
+    std::filesystem::remove_all("memory");
+    doris::io::FileCacheSettings settings;
+    settings.storage = "memory";
+    settings.capacity = 1024 * 1024;
+    settings.max_file_block_size = 64 * 1024;
+    settings.query_queue_size = 1024 * 1024;
+    settings.query_queue_elements = 16;
+    auto* factory = doris::io::FileCacheFactory::instance();
+    ASSERT_TRUE(factory->create_file_cache("memory", settings).ok());
+    _cache = factory->get_by_path("memory");
+    ASSERT_NE(_cache, nullptr);
+
+    HttpRequest req(_evhttp_req);
+    std::string json_metrics;
+    req._params["op"] = "reset";
+    req._params["path"] = "memory";
+    req._params["capacity"] = std::to_string(2 * 1024 * 1024);
+
+    Status status = _action->_handle_header(&req, &json_metrics);
+
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(_cache->capacity(), 2 * 1024 * 1024);
+    EXPECT_EQ(factory->get_capacity(), 2 * 1024 * 1024);
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Memory file cache storage still followed disk-oriented LRU persistence behavior and skipped capacity-based resource limit monitoring. The adapted monitor also crashed when a memory cache had zero capacity, narrowed unbounded capacity percentages after tiny resets, and accessed pressure-mode flags concurrently without synchronization. Pressure mode used an enlarged eviction target for query accounting, making query LRU records inconsistent with actual cells. The production RESET path validated the literal memory cache path with `statfs`, and an all-cache reset could partially mutate earlier targets before validation failed. Memory holder cleanup could also enqueue a stale key-only deletion or miss the final-holder handoff, leaving a replacement payload deleted or an over-capacity block resident.

Adapt the required SelectDB fixes to current Doris master while preserving the newer sharded memory-storage behavior already present on master. Keep pressure percentages wide, separate eviction targets from query-accounting sizes, make pressure signals atomic, handle zero capacity safely, prevalidate storage-aware RESET targets, delete memory payloads synchronously, and serialize RESET deletion marks with the final holder release under the established cache-to-block lock order.

### Release note

Improve memory file cache resource monitoring, query accounting, deletion safety, and capacity RESET behavior while avoiding disk-only persistence and validation work.

### Check List (For Author)

- Test: Unit Test
    - ASAN BE UT: `BlockFileCacheMemModeTest.reset_capacity_should_not_miss_last_holder_release`
    - ASAN BE UT: `BlockFileCacheMemModeTest.reset_capacity_memory_should_not_overcount_unreleasable_blocks`
    - ASAN BE UT: `BlockFileCacheMemModeTest.reset_holder_cleanup_should_not_remove_redownloaded_block`
    - All 3 targeted tests passed
    - BE implementation and test targets compiled successfully; the full UT build required a temporary local fix for an unrelated stale `allocate_binlog_lsn` test call, which was restored and is not part of this PR
    - `build-support/clang-format.sh` and `build-support/check-format.sh` passed with clang-format 16
- Behavior changed: Yes. Memory file cache uses capacity percentage for pressure modes, synchronizes pressure signals, keeps query accounting at actual block sizes, safely handles extreme and zero capacity percentages, skips disk-only LRU persistence, deletes memory payloads synchronously, and closes the RESET/last-holder deletion handoff.
- Does this need documentation: No
