### PR TITLE
[fix](be) Fix macOS BE compilation errors

### DIFF
--- a/be/src/common/phdr_cache.h
+++ b/be/src/common/phdr_cache.h
@@ -75,5 +75,7 @@ public:
     ScopedPHDRCacheRead& operator=(const ScopedPHDRCacheRead&) = delete;
 
 private:
+#if defined(__linux__) && !defined(THREAD_SANITIZER) && !defined(USE_MUSL)
     bool _previous = false;
+#endif
 };

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -1046,8 +1046,8 @@ bool set_page_decoded_min_max(const std::shared_ptr<::parquet::ColumnIndex>& col
         page_idx >= typed_index->max_values().size()) {
         return false;
     }
-    const auto& min_value = typed_index->min_values()[page_idx];
-    const auto& max_value = typed_index->max_values()[page_idx];
+    const typename ParquetDType::c_type min_value = typed_index->min_values()[page_idx];
+    const typename ParquetDType::c_type max_value = typed_index->max_values()[page_idx];
     if constexpr (std::is_same_v<ParquetDType, ::parquet::Int64Type>) {
         if (!timestamp_min_max_is_safe(column_schema, min_value, max_value, timezone)) {
             return false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Clang 20 fails the macOS BE build because the Linux-only PHDR cache state is unused on macOS and Parquet boolean column-index values are represented by std::vector<bool> proxy references. Restrict the PHDR state field to supported Linux builds and materialize Parquet page bounds as their physical C++ value types before decoding.
