### PR TITLE
[test](fe) Stabilize async cache refresh test

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Lists;
 import com.google.common.testing.FakeTicker;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -237,8 +238,8 @@ public class CacheFactoryTest {
         // refresh in background, so still get value1
         Assertions.assertTrue(futureValue.isDone());
         Assertions.assertEquals("value1", futureValue.get().get().getValue());
-        // sleep longer to wait for refresh
-        Thread.sleep(2500);
+        // Wait for the refresh triggered above instead of relying on executor scheduling time.
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> counter.get() == 2);
         futureValue = loadingCache.get(1);
         Assertions.assertEquals("value1", futureValue.get().get().getValue());
         // refreshed, so counter +1

--- a/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
@@ -231,6 +231,7 @@ public class CacheFactoryTest {
         Assertions.assertTrue(futureValue.isDone());
         Assertions.assertEquals("value1", futureValue.get().get().getValue());
         Assertions.assertEquals(1, counter.get());
+        CompletableFuture<Optional<CacheValue>> cachedFuture = futureValue;
         // advance 11 seconds to pass the refreshAfterWrite
         ticker.advance(11, TimeUnit.SECONDS);
         // trigger refresh
@@ -238,8 +239,11 @@ public class CacheFactoryTest {
         // refresh in background, so still get value1
         Assertions.assertTrue(futureValue.isDone());
         Assertions.assertEquals("value1", futureValue.get().get().getValue());
-        // Wait for the refresh triggered above instead of relying on executor scheduling time.
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> counter.get() == 2);
+        // Wait until the refresh is published to the cache instead of observing loader-side progress.
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+            CompletableFuture<Optional<CacheValue>> refreshedFuture = loadingCache.get(1);
+            return refreshedFuture != cachedFuture && refreshedFuture.isDone();
+        });
         futureValue = loadingCache.get(1);
         Assertions.assertEquals("value1", futureValue.get().get().getValue());
         // refreshed, so counter +1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`CacheFactoryTest.testAsyncLoadingCacheWithExpireAfterWrite` waited a fixed 2.5 seconds for an asynchronous refresh whose loader deliberately sleeps for 2 seconds. Executor scheduling, JVM pauses, or an oversleep of more than the remaining 500 ms can leave the legal background refresh in flight and make the counter assertion flaky.

Replace the wall-clock sleep with a bounded Awaitility wait for the existing `counter == 2` semantic oracle. The assertions that refresh immediately returns the old cached value and that expiry performs a new load remain unchanged.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Validation:

- `./run-fe-ut.sh --run org.apache.doris.common.CacheFactoryTest#testAsyncLoadingCacheWithExpireAfterWrite`: passed
- Exact method repeated 10 times: 10/10 passed
- Full `CacheFactoryTest` repeated twice: 2/2 passed, 6 tests per round
- Exact method after rebasing onto the latest `master`: passed

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
