### PR TITLE
[fix](cdc) Encode multi-table CDC records as UTF-8

### DIFF
--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
@@ -621,7 +621,7 @@ public class PipelineCoordinator {
                         String dorisTable = targetTableMappings.getOrDefault(table, table);
                         for (String record : result.getRecords()) {
                             scannedRows++;
-                            batchStreamLoad.writeRecord(targetDb, dorisTable, record.getBytes());
+                            batchStreamLoad.writeRecord(targetDb, dorisTable, encodeRecord(record));
                         }
                         // Mark last message as data (not heartbeat)
                         lastMessageIsHeartbeat = false;
@@ -690,6 +690,10 @@ public class PipelineCoordinator {
                 batchStreamLoad.getLoadStatistic(),
                 tableSchemas);
         taskProgressMap.remove(writeRecordRequest.getTaskId());
+    }
+
+    static byte[] encodeRecord(String record) {
+        return record.getBytes(StandardCharsets.UTF_8);
     }
 
     public static boolean isHeartbeatEvent(SourceRecord record) {

--- a/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/service/PipelineCoordinatorTest.java
+++ b/fs_brokers/cdc_client/src/test/java/org/apache/doris/cdcclient/service/PipelineCoordinatorTest.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cdcclient.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.HexFormat;
+import java.util.List;
+
+class PipelineCoordinatorTest {
+
+    private static final String RECORD = "挖隧道、修道路";
+    private static final String EXPECTED_UTF8_HEX =
+            "e68c96e99aa7e98193e38081e4bfaee98193e8b7af";
+
+    @Test
+    void encodeRecordUsesUtf8WhenDefaultCharsetIsNotUtf8() throws Exception {
+        String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+        String classpath =
+                System.getProperty(
+                        "surefire.test.class.path", System.getProperty("java.class.path"));
+        Process process =
+                new ProcessBuilder(
+                                java,
+                                "-Dfile.encoding=US-ASCII",
+                                "-cp",
+                                classpath,
+                                EncodingProbe.class.getName())
+                        .redirectErrorStream(true)
+                        .start();
+
+        List<String> output;
+        try (BufferedReader reader =
+                new BufferedReader(
+                        new InputStreamReader(
+                                process.getInputStream(), StandardCharsets.US_ASCII))) {
+            output = reader.lines().toList();
+        }
+
+        assertEquals(0, process.waitFor(), String.join(System.lineSeparator(), output));
+        assertEquals(List.of("US-ASCII", EXPECTED_UTF8_HEX), output);
+    }
+
+    public static final class EncodingProbe {
+
+        public static void main(String[] args) {
+            System.out.println(Charset.defaultCharset().name());
+            System.out.println(HexFormat.of().formatHex(PipelineCoordinator.encodeRecord(RECORD)));
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64806

Related PR: None

Problem Summary:

The multi-table CDC write path converted deserialized JSON records with the JVM default charset before Stream Load. On a non-UTF-8 CDC client JVM, Chinese characters were replaced with literal `?` bytes. This change encodes records explicitly as UTF-8 at that conversion boundary.

AI assistance: YES. This pull request was assisted by Hermes Agent / OpenAI Codex for root-cause analysis, focused tests, and code changes. The scope and final submission were directed by the contributor.

### Release note

Fix Chinese-character corruption in MySQL multi-table CDC synchronization when the CDC client JVM default charset is not UTF-8.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Focused test: `cd fs_brokers/cdc_client && mvn -DskipITs -Dtest=PipelineCoordinatorTest test`

- Behavior changed:
    - [ ] No.
    - [x] Yes. Multi-table CDC records are always encoded as UTF-8 before Stream Load.

- Does this need documentation?
    - [x] No. This restores the intended UTF-8 data handling and does not add or change a user-facing interface.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
