### PR TITLE
[fix](brpc) Make secondary package aliases non-owning

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -2144,37 +2144,26 @@ build_lance_c() {
         exit 1
     fi
 
+    local required_rust_version="1.91.0"
     local cargo_env=(
         "CARGO_BUILD_JOBS=${PARALLEL}"
         "CARGO_TARGET_DIR=${PWD}/${BUILD_DIR}"
         "PROTOC=${TP_INSTALL_DIR}/bin/protoc"
     )
     if command -v rustup >/dev/null 2>&1 && [[ -z "${RUSTUP_TOOLCHAIN}" ]]; then
-        if rustup toolchain list | grep -q '^1.91.0'; then
-            cargo_env+=("RUSTUP_TOOLCHAIN=1.91.0")
+        if ! rustup toolchain list | grep -Eq '^1\.91\.0([[:space:]-]|$)'; then
+            rustup toolchain install "${required_rust_version}" --profile minimal
         fi
+        cargo_env+=("RUSTUP_TOOLCHAIN=${required_rust_version}")
     fi
 
-    local required_rust_version="1.91.0"
     local cargo_version
     if ! cargo_version="$(env "${cargo_env[@]}" "${cargo_bin}" --version | awk '{print $2}')"; then
         echo "failed to get cargo version for lance-c. Install Rust ${required_rust_version} or set LANCE_C_CARGO/RUSTUP_TOOLCHAIN."
         exit 1
     fi
-    if ! awk -v required="${required_rust_version}" -v actual="${cargo_version}" 'BEGIN {
-            split(required, r, ".");
-            split(actual, a, ".");
-            for (i = 1; i <= 3; i++) {
-                if ((a[i] + 0) > (r[i] + 0)) {
-                    exit 0;
-                }
-                if ((a[i] + 0) < (r[i] + 0)) {
-                    exit 1;
-                }
-            }
-            exit 0;
-        }'; then
-        echo "lance-c requires Rust/Cargo ${required_rust_version} or newer, but found ${cargo_version}."
+    if [[ "${cargo_version}" != "${required_rust_version}" ]]; then
+        echo "lance-c requires Rust/Cargo ${required_rust_version}, but found ${cargo_version}."
         echo "Install Rust ${required_rust_version} or set LANCE_C_CARGO/RUSTUP_TOOLCHAIN."
         exit 1
     fi

--- a/thirdparty/patches/brpc-1.4.0-secondary-package-name.patch
+++ b/thirdparty/patches/brpc-1.4.0-secondary-package-name.patch
@@ -17,7 +17,7 @@ index 2087cbcf..7aede561 100644
      Tabbed* tabbed = dynamic_cast<Tabbed*>(service);
      for (int i = 0; i < sd->method_count(); ++i) {
          const google::protobuf::MethodDescriptor* md = sd->method(i);
-@@ -1282,6 +1290,14 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
+@@ -1282,6 +1290,16 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
          mp.method = md;
          mp.status = new MethodStatus;
          _method_map[md->full_name()] = mp;
@@ -27,17 +27,21 @@ index 2087cbcf..7aede561 100644
 +            secondary_method_name.append(secondary_full_name);
 +            secondary_method_name.push_back('.');
 +            secondary_method_name.append(md->name());
-+            _method_map[secondary_method_name] = mp;
++            MethodProperty secondary_mp = mp;
++            secondary_mp.own_method_status = false;
++            _method_map[secondary_method_name] = secondary_mp;
 +        }
          if (is_idl_support && sd->name() != sd->full_name()/*has ns*/) {
              MethodProperty mp2 = mp;
              mp2.own_method_status = false;
-@@ -1306,6 +1322,9 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
+@@ -1306,6 +1324,11 @@ int Server::AddServiceInternal(google::protobuf::Service* service,
          is_builtin_service, svc_opt.ownership, service, NULL };
      _fullname_service_map[sd->full_name()] = ss;
      _service_map[sd->name()] = ss;
 +    if (!secondary_full_name.empty()) {
-+        _fullname_service_map[secondary_full_name] = ss;
++        ServiceProperty secondary_ss = ss;
++        secondary_ss.ownership = SERVER_DOESNT_OWN_SERVICE;
++        _fullname_service_map[secondary_full_name] = secondary_ss;
 +    }
      if (is_builtin_service) {
          ++_builtin_service_count;


### PR DESCRIPTION
## Proposed changes

Fix DORIS-27128 in the brpc secondary package alias implementation.

The existing brpc secondary_package_name patch registers the secondary service name by copying the primary ServiceProperty, and registers secondary methods by copying the primary MethodProperty as owning entries. During brpc::Server destruction, ClearServices() iterates all service and method map entries:

- copied ServiceProperty with SERVER_OWNS_SERVICE can delete the same service twice
- copied MethodProperty with own_method_status=true can delete the same MethodStatus twice

This matches the cloud MetaService secondary package shutdown/coredump path. The patch now makes secondary aliases non-owning:

- secondary MethodProperty sets own_method_status=false and shares the primary MethodStatus
- secondary ServiceProperty sets ownership=SERVER_DOESNT_OWN_SERVICE and shares the primary service pointer only for lookup

The previous variant regression retry change and the TLS starter change have both been removed from this PR.

The failed thirdparty CI was unrelated to the brpc patch application: brpc had already built and installed successfully, then Linux/macOS failed while building lance-c because runner cargo selected a newer Rust toolchain and ethnum v1.5.2 failed with E0512. The PR now pins lance-c to Rust/Cargo 1.91.0 through rustup when available, and fails early with a clear message otherwise.

## Testing

- bash -n thirdparty/build-thirdparty.sh
- git diff --check
- Checked failed thirdparty logs for Linux/macOS: both failed at ethnum v1.5.2 in lance-c after brpc install completed.
- Verified the brpc patch with a temporary local apply check: reverse-applied the old patch from origin/master to the local brpc-1.4.0 source copy, then applied the updated patch successfully.

Issue: DORIS-27128