### PR TITLE
branch-4.1: [fix](test) stabilize PruneOlapScanTabletTest mocks

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanTabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanTabletTest.java
@@ -47,7 +47,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import mockit.Expectations;
-import mockit.Mocked;
+import mockit.Injectable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -57,9 +57,9 @@ import java.util.Objects;
 class PruneOlapScanTabletTest extends SqlTestBase implements MemoPatternMatchSupported {
 
     @Test
-    void testPruneOlapScanTablet(@Mocked OlapTable olapTable,
-            @Mocked Partition partition, @Mocked MaterializedIndex index,
-            @Mocked HashDistributionInfo distributionInfo) {
+    void testPruneOlapScanTablet(@Injectable OlapTable olapTable,
+            @Injectable Partition partition, @Injectable MaterializedIndex index,
+            @Injectable HashDistributionInfo distributionInfo) {
         List<Long> tabletIds = Lists.newArrayListWithExpectedSize(300);
         for (long i = 0; i < 300; i++) {
             tabletIds.add(i);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

`PruneOlapScanTabletTest` extends `SqlTestBase`, which starts a live FE, but the
test used method-parameter `@Mocked` objects for four core catalog types. JMockit
therefore mocked every instance of those types in the test JVM, including live FE
objects used by background threads. This made expectation recording/replay race
with FE activity and caused intermittent default results or missing invocations
before the tablet-pruning assertion. One example is the null table name failure
in [FE UT build 998284](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/998284?buildTab=tests&expandedTest=build%3A%28id%3A998284%29%2Cid%3A2000005656).

This change replaces the four type-wide mocks with instance-scoped `@Injectable`
mocks. The expectations, pruning rule, and 19-tablet assertion are unchanged.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  Exact FE UT class passed in three independent runs (6/6 tests total):

  ```text
  mvn -pl fe-core -am test -Dcheckstyle.skip=true \
      -DfailIfNoTests=false \
      -Dtest=org.apache.doris.nereids.rules.rewrite.PruneOlapScanTabletTest
  ```

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
