### PR TITLE
[improvement](agg) Add passthrough local exchange before streaming ag…

### DIFF
--- a/be/src/exec/operator/streaming_aggregation_operator.h
+++ b/be/src/exec/operator/streaming_aggregation_operator.h
@@ -220,7 +220,11 @@ public:
             state->enable_streaming_agg_hash_join_force_passthrough()) {
             return DataDistribution(ExchangeType::PASSTHROUGH);
         }
-        if (!_needs_finalize && !state->enable_local_exchange_before_agg()) {
+        // Streaming aggregation needs pipeline decoupling but not a key repartition.
+        if (!_needs_finalize && state->enable_local_exchange_before_agg()) {
+            return DataDistribution(ExchangeType::PASSTHROUGH);
+        }
+        if (!_needs_finalize) {
             return StatefulOperatorX<StreamingAggLocalState>::required_data_distribution(state);
         }
         if (_partition_exprs.empty()) {

--- a/be/test/exec/operator/streaming_agg_operator_test.cpp
+++ b/be/test/exec/operator/streaming_agg_operator_test.cpp
@@ -154,6 +154,15 @@ TEST_F(StreamingAggOperatorTest, test1) {
     { EXPECT_TRUE(local_state->close(state.get()).ok()); }
 }
 
+TEST_F(StreamingAggOperatorTest, require_passthrough_local_exchange_before_non_finalize_agg) {
+    state->_query_options.__set_enable_local_exchange_before_agg(true);
+    op->_needs_finalize = false;
+    op->_partition_exprs.emplace_back();
+
+    const auto distribution = op->required_data_distribution(state.get());
+    EXPECT_EQ(ExchangeType::PASSTHROUGH, distribution.distribution_type);
+}
+
 TEST_F(StreamingAggOperatorTest, test2) {
     op->_aggregate_evaluators.push_back(create_mock_agg_fn_evaluator(
             pool, MockSlotRef::create_mock_contexts(1, std::make_shared<DataTypeInt64>()), false,

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -220,6 +220,19 @@ public class VariableMgrTest {
     }
 
     @Test
+    public void testLocalExchangeBeforeAggDefaultsToThrift() {
+        SessionVariable var = new SessionVariable();
+        TQueryOptions options = var.toThrift();
+
+        Assert.assertTrue(var.enableLocalExchangeBeforeAgg);
+        Assert.assertTrue(options.isEnableLocalExchangeBeforeAgg());
+
+        var.enableLocalExchangeBeforeAgg = false;
+        options = var.toThrift();
+        Assert.assertFalse(options.isEnableLocalExchangeBeforeAgg());
+    }
+
+    @Test
     public void testAdaptiveBatchSizeRejectsTinyNonZeroBytes() {
         SessionVariable var = new SessionVariable();
         DdlException exception = Assert.assertThrows(DdlException.class, () -> VariableMgr.setVar(var,


### PR DESCRIPTION
…gregation

Problem: non-final streaming aggregation can consume rows directly from its upstream pipeline, even when separating the pipelines with a local passthrough exchange is required to match the intended Repeat-to-streaming-aggregation execution shape. opt_perf_4.1 already carries the thrift field but does not expose or consume it end to end.

Solution: expose enable_local_exchange_before_agg as a default-enabled session variable and propagate it to TQueryOptions. StreamingAggOperatorX requests PASSTHROUGH only for non-final streaming aggregation. The existing hash-join passthrough priority and explicit shuffled_agg_ids HASH_SHUFFLE override remain intact; disabling the variable, or receiving an unset field from an older FE, retains the original distribution behavior.

Validation: ./build.sh --fe; ./build.sh --be -j 48; ./run-fe-ut.sh --run org.apache.doris.qe.VariableMgrTest; ./run-be-ut.sh --run --filter=StreamingAggOperatorTest.require_passthrough_local_exchange_before_non_finalize_agg -j 90. On an isolated FE/BE, an uncached GROUPING SETS query with agg_phase=2 produced REPEAT -> LOCAL_EXCHANGE(PASSTHROUGH) -> STREAMING_AGGREGATION by default; setting the variable false removed that local exchange while retaining the streaming aggregation and result rows.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

