### PR TITLE
[fix](be) Guard empty stack trace formatting

### DIFF
--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -44,6 +44,7 @@
 #include "common/memory_sanitizer.h"
 #include "common/symbol_index.h"
 #include "exec/common/hex.h"
+#include "util/debug_points.h"
 #include "util/string_util.h"
 
 namespace {
@@ -304,11 +305,17 @@ StackTrace::StackTrace(const ucontext_t& signal_context) {
 }
 
 void StackTrace::tryCapture() {
+    int frame_count = 0;
 #if defined(USE_UNWIND) && USE_UNWIND && defined(__x86_64__)
-    size = unw_backtrace(frame_pointers.data(), capacity);
+    frame_count = unw_backtrace(frame_pointers.data(), capacity);
 #else
-    size = backtrace(frame_pointers.data(), capacity);
+    frame_count = backtrace(frame_pointers.data(), capacity);
 #endif
+    size = frame_count > 0 ? static_cast<size_t>(frame_count) : 0;
+    if (doris::config::enable_debug_points &&
+        doris::DebugPoints::instance()->is_enable("StackTrace::tryCapture.empty_trace")) {
+        size = 0;
+    }
     __msan_unpoison(frame_pointers.data(), size * sizeof(frame_pointers[0]));
 }
 
@@ -480,11 +487,17 @@ std::string StackTrace::toString(int start_pointers_index,
                                  const std::string& dwarf_location_info_mode) const {
     // Default delete the first three frame pointers, which are inside the stack_trace.cpp.
     start_pointers_index += 3;
+    if (start_pointers_index < 0 || static_cast<size_t>(start_pointers_index) >= size) {
+        // Unwind can legitimately return fewer frames than the internal frames we normally hide.
+        return toStringCached({}, 0, 0, dwarf_location_info_mode);
+    }
+
+    const auto first_frame = static_cast<size_t>(start_pointers_index);
     StackTrace::FramePointers frame_pointers_raw {};
-    std::copy(frame_pointers.begin() + start_pointers_index, frame_pointers.end(),
+    std::copy(frame_pointers.begin() + first_frame, frame_pointers.end(),
               frame_pointers_raw.begin());
-    return toStringCached(frame_pointers_raw, offset, size - start_pointers_index,
-                          dwarf_location_info_mode);
+    return toStringCached(frame_pointers_raw, offset > first_frame ? offset - first_frame : 0,
+                          size - first_frame, dwarf_location_info_mode);
 }
 
 std::string StackTrace::toString(void** frame_pointers_raw, size_t offset, size_t size,

--- a/be/test/common/status_test.cpp
+++ b/be/test/common/status_test.cpp
@@ -21,10 +21,32 @@
 #include <gtest/gtest-test-part.h>
 
 #include "gtest/gtest_pred_impl.h"
+#include "util/debug_points.h"
 
 namespace doris {
 
 class StatusTest : public testing::Test {};
+
+class ScopedEmptyStackTraceFault {
+public:
+    ScopedEmptyStackTraceFault()
+            : _enable_debug_points(config::enable_debug_points),
+              _enable_stacktrace(config::enable_stacktrace) {
+        config::enable_debug_points = true;
+        config::enable_stacktrace = true;
+        DebugPoints::instance()->add("StackTrace::tryCapture.empty_trace");
+    }
+
+    ~ScopedEmptyStackTraceFault() {
+        DebugPoints::instance()->remove("StackTrace::tryCapture.empty_trace");
+        config::enable_stacktrace = _enable_stacktrace;
+        config::enable_debug_points = _enable_debug_points;
+    }
+
+private:
+    const bool _enable_debug_points;
+    const bool _enable_stacktrace;
+};
 
 TEST_F(StatusTest, OK) {
     // default
@@ -115,6 +137,13 @@ TEST_F(StatusTest, Error) {
         EXPECT_TRUE(other.to_string().find("[INTERNAL_ERROR]") != std::string::npos);
         EXPECT_TRUE(other.to_string().find("456") != std::string::npos);
     }
+}
+
+TEST_F(StatusTest, EmptyCapturedStackTrace) {
+    ScopedEmptyStackTraceFault fault;
+
+    Status status = Status::NotFound("fault-injected empty stack trace");
+    EXPECT_NE(status.to_string().find("<Empty trace>"), std::string::npos);
 }
 
 TEST_F(StatusTest /*unused*/, Format /*unused*/) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

An empty or too-short libunwind stack trace underflows the remaining-frame count in `StackTrace::toString()` after it skips its internal frames. Formatting an error `Status` then reads beyond the fixed frame array and can crash the BE.

Treat non-positive stack-capture results as empty, render a trace with fewer frames than the requested skip as the existing `<Empty trace>`, and preserve signal-context offsets after slicing. A debug-point BEUT injects an empty trace into the real `Status::NotFound` capture/logging path.

### Release note

None

### Check List (For Author)

- [x] ASAN BEUT: `StatusTest.EmptyCapturedStackTrace`
- [x] `build-support/check-format.sh`
- [x] `git diff --check`

### Validation note

The latest branch has an unrelated full-BE-build `-Werror` failure in `be/src/format_v2/column_mapper.cpp` for unused catch parameters. The targeted BEUT was built and passed with that single warning disabled in the test environment; no source workaround is included here.