### PR TITLE
[improvement](RF) Support RF partition pruning for sync MV aliases

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -86,10 +86,12 @@ final class RuntimeFilterPartitionPruneClassifier {
 
         if (targetExpr instanceof SlotRef) {
             SlotRef slotRef = (SlotRef) targetExpr;
-            if (!isPartitionColumnSlot(slotRef, partitionInfo.getPartitionColumns())) {
+            int partitionColumnIndex = findPartitionColumnIndex(
+                    slotRef, partitionInfo.getPartitionColumns());
+            if (partitionColumnIndex < 0) {
                 return Classification.unsupported("target SlotRef is not a partition column");
             }
-            if (!hasSerializedBoundary(slotRef, partitionInfo, partType)) {
+            if (!hasSerializedBoundary(partitionColumnIndex, partType)) {
                 return Classification.unsupported("target SlotRef has no serialized partition boundary");
             }
             Map<Long, TTargetExprMonotonicity> partitionMonotonicity =
@@ -97,14 +99,16 @@ final class RuntimeFilterPartitionPruneClassifier {
             if (partitionMonotonicity.isEmpty()) {
                 return Classification.unsupported("target SlotRef has no prunable selected partitions");
             }
-            return Classification.supportedPartitions(slotRef, partitionMonotonicity);
+            return Classification.supportedPartitions(slotRef, partitionColumnIndex, partitionMonotonicity);
         }
 
         SlotRef leafSlot = findUniqueSlotRef(targetExpr);
-        if (leafSlot == null || !isPartitionColumnSlot(leafSlot, partitionInfo.getPartitionColumns())) {
+        int partitionColumnIndex = leafSlot == null ? -1
+                : findPartitionColumnIndex(leafSlot, partitionInfo.getPartitionColumns());
+        if (partitionColumnIndex < 0) {
             return Classification.unsupported("target expression is not rooted on one partition column");
         }
-        if (!hasSerializedBoundary(leafSlot, partitionInfo, partType)) {
+        if (!hasSerializedBoundary(partitionColumnIndex, partType)) {
             return Classification.unsupported("target expression has no serialized partition boundary");
         }
         if (partType == PartitionType.LIST) {
@@ -116,7 +120,7 @@ final class RuntimeFilterPartitionPruneClassifier {
             if (partitionMonotonicity.isEmpty()) {
                 return Classification.unsupported("target expression has no prunable selected partitions");
             }
-            return Classification.supportedPartitions(leafSlot, partitionMonotonicity);
+            return Classification.supportedPartitions(leafSlot, partitionColumnIndex, partitionMonotonicity);
         }
 
         Map<Long, TTargetExprMonotonicity> partitionMonotonicity =
@@ -124,7 +128,7 @@ final class RuntimeFilterPartitionPruneClassifier {
         if (partitionMonotonicity.isEmpty()) {
             return Classification.unsupported("target expression is not monotonic on selected partitions");
         }
-        return Classification.supportedPartitions(leafSlot, partitionMonotonicity);
+        return Classification.supportedPartitions(leafSlot, partitionColumnIndex, partitionMonotonicity);
     }
 
     private static boolean hasUnsupportedAutomaticPartitionExpression(PartitionInfo partitionInfo) {
@@ -151,45 +155,49 @@ final class RuntimeFilterPartitionPruneClassifier {
         return false;
     }
 
-    private static boolean hasSerializedBoundary(SlotRef slotRef, PartitionInfo partitionInfo, PartitionType partType) {
-        if (partType != PartitionType.RANGE) {
-            return true;
-        }
-        List<Column> partitionColumns = partitionInfo.getPartitionColumns();
-        return !partitionColumns.isEmpty() && sameColumn(slotRef.getColumn(), partitionColumns.get(0));
+    private static boolean hasSerializedBoundary(int partitionColumnIndex, PartitionType partType) {
+        return partType != PartitionType.RANGE || partitionColumnIndex == 0;
     }
 
-    private static boolean isPartitionColumnSlot(SlotRef slotRef, List<Column> partitionColumns) {
+    private static int findPartitionColumnIndex(SlotRef slotRef, List<Column> partitionColumns) {
         Column targetColumn = slotRef.getColumn();
         if (targetColumn == null) {
-            return false;
+            return -1;
         }
-        for (Column partitionColumn : partitionColumns) {
-            if (sameColumn(targetColumn, partitionColumn)) {
-                return true;
+        for (int i = 0; i < partitionColumns.size(); i++) {
+            if (sameColumn(targetColumn, partitionColumns.get(i))) {
+                return i;
             }
         }
-        return false;
+        return -1;
     }
 
     private static boolean sameColumn(Column targetColumn, Column partitionColumn) {
+        targetColumn = getBaseColumn(targetColumn);
+        if (targetColumn == null) {
+            return false;
+        }
         if (targetColumn == partitionColumn) {
             return true;
-        }
-        // A synchronous MV column has its own physical name and index-local unique ID.
-        // Use the simple SlotRef definition to recover its base-column lineage instead
-        // of comparing those rollup-local attributes with the base partition column.
-        if (targetColumn.isMaterializedViewColumn()) {
-            return targetColumn.tryGetBaseColumnName().equalsIgnoreCase(partitionColumn.getName());
         }
         int targetUniqueId = targetColumn.getUniqueId();
         int partitionUniqueId = partitionColumn.getUniqueId();
         if (targetUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE
-                && partitionUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE
-                && targetUniqueId == partitionUniqueId) {
-            return true;
+                && partitionUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
+            return targetUniqueId == partitionUniqueId;
         }
         return targetColumn.equals(partitionColumn);
+    }
+
+    private static Column getBaseColumn(Column targetColumn) {
+        if (!targetColumn.isMaterializedViewColumn()) {
+            return targetColumn;
+        }
+        Expr defineExpr = targetColumn.getDefineExpr();
+        if (defineExpr instanceof SlotRef && ((SlotRef) defineExpr).getColumn() != null) {
+            return ((SlotRef) defineExpr).getColumn();
+        }
+        return null;
     }
 
     private static SlotRef findUniqueSlotRef(Expr expr) {
@@ -225,7 +233,7 @@ final class RuntimeFilterPartitionPruneClassifier {
             return result;
         }
 
-        Column partitionColumn = leafSlot.getColumn();
+        Column partitionColumn = getBaseColumn(leafSlot.getColumn());
         for (Long partitionId : scanNode.getSelectedPartitionIds()) {
             PartitionItem item = partitionInfo.getItem(partitionId);
             if (!(item instanceof RangePartitionItem)) {
@@ -289,24 +297,26 @@ final class RuntimeFilterPartitionPruneClassifier {
     static final class Classification {
         private final boolean canPrunePartitions;
         private final SlotRef partitionSlot;
+        private final int partitionColumnIndex;
         private final Map<Long, TTargetExprMonotonicity> partitionMonotonicity;
         private final String unsupportedReason;
 
-        private Classification(boolean canPrunePartitions, SlotRef partitionSlot,
+        private Classification(boolean canPrunePartitions, SlotRef partitionSlot, int partitionColumnIndex,
                 Map<Long, TTargetExprMonotonicity> partitionMonotonicity, String unsupportedReason) {
             this.canPrunePartitions = canPrunePartitions;
             this.partitionSlot = partitionSlot;
+            this.partitionColumnIndex = partitionColumnIndex;
             this.partitionMonotonicity = partitionMonotonicity;
             this.unsupportedReason = unsupportedReason;
         }
 
-        static Classification supportedPartitions(SlotRef partitionSlot,
+        static Classification supportedPartitions(SlotRef partitionSlot, int partitionColumnIndex,
                 Map<Long, TTargetExprMonotonicity> partitionMonotonicity) {
-            return new Classification(true, partitionSlot, partitionMonotonicity, "");
+            return new Classification(true, partitionSlot, partitionColumnIndex, partitionMonotonicity, "");
         }
 
         static Classification unsupported(String reason) {
-            return new Classification(false, null, new HashMap<>(), reason);
+            return new Classification(false, null, -1, new HashMap<>(), reason);
         }
 
         boolean canPrunePartitions() {
@@ -315,6 +325,10 @@ final class RuntimeFilterPartitionPruneClassifier {
 
         SlotRef getPartitionSlot() {
             return partitionSlot;
+        }
+
+        int getPartitionColumnIndex() {
+            return partitionColumnIndex;
         }
 
         Map<Long, TTargetExprMonotonicity> getPartitionMonotonicity() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -176,6 +176,12 @@ final class RuntimeFilterPartitionPruneClassifier {
         if (targetColumn == partitionColumn) {
             return true;
         }
+        // A synchronous MV column has its own physical name and index-local unique ID.
+        // Use the simple SlotRef definition to recover its base-column lineage instead
+        // of comparing those rollup-local attributes with the base partition column.
+        if (targetColumn.isMaterializedViewColumn()) {
+            return targetColumn.tryGetBaseColumnName().equalsIgnoreCase(partitionColumn.getName());
+        }
         int targetUniqueId = targetColumn.getUniqueId();
         int partitionUniqueId = partitionColumn.getUniqueId();
         if (targetUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -182,6 +182,9 @@ final class RuntimeFilterPartitionPruneClassifier {
         if (targetColumn == partitionColumn) {
             return true;
         }
+        // Metadata reload and deep copy do not preserve Column object identity.
+        // Prefer stable unique IDs when present; legacy schemas without unique
+        // IDs must fall back to structural equality.
         int targetUniqueId = targetColumn.getUniqueId();
         int partitionUniqueId = partitionColumn.getUniqueId();
         if (targetUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -37,13 +37,13 @@ import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanNode;
+import org.apache.doris.planner.RuntimeFilterPartitionColumnResolver;
 import org.apache.doris.thrift.TRuntimeFilterType;
 import org.apache.doris.thrift.TTargetExprMonotonicity;
 
 import com.google.common.collect.Range;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -86,8 +86,8 @@ final class RuntimeFilterPartitionPruneClassifier {
 
         if (targetExpr instanceof SlotRef) {
             SlotRef slotRef = (SlotRef) targetExpr;
-            int partitionColumnIndex = findPartitionColumnIndex(
-                    slotRef, partitionInfo.getPartitionColumns());
+            int partitionColumnIndex = RuntimeFilterPartitionColumnResolver.findPartitionColumnIndex(
+                    olapScanNode, slotRef.getColumn());
             if (partitionColumnIndex < 0) {
                 return Classification.unsupported("target SlotRef is not a partition column");
             }
@@ -107,8 +107,8 @@ final class RuntimeFilterPartitionPruneClassifier {
         if (leafSlot == null) {
             return Classification.unsupported("target expression is not rooted on one partition column");
         }
-        int partitionColumnIndex = findPartitionColumnIndex(
-                leafSlot, partitionInfo.getPartitionColumns());
+        int partitionColumnIndex = RuntimeFilterPartitionColumnResolver.findPartitionColumnIndex(
+                olapScanNode, leafSlot.getColumn());
         if (partitionColumnIndex < 0) {
             return Classification.unsupported("target expression is not rooted on one partition column");
         }
@@ -129,7 +129,8 @@ final class RuntimeFilterPartitionPruneClassifier {
         }
 
         Map<Long, TTargetExprMonotonicity> partitionMonotonicity =
-                classifyLocalMonotonicity(nereidsTargetExpr, olapScanNode, partitionInfo, leafSlot);
+                classifyLocalMonotonicity(nereidsTargetExpr, olapScanNode, partitionInfo,
+                        partitionInfo.getPartitionColumns().get(partitionColumnIndex));
         if (partitionMonotonicity.isEmpty()) {
             return Classification.unsupported("target expression is not monotonic on selected partitions");
         }
@@ -161,50 +162,6 @@ final class RuntimeFilterPartitionPruneClassifier {
         return false;
     }
 
-    private static int findPartitionColumnIndex(SlotRef slotRef, List<Column> partitionColumns) {
-        Column targetColumn = slotRef.getColumn();
-        if (targetColumn == null) {
-            return -1;
-        }
-        for (int i = 0; i < partitionColumns.size(); i++) {
-            if (sameColumn(targetColumn, partitionColumns.get(i))) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    private static boolean sameColumn(Column targetColumn, Column partitionColumn) {
-        targetColumn = getBaseColumn(targetColumn);
-        if (targetColumn == null) {
-            return false;
-        }
-        if (targetColumn == partitionColumn) {
-            return true;
-        }
-        // Metadata reload and deep copy do not preserve Column object identity.
-        // Prefer stable unique IDs when present; legacy schemas without unique
-        // IDs must fall back to structural equality.
-        int targetUniqueId = targetColumn.getUniqueId();
-        int partitionUniqueId = partitionColumn.getUniqueId();
-        if (targetUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE
-                && partitionUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
-            return targetUniqueId == partitionUniqueId;
-        }
-        return targetColumn.equals(partitionColumn);
-    }
-
-    private static Column getBaseColumn(Column targetColumn) {
-        if (!targetColumn.isMaterializedViewColumn()) {
-            return targetColumn;
-        }
-        Expr defineExpr = targetColumn.getDefineExpr();
-        if (defineExpr instanceof SlotRef && ((SlotRef) defineExpr).getColumn() != null) {
-            return ((SlotRef) defineExpr).getColumn();
-        }
-        return null;
-    }
-
     private static SlotRef findUniqueSlotRef(Expr expr) {
         if (expr instanceof SlotRef) {
             return (SlotRef) expr;
@@ -224,7 +181,8 @@ final class RuntimeFilterPartitionPruneClassifier {
     }
 
     private static Map<Long, TTargetExprMonotonicity> classifyLocalMonotonicity(
-            Expression nereidsTargetExpr, OlapScanNode scanNode, PartitionInfo partitionInfo, SlotRef leafSlot) {
+            Expression nereidsTargetExpr, OlapScanNode scanNode, PartitionInfo partitionInfo,
+            Column partitionColumn) {
         Map<Long, TTargetExprMonotonicity> result = new HashMap<>();
         if (!(nereidsTargetExpr instanceof Monotonic)) {
             return result;
@@ -238,7 +196,6 @@ final class RuntimeFilterPartitionPruneClassifier {
             return result;
         }
 
-        Column partitionColumn = getBaseColumn(leafSlot.getColumn());
         for (Long partitionId : scanNode.getSelectedPartitionIds()) {
             PartitionItem item = partitionInfo.getItem(partitionId);
             if (!(item instanceof RangePartitionItem)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -91,7 +91,7 @@ final class RuntimeFilterPartitionPruneClassifier {
             if (partitionColumnIndex < 0) {
                 return Classification.unsupported("target SlotRef is not a partition column");
             }
-            if (!hasSerializedBoundary(partitionColumnIndex, partType)) {
+            if (partType == PartitionType.RANGE && partitionColumnIndex != 0) {
                 return Classification.unsupported("target SlotRef has no serialized partition boundary");
             }
             Map<Long, TTargetExprMonotonicity> partitionMonotonicity =
@@ -99,16 +99,20 @@ final class RuntimeFilterPartitionPruneClassifier {
             if (partitionMonotonicity.isEmpty()) {
                 return Classification.unsupported("target SlotRef has no prunable selected partitions");
             }
-            return Classification.supportedPartitions(slotRef, partitionColumnIndex, partitionMonotonicity);
+            return Classification.supportedPartitions(
+                    slotRef, partitionColumnIndex, partitionMonotonicity);
         }
 
         SlotRef leafSlot = findUniqueSlotRef(targetExpr);
-        int partitionColumnIndex = leafSlot == null ? -1
-                : findPartitionColumnIndex(leafSlot, partitionInfo.getPartitionColumns());
+        if (leafSlot == null) {
+            return Classification.unsupported("target expression is not rooted on one partition column");
+        }
+        int partitionColumnIndex = findPartitionColumnIndex(
+                leafSlot, partitionInfo.getPartitionColumns());
         if (partitionColumnIndex < 0) {
             return Classification.unsupported("target expression is not rooted on one partition column");
         }
-        if (!hasSerializedBoundary(partitionColumnIndex, partType)) {
+        if (partType == PartitionType.RANGE && partitionColumnIndex != 0) {
             return Classification.unsupported("target expression has no serialized partition boundary");
         }
         if (partType == PartitionType.LIST) {
@@ -120,7 +124,8 @@ final class RuntimeFilterPartitionPruneClassifier {
             if (partitionMonotonicity.isEmpty()) {
                 return Classification.unsupported("target expression has no prunable selected partitions");
             }
-            return Classification.supportedPartitions(leafSlot, partitionColumnIndex, partitionMonotonicity);
+            return Classification.supportedPartitions(
+                    leafSlot, partitionColumnIndex, partitionMonotonicity);
         }
 
         Map<Long, TTargetExprMonotonicity> partitionMonotonicity =
@@ -128,7 +133,8 @@ final class RuntimeFilterPartitionPruneClassifier {
         if (partitionMonotonicity.isEmpty()) {
             return Classification.unsupported("target expression is not monotonic on selected partitions");
         }
-        return Classification.supportedPartitions(leafSlot, partitionColumnIndex, partitionMonotonicity);
+        return Classification.supportedPartitions(
+                leafSlot, partitionColumnIndex, partitionMonotonicity);
     }
 
     private static boolean hasUnsupportedAutomaticPartitionExpression(PartitionInfo partitionInfo) {
@@ -153,10 +159,6 @@ final class RuntimeFilterPartitionPruneClassifier {
             }
         }
         return false;
-    }
-
-    private static boolean hasSerializedBoundary(int partitionColumnIndex, PartitionType partType) {
-        return partType != PartitionType.RANGE || partitionColumnIndex == 0;
     }
 
     private static int findPartitionColumnIndex(SlotRef slotRef, List<Column> partitionColumns) {
@@ -312,7 +314,8 @@ final class RuntimeFilterPartitionPruneClassifier {
 
         static Classification supportedPartitions(SlotRef partitionSlot, int partitionColumnIndex,
                 Map<Long, TTargetExprMonotonicity> partitionMonotonicity) {
-            return new Classification(true, partitionSlot, partitionColumnIndex, partitionMonotonicity, "");
+            return new Classification(
+                    true, partitionSlot, partitionColumnIndex, partitionMonotonicity, "");
         }
 
         static Classification unsupported(String reason) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -386,9 +386,7 @@ public class RuntimeFilterTranslator {
         if (classification.canPrunePartitions()) {
             Preconditions.checkState(scanNode instanceof OlapScanNode,
                     "partition-pruning runtime filter target must be an OlapScanNode");
-            runtimeFilter.markTargetCanPrunePartitions(
-                    scanNode.getId(), classification.getPartitionColumnIndex(),
-                    classification.getPartitionSlot().getSlotId());
+            runtimeFilter.markTargetCanPrunePartitions(scanNode.getId());
             ((OlapScanNode) scanNode).snapshotPartitionBoundariesForRuntimeFilter(
                     classification.getPartitionColumnIndex(),
                     classification.getPartitionSlot().getSlotId().asInt());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -386,8 +386,12 @@ public class RuntimeFilterTranslator {
         if (classification.canPrunePartitions()) {
             Preconditions.checkState(scanNode instanceof OlapScanNode,
                     "partition-pruning runtime filter target must be an OlapScanNode");
-            runtimeFilter.markTargetCanPrunePartitions(scanNode.getId());
-            ((OlapScanNode) scanNode).snapshotPartitionBoundariesForRuntimeFilter();
+            runtimeFilter.markTargetCanPrunePartitions(
+                    scanNode.getId(), classification.getPartitionColumnIndex(),
+                    classification.getPartitionSlot().getSlotId());
+            ((OlapScanNode) scanNode).snapshotPartitionBoundariesForRuntimeFilter(
+                    classification.getPartitionColumnIndex(),
+                    classification.getPartitionSlot().getSlotId().asInt());
         }
         runtimeFilter.setTargetPartitionMonotonicity(
                 scanNode.getId(), classification.getPartitionMonotonicity());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -187,6 +187,7 @@ public class OlapScanNode extends ScanNode {
     // partition monotonicity. Thrift serialization can happen after query queueing, when
     // the catalog may already contain replacement partition IDs.
     private List<TPartitionBoundary> runtimeFilterPartitionBoundaries;
+    private final Set<Integer> runtimeFilterPartitionBoundarySlotIds = new HashSet<>();
     private long totalBytes = 0;
     // tablet id to single replica bytes
     private Map<Long, Long> tabletBytes = Maps.newLinkedHashMap();
@@ -1393,11 +1394,15 @@ public class OlapScanNode extends ScanNode {
      * partition pruning. A scan can be targeted by multiple runtime filters, so retain
      * the first snapshot.
      */
-    public void snapshotPartitionBoundariesForRuntimeFilter() {
-        if (runtimeFilterPartitionBoundaries != null) {
+    public void snapshotPartitionBoundariesForRuntimeFilter(int partitionColumnIndex, int slotId) {
+        if (!runtimeFilterPartitionBoundarySlotIds.add(slotId)) {
             return;
         }
-        runtimeFilterPartitionBoundaries = buildPartitionBoundariesForRuntimeFilter();
+        if (runtimeFilterPartitionBoundaries == null) {
+            runtimeFilterPartitionBoundaries = new ArrayList<>();
+        }
+        buildPartitionBoundariesForRuntimeFilter(
+                runtimeFilterPartitionBoundaries, partitionColumnIndex, slotId);
     }
 
     @VisibleForTesting
@@ -1420,56 +1425,38 @@ public class OlapScanNode extends ScanNode {
         }
     }
 
-    private List<TPartitionBoundary> buildPartitionBoundariesForRuntimeFilter() {
+    private void buildPartitionBoundariesForRuntimeFilter(List<TPartitionBoundary> boundaries,
+            int partitionColumnIndex, int slotId) {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         PartitionType partType = partitionInfo.getType();
         if (partType != PartitionType.RANGE && partType != PartitionType.LIST) {
-            return Collections.emptyList();
+            return;
         }
         List<Column> partColumns = partitionInfo.getPartitionColumns();
         if (partColumns.isEmpty()) {
-            return Collections.emptyList();
+            return;
         }
 
-        // Build base partition column name → scan slot ID mapping. A synchronous
-        // MV scan uses the rollup's physical column (for example mv_k) in its tuple,
-        // so recover the base name (k) from the column's simple SlotRef definition.
-        Map<String, Integer> partColToSlotId = Maps.newHashMap();
-        for (SlotDescriptor slot : desc.getSlots()) {
-            if (slot.getColumn() == null) {
-                continue;
-            }
-            for (Column partCol : partColumns) {
-                if (slot.getColumn().tryGetBaseColumnName().equalsIgnoreCase(partCol.getName())) {
-                    partColToSlotId.put(partCol.getName(), slot.getId().asInt());
-                    break;
-                }
-            }
-        }
-        if (partColToSlotId.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<TPartitionBoundary> boundaries = new ArrayList<>();
         for (Long partitionId : selectedPartitionIds) {
             PartitionItem item = partitionInfo.getItem(partitionId);
             if (item == null) {
                 continue;
             }
             if (item instanceof RangePartitionItem) {
+                Preconditions.checkState(partitionColumnIndex == 0);
                 addRangeBoundaries(boundaries, partitionId, (RangePartitionItem) item,
-                        partColumns, partColToSlotId);
+                        partColumns, Collections.singletonMap(0, Collections.singleton(slotId)));
             } else if (item instanceof ListPartitionItem) {
                 addListBoundaries(boundaries, partitionId, (ListPartitionItem) item,
-                        partColumns, partColToSlotId);
+                        partColumns, Collections.singletonMap(
+                                partitionColumnIndex, Collections.singleton(slotId)));
             }
         }
-        return boundaries;
     }
 
     private void addRangeBoundaries(List<TPartitionBoundary> boundaries, long partitionId,
             RangePartitionItem rangeItem, List<Column> partColumns,
-            Map<String, Integer> partColToSlotId) {
+            Map<Integer, Set<Integer>> partitionColumnToSlotIds) {
         // We always project a (possibly multi-column) RANGE partition onto its
         // first partition column, since the BE pruner only consumes per-column
         // boundaries. Projection rules (lex compare semantics):
@@ -1488,38 +1475,39 @@ public class OlapScanNode extends ScanNode {
         // UNDER-approximation. Example: partition [(1,1), (1,5)) projects to
         // {1}, but [1, 1) is empty and would let the BE wrongly prune the
         // partition for an RF like k1 = 1.
-        String colName = partColumns.get(0).getName();
-        Integer slotId = partColToSlotId.get(colName);
-        if (slotId == null) {
+        Set<Integer> slotIds = partitionColumnToSlotIds.get(0);
+        if (slotIds == null) {
             return;
         }
         com.google.common.collect.Range<PartitionKey> range = rangeItem.getItems();
-        TPartitionBoundary boundary = new TPartitionBoundary();
-        boundary.setPartitionId(partitionId);
-        boundary.setSlotId(slotId);
-        if (range.hasLowerBound() && !range.lowerEndpoint().isMinValue()) {
-            LiteralExpr lower = range.lowerEndpoint().getKeys().get(0);
-            if (!(lower instanceof MaxLiteral)) {
-                boundary.setRangeStart(
-                        ExprToThriftVisitor.treeToThrift(lower).getNodes().get(0));
+        for (Integer slotId : slotIds) {
+            TPartitionBoundary boundary = new TPartitionBoundary();
+            boundary.setPartitionId(partitionId);
+            boundary.setSlotId(slotId);
+            if (range.hasLowerBound() && !range.lowerEndpoint().isMinValue()) {
+                LiteralExpr lower = range.lowerEndpoint().getKeys().get(0);
+                if (!(lower instanceof MaxLiteral)) {
+                    boundary.setRangeStart(
+                            ExprToThriftVisitor.treeToThrift(lower).getNodes().get(0));
+                }
             }
-        }
-        if (range.hasUpperBound() && !range.upperEndpoint().isMaxValue()) {
-            LiteralExpr upper = range.upperEndpoint().getKeys().get(0);
-            if (!(upper instanceof MaxLiteral)) {
-                boundary.setRangeEnd(
-                        ExprToThriftVisitor.treeToThrift(upper).getNodes().get(0));
+            if (range.hasUpperBound() && !range.upperEndpoint().isMaxValue()) {
+                LiteralExpr upper = range.upperEndpoint().getKeys().get(0);
+                if (!(upper instanceof MaxLiteral)) {
+                    boundary.setRangeEnd(
+                            ExprToThriftVisitor.treeToThrift(upper).getNodes().get(0));
+                }
             }
+            if (partColumns.size() > 1) {
+                boundary.setRangeEndInclusive(true);
+            }
+            boundaries.add(boundary);
         }
-        if (partColumns.size() > 1) {
-            boundary.setRangeEndInclusive(true);
-        }
-        boundaries.add(boundary);
     }
 
     private void addListBoundaries(List<TPartitionBoundary> boundaries, long partitionId,
             ListPartitionItem listItem, List<Column> partColumns,
-            Map<String, Integer> partColToSlotId) {
+            Map<Integer, Set<Integer>> partitionColumnToSlotIds) {
         if (listItem.isDefaultPartition()) {
             return;
         }
@@ -1530,14 +1518,10 @@ public class OlapScanNode extends ScanNode {
         // treating NULL as an ordinary fixed value (which would crash the
         // typed value extractor in the parser).
         for (int i = 0; i < partColumns.size(); i++) {
-            String colName = partColumns.get(i).getName();
-            Integer slotId = partColToSlotId.get(colName);
-            if (slotId == null) {
+            Set<Integer> slotIds = partitionColumnToSlotIds.get(i);
+            if (slotIds == null) {
                 continue;
             }
-            TPartitionBoundary boundary = new TPartitionBoundary();
-            boundary.setPartitionId(partitionId);
-            boundary.setSlotId(slotId);
             List<TExprNode> listValues = new ArrayList<>(partitionKeys.size());
             for (PartitionKey pk : partitionKeys) {
                 LiteralExpr literalExpr = pk.getKeys().get(i);
@@ -1549,8 +1533,13 @@ public class OlapScanNode extends ScanNode {
                             ExprToThriftVisitor.treeToThrift(literalExpr).getNodes().get(0));
                 }
             }
-            boundary.setListValues(listValues);
-            boundaries.add(boundary);
+            for (Integer slotId : slotIds) {
+                TPartitionBoundary boundary = new TPartitionBoundary();
+                boundary.setPartitionId(partitionId);
+                boundary.setSlotId(slotId);
+                boundary.setListValues(listValues);
+                boundaries.add(boundary);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1444,19 +1444,17 @@ public class OlapScanNode extends ScanNode {
             }
             if (item instanceof RangePartitionItem) {
                 Preconditions.checkState(partitionColumnIndex == 0);
-                addRangeBoundaries(boundaries, partitionId, (RangePartitionItem) item,
-                        partColumns, Collections.singletonMap(0, Collections.singleton(slotId)));
+                addRangeBoundary(boundaries, partitionId, (RangePartitionItem) item,
+                        partColumns.size(), slotId);
             } else if (item instanceof ListPartitionItem) {
-                addListBoundaries(boundaries, partitionId, (ListPartitionItem) item,
-                        partColumns, Collections.singletonMap(
-                                partitionColumnIndex, Collections.singleton(slotId)));
+                addListBoundary(boundaries, partitionId, (ListPartitionItem) item,
+                        partitionColumnIndex, slotId);
             }
         }
     }
 
-    private void addRangeBoundaries(List<TPartitionBoundary> boundaries, long partitionId,
-            RangePartitionItem rangeItem, List<Column> partColumns,
-            Map<Integer, Set<Integer>> partitionColumnToSlotIds) {
+    private void addRangeBoundary(List<TPartitionBoundary> boundaries, long partitionId,
+            RangePartitionItem rangeItem, int partitionColumnCount, int slotId) {
         // We always project a (possibly multi-column) RANGE partition onto its
         // first partition column, since the BE pruner only consumes per-column
         // boundaries. Projection rules (lex compare semantics):
@@ -1475,39 +1473,32 @@ public class OlapScanNode extends ScanNode {
         // UNDER-approximation. Example: partition [(1,1), (1,5)) projects to
         // {1}, but [1, 1) is empty and would let the BE wrongly prune the
         // partition for an RF like k1 = 1.
-        Set<Integer> slotIds = partitionColumnToSlotIds.get(0);
-        if (slotIds == null) {
-            return;
-        }
         com.google.common.collect.Range<PartitionKey> range = rangeItem.getItems();
-        for (Integer slotId : slotIds) {
-            TPartitionBoundary boundary = new TPartitionBoundary();
-            boundary.setPartitionId(partitionId);
-            boundary.setSlotId(slotId);
-            if (range.hasLowerBound() && !range.lowerEndpoint().isMinValue()) {
-                LiteralExpr lower = range.lowerEndpoint().getKeys().get(0);
-                if (!(lower instanceof MaxLiteral)) {
-                    boundary.setRangeStart(
-                            ExprToThriftVisitor.treeToThrift(lower).getNodes().get(0));
-                }
+        TPartitionBoundary boundary = new TPartitionBoundary();
+        boundary.setPartitionId(partitionId);
+        boundary.setSlotId(slotId);
+        if (range.hasLowerBound() && !range.lowerEndpoint().isMinValue()) {
+            LiteralExpr lower = range.lowerEndpoint().getKeys().get(0);
+            if (!(lower instanceof MaxLiteral)) {
+                boundary.setRangeStart(
+                        ExprToThriftVisitor.treeToThrift(lower).getNodes().get(0));
             }
-            if (range.hasUpperBound() && !range.upperEndpoint().isMaxValue()) {
-                LiteralExpr upper = range.upperEndpoint().getKeys().get(0);
-                if (!(upper instanceof MaxLiteral)) {
-                    boundary.setRangeEnd(
-                            ExprToThriftVisitor.treeToThrift(upper).getNodes().get(0));
-                }
-            }
-            if (partColumns.size() > 1) {
-                boundary.setRangeEndInclusive(true);
-            }
-            boundaries.add(boundary);
         }
+        if (range.hasUpperBound() && !range.upperEndpoint().isMaxValue()) {
+            LiteralExpr upper = range.upperEndpoint().getKeys().get(0);
+            if (!(upper instanceof MaxLiteral)) {
+                boundary.setRangeEnd(
+                        ExprToThriftVisitor.treeToThrift(upper).getNodes().get(0));
+            }
+        }
+        if (partitionColumnCount > 1) {
+            boundary.setRangeEndInclusive(true);
+        }
+        boundaries.add(boundary);
     }
 
-    private void addListBoundaries(List<TPartitionBoundary> boundaries, long partitionId,
-            ListPartitionItem listItem, List<Column> partColumns,
-            Map<Integer, Set<Integer>> partitionColumnToSlotIds) {
+    private void addListBoundary(List<TPartitionBoundary> boundaries, long partitionId,
+            ListPartitionItem listItem, int partitionColumnIndex, int slotId) {
         if (listItem.isDefaultPartition()) {
             return;
         }
@@ -1517,30 +1508,22 @@ public class OlapScanNode extends ScanNode {
         // them into ColumnValueRange::set_contain_null(true) rather than
         // treating NULL as an ordinary fixed value (which would crash the
         // typed value extractor in the parser).
-        for (int i = 0; i < partColumns.size(); i++) {
-            Set<Integer> slotIds = partitionColumnToSlotIds.get(i);
-            if (slotIds == null) {
-                continue;
-            }
-            List<TExprNode> listValues = new ArrayList<>(partitionKeys.size());
-            for (PartitionKey pk : partitionKeys) {
-                LiteralExpr literalExpr = pk.getKeys().get(i);
-                if (literalExpr.isNullLiteral()) {
-                    listValues.add(ExprToThriftVisitor.treeToThrift(
-                            NullLiteral.create(literalExpr.getType())).getNodes().get(0));
-                } else {
-                    listValues.add(
-                            ExprToThriftVisitor.treeToThrift(literalExpr).getNodes().get(0));
-                }
-            }
-            for (Integer slotId : slotIds) {
-                TPartitionBoundary boundary = new TPartitionBoundary();
-                boundary.setPartitionId(partitionId);
-                boundary.setSlotId(slotId);
-                boundary.setListValues(listValues);
-                boundaries.add(boundary);
+        List<TExprNode> listValues = new ArrayList<>(partitionKeys.size());
+        for (PartitionKey pk : partitionKeys) {
+            LiteralExpr literalExpr = pk.getKeys().get(partitionColumnIndex);
+            if (literalExpr.isNullLiteral()) {
+                listValues.add(ExprToThriftVisitor.treeToThrift(
+                        NullLiteral.create(literalExpr.getType())).getNodes().get(0));
+            } else {
+                listValues.add(
+                        ExprToThriftVisitor.treeToThrift(literalExpr).getNodes().get(0));
             }
         }
+        TPartitionBoundary boundary = new TPartitionBoundary();
+        boundary.setPartitionId(partitionId);
+        boundary.setSlotId(slotId);
+        boundary.setListValues(listValues);
+        boundaries.add(boundary);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1431,14 +1431,16 @@ public class OlapScanNode extends ScanNode {
             return Collections.emptyList();
         }
 
-        // Build partition column name → slot ID mapping
+        // Build base partition column name → scan slot ID mapping. A synchronous
+        // MV scan uses the rollup's physical column (for example mv_k) in its tuple,
+        // so recover the base name (k) from the column's simple SlotRef definition.
         Map<String, Integer> partColToSlotId = Maps.newHashMap();
         for (SlotDescriptor slot : desc.getSlots()) {
             if (slot.getColumn() == null) {
                 continue;
             }
             for (Column partCol : partColumns) {
-                if (slot.getColumn().getName().equalsIgnoreCase(partCol.getName())) {
+                if (slot.getColumn().tryGetBaseColumnName().equalsIgnoreCase(partCol.getName())) {
                     partColToSlotId.put(partCol.getName(), slot.getId().asInt());
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -41,6 +41,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -145,7 +146,10 @@ public final class RuntimeFilter {
     // legacy target expression that will be sent to BE.
     private final Map<PlanNodeId, Map<Long, TTargetExprMonotonicity>> targetPartitionMonotonicityByScanId
             = new HashMap<>();
-    private final Set<PlanNodeId> partitionPruningTargetScanIds = new HashSet<>();
+    // Exact RF leaf slots that must receive serialized partition boundaries,
+    // grouped by target scan node and base partition-column ordinal.
+    private final Map<PlanNodeId, Map<Integer, Set<Integer>>> partitionPruningTargetSlotsByScanId
+            = new HashMap<>();
 
     /**
      * Internal representation of a runtime filter target.
@@ -395,10 +399,16 @@ public final class RuntimeFilter {
     }
 
     /**
-     * Record that a target can drive partition pruning and needs scan boundaries serialized.
+     * Record the exact RF leaf slot that needs boundaries for one base partition column.
      */
-    public void markTargetCanPrunePartitions(PlanNodeId scanNodeId) {
-        partitionPruningTargetScanIds.add(scanNodeId);
+    public void markTargetCanPrunePartitions(
+            PlanNodeId scanNodeId, int partitionColumnIndex, SlotId partitionSlotId) {
+        Preconditions.checkArgument(partitionColumnIndex >= 0);
+        Preconditions.checkNotNull(partitionSlotId);
+        partitionPruningTargetSlotsByScanId
+                .computeIfAbsent(scanNodeId, id -> new HashMap<>())
+                .computeIfAbsent(partitionColumnIndex, index -> new HashSet<>())
+                .add(partitionSlotId.asInt());
     }
 
     /**
@@ -419,7 +429,11 @@ public final class RuntimeFilter {
      * RuntimeFilterPartitionPruneClassifier.
      */
     public boolean canPrunePartitionsFor(PlanNodeId scanNodeId) {
-        return partitionPruningTargetScanIds.contains(scanNodeId);
+        return partitionPruningTargetSlotsByScanId.containsKey(scanNodeId);
+    }
+
+    public Map<Integer, Set<Integer>> getPartitionPruningTargetSlots(PlanNodeId scanNodeId) {
+        return partitionPruningTargetSlotsByScanId.getOrDefault(scanNodeId, Collections.emptyMap());
     }
 
     public boolean hasTargets() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -146,10 +145,7 @@ public final class RuntimeFilter {
     // legacy target expression that will be sent to BE.
     private final Map<PlanNodeId, Map<Long, TTargetExprMonotonicity>> targetPartitionMonotonicityByScanId
             = new HashMap<>();
-    // Exact RF leaf slots that must receive serialized partition boundaries,
-    // grouped by target scan node and base partition-column ordinal.
-    private final Map<PlanNodeId, Map<Integer, Set<Integer>>> partitionPruningTargetSlotsByScanId
-            = new HashMap<>();
+    private final Set<PlanNodeId> partitionPruningTargetScanIds = new HashSet<>();
 
     /**
      * Internal representation of a runtime filter target.
@@ -399,16 +395,10 @@ public final class RuntimeFilter {
     }
 
     /**
-     * Record the exact RF leaf slot that needs boundaries for one base partition column.
+     * Record that a target can drive partition pruning and needs scan boundaries serialized.
      */
-    public void markTargetCanPrunePartitions(
-            PlanNodeId scanNodeId, int partitionColumnIndex, SlotId partitionSlotId) {
-        Preconditions.checkArgument(partitionColumnIndex >= 0);
-        Preconditions.checkNotNull(partitionSlotId);
-        partitionPruningTargetSlotsByScanId
-                .computeIfAbsent(scanNodeId, id -> new HashMap<>())
-                .computeIfAbsent(partitionColumnIndex, index -> new HashSet<>())
-                .add(partitionSlotId.asInt());
+    public void markTargetCanPrunePartitions(PlanNodeId scanNodeId) {
+        partitionPruningTargetScanIds.add(scanNodeId);
     }
 
     /**
@@ -429,11 +419,7 @@ public final class RuntimeFilter {
      * RuntimeFilterPartitionPruneClassifier.
      */
     public boolean canPrunePartitionsFor(PlanNodeId scanNodeId) {
-        return partitionPruningTargetSlotsByScanId.containsKey(scanNodeId);
-    }
-
-    public Map<Integer, Set<Integer>> getPartitionPruningTargetSlots(PlanNodeId scanNodeId) {
-        return partitionPruningTargetSlotsByScanId.getOrDefault(scanNodeId, Collections.emptyMap());
+        return partitionPruningTargetScanIds.contains(scanNodeId);
     }
 
     public boolean hasTargets() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterPartitionColumnResolver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterPartitionColumnResolver.java
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+
+import java.util.List;
+
+/**
+ * Resolves a selected-index column to its base-table partition column.
+ */
+public final class RuntimeFilterPartitionColumnResolver {
+    private RuntimeFilterPartitionColumnResolver() {
+    }
+
+    /**
+     * Returns the matching partition-column ordinal, or -1 when the target is
+     * not a value-preserving representation of a base partition column.
+     */
+    public static int findPartitionColumnIndex(OlapScanNode scanNode, Column targetColumn) {
+        if (targetColumn == null) {
+            return -1;
+        }
+        OlapTable table = scanNode.getOlapTable();
+        List<Column> partitionColumns = table.getPartitionInfo().getPartitionColumns();
+        if (targetColumn.isMaterializedViewColumn()) {
+            if (targetColumn.isAggregated()) {
+                return -1;
+            }
+            Expr defineExpr = targetColumn.getDefineExpr();
+            if (!(defineExpr instanceof SlotRef)) {
+                return -1;
+            }
+            Column baseColumn = ((SlotRef) defineExpr).getColumn();
+            return baseColumn == null ? -1 : findSameIndexColumn(baseColumn, partitionColumns);
+        }
+        if (scanNode.getSelectedIndexId() == table.getBaseIndexId()) {
+            return findSameIndexColumn(targetColumn, partitionColumns);
+        }
+        return findColumnByName(targetColumn.getName(), partitionColumns);
+    }
+
+    private static int findSameIndexColumn(Column targetColumn, List<Column> columns) {
+        for (int i = 0; i < columns.size(); i++) {
+            Column column = columns.get(i);
+            if (targetColumn == column) {
+                return i;
+            }
+            int targetUniqueId = targetColumn.getUniqueId();
+            int columnUniqueId = column.getUniqueId();
+            if (targetUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE
+                    && columnUniqueId != Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
+                if (targetUniqueId == columnUniqueId) {
+                    return i;
+                }
+            } else if (targetColumn.equals(column)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findColumnByName(String targetColumnName, List<Column> columns) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (targetColumnName.equalsIgnoreCase(columns.get(i).getName())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterPartitionColumnResolver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterPartitionColumnResolver.java
@@ -42,6 +42,9 @@ public final class RuntimeFilterPartitionColumnResolver {
         OlapTable table = scanNode.getOlapTable();
         List<Column> partitionColumns = table.getPartitionInfo().getPartitionColumns();
         if (targetColumn.isMaterializedViewColumn()) {
+            if (table.getIndexMetaByIndexId(scanNode.getSelectedIndexId()).getDefineStmt() == null) {
+                return -1;
+            }
             if (targetColumn.isAggregated()) {
                 return -1;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -118,6 +118,35 @@ class RuntimeFilterPartitionPruneClassifierTest {
     }
 
     @Test
+    void testSyncMvAliasMatchesCopiedBaseColumnByUniqueId() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column copiedBaseColumn = new Column("part_col", PrimitiveType.INT);
+        copiedBaseColumn.setUniqueId(1);
+        copiedBaseColumn.setComment("copied metadata");
+        Column mvColumn = createSyncMvColumn("mv_part_col", 0, copiedBaseColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    @Test
+    void testSyncMvAliasMatchesLegacyCopiedBaseColumnByEquality() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        Column copiedBaseColumn = new Column("part_col", PrimitiveType.INT);
+        Column mvColumn = createSyncMvColumn("mv_part_col", 0, copiedBaseColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    @Test
     void testSyncMvAliasUsesLineageInsteadOfIndexLocalUniqueId() {
         Column partitionColumn = new Column("part_col", PrimitiveType.INT);
         partitionColumn.setUniqueId(1);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -133,21 +133,6 @@ class RuntimeFilterPartitionPruneClassifierTest {
     }
 
     @Test
-    void testSyncMvAliasMatchesBoundBaseColumnIdentityInsteadOfName() {
-        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
-        partitionColumn.setUniqueId(1);
-        Column renamedBaseColumn = new Column("renamed_part_col", PrimitiveType.INT);
-        renamedBaseColumn.setUniqueId(1);
-        Column mvColumn = createSyncMvColumn("mv_part_col", 0, renamedBaseColumn);
-
-        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
-                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
-                partitionColumn, mvColumn);
-
-        assertSupportedIncreasingPartitions(classification);
-    }
-
-    @Test
     void testSyncMvAliasRejectsSameNamedBaseColumnWithDifferentIdentity() {
         Column partitionColumn = new Column("part_col", PrimitiveType.INT);
         partitionColumn.setUniqueId(1);
@@ -256,7 +241,6 @@ class RuntimeFilterPartitionPruneClassifierTest {
     private void assertSupportedIncreasingPartitions(
             RuntimeFilterPartitionPruneClassifier.Classification classification) {
         Assertions.assertTrue(classification.canPrunePartitions());
-        Assertions.assertEquals(0, classification.getPartitionColumnIndex());
         Assertions.assertEquals(1, classification.getPartitionSlot().getSlotId().asInt());
         Map<Long, TTargetExprMonotonicity> monotonicity = classification.getPartitionMonotonicity();
         Assertions.assertEquals(2, monotonicity.size());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.analysis.SlotId;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ListPartitionItem;
 import org.apache.doris.catalog.OlapTable;
@@ -194,6 +195,50 @@ class RuntimeFilterPartitionPruneClassifierTest {
     }
 
     @Test
+    void testAggregateSyncMvColumnIsNotValuePreservingAlias() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column mvColumn = createSyncMvColumn("sum_part_col", 1, partitionColumn);
+        mvColumn.setAggregationType(AggregateType.SUM, false);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("not a partition column"));
+    }
+
+    @Test
+    void testOrdinaryRollupRejectsCrossIndexUniqueIdCollision() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column rollupValueColumn = new Column("value_col", PrimitiveType.INT);
+        rollupValueColumn.setUniqueId(1);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, rollupValueColumn, 2L);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("not a partition column"));
+    }
+
+    @Test
+    void testOrdinaryRollupPartitionColumnMatchesByBaseName() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column rollupPartitionColumn = new Column("part_col", PrimitiveType.INT);
+        rollupPartitionColumn.setUniqueId(0);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, rollupPartitionColumn, 2L);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    @Test
     void testRejectNoneMovableListTargetExpression() {
         RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
                 TRuntimeFilterType.IN, PartitionType.LIST, ListPartitionItem.DUMMY_ITEM,
@@ -227,13 +272,30 @@ class RuntimeFilterPartitionPruneClassifierTest {
     private RuntimeFilterPartitionPruneClassifier.Classification classify(
             TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
             Column partitionColumn, Column targetColumn) {
+        long selectedIndexId = targetColumn.isMaterializedViewColumn() ? 2L : 1L;
         return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
-                targetSlot -> targetSlot, targetSlot -> targetSlot);
+                selectedIndexId);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
+            Column partitionColumn, Column targetColumn, long selectedIndexId) {
+        return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
+                selectedIndexId, targetSlot -> targetSlot, targetSlot -> targetSlot);
     }
 
     private RuntimeFilterPartitionPruneClassifier.Classification classify(
             TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
             Column partitionColumn, Column targetColumn,
+            Function<SlotRef, Expr> legacyTargetFactory,
+            Function<SlotReference, Expression> nereidsTargetFactory) {
+        return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
+                1L, legacyTargetFactory, nereidsTargetFactory);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
+            Column partitionColumn, Column targetColumn, long selectedIndexId,
             Function<SlotRef, Expr> legacyTargetFactory,
             Function<SlotReference, Expression> nereidsTargetFactory) {
         SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(1), new TupleId(1));
@@ -246,7 +308,9 @@ class RuntimeFilterPartitionPruneClassifierTest {
         PartitionInfo partitionInfo = Mockito.mock(PartitionInfo.class);
         OlapScanNode scanNode = Mockito.mock(OlapScanNode.class);
         Mockito.when(scanNode.getOlapTable()).thenReturn(table);
+        Mockito.when(scanNode.getSelectedIndexId()).thenReturn(selectedIndexId);
         Mockito.when(scanNode.getSelectedPartitionIds()).thenReturn(ImmutableList.of(1L, 2L));
+        Mockito.when(table.getBaseIndexId()).thenReturn(1L);
         Mockito.when(table.getPartitionInfo()).thenReturn(partitionInfo);
         Mockito.when(partitionInfo.getType()).thenReturn(partitionType);
         Mockito.when(partitionInfo.getPartitionColumns()).thenReturn(ImmutableList.of(partitionColumn));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -105,6 +105,34 @@ class RuntimeFilterPartitionPruneClassifierTest {
     }
 
     @Test
+    void testSyncMvAliasOfPartitionColumnSupported() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column mvColumn = createSyncMvColumn("mv_part_col", 0, partitionColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    @Test
+    void testSyncMvAliasUsesLineageInsteadOfIndexLocalUniqueId() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column nonPartitionColumn = new Column("other_col", PrimitiveType.INT);
+        Column mvColumn = createSyncMvColumn("mv_other_col", 1, nonPartitionColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("not a partition column"));
+    }
+
+    @Test
     void testRejectNoneMovableListTargetExpression() {
         RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
                 TRuntimeFilterType.IN, PartitionType.LIST, ListPartitionItem.DUMMY_ITEM,
@@ -131,11 +159,27 @@ class RuntimeFilterPartitionPruneClassifierTest {
             Function<SlotRef, Expr> legacyTargetFactory,
             Function<SlotReference, Expression> nereidsTargetFactory) {
         Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        return classify(filterType, partitionType, partitionItem, partitionColumn, partitionColumn,
+                legacyTargetFactory, nereidsTargetFactory);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
+            Column partitionColumn, Column targetColumn) {
+        return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
+                targetSlot -> targetSlot, targetSlot -> targetSlot);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
+            Column partitionColumn, Column targetColumn,
+            Function<SlotRef, Expr> legacyTargetFactory,
+            Function<SlotReference, Expression> nereidsTargetFactory) {
         SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(1), new TupleId(1));
-        slotDescriptor.setColumn(partitionColumn);
-        slotDescriptor.setType(partitionColumn.getType());
+        slotDescriptor.setColumn(targetColumn);
+        slotDescriptor.setType(targetColumn.getType());
         SlotRef targetSlot = new SlotRef(slotDescriptor);
-        SlotReference nereidsTarget = new SlotReference("part_col", IntegerType.INSTANCE);
+        SlotReference nereidsTarget = new SlotReference(targetColumn.getName(), IntegerType.INSTANCE);
 
         OlapTable table = Mockito.mock(OlapTable.class);
         PartitionInfo partitionInfo = Mockito.mock(PartitionInfo.class);
@@ -150,6 +194,16 @@ class RuntimeFilterPartitionPruneClassifierTest {
 
         return RuntimeFilterPartitionPruneClassifier.classify(filterType,
                 legacyTargetFactory.apply(targetSlot), nereidsTargetFactory.apply(nereidsTarget), scanNode);
+    }
+
+    private Column createSyncMvColumn(String name, int uniqueId, Column baseColumn) {
+        SlotDescriptor baseSlotDescriptor = new SlotDescriptor(new SlotId(2), new TupleId(2));
+        baseSlotDescriptor.setColumn(baseColumn);
+        baseSlotDescriptor.setType(baseColumn.getType());
+        Column mvColumn = new Column(name, PrimitiveType.INT);
+        mvColumn.setUniqueId(uniqueId);
+        mvColumn.setDefineExpr(new SlotRef(baseSlotDescriptor));
+        return mvColumn;
     }
 
     private void assertSupportedIncreasingPartitions(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -133,6 +133,53 @@ class RuntimeFilterPartitionPruneClassifierTest {
     }
 
     @Test
+    void testSyncMvAliasMatchesBoundBaseColumnIdentityInsteadOfName() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column renamedBaseColumn = new Column("renamed_part_col", PrimitiveType.INT);
+        renamedBaseColumn.setUniqueId(1);
+        Column mvColumn = createSyncMvColumn("mv_part_col", 0, renamedBaseColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        assertSupportedIncreasingPartitions(classification);
+    }
+
+    @Test
+    void testSyncMvAliasRejectsSameNamedBaseColumnWithDifferentIdentity() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column differentBaseColumn = new Column("part_col", PrimitiveType.INT);
+        differentBaseColumn.setUniqueId(2);
+        Column mvColumn = createSyncMvColumn("mv_part_col", 0, differentBaseColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("not a partition column"));
+    }
+
+    @Test
+    void testSyncMvExpressionRejectsIndexLocalUniqueIdCollision() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column mvColumn = new Column("mv_expr", PrimitiveType.INT);
+        mvColumn.setUniqueId(1);
+        mvColumn.setDefineExpr(new IntLiteral(1));
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, mvColumn);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("not a partition column"));
+    }
+
+    @Test
     void testRejectNoneMovableListTargetExpression() {
         RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
                 TRuntimeFilterType.IN, PartitionType.LIST, ListPartitionItem.DUMMY_ITEM,
@@ -209,6 +256,8 @@ class RuntimeFilterPartitionPruneClassifierTest {
     private void assertSupportedIncreasingPartitions(
             RuntimeFilterPartitionPruneClassifier.Classification classification) {
         Assertions.assertTrue(classification.canPrunePartitions());
+        Assertions.assertEquals(0, classification.getPartitionColumnIndex());
+        Assertions.assertEquals(1, classification.getPartitionSlot().getSlotId().asInt());
         Map<Long, TTargetExprMonotonicity> monotonicity = classification.getPartitionMonotonicity();
         Assertions.assertEquals(2, monotonicity.size());
         Assertions.assertEquals(TTargetExprMonotonicity.MONOTONIC_INCREASING, monotonicity.get(1L));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ListPartitionItem;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionItem;
@@ -46,6 +47,7 @@ import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.thrift.TRuntimeFilterType;
 import org.apache.doris.thrift.TTargetExprMonotonicity;
 
@@ -210,6 +212,20 @@ class RuntimeFilterPartitionPruneClassifierTest {
     }
 
     @Test
+    void testDerivedRollupRejectsInheritedAggregateMvDefinition() {
+        Column partitionColumn = new Column("part_col", PrimitiveType.INT);
+        partitionColumn.setUniqueId(1);
+        Column inheritedMvColumn = createSyncMvColumn("sum_part_col", 1, partitionColumn);
+
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.MIN_MAX, PartitionType.RANGE, RangePartitionItem.DUMMY_ITEM,
+                partitionColumn, inheritedMvColumn, 2L, false);
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("not a partition column"));
+    }
+
+    @Test
     void testOrdinaryRollupRejectsCrossIndexUniqueIdCollision() {
         Column partitionColumn = new Column("part_col", PrimitiveType.INT);
         partitionColumn.setUniqueId(1);
@@ -281,7 +297,16 @@ class RuntimeFilterPartitionPruneClassifierTest {
             TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
             Column partitionColumn, Column targetColumn, long selectedIndexId) {
         return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
-                selectedIndexId, targetSlot -> targetSlot, targetSlot -> targetSlot);
+                selectedIndexId, true);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
+            Column partitionColumn, Column targetColumn, long selectedIndexId,
+            boolean selectedIndexHasDefineStmt) {
+        return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
+                selectedIndexId, selectedIndexHasDefineStmt,
+                targetSlot -> targetSlot, targetSlot -> targetSlot);
     }
 
     private RuntimeFilterPartitionPruneClassifier.Classification classify(
@@ -290,12 +315,13 @@ class RuntimeFilterPartitionPruneClassifierTest {
             Function<SlotRef, Expr> legacyTargetFactory,
             Function<SlotReference, Expression> nereidsTargetFactory) {
         return classify(filterType, partitionType, partitionItem, partitionColumn, targetColumn,
-                1L, legacyTargetFactory, nereidsTargetFactory);
+                1L, false, legacyTargetFactory, nereidsTargetFactory);
     }
 
     private RuntimeFilterPartitionPruneClassifier.Classification classify(
             TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
             Column partitionColumn, Column targetColumn, long selectedIndexId,
+            boolean selectedIndexHasDefineStmt,
             Function<SlotRef, Expr> legacyTargetFactory,
             Function<SlotReference, Expression> nereidsTargetFactory) {
         SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(1), new TupleId(1));
@@ -312,6 +338,12 @@ class RuntimeFilterPartitionPruneClassifierTest {
         Mockito.when(scanNode.getSelectedPartitionIds()).thenReturn(ImmutableList.of(1L, 2L));
         Mockito.when(table.getBaseIndexId()).thenReturn(1L);
         Mockito.when(table.getPartitionInfo()).thenReturn(partitionInfo);
+        MaterializedIndexMeta selectedIndexMeta = Mockito.mock(MaterializedIndexMeta.class);
+        Mockito.when(table.getIndexMetaByIndexId(selectedIndexId)).thenReturn(selectedIndexMeta);
+        if (selectedIndexHasDefineStmt) {
+            Mockito.when(selectedIndexMeta.getDefineStmt())
+                    .thenReturn(new OriginStatement("CREATE MATERIALIZED VIEW", 0));
+        }
         Mockito.when(partitionInfo.getType()).thenReturn(partitionType);
         Mockito.when(partitionInfo.getPartitionColumns()).thenReturn(ImmutableList.of(partitionColumn));
         Mockito.when(partitionInfo.getItem(1L)).thenReturn(partitionItem);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
@@ -257,7 +257,8 @@ public class OlapScanNodeTest {
                 new PlanNodeId(1), tupleDescriptor, "rfppScanNode", ScanContext.EMPTY);
         scanNode.setSelectedPartitionIds(Lists.newArrayList(oldTargetPartitionId, afterPartitionId));
         scanNode.snapshotSelectedPartitionNames();
-        scanNode.snapshotPartitionBoundariesForRuntimeFilter();
+        scanNode.snapshotPartitionBoundariesForRuntimeFilter(
+                0, partitionSlot.getId().asInt());
 
         // Simulate REPLACE PARTITION after planning but before Thrift serialization.
         partitionInfo.dropPartition(oldTargetPartitionId);
@@ -265,7 +266,8 @@ public class OlapScanNodeTest {
         livePartitions.remove(oldTargetPartitionId);
         livePartitions.put(replacementPartitionId, mockPartition("p_target"));
 
-        scanNode.snapshotPartitionBoundariesForRuntimeFilter();
+        scanNode.snapshotPartitionBoundariesForRuntimeFilter(
+                0, partitionSlot.getId().asInt());
         TOlapScanNode thriftScanNode = new TOlapScanNode();
         scanNode.setPartitionBoundariesForRuntimeFilter(thriftScanNode);
         List<Long> serializedPartitionIds = thriftScanNode.getPartitionBoundaries().stream()

--- a/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
+++ b/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
@@ -144,3 +144,6 @@ Beijing	3
 
 -- !list_str_bloom --
 3	c
+
+-- !sync_mv_alias_minmax --
+100	596100

--- a/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
+++ b/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
@@ -147,3 +147,9 @@ Beijing	3
 
 -- !sync_mv_alias_minmax --
 100	596100
+
+-- !rollup_local_unique_id_collision --
+1	107
+
+-- !aggregate_mv_not_alias --
+1	13

--- a/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
+++ b/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
@@ -153,3 +153,6 @@ Beijing	3
 
 -- !aggregate_mv_not_alias --
 1	13
+
+-- !derived_rollup_inherited_mv_definition_not_alias --
+1	13

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -1623,7 +1623,67 @@ suite("rf_partition_pruning", "nonConcurrent") {
         "IN_OR_BLOOM_FILTER", 8, 6)
 
     // ============================================================
-    // Test 53: Switch off enable_runtime_filter_partition_prune -> no pruning
+    // Test 53: Sync MV aliases the base RANGE partition column.
+    // The RF target uses the rollup slot mv_k, while partition metadata is
+    // defined on base column k. FE must serialize the base boundaries with
+    // the MV target slot ID so BE can prune before creating scanners.
+    // ============================================================
+    sql "drop table if exists rf_prune_mv_alias_fact"
+    sql """
+        CREATE TABLE rf_prune_mv_alias_fact (
+            id BIGINT NOT NULL,
+            k INT NOT NULL,
+            v BIGINT NOT NULL
+        ) DUPLICATE KEY(id)
+        PARTITION BY RANGE(k) (
+            PARTITION p0 VALUES [(0),(10)),
+            PARTITION p1 VALUES [(10),(20)),
+            PARTITION p2 VALUES [(20),(30)),
+            PARTITION p3 VALUES [(30),(40))
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 2
+        PROPERTIES("replication_num" = "1")
+    """
+    sql """
+        INSERT INTO rf_prune_mv_alias_fact
+        SELECT number, number % 40, number * 3
+        FROM numbers("number" = "4000")
+    """
+
+    sql "drop table if exists rf_prune_mv_alias_dim"
+    sql """
+        CREATE TABLE rf_prune_mv_alias_dim (
+            scenario VARCHAR(16) NOT NULL,
+            k INT NOT NULL
+        ) DUPLICATE KEY(scenario, k)
+        DISTRIBUTED BY HASH(k) BUCKETS 2
+        PROPERTIES("replication_num" = "1")
+    """
+    sql """INSERT INTO rf_prune_mv_alias_dim VALUES ('one', 7), ('two', 7), ('two', 27)"""
+
+    create_sync_mv(context.dbName, "rf_prune_mv_alias_fact", "rf_prune_mv_alias_detail", """
+        SELECT k AS mv_k, id AS mv_id, v AS mv_v
+        FROM rf_prune_mv_alias_fact
+    """)
+    sql "set enable_materialized_view_rewrite=true"
+    sql "set pre_materialized_view_rewrite_strategy='TRY_IN_RBO'"
+
+    order_qt_sync_mv_alias_minmax """
+        SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+            COUNT(*), COALESCE(SUM(f.v), 0)
+        FROM rf_prune_mv_alias_fact f
+        JOIN [broadcast] (
+            SELECT k FROM rf_prune_mv_alias_dim WHERE scenario = 'one'
+        ) d ON f.k = d.k
+    """
+    assertPruningProfile(
+        "count(*), coalesce(sum(f.v), 0) FROM rf_prune_mv_alias_fact f "
+                + "JOIN [broadcast] (SELECT k FROM rf_prune_mv_alias_dim WHERE scenario = 'one') d "
+                + "ON f.k = d.k",
+        "MIN_MAX", 4, 3)
+
+    // ============================================================
+    // Test 54: Switch off enable_runtime_filter_partition_prune -> no pruning
     // ============================================================
     sql "set enable_runtime_filter_partition_prune=false"
     def token_off = UUID.randomUUID().toString()

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -1668,6 +1668,19 @@ suite("rf_partition_pruning", "nonConcurrent") {
     sql "set enable_materialized_view_rewrite=true"
     sql "set pre_materialized_view_rewrite_strategy='TRY_IN_RBO'"
 
+    explain {
+        verbose true
+        sql """
+            SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+                COUNT(*), COALESCE(SUM(f.v), 0)
+            FROM rf_prune_mv_alias_fact f
+            JOIN [broadcast] (
+                SELECT k FROM rf_prune_mv_alias_dim WHERE scenario = 'one'
+            ) d ON f.k = d.k
+        """
+        contains "TABLE: rf_prune_mv_alias_fact(rf_prune_mv_alias_detail)"
+    }
+
     order_qt_sync_mv_alias_minmax """
         SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
             COUNT(*), COALESCE(SUM(f.v), 0)

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -1678,7 +1678,7 @@ suite("rf_partition_pruning", "nonConcurrent") {
                 SELECT k FROM rf_prune_mv_alias_dim WHERE scenario = 'one'
             ) d ON f.k = d.k
         """
-        contains "TABLE: rf_prune_mv_alias_fact(rf_prune_mv_alias_detail)"
+        contains "rf_prune_mv_alias_fact(rf_prune_mv_alias_detail)"
     }
 
     order_qt_sync_mv_alias_minmax """
@@ -1696,7 +1696,145 @@ suite("rf_partition_pruning", "nonConcurrent") {
         "MIN_MAX", 4, 3)
 
     // ============================================================
-    // Test 54: Switch off enable_runtime_filter_partition_prune -> no pruning
+    // Test 54: Ordinary rollup column IDs are local to that index.
+    // The rollup's v column and the base partition column k both have ID 1,
+    // but v must not use k's partition boundaries.
+    // ============================================================
+    sql "drop table if exists rf_prune_rollup_collision_fact"
+    sql """
+        CREATE TABLE rf_prune_rollup_collision_fact (
+            id BIGINT NOT NULL,
+            k INT NOT NULL,
+            v BIGINT NOT NULL
+        ) DUPLICATE KEY(id, k)
+        PARTITION BY RANGE(k) (
+            PARTITION p0 VALUES [(0),(10)),
+            PARTITION p1 VALUES [(10),(20))
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 2
+        PROPERTIES(
+            "replication_num" = "1",
+            "light_schema_change" = "true"
+        )
+    """
+    sql """INSERT INTO rf_prune_rollup_collision_fact VALUES (1, 7, 107), (2, 17, 207)"""
+    sql """
+        ALTER TABLE rf_prune_rollup_collision_fact
+        ADD ROLLUP rf_prune_rollup_id_v(id, v)
+    """
+    waitingMVTaskFinishedByMvName(
+        context.dbName, "rf_prune_rollup_collision_fact", "rf_prune_rollup_id_v")
+    sql "sync"
+
+    sql "drop table if exists rf_prune_rollup_value_dim"
+    sql """
+        CREATE TABLE rf_prune_rollup_value_dim (
+            scenario VARCHAR(16) NOT NULL,
+            value BIGINT NOT NULL
+        ) DUPLICATE KEY(scenario, value)
+        DISTRIBUTED BY HASH(value) BUCKETS 2
+        PROPERTIES("replication_num" = "1")
+    """
+    sql """
+        INSERT INTO rf_prune_rollup_value_dim
+        VALUES ('rollup', 107), ('aggregate', 13)
+    """
+
+    explain {
+        verbose true
+        sql """
+            SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+                COUNT(*), COALESCE(SUM(f.v), 0)
+            FROM (
+                SELECT id, v
+                FROM rf_prune_rollup_collision_fact INDEX rf_prune_rollup_id_v
+            ) f
+            JOIN [broadcast] (
+                SELECT value FROM rf_prune_rollup_value_dim WHERE scenario = 'rollup'
+            ) d ON f.v = d.value
+        """
+        contains "rf_prune_rollup_collision_fact(rf_prune_rollup_id_v)"
+    }
+    order_qt_rollup_local_unique_id_collision """
+        SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+            COUNT(*), COALESCE(SUM(f.v), 0)
+        FROM (
+            SELECT id, v
+            FROM rf_prune_rollup_collision_fact INDEX rf_prune_rollup_id_v
+        ) f
+        JOIN [broadcast] (
+            SELECT value FROM rf_prune_rollup_value_dim WHERE scenario = 'rollup'
+        ) d ON f.v = d.value
+    """
+    assertNoPartitionPruningProfile(
+        "count(*), coalesce(sum(f.v), 0) "
+                + "FROM (SELECT id, v FROM rf_prune_rollup_collision_fact "
+                + "INDEX rf_prune_rollup_id_v) f "
+                + "JOIN [broadcast] (SELECT value FROM rf_prune_rollup_value_dim "
+                + "WHERE scenario = 'rollup') d ON f.v = d.value",
+        "MIN_MAX")
+
+    // ============================================================
+    // Test 55: Aggregate MV columns are not value-preserving aliases.
+    // sum_k=13 is stored in partition [0,10); applying k's raw boundary to
+    // sum_k would incorrectly prune the matching row.
+    // ============================================================
+    sql "drop table if exists rf_prune_aggregate_mv_fact"
+    sql """
+        CREATE TABLE rf_prune_aggregate_mv_fact (
+            grp INT NOT NULL,
+            k INT NOT NULL
+        ) DUPLICATE KEY(grp, k)
+        PARTITION BY RANGE(k) (
+            PARTITION p0 VALUES [(0),(10)),
+            PARTITION p1 VALUES [(10),(20))
+        )
+        DISTRIBUTED BY HASH(grp) BUCKETS 2
+        PROPERTIES("replication_num" = "1")
+    """
+    sql """INSERT INTO rf_prune_aggregate_mv_fact VALUES (1, 6), (1, 7), (2, 16)"""
+    create_sync_mv(context.dbName, "rf_prune_aggregate_mv_fact", "rf_prune_aggregate_mv_sum", """
+        SELECT grp AS mv_grp, SUM(k) AS sum_k
+        FROM rf_prune_aggregate_mv_fact
+        GROUP BY grp
+    """)
+
+    explain {
+        verbose true
+        sql """
+            SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+                COUNT(*), COALESCE(SUM(f.sum_k), 0)
+            FROM (
+                SELECT sum_k
+                FROM rf_prune_aggregate_mv_fact INDEX rf_prune_aggregate_mv_sum
+            ) f
+            JOIN [broadcast] (
+                SELECT value FROM rf_prune_rollup_value_dim WHERE scenario = 'aggregate'
+            ) d ON f.sum_k = d.value
+        """
+        contains "rf_prune_aggregate_mv_fact(rf_prune_aggregate_mv_sum)"
+    }
+    order_qt_aggregate_mv_not_alias """
+        SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+            COUNT(*), COALESCE(SUM(f.sum_k), 0)
+        FROM (
+            SELECT sum_k
+            FROM rf_prune_aggregate_mv_fact INDEX rf_prune_aggregate_mv_sum
+        ) f
+        JOIN [broadcast] (
+            SELECT value FROM rf_prune_rollup_value_dim WHERE scenario = 'aggregate'
+        ) d ON f.sum_k = d.value
+    """
+    assertNoPartitionPruningProfile(
+        "count(*), coalesce(sum(f.sum_k), 0) "
+                + "FROM (SELECT sum_k FROM rf_prune_aggregate_mv_fact "
+                + "INDEX rf_prune_aggregate_mv_sum) f "
+                + "JOIN [broadcast] (SELECT value FROM rf_prune_rollup_value_dim "
+                + "WHERE scenario = 'aggregate') d ON f.sum_k = d.value",
+        "MIN_MAX")
+
+    // ============================================================
+    // Test 56: Switch off enable_runtime_filter_partition_prune -> no pruning
     // ============================================================
     sql "set enable_runtime_filter_partition_prune=false"
     def token_off = UUID.randomUUID().toString()

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -1783,7 +1783,7 @@ suite("rf_partition_pruning", "nonConcurrent") {
     sql """
         CREATE TABLE rf_prune_aggregate_mv_fact (
             grp INT NOT NULL,
-            k INT NOT NULL
+            k BIGINT NOT NULL
         ) DUPLICATE KEY(grp, k)
         PARTITION BY RANGE(k) (
             PARTITION p0 VALUES [(0),(10)),
@@ -1829,6 +1829,53 @@ suite("rf_partition_pruning", "nonConcurrent") {
         "count(*), coalesce(sum(f.sum_k), 0) "
                 + "FROM (SELECT sum_k FROM rf_prune_aggregate_mv_fact "
                 + "INDEX rf_prune_aggregate_mv_sum) f "
+                + "JOIN [broadcast] (SELECT value FROM rf_prune_rollup_value_dim "
+                + "WHERE scenario = 'aggregate') d ON f.sum_k = d.value",
+        "MIN_MAX")
+
+    // A rollup derived from the aggregate MV inherits sum_k's SlotRef(k)
+    // definition, while DUP KEY conversion clears its SUM marker. It must
+    // still be rejected because the selected rollup does not define that
+    // value-preserving lineage itself.
+    sql """
+        ALTER TABLE rf_prune_aggregate_mv_fact
+        ADD ROLLUP rf_prune_aggregate_rollup_sum(sum_k)
+        FROM rf_prune_aggregate_mv_sum
+    """
+    waitingMVTaskFinishedByMvName(
+        context.dbName, "rf_prune_aggregate_mv_fact", "rf_prune_aggregate_rollup_sum")
+    sql "sync"
+
+    explain {
+        verbose true
+        sql """
+            SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+                COUNT(*), COALESCE(SUM(f.sum_k), 0)
+            FROM (
+                SELECT sum_k
+                FROM rf_prune_aggregate_mv_fact INDEX rf_prune_aggregate_rollup_sum
+            ) f
+            JOIN [broadcast] (
+                SELECT value FROM rf_prune_rollup_value_dim WHERE scenario = 'aggregate'
+            ) d ON f.sum_k = d.value
+        """
+        contains "rf_prune_aggregate_mv_fact(rf_prune_aggregate_rollup_sum)"
+    }
+    order_qt_derived_rollup_inherited_mv_definition_not_alias """
+        SELECT /*+ SET_VAR(runtime_filter_type='MIN_MAX') */
+            COUNT(*), COALESCE(SUM(f.sum_k), 0)
+        FROM (
+            SELECT sum_k
+            FROM rf_prune_aggregate_mv_fact INDEX rf_prune_aggregate_rollup_sum
+        ) f
+        JOIN [broadcast] (
+            SELECT value FROM rf_prune_rollup_value_dim WHERE scenario = 'aggregate'
+        ) d ON f.sum_k = d.value
+    """
+    assertNoPartitionPruningProfile(
+        "count(*), coalesce(sum(f.sum_k), 0) "
+                + "FROM (SELECT sum_k FROM rf_prune_aggregate_mv_fact "
+                + "INDEX rf_prune_aggregate_rollup_sum) f "
                 + "JOIN [broadcast] (SELECT value FROM rf_prune_rollup_value_dim "
                 + "WHERE scenario = 'aggregate') d ON f.sum_k = d.value",
         "MIN_MAX")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #38527

Problem Summary:

When a query is rewritten to a synchronous materialized view whose RANGE partition column is aliased, the runtime filter is applied to the MV scan but runtime-filter partition pruning is not enabled. The synchronous MV scan exposes a rollup-local slot, while partition metadata belongs to the base-table column. FE therefore did not serialize partition boundaries for the runtime-filter target slot.

The query result remains correct, but all partitions and tablets are scanned. In the reproduced case, the MV path created 8 scanners with zero partition-pruning counters, while disabling the MV pruned 3 of 4 partitions and 6 of 8 tablets.

This change follows the optimizer's synchronous-MV lineage handling. The classifier resolves a simple MV column to the already-bound base `Column` through its `defineExpr` / `SlotRef`, instead of comparing the rollup-local name or unique ID. When serializing partition boundaries, `OlapScanNode` extracts the unique SlotId directly from the runtime filter's existing translated target expression and resolves the matching base partition-column ordinal through the same bound-column lineage. No additional target-slot state is carried through `RuntimeFilter` or the translator.

Complex MV expressions and conflicting valid column unique IDs are rejected from partition pruning.

After the change on the reproduced query:

- `TotalPartitionsForRFPruning`: 4
- `PartitionsPrunedByRuntimeFilter`: 3
- `TabletsPrunedByRuntimeFilter`: 6
- `NumScanners`: 2
- Query result remains `100 / 596100`

### Release note

Support runtime filter partition pruning for synchronous materialized views with aliased partition columns.

### Check List (For Author)

- Test: Regression test / Unit Test / Manual test
    - FE unit test: `RuntimeFilterPartitionPruneClassifierTest` (9 tests passed)
    - Regression test: `query_p0/runtime_filter/rf_partition_pruning` (1 suite passed)
    - Manual test: verified exact profile counters on the local 9333 cluster
    - Build: `./build.sh --fe`
- Behavior changed: Yes. Eligible runtime filters can now prune base-table partitions when scanning a synchronous MV alias, with boundaries bound to the existing translated target SlotId.
- Does this need documentation: No
