### PR TITLE
[branch-4.1][fix](regression) Avoid loopback HTTP TVF host

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -144,9 +144,11 @@ suite("test_http_tvf", "p2") {
     String httpServerHost = context.config.otherConfigs.get("httpTvfHost")
     if (httpServerHost == null || httpServerHost.trim().isEmpty()) {
         httpServerHost = context.config.otherConfigs.get("externalEnvIp")
-    }
-    if (httpServerHost == null || httpServerHost.trim().isEmpty()) {
-        httpServerHost = InetAddress.getLocalHost().getHostAddress()
+        if (httpServerHost == null || httpServerHost.trim().isEmpty()
+                || InetAddress.getByName(httpServerHost).isLoopbackAddress()
+                || InetAddress.getByName(httpServerHost).isAnyLocalAddress()) {
+            httpServerHost = InetAddress.getLocalHost().getHostAddress()
+        }
     }
     String httpBaseUrl = "http://${httpServerHost}:${httpServer.address.port}"
     def httpUrl = { String relativePath -> "${httpBaseUrl}/${relativePath}" }


### PR DESCRIPTION
### What problem does this PR solve?

`test_http_tvf` starts an in-process HTTP server on the regression runner and asks Doris BE nodes to read from it. In branch-4.1 P2 build 203694, `externalEnvIp` is `127.0.0.1`, so the case builds a URL such as `http://127.0.0.1:46739/...`. The remote BE interprets loopback as itself and fails with `Connection refused`.

### What is changed?

Keep an explicit `httpTvfHost` override, but reject loopback/any-local values inherited from `externalEnvIp` and fall back to the runner host address.

TeamCity: http://172.20.48.17:8111/buildConfiguration/Doris_Doris_x64_branch41_Regression_P2/203694
Related backport: #65313