### PR TITLE
branch-4.1: [fix](ut-opt)Update JVM arguments in pom.xml for testing

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -911,7 +911,7 @@ under the License.
                     <reuseForks>false</reuseForks>
                     <useFile>false</useFile>
                     <argLine>
-                        -Xmx1024m -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar @{argLine}
+                        -Xmx1024m --add-reads=org.apache.arrow.flight.core=ALL-UNNAMED --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar @{argLine}
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
https://github.com/apache/doris/pull/65311/changes

```
java.lang.AssertionError: no createPreparedStatement call should fail expected:<0> but was:<100>
  at org.apache.doris.service.arrowflight.DorisFlightSqlProducerTest.createPreparedStatementDoesNotLeakChannelAllocator(DorisFlightSqlProducerTest.java:136)
------- Stdout: -------
2026-07-17 14:38:41 [main] INFO  BaseAllocator:62 - Debug mode disabled. Enable with the VM option -Darrow.memory.debug.allocator=true.
2026-07-17 14:38:41 [main] INFO  DefaultAllocationManagerOption:91 - allocation manager type not specified, using netty as the default type
2026-07-17 14:38:41 [main] INFO  CheckAllocator:99 - Using DefaultAllocationManager at memory-netty/17.0.0/arrow-memory-netty-17.0.0.jar!/org/apache/arrow/memory/netty/DefaultAllocationManagerFactory.class
------- Stderr: -------
java.lang.RuntimeException: Failed to initialize MemoryUtil. You must start Java with `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` (See https://arrow.apache.org/docs/java/install.html
  at org.apache.arrow.memory.util.MemoryUtil.<clinit>(MemoryUtil.java:140)
  at org.apache.arrow.memory.ArrowBuf.setZero(ArrowBuf.java:1176)
  at org.apache.arrow.vector.BaseVariableWidthVector.initOffsetBuffer(BaseVariableWidthVector.java:245)
  at org.apache.arrow.vector.BaseVariableWidthVector.allocateBytes(BaseVariableWidthVector.java:505)
  at org.apache.arrow.vector.BaseVariableWidthVector.allocateNew(BaseVariableWidthVector.java:446)
  at org.apache.arrow.vector.BaseVariableWidthVector.allocateNew(BaseVariableWidthVector.java:407)
  at org.apache.doris.service.arrowflight.results.FlightSqlChannel.createOneOneSchemaRoot(FlightSqlChannel.java:133)
  at org.apache.doris.service.arrowflight.DorisFlightSqlProducer.lambda$createPreparedStatement$1(DorisFlightSqlProducer.java:372)
  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field long java.nio.Buffer.address accessible: module java.base does not "opens java.nio" to unnamed module @221af3c0
  at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
  at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
  at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
  at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
  at org.apache.arrow.memory.util.MemoryUtil.<clinit>(MemoryUtil.java:84)
```