### PR TITLE
[chore](auth) Fix mislabeled log strings and remove debug main in authorization plugin path

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerDorisAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerDorisAccessController.java
@@ -329,17 +329,4 @@ public class RangerDorisAccessController extends RangerAccessController {
     protected RangerAccessResultProcessor getAccessResultProcessor() {
         return null;
     }
-
-    // For test only
-    public static void main(String[] args) {
-        RangerDorisAccessController ac = new RangerDorisAccessController("doris");
-        UserIdentity user = new UserIdentity("user1", "127.0.0.1");
-        user.setIsAnalyzed();
-        boolean res = ac.checkDbPriv(user, "internal", "db1", PrivPredicate.SHOW);
-        System.out.println("res: " + res);
-        user = new UserIdentity("user2", "127.0.0.1");
-        user.setIsAnalyzed();
-        res = ac.checkTblPriv(user, "internal", "db1", "tbl1", PrivPredicate.SELECT);
-        System.out.println("res: " + res);
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
@@ -49,7 +49,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * AccessControllerManager is the entry point of privilege authentication.
+ * AccessControllerManager is the entry point of privilege authorization.
  * There are 2 kinds of access controller:
  * SystemAccessController: for global level priv, resource priv and other Doris internal priv checking
  * CatalogAccessController: for specified catalog's priv checking, can be customized.
@@ -98,7 +98,7 @@ public class AccessControllerManager {
     private void loadAccessControllerPlugins() {
         ServiceLoader<AccessControllerFactory> loaderFromClasspath = ServiceLoader.load(AccessControllerFactory.class);
         for (AccessControllerFactory factory : loaderFromClasspath) {
-            LOG.info("Found Authentication Plugin Factories: {} from class path.", factory.factoryIdentifier());
+            LOG.info("Found Access Controller Plugin Factory: {} from class path.", factory.factoryIdentifier());
             accessControllerFactoriesCache.put(factory.factoryIdentifier(), factory);
             accessControllerClassNameMapping.put(factory.getClass().getName(), factory.factoryIdentifier());
         }
@@ -106,7 +106,7 @@ public class AccessControllerManager {
         try {
             loader = ClassLoaderUtils.loadServicesFromDirectory(AccessControllerFactory.class);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load Authentication Plugin Factories", e);
+            throw new RuntimeException("Failed to load Access Controller Plugin Factories", e);
         }
         for (AccessControllerFactory factory : loader) {
             LOG.info("Found Access Controller Plugin Factory: {} from directory.", factory.factoryIdentifier());


### PR DESCRIPTION
### What problem does this PR solve?

Small tidy-ups I noticed while reading through the authorization plugin path (`AccessControllerManager` and the Ranger controller) for the OpenFGA work.

Two things:

- In `AccessControllerManager.loadAccessControllerPlugins()` the two log/exception strings for the classpath loader say "Authentication Plugin Factories", but this method loads `AccessControllerFactory` instances (authorization). The directory loader a few lines down already logs "Access Controller Plugin Factory", so this just makes the classpath branch consistent and stops the messages from pointing a reader at the wrong subsystem. The class javadoc also called the manager the entry point of "privilege authentication"; corrected to "authorization".
- `RangerDorisAccessController` still carries a leftover `public static void main` marked "For test only" that constructs a controller and prints to stdout. It is dead code (nothing references it, and it is not a real test) so I removed it.

No behavior change, log wording and a dead method only.

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

I'll keep looking at where I can help Doris support different authentication and authorization systems as I go.
