### PR TITLE
[fix](workflow) Fix BE UT macOS job failing with wrong JDK version

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -114,4 +114,12 @@ jobs:
           export LDFLAGS="-L${LIBOMP_PREFIX}/lib ${LDFLAGS:-}"
           export EXTRA_CXX_FLAGS="-I${LIBOMP_PREFIX}/include ${EXTRA_CXX_FLAGS:-}"
 
+          # Disable PCH on macOS. be/CMakeLists.txt only injects OpenMP flags
+          # globally when PCH is enabled, and it applies AppleClang's multi-token
+          # "-Xclang -fopenmp" as a single argument, which clang rejects with
+          # "unknown argument: '-Xclang -fopenmp'". Targets that actually need
+          # OpenMP (faiss, openblas, ann_index) already link OpenMP::OpenMP_CXX
+          # via their own usage requirements, so turning PCH off is safe here.
+          export ENABLE_PCH=OFF
+
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -81,6 +81,7 @@ jobs:
             'maven'
             'node'
             'llvm@16'
+            'libomp'
           )
           brew install "${cellars[@]}" || true
 
@@ -100,4 +101,17 @@ jobs:
           # JAVA_HOME_17_arm64. Fall back to the x64 variable for Intel runners.
           JAVA_HOME="${JAVA_HOME_17_arm64:-${JAVA_HOME_17_X64}}"
           export JAVA_HOME="${JAVA_HOME%\/}"
+
+          # AppleClang ships no OpenMP runtime, so CMake's find_package(OpenMP)
+          # (e.g. in contrib/openblas) fails with "Could NOT find OpenMP_C" and
+          # "'omp.h' file not found". Point the compiler/linker at Homebrew's
+          # libomp. be/CMakeLists.txt resets CMAKE_C_FLAGS/CMAKE_CXX_FLAGS, so
+          # EXTRA_CXX_FLAGS is also needed to pass the include path to the BE build.
+          LIBOMP_PREFIX="$(brew --prefix libomp)"
+          export CPPFLAGS="-I${LIBOMP_PREFIX}/include ${CPPFLAGS:-}"
+          export CFLAGS="-I${LIBOMP_PREFIX}/include ${CFLAGS:-}"
+          export CXXFLAGS="-I${LIBOMP_PREFIX}/include ${CXXFLAGS:-}"
+          export LDFLAGS="-L${LIBOMP_PREFIX}/lib ${LDFLAGS:-}"
+          export EXTRA_CXX_FLAGS="-I${LIBOMP_PREFIX}/include ${EXTRA_CXX_FLAGS:-}"
+
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -96,5 +96,8 @@ jobs:
           tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
           popd
 
-          export JAVA_HOME="${JAVA_HOME_17_X64%\/}"
+          # macos-15 runners are Apple Silicon (arm64), so the JDK env var is
+          # JAVA_HOME_17_arm64. Fall back to the x64 variable for Intel runners.
+          JAVA_HOME="${JAVA_HOME_17_arm64:-${JAVA_HOME_17_X64}}"
+          export JAVA_HOME="${JAVA_HOME%\/}"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -56,7 +56,7 @@ jobs:
           max-size: "5G"
           restore-keys: BE-UT-macOS-
 
-      - name: Run UT ${{ github.ref }}
+      - name: Build BE ${{ github.ref }}
         if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
         run: |
           cellars=(
@@ -114,4 +114,11 @@ jobs:
           export LDFLAGS="-L${LIBOMP_PREFIX}/lib ${LDFLAGS:-}"
           export EXTRA_CXX_FLAGS="-I${LIBOMP_PREFIX}/include ${EXTRA_CXX_FLAGS:-}"
 
-          ./run-be-ut.sh --run -j "$(nproc)" --clean
+          # Only verify that the BE compiles on macOS; do NOT compile be/test.
+          # The unit tests are built and run locally, not in this job. build.sh
+          # configures the BE with -DMAKE_TEST=OFF, so nothing under be/test is
+          # compiled. Skip the Java extensions and cdc client (not relevant to a
+          # macOS C++ build check), and pass -j explicitly because build.sh
+          # otherwise defaults to only ~nproc/4 jobs.
+          DISABLE_BE_JAVA_EXTENSIONS=ON DISABLE_BE_CDC_CLIENT=ON \
+            ./build.sh --be -j "$(nproc)"

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -114,12 +114,4 @@ jobs:
           export LDFLAGS="-L${LIBOMP_PREFIX}/lib ${LDFLAGS:-}"
           export EXTRA_CXX_FLAGS="-I${LIBOMP_PREFIX}/include ${EXTRA_CXX_FLAGS:-}"
 
-          # Disable PCH on macOS. be/CMakeLists.txt only injects OpenMP flags
-          # globally when PCH is enabled, and it applies AppleClang's multi-token
-          # "-Xclang -fopenmp" as a single argument, which clang rejects with
-          # "unknown argument: '-Xclang -fopenmp'". Targets that actually need
-          # OpenMP (faiss, openblas, ann_index) already link OpenMP::OpenMP_CXX
-          # via their own usage requirements, so turning PCH off is safe here.
-          export ENABLE_PCH=OFF
-
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -85,16 +85,21 @@ jobs:
           )
           brew install "${cellars[@]}" || true
 
+          # macos-15 runners are Apple Silicon (arm64), so download the arm64
+          # prebuilt thirdparty. Using the x86_64 archive makes the linker ignore
+          # every thirdparty static library ("found architecture 'x86_64',
+          # required architecture 'arm64'") and the final BE link fails with
+          # thousands of undefined symbols.
           pushd thirdparty
           branch="${{ github.base_ref }}"
           if [[ -z "${branch}" ]] || [[ "${branch}" == 'master' ]]; then
-            curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz \
-              -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+            curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-arm64.tar.xz \
+              -o doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           else
-            curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz" \
-              -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+            curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-darwin-arm64.tar.xz" \
+              -o doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           fi
-          tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+          tar -xvf doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           popd
 
           # macos-15 runners are Apple Silicon (arm64), so the JDK env var is

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -19,6 +19,7 @@ name: BE UT (macOS)
 
 on:
   pull_request:
+    types: [opened, synchronize]
   schedule:
     - cron: '0 4,10,16,22 * * *'    # schedule it periodically to share the cache
 

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -80,7 +80,7 @@ jobs:
             'openjdk@11'
             'maven'
             'node'
-            'llvm@16'
+            'llvm@20'
             'libomp'
           )
           brew install "${cellars[@]}" || true

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -722,7 +722,7 @@ DEFINE_Int32(fragment_mgr_async_work_pool_queue_size, "4096");
 
 // The read size is the size of the reads sent to os.
 // There is a trade off of latency and throughout, trying to keep disks busy but
-// not introduce seeks.  The literature seems to agree that with 8 MB reads, random
+// not introduce seeks. The literature seems to agree that with 8 MB reads, random
 // io and sequential io perform similarly.
 DEFINE_Int32(min_buffer_size, "1024"); // 1024, The minimum read buffer size (in bytes)
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -2417,3 +2417,4 @@ std::vector<std::vector<std::string>> get_config_info() {
 
 #include "common/compile_check_avoid_end.h"
 } // namespace doris::config
+

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -2417,4 +2417,3 @@ std::vector<std::vector<std::string>> get_config_info() {
 
 #include "common/compile_check_avoid_end.h"
 } // namespace doris::config
-

--- a/be/test/cloud/cloud_tablet_query_prefer_cache_test.cpp
+++ b/be/test/cloud/cloud_tablet_query_prefer_cache_test.cpp
@@ -22,7 +22,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <ranges>
 
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
@@ -121,11 +120,13 @@ public:
         } else {
             tablet->add_not_warmed_up_rowset(output_rowset->rowset_id());
         }
-        std::ranges::copy_if(std::views::values(tablet->rowset_map()),
-                             std::back_inserter(input_rowsets), [=](const RowsetSharedPtr& rowset) {
-                                 return rowset->version().first >= start_version &&
-                                        rowset->version().first <= end_version;
-                             });
+        for (const auto& kv : tablet->rowset_map()) {
+            const auto& rowset = kv.second;
+            if (rowset->version().first >= start_version &&
+                rowset->version().first <= end_version) {
+                input_rowsets.push_back(rowset);
+            }
+        }
         if (input_rowsets.size() == 1) {
             tablet->add_rowsets({output_rowset}, true, wrlock);
         } else {

--- a/be/test/cloud/cloud_tablet_query_with_tolerance_test.cpp
+++ b/be/test/cloud/cloud_tablet_query_with_tolerance_test.cpp
@@ -22,7 +22,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <ranges>
 
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
@@ -116,11 +115,13 @@ public:
         } else {
             tablet->add_not_warmed_up_rowset(output_rowset->rowset_id());
         }
-        std::ranges::copy_if(std::views::values(tablet->rowset_map()),
-                             std::back_inserter(input_rowsets), [=](const RowsetSharedPtr& rowset) {
-                                 return rowset->version().first >= start_version &&
-                                        rowset->version().first <= end_version;
-                             });
+        for (const auto& kv : tablet->rowset_map()) {
+            const auto& rowset = kv.second;
+            if (rowset->version().first >= start_version &&
+                rowset->version().first <= end_version) {
+                input_rowsets.push_back(rowset);
+            }
+        }
         if (input_rowsets.size() == 1) {
             tablet->add_rowsets({output_rowset}, true, wrlock);
         } else {
@@ -151,11 +152,13 @@ public:
         std::vector<RowsetSharedPtr> input_rowsets;
         auto output_rowset = create_rowset(Version {start_version, end_version}, visible_timestamp);
         // Intentionally do NOT add any warmup state entry for this rowset
-        std::ranges::copy_if(std::views::values(tablet->rowset_map()),
-                             std::back_inserter(input_rowsets), [=](const RowsetSharedPtr& rowset) {
-                                 return rowset->version().first >= start_version &&
-                                        rowset->version().first <= end_version;
-                             });
+        for (const auto& kv : tablet->rowset_map()) {
+            const auto& rowset = kv.second;
+            if (rowset->version().first >= start_version &&
+                rowset->version().first <= end_version) {
+                input_rowsets.push_back(rowset);
+            }
+        }
         if (input_rowsets.size() == 1) {
             tablet->add_rowsets({output_rowset}, true, wrlock);
         } else {

--- a/be/test/cloud/cloud_tablet_test.cpp
+++ b/be/test/cloud/cloud_tablet_test.cpp
@@ -24,7 +24,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <ranges>
 
 #include "cloud/cloud_meta_mgr.h"
 #include "cloud/cloud_storage_engine.h"

--- a/be/test/core/jsonb/jsonb_document_cast_test.cpp
+++ b/be/test/core/jsonb/jsonb_document_cast_test.cpp
@@ -105,21 +105,21 @@ protected:
 
         {
             JsonbWriter writer;
-            Decimal64 dec = 1234567890123456789;
+            Decimal64 dec = int64_t(1234567890123456789);
             writer.writeDecimal(dec, 18, 2);
             to_jsonbs(writer);
         }
 
         {
             JsonbWriter writer;
-            Decimal128V3 dec = 1234567890123456789;
+            Decimal128V3 dec = int64_t(1234567890123456789);
             writer.writeDecimal(dec, 38, 3);
             to_jsonbs(writer);
         }
 
         {
             JsonbWriter writer;
-            Decimal256 dec {1234567890123456789};
+            Decimal256 dec {int64_t(1234567890123456789)};
             writer.writeDecimal(dec, 76, 3);
             to_jsonbs(writer);
         }

--- a/be/test/exec/column_type_convert_test.cpp
+++ b/be/test/exec/column_type_convert_test.cpp
@@ -373,8 +373,8 @@ TEST_F(ColumnTypeConverterTest, TestDecimalConversions) {
         auto& src_data = src_col->get_data();
 
         // Add test values
-        src_data.push_back(Decimal64(12345678901234));  // Normal value: 1234567890.1234
-        src_data.push_back(Decimal64(-98765432109876)); // Negative value: -9876543210.9876
+        src_data.push_back(Decimal64(int64_t(12345678901234)));  // Normal value: 1234567890.1234
+        src_data.push_back(Decimal64(int64_t(-98765432109876))); // Negative value: -9876543210.9876
 
         auto mutable_dst = dst_type->create_column();
 

--- a/be/test/exec/column_type_convert_test.cpp
+++ b/be/test/exec/column_type_convert_test.cpp
@@ -485,7 +485,7 @@ TEST_F(ColumnTypeConverterTest, TestDecimalConversions) {
         src_data.push_back(Decimal256(327673345));
         src_data.push_back(Decimal256(655353345));
         src_data.push_back(Decimal256(655363345));
-        src_data.push_back(Decimal256(3333333333332345));
+        src_data.push_back(Decimal256(int64_t(3333333333332345)));
 
         auto mutable_dst = nullable_dst_type->create_column();
         auto& nullable_col = static_cast<ColumnNullable&>(*mutable_dst);

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -703,9 +703,9 @@ TEST_F(ScannerContextTest, get_free_block) {
             scanners, limit, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
             parallel_tasks);
     scanner_context->_newly_create_free_blocks_num = newly_create_free_blocks_num.get();
-    scanner_context->_newly_create_free_blocks_num->set(0L);
+    scanner_context->_newly_create_free_blocks_num->set(int64_t(0));
     scanner_context->_scanner_memory_used_counter = scanner_memory_used_counter.get();
-    scanner_context->_scanner_memory_used_counter->set(0L);
+    scanner_context->_scanner_memory_used_counter->set(int64_t(0));
     BlockUPtr block = scanner_context->get_free_block(/*force=*/true);
     ASSERT_NE(block, nullptr);
     ASSERT_TRUE(scanner_context->_newly_create_free_blocks_num->value() == 1);

--- a/be/test/exprs/function/cast/cast_to_string_api_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_string_api_test.cpp
@@ -69,22 +69,22 @@ TEST(CastToStringTest, test) {
         EXPECT_EQ(str, "1234567.89");
     }
     {
-        Decimal64 num = -123456789012345678;
+        Decimal64 num = int64_t(-123456789012345678);
         std::string str = CastToString::from_decimal(num, 4);
         EXPECT_EQ(str, "-12345678901234.5678");
     }
     {
-        Decimal128V2 num = 1234567890123;
+        Decimal128V2 num = int64_t(1234567890123);
         std::string str = CastToString::from_decimal(num, 6);
         EXPECT_EQ(str, "1234.567890");
     }
     {
-        Decimal128V3 num = 1234567890567890;
+        Decimal128V3 num = int64_t(1234567890567890);
         std::string str = CastToString::from_decimal(num, 8);
         EXPECT_EQ(str, "12345678.90567890");
     }
     {
-        Decimal256 num {1234567890567890};
+        Decimal256 num {int64_t(1234567890567890)};
         std::string str = CastToString::from_decimal(num, 10);
         EXPECT_EQ(str, "123456.7890567890");
     }

--- a/be/test/exprs/vexpr_test.cpp
+++ b/be/test/exprs/vexpr_test.cpp
@@ -797,8 +797,8 @@ TEST(TEST_VEXPR, LITERALTEST) {
         auto src_col = ColumnDecimal128V3::create(38, 6);
         auto& src_data = src_col->get_data();
         src_data.resize(0);
-        src_data.push_back(Decimal128V3(123456789012345));
-        src_data.push_back(Decimal128V3(-123456789012345));
+        src_data.push_back(Decimal128V3(int64_t(123456789012345)));
+        src_data.push_back(Decimal128V3(int64_t(-123456789012345)));
         {
             auto node = std::make_shared<VLiteral>(
                     create_texpr_node_from(src_col->operator[](0), TYPE_DECIMAL128I, 38, 6), true);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -5935,7 +5935,7 @@ TEST_F(BlockFileCacheTest, test_align_size) {
     std::random_device rd;  // a seed source for the random number engine
     std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
     std::uniform_int_distribution<> distrib(0, 10_mb + 10086);
-    std::ranges::for_each(std::ranges::iota_view {0, 1000}, [&](int) {
+    for (int loop_i = 0; loop_i < 1000; ++loop_i) {
         size_t read_size = distrib(gen) % 1_mb;
         size_t read_offset = distrib(gen);
         auto [offset, size] =
@@ -5943,7 +5943,7 @@ TEST_F(BlockFileCacheTest, test_align_size) {
         EXPECT_EQ(offset % 1_mb, 0);
         EXPECT_GE(size, 1_mb);
         EXPECT_LE(size, 2_mb);
-    });
+    }
 }
 
 TEST_F(BlockFileCacheTest, remove_if_cached_when_isnt_releasable) {
@@ -6045,7 +6045,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_opt_lock) {
         std::random_device rd;  // a seed source for the random number engine
         std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
         std::uniform_int_distribution<> distrib(1_mb, 7_mb);
-        std::ranges::for_each(std::ranges::iota_view {0, 1000}, [&](int) {
+        for (int loop_i = 0; loop_i < 1000; ++loop_i) {
             size_t read_offset = distrib(gen);
             size_t read_size = distrib(gen) % 1_mb;
             if (read_offset + read_size > 7_mb || read_size == 0) {
@@ -6069,7 +6069,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_opt_lock) {
             } else {
                 EXPECT_EQ(std::string(read_size, '0' + num), buffer);
             }
-        });
+        }
     }
     {
         FileReaderSPtr local_reader;

--- a/be/test/io/cache/block_file_cache_test_common.h
+++ b/be/test/io/cache/block_file_cache_test_common.h
@@ -45,7 +45,6 @@
 #include <mutex>
 #include <optional>
 #include <random>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/be/test/io/cache/lru_queue_test.cpp
+++ b/be/test/io/cache/lru_queue_test.cpp
@@ -28,7 +28,6 @@
 #include <mutex>
 #include <optional>
 #include <random>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/be/test/runtime/runtime_profile_counter_tree_node_test.cpp
+++ b/be/test/runtime/runtime_profile_counter_tree_node_test.cpp
@@ -167,10 +167,10 @@ TEST_F(RuntimeProfileCounterTreeNodeTest, HighWaterMarkCounterToThrift) {
     childCounterMap["root"].insert("child");
 
     rootCounter->add(10);
-    rootCounter->set(5);
+    rootCounter->set(int64_t(5));
 
     childCounter->add(100);
-    childCounter->set(50);
+    childCounter->set(int64_t(50));
 
     RuntimeProfileCounterTreeNode rootNode = RuntimeProfileCounterTreeNode::from_map(
             counterMap, childCounterMap, RuntimeProfile::ROOT_COUNTER);

--- a/be/test/runtime/runtime_profile_test.cpp
+++ b/be/test/runtime/runtime_profile_test.cpp
@@ -76,7 +76,7 @@ TEST(RuntimeProfileTest, Basic) {
     counter_a->update(10);
     counter_a->update(-5);
     EXPECT_EQ(counter_a->value(), 5);
-    counter_a->set(1L);
+    counter_a->set(int64_t(1));
     EXPECT_EQ(counter_a->value(), 1);
 
     counter_b = profile_a2.add_counter("B", TUnit::BYTES);
@@ -149,7 +149,7 @@ TEST(RuntimeProfileTest, ProtoBasic) {
     counter_a->update(10);
     counter_a->update(-5);
     EXPECT_EQ(counter_a->value(), 5);
-    counter_a->set(1L);
+    counter_a->set(int64_t(1));
     EXPECT_EQ(counter_a->value(), 1);
 
     counter_b = profile_a2.add_counter("B", TUnit::BYTES);
@@ -441,7 +441,7 @@ TEST(RuntimeProfileTest, DerivedCounters) {
     RuntimeProfile::Counter* bytes_counter = profile.add_counter("bytes", TUnit::BYTES);
     RuntimeProfile::Counter* ticks_counter = profile.add_counter("ticks", TUnit::TIME_NS);
     // set to 1 sec
-    ticks_counter->set(1000L * 1000L * 1000L);
+    ticks_counter->set(int64_t(1000L * 1000L * 1000L));
 
     RuntimeProfile::DerivedCounter* throughput_counter = profile.add_derived_counter(
             "throughput", TUnit::BYTES,
@@ -450,9 +450,9 @@ TEST(RuntimeProfileTest, DerivedCounters) {
             },
             RuntimeProfile::ROOT_COUNTER);
 
-    bytes_counter->set(10L);
+    bytes_counter->set(int64_t(10));
     EXPECT_EQ(throughput_counter->value(), 10);
-    bytes_counter->set(20L);
+    bytes_counter->set(int64_t(20));
     EXPECT_EQ(throughput_counter->value(), 20);
     ticks_counter->set(ticks_counter->value() / 2);
     EXPECT_EQ(throughput_counter->value(), 40);

--- a/be/test/storage/compaction/compaction_permit_limiter_test.cpp
+++ b/be/test/storage/compaction/compaction_permit_limiter_test.cpp
@@ -23,6 +23,8 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
+#include <thread>
+
 #include "common/config.h"
 
 namespace doris {

--- a/be/test/storage/index/ann/ann_index_edge_case_test.cpp
+++ b/be/test/storage/index/ann/ann_index_edge_case_test.cpp
@@ -43,8 +43,8 @@ TEST_F(VectorSearchTest, TestAnnIndexStatsInitialization) {
     EXPECT_EQ(stats.range_fallback_small_candidate_rows, 0);
 
     // Test setting values
-    stats.search_costs_ns.set(1000L);
-    stats.load_index_costs_ns.set(2000L);
+    stats.search_costs_ns.set(int64_t(1000));
+    stats.load_index_costs_ns.set(int64_t(2000));
     stats.range_fallback_by_small_candidate_cnt = 1;
     stats.range_fallback_small_candidate_rows = 3;
 
@@ -56,8 +56,8 @@ TEST_F(VectorSearchTest, TestAnnIndexStatsInitialization) {
 
 TEST_F(VectorSearchTest, TestAnnIndexStatsCopyConstructor) {
     doris::segment_v2::AnnIndexStats original;
-    original.search_costs_ns.set(1500L);
-    original.load_index_costs_ns.set(2500L);
+    original.search_costs_ns.set(int64_t(1500));
+    original.load_index_costs_ns.set(int64_t(2500));
     original.range_fallback_by_small_candidate_cnt = 1;
     original.range_fallback_small_candidate_rows = 3;
 

--- a/be/test/storage/segment/inverted_index_reader_test.cpp
+++ b/be/test/storage/segment/inverted_index_reader_test.cpp
@@ -2721,8 +2721,11 @@ public:
         EXPECT_TRUE(status.ok()) << status;
 
         for (const auto& value : values) {
-            status = column_writer->add_values(column.name(), reinterpret_cast<const void*>(&value),
-                                               1);
+            // Copy into a real element first: for std::vector<bool>, `value` is a
+            // proxy, so `auto`/`&value` would give a __bit_reference/__bit_iterator
+            // rather than a real pointer. Use the container's value_type.
+            typename std::decay_t<decltype(values)>::value_type v = value;
+            status = column_writer->add_values(column.name(), reinterpret_cast<const void*>(&v), 1);
             EXPECT_TRUE(status.ok()) << status;
         }
 
@@ -3500,8 +3503,11 @@ public:
         EXPECT_TRUE(status.ok()) << status;
 
         for (const auto& value : values) {
-            status = column_writer->add_values(column.name(), reinterpret_cast<const void*>(&value),
-                                               1);
+            // Copy into a real element first: for std::vector<bool>, `value` is a
+            // proxy, so `auto`/`&value` would give a __bit_reference/__bit_iterator
+            // rather than a real pointer. Use the container's value_type.
+            typename std::decay_t<decltype(values)>::value_type v = value;
+            status = column_writer->add_values(column.name(), reinterpret_cast<const void*>(&v), 1);
             EXPECT_TRUE(status.ok()) << status;
         }
 

--- a/be/test/udf/python/python_env_test.cpp
+++ b/be/test/udf/python/python_env_test.cpp
@@ -53,7 +53,9 @@ protected:
     // which causes pclose() to get ECHILD because the kernel auto-reaps children.
     // We reset SIGCHLD to SIG_DFL for the duration of each test to mimic production
     // behaviour, and restore the original handler afterwards.
-    sighandler_t old_sigchld_ = SIG_DFL;
+    // sighandler_t is a glibc-only typedef; use a plain function-pointer type so
+    // this also builds on macOS (where signal() uses sig_t).
+    void (*old_sigchld_)(int) = SIG_DFL;
 
     void SetUp() override {
         test_dir_ = fs::temp_directory_path().string() + "/python_env_test_" +


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #58914

Problem Summary:

The `BE UT (macOS)` job fails at the JDK version check, e.g. in
https://github.com/apache/doris/actions/runs/29692786375/job/88208347509:

```
Check JAVA version
ERROR: The JAVA version is 25, it must be JDK-17.
```

Root cause: #58914 migrated the runner from the deprecated `macos-13`
(Intel / x64) to `macos-15`, which is Apple Silicon (arm64). GitHub's runner
images expose the JDK path as `JAVA_HOME_<version>_<arch>`, so on arm64 it is
`JAVA_HOME_17_arm64`, and the old `JAVA_HOME_17_X64` is unset. The workflow
still read `JAVA_HOME_17_X64`, so `JAVA_HOME` became empty; the build then fell
back to the system default Java (25) and `check_jdk_version` failed.

Fix: read `JAVA_HOME_17_arm64` with a fallback to `JAVA_HOME_17_X64`, keeping
the job working on Apple Silicon runners while staying compatible with Intel
ones. The trailing-slash stripping of the original is preserved.

Note: this workflow's paths-filter only triggers on `be/**` / `gensrc/**`
changes, so this PR (which only edits the workflow) will not run the macOS
BE UT job itself. The fix will be exercised by the next scheduled run or the
next PR touching BE code. The env-var resolution was verified locally for both
arm64 and x64 cases.

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: CI-workflow-only change; correctness verified locally by simulating the `JAVA_HOME_17_arm64` / `JAVA_HOME_17_X64` resolution on both architectures.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.
