### PR TITLE
[fix](regression) Isolate non-catalog Kerberos test database

### DIFF
--- a/regression-test/suites/external_table_p0/kerberos/test_non_catalog_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_non_catalog_kerberos.groovy
@@ -56,8 +56,8 @@ suite("test_non_catalog_kerberos", "p0,external") {
         """
 
     sql """ switch ${hms_catalog_name} """
-    sql """ create database if not exists test_krb_hive_db """
-    sql """ use test_krb_hive_db """
+    sql """ create database if not exists test_non_catalog_krb_hive_db """
+    sql """ use test_non_catalog_krb_hive_db """
     sql """ drop table  if exists ${test_tbl_name}"""
     sql """
         CREATE TABLE `${test_tbl_name}` (
@@ -147,7 +147,7 @@ suite("test_non_catalog_kerberos", "p0,external") {
     Awaitility.await("queery-export-task-result-test").atMost(60, SECONDS).pollInterval(5, SECONDS).until(
             {
                 sql """ switch ${hms_catalog_name} """
-                sql """ use test_krb_hive_db """
+                sql """ use test_non_catalog_krb_hive_db """
                 def res = sql """ show export where label = "${export_task_label}" """
                 if (res[0][2] == "FINISHED") {
                     return true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:

The Kerberos external regression suites can run concurrently against the same Hive Metastore. Both `test_non_catalog_kerberos` and `test_two_hive_kerberos` used the database name `test_krb_hive_db`.

Creating an external HMS database with `IF NOT EXISTS` performs a check followed by a create operation. When both suites create the database concurrently, both checks can observe that it is absent, and one request then fails with an HMS `AlreadyExistsException`.

Use a dedicated `test_non_catalog_krb_hive_db` database for the non-catalog Kerberos suite. This isolates its fixture from the two-Hive suite without changing the tested export, outfile, HDFS, or Kerberos behavior.

### Release note

None

### Check List (For Author)

- Test: Static validation
    - `git diff --check`
    - Verified the two concurrent Kerberos suites no longer share the same HMS database name
- Behavior changed: No
- Does this need documentation: No
