### PR TITLE
[fix](runtime-filter) Preserve query semantics during partition pruning

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifier.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.Monotonic;
+import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanNode;
@@ -78,6 +79,9 @@ final class RuntimeFilterPartitionPruneClassifier {
         }
         if (hasUnsupportedAutomaticPartitionExpression(partitionInfo)) {
             return Classification.unsupported("automatic partition expression boundary is not modeled");
+        }
+        if (nereidsTargetExpr.containsType(NoneMovableFunction.class)) {
+            return Classification.unsupported("target expression contains non-movable function");
         }
 
         if (targetExpr instanceof SlotRef) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/RuntimeFilterPartitionPruneClassifierTest.java
@@ -17,9 +17,14 @@
 
 package org.apache.doris.nereids.glue.translator;
 
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
+import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotId;
 import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ListPartitionItem;
@@ -29,9 +34,13 @@ import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RangePartitionItem;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.Monotonic;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.AssertTrue;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateTrunc;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.IntegerType;
@@ -45,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Map;
+import java.util.function.Function;
 
 class RuntimeFilterPartitionPruneClassifierTest {
     @Test
@@ -94,8 +104,32 @@ class RuntimeFilterPartitionPruneClassifierTest {
         assertSupportedIncreasingPartitions(classification);
     }
 
+    @Test
+    void testRejectNoneMovableListTargetExpression() {
+        RuntimeFilterPartitionPruneClassifier.Classification classification = classify(
+                TRuntimeFilterType.IN, PartitionType.LIST, ListPartitionItem.DUMMY_ITEM,
+                targetSlot -> new FunctionCallExpr("assert_true", ImmutableList.of(
+                        new BinaryPredicate(BinaryPredicate.Operator.NE, targetSlot, new IntLiteral(0)),
+                        new StringLiteral("rfpp_expr_in_only_error")), false),
+                targetSlot -> new AssertTrue(
+                        new GreaterThan(targetSlot, new IntegerLiteral(0)),
+                        new VarcharLiteral("rfpp_expr_in_only_error")));
+
+        Assertions.assertFalse(classification.canPrunePartitions());
+        Assertions.assertTrue(classification.getUnsupportedReason().contains("non-movable"));
+        Assertions.assertTrue(classification.getPartitionMonotonicity().isEmpty());
+    }
+
     private RuntimeFilterPartitionPruneClassifier.Classification classify(
             TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem) {
+        return classify(filterType, partitionType, partitionItem, targetSlot -> targetSlot,
+                targetSlot -> targetSlot);
+    }
+
+    private RuntimeFilterPartitionPruneClassifier.Classification classify(
+            TRuntimeFilterType filterType, PartitionType partitionType, PartitionItem partitionItem,
+            Function<SlotRef, Expr> legacyTargetFactory,
+            Function<SlotReference, Expression> nereidsTargetFactory) {
         Column partitionColumn = new Column("part_col", PrimitiveType.INT);
         SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(1), new TupleId(1));
         slotDescriptor.setColumn(partitionColumn);
@@ -114,7 +148,8 @@ class RuntimeFilterPartitionPruneClassifierTest {
         Mockito.when(partitionInfo.getItem(1L)).thenReturn(partitionItem);
         Mockito.when(partitionInfo.getItem(2L)).thenReturn(partitionItem);
 
-        return RuntimeFilterPartitionPruneClassifier.classify(filterType, targetSlot, nereidsTarget, scanNode);
+        return RuntimeFilterPartitionPruneClassifier.classify(filterType,
+                legacyTargetFactory.apply(targetSlot), nereidsTargetFactory.apply(nereidsTarget), scanNode);
     }
 
     private void assertSupportedIncreasingPartitions(

--- a/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
+++ b/regression-test/data/query_p0/runtime_filter/rf_partition_pruning.out
@@ -136,5 +136,11 @@ Beijing	3
 5	3	e
 6	3	f
 
+-- !rf_prune_expr_without_partition_prune --
+1
+
+-- !rf_prune_expr_with_partition_prune --
+1
+
 -- !list_str_bloom --
 3	c

--- a/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
+++ b/regression-test/suites/query_p0/runtime_filter/rf_partition_pruning.groovy
@@ -1479,6 +1479,59 @@ suite("rf_partition_pruning", "nonConcurrent") {
                 + "ON f.region_id + f.region_id = d.dim_region",
         "BLOOM_FILTER", 5, 3)
 
+    // Test 50b: NoneMovable target expressions must not be evaluated speculatively
+    // against LIST partition values. The part_key=0 row is removed by keep_row=1
+    // before the join, so assert_true must not fail only because RF partition pruning
+    // evaluates the target expression on the p_zero boundary.
+    sql "drop table if exists rf_prune_expr_fact"
+    sql """
+        CREATE TABLE rf_prune_expr_fact (
+            id BIGINT NOT NULL,
+            part_key INT NOT NULL,
+            keep_row INT NOT NULL
+        ) DUPLICATE KEY(id)
+        PARTITION BY LIST(part_key) (
+            PARTITION p_zero VALUES IN (0),
+            PARTITION p_one VALUES IN (1)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES("replication_num" = "1")
+    """
+    sql "INSERT INTO rf_prune_expr_fact VALUES (0, 0, 0), (1, 1, 1)"
+
+    sql "drop table if exists rf_prune_expr_dim"
+    sql """
+        CREATE TABLE rf_prune_expr_dim (
+            flag BOOLEAN NOT NULL
+        ) DUPLICATE KEY(flag)
+        DISTRIBUTED BY HASH(flag) BUCKETS 1
+        PROPERTIES("replication_num" = "1")
+    """
+    sql "INSERT INTO rf_prune_expr_dim VALUES (true)"
+
+    sql "set enable_runtime_filter_partition_prune=false"
+    qt_rf_prune_expr_without_partition_prune """
+        SELECT /*+ SET_VAR(runtime_filter_type='IN') */ COUNT(*)
+        FROM rf_prune_expr_fact fact
+        JOIN [broadcast] rf_prune_expr_dim dim
+          ON assert_true(fact.part_key != 0, 'rfpp_expr_in_only_error') = dim.flag
+        WHERE fact.keep_row = 1
+    """
+
+    sql "set enable_runtime_filter_partition_prune=true"
+    qt_rf_prune_expr_with_partition_prune """
+        SELECT /*+ SET_VAR(runtime_filter_type='IN') */ COUNT(*)
+        FROM rf_prune_expr_fact fact
+        JOIN [broadcast] rf_prune_expr_dim dim
+          ON assert_true(fact.part_key != 0, 'rfpp_expr_in_only_error') = dim.flag
+        WHERE fact.keep_row = 1
+    """
+    assertNoPartitionPruningProfile(
+        "COUNT(*) FROM rf_prune_expr_fact fact JOIN [broadcast] rf_prune_expr_dim dim "
+                + "ON assert_true(fact.part_key != 0, 'rfpp_expr_in_only_error') = dim.flag "
+                + "WHERE fact.keep_row = 1",
+        "IN")
+
     // ============================================================
     // Test 51: String partition column (LIST partition on VARCHAR).
     //


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

With runtime filter partition pruning enabled, a join target expression was eligible for partition pruning even when it contained a non-movable function such as `assert_true`. The pruning path then evaluated `assert_true` against LIST partition boundary values before normal row predicates ran. A boundary belonging only to filtered-out rows could therefore introduce an `INVALID_ARGUMENT` error, while the same query returned `1` with partition pruning disabled.

The FE runtime-filter partition-prune classifier now rejects target expressions containing `NoneMovableFunction`. This prevents speculative partition-boundary evaluation of `assert_true`; both partition-pruning modes preserve normal query semantics and return `1`.

### Release note

Fix runtime filter partition pruning to preserve query behavior for non-movable target expressions.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Tested with:

- `RuntimeFilterPartitionPruneClassifierTest`: 6 tests passed
- `query_p0/runtime_filter/rf_partition_pruning`: 1 suite passed
- Manual comparison on FE port 9333: both `enable_runtime_filter_partition_prune=false` and `true` return `1`

- Behavior changed:
    - [ ] No.
    - [x] Yes. Target expressions containing non-movable functions no longer participate in runtime filter partition pruning.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label