### PR TITLE
[test](flaky) Stabilize cache hotspot filter performance check

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerTableFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerTableFilterTest.java
@@ -999,20 +999,36 @@ public class CacheHotspotManagerTableFilterTest {
                 new TableFilterRule(RuleType.EXCLUDE, "*.tbl_00003"),
                 new TableFilterRule(RuleType.EXCLUDE, "*.tbl_00004"));
 
-        long start = System.nanoTime();
-        int matched = 0;
-        for (String[] pair : names) {
-            if (filter.shouldWarmUp(pair[0], pair[1])) {
-                matched++;
-            }
+        // Warm up the stream/lambda and regex paths before measuring. FE UT runs with coverage
+        // and multiple forked JVMs, so a single cold wall-clock sample can include JIT compilation
+        // or an unrelated scheduling pause. Keep the best of several full-size samples so a
+        // persistent throughput regression still fails the original absolute performance guard.
+        for (String[] pair : names.subList(0, 20000)) {
+            filter.shouldWarmUp(pair[0], pair[1]);
         }
-        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
-        // 10 dbs × 2000 tables = 20000 included, minus 10 × 5 excluded = 19950
-        Assertions.assertEquals(19950, matched);
-        System.out.println("[Perf] 200K tables, 15 rules (10 incl + 5 excl): " + elapsedMs + " ms");
-        Assertions.assertTrue(elapsedMs < 3000,
-                "200K regex matches with 15 rules should complete within 3s, took " + elapsedMs + " ms");
+        long bestElapsedMs = Long.MAX_VALUE;
+        int samples = 3;
+        for (int sample = 0; sample < samples; sample++) {
+            long start = System.nanoTime();
+            int matched = 0;
+            for (String[] pair : names) {
+                if (filter.shouldWarmUp(pair[0], pair[1])) {
+                    matched++;
+                }
+            }
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            // 10 dbs × 2000 tables = 20000 included, minus 10 × 5 excluded = 19950
+            Assertions.assertEquals(19950, matched);
+            bestElapsedMs = Math.min(bestElapsedMs, elapsedMs);
+        }
+
+        System.out.println("[Perf] 200K tables, 15 rules (10 incl + 5 excl), best of "
+                + samples + ": " + bestElapsedMs + " ms");
+        Assertions.assertTrue(bestElapsedMs < 3000,
+                "200K regex matches with 15 rules should complete within 3s, best="
+                        + bestElapsedMs + " ms");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerTableFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerTableFilterTest.java
@@ -999,36 +999,25 @@ public class CacheHotspotManagerTableFilterTest {
                 new TableFilterRule(RuleType.EXCLUDE, "*.tbl_00003"),
                 new TableFilterRule(RuleType.EXCLUDE, "*.tbl_00004"));
 
-        // Warm up the stream/lambda and regex paths before measuring. FE UT runs with coverage
-        // and multiple forked JVMs, so a single cold wall-clock sample can include JIT compilation
-        // or an unrelated scheduling pause. Keep the best of several full-size samples so a
-        // persistent throughput regression still fails the original absolute performance guard.
-        for (String[] pair : names.subList(0, 20000)) {
+        // JIT warm-up
+        for (String[] pair : names) {
             filter.shouldWarmUp(pair[0], pair[1]);
         }
 
-        long bestElapsedMs = Long.MAX_VALUE;
-        int samples = 3;
-        for (int sample = 0; sample < samples; sample++) {
-            long start = System.nanoTime();
-            int matched = 0;
-            for (String[] pair : names) {
-                if (filter.shouldWarmUp(pair[0], pair[1])) {
-                    matched++;
-                }
+        long start = System.nanoTime();
+        int matched = 0;
+        for (String[] pair : names) {
+            if (filter.shouldWarmUp(pair[0], pair[1])) {
+                matched++;
             }
-            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
-
-            // 10 dbs × 2000 tables = 20000 included, minus 10 × 5 excluded = 19950
-            Assertions.assertEquals(19950, matched);
-            bestElapsedMs = Math.min(bestElapsedMs, elapsedMs);
         }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
-        System.out.println("[Perf] 200K tables, 15 rules (10 incl + 5 excl), best of "
-                + samples + ": " + bestElapsedMs + " ms");
-        Assertions.assertTrue(bestElapsedMs < 3000,
-                "200K regex matches with 15 rules should complete within 3s, best="
-                        + bestElapsedMs + " ms");
+        // 10 dbs × 2000 tables = 20000 included, minus 10 × 5 excluded = 19950
+        Assertions.assertEquals(19950, matched);
+        System.out.println("[Perf] 200K tables, 15 rules (10 incl + 5 excl): " + elapsedMs + " ms");
+        Assertions.assertTrue(elapsedMs < 3000,
+                "200K regex matches with 15 rules should complete within 3s, took " + elapsedMs + " ms");
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

`CacheHotspotManagerTableFilterTest.testShouldWarmUpPerformanceManyRules200k` intermittently fails its 3-second wall-clock assertion while still producing the correct 19,950 matches. The same timing-only signature appeared in FE UT builds 995541, 999142, and 1001937 across unrelated PRs and different agents.

FE UT runs Java 17 with JaCoCo coverage and 12 forked JVMs. This test measured the regex/stream path without a method-specific warm-up, so cold JIT compilation could be charged to its only timed sample. In the slowest build, four adjacent performance assertions also failed and the class runtime grew from about 55 seconds in a nearby pass to about 134 seconds, without a functional mismatch.

### What is changed?

- Run one complete 200K JIT warm-up pass outside the timed section.
- Keep the original single complete 200K timed pass and 3-second threshold.
- Keep the original 15-rule workload and exact 19,950-match correctness assertion.

The final diff from `master` only adds the five-line untimed warm-up. It removes cold JIT from the measurement without changing the performance oracle to a best-of-N result.

### Validation

- Pre-fix local baseline: 3/3 passes at 439 ms, 391 ms, and 342 ms.
- The earlier, superseded best-of-three version passed three fresh-JVM rounds and one JaCoCo round.
- Revised minimal source: `mvn -pl fe-core -am -DskipTests test-compile` passed.
- Revised target UT: not rerun at user request.
- `git diff --check`: pass.
