### PR TITLE
[fix](ci) adapt PR checks to safer checkout defaults

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,7 +21,6 @@ name: Code Formatter
 
 on:
   pull_request:
-  pull_request_target:
   workflow_dispatch:
   issue_comment:
     types: [ created ]
@@ -35,23 +34,16 @@ jobs:
     name: "Clang Formatter"
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request') || (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' &&
        github.event.comment.body == 'run buildall' &&
        github.actor == 'doris-robot' &&
        github.event.issue.user.login == 'github-actions[bot]')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
-
-      - name: Checkout ${{ github.ref }} ( ${{ github.event.pull_request.head.sha }} )
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout paths-filter
         run: |

--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -18,7 +18,7 @@
 ---
 name: License Check
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - master
@@ -26,12 +26,16 @@ on:
   issue_comment:
     types: [ created ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   license-check:
     name: "License Check"
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'issue_comment' &&
        github.event.comment.body == 'run buildall' &&
@@ -39,18 +43,12 @@ jobs:
        github.event.issue.user.login == 'github-actions[bot]')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v3
-
-      - name: Checkout ${{ github.ref }} ( ${{ github.event.pull_request.head.sha }} )
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Get changed files
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         id: changed-files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +83,7 @@ jobs:
 
       - name: Generate incremental licenserc
         if: >-
-          github.event_name == 'pull_request_target' &&
+          github.event_name == 'pull_request' &&
           steps.changed-files.outputs.added_modified != ''
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.added_modified }}
@@ -110,7 +108,7 @@ jobs:
 
       - name: Check License
         if: >-
-          github.event_name != 'pull_request_target' ||
+          github.event_name != 'pull_request' ||
           steps.changed-files.outputs.config_file != ''
         uses: apache/skywalking-eyes@v0.8.0
         env:


### PR DESCRIPTION
### What problem does this PR solve?

GitHub now blocks `actions/checkout` from checking out fork PR code in a `pull_request_target` workflow by default. As a result, License Check and the `pull_request_target` instance of Code Formatter fail during checkout before their actual checks run.

Example failure: https://github.com/apache/doris/actions/runs/29789987113/job/88526293992?pr=64849

GitHub announcement: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

### What changed?

- Run License Check for PRs with the unprivileged `pull_request` event.
- Keep the incremental license configuration generation for PR files.
- Remove the duplicate `pull_request_target` trigger and checkout path from Code Formatter.
- Restrict License Check permissions to read-only access.
- Upgrade both checkout steps from `actions/checkout@v3` to `actions/checkout@v7`.

Push, workflow dispatch, and `run buildall` issue-comment behavior remain unchanged.

### Check List

- `actionlint .github/workflows/license-eyes.yml .github/workflows/clang-format.yml`
- `git diff --check`

### Validation note

This PR uses a same-repository branch so the default branch's existing `pull_request_target` workflows can bootstrap the change. Both the existing target-side runs and the new `pull_request` runs completed successfully for License Check and Code Formatter. After this change reaches `master`, fork PRs will only use the safe `pull_request` definitions.
