### PR TITLE
[fix](be) Align file cache writer allocations to block boundaries

### DIFF
--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -214,6 +214,9 @@ public:
     /// Cache capacity in bytes.
     [[nodiscard]] size_t capacity() const { return _capacity; }
 
+    /// Canonical size used to partition a cached file into blocks.
+    [[nodiscard]] size_t max_file_block_size() const { return _max_file_block_size; }
+
     // try to release all releasable block
     // it maybe hang the io/system
     size_t try_release();

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -191,19 +191,15 @@ Status CachedRemoteFileReader::close() {
 
 std::pair<size_t, size_t> CachedRemoteFileReader::s_align_size(size_t offset, size_t read_size,
                                                                size_t length) {
-    size_t left = offset;
-    size_t right = offset + read_size - 1;
-    size_t align_left =
-            (left / config::file_cache_each_block_size) * config::file_cache_each_block_size;
-    size_t align_right =
-            (right / config::file_cache_each_block_size + 1) * config::file_cache_each_block_size;
-    align_right = align_right < length ? align_right : length;
-    size_t align_size = align_right - align_left;
-    if (align_size < config::file_cache_each_block_size && align_left != 0) {
-        align_size += config::file_cache_each_block_size;
-        align_left -= config::file_cache_each_block_size;
+    auto aligned_range =
+            align_file_cache_range(offset, read_size, config::file_cache_each_block_size);
+    aligned_range.size =
+            std::min(aligned_range.offset + aligned_range.size, length) - aligned_range.offset;
+    if (aligned_range.size < config::file_cache_each_block_size && aligned_range.offset != 0) {
+        aligned_range.size += config::file_cache_each_block_size;
+        aligned_range.offset -= config::file_cache_each_block_size;
     }
-    return std::make_pair(align_left, align_size);
+    return std::make_pair(aligned_range.offset, aligned_range.size);
 }
 
 namespace {

--- a/be/src/io/cache/file_cache_common.cpp
+++ b/be/src/io/cache/file_cache_common.cpp
@@ -133,15 +133,6 @@ std::string UInt128Wrapper::to_string() const {
     return get_hex_uint_lowercase(value_);
 }
 
-FileCacheRange align_file_cache_range(size_t offset, size_t size, size_t block_size) {
-    const size_t range_end = offset + size;
-    const size_t aligned_offset = offset - offset % block_size;
-    const size_t end_remainder = range_end % block_size;
-    const size_t aligned_end =
-            end_remainder == 0 ? range_end : range_end + block_size - end_remainder;
-    return {.offset = aligned_offset, .size = aligned_end - aligned_offset};
-}
-
 FileBlocksHolderPtr FileCacheAllocatorBuilder::allocate_cache_holder(size_t offset, size_t size,
                                                                      int64_t tablet_id) const {
     const auto aligned_range = align_file_cache_range(offset, size, _cache->max_file_block_size());

--- a/be/src/io/cache/file_cache_common.cpp
+++ b/be/src/io/cache/file_cache_common.cpp
@@ -133,8 +133,19 @@ std::string UInt128Wrapper::to_string() const {
     return get_hex_uint_lowercase(value_);
 }
 
+FileCacheRange align_file_cache_range(size_t offset, size_t size, size_t block_size) {
+    const size_t range_end = offset + size;
+    const size_t aligned_offset = offset - offset % block_size;
+    const size_t end_remainder = range_end % block_size;
+    const size_t aligned_end =
+            end_remainder == 0 ? range_end : range_end + block_size - end_remainder;
+    return {.offset = aligned_offset, .size = aligned_end - aligned_offset};
+}
+
 FileBlocksHolderPtr FileCacheAllocatorBuilder::allocate_cache_holder(size_t offset, size_t size,
                                                                      int64_t tablet_id) const {
+    const auto aligned_range = align_file_cache_range(offset, size, _cache->max_file_block_size());
+
     CacheContext ctx;
     ctx.cache_type = _expiration_time == 0 ? FileCacheType::NORMAL : FileCacheType::TTL;
     ctx.expiration_time = _expiration_time;
@@ -142,7 +153,7 @@ FileBlocksHolderPtr FileCacheAllocatorBuilder::allocate_cache_holder(size_t offs
     ctx.tablet_id = tablet_id;
     ReadStatistics stats;
     ctx.stats = &stats;
-    auto holder = _cache->get_or_set(_cache_hash, offset, size, ctx);
+    auto holder = _cache->get_or_set(_cache_hash, aligned_range.offset, aligned_range.size, ctx);
     return std::make_unique<FileBlocksHolder>(std::move(holder));
 }
 

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -102,7 +102,14 @@ struct FileCacheRange {
 /// @param size Length of the requested byte range.
 /// @param block_size Canonical cache block size.
 /// @return Block-aligned offset and size covering the requested range.
-FileCacheRange align_file_cache_range(size_t offset, size_t size, size_t block_size);
+inline FileCacheRange align_file_cache_range(size_t offset, size_t size, size_t block_size) {
+    const size_t range_end = offset + size;
+    const size_t aligned_offset = offset - offset % block_size;
+    const size_t end_remainder = range_end % block_size;
+    const size_t aligned_end =
+            end_remainder == 0 ? range_end : range_end + block_size - end_remainder;
+    return {.offset = aligned_offset, .size = aligned_end - aligned_offset};
+}
 
 struct FileCacheAllocatorBuilder {
     bool _is_cold_data;

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -92,11 +92,26 @@ class BlockFileCache;
 struct FileBlocksHolder;
 using FileBlocksHolderPtr = std::unique_ptr<FileBlocksHolder>;
 
+struct FileCacheRange {
+    size_t offset;
+    size_t size;
+};
+
+/// Expand `[offset, offset + size)` to cover complete cache blocks.
+/// @param offset Start of the requested byte range.
+/// @param size Length of the requested byte range.
+/// @param block_size Canonical cache block size.
+/// @return Block-aligned offset and size covering the requested range.
+FileCacheRange align_file_cache_range(size_t offset, size_t size, size_t block_size);
+
 struct FileCacheAllocatorBuilder {
     bool _is_cold_data;
     uint64_t _expiration_time;
     UInt128Wrapper _cache_hash;
     BlockFileCache* _cache; // Only one ref, the lifetime is owned by FileCache
+    /// Allocate cache blocks covering `[offset, offset + size)`. The requested range is expanded
+    /// to the cache's canonical block boundaries so metadata-only allocations and data-buffer
+    /// allocations for the same remote file always produce compatible cells.
     FileBlocksHolderPtr allocate_cache_holder(size_t offset, size_t size, int64_t tablet_id) const;
 };
 

--- a/be/src/storage/segment/segment_writer.cpp
+++ b/be/src/storage/segment/segment_writer.cpp
@@ -39,6 +39,7 @@
 #include "core/field.h"
 #include "core/types.h"
 #include "core/value/vdatetime_value.h"
+#include "cpp/sync_point.h"
 #include "exec/common/variant_util.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/block_file_cache_factory.h"
@@ -1041,6 +1042,7 @@ Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size
         for (auto& segment : holder->file_blocks) {
             static_cast<void>(segment->change_cache_type(io::FileCacheType::INDEX));
         }
+        TEST_INJECTION_POINT_CALLBACK("SegmentWriter::finalize::index_cache_holder", holder.get());
     }
     return Status::OK();
 }

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -5884,6 +5884,29 @@ TEST_F(BlockFileCacheTest, test_check_disk_reource_limit_3) {
     }
 }
 
+TEST(FileCacheRangeAlignmentTest, ExpandsToCanonicalBlockBoundaries) {
+    struct TestCase {
+        size_t offset;
+        size_t size;
+        size_t expected_offset;
+        size_t expected_size;
+    };
+    constexpr size_t block_size = 4;
+    const std::vector<TestCase> test_cases = {
+            {.offset = 0, .size = 4, .expected_offset = 0, .expected_size = 4},
+            {.offset = 1, .size = 2, .expected_offset = 0, .expected_size = 4},
+            {.offset = 3, .size = 2, .expected_offset = 0, .expected_size = 8},
+            {.offset = 5, .size = 8, .expected_offset = 4, .expected_size = 12},
+    };
+
+    for (const auto& test_case : test_cases) {
+        const auto aligned_range =
+                align_file_cache_range(test_case.offset, test_case.size, block_size);
+        EXPECT_EQ(aligned_range.offset, test_case.expected_offset);
+        EXPECT_EQ(aligned_range.size, test_case.expected_size);
+    }
+}
+
 TEST_F(BlockFileCacheTest, test_align_size) {
     const size_t total_size = 10_mb + 10086;
     {

--- a/be/test/storage/cloud_file_cache_write_index_only_test.cpp
+++ b/be/test/storage/cloud_file_cache_write_index_only_test.cpp
@@ -17,12 +17,15 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -44,7 +47,11 @@
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/segment/segment_index_file_cache_loader.h"
+#include "storage/segment/segment_writer.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet/tablet.h"
+#include "storage/tablet/tablet_meta.h"
+#include "util/defer_op.h"
 #include "util/threadpool.h"
 #include "util/time.h"
 
@@ -794,6 +801,146 @@ TEST_F(CloudFileCacheWriteIndexOnlyTest,
     EXPECT_EQ(preload_task_count, 0);
     EXPECT_EQ(index_writer_create_count, 1);
     expect_segment_write_bypasses_file_cache(created_files);
+}
+
+class SegmentWriterFileCacheAlignmentTest : public CloudFileCacheWriteIndexOnlyTest {};
+
+TEST_F(SegmentWriterFileCacheAlignmentTest,
+       FinalizeCreatesCanonicalCacheBlocksBeforeAsyncUploadCompletes) {
+    config::enable_file_cache_write_index_file_only = false;
+
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->clear_all_call_backs();
+    sync_point->enable_processing();
+    SyncPoint::CallbackGuard s3_client_guard;
+    sync_point->set_call_back(
+            "s3_client_factory::create",
+            [](auto&& args) {
+                auto* ret = try_any_cast_ret<std::shared_ptr<io::S3ObjStorageClient>>(args);
+                ret->second = true;
+            },
+            &s3_client_guard);
+    SyncPoint::CallbackGuard s3_put_guard;
+    sync_point->set_call_back(
+            "S3FileWriter::_put_object",
+            [](auto&& args) {
+                auto* should_return = try_any_cast<bool*>(args.back());
+                *should_return = true;
+            },
+            &s3_put_guard);
+
+    std::mutex upload_mutex;
+    std::condition_variable upload_cv;
+    bool upload_entered_cache_stage = false;
+    bool release_upload = false;
+    SyncPoint::CallbackGuard upload_cache_guard;
+    sync_point->set_call_back(
+            "UploadFileBuffer::upload_to_local_file_cache",
+            [&](auto&& /*args*/) {
+                std::unique_lock lock(upload_mutex);
+                upload_entered_cache_stage = true;
+                upload_cv.notify_all();
+                upload_cv.wait(lock, [&]() { return release_upload; });
+            },
+            &upload_cache_guard);
+    const auto unblock_upload = [&]() {
+        {
+            std::lock_guard lock(upload_mutex);
+            release_upload = true;
+        }
+        upload_cv.notify_all();
+    };
+
+    const std::string segment_path = "segment_writer_finalize_cache_alignment_0.dat";
+    io::FileWriterOptions file_options;
+    file_options.write_file_cache = true;
+    io::FileWriterPtr file_writer;
+    auto status = _remote_fs->create_file(segment_path, &file_writer, &file_options);
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_NE(file_writer->cache_builder(), nullptr);
+    Defer unblock_upload_on_exit {unblock_upload};
+    const auto cache_hash = file_writer->cache_builder()->_cache_hash;
+    auto* cache = file_writer->cache_builder()->_cache;
+    bool observed_index_cache_holder = false;
+    SyncPoint::CallbackGuard index_cache_holder_guard;
+    sync_point->set_call_back(
+            "SegmentWriter::finalize::index_cache_holder",
+            [&](auto&& args) {
+                auto* holder = try_any_cast<io::FileBlocksHolder*>(args[0]);
+                ASSERT_NE(holder, nullptr);
+                ASSERT_EQ(holder->file_blocks.size(), 1);
+                const auto& block = holder->file_blocks.front();
+                const size_t cache_block_size =
+                        static_cast<size_t>(config::file_cache_each_block_size);
+                EXPECT_EQ(block->range().left, 0);
+                EXPECT_EQ(block->range().right, cache_block_size - 1);
+                EXPECT_EQ(block->state(), io::FileBlock::State::EMPTY);
+                EXPECT_EQ(block->cache_type(), io::FileCacheType::INDEX);
+                observed_index_cache_holder = true;
+            },
+            &index_cache_holder_guard);
+
+    auto tablet_schema = create_schema();
+    TabletMetaPB tablet_meta_pb;
+    tablet_meta_pb.set_tablet_id(kIndexOnlyTabletId);
+    tablet_meta_pb.set_schema_hash(kIndexOnlyTabletSchemaHash);
+    tablet_meta_pb.set_tablet_state(PB_RUNNING);
+    tablet_schema->to_schema_pb(tablet_meta_pb.mutable_schema());
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->init_from_pb(tablet_meta_pb);
+    auto tablet = std::make_shared<Tablet>(*_engine, tablet_meta, nullptr);
+    auto rowset_context = create_context(tablet_schema);
+    segment_v2::SegmentWriterOptions writer_options;
+    writer_options.compression_type = NO_COMPRESSION;
+    writer_options.rowset_ctx = &rowset_context;
+    writer_options.write_type = rowset_context.write_type;
+    segment_v2::SegmentWriter writer(file_writer.get(), 0, tablet_schema, tablet, nullptr,
+                                     writer_options, nullptr);
+    status = writer.init();
+    ASSERT_TRUE(status.ok()) << status;
+    auto block = create_full_block(tablet_schema);
+    status = writer.append_block(&block, 0, block.rows());
+    ASSERT_TRUE(status.ok()) << status;
+
+    uint64_t segment_file_size = 0;
+    uint64_t index_size = 0;
+    segment_v2::SegmentIndexFileCacheInfo index_cache_info;
+    status = writer.finalize(&segment_file_size, &index_size, &index_cache_info);
+    ASSERT_TRUE(status.ok()) << status;
+
+    {
+        std::unique_lock lock(upload_mutex);
+        ASSERT_TRUE(upload_cv.wait_for(lock, std::chrono::seconds(10),
+                                       [&]() { return upload_entered_cache_stage; }));
+    }
+
+    const size_t cache_block_size = static_cast<size_t>(config::file_cache_each_block_size);
+    ASSERT_GT(cache_block_size, 0);
+    ASSERT_GT(segment_file_size, 0);
+    ASSERT_LT(segment_file_size, cache_block_size);
+    ASSERT_GT(index_size, 0);
+    ASSERT_GT(index_cache_info.cache_start_offset(), 0);
+    ASSERT_LT(index_cache_info.cache_start_offset(), segment_file_size);
+    ASSERT_NE(index_cache_info.cache_start_offset() % cache_block_size, 0);
+    EXPECT_TRUE(observed_index_cache_holder);
+
+    unblock_upload();
+    const auto close_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    do {
+        status = file_writer->try_finish_close();
+        if (status.is<ErrorCode::NEED_SEND_AGAIN>()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    } while (status.is<ErrorCode::NEED_SEND_AGAIN>() &&
+             std::chrono::steady_clock::now() < close_deadline);
+    ASSERT_TRUE(status.ok()) << status;
+
+    auto cache_blocks = cache->get_blocks_by_key(cache_hash);
+    ASSERT_FALSE(cache_blocks.empty());
+    const auto& downloaded_block = cache_blocks.begin()->second;
+    EXPECT_EQ(downloaded_block->range().left, 0);
+    EXPECT_EQ(downloaded_block->range().right, segment_file_size - 1);
+    EXPECT_EQ(downloaded_block->state(), io::FileBlock::State::DOWNLOADED);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`FileCacheAllocatorBuilder` previously forwarded the caller's exact byte range to
`BlockFileCache::get_or_set`. This is unsafe for metadata writers because their ranges do not
necessarily begin at a file-cache block boundary. For example, a real `SegmentWriter::finalize`
in the new test asks to classify index bytes beginning at offset 113. Before the fix, the cache
contains an `EMPTY` `INDEX` cell `[113, 757]`, while normal cache partitioning for the same file
uses the canonical one-megabyte slot `[0, 1048575]`.

Once another reader or writer addresses the same cache key using canonical block boundaries, the
same logical block can be represented by incompatible ranges. Strict range checks then fail rather
than allowing two conflicting cache layouts to coexist.

This PR fixes the invariant at the shared writer-allocation boundary:

1. `SegmentWriter::finalize` writes the segment indexes and footer, then allocates a temporary
   holder to classify the index-covered cache block as `INDEX`.
2. `FileCacheAllocatorBuilder` treats the requested bytes as `[offset, offset + size)` and expands
   both ends to the owning `BlockFileCache` instance's canonical block boundaries.
3. Metadata classification and asynchronous S3/HDFS data persistence therefore create or reuse
   compatible cells for the same remote file.
4. When the last block contains less than a full cache block, the existing `FileBlock::finalize`
   behavior still shrinks the downloaded block to the actual EOF.

The alignment is centralized in `FileCacheAllocatorBuilder` instead of weakening reader/probe
checks or adding a `SegmentWriter` special case. It consequently covers every current writer-side
allocation call site. The implementation reads the block size from the actual cache instance and
checks both range additions for overflow.

The commit history is intentionally split:

- `[test](be) Reproduce unaligned segment file cache allocation` adds a real SegmentWriter E2E
  BEUT and a test-only observation point. On unmodified master it fails with `[113, 757]` versus
  `[0, 1048575]`.
- `[fix](be) Align file cache writer allocations to block boundaries` implements the shared
  allocator fix.

### Release note

Fix incompatible file-cache block boundaries created by unaligned writer allocations.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - Pre-fix reproducer run with `-j100`: failed as expected with `[113, 757]`.
        - Post-fix `SegmentWriterFileCacheAlignmentTest.FinalizeCreatesCanonicalCacheBlocksBeforeAsyncUploadCompletes` with `-j100`: passed 1/1.
        - Post-fix `CloudFileCacheWriteIndexOnlyTest.*` with `-j100`: passed 3/3.
        - `build-support/check-format.sh`: passed.
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes. File-cache writer allocations are expanded to the owning cache's canonical block
      boundaries before cells are created or reused.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
