### PR TITLE
[fix](debug) roll byte sizes up at exact unit boundaries in getByteUint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DebugUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DebugUtil.java
@@ -103,16 +103,16 @@ public class DebugUtil {
         if (value == 0) {
             // nothing
             unit = "";
-        } else if (value > TERABYTE) {
+        } else if (value >= TERABYTE) {
             unit = "TB";
             doubleValue /= TERABYTE;
-        } else if (value > GIGABYTE) {
+        } else if (value >= GIGABYTE) {
             unit = "GB";
             doubleValue /= GIGABYTE;
-        } else if (value > MEGABYTE) {
+        } else if (value >= MEGABYTE) {
             unit = "MB";
             doubleValue /= MEGABYTE;
-        } else if (value > KILOBYTE)  {
+        } else if (value >= KILOBYTE)  {
             unit = "KB";
             doubleValue /= KILOBYTE;
         } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugUtilTest.java
@@ -84,6 +84,23 @@ public class DebugUtilTest {
         result = DebugUtil.getByteUint(1234567890L);  // G
         Assert.assertEquals(result.first, Double.valueOf(1.1497809458523989));
         Assert.assertEquals(result.second, "GB");
+
+        // exact unit boundaries should roll up to the larger unit
+        result = DebugUtil.getByteUint(1024L);  // exactly 1 KB
+        Assert.assertEquals(result.first, Double.valueOf(1.0));
+        Assert.assertEquals(result.second, "KB");
+
+        result = DebugUtil.getByteUint(1024L * 1024);  // exactly 1 MB
+        Assert.assertEquals(result.first, Double.valueOf(1.0));
+        Assert.assertEquals(result.second, "MB");
+
+        result = DebugUtil.getByteUint(1024L * 1024 * 1024);  // exactly 1 GB
+        Assert.assertEquals(result.first, Double.valueOf(1.0));
+        Assert.assertEquals(result.second, "GB");
+
+        result = DebugUtil.getByteUint(1024L * 1024 * 1024 * 1024);  // exactly 1 TB
+        Assert.assertEquals(result.first, Double.valueOf(1.0));
+        Assert.assertEquals(result.second, "TB");
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

`getByteUint` used strict `>` for each unit threshold, so a value that lands exactly on a boundary drops to the next smaller unit. A 1 TB data quota shows up as "1024.000 GB", 1 GB as "1024.000 MB", and so on. This is visible in SHOW DATA and in the "data size exceeds quota[...]" error from Database.checkDataSizeQuota, and round quotas like SET DATA QUOTA 1T hit it directly.

The sibling method `getUint` already uses `>=` for the same kind of formatting, so this just makes `getByteUint` consistent with it. Changed the four comparisons to `>=` so exact multiples of 1024 roll up to the right unit.

### Release note

None

### Check List

Added boundary cases (1 KB, 1 MB, 1 GB, 1 TB) to DebugUtilTest. The existing non-boundary assertions are unchanged.