### PR TITLE
[fix](ci) do not block TeamCity trigger on cancellation failure

### DIFF
--- a/regression-test/pipeline/common/teamcity-utils.sh
+++ b/regression-test/pipeline/common/teamcity-utils.sh
@@ -300,8 +300,10 @@ trigger_or_skip_build() {
     fi
 
     if [[ "${FILE_CHANGED:-"true"}" == "true" ]]; then
-        cancel_running_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"
-        cancel_queue_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"
+        cancel_running_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}" ||
+            echo "WARNING: failed to cancel running build; continue triggering the new build"
+        cancel_queue_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}" ||
+            echo "WARNING: failed to cancel queued build; continue triggering the new build"
         trigger_build "${PULL_REQUEST_NUM}" "${COMMIT_ID_FROM_TRIGGER}" "${COMMENT_TRIGGER_TYPE}" "${COMMENT_REPEAT_TIMES}"
     else
         cancel_running_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Before triggering a TeamCity build, `trigger_or_skip_build` already cancels running and queued builds for the same PR and the same pipeline type. For example, an FE UT trigger only cancels existing FE UT builds for that PR.

If either cancellation lookup returns an error, the GitHub Actions `bash -e` shell can stop before `trigger_build`, even though cancellation is only a best-effort optimization.

This change keeps the existing per-PR, per-pipeline cancellation behavior and converts lookup failures into warnings. The new TeamCity build is still triggered when cancellation fails.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `bash -n regression-test/pipeline/common/teamcity-utils.sh`
        - Stubbed cancellation failures and verified the same PR/pipeline arguments were used and `trigger_build` still ran.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Cancellation lookup failures now warn instead of blocking the subsequent TeamCity trigger.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
