### PR TITLE
[feature](fe) Show inverted index storage format by partition ID

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -3190,6 +3190,15 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         return tableProperty.getInvertedIndexFileStorageFormat();
     }
 
+    public TInvertedIndexFileStorageFormat getEffectiveInvertedIndexFileStorageFormat() {
+        if (tableProperty == null) {
+            return TInvertedIndexFileStorageFormat.V1;
+        }
+        TInvertedIndexFileStorageFormat storageFormat = getInvertedIndexFileStorageFormat();
+        return storageFormat == TInvertedIndexFileStorageFormat.DEFAULT
+                ? TInvertedIndexFileStorageFormat.V1 : storageFormat;
+    }
+
     public TCompressionType getCompressionType() {
         if (tableProperty == null) {
             return TCompressionType.LZ4F;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPartitionIdCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPartitionIdCommand.java
@@ -69,6 +69,7 @@ public class ShowPartitionIdCommand extends ShowCommand {
         builder.addColumn(new Column("PartitionName", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("DbId", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("TableId", ScalarType.createVarchar(30)));
+        builder.addColumn(new Column("InvertedIndexStorageFormat", ScalarType.createVarchar(30)));
         return builder.build();
     }
 
@@ -86,7 +87,8 @@ public class ShowPartitionIdCommand extends ShowCommand {
                 if (tbl instanceof OlapTable) {
                     tbl.readLock();
                     try {
-                        Partition partition = ((OlapTable) tbl).getPartition(partitionId);
+                        OlapTable olapTable = (OlapTable) tbl;
+                        Partition partition = olapTable.getPartition(partitionId);
                         if (partition != null) {
                             List<String> row = new ArrayList<>();
                             row.add(database.getFullName());
@@ -101,6 +103,7 @@ public class ShowPartitionIdCommand extends ShowCommand {
                             row.add(partition.getName());
                             row.add(String.valueOf(database.getId()));
                             row.add(String.valueOf(tbl.getId()));
+                            row.add(olapTable.getEffectiveInvertedIndexFileStorageFormat().name());
                             rows.add(row);
                             break;
                         }

--- a/regression-test/suites/cloud_p0/test_partition_cloud_inverted_index_format.groovy
+++ b/regression-test/suites/cloud_p0/test_partition_cloud_inverted_index_format.groovy
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_cloud_show_inverted_index_storage_format", "p0, docker") {
+    def options = new ClusterOptions()
+    options.cloudMode = true
+    options.setFeNum(1)
+    options.setBeNum(1)
+
+    docker(options) {
+        def assertPartitionFormats = { tableName, expectedPartitionCount, expectedFormat ->
+            def partitions = sql_return_maparray("SHOW PARTITIONS FROM ${tableName}")
+            assertEquals(expectedPartitionCount, partitions.size())
+            assertTrue(partitions.every { !it.containsKey("InvertedIndexStorageFormat") })
+            def partitionDetails = partitions.collect {
+                sql_return_maparray("SHOW PARTITION ${it.PartitionId}")
+            }
+            assertTrue(partitionDetails.every { it.size() == 1 })
+            assertTrue(partitionDetails.every { it[0].InvertedIndexStorageFormat == expectedFormat })
+        }
+
+        sql "DROP TABLE IF EXISTS test_cloud_show_inverted_format_range"
+        sql """
+            CREATE TABLE test_cloud_show_inverted_format_range (
+                k INT,
+                v VARCHAR(20),
+                INDEX idx_v (v) USING INVERTED
+            )
+            DUPLICATE KEY(k)
+            PARTITION BY RANGE(k) (
+                PARTITION p1 VALUES [("0"), ("10")),
+                PARTITION p2 VALUES [("10"), ("20")),
+                PARTITION p3 VALUES [("20"), ("30"))
+            )
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "inverted_index_storage_format" = "V3"
+            )
+        """
+        sql """
+            INSERT INTO test_cloud_show_inverted_format_range VALUES
+                (1, 'range-1a'), (2, 'range-1b'), (3, 'range-1c'),
+                (11, 'range-2a'), (12, 'range-2b'), (13, 'range-2c'),
+                (21, 'range-3a'), (22, 'range-3b'), (23, 'range-3c')
+        """
+
+        sql "DROP TABLE IF EXISTS test_cloud_show_inverted_format_list"
+        sql """
+            CREATE TABLE test_cloud_show_inverted_format_list (
+                k INT,
+                category VARCHAR(20),
+                INDEX idx_category (category) USING INVERTED
+            )
+            DUPLICATE KEY(k, category)
+            PARTITION BY LIST(category) (
+                PARTITION p_east VALUES IN ('east', 'north'),
+                PARTITION p_west VALUES IN ('west', 'south'),
+                PARTITION p_central VALUES IN ('central', 'overseas')
+            )
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "inverted_index_storage_format" = "V2"
+            )
+        """
+        sql """
+            INSERT INTO test_cloud_show_inverted_format_list VALUES
+                (1, 'east'), (2, 'north'), (3, 'west'),
+                (4, 'south'), (5, 'central'), (6, 'overseas')
+        """
+
+        sql "DROP TABLE IF EXISTS test_cloud_show_inverted_format_auto"
+        sql """
+            CREATE TABLE test_cloud_show_inverted_format_auto (
+                k INT,
+                category VARCHAR(20),
+                INDEX idx_category (category) USING INVERTED
+            )
+            DUPLICATE KEY(k, category)
+            AUTO PARTITION BY LIST(category) ()
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "inverted_index_storage_format" = "V3"
+            )
+        """
+        sql """
+            INSERT INTO test_cloud_show_inverted_format_auto VALUES
+                (1, 'book'), (2, 'book'), (3, 'music'),
+                (4, 'music'), (5, 'video'), (6, 'video')
+        """
+
+        sql "DROP TABLE IF EXISTS test_cloud_show_inverted_format_dynamic"
+        sql """
+            CREATE TABLE test_cloud_show_inverted_format_dynamic (
+                k INT,
+                dt DATE,
+                v VARCHAR(20),
+                INDEX idx_v (v) USING INVERTED
+            )
+            DUPLICATE KEY(k, dt)
+            PARTITION BY RANGE(dt) ()
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "dynamic_partition.enable" = "true",
+                "dynamic_partition.time_unit" = "DAY",
+                "dynamic_partition.start" = "-3",
+                "dynamic_partition.end" = "3",
+                "dynamic_partition.prefix" = "p",
+                "dynamic_partition.buckets" = "1",
+                "dynamic_partition.create_history_partition" = "true",
+                "inverted_index_storage_format" = "V3"
+            )
+        """
+        sql """
+            INSERT INTO test_cloud_show_inverted_format_dynamic
+            SELECT 1, date_sub(curdate(), INTERVAL 3 DAY), 'dynamic-0'
+            UNION ALL SELECT 2, date_sub(curdate(), INTERVAL 2 DAY), 'dynamic-1a'
+            UNION ALL SELECT 3, date_sub(curdate(), INTERVAL 2 DAY), 'dynamic-1b'
+            UNION ALL SELECT 4, date_sub(curdate(), INTERVAL 1 DAY), 'dynamic-2a'
+            UNION ALL SELECT 5, date_sub(curdate(), INTERVAL 1 DAY), 'dynamic-2b'
+            UNION ALL SELECT 6, curdate(), 'dynamic-3a'
+            UNION ALL SELECT 7, curdate(), 'dynamic-3b'
+            UNION ALL SELECT 8, date_add(curdate(), INTERVAL 1 DAY), 'dynamic-4'
+            UNION ALL SELECT 9, date_add(curdate(), INTERVAL 2 DAY), 'dynamic-5'
+            UNION ALL SELECT 10, date_add(curdate(), INTERVAL 3 DAY), 'dynamic-6'
+        """
+        sql "SYNC"
+
+        def rangeCount = sql "SELECT COUNT(*) FROM test_cloud_show_inverted_format_range"
+        def listCount = sql "SELECT COUNT(*) FROM test_cloud_show_inverted_format_list"
+        def autoCount = sql "SELECT COUNT(*) FROM test_cloud_show_inverted_format_auto"
+        def dynamicCount = sql "SELECT COUNT(*) FROM test_cloud_show_inverted_format_dynamic"
+        assertEquals(9L, rangeCount[0][0])
+        assertEquals(6L, listCount[0][0])
+        assertEquals(6L, autoCount[0][0])
+        assertEquals(10L, dynamicCount[0][0])
+
+        assertPartitionFormats("test_cloud_show_inverted_format_range", 3, "V3")
+        assertPartitionFormats("test_cloud_show_inverted_format_list", 3, "V2")
+        assertPartitionFormats("test_cloud_show_inverted_format_auto", 3, "V3")
+        assertPartitionFormats("test_cloud_show_inverted_format_dynamic", 7, "V3")
+
+    }
+}

--- a/regression-test/suites/query_p0/show/test_partition_local_inverted_index_format.groovy
+++ b/regression-test/suites/query_p0/show/test_partition_local_inverted_index_format.groovy
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_inverted_index_storage_format") {
+    if (isCloudMode()) {
+        return
+    }
+
+    def assertPartitionFormats = { tableName, expectedPartitionCount, expectedFormat ->
+        def partitions = sql_return_maparray("SHOW PARTITIONS FROM ${tableName}")
+        assertEquals(expectedPartitionCount, partitions.size())
+        assertTrue(partitions.every { !it.containsKey("InvertedIndexStorageFormat") })
+        def partitionDetails = partitions.collect {
+            sql_return_maparray("SHOW PARTITION ${it.PartitionId}")
+        }
+        assertTrue(partitionDetails.every { it.size() == 1 })
+        assertTrue(partitionDetails.every { it[0].InvertedIndexStorageFormat == expectedFormat })
+    }
+
+    sql "DROP TABLE IF EXISTS test_show_inverted_format_range"
+    sql """
+        CREATE TABLE test_show_inverted_format_range (
+            k INT,
+            v VARCHAR(20),
+            INDEX idx_v (v) USING INVERTED
+        )
+        DUPLICATE KEY(k)
+        PARTITION BY RANGE(k) (
+            PARTITION p1 VALUES [("0"), ("10")),
+            PARTITION p2 VALUES [("10"), ("20")),
+            PARTITION p3 VALUES [("20"), ("30"))
+        )
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "inverted_index_storage_format" = "V3"
+        )
+    """
+    sql """
+        INSERT INTO test_show_inverted_format_range VALUES
+            (1, 'range-1a'), (2, 'range-1b'), (3, 'range-1c'),
+            (11, 'range-2a'), (12, 'range-2b'), (13, 'range-2c'),
+            (21, 'range-3a'), (22, 'range-3b'), (23, 'range-3c')
+    """
+
+    sql "DROP TABLE IF EXISTS test_show_inverted_format_list"
+    sql """
+        CREATE TABLE test_show_inverted_format_list (
+            k INT,
+            category VARCHAR(20),
+            INDEX idx_category (category) USING INVERTED
+        )
+        DUPLICATE KEY(k, category)
+        PARTITION BY LIST(category) (
+            PARTITION p_east VALUES IN ('east', 'north'),
+            PARTITION p_west VALUES IN ('west', 'south'),
+            PARTITION p_central VALUES IN ('central', 'overseas')
+        )
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "inverted_index_storage_format" = "V2"
+        )
+    """
+    sql """
+        INSERT INTO test_show_inverted_format_list VALUES
+            (1, 'east'), (2, 'north'), (3, 'west'),
+            (4, 'south'), (5, 'central'), (6, 'overseas')
+    """
+
+    sql "DROP TABLE IF EXISTS test_show_inverted_format_auto"
+    sql """
+        CREATE TABLE test_show_inverted_format_auto (
+            k INT,
+            category VARCHAR(20),
+            INDEX idx_category (category) USING INVERTED
+        )
+        DUPLICATE KEY(k, category)
+        AUTO PARTITION BY LIST(category) ()
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "inverted_index_storage_format" = "V3"
+        )
+    """
+    sql """
+        INSERT INTO test_show_inverted_format_auto VALUES
+            (1, 'book'), (2, 'book'), (3, 'music'),
+            (4, 'music'), (5, 'video'), (6, 'video')
+    """
+
+    sql "DROP TABLE IF EXISTS test_show_inverted_format_dynamic"
+    sql """
+        CREATE TABLE test_show_inverted_format_dynamic (
+            k INT,
+            dt DATE,
+            v VARCHAR(20),
+            INDEX idx_v (v) USING INVERTED
+        )
+        DUPLICATE KEY(k, dt)
+        PARTITION BY RANGE(dt) ()
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "dynamic_partition.enable" = "true",
+            "dynamic_partition.time_unit" = "DAY",
+            "dynamic_partition.start" = "-3",
+            "dynamic_partition.end" = "3",
+            "dynamic_partition.prefix" = "p",
+            "dynamic_partition.buckets" = "1",
+            "dynamic_partition.create_history_partition" = "true",
+            "inverted_index_storage_format" = "V3"
+        )
+    """
+    sql """
+        INSERT INTO test_show_inverted_format_dynamic
+        SELECT 1, date_sub(curdate(), INTERVAL 2 DAY), 'dynamic-1a'
+        UNION ALL SELECT 2, date_sub(curdate(), INTERVAL 2 DAY), 'dynamic-1b'
+        UNION ALL SELECT 3, date_sub(curdate(), INTERVAL 1 DAY), 'dynamic-2a'
+        UNION ALL SELECT 4, date_sub(curdate(), INTERVAL 1 DAY), 'dynamic-2b'
+        UNION ALL SELECT 5, curdate(), 'dynamic-3a'
+        UNION ALL SELECT 6, curdate(), 'dynamic-3b'
+    """
+    sql "SYNC"
+
+    assertPartitionFormats("test_show_inverted_format_range", 3, "V3")
+    assertPartitionFormats("test_show_inverted_format_list", 3, "V2")
+    assertPartitionFormats("test_show_inverted_format_auto", 3, "V3")
+    assertPartitionFormats("test_show_inverted_format_dynamic", 7, "V3")
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`SHOW PARTITION <partition_id>` did not expose a table's inverted-index storage format. This made it difficult to inspect the configured format for a specific partition after obtaining its ID.

This change adds `InvertedIndexStorageFormat` only to `SHOW PARTITION <partition_id>`. `SHOW PARTITIONS FROM <table>` intentionally retains its existing result columns; it is used to obtain `PartitionId`, which can then be supplied to `SHOW PARTITION`. Tables without a persisted format report `V1`, matching the legacy BE tablet-schema behavior.

Example:

```sql
SHOW PARTITIONS FROM events_full;
```

| PartitionId | PartitionName |
| --- | --- |
| 123456 | p20260722 |

```sql
SHOW PARTITION 123456;
```

| PartitionId | PartitionName | InvertedIndexStorageFormat |
| --- | --- | --- |
| 123456 | p20260722 | V3 |

### Release note

`SHOW PARTITION <partition_id>` now displays `InvertedIndexStorageFormat`.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test: `regression-test/suites/cloud_p0/test_partition_cloud_inverted_index_format.groovy`, `regression-test/suites/query_p0/show/test_partition_local_inverted_index_format.groovy`
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. `SHOW PARTITION <partition_id>` displays the effective inverted-index storage format.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->