### PR TITLE
branch-4.0: [fix](regression) Disable auto compaction for physical row inspections #65536

### DIFF
--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_publish_conflict_seq.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_publish_conflict_seq.groovy
@@ -32,6 +32,7 @@ suite("test_partial_update_publish_conflict_seq", "nonConcurrent") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/publish/test_auto_inc_replica_consistency.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/publish/test_auto_inc_replica_consistency.groovy
@@ -36,6 +36,7 @@ suite("test_auto_inc_replica_consistency") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/publish/test_f_seq_publish_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/publish/test_f_seq_publish_read_from_old.groovy
@@ -36,6 +36,7 @@ suite("test_f_seq_publish_read_from_old") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/publish/test_fleixble_partial_update_publish_conflict_seq.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/publish/test_fleixble_partial_update_publish_conflict_seq.groovy
@@ -36,6 +36,7 @@ suite("test_flexible_partial_update_publish_conflict_seq") {
         ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
         PROPERTIES(
         "replication_num" = "1",
+        "disable_auto_compaction" = "true",
         "enable_unique_key_merge_on_write" = "true",
         "light_schema_change" = "true",
         "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/test_f_seq_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/test_f_seq_read_from_old.groovy
@@ -39,6 +39,7 @@ suite('test_f_seq_read_from_old') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_delete_sign.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_delete_sign.groovy
@@ -43,6 +43,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -93,6 +94,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -130,6 +132,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -161,6 +164,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -193,6 +197,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -264,6 +269,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
@@ -336,6 +342,7 @@ suite('test_flexible_partial_update_delete_sign') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",

--- a/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_seq_col.groovy
+++ b/regression-test/suites/unique_with_mow_p0/flexible/test_flexible_partial_update_seq_col.groovy
@@ -287,6 +287,7 @@ suite('test_flexible_partial_update_seq_col') {
             DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES (
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
             "function_column.sequence_col" = "c1");
@@ -321,6 +322,7 @@ suite('test_flexible_partial_update_seq_col') {
             DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES (
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",
             "function_column.sequence_col" = "c1");

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_seq_read_from_old.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_seq_read_from_old.groovy
@@ -40,6 +40,7 @@ suite('test_partial_update_seq_read_from_old') {
             ) UNIQUE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 1
             PROPERTIES(
             "replication_num" = "1",
+            "disable_auto_compaction" = "true",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "enable_unique_key_skip_bitmap_column" = "true",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65536

Problem Summary:

Backport #65536 to branch-4.0. The affected unique-key MOW regression cases inspect historical physical rows, sequence values, skip bitmaps, or rowset versions. Background auto compaction can merge those rowsets before the physical-row assertion runs even though user-visible SQL results remain correct.

This backport adds table-level `disable_auto_compaction=true` to the eight still-affected case files. `test_p_seq_publish_read_from_old.groovy` is intentionally omitted because branch-4.0 already contains the same protection.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test.

  Validation:
  - The representative `test_flexible_partial_update_publish_conflict_seq` suite passed on an authorized branch-4.1 cluster during #65536 validation; the affected pre-fix files are identical on branch-4.0.
  - `git diff --check origin/branch-4.0...HEAD` passed.
  - The branch diff contains only the eight intended regression case files.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

