### PR TITLE
[feature](cloud) Support single rowset grouped compaction

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -26,18 +26,42 @@
 #include "cloud/config.h"
 #include "common/config.h"
 #include "common/logging.h"
+#include "common/metrics/doris_metrics.h"
 #include "common/status.h"
 #include "cpp/sync_point.h"
 #include "service/backend_options.h"
 #include "storage/compaction/compaction.h"
 #include "storage/compaction/cumulative_compaction_policy.h"
 #include "storage/compaction/cumulative_compaction_time_series_policy.h"
+#include "storage/merger.h"
+#include "storage/rowset/rowset_reader.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/tablet/tablet_schema.h"
 #include "util/debug_points.h"
 #include "util/trace.h"
 #include "util/uuid_generator.h"
 
 namespace doris {
 using namespace ErrorCode;
+
+namespace cloud {
+
+bool is_single_rowset_compaction_candidate(const RowsetSharedPtr& rowset) {
+    return !rowset->rowset_meta()->has_delete_predicate() &&
+           rowset->rowset_meta()->is_segments_overlapping() &&
+           rowset->num_segments() >= config::cloud_single_rowset_compaction_min_segments;
+}
+
+bool should_use_single_rowset_grouped_compaction(const std::vector<RowsetSharedPtr>& input_rowsets,
+                                                 const TabletSchema& tablet_schema,
+                                                 std::string_view compaction_policy) {
+    return compaction_policy == CUMULATIVE_SIZE_BASED_POLICY &&
+           tablet_schema.num_key_columns() > 0 && tablet_schema.cluster_key_uids().empty() &&
+           config::enable_cloud_single_rowset_compaction && input_rowsets.size() == 1 &&
+           is_single_rowset_compaction_candidate(input_rowsets.front());
+}
+
+} // namespace cloud
 
 bvar::Adder<uint64_t> cumu_output_size("cumu_compaction", "output_size");
 bvar::LatencyRecorder g_cu_compaction_hold_delete_bitmap_lock_time_ms(
@@ -266,17 +290,19 @@ Status CloudCumulativeCompaction::modify_rowsets() {
     }
     auto compaction_policy = cloud_tablet()->tablet_meta()->compaction_policy();
     int64_t new_cumulative_point = input_cumulative_point;
-    if (!_enable_parallel_cumu_compaction && input_tablet_state == TABLET_NOTREADY &&
-        _output_rowset->start_version() > input_cumulative_point) {
-        // Historical rowsets are absent from a schema-change target until conversion finishes.
-        DORIS_CHECK_LE(input_cumulative_point, input_alter_version);
-        DORIS_CHECK_GT(_output_rowset->start_version(), input_alter_version);
-    } else if (!_enable_parallel_cumu_compaction ||
-               _output_rowset->start_version() == input_cumulative_point) {
-        new_cumulative_point =
-                _engine.cumu_compaction_policy(compaction_policy)
-                        ->new_cumulative_point(cloud_tablet(), _output_rowset, _last_delete_version,
-                                               input_cumulative_point);
+    if (!_single_rowset_compaction_segment_group_size.has_value()) {
+        if (!_enable_parallel_cumu_compaction && input_tablet_state == TABLET_NOTREADY &&
+            _output_rowset->start_version() > input_cumulative_point) {
+            // Historical rowsets are absent from a schema-change target until conversion finishes.
+            DORIS_CHECK_LE(input_cumulative_point, input_alter_version);
+            DORIS_CHECK_GT(_output_rowset->start_version(), input_alter_version);
+        } else if (!_enable_parallel_cumu_compaction ||
+                   _output_rowset->start_version() == input_cumulative_point) {
+            new_cumulative_point =
+                    _engine.cumu_compaction_policy(compaction_policy)
+                            ->new_cumulative_point(cloud_tablet(), _output_rowset,
+                                                   _last_delete_version, input_cumulative_point);
+        }
     }
     // commit compaction job
     cloud::TabletJobInfoPB job;
@@ -607,6 +633,7 @@ Status CloudCumulativeCompaction::advance_cumulative_point_before_pick(
 
 Status CloudCumulativeCompaction::pick_rowsets_to_compact() {
     _input_rowsets.clear();
+    _single_rowset_compaction_segment_group_size.reset();
 
     int64_t min_conflict_version = _min_conflict_version;
     int64_t max_conflict_version = _max_conflict_version;
@@ -644,6 +671,19 @@ Status CloudCumulativeCompaction::pick_rowsets_to_compact() {
                 ->pick_input_rowsets(cloud_tablet(), candidates, max_score,
                                      config::cumulative_compaction_min_deltas, &_input_rowsets,
                                      &_last_delete_version, &compaction_score);
+
+        if (config::enable_cloud_single_rowset_compaction) {
+            for (const auto& rowset : _input_rowsets) {
+                if (cloud::should_use_single_rowset_grouped_compaction(
+                            {rowset}, *cloud_tablet()->tablet_schema(), compaction_policy)) {
+                    auto grouped_input_rowset = rowset;
+                    _input_rowsets = {std::move(grouped_input_rowset)};
+                    _single_rowset_compaction_segment_group_size =
+                            config::cloud_single_rowset_compaction_segment_group_size;
+                    return Status::OK();
+                }
+            }
+        }
 
         if (_input_rowsets.empty()) {
             return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>(
@@ -706,6 +746,88 @@ Status CloudCumulativeCompaction::pick_rowsets_to_compact() {
 
     apply_txn_size_truncation_and_log("CloudCumulativeCompaction");
     return Status::OK();
+}
+
+Status CloudCumulativeCompaction::prepare_merge_input_rowsets(MergeInputRowsetsResult* result) {
+    if (!_single_rowset_compaction_segment_group_size.has_value()) {
+        return Status::OK();
+    }
+
+    const int64_t segment_group_size = *_single_rowset_compaction_segment_group_size;
+    if (segment_group_size <= 0) {
+        return Status::InvalidArgument(
+                "cloud_single_rowset_compaction_segment_group_size must be positive, value={}",
+                segment_group_size);
+    }
+    result->is_segment_grouped = true;
+    result->segment_group_size = segment_group_size;
+    return Status::OK();
+}
+
+Status CloudCumulativeCompaction::do_merge_input_rowsets(
+        const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+        MergeInputRowsetsResult* result) {
+    if (!result->is_segment_grouped) {
+        return Compaction::do_merge_input_rowsets(input_rs_readers, result);
+    }
+
+    const int64_t segment_group_size = result->segment_group_size;
+    const auto& input_rowset = _input_rowsets.front();
+    const int64_t segment_group_count =
+            (input_rowset->num_segments() + segment_group_size - 1) / segment_group_size;
+    for (int64_t segment_start = 0; segment_start < input_rowset->num_segments();
+         segment_start += segment_group_size) {
+        const int64_t segment_end =
+                std::min(segment_start + segment_group_size, input_rowset->num_segments());
+        const int32_t output_segment_start = _output_rs_writer->get_allocated_segment_id();
+
+        RowsetReaderSharedPtr rs_reader;
+        RETURN_IF_ERROR(input_rowset->create_reader(&rs_reader));
+        std::vector<RowsetReaderSharedPtr> group_readers;
+        group_readers.push_back(std::move(rs_reader));
+
+        Merger::Statistics group_stats;
+        group_stats.rowid_conversion = _stats.rowid_conversion;
+        RETURN_IF_ERROR(execute_merge(group_readers, segment_end - segment_start, &group_stats,
+                                      std::make_pair(segment_start, segment_end),
+                                      {.total_ranges = segment_group_count,
+                                       .range_index = segment_start / segment_group_size}));
+
+        _stats.output_rows += group_stats.output_rows;
+        _stats.merged_rows += group_stats.merged_rows;
+        _stats.filtered_rows += group_stats.filtered_rows;
+        _stats.bytes_read_from_local += group_stats.bytes_read_from_local;
+        _stats.bytes_read_from_remote += group_stats.bytes_read_from_remote;
+        _stats.cached_bytes_total += group_stats.cached_bytes_total;
+        _stats.cloud_local_read_time += group_stats.cloud_local_read_time;
+        _stats.cloud_remote_read_time += group_stats.cloud_remote_read_time;
+
+        const int32_t output_segment_end = _output_rs_writer->get_allocated_segment_id();
+        const int32_t output_group_size = output_segment_end - output_segment_start;
+        if (output_group_size > 0) {
+            ++result->output_segment_group_count;
+        }
+    }
+    return Status::OK();
+}
+
+void CloudCumulativeCompaction::update_output_rowset_after_build(
+        const MergeInputRowsetsResult& result) {
+    if (!result.is_segment_grouped) {
+        return;
+    }
+    if (result.output_segment_group_count > 1) {
+        _output_rowset->rowset_meta()->set_segments_overlap(OVERLAPPING);
+    }
+
+    const auto& input_rowset = _input_rowsets.front();
+    LOG_INFO("finish single rowset grouped compaction, tablet_id={}, version=[{}-{}]",
+             _tablet->tablet_id(), input_rowset->start_version(), input_rowset->end_version())
+            .tag("job_id", _uuid)
+            .tag("input_segments", input_rowset->num_segments())
+            .tag("segment_group_size", result.segment_group_size)
+            .tag("output_segments", _output_rowset->num_segments())
+            .tag("output_groups", result.output_segment_group_count);
 }
 
 void CloudCumulativeCompaction::update_cumulative_point(int64_t input_cumulative_point,

--- a/be/src/cloud/cloud_cumulative_compaction.h
+++ b/be/src/cloud/cloud_cumulative_compaction.h
@@ -20,13 +20,26 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <string_view>
+#include <vector>
 
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
 #include "storage/compaction/compaction.h"
 #include "storage/compaction_task_tracker.h"
+#include "storage/tablet/tablet_fwd.h"
 
 namespace doris {
+
+namespace cloud {
+
+bool is_single_rowset_compaction_candidate(const RowsetSharedPtr& rowset);
+
+bool should_use_single_rowset_grouped_compaction(const std::vector<RowsetSharedPtr>& input_rowsets,
+                                                 const TabletSchema& tablet_schema,
+                                                 std::string_view compaction_policy);
+
+} // namespace cloud
 
 class CloudCumulativeCompaction : public CloudCompactionMixin {
 public:
@@ -53,6 +66,13 @@ private:
 
     Status pick_rowsets_to_compact();
 
+    Status prepare_merge_input_rowsets(MergeInputRowsetsResult* result) override;
+
+    Status do_merge_input_rowsets(const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+                                  MergeInputRowsetsResult* result) override;
+
+    void update_output_rowset_after_build(const MergeInputRowsetsResult& result) override;
+
     std::string_view compaction_name() const override { return "CloudCumulativeCompaction"; }
 
 protected:
@@ -75,6 +95,7 @@ private:
     int64_t _cumulative_compaction_cnt = 0;
     int64_t _picked_cumulative_point = 0;
     Version _last_delete_version {-1, -1};
+    std::optional<int64_t> _single_rowset_compaction_segment_group_size;
 };
 
 } // namespace doris

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -55,6 +55,9 @@ DEFINE_mInt32(max_base_compaction_task_num_per_disk, "2");
 DEFINE_mBool(prioritize_query_perf_in_compaction, "false");
 DEFINE_mInt32(compaction_max_rowset_count, "10000");
 DEFINE_mInt64(compaction_txn_max_size_bytes, "7340032"); // 7MB
+DEFINE_mBool(enable_cloud_single_rowset_compaction, "false");
+DEFINE_mInt32(cloud_single_rowset_compaction_min_segments, "512");
+DEFINE_mInt32(cloud_single_rowset_compaction_segment_group_size, "64");
 
 DEFINE_mInt32(refresh_s3_info_interval_s, "60");
 DEFINE_mInt32(vacuum_stale_rowsets_interval_s, "300");

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -96,6 +96,9 @@ DECLARE_mInt32(max_base_compaction_task_num_per_disk);
 DECLARE_mBool(prioritize_query_perf_in_compaction);
 DECLARE_mInt32(compaction_max_rowset_count);
 DECLARE_mInt64(compaction_txn_max_size_bytes);
+DECLARE_mBool(enable_cloud_single_rowset_compaction);
+DECLARE_mInt32(cloud_single_rowset_compaction_min_segments);
+DECLARE_mInt32(cloud_single_rowset_compaction_segment_group_size);
 
 // CloudStorageEngine config
 DECLARE_mInt32(refresh_s3_info_interval_s);

--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -280,6 +280,9 @@ int64_t Compaction::merge_way_num() {
 }
 
 Status Compaction::merge_input_rowsets() {
+    MergeInputRowsetsResult result;
+    RETURN_IF_ERROR(prepare_merge_input_rowsets(&result));
+
     std::vector<RowsetReaderSharedPtr> input_rs_readers;
     input_rs_readers.reserve(_input_rowsets.size());
     for (auto& rowset : _input_rowsets) {
@@ -305,38 +308,10 @@ Status Compaction::merge_input_rowsets() {
         _stats.rowid_conversion = _rowid_conversion.get();
     }
 
-    int64_t way_num = merge_way_num();
-
-    Status res;
     {
         SCOPED_TIMER(_merge_rowsets_latency_timer);
         // 1. Merge segment files and write bkd inverted index
-        // TODO implement vertical compaction for seq map
-        if (_is_vertical && !_tablet->tablet_schema()->has_seq_map()) {
-            if (!_tablet->tablet_schema()->cluster_key_uids().empty()) {
-                RETURN_IF_ERROR(update_delete_bitmap());
-            }
-            auto progress_cb = [compaction_id = this->_compaction_id](int64_t total,
-                                                                      int64_t completed) {
-                CompactionTaskTracker::instance()->update_progress(compaction_id, total, completed);
-            };
-            res = Merger::vertical_merge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
-                                                 input_rs_readers, _output_rs_writer.get(),
-                                                 cast_set<uint32_t>(get_avg_segment_rows()),
-                                                 way_num, &_stats, progress_cb);
-        } else {
-            if (!_tablet->tablet_schema()->cluster_key_uids().empty()) {
-                return Status::InternalError(
-                        "mow table with cluster keys does not support non vertical compaction");
-            }
-            res = Merger::vmerge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
-                                         input_rs_readers, _output_rs_writer.get(), &_stats);
-        }
-
-        _tablet->last_compaction_status = res;
-        if (!res.ok()) {
-            return res;
-        }
+        RETURN_IF_ERROR(do_merge_input_rowsets(input_rs_readers, &result));
         // 2. Merge the remaining inverted index files of the string type
         RETURN_IF_ERROR(do_inverted_index_compaction());
     }
@@ -362,6 +337,7 @@ Status Compaction::merge_input_rowsets() {
 
     //RETURN_IF_ERROR(_engine.meta_mgr().commit_rowset(*_output_rowset->rowset_meta().get()));
     set_delete_predicate_for_output_rowset();
+    update_output_rowset_after_build(result);
 
     _local_read_bytes_total = _stats.bytes_read_from_local;
     _remote_read_bytes_total = _stats.bytes_read_from_remote;
@@ -376,6 +352,46 @@ Status Compaction::merge_input_rowsets() {
     COUNTER_UPDATE(_output_segments_num_counter, _output_rowset->num_segments());
 
     return check_correctness();
+}
+
+Status Compaction::do_merge_input_rowsets(
+        const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+        MergeInputRowsetsResult* /*result*/) {
+    return execute_merge(input_rs_readers, merge_way_num(), &_stats);
+}
+
+Status Compaction::execute_merge(const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+                                 int64_t merge_way_num, Merger::Statistics* stats,
+                                 std::optional<std::pair<int64_t, int64_t>> segment_range,
+                                 VerticalMergeProgressContext progress) {
+    Status status;
+    // TODO implement vertical compaction for seq map
+    if (_is_vertical && !_tablet->tablet_schema()->has_seq_map()) {
+        if (!_tablet->tablet_schema()->cluster_key_uids().empty() && !segment_range.has_value()) {
+            RETURN_IF_ERROR(update_delete_bitmap());
+        }
+        auto progress_cb = [compaction_id = this->_compaction_id, progress](int64_t total,
+                                                                            int64_t completed) {
+            CompactionTaskTracker::instance()->update_progress(
+                    compaction_id, total * progress.total_ranges,
+                    total * progress.range_index + completed);
+        };
+        status = Merger::vertical_merge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
+                                                input_rs_readers, _output_rs_writer.get(),
+                                                cast_set<uint32_t>(get_avg_segment_rows()),
+                                                merge_way_num, stats, progress_cb, segment_range);
+    } else {
+        if (!_tablet->tablet_schema()->cluster_key_uids().empty()) {
+            return Status::InternalError(
+                    "mow table with cluster keys does not support non vertical compaction");
+        }
+        status = Merger::vmerge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
+                                        input_rs_readers, _output_rs_writer.get(), stats,
+                                        segment_range);
+    }
+
+    _tablet->last_compaction_status = status;
+    return status;
 }
 
 void Compaction::set_delete_predicate_for_output_rowset() {

--- a/be/src/storage/compaction/compaction.h
+++ b/be/src/storage/compaction/compaction.h
@@ -30,6 +30,7 @@
 #endif
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cloud/cloud_tablet.h"
@@ -102,7 +103,34 @@ private:
     void set_delete_predicate_for_output_rowset();
 
 protected:
+    struct MergeInputRowsetsResult {
+        bool is_segment_grouped = false;
+        int64_t segment_group_size = 0;
+        int64_t output_segment_group_count = 0;
+    };
+
     Status merge_input_rowsets();
+
+    virtual Status prepare_merge_input_rowsets(MergeInputRowsetsResult* /*result*/) {
+        return Status::OK();
+    }
+
+    virtual Status do_merge_input_rowsets(
+            const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+            MergeInputRowsetsResult* result);
+
+    virtual void update_output_rowset_after_build(const MergeInputRowsetsResult& /*result*/) {}
+
+    // Maps one segment-range merge's column-group progress into the whole compaction task.
+    struct VerticalMergeProgressContext {
+        int64_t total_ranges;
+        int64_t range_index;
+    };
+
+    Status execute_merge(const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+                         int64_t merge_way_num, Merger::Statistics* stats,
+                         std::optional<std::pair<int64_t, int64_t>> segment_range = std::nullopt,
+                         VerticalMergeProgressContext progress = {1, 0});
 
     // merge inverted index files
     Status do_inverted_index_compaction();
@@ -255,6 +283,8 @@ protected:
 
     virtual Status garbage_collection();
 
+    Status construct_output_rowset_writer(RowsetWriterContext& ctx) override;
+
     // Helper function to apply truncation and log the result
     // Returns the number of rowsets that were truncated
     size_t apply_txn_size_truncation_and_log(const std::string& compaction_name);
@@ -271,8 +301,6 @@ protected:
     virtual Status rebuild_tablet_schema() { return Status::OK(); }
 
 private:
-    Status construct_output_rowset_writer(RowsetWriterContext& ctx) override;
-
     Status set_storage_resource_from_input_rowsets(RowsetWriterContext& ctx);
 
     Status execute_compact_impl(int64_t permits);

--- a/be/src/storage/iterator/vertical_block_reader.cpp
+++ b/be/src/storage/iterator/vertical_block_reader.cpp
@@ -79,10 +79,12 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
         return res;
     }
     for (const auto& rs_split : read_params.rs_splits) {
+        RETURN_IF_ERROR(rs_split.rs_reader->init(&_reader_context, rs_split));
         // segment iterator will be inited here
         // In vertical compaction, every group will load segment so we should cache
         // segment to avoid tot many s3 head request
         bool use_cache = !rs_split.rs_reader->rowset()->is_local();
+        size_t iterators_start = segment_iters->size();
         RETURN_IF_ERROR(rs_split.rs_reader->get_segment_iterators(&_reader_context, segment_iters,
                                                                   use_cache));
         // if segments overlapping, all segment iterator should be inited in
@@ -90,12 +92,13 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
         // rowset will be inited and push to heap, other segment will be inited later when current
         // segment reached it's end.
         // Use this iterator_init_flag so we can load few segments in HeapMergeIterator to save memory
+        size_t added_iterators = segment_iters->size() - iterators_start;
         if (rs_split.rs_reader->rowset()->is_segments_overlapping()) {
-            for (int i = 0; i < rs_split.rs_reader->rowset()->num_segments(); ++i) {
+            for (size_t i = 0; i < added_iterators; ++i) {
                 iterator_init_flag->push_back(true);
             }
         } else {
-            for (int i = 0; i < rs_split.rs_reader->rowset()->num_segments(); ++i) {
+            for (size_t i = 0; i < added_iterators; ++i) {
                 if (i == 0) {
                     iterator_init_flag->push_back(true);
                     continue;
@@ -103,7 +106,7 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
                 iterator_init_flag->push_back(false);
             }
         }
-        for (int i = 0; i < rs_split.rs_reader->rowset()->num_segments(); ++i) {
+        for (size_t i = 0; i < added_iterators; ++i) {
             rowset_ids->push_back(rs_split.rs_reader->rowset()->rowset_id());
         }
         rs_split.rs_reader->reset_read_options();

--- a/be/src/storage/merger.cpp
+++ b/be/src/storage/merger.cpp
@@ -67,7 +67,8 @@ namespace doris {
 Status Merger::vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
                               const TabletSchema& cur_tablet_schema,
                               const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
-                              RowsetWriter* dst_rowset_writer, Statistics* stats_output) {
+                              RowsetWriter* dst_rowset_writer, Statistics* stats_output,
+                              std::optional<std::pair<int64_t, int64_t>> segment_range) {
     if (!cur_tablet_schema.cluster_key_uids().empty()) {
         return Status::InternalError(
                 "mow table with cluster keys does not support non vertical compaction");
@@ -81,7 +82,11 @@ Status Merger::vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
     TabletReadSource read_source;
     read_source.rs_splits.reserve(src_rowset_readers.size());
     for (const RowsetReaderSharedPtr& rs_reader : src_rowset_readers) {
-        read_source.rs_splits.emplace_back(rs_reader);
+        auto& rs_split = read_source.rs_splits.emplace_back(rs_reader);
+        if (segment_range.has_value()) {
+            DCHECK_EQ(src_rowset_readers.size(), 1);
+            rs_split.segment_offsets = segment_range.value();
+        }
     }
     read_source.fill_delete_predicates();
     reader_params.set_read_source(std::move(read_source));
@@ -247,7 +252,7 @@ Status Merger::vertical_compact_one_group(
         RowsetWriter* dst_rowset_writer, uint32_t max_rows_per_segment, Statistics* stats_output,
         std::vector<uint32_t> key_group_cluster_key_idxes, int64_t batch_size,
         CompactionSampleInfo* sample_info, VerticalCompactionContextStats* context_stats,
-        bool enable_sparse_optimization) {
+        bool enable_sparse_optimization, std::optional<std::pair<int64_t, int64_t>> segment_range) {
     // build tablet reader
     VLOG_NOTICE << "vertical compact one group, max_rows_per_segment=" << max_rows_per_segment;
     VerticalBlockReader reader(row_source_buf, context_stats);
@@ -262,7 +267,11 @@ Status Merger::vertical_compact_one_group(
     TabletReadSource read_source;
     read_source.rs_splits.reserve(src_rowset_readers.size());
     for (const RowsetReaderSharedPtr& rs_reader : src_rowset_readers) {
-        read_source.rs_splits.emplace_back(rs_reader);
+        auto& rs_split = read_source.rs_splits.emplace_back(rs_reader);
+        if (segment_range.has_value()) {
+            DCHECK_EQ(src_rowset_readers.size(), 1);
+            rs_split.segment_offsets = segment_range.value();
+        }
     }
     read_source.fill_delete_predicates();
     reader_params.set_read_source(std::move(read_source));
@@ -486,7 +495,8 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
                                       RowsetWriter* dst_rowset_writer,
                                       uint32_t max_rows_per_segment, int64_t merge_way_num,
                                       Statistics* stats_output,
-                                      VerticalCompactionProgressCallback progress_cb) {
+                                      VerticalCompactionProgressCallback progress_cb,
+                                      std::optional<std::pair<int64_t, int64_t>> segment_range) {
     LOG(INFO) << "Start to do vertical compaction, tablet_id: " << tablet->tablet_id();
     VerticalCompactionContextStats context_stats;
     Defer log_context_stats {[&] {
@@ -529,29 +539,33 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
         progress_cb(column_groups.size(), 0);
     }
 
-    // Calculate total rows for density calculation after compaction
+    // Segment-range vertical compaction only sees part of a rowset. Do not use partial rows to
+    // update tablet-level density or drive sparse optimization.
     int64_t total_rows = 0;
-    for (const auto& rs_reader : src_rowset_readers) {
-        total_rows += rs_reader->rowset()->rowset_meta()->num_rows();
-    }
-
     // Use historical density for sparse wide table optimization
     // density = (total_cells - null_cells) / total_cells, smaller means more sparse
     // When density <= threshold, enable sparse optimization
     // threshold = 0 means disable, 1 means always enable (default)
     bool enable_sparse_optimization = false;
-    if (config::sparse_column_compaction_threshold_percent > 0 &&
-        tablet->keys_type() == KeysType::UNIQUE_KEYS) {
-        double density = tablet->compaction_density.load();
-        enable_sparse_optimization = density <= config::sparse_column_compaction_threshold_percent;
+    if (!segment_range.has_value()) {
+        for (const auto& rs_reader : src_rowset_readers) {
+            total_rows += rs_reader->rowset()->rowset_meta()->num_rows();
+        }
 
-        LOG(INFO) << "Vertical compaction sparse optimization check: tablet_id="
-                  << tablet->tablet_id() << ", density=" << density
-                  << ", threshold=" << config::sparse_column_compaction_threshold_percent
-                  << ", total_rows=" << total_rows
-                  << ", num_columns=" << tablet_schema.num_columns()
-                  << ", total_cells=" << total_rows * tablet_schema.num_columns()
-                  << ", enable_sparse_optimization=" << enable_sparse_optimization;
+        if (config::sparse_column_compaction_threshold_percent > 0 &&
+            tablet->keys_type() == KeysType::UNIQUE_KEYS) {
+            double density = tablet->compaction_density.load();
+            enable_sparse_optimization =
+                    density <= config::sparse_column_compaction_threshold_percent;
+
+            LOG(INFO) << "Vertical compaction sparse optimization check: tablet_id="
+                      << tablet->tablet_id() << ", density=" << density
+                      << ", threshold=" << config::sparse_column_compaction_threshold_percent
+                      << ", total_rows=" << total_rows
+                      << ", num_columns=" << tablet_schema.num_columns()
+                      << ", total_cells=" << total_rows * tablet_schema.num_columns()
+                      << ", enable_sparse_optimization=" << enable_sparse_optimization;
+        }
     }
 
     RowSourcesBuffer row_sources_buf(tablet->tablet_id(), dst_rowset_writer->context().tablet_path,
@@ -586,7 +600,7 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
             }
         }
     }
-    if (need_footer_collection) {
+    if (!segment_range.has_value() && need_footer_collection) {
         for (const auto& rs_reader : src_rowset_readers) {
             auto beta_rowset = std::dynamic_pointer_cast<BetaRowset>(rs_reader->rowset());
             if (!beta_rowset) {
@@ -600,7 +614,8 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
                              << ", rowset_id: " << beta_rowset->rowset_id() << ", status: " << st;
                 continue;
             }
-            for (const auto& segment : segments) {
+            for (int64_t segment_idx = 0; segment_idx < segments.size(); ++segment_idx) {
+                const auto& segment = segments[segment_idx];
                 int64_t row_count = segment->num_rows();
                 auto collect_st = segment->traverse_column_meta_pbs(
                         [&](const segment_v2::ColumnMetaPB& meta) {
@@ -622,7 +637,7 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
 
     // Pre-compute per-row estimate for each column group from footer data.
     std::vector<int64_t> group_per_row_from_footer(column_groups.size(), 0);
-    std::vector<bool> group_footer_fallback(column_groups.size(), false);
+    std::vector<bool> group_footer_fallback(column_groups.size(), segment_range.has_value());
     for (size_t i = 0; i < column_groups.size(); ++i) {
         int64_t group_per_row = 0;
         bool need_fallback = false;
@@ -700,7 +715,7 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
                 tablet, reader_type, tablet_schema, is_key, column_groups[i], &row_sources_buf,
                 src_rowset_readers, dst_rowset_writer, max_rows_per_segment, group_stats_ptr,
                 key_group_cluster_key_idxes, batch_size, &sample_info, &context_stats,
-                enable_sparse_optimization);
+                enable_sparse_optimization, segment_range);
         {
             std::unique_lock<std::mutex> lock(sample_info_lock);
             sample_infos[i] = sample_info;
@@ -731,7 +746,7 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
     // Calculate and store density for next compaction's sparse optimization threshold
     // density = (total_cells - total_null_count) / total_cells
     // Smaller density means more sparse
-    {
+    if (!segment_range.has_value()) {
         std::unique_lock<std::mutex> lock(sample_info_lock);
         int64_t total_null_count = 0;
         for (const auto& info : sample_infos) {

--- a/be/src/storage/merger.h
+++ b/be/src/storage/merger.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <functional>
+#include <optional>
+#include <utility>
 #include <vector>
 
 #include "common/status.h"
@@ -64,15 +66,17 @@ public:
     // return OK and set statistics into `*stats_output`.
     // return others on error
 
-    static Status vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
-                                 const TabletSchema& cur_tablet_schema,
-                                 const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
-                                 RowsetWriter* dst_rowset_writer, Statistics* stats_output);
+    static Status vmerge_rowsets(
+            BaseTabletSPtr tablet, ReaderType reader_type, const TabletSchema& cur_tablet_schema,
+            const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
+            RowsetWriter* dst_rowset_writer, Statistics* stats_output,
+            std::optional<std::pair<int64_t, int64_t>> segment_range = std::nullopt);
     static Status vertical_merge_rowsets(
             BaseTabletSPtr tablet, ReaderType reader_type, const TabletSchema& tablet_schema,
             const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
             RowsetWriter* dst_rowset_writer, uint32_t max_rows_per_segment, int64_t merge_way_num,
-            Statistics* stats_output, VerticalCompactionProgressCallback progress_cb = nullptr);
+            Statistics* stats_output, VerticalCompactionProgressCallback progress_cb = nullptr,
+            std::optional<std::pair<int64_t, int64_t>> segment_range = std::nullopt);
 
     // for vertical compaction
     static void vertical_split_columns(const TabletSchema& tablet_schema,
@@ -87,7 +91,8 @@ public:
             RowsetWriter* dst_rowset_writer, uint32_t max_rows_per_segment,
             Statistics* stats_output, std::vector<uint32_t> key_group_cluster_key_idxes,
             int64_t batch_size, CompactionSampleInfo* sample_info,
-            VerticalCompactionContextStats* context_stats, bool enable_sparse_optimization = false);
+            VerticalCompactionContextStats* context_stats, bool enable_sparse_optimization = false,
+            std::optional<std::pair<int64_t, int64_t>> segment_range = std::nullopt);
 
     // for segcompaction
     static Status vertical_compact_one_group(

--- a/be/src/storage/rowid_conversion.h
+++ b/be/src/storage/rowid_conversion.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "common/cast_set.h"
+#include "common/check.h"
 #include "runtime/thread_context.h"
 #include "storage/olap_common.h"
 #include "storage/utils.h"
@@ -40,6 +41,15 @@ public:
     // resize segment rowid map to its rows num
     Status init_segment_map(const RowsetId& src_rowset_id, const std::vector<uint32_t>& num_rows) {
         for (size_t i = 0; i < num_rows.size(); i++) {
+            auto src_segment = std::pair<RowsetId, uint32_t> {src_rowset_id, cast_set<uint32_t>(i)};
+            auto iter = _segment_to_id_map.find(src_segment);
+            // Each segment-group reader initializes all source segments, so reuse existing maps.
+            if (iter != _segment_to_id_map.end()) {
+                DORIS_CHECK_LT(iter->second, _segments_rowid_map.size());
+                DORIS_CHECK_EQ(_segments_rowid_map[iter->second].size(), num_rows[i]);
+                continue;
+            }
+
             constexpr size_t RESERVED_MEMORY = 10 * 1024 * 1024; // 10M
             if (doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(RESERVED_MEMORY)) {
                 return Status::MemoryLimitExceeded(fmt::format(
@@ -59,9 +69,10 @@ public:
                                 ->consumption()));
             }
 
-            uint32_t id = static_cast<uint32_t>(_segments_rowid_map.size());
-            _segment_to_id_map.emplace(std::pair<RowsetId, uint32_t> {src_rowset_id, i}, id);
-            _id_to_segment_map.emplace_back(src_rowset_id, i);
+            uint32_t id = cast_set<uint32_t>(_segments_rowid_map.size());
+            auto insert_result = _segment_to_id_map.emplace(src_segment, id);
+            DORIS_CHECK(insert_result.second);
+            _id_to_segment_map.push_back(src_segment);
             std::vector<std::pair<uint32_t, uint32_t>> vec(
                     num_rows[i], std::pair<uint32_t, uint32_t>(UINT32_MAX, UINT32_MAX));
 

--- a/be/src/storage/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/vertical_beta_rowset_writer.cpp
@@ -140,8 +140,11 @@ Status VerticalBetaRowsetWriter<T>::_flush_columns(segment_v2::SegmentWriter* se
         key_bounds.set_min_key(min_key.to_string());
         key_bounds.set_max_key(max_key.to_string());
         this->_segments_encoded_key_bounds.emplace_back(std::move(key_bounds));
-        this->_segment_num_rows.resize(_cur_writer_idx + 1);
-        this->_segment_num_rows[_cur_writer_idx] = _segment_writers[_cur_writer_idx]->row_count();
+        const auto segment_id = segment_writer->get_segment_id();
+        if (segment_id >= this->_segment_num_rows.size()) {
+            this->_segment_num_rows.resize(segment_id + 1);
+        }
+        this->_segment_num_rows[segment_id] = segment_writer->row_count();
     }
     return Status::OK();
 }
@@ -205,6 +208,7 @@ template <class T>
     requires std::is_base_of_v<BaseBetaRowsetWriter, T>
 Status VerticalBetaRowsetWriter<T>::final_flush() {
     for (auto& segment_writer : _segment_writers) {
+        DCHECK(segment_writer);
         uint64_t segment_size = 0;
         //uint64_t footer_position = 0;
         segment_v2::SegmentIndexFileCacheInfo index_file_cache_info;
@@ -220,6 +224,8 @@ Status VerticalBetaRowsetWriter<T>::final_flush() {
         segment_writer.reset();
         _record_segment_index_file_cache_preload(segment_id, index_file_cache_info);
     }
+    _segment_writers.clear();
+    _cur_writer_idx = 0;
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/vertical_beta_rowset_writer.h
+++ b/be/src/storage/rowset/vertical_beta_rowset_writer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <type_traits>
@@ -48,6 +49,10 @@ public:
 
     // flush when all column finished, flush column footer
     Status final_flush() override;
+
+    int32_t get_allocated_segment_id() override {
+        return this->_num_segment.load(std::memory_order_relaxed);
+    }
 
     int64_t num_rows() const override { return _total_key_group_rows; }
 

--- a/be/test/cloud/cloud_compaction_test.cpp
+++ b/be/test/cloud/cloud_compaction_test.cpp
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 
@@ -395,7 +396,7 @@ TEST_F(CloudCompactionTest, generate_cloud_compaction_tasks_clears_metrics_witho
 }
 
 static RowsetSharedPtr create_rowset(Version version, int num_segments, bool overlapping,
-                                     int data_size) {
+                                     int data_size, int num_key_columns = 1) {
     auto rs_meta = std::make_shared<RowsetMeta>();
     rs_meta->set_rowset_type(BETA_ROWSET); // important
     rs_meta->_rowset_meta_pb.set_start_version(version.first);
@@ -403,6 +404,19 @@ static RowsetSharedPtr create_rowset(Version version, int num_segments, bool ove
     rs_meta->set_num_segments(num_segments);
     rs_meta->set_segments_overlap(overlapping ? OVERLAPPING : NONOVERLAPPING);
     rs_meta->set_total_disk_size(data_size);
+    TabletSchemaPB tablet_schema_pb;
+    tablet_schema_pb.set_keys_type(DUP_KEYS);
+    for (int i = 0; i < num_key_columns + 1; ++i) {
+        ColumnPB* column = tablet_schema_pb.add_column();
+        column->set_unique_id(i);
+        column->set_name("c" + std::to_string(i));
+        column->set_type("INT");
+        column->set_is_key(i < num_key_columns);
+        column->set_is_nullable(false);
+    }
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(tablet_schema_pb);
+    rs_meta->set_tablet_schema(tablet_schema);
     RowsetSharedPtr rowset;
     Status st = RowsetFactory::create_rowset(nullptr, "", rs_meta, &rowset);
     if (!st.ok()) {
@@ -1153,6 +1167,228 @@ TEST_F(CloudCompactionTest, should_cache_compaction_output) {
     config::enable_file_cache_write_index_file_only = true;
     ASSERT_EQ(cloud_base_compaction.should_cache_compaction_output(), false);
     LOG(INFO) << "should_cache_compaction_output done";
+}
+
+TEST_F(CloudCompactionTest, single_rowset_grouped_compaction_execution_path_conditions) {
+    auto old_enable = config::enable_cloud_single_rowset_compaction;
+    auto old_min_segments = config::cloud_single_rowset_compaction_min_segments;
+    auto old_group_size = config::cloud_single_rowset_compaction_segment_group_size;
+    Defer restore_config {[&] {
+        config::enable_cloud_single_rowset_compaction = old_enable;
+        config::cloud_single_rowset_compaction_min_segments = old_min_segments;
+        config::cloud_single_rowset_compaction_segment_group_size = old_group_size;
+    }};
+    config::enable_cloud_single_rowset_compaction = true;
+    config::cloud_single_rowset_compaction_min_segments = 4;
+    config::cloud_single_rowset_compaction_segment_group_size = 2;
+
+    RowsetSharedPtr candidate = create_rowset(Version(2, 2), 4, true, 1024);
+    ASSERT_TRUE(candidate != nullptr);
+    const auto& tablet_schema = *candidate->tablet_schema();
+    EXPECT_TRUE(cloud::is_single_rowset_compaction_candidate(candidate));
+    EXPECT_TRUE(cloud::should_use_single_rowset_grouped_compaction({candidate}, tablet_schema,
+                                                                   CUMULATIVE_SIZE_BASED_POLICY));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction({candidate}, tablet_schema,
+                                                                    CUMULATIVE_TIME_SERIES_POLICY));
+
+    TabletSchemaPB cluster_key_schema_pb;
+    tablet_schema.to_schema_pb(&cluster_key_schema_pb);
+    cluster_key_schema_pb.set_keys_type(UNIQUE_KEYS);
+    cluster_key_schema_pb.add_cluster_key_uids(1);
+    TabletSchema cluster_key_schema;
+    cluster_key_schema.init_from_pb(cluster_key_schema_pb);
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction({candidate}, cluster_key_schema,
+                                                                    CUMULATIVE_SIZE_BASED_POLICY));
+
+    config::enable_cloud_single_rowset_compaction = false;
+    EXPECT_TRUE(cloud::is_single_rowset_compaction_candidate(candidate));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction({candidate}, tablet_schema,
+                                                                    CUMULATIVE_SIZE_BASED_POLICY));
+    config::enable_cloud_single_rowset_compaction = true;
+
+    RowsetSharedPtr non_overlapping = create_rowset(Version(3, 3), 4, false, 1024);
+    ASSERT_TRUE(non_overlapping != nullptr);
+    EXPECT_FALSE(cloud::is_single_rowset_compaction_candidate(non_overlapping));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction(
+            {non_overlapping}, tablet_schema, CUMULATIVE_SIZE_BASED_POLICY));
+
+    RowsetSharedPtr too_few_segments = create_rowset(Version(4, 4), 3, true, 1024);
+    ASSERT_TRUE(too_few_segments != nullptr);
+    EXPECT_FALSE(cloud::is_single_rowset_compaction_candidate(too_few_segments));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction(
+            {too_few_segments}, tablet_schema, CUMULATIVE_SIZE_BASED_POLICY));
+
+    RowsetSharedPtr no_key_columns = create_rowset(Version(5, 5), 4, true, 1024, 0);
+    ASSERT_TRUE(no_key_columns != nullptr);
+    EXPECT_TRUE(cloud::is_single_rowset_compaction_candidate(no_key_columns));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction(
+            {no_key_columns}, *no_key_columns->tablet_schema(), CUMULATIVE_SIZE_BASED_POLICY));
+
+    RowsetSharedPtr with_delete_predicate = create_rowset(Version(6, 6), 4, true, 1024);
+    ASSERT_TRUE(with_delete_predicate != nullptr);
+    DeletePredicatePB delete_predicate;
+    auto* in_predicate = delete_predicate.add_in_predicates();
+    in_predicate->set_column_name("c1");
+    in_predicate->add_values("1");
+    with_delete_predicate->rowset_meta()->set_delete_predicate(std::move(delete_predicate));
+    EXPECT_FALSE(cloud::is_single_rowset_compaction_candidate(with_delete_predicate));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction(
+            {with_delete_predicate}, tablet_schema, CUMULATIVE_SIZE_BASED_POLICY));
+
+    RowsetSharedPtr another_candidate = create_rowset(Version(7, 7), 4, true, 1024);
+    ASSERT_TRUE(another_candidate != nullptr);
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction(
+            {candidate, another_candidate}, tablet_schema, CUMULATIVE_SIZE_BASED_POLICY));
+    EXPECT_FALSE(cloud::should_use_single_rowset_grouped_compaction({}, tablet_schema,
+                                                                    CUMULATIVE_SIZE_BASED_POLICY));
+
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(_engine, _tablet_meta);
+    CloudCumulativeCompaction compaction(_engine, tablet);
+    compaction._input_rowsets = {candidate};
+    compaction._cur_tablet_schema = candidate->tablet_schema();
+    compaction._single_rowset_compaction_segment_group_size =
+            config::cloud_single_rowset_compaction_segment_group_size;
+    Compaction::MergeInputRowsetsResult result;
+    ASSERT_TRUE(compaction.prepare_merge_input_rowsets(&result).ok());
+    EXPECT_TRUE(compaction._single_rowset_compaction_segment_group_size.has_value());
+    EXPECT_TRUE(result.is_segment_grouped);
+    EXPECT_EQ(result.segment_group_size, config::cloud_single_rowset_compaction_segment_group_size);
+
+    _tablet_meta->set_compaction_policy(std::string(CUMULATIVE_TIME_SERIES_POLICY));
+    CloudCumulativeCompaction time_series_compaction(_engine, tablet);
+    time_series_compaction._input_rowsets = {candidate};
+    time_series_compaction._cur_tablet_schema = candidate->tablet_schema();
+    Compaction::MergeInputRowsetsResult time_series_result;
+    ASSERT_TRUE(time_series_compaction.prepare_merge_input_rowsets(&time_series_result).ok());
+    EXPECT_FALSE(time_series_compaction._single_rowset_compaction_segment_group_size.has_value());
+    EXPECT_FALSE(time_series_result.is_segment_grouped);
+}
+
+TEST_F(CloudCompactionTest, single_rowset_grouped_compaction_rejects_invalid_group_size) {
+    auto old_enable = config::enable_cloud_single_rowset_compaction;
+    auto old_min_segments = config::cloud_single_rowset_compaction_min_segments;
+    auto old_group_size = config::cloud_single_rowset_compaction_segment_group_size;
+    Defer restore_config {[&] {
+        config::enable_cloud_single_rowset_compaction = old_enable;
+        config::cloud_single_rowset_compaction_min_segments = old_min_segments;
+        config::cloud_single_rowset_compaction_segment_group_size = old_group_size;
+    }};
+    config::enable_cloud_single_rowset_compaction = true;
+    config::cloud_single_rowset_compaction_min_segments = 4;
+    config::cloud_single_rowset_compaction_segment_group_size = 0;
+
+    RowsetSharedPtr candidate = create_rowset(Version(2, 2), 4, true, 1024);
+    ASSERT_TRUE(candidate != nullptr);
+
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(_engine, _tablet_meta);
+    CloudCumulativeCompaction compaction(_engine, tablet);
+    compaction._input_rowsets = {candidate};
+    compaction._cur_tablet_schema = candidate->tablet_schema();
+    compaction._single_rowset_compaction_segment_group_size =
+            config::cloud_single_rowset_compaction_segment_group_size;
+
+    Compaction::MergeInputRowsetsResult result;
+    Status st = compaction.prepare_merge_input_rowsets(&result);
+    EXPECT_TRUE(st.is<ErrorCode::INVALID_ARGUMENT>()) << st;
+    EXPECT_TRUE(st.to_string().find(
+                        "cloud_single_rowset_compaction_segment_group_size must be positive") !=
+                std::string::npos)
+            << st;
+}
+
+TEST_F(CloudCompactionTest, single_rowset_grouped_compaction_uses_selection_snapshot) {
+    auto old_enable = config::enable_cloud_single_rowset_compaction;
+    auto old_min_segments = config::cloud_single_rowset_compaction_min_segments;
+    auto old_group_size = config::cloud_single_rowset_compaction_segment_group_size;
+    Defer restore_config {[&] {
+        config::enable_cloud_single_rowset_compaction = old_enable;
+        config::cloud_single_rowset_compaction_min_segments = old_min_segments;
+        config::cloud_single_rowset_compaction_segment_group_size = old_group_size;
+    }};
+    config::enable_cloud_single_rowset_compaction = true;
+    config::cloud_single_rowset_compaction_min_segments = 4;
+    config::cloud_single_rowset_compaction_segment_group_size = 2;
+
+    std::vector<RowsetSharedPtr> rowsets;
+    auto grouped_rowset = create_rowset(Version(2, 2), 4, true, 1024);
+    ASSERT_TRUE(grouped_rowset != nullptr);
+    rowsets.push_back(grouped_rowset);
+    for (int64_t version = 3; version <= 13; ++version) {
+        auto rowset = create_rowset(Version(version, version), 1, false, 1024);
+        ASSERT_TRUE(rowset != nullptr);
+        rowsets.push_back(std::move(rowset));
+    }
+
+    TabletSchemaPB tablet_schema_pb;
+    grouped_rowset->tablet_schema()->to_schema_pb(&tablet_schema_pb);
+    _tablet_meta->mutable_tablet_schema()->init_from_pb(tablet_schema_pb);
+    _tablet_meta->set_compaction_policy(std::string(CUMULATIVE_SIZE_BASED_POLICY));
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(_engine, _tablet_meta);
+    {
+        std::unique_lock wlock(tablet->get_header_lock());
+        tablet->add_rowsets(std::move(rowsets), false, wlock, false);
+    }
+
+    CloudCumulativeCompaction compaction(_engine, tablet);
+    ASSERT_TRUE(compaction.pick_rowsets_to_compact().ok());
+    ASSERT_EQ(compaction._input_rowsets.size(), 1);
+    EXPECT_EQ(compaction._input_rowsets.front(), grouped_rowset);
+    ASSERT_TRUE(compaction._single_rowset_compaction_segment_group_size.has_value());
+    EXPECT_EQ(*compaction._single_rowset_compaction_segment_group_size, 2);
+
+    config::enable_cloud_single_rowset_compaction = false;
+    config::cloud_single_rowset_compaction_min_segments = 5;
+    config::cloud_single_rowset_compaction_segment_group_size = 3;
+
+    Compaction::MergeInputRowsetsResult result;
+    ASSERT_TRUE(compaction.prepare_merge_input_rowsets(&result).ok());
+    EXPECT_TRUE(compaction._single_rowset_compaction_segment_group_size.has_value());
+    EXPECT_TRUE(result.is_segment_grouped);
+    EXPECT_EQ(result.segment_group_size, 2);
+}
+
+TEST_F(CloudCompactionTest, single_rowset_grouped_compaction_honors_notready_policy_filter) {
+    auto old_enable = config::enable_cloud_single_rowset_compaction;
+    auto old_min_segments = config::cloud_single_rowset_compaction_min_segments;
+    auto old_enable_empty_rowset_compaction = config::enable_empty_rowset_compaction;
+    Defer restore_config {[&] {
+        config::enable_cloud_single_rowset_compaction = old_enable;
+        config::cloud_single_rowset_compaction_min_segments = old_min_segments;
+        config::enable_empty_rowset_compaction = old_enable_empty_rowset_compaction;
+    }};
+    config::enable_cloud_single_rowset_compaction = true;
+    config::cloud_single_rowset_compaction_min_segments = 4;
+    config::enable_empty_rowset_compaction = false;
+
+    std::vector<RowsetSharedPtr> rowsets;
+    // Keep enough older inputs mergeable after the NOTREADY policy filters versions 11 through 20.
+    for (int64_t version = 2; version <= 19; ++version) {
+        auto rowset = create_rowset(Version(version, version), 1, false, 1024);
+        ASSERT_TRUE(rowset != nullptr);
+        rowsets.push_back(std::move(rowset));
+    }
+    auto filtered_grouped_rowset = create_rowset(Version(20, 20), 4, true, 1024);
+    ASSERT_TRUE(filtered_grouped_rowset != nullptr);
+    rowsets.push_back(filtered_grouped_rowset);
+
+    TabletSchemaPB tablet_schema_pb;
+    filtered_grouped_rowset->tablet_schema()->to_schema_pb(&tablet_schema_pb);
+    _tablet_meta->mutable_tablet_schema()->init_from_pb(tablet_schema_pb);
+    _tablet_meta->set_compaction_policy(std::string(CUMULATIVE_SIZE_BASED_POLICY));
+    _tablet_meta->set_tablet_state(TABLET_NOTREADY);
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(_engine, _tablet_meta);
+    tablet->set_alter_version(1);
+    {
+        std::unique_lock wlock(tablet->get_header_lock());
+        tablet->add_rowsets(std::move(rowsets), false, wlock, false);
+    }
+
+    CloudCumulativeCompaction compaction(_engine, tablet);
+    ASSERT_TRUE(compaction.pick_rowsets_to_compact().ok());
+    ASSERT_EQ(compaction._input_rowsets.size(), 9);
+    EXPECT_EQ(compaction._input_rowsets.front()->version(), Version(2, 2));
+    EXPECT_EQ(compaction._input_rowsets.back()->version(), Version(10, 10));
+    EXPECT_FALSE(compaction._single_rowset_compaction_segment_group_size.has_value());
 }
 
 TEST_F(CloudCompactionTest, test_truncate_rowsets_by_txn_size_empty_input) {

--- a/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
+++ b/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
@@ -247,6 +247,25 @@ TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
 }
 
 TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       overlapping_output_uses_policy_to_advance_cumulative_point) {
+    _tablet_meta->set_tablet_state(TABLET_RUNNING);
+    _tablet_meta->set_time_series_compaction_level_threshold(1);
+    CloudTablet tablet(_engine, _tablet_meta);
+    tablet._base_size = 100;
+
+    auto output_rowset = create_rowset(Version(3, 3), 5, true, 256 * kMiB);
+    Version last_delete_version {-1, -1};
+
+    CloudSizeBasedCumulativeCompactionPolicy size_based_policy;
+    EXPECT_EQ(4, size_based_policy.new_cumulative_point(&tablet, output_rowset, last_delete_version,
+                                                        2));
+
+    CloudTimeSeriesCumulativeCompactionPolicy time_series_policy;
+    EXPECT_EQ(4, time_series_policy.new_cumulative_point(&tablet, output_rowset,
+                                                         last_delete_version, 2));
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
        pick_input_rowsets_large_head_not_repeated_when_output_below_promotion) {
     CloudTablet _tablet(_engine, _tablet_meta);
     _tablet._base_size = 20L * kGiB;

--- a/be/test/storage/cloud_file_cache_write_index_only_test.cpp
+++ b/be/test/storage/cloud_file_cache_write_index_only_test.cpp
@@ -699,21 +699,26 @@ TEST_F(CloudFileCacheWriteIndexOnlyTest,
     auto writer_result = RowsetFactory::create_rowset_writer(*_engine, context, true);
     ASSERT_TRUE(writer_result.has_value()) << writer_result.error();
     auto rowset_writer = std::move(writer_result).value();
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 0);
 
     std::vector<uint32_t> key_column_ids = {0};
     auto key_block = create_column_block(tablet_schema, key_column_ids, 8, 1);
     auto st = rowset_writer->add_columns(&key_block, key_column_ids, true, 4, false);
     ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 1);
     auto second_key_block = create_column_block(tablet_schema, key_column_ids, 8, 100);
     st = rowset_writer->add_columns(&second_key_block, key_column_ids, true, 4, false);
     ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 2);
     st = rowset_writer->flush_columns(true);
     ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 2);
 
     std::vector<uint32_t> value_column_ids = {1};
     auto value_block = create_column_block(tablet_schema, value_column_ids, 16, 1);
     st = rowset_writer->add_columns(&value_block, value_column_ids, false, UINT32_MAX, false);
     ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(rowset_writer->get_allocated_segment_id(), 2);
     st = rowset_writer->flush_columns(false);
     ASSERT_TRUE(st.ok()) << st;
     st = rowset_writer->final_flush();

--- a/be/test/storage/rowid_conversion_test.cpp
+++ b/be/test/storage/rowid_conversion_test.cpp
@@ -29,11 +29,16 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <tuple>
 #include <unordered_map>
 
+#include "cloud/cloud_cumulative_compaction.h"
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
+#include "common/config.h"
 #include "common/status.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
@@ -43,7 +48,10 @@
 #include "io/io_common.h"
 #include "json2pb/json_to_pb.h"
 #include "runtime/exec_env.h"
+#include "storage/compaction_task_tracker.h"
 #include "storage/delete/delete_handler.h"
+#include "storage/index/index_writer.h"
+#include "storage/index/inverted/inverted_index_desc.h"
 #include "storage/merger.h"
 #include "storage/options.h"
 #include "storage/rowset/beta_rowset.h"
@@ -55,10 +63,12 @@
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/schema.h"
+#include "storage/segment/segment.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet.h"
 #include "storage/tablet/tablet_meta.h"
 #include "storage/tablet/tablet_schema.h"
+#include "util/defer_op.h"
 #include "util/uid_util.h"
 
 namespace doris {
@@ -80,6 +90,14 @@ protected:
         EXPECT_TRUE(io::global_local_filesystem()
                             ->create_directory(absolute_dir + "/tablet_path")
                             .ok());
+
+        std::vector<StorePath> tmp_paths;
+        tmp_paths.emplace_back(absolute_dir, 1024000000);
+        auto tmp_file_dirs = std::make_unique<segment_v2::TmpFileDirs>(tmp_paths);
+        st = tmp_file_dirs->init();
+        ASSERT_TRUE(st.ok()) << st;
+        ExecEnv::GetInstance()->set_tmp_file_dir(std::move(tmp_file_dirs));
+
         doris::EngineOptions options;
         auto engine = std::make_unique<StorageEngine>(options);
         engine_ref = engine.get();
@@ -87,12 +105,14 @@ protected:
     }
 
     void TearDown() override {
+        ExecEnv::GetInstance()->set_tmp_file_dir(nullptr);
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(absolute_dir).ok());
         engine_ref = nullptr;
         ExecEnv::GetInstance()->set_storage_engine(nullptr);
     }
 
-    TabletSchemaSPtr create_schema(KeysType keys_type = DUP_KEYS) {
+    TabletSchemaSPtr create_schema(KeysType keys_type = DUP_KEYS,
+                                   bool with_inverted_index = false) {
         TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
         TabletSchemaPB tablet_schema_pb;
         tablet_schema_pb.set_keys_type(keys_type);
@@ -134,6 +154,15 @@ protected:
             column_3->set_is_key(false);
             column_3->set_is_nullable(false);
             column_3->set_is_bf_column(false);
+        }
+
+        if (with_inverted_index) {
+            tablet_schema_pb.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::V2);
+            auto* index = tablet_schema_pb.add_index();
+            index->set_index_id(1);
+            index->set_index_name("c2_idx");
+            index->set_index_type(IndexType::INVERTED);
+            index->add_col_unique_id(2);
         }
 
         tablet_schema->init_from_pb(tablet_schema_pb);
@@ -186,7 +215,7 @@ protected:
         }
         auto writer_context = create_rowset_writer_context(tablet_schema, overlap, UINT32_MAX,
                                                            {version, version});
-        auto res = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, true);
+        auto res = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, false);
         EXPECT_TRUE(res.has_value()) << res.error();
         auto rowset_writer = std::move(res).value();
 
@@ -547,6 +576,265 @@ TEST_F(TestRowIdConversion, Basic) {
     RowLocation dst4;
     res = rowid_conversion.get(src4, &dst4);
     EXPECT_EQ(res, -1);
+}
+
+TEST_F(TestRowIdConversion, SingleRowsetGroupedCompactionRowIdConversionIsComplete) {
+    constexpr int64_t num_segments = 5;
+    constexpr int64_t rows_per_segment = 1500;
+    constexpr int64_t segment_group_size = 2;
+    constexpr int32_t schema_version = 1234;
+    constexpr int64_t newest_write_timestamp = 123456789;
+    constexpr int64_t compaction_level = 2;
+    const bool old_enable_compaction_task_tracker = config::enable_compaction_task_tracker;
+    Defer restore_config {
+            [&] { config::enable_compaction_task_tracker = old_enable_compaction_task_tracker; }};
+    config::enable_compaction_task_tracker = true;
+
+    std::vector<std::vector<std::tuple<int64_t, int64_t>>> input_data;
+    for (int64_t segment_id = 0; segment_id < num_segments; ++segment_id) {
+        std::vector<std::tuple<int64_t, int64_t>> segment_data;
+        for (int64_t row_id = 0; row_id < rows_per_segment; ++row_id) {
+            int64_t key = segment_id * rows_per_segment + row_id;
+            segment_data.emplace_back(key, key + 1);
+        }
+        input_data.push_back(std::move(segment_data));
+    }
+
+    CloudStorageEngine cloud_engine(EngineOptions {});
+    for (bool is_vertical : {false, true}) {
+        SCOPED_TRACE(is_vertical ? "vertical merge" : "horizontal merge");
+
+        TabletSchemaSPtr tablet_schema = create_schema(UNIQUE_KEYS, true);
+        tablet_schema->set_schema_version(schema_version);
+        tablet_schema->set_db_id(1000);
+        RowsetSharedPtr input_rowset = create_rowset(tablet_schema, OVERLAPPING, input_data, 2);
+        ASSERT_TRUE(input_rowset != nullptr);
+
+        TabletSharedPtr local_tablet = create_tablet(*tablet_schema, true);
+        auto writer_context = create_rowset_writer_context(
+                tablet_schema, NONOVERLAPPING, rows_per_segment, input_rowset->version());
+        writer_context.db_id = tablet_schema->db_id();
+        writer_context.table_id = local_tablet->table_id();
+        writer_context.tablet_id = local_tablet->tablet_id();
+        writer_context.index_id = local_tablet->index_id();
+        writer_context.partition_id = local_tablet->partition_id();
+        writer_context.tablet_schema_hash = local_tablet->schema_hash();
+        writer_context.tablet_uid = local_tablet->tablet_uid();
+        writer_context.newest_write_timestamp = newest_write_timestamp;
+        writer_context.compaction_level = compaction_level;
+        writer_context.enable_unique_key_merge_on_write = true;
+        auto writer_result =
+                RowsetFactory::create_rowset_writer(*engine_ref, writer_context, is_vertical);
+        ASSERT_TRUE(writer_result.has_value()) << writer_result.error();
+
+        auto cloud_tablet = std::make_shared<CloudTablet>(
+                cloud_engine, std::make_shared<TabletMeta>(*local_tablet->tablet_meta()));
+        CloudCumulativeCompaction compaction(cloud_engine, cloud_tablet);
+        compaction._input_rowsets = {input_rowset};
+        compaction._cur_tablet_schema = tablet_schema;
+        compaction._output_rs_writer = std::move(writer_result).value();
+        compaction._is_vertical = is_vertical;
+        compaction._input_row_num = input_rowset->num_rows();
+        compaction._input_rowsets_data_size = input_rowset->data_disk_size();
+        compaction._stats.rowid_conversion = compaction._rowid_conversion.get();
+
+        auto* compaction_task_tracker = CompactionTaskTracker::instance();
+        CompactionTaskInfo task_info;
+        task_info.compaction_id = compaction.compaction_id();
+        compaction_task_tracker->register_task(std::move(task_info));
+        Defer remove_tracker_task {
+                [compaction_task_tracker, compaction_id = compaction.compaction_id()] {
+                    compaction_task_tracker->remove_task(compaction_id);
+                }};
+
+        Compaction::MergeInputRowsetsResult merge_result;
+        merge_result.is_segment_grouped = true;
+        merge_result.segment_group_size = segment_group_size;
+        ASSERT_TRUE(compaction.do_merge_input_rowsets({}, &merge_result).ok());
+        const int64_t segment_group_count =
+                (num_segments + segment_group_size - 1) / segment_group_size;
+        EXPECT_EQ(merge_result.output_segment_group_count, segment_group_count);
+        if (is_vertical) {
+            constexpr int32_t default_num_columns_per_group = 5;
+            const int32_t num_columns_per_group =
+                    config::vertical_compaction_num_columns_per_group !=
+                                    default_num_columns_per_group
+                            ? config::vertical_compaction_num_columns_per_group
+                            : cloud_tablet->tablet_meta()
+                                      ->vertical_compaction_num_columns_per_group();
+            std::vector<std::vector<uint32_t>> column_groups;
+            std::vector<uint32_t> key_group_cluster_key_idxes;
+            Merger::vertical_split_columns(*tablet_schema, &column_groups,
+                                           &key_group_cluster_key_idxes, num_columns_per_group);
+
+            const auto tracked_tasks = compaction_task_tracker->get_all_tasks();
+            const auto task_it = std::find_if(
+                    tracked_tasks.begin(), tracked_tasks.end(), [&](const auto& tracked_task) {
+                        return tracked_task.compaction_id == compaction.compaction_id();
+                    });
+            ASSERT_NE(task_it, tracked_tasks.end());
+            const int64_t expected_total_groups =
+                    static_cast<int64_t>(column_groups.size()) * segment_group_count;
+            EXPECT_EQ(task_it->vertical_total_groups, expected_total_groups);
+            EXPECT_EQ(task_it->vertical_completed_groups, expected_total_groups);
+        }
+
+        RowsetSharedPtr output_rowset;
+        ASSERT_EQ(Status::OK(), compaction._output_rs_writer->build(output_rowset));
+        ASSERT_TRUE(output_rowset != nullptr);
+        compaction._output_rowset = output_rowset;
+        compaction.update_output_rowset_after_build(merge_result);
+        EXPECT_EQ(compaction._stats.output_rows, input_rowset->num_rows());
+        if (is_vertical) {
+            EXPECT_GT(output_rowset->num_segments(), merge_result.output_segment_group_count);
+        }
+        EXPECT_EQ(output_rowset->rowset_meta()->get_num_segment_rows().size(),
+                  output_rowset->num_segments());
+
+        RowsetReaderContext reader_context;
+        reader_context.tablet_schema = tablet_schema;
+        reader_context.need_ordered_result = false;
+        std::vector<uint32_t> return_columns = {0, 1};
+        auto read_schema = std::make_shared<ReadSchema>(
+                project_columns_by_ordinal(tablet_schema->columns(), return_columns));
+        reader_context.read_schema = read_schema;
+        RowsetReaderSharedPtr output_reader;
+        create_and_init_rowset_reader(output_rowset.get(), reader_context, &output_reader);
+
+        std::vector<std::tuple<int64_t, int64_t>> output_data;
+        Status read_status;
+        do {
+            Block output_block = read_schema->create_read_block();
+            read_status = output_reader->next_batch(&output_block);
+            const auto& columns = output_block.get_columns_with_type_and_name();
+            ASSERT_EQ(columns.size(), return_columns.size());
+            for (size_t row_id = 0; row_id < output_block.rows(); ++row_id) {
+                output_data.emplace_back(columns[0].column->get_int(row_id),
+                                         columns[1].column->get_int(row_id));
+            }
+        } while (read_status.ok());
+        ASSERT_TRUE(read_status.is<END_OF_FILE>()) << read_status;
+        ASSERT_EQ(output_data.size(), input_rowset->num_rows());
+
+        auto beta_rowset = std::dynamic_pointer_cast<BetaRowset>(output_rowset);
+        ASSERT_TRUE(beta_rowset != nullptr);
+        const auto& rowset_meta = output_rowset->rowset_meta();
+        const auto rowset_meta_pb = rowset_meta->get_rowset_pb();
+        const auto& segment_num_rows_from_meta = rowset_meta->get_num_segment_rows();
+
+        EXPECT_EQ(rowset_meta_pb.rowset_id_v2(), writer_context.rowset_id.to_string());
+        EXPECT_EQ(rowset_meta->rowset_id().to_string(), writer_context.rowset_id.to_string());
+
+        EXPECT_EQ(rowset_meta->rowset_type(), BETA_ROWSET);
+        EXPECT_EQ(rowset_meta->rowset_state(), VISIBLE);
+        EXPECT_TRUE(rowset_meta->has_version());
+        EXPECT_EQ(rowset_meta->version(), input_rowset->version());
+        EXPECT_FALSE(rowset_meta->empty());
+        EXPECT_EQ(rowset_meta->num_rows(), input_rowset->num_rows());
+        EXPECT_EQ(rowset_meta->segments_overlap(), OVERLAPPING);
+        EXPECT_TRUE(rowset_meta->is_segments_overlapping());
+
+        ASSERT_TRUE(rowset_meta->tablet_schema() != nullptr);
+        EXPECT_EQ(*rowset_meta->tablet_schema(), *tablet_schema);
+        EXPECT_TRUE(rowset_meta_pb.has_tablet_schema());
+        TabletSchemaPB expected_tablet_schema_pb;
+        tablet_schema->to_schema_pb(&expected_tablet_schema_pb);
+        EXPECT_EQ(rowset_meta_pb.tablet_schema().SerializeAsString(),
+                  expected_tablet_schema_pb.SerializeAsString());
+        EXPECT_EQ(rowset_meta_pb.schema_version(), schema_version);
+        EXPECT_TRUE(rowset_meta_pb.has_has_variant_type_in_schema());
+        EXPECT_FALSE(rowset_meta_pb.has_variant_type_in_schema());
+
+        std::vector<segment_v2::SegmentSharedPtr> output_segments;
+        ASSERT_TRUE(beta_rowset->load_segments(&output_segments).ok());
+        ASSERT_EQ(rowset_meta->num_segments(), output_segments.size());
+        ASSERT_EQ(segment_num_rows_from_meta.size(), output_segments.size());
+
+        const auto& segment_key_bounds_from_meta = rowset_meta->get_segments_key_bounds();
+        EXPECT_FALSE(rowset_meta->is_segments_key_bounds_aggregated());
+        EXPECT_FALSE(rowset_meta->is_segments_key_bounds_truncated());
+        ASSERT_EQ(segment_key_bounds_from_meta.size(), output_segments.size());
+
+        const auto& inverted_index_file_info_from_meta = rowset_meta->inverted_index_file_info();
+        EXPECT_TRUE(rowset_meta_pb.enable_inverted_index_file_info());
+        ASSERT_EQ(inverted_index_file_info_from_meta.size(), output_segments.size());
+
+        EXPECT_FALSE(rowset_meta_pb.enable_segments_file_size());
+        EXPECT_TRUE(rowset_meta_pb.segments_file_size().empty());
+
+        int64_t actual_data_disk_size = 0;
+        int64_t actual_index_disk_size = 0;
+        int64_t actual_num_rows = 0;
+        for (size_t segment_id = 0; segment_id < output_segments.size(); ++segment_id) {
+            EXPECT_EQ(output_segments[segment_id]->id(), segment_id);
+            EXPECT_EQ(segment_num_rows_from_meta[segment_id],
+                      output_segments[segment_id]->num_rows())
+                    << "segment_id=" << segment_id;
+            EXPECT_EQ(segment_key_bounds_from_meta[segment_id].min_key(),
+                      output_segments[segment_id]->min_key())
+                    << "segment_id=" << segment_id;
+            EXPECT_EQ(segment_key_bounds_from_meta[segment_id].max_key(),
+                      output_segments[segment_id]->max_key())
+                    << "segment_id=" << segment_id;
+
+            const auto& index_file_info = inverted_index_file_info_from_meta[segment_id];
+            ASSERT_TRUE(index_file_info.has_index_size()) << "segment_id=" << segment_id;
+            const auto segment_path = output_rowset->segment_path(segment_id);
+            ASSERT_TRUE(segment_path.has_value()) << segment_path.error();
+            int64_t segment_file_size = 0;
+            const auto segment_file_size_status =
+                    rowset_meta->fs()->file_size(segment_path.value(), &segment_file_size);
+            ASSERT_TRUE(segment_file_size_status.ok()) << segment_file_size_status;
+            actual_data_disk_size += segment_file_size;
+            actual_num_rows += output_segments[segment_id]->num_rows();
+
+            const auto index_file_path =
+                    segment_v2::InvertedIndexDescriptor::get_index_file_path_v2(
+                            segment_v2::InvertedIndexDescriptor::get_index_file_path_prefix(
+                                    segment_path.value()));
+            int64_t index_file_size = 0;
+            const auto index_file_size_status =
+                    rowset_meta->fs()->file_size(index_file_path, &index_file_size);
+            ASSERT_TRUE(index_file_size_status.ok()) << index_file_size_status;
+            EXPECT_EQ(index_file_info.index_size(), index_file_size) << "segment_id=" << segment_id;
+            actual_index_disk_size += index_file_size;
+        }
+        EXPECT_EQ(rowset_meta->num_rows(), actual_num_rows);
+        EXPECT_EQ(rowset_meta->data_disk_size(), actual_data_disk_size);
+        EXPECT_EQ(rowset_meta->index_disk_size(), actual_index_disk_size);
+        EXPECT_EQ(rowset_meta->total_disk_size(),
+                  rowset_meta->data_disk_size() + rowset_meta->index_disk_size());
+
+        std::vector<uint32_t> output_segment_num_rows;
+        OlapReaderStatistics reader_stats;
+        ASSERT_TRUE(
+                beta_rowset->get_segment_num_rows(&output_segment_num_rows, false, &reader_stats)
+                        .ok());
+
+        RowIdConversion& rowid_conversion = *compaction._stats.rowid_conversion;
+        EXPECT_EQ(rowid_conversion.get_src_segment_to_id_map().size(), num_segments);
+        EXPECT_EQ(rowid_conversion.get_rowid_conversion_map().size(), num_segments);
+        EXPECT_EQ(rowid_conversion.get_rowid_conversion_map().size(),
+                  rowid_conversion.get_src_segment_to_id_map().size());
+        for (int64_t segment_id = 0; segment_id < num_segments; ++segment_id) {
+            for (int64_t row_id = 0; row_id < rows_per_segment; ++row_id) {
+                RowLocation src(input_rowset->rowset_id(), segment_id, row_id);
+                RowLocation dst;
+                ASSERT_EQ(rowid_conversion.get(src, &dst), 0)
+                        << "segment_id=" << segment_id << ", row_id=" << row_id;
+                ASSERT_LT(dst.segment_id, output_segment_num_rows.size());
+                ASSERT_LT(dst.row_id, output_segment_num_rows[dst.segment_id]);
+
+                size_t output_row_id = dst.row_id;
+                for (uint32_t output_segment_id = 0; output_segment_id < dst.segment_id;
+                     ++output_segment_id) {
+                    output_row_id += output_segment_num_rows[output_segment_id];
+                }
+                ASSERT_LT(output_row_id, output_data.size());
+                EXPECT_EQ(output_data[output_row_id], input_data[segment_id][row_id]);
+            }
+        }
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/regression-test/suites/cloud_p0/compaction/test_cloud_single_rowset_grouped_compaction.groovy
+++ b/regression-test/suites/cloud_p0/compaction/test_cloud_single_rowset_grouped_compaction.groovy
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_cloud_single_rowset_grouped_compaction", "docker") {
+    def options = new ClusterOptions()
+    options.cloudMode = true
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.enableDebugPoints()
+    int initialSegmentGroupSize = 2
+    long compactionTimeoutMs = 90000L
+    options.beConfigs += [
+        "doris_scanner_row_bytes=1",
+        "enable_cloud_single_rowset_compaction=true",
+        "cloud_single_rowset_compaction_min_segments=2",
+        "cloud_single_rowset_compaction_segment_group_size=${initialSegmentGroupSize}",
+        "disable_auto_compaction=true",
+        "enable_java_support=false"
+    ]
+
+    docker(options) {
+        def showTablet = { tableName, beHost, bePort, tabletId ->
+            sql "SELECT COUNT(*) FROM ${tableName}"
+            def (code, out, err) = be_show_tablet_status(beHost, bePort, tabletId)
+            logger.info("Show tablet status: code=${code}, out=${out}, err=${err}")
+            assertEquals(0, code)
+            return parseJson(out.trim())
+        }
+
+        def rowsetByVersion = { tabletJson, int version ->
+            def rowset = tabletJson.rowsets.find { it.startsWith("[${version}-${version}] ") }
+            assertNotNull(rowset)
+            return rowset
+        }
+
+        def parseRowsetInfo = { rowset ->
+            def matcher = rowset =~ /\[[0-9]+-[0-9]+\]\s+([0-9]+)\s+DATA\s+([A-Z_]+)/
+            assertTrue(matcher.find(), "unexpected rowset format: ${rowset}")
+            return [segments: matcher.group(1).toInteger(), overlap: matcher.group(2)]
+        }
+
+        def waitForCompaction = { beHost, bePort, tabletId, timeoutMs ->
+            long deadline = System.currentTimeMillis() + timeoutMs
+            def lastStatus = null
+            while (System.currentTimeMillis() < deadline) {
+                def (code, out, err) = be_get_compaction_status(beHost, bePort, tabletId)
+                logger.info("Get compaction status: code=${code}, out=${out}, err=${err}")
+                assertEquals(0, code)
+                lastStatus = parseJson(out.trim())
+                assertEquals("success", lastStatus.status.toLowerCase())
+                if (!lastStatus.run_status) {
+                    return
+                }
+                Thread.sleep(1000)
+            }
+            assertTrue(false, "compaction did not finish on ${beHost}:${bePort}, " +
+                    "tablet=${tabletId}, timeoutMs=${timeoutMs}, last=${lastStatus}")
+        }
+
+        def readPointRows = { String tableName ->
+            def pointResult = sql "SELECT k, v FROM ${tableName} WHERE k = 100 ORDER BY v"
+            return pointResult.collect { row -> row.collect { column -> column.toString() } }
+        }
+
+        def checkPointRows = { String tableName, List<List<String>> expectedPointRows ->
+            def pointRows = readPointRows(tableName)
+            if (expectedPointRows != null) {
+                assertEquals(expectedPointRows, pointRows)
+            }
+            return pointRows
+        }
+
+        def checkSingleRowsetGroupedCompaction = {
+                String tableName, String keyType, String valueColumn, String extraProperties,
+                int segmentGroupSize, int rowsPerLoadRound, int expectedRows,
+                List<List<String>> expectedPointRows, boolean expectMultipleOutputSegmentsPerGroup ->
+            sql "DROP TABLE IF EXISTS ${tableName}"
+            sql """
+                CREATE TABLE ${tableName} (
+                    k INT,
+                    ${valueColumn}
+                )
+                ${keyType}(k)
+                DISTRIBUTED BY HASH(k) BUCKETS 1
+                PROPERTIES (
+                    "replication_num" = "1",
+                    "disable_auto_compaction" = "true"${extraProperties}
+                )
+            """
+
+            StringBuilder content = new StringBuilder()
+            for (int i = 0; i < 2; i++) {
+                (1..rowsPerLoadRound).each {
+                    content.append("${it},${it + i}\n")
+                }
+            }
+            streamLoad {
+                table "${tableName}"
+                set "column_separator", ","
+                inputStream new ByteArrayInputStream(content.toString().getBytes())
+                time 30000
+                check { result, exception, startTime, endTime ->
+                    if (exception != null) {
+                        throw exception
+                    }
+                    def json = parseJson(result)
+                    assertEquals("success", json.Status.toLowerCase())
+                    assertEquals(rowsPerLoadRound * 2, json.NumberTotalRows)
+                    assertEquals(0, json.NumberFilteredRows)
+                }
+            }
+            sql "sync"
+
+            def pointRowsBeforeCompaction = checkPointRows(tableName, expectedPointRows)
+            if (expectedPointRows == null) {
+                assertEquals(1, pointRowsBeforeCompaction.size())
+            }
+
+            def tablets = sql_return_maparray "SHOW TABLETS FROM ${tableName}"
+            assertEquals(1, tablets.size())
+            def tabletId = tablets[0].TabletId
+            def backendId = tablets[0].BackendId
+            def backends = sql_return_maparray "SHOW BACKENDS"
+            def backend = backends.find { it.BackendId == backendId }
+            assertNotNull(backend)
+
+            def before = showTablet(tableName, backend.Host, backend.HttpPort, tabletId)
+            def inputRowset = rowsetByVersion(before, 2)
+            def inputInfo = parseRowsetInfo(inputRowset)
+            assertEquals("OVERLAPPING", inputInfo.overlap)
+            assertTrue(inputInfo.segments >= 3, inputRowset)
+
+            def (code, out, err) =
+                    be_run_cumulative_compaction(backend.Host, backend.HttpPort, tabletId)
+            logger.info("Run compaction: code=${code}, out=${out}, err=${err}")
+            assertEquals(0, code)
+            def compactJson = parseJson(out.trim())
+            assertEquals("success", compactJson.status.toLowerCase())
+            waitForCompaction(backend.Host, backend.HttpPort, tabletId, compactionTimeoutMs)
+
+            def after = showTablet(tableName, backend.Host, backend.HttpPort, tabletId)
+            def outputRowset = rowsetByVersion(after, 2)
+            def outputInfo = parseRowsetInfo(outputRowset)
+            assertEquals("OVERLAPPING", outputInfo.overlap)
+            def expectedOutputSegments =
+                    (inputInfo.segments + segmentGroupSize - 1).intdiv(segmentGroupSize)
+            if (expectMultipleOutputSegmentsPerGroup) {
+                assertTrue(outputInfo.segments > expectedOutputSegments, outputRowset)
+            } else {
+                assertEquals(expectedOutputSegments, outputInfo.segments)
+            }
+            def countResult = sql "SELECT COUNT(*) FROM ${tableName}"
+            assertEquals(expectedRows, countResult[0][0])
+            if (expectedPointRows != null) {
+                checkPointRows(tableName, expectedPointRows)
+            } else {
+                def pointRowsAfterCompaction = checkPointRows(tableName, null)
+                if (pointRowsAfterCompaction != pointRowsBeforeCompaction) {
+                    logger.warn("Point query result changed after single rowset grouped compaction" +
+                            ", table=${tableName}, before=${pointRowsBeforeCompaction}" +
+                            ", after=${pointRowsAfterCompaction}")
+                }
+            }
+        }
+
+        GetDebugPoint().clearDebugPointsForAllBEs()
+
+        try {
+            GetDebugPoint().enableDebugPointForAllBEs("MemTable.need_flush")
+
+            [2, 4].each { int segmentGroupSize ->
+                set_be_param("cloud_single_rowset_compaction_segment_group_size",
+                        segmentGroupSize.toString())
+
+                checkSingleRowsetGroupedCompaction(
+                        "test_cloud_single_rowset_grouped_compaction_g${segmentGroupSize}_dup",
+                        "DUPLICATE KEY", "v INT", "", segmentGroupSize, 8192, 8192 * 2,
+                        [["100", "100"], ["100", "101"]], false)
+                checkSingleRowsetGroupedCompaction(
+                        "test_cloud_single_rowset_grouped_compaction_g${segmentGroupSize}_agg",
+                        "AGGREGATE KEY", "v INT SUM", "", segmentGroupSize, 8192, 8192,
+                        [["100", "201"]], false)
+                checkSingleRowsetGroupedCompaction(
+                        "test_cloud_single_rowset_grouped_compaction_g${segmentGroupSize}_mow",
+                        "UNIQUE KEY", "v INT",
+                        ", \"enable_unique_key_merge_on_write\" = \"true\"", segmentGroupSize, 8192,
+                        8192, [["100", "101"]], false)
+                checkSingleRowsetGroupedCompaction(
+                        "test_cloud_single_rowset_grouped_compaction_g${segmentGroupSize}_mor",
+                        "UNIQUE KEY", "v INT",
+                        ", \"enable_unique_key_merge_on_write\" = \"false\"", segmentGroupSize,
+                        8192, 8192, null, false)
+            }
+
+            set_be_param("cloud_single_rowset_compaction_segment_group_size",
+                    initialSegmentGroupSize.toString())
+            set_be_param("vertical_compaction_max_segment_size", "2048")
+            set_be_param("compaction_batch_size", "512")
+            checkSingleRowsetGroupedCompaction(
+                    "test_cloud_single_rowset_grouped_compact_multi_seg_dup",
+                    "DUPLICATE KEY", "v INT", "", initialSegmentGroupSize, 32768, 32768 * 2,
+                    [["100", "100"], ["100", "101"]], true)
+        } finally {
+            GetDebugPoint().clearDebugPointsForAllBEs()
+        }
+    }
+}


### PR DESCRIPTION
Cloud mode does not support seg compaction. If one rowset has too many segments, the compaction may consume much memory. 
This pr support compacting one rowset which has more than `cloud_single_rowset_compaction_min_segments` segments by compacting every `cloud_single_rowset_compaction_segment_group_size` segments.
For example, compact `seg0 - seg63` first, then `seg64 - seg127` and so on.
If the segment group is more than 1, the output rowset is still `OVERLAPPING`. 
This kind of compaction does not calculate cu_point.