### PR TITLE
[fix](be) Backport deterministic replica fault injection to branch-4.0

### DIFF
--- a/be/src/io/fs/stream_sink_file_writer.cpp
+++ b/be/src/io/fs/stream_sink_file_writer.cpp
@@ -19,6 +19,8 @@
 
 #include <gen_cpp/internal_service.pb.h>
 
+#include <algorithm>
+
 #include "olap/olap_common.h"
 #include "olap/rowset/beta_rowset_writer.h"
 #include "util/debug_points.h"
@@ -26,6 +28,28 @@
 #include "vec/sink/load_stream_stub.h"
 
 namespace doris::io {
+
+std::unordered_set<int64_t> StreamSinkFileWriter::_get_fault_injection_failed_dst_ids() const {
+    size_t failed_replica_num = 0;
+    DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_one_replica",
+                    { failed_replica_num = 1; });
+    DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_two_replica",
+                    { failed_replica_num = 2; });
+    DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_all_replica",
+                    { failed_replica_num = _streams.size(); });
+    if (failed_replica_num == 0) {
+        return {};
+    }
+
+    std::vector<int64_t> dst_ids;
+    dst_ids.reserve(_streams.size());
+    for (const auto& stream : _streams) {
+        dst_ids.push_back(stream->dst_id());
+    }
+    std::sort(dst_ids.begin(), dst_ids.end());
+    dst_ids.resize(std::min(failed_replica_num, dst_ids.size()));
+    return std::unordered_set<int64_t>(dst_ids.begin(), dst_ids.end());
+}
 
 void StreamSinkFileWriter::init(PUniqueId load_id, int64_t partition_id, int64_t index_id,
                                 int64_t tablet_id, int32_t segment_id, FileType file_type) {
@@ -52,24 +76,16 @@ Status StreamSinkFileWriter::appendv(const Slice* data, size_t data_cnt) {
                << ", data_length: " << bytes_req << "file_type" << _file_type;
 
     std::span<const Slice> slices {data, data_cnt};
-    size_t fault_injection_skipped_streams = 0;
+    auto fault_injection_failed_dst_ids = _get_fault_injection_failed_dst_ids();
     bool ok = false;
     Status st;
     for (auto& stream : _streams) {
-        DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_one_replica", {
-            if (fault_injection_skipped_streams < 1) {
-                fault_injection_skipped_streams++;
-                continue;
-            }
-        });
-        DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_two_replica", {
-            if (fault_injection_skipped_streams < 2) {
-                fault_injection_skipped_streams++;
-                continue;
-            }
-        });
-        DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_all_replica",
-                        { continue; });
+        if (fault_injection_failed_dst_ids.contains(stream->dst_id())) {
+            LOG(INFO) << "fault injection skips segment data to backend " << stream->dst_id()
+                      << ", load_id: " << print_id(_load_id) << ", index_id: " << _index_id
+                      << ", tablet_id: " << _tablet_id << ", segment_id: " << _segment_id;
+            continue;
+        }
         st = stream->append_data(_partition_id, _index_id, _tablet_id, _segment_id, _bytes_appended,
                                  slices, false, _file_type);
         ok = ok || st.ok();
@@ -123,23 +139,15 @@ Status StreamSinkFileWriter::_finalize() {
     VLOG_DEBUG << "writer finalize, load_id: " << print_id(_load_id) << ", index_id: " << _index_id
                << ", tablet_id: " << _tablet_id << ", segment_id: " << _segment_id;
     // TODO(zhengyu): update get_inverted_index_file_size into stat
-    size_t fault_injection_skipped_streams = 0;
+    auto fault_injection_failed_dst_ids = _get_fault_injection_failed_dst_ids();
     bool ok = false;
     for (auto& stream : _streams) {
-        DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_one_replica", {
-            if (fault_injection_skipped_streams < 1) {
-                fault_injection_skipped_streams++;
-                continue;
-            }
-        });
-        DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_two_replica", {
-            if (fault_injection_skipped_streams < 2) {
-                fault_injection_skipped_streams++;
-                continue;
-            }
-        });
-        DBUG_EXECUTE_IF("StreamSinkFileWriter.appendv.write_segment_failed_all_replica",
-                        { continue; });
+        if (fault_injection_failed_dst_ids.contains(stream->dst_id())) {
+            LOG(INFO) << "fault injection skips segment eos to backend " << stream->dst_id()
+                      << ", load_id: " << print_id(_load_id) << ", index_id: " << _index_id
+                      << ", tablet_id: " << _tablet_id << ", segment_id: " << _segment_id;
+            continue;
+        }
         auto st = stream->append_data(_partition_id, _index_id, _tablet_id, _segment_id,
                                       _bytes_appended, {}, true, _file_type);
         ok = ok || st.ok();

--- a/be/src/io/fs/stream_sink_file_writer.h
+++ b/be/src/io/fs/stream_sink_file_writer.h
@@ -21,6 +21,7 @@
 #include <gen_cpp/olap_common.pb.h>
 
 #include <queue>
+#include <unordered_set>
 
 #include "io/fs/file_writer.h"
 #include "util/uid_util.h"
@@ -57,6 +58,7 @@ public:
 
 private:
     Status _finalize();
+    std::unordered_set<int64_t> _get_fault_injection_failed_dst_ids() const;
     std::vector<std::shared_ptr<LoadStreamStub>> _streams;
 
     PUniqueId _load_id;

--- a/be/test/io/fs/stream_sink_file_writer_test.cpp
+++ b/be/test/io/fs/stream_sink_file_writer_test.cpp
@@ -20,9 +20,14 @@
 #include <brpc/channel.h>
 #include <brpc/server.h>
 
+#include <array>
+#include <unordered_map>
+
+#include "common/config.h"
 #include "gtest/gtest_pred_impl.h"
 #include "olap/olap_common.h"
 #include "util/debug/leakcheck_disabler.h"
+#include "util/debug_points.h"
 #include "util/faststring.h"
 #include "vec/sink/load_stream_stub.h"
 
@@ -47,13 +52,16 @@ const std::string DATA0 = "segment data";
 const std::string DATA1 = "hello world";
 
 static std::atomic<int64_t> g_num_request;
+static std::unordered_map<int64_t, int64_t> g_num_requests_by_dst;
 
 class StreamSinkFileWriterTest : public testing::Test {
     class MockStreamStub : public LoadStreamStub {
     public:
-        MockStreamStub(PUniqueId load_id, int64_t src_id)
+        MockStreamStub(PUniqueId load_id, int64_t src_id, int64_t dst_id)
                 : LoadStreamStub(load_id, src_id, std::make_shared<IndexToTabletSchema>(),
-                                 std::make_shared<IndexToEnableMoW>()) {};
+                                 std::make_shared<IndexToEnableMoW>()) {
+            _dst_id = dst_id;
+        }
 
         virtual ~MockStreamStub() = default;
 
@@ -76,6 +84,7 @@ class StreamSinkFileWriterTest : public testing::Test {
                 EXPECT_EQ(0, offset);
             }
             g_num_request++;
+            g_num_requests_by_dst[_dst_id]++;
             return Status::OK();
         }
     };
@@ -88,15 +97,30 @@ protected:
     virtual void SetUp() {
         _load_id.set_hi(LOAD_ID_HI);
         _load_id.set_lo(LOAD_ID_LO);
+        std::array<int64_t, NUM_STREAM> dst_ids {103, 101, 102};
         for (int src_id = 0; src_id < NUM_STREAM; src_id++) {
-            _streams.emplace_back(new MockStreamStub(_load_id, src_id));
+            _streams.emplace_back(new MockStreamStub(_load_id, src_id, dst_ids[src_id]));
         }
+        _enable_debug_points = config::enable_debug_points;
+        g_num_requests_by_dst.clear();
     }
 
-    virtual void TearDown() {}
+    virtual void TearDown() {
+        DebugPoints::instance()->clear();
+        config::enable_debug_points = _enable_debug_points;
+    }
+
+    void write_with_streams(const std::vector<std::shared_ptr<LoadStreamStub>>& streams) {
+        io::StreamSinkFileWriter writer(streams);
+        writer.init(_load_id, PARTITION_ID, INDEX_ID, TABLET_ID, SEGMENT_ID);
+        std::vector<Slice> slices {DATA0, DATA1};
+        CHECK_STATUS_OK(writer.appendv(&(*slices.begin()), slices.size()));
+        CHECK_STATUS_OK(writer.close());
+    }
 
     PUniqueId _load_id;
     std::vector<std::shared_ptr<LoadStreamStub>> _streams;
+    bool _enable_debug_points;
 };
 
 TEST_F(StreamSinkFileWriterTest, Test) {
@@ -109,6 +133,30 @@ TEST_F(StreamSinkFileWriterTest, Test) {
     EXPECT_EQ(NUM_STREAM, g_num_request);
     CHECK_STATUS_OK(writer.close());
     EXPECT_EQ(NUM_STREAM * 2, g_num_request);
+}
+
+TEST_F(StreamSinkFileWriterTest, DeterministicOneReplicaFaultInjection) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add("StreamSinkFileWriter.appendv.write_segment_failed_one_replica");
+
+    write_with_streams(_streams);
+    write_with_streams({_streams[2], _streams[0], _streams[1]});
+
+    EXPECT_EQ(0, g_num_requests_by_dst[101]);
+    EXPECT_EQ(4, g_num_requests_by_dst[102]);
+    EXPECT_EQ(4, g_num_requests_by_dst[103]);
+}
+
+TEST_F(StreamSinkFileWriterTest, DeterministicTwoReplicaFaultInjection) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add("StreamSinkFileWriter.appendv.write_segment_failed_two_replica");
+
+    write_with_streams(_streams);
+    write_with_streams({_streams[2], _streams[0], _streams[1]});
+
+    EXPECT_EQ(0, g_num_requests_by_dst[101]);
+    EXPECT_EQ(0, g_num_requests_by_dst[102]);
+    EXPECT_EQ(4, g_num_requests_by_dst[103]);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65627, #47082

Problem Summary:

This backports #65627 to `branch-4.0`.

`StreamSinkFileWriter` implemented the one/two-replica fault-injection debug points by skipping entries in each writer's local stream order. Writers for the same tablet can have different stream orders, so they could skip different destination backends and accidentally remove a quorum.

The backport derives the failed replica set from sorted destination backend IDs. Writers with the same replica set therefore skip the same physical backend(s), independent of local stream order. The added BE unit tests cover one- and two-replica injection with reordered stream lists.

Backport notes:

- Cherry-picked from `4712b1ddb114f5e9486e5dba973de00bd9b5fc35` with `-x`.
- Resolved only the branch-4.0 source layout differences (`olap/` and `vec/sink/` include paths); the fix semantics and tests are unchanged.

Local validation:

- `git diff --check origin/branch-4.0...HEAD`: passed.
- clang-format 16.0.6 `--dry-run --Werror` on all three changed files: passed.
- The regression Groovy case is unchanged.
- Targeted local BE UT was not run because the fresh branch-4.0 worktree has no third-party or UT build cache; `run buildall` will provide branch-native compile and UT validation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. The change only makes test-only debug point behavior deterministic.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
