### PR TITLE
[fix](ci) backport safer PR checks to branch-4.0

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,32 +21,29 @@ name: Code Formatter
 
 on:
   pull_request:
-  pull_request_target:
   workflow_dispatch:
   issue_comment:
     types: [ created ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   clang-format:
     name: "Clang Formatter"
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request') || (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' &&
        github.event.comment.body == 'run buildall' &&
        github.actor == 'doris-robot' &&
        github.event.issue.user.login == 'github-actions[bot]')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
-
-      - name: Checkout ${{ github.ref }} ( ${{ github.event.pull_request.head.sha }} )
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout paths-filter
         run: |

--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -18,7 +18,7 @@
 ---
 name: License Check
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - master
@@ -26,12 +26,16 @@ on:
   issue_comment:
     types: [ created ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   license-check:
     name: "License Check"
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'issue_comment' &&
        github.event.comment.body == 'run buildall' &&
@@ -39,17 +43,12 @@ jobs:
        github.event.issue.user.login == 'github-actions[bot]')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v3
-
-      - name: Checkout ${{ github.ref }} ( ${{ github.event.pull_request.head.sha }} )
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Get changed files
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         id: changed-files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,12 +83,15 @@ jobs:
 
       - name: Generate incremental licenserc
         if: >-
-          github.event_name == 'pull_request_target' &&
+          github.event_name == 'pull_request' &&
           steps.changed-files.outputs.added_modified != ''
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.added_modified }}
         run: |
           python3 - <<'EOF'
+          import sys
+          # Prevent fork-supplied files from shadowing stdlib modules
+          sys.path = [p for p in sys.path if p not in ('', '.')]
           import yaml, os
 
           with open('.licenserc.yaml') as f:
@@ -105,6 +107,11 @@ jobs:
           EOF
 
       - name: Check License
-        uses: apache/skywalking-eyes@v0.2.0
+        if: >-
+          github.event_name != 'pull_request' ||
+          steps.changed-files.outputs.config_file != ''
+        uses: apache/skywalking-eyes@v0.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: ${{ steps.changed-files.outputs.config_file || '.licenserc.yaml' }}


### PR DESCRIPTION
## What changed

- Backport the License Check trigger from `pull_request_target` to `pull_request`.
- Remove the duplicate Code Formatter `pull_request_target` path.
- Use `actions/checkout@v7` without explicitly checking out fork HEAD code.
- Restrict workflow permissions to read-only.
- Backport the hardened incremental license configuration and SkyWalking Eyes v0.8.0.

## Why

GitHub now refuses fork HEAD checkout from `pull_request_target`. PRs targeting `branch-4.0` read the workflow from their merge ref, so the master-only fix in #65833 does not create a License Check for those PRs.

## Validation

- Both workflow files match the versions fixed on master by #65833.
- YAML parsing passed.
- No `pull_request_target`, old checkout version, or explicit fork HEAD checkout remains in these workflows.