### PR TITLE
[fix](be) Fix mismatched format arguments

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -202,8 +202,8 @@ void alter_tablet(StorageEngine& engine, const TAgentTaskRequest& agent_task_req
                 MemTrackerLimiter::Type::SCHEMA_CHANGE,
                 fmt::format("EngineAlterTabletTask#baseTabletId={}:newTabletId={}",
                             std::to_string(agent_task_req.alter_tablet_req_v2.base_tablet_id),
-                            std::to_string(agent_task_req.alter_tablet_req_v2.new_tablet_id),
-                            engine.memory_limitation_bytes_per_thread_for_schema_change()));
+                            std::to_string(agent_task_req.alter_tablet_req_v2.new_tablet_id)),
+                engine.memory_limitation_bytes_per_thread_for_schema_change());
         SCOPED_ATTACH_TASK(mem_tracker);
         DorisMetrics::instance()->create_rollup_requests_total->increment(1);
         Status res = Status::OK();
@@ -277,8 +277,8 @@ void alter_cloud_tablet(CloudStorageEngine& engine, const TAgentTaskRequest& age
             MemTrackerLimiter::Type::SCHEMA_CHANGE,
             fmt::format("EngineAlterTabletTask#baseTabletId={}:newTabletId={}",
                         std::to_string(agent_task_req.alter_tablet_req_v2.base_tablet_id),
-                        std::to_string(agent_task_req.alter_tablet_req_v2.new_tablet_id),
-                        engine.memory_limitation_bytes_per_thread_for_schema_change()));
+                        std::to_string(agent_task_req.alter_tablet_req_v2.new_tablet_id)),
+            engine.memory_limitation_bytes_per_thread_for_schema_change());
     SCOPED_ATTACH_TASK(mem_tracker);
     DorisMetrics::instance()->create_rollup_requests_total->increment(1);
 

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -101,7 +101,7 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
                      << request.base_tablet_id;
         return Status::Error<TRY_LOCK_FAILED>(
                 "Failed to obtain schema change lock, there might be inverted index being "
-                "built on base_tablet=",
+                "built on base_tablet={}",
                 request.base_tablet_id);
     }
     // MUST sync rowsets before capturing rowset readers and building DeleteHandler

--- a/be/src/core/data_type_serde/data_type_struct_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_struct_serde.cpp
@@ -158,7 +158,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
                 }
                 return Status::InvalidArgument(
                         "Actual struct field number {} is more than schema field number {}.",
-                        field_pos, elem_size);
+                        field_pos + 1, elem_size);
             }
             if (elem_names[field_pos] != next) {
                 // we should do column revert if error
@@ -188,7 +188,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
                 }
                 return Status::InvalidArgument(
                         "Actual struct field number {} is more than schema field number {}.",
-                        field_pos, elem_size);
+                        field_pos + 1, elem_size);
             }
             if (Status st = elem_serdes_ptrs[field_pos]->deserialize_one_cell_from_json(
                         struct_column.get_column(field_pos), next, options);
@@ -218,8 +218,8 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
                 struct_column.get_column(j).pop_back(1);
             }
             return Status::InvalidArgument(
-                    "Actual struct field number {} is more than schema field number {}.", field_pos,
-                    elem_size);
+                    "Actual struct field number {} is more than schema field number {}.",
+                    field_pos + 1, elem_size);
         }
         if (Status st = elem_serdes_ptrs[field_pos]->deserialize_one_cell_from_json(
                     struct_column.get_column(field_pos), next, options);

--- a/be/src/core/data_type_serde/data_type_struct_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_struct_serde.cpp
@@ -157,7 +157,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
                     struct_column.get_column(j).pop_back(1);
                 }
                 return Status::InvalidArgument(
-                        "Actual struct field number is more than schema field number {}.",
+                        "Actual struct field number {} is more than schema field number {}.",
                         field_pos, elem_size);
             }
             if (elem_names[field_pos] != next) {
@@ -187,7 +187,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
                     struct_column.get_column(j).pop_back(1);
                 }
                 return Status::InvalidArgument(
-                        "Actual struct field number is more than schema field number {}.",
+                        "Actual struct field number {} is more than schema field number {}.",
                         field_pos, elem_size);
             }
             if (Status st = elem_serdes_ptrs[field_pos]->deserialize_one_cell_from_json(
@@ -218,7 +218,7 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
                 struct_column.get_column(j).pop_back(1);
             }
             return Status::InvalidArgument(
-                    "Actual struct field number is more than schema field number {}.", field_pos,
+                    "Actual struct field number {} is more than schema field number {}.", field_pos,
                     elem_size);
         }
         if (Status st = elem_serdes_ptrs[field_pos]->deserialize_one_cell_from_json(

--- a/be/src/exec/operator/exchange_sink_operator.cpp
+++ b/be/src/exec/operator/exchange_sink_operator.cpp
@@ -596,7 +596,7 @@ std::string ExchangeSinkLocalState::debug_string(int indentation_level) const {
     fmt::format_to(debug_string_buffer, "{}", Base::debug_string(indentation_level));
     if (_sink_buffer) {
         fmt::format_to(debug_string_buffer,
-                       ", Sink Buffer: (_is_finishing = {}, blocks in queue: {}, queue capacity: "
+                       ", Sink Buffer: (_is_failed = {}, blocks in queue: {}, queue capacity: "
                        "{}, queue dep: {}), _reach_limit: {}, working channels: {}, total "
                        "channels: {}, remote channels: {}, each queue size: {}",
                        _sink_buffer->_is_failed.load(), _sink_buffer->_total_queue_size,

--- a/be/src/exec/pipeline/pipeline_task.cpp
+++ b/be/src/exec/pipeline/pipeline_task.cpp
@@ -951,7 +951,7 @@ std::string PipelineTask::debug_string() {
 
     fmt::format_to(debug_string_buffer,
                    "PipelineTask[id = {}, open = {}, eos = {}, state = {}, dry run = "
-                   "{}, _wake_up_early = {}, _wake_up_by = {}, time elapsed since last state "
+                   "{}, _wake_up_early = {}, _wake_by = {}, time elapsed since last state "
                    "changing = {}s, spilling = {}, is running = {}]",
                    _index, _opened, _eos, _to_string(_exec_state), _dry_run, _wake_up_early.load(),
                    _wake_by, _state_change_watcher.elapsed_time() / NANOS_PER_SEC, _spilling,

--- a/be/src/exec/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_mgr.cpp
@@ -615,7 +615,7 @@ Status RuntimeFilterMergeControllerEntity::_send_rf_to_target(
     }
 
     if (cnt_val.done) {
-        return Status::InternalError("Runtime filter has been sent",
+        return Status::InternalError("Runtime filter has been sent, filter: {}",
                                      cnt_val.merger->debug_string());
     }
     cnt_val.done = true;

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -528,8 +528,9 @@ std::string ScannerContext::debug_string() {
     return fmt::format(
             "_query_id: {}, id: {}, total scanners: {}, pending tasks: {}, completed tasks: {},"
             " _should_stop: {}, _is_finished: {}, free blocks: {},"
-            " limit: {}, _in_flight_tasks_num: {}, remaining_limit: {}, _num_running_scanners: {}, "
-            "_max_thread_num: {},"
+            " limit: {}, remaining_limit: {}, _in_flight_tasks_num: {}, "
+            "_num_finished_scanners: {}, "
+            "_max_scan_concurrency: {},"
             " _max_bytes_in_queue: {}, _ins_idx: {}, _enable_adaptive_scanners: {}, "
             "_mem_share_arb: {}, _scanner_mem_limiter: {}",
             print_id(_query_id), ctx_id, _all_scanners.size(), _pending_tasks.size(),

--- a/be/src/exec/sink/writer/varrow_flight_result_writer.cpp
+++ b/be/src/exec/sink/writer/varrow_flight_result_writer.cpp
@@ -90,10 +90,11 @@ Status ArrowFlightResultBlockBuffer::get_schema(std::shared_ptr<arrow::Schema>* 
     }
 
     if (_is_close) {
-        return Status::RuntimeError(fmt::format("Closed ()", print_id(_fragment_id)));
+        return Status::RuntimeError(fmt::format("Closed (fragment_id={})", print_id(_fragment_id)));
     }
-    return Status::InternalError(fmt::format("Get Arrow Schema Abnormal Ending (), ()",
-                                             print_id(_fragment_id), _status));
+    return Status::InternalError(
+            fmt::format("Get Arrow Schema Abnormal Ending (fragment_id={}), status=({})",
+                        print_id(_fragment_id), _status));
 }
 
 Status ArrowFlightResultBlockBuffer::get_arrow_batch(std::shared_ptr<Block>* result) {
@@ -138,7 +139,8 @@ Status ArrowFlightResultBlockBuffer::get_arrow_batch(std::shared_ptr<Block>* res
         return Status::OK();
     }
     return Status::InternalError(
-            fmt::format("Get Arrow Batch Abnormal Ending (), ()", print_id(_fragment_id), _status));
+            fmt::format("Get Arrow Batch Abnormal Ending (fragment_id={}), status=({})",
+                        print_id(_fragment_id), _status));
 }
 
 VArrowFlightResultWriter::VArrowFlightResultWriter(std::shared_ptr<ResultBlockBufferBase> sinker,

--- a/be/src/exprs/function/math.cpp
+++ b/be/src/exprs/function/math.cpp
@@ -449,7 +449,7 @@ private:
                 check_and_get_column<ColumnInt64>(block.get_by_position(arguments[0]).column.get());
         if (!data_col) {
             return Status::InternalError(
-                    "Unexpected column '%s' for argument of function %s",
+                    "Unexpected column '{}' for argument of function {}",
                     block.get_by_position(arguments[0]).column->get_name().c_str(), get_name());
         }
 

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -2208,7 +2208,7 @@ Status OrcReader::_orc_column_to_doris_column(
                                                                   converter::FileFormat::ORC);
             if (!converter->support()) {
                 return Status::InternalError(
-                        "The column type of '{}' has changed and is not supported: ", col_name,
+                        "The column type of '{}' has changed and is not supported: {}", col_name,
                         converter->get_error_msg());
             }
             // reuse the cached converter

--- a/be/src/information_schema/schema_encryption_keys_scanner.cpp
+++ b/be/src/information_schema/schema_encryption_keys_scanner.cpp
@@ -21,7 +21,6 @@
 #include <gen_cpp/FrontendService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
 #include <gen_cpp/olap_file.pb.h>
-#include <thrift/protocol/TDebugProtocol.h>
 
 #include <cstdint>
 #include <string>
@@ -72,8 +71,7 @@ Status SchemaEncryptionKeysScanner::start(RuntimeState* state) {
     for (const auto& tk : result.master_keys) {
         EncryptionKeyPB pb;
         if (!pb.ParseFromString(tk.key_pb)) {
-            return Status::InternalError("Parse master key error, master_key=",
-                                         apache::thrift::ThriftDebugString(tk));
+            return Status::InternalError("Parse master key error");
         }
         _master_keys.emplace_back(std::move(pb));
     }

--- a/be/src/information_schema/schema_processlist_scanner.cpp
+++ b/be/src/information_schema/schema_processlist_scanner.cpp
@@ -144,7 +144,8 @@ Status SchemaProcessListScanner::_fill_block_impl(Block* block) {
                             {column_value.data(), column_value.size()}, *dv, nullptr, -1, params)) {
                     return Status::InternalError(
                             "process list meet invalid data, column={}, data={}, reason={}",
-                            _s_processlist_columns[col_idx].name, column_value);
+                            _s_processlist_columns[col_idx].name, column_value,
+                            "failed to parse datetime");
                 }
                 datas[row_idx] = &int_vals[row_idx];
             } else {

--- a/be/src/io/fs/broker_file_reader.cpp
+++ b/be/src/io/fs/broker_file_reader.cpp
@@ -96,7 +96,7 @@ Status BrokerFileReader::close() {
 Status BrokerFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                       const IOContext* /*io_ctx*/) {
     if (closed()) [[unlikely]] {
-        return Status::InternalError("read closed file: ", _path.native());
+        return Status::InternalError("read closed file: {}", _path.native());
     }
 
     size_t bytes_req = result.size;

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -191,7 +191,7 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
 Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                        const IOContext* /*io_ctx*/) {
     if (closed()) [[unlikely]] {
-        return Status::InternalError("read closed file: ", _path.native());
+        return Status::InternalError("read closed file: {}", _path.native());
     }
 
     if (offset > _handle->file_size()) {

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -151,7 +151,7 @@ Status LocalFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_
     TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileReader::read_at_impl",
                                       Status::IOError("inject io error"));
     if (closed()) [[unlikely]] {
-        return Status::InternalError("read closed file: ", _path.native());
+        return Status::InternalError("read closed file: {}", _path.native());
     }
 
     if (offset > _file_size) {
@@ -203,7 +203,7 @@ Status LocalFileReader::read_at_iobuf_impl(size_t offset, size_t bytes_req, buti
         return Status::InvalidArgument("read_at_iobuf requires non-null out and bytes_read");
     }
     if (closed()) [[unlikely]] {
-        return Status::InternalError("read closed file: ", _path.native());
+        return Status::InternalError("read closed file: {}", _path.native());
     }
 
     if (offset > _file_size) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -931,7 +931,7 @@ void FragmentMgr::_collect_invalid_queries(
                                 "Coordinator {}:{} is not found, but its host is still "
                                 "running with an unstable brpc port, not going to "
                                 "cancel "
-                                "it.",
+                                "it, query_id={}.",
                                 q_ctx->coord_addr.hostname, q_ctx->coord_addr.port,
                                 print_id(q_ctx->query_id()));
                         continue;

--- a/be/src/service/http/action/check_rpc_channel_action.cpp
+++ b/be/src/service/http/action/check_rpc_channel_action.cpp
@@ -66,7 +66,7 @@ void CheckRPCChannelAction::handle(HttpRequest* req) {
             return;
         }
     } catch (const std::exception& e) {
-        std::string err = fmt::format("invalid argument. port: {0}, payload_size: {1}, reason: {}",
+        std::string err = fmt::format("invalid argument. port: {}, payload_size: {}, reason: {}",
                                       req_port, req_payload_size, e.what());
         LOG(WARNING) << err;
         HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, err);

--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -766,8 +766,8 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         auto it = policy_map.find(policy_name);
         if (it == policy_map.end()) {
             return Status::InvalidArgument(
-                    "Invalid partial_update_new_key_behavior {}, must be one of {'APPEND', "
-                    "'ERROR'}",
+                    "Invalid partial_update_new_key_behavior {}, must be one of {{'APPEND', "
+                    "'ERROR'}}",
                     policy_name);
         }
         request.__set_partial_update_new_key_policy(it->second);

--- a/be/src/storage/delete/delete_bitmap_calculator.cpp
+++ b/be/src/storage/delete/delete_bitmap_calculator.cpp
@@ -91,7 +91,7 @@ Status MergeIndexDeleteBitmapCalculatorContext::_next_batch(uint32_t row_id) {
     size_t num_read = num_to_read;
     RETURN_IF_ERROR(_iter->next_batch(&num_read, _index_column));
     DCHECK(num_to_read == num_read) << fmt::format(
-            "num_to_read: {} should be equal to num_to_read: {}", num_to_read, num_read);
+            "num_to_read: {} should be equal to num_read: {}", num_to_read, num_read);
     _block_size = num_read;
     _cur_pos = 0;
     _cur_row_id = row_id;

--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -666,7 +666,7 @@ Status Segment::_parse_footer(std::shared_ptr<SegmentFooterPB>& footer, OlapRead
         }
         return Status::Corruption(
                 "Bad segment file {}: file_size = {}, failed to parse SegmentFooterPB, "
-                "cache_key: ",
+                "cache_key: {}",
                 _file_reader->path().native(), file_size,
                 file_cache_key_str(_file_reader->path().native()));
     }

--- a/be/src/storage/segment/segment_writer.cpp
+++ b/be/src/storage/segment/segment_writer.cpp
@@ -206,11 +206,11 @@ Status SegmentWriter::_create_column_writer(uint32_t cid, const TabletColumn& co
         auto gram_size = tablet_index->get_gram_size();
         auto gram_bf_size = tablet_index->get_gram_bf_size();
         if (gram_size > 256 || gram_size < 1) {
-            return Status::NotSupported("Do not support ngram bloom filter for ngram_size: ",
+            return Status::NotSupported("Do not support ngram bloom filter for ngram_size: {}",
                                         gram_size);
         }
         if (gram_bf_size > 65535 || gram_bf_size < 64) {
-            return Status::NotSupported("Do not support ngram bloom filter for bf_size: ",
+            return Status::NotSupported("Do not support ngram bloom filter for bf_size: {}",
                                         gram_bf_size);
         }
         opts.gram_size = cast_set<uint8_t>(gram_size);

--- a/be/src/storage/segment/variant/binary_column_reader.cpp
+++ b/be/src/storage/segment/variant/binary_column_reader.cpp
@@ -119,7 +119,8 @@ Status MultipleBinaryColumnReader::new_binary_column_iterator(ColumnIteratorUPtr
     iters.reserve(_multiple_column_readers.size());
     for (const auto& [index, reader] : _multiple_column_readers) {
         if (!reader) {
-            return Status::NotFound("No column reader available, binary column index is: ", index);
+            return Status::NotFound("No column reader available, binary column index is: {}",
+                                    index);
         }
         ColumnIteratorUPtr it;
         RETURN_IF_ERROR(reader->new_iterator(&it, nullptr));
@@ -133,7 +134,7 @@ Status MultipleBinaryColumnReader::add_binary_column_reader(std::shared_ptr<Colu
                                                             uint32_t index) {
     if (_multiple_column_readers.find(index) != _multiple_column_readers.end()) {
         return Status::AlreadyExist(
-                "Multiple sparse column reader already exists, binary column index is: ", index);
+                "Multiple sparse column reader already exists, binary column index is: {}", index);
     }
     _multiple_column_readers.emplace(index, std::move(reader));
     return Status::OK();

--- a/be/src/storage/segment/vertical_segment_writer.cpp
+++ b/be/src/storage/segment/vertical_segment_writer.cpp
@@ -215,11 +215,11 @@ Status VerticalSegmentWriter::_create_column_writer(uint32_t cid, const TabletCo
         auto gram_size = tablet_index->get_gram_size();
         auto gram_bf_size = tablet_index->get_gram_bf_size();
         if (gram_size > 256 || gram_size < 1) {
-            return Status::NotSupported("Do not support ngram bloom filter for ngram_size: ",
+            return Status::NotSupported("Do not support ngram bloom filter for ngram_size: {}",
                                         gram_size);
         }
         if (gram_bf_size > 65535 || gram_bf_size < 64) {
-            return Status::NotSupported("Do not support ngram bloom filter for bf_size: ",
+            return Status::NotSupported("Do not support ngram bloom filter for bf_size: {}",
                                         gram_bf_size);
         }
         opts.gram_size = cast_set<uint8_t>(gram_size);

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -168,7 +168,7 @@ Status TxnManager::prepare_txn(TPartitionId partition_id, TTransactionId transac
     txn_partition_map_t& txn_partition_map = _get_txn_partition_map(transaction_id);
     if (txn_partition_map.size() > config::max_runnings_transactions_per_txn_map) {
         return Status::Error<TOO_MANY_TRANSACTIONS>("too many transactions: {}, limit: {}",
-                                                    txn_tablet_map.size(),
+                                                    txn_partition_map.size(),
                                                     config::max_runnings_transactions_per_txn_map);
     }
 

--- a/be/test/common/status_test.cpp
+++ b/be/test/common/status_test.cpp
@@ -156,4 +156,16 @@ TEST_F(StatusTest /*unused*/, Format /*unused*/) {
     EXPECT_TRUE(fmt::format("{}", st_error).compare(fmt::format("{}", st_error.to_string())) == 0);
 }
 
+TEST_F(StatusTest, RuntimeFormatMismatch) {
+    EXPECT_THROW(static_cast<void>(Status::InternalError("left={}, right={}", 1)),
+                 fmt::format_error);
+
+    EXPECT_THROW(static_cast<void>(Status::InvalidArgument("value={}, allowed={'APPEND', 'ERROR'}",
+                                                           "UNKNOWN")),
+                 fmt::format_error);
+
+    Status status = Status::InternalError("value={}", 1, 2);
+    EXPECT_EQ(status.msg(), "value=1");
+}
+
 } // namespace doris

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -749,7 +749,7 @@ int InstanceRecycler::init_storage_vault_accessors() {
         LOG(WARNING) << "no accessors for instance=" << instance_id_;
         return -2;
     }
-    LOG_INFO("finish init instance recycler number_accessors={} instance=", accessor_map_.size(),
+    LOG_INFO("finish init instance recycler number_accessors={} instance={}", accessor_map_.size(),
              instance_id_);
 
     return 0;

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -207,7 +207,8 @@ std::optional<S3Conf> S3Conf::from_obj_store_info(const ObjectStoreInfoPB& obj_i
         s3_conf.provider = S3Conf::AZURE;
         break;
     default:
-        LOG_WARNING("unknown provider type {}").tag("obj_info", proto_to_json(obj_info));
+        LOG_WARNING("unknown provider type {}", static_cast<int>(obj_info.provider()))
+                .tag("obj_info", proto_to_json(obj_info));
         return std::nullopt;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Several runtime format strings had missing, extra, reordered, or mixed-index arguments. These issues could throw `fmt::format_error`, omit diagnostic values, and pass the schema change memory limit to `fmt::format` instead of `MemTrackerLimiter`.

Root cause: fmt 7 allows unused arguments, while Doris `Status` formats runtime `std::string_view` values, so these mismatches were not caught at compile time. This change aligns the format strings and arguments, restores the task-level memory limit for normal and cloud schema changes, and avoids logging master-key contents on parse failures.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

