### PR TITLE
[fix](topn) Resolve topn lazy materialization column indexes for aliases

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
@@ -180,7 +180,7 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
                 }
                 outputBuilder.add(outputSlot);
                 lazyColumnForRel.add(originalColumn);
-                lazyBaseColumnIdxForRel.add(relationTable.getBaseColumnIdxByName(lazySlot.getName()));
+                lazyBaseColumnIdxForRel.add(relationTable.getBaseColumnIdxByName(originalColumn.getName()));
                 lazySlotLocationForRel.add(loc);
                 loc++;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/TopnLazyMaterializeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/TopnLazyMaterializeTest.java
@@ -24,6 +24,8 @@ import org.apache.doris.nereids.datasets.ssb.SSBTestBase;
 import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
 import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.processor.post.PlanPostProcessors;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalLazyMaterialize;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.planner.MaterializationNode;
@@ -115,6 +117,29 @@ public class TopnLazyMaterializeTest extends SSBTestBase {
                 .orElseThrow(() -> new AssertionError("lazy user_profile slot not found"));
         Assertions.assertTrue(userProfileSlot.getAllAccessPaths().contains(
                 ColumnAccessPath.data(ImmutableList.of("user_profile", "professional", "skills"))));
+    }
+
+    @Test
+    public void testLazyBaseColumnIndexUsesOriginalColumnNameForAlias() throws Exception {
+        this.createTable("create table lazy_materialize_alias_tbl("
+                + "sort_col int, lazy_col int) "
+                + "duplicate key(sort_col) distributed by hash(sort_col) buckets 1 "
+                + "properties('replication_num' = '1')");
+        String sql = "select lazy_col as lazy_alias from lazy_materialize_alias_tbl "
+                + "order by sort_col limit 1";
+
+        PlanChecker checker = PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .implement();
+        PhysicalPlan plan = checker.getPhysicalPlan();
+        plan = new PlanPostProcessors(checker.getCascadesContext()).process(plan);
+
+        List<PhysicalLazyMaterialize<? extends Plan>> materializeNodes = plan.collectToList(
+                node -> node instanceof PhysicalLazyMaterialize);
+        Assertions.assertEquals(1, materializeNodes.size(), plan.treeString());
+        Assertions.assertEquals(ImmutableList.of(ImmutableList.of(1)),
+                materializeNodes.get(0).getLazyBaseColumnIndices());
     }
 
     @Test

--- a/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
@@ -223,6 +223,15 @@ suite("test_hive_topn_lazy_mat", "p0,external") {
             contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__orc_topn_lazy_mat_table]")
         }
 
+        // Output aliases must not be used to resolve physical Hive column indices.
+        explain {
+            sql "select name as lazy_alias from orc_topn_lazy_mat_table order by id limit 10;"
+            contains("VMaterializeNode")
+            contains("column_descs_lists[[`name` text NULL]]")
+            contains("column_idxs_lists: [[1]]")
+            contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__orc_topn_lazy_mat_table]")
+        }
+
         explain {
             sql """ select a.name,length(a.name),a.value,b.*,a.* from  parquet_topn_lazy_mat_table as a    
             join  orc_topn_lazy_mat_table as b on a.id = b.id order by a.name    limit 10 """


### PR DESCRIPTION
### What problem does this PR solve?
Related pr #52114

Problem Summary:
Problem Summary: TopN lazy materialization resolved deferred column indexes with output slot names. Queries that renamed Hive columns therefore produced -1 indexes, and external row-id fetch could fill those columns with NULL when positional reading was used. Resolve the index from the already traced original base column so the descriptor and index share one column identity. Add a focused planner unit test and a Hive ORC Explain regression for the alias path.

Fix incorrect NULL values from aliased external-table columns when TopN lazy materialization is used.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

