### PR TITLE
[fix](regression) Align map_agg null-key golden on branch-4.1

### DIFF
--- a/regression-test/data/nereids_syntax_p1/mv/aggregate/agg_sync_mv.out
+++ b/regression-test/data/nereids_syntax_p1/mv/aggregate/agg_sync_mv.out
@@ -1500,7 +1500,7 @@
 11	[0, 0]
 
 -- !test --
-\N	{}
+\N	{null:"null"}
 1	{0:"string1"}
 2	{1:"string2"}
 3	{2:"string3"}


### PR DESCRIPTION
Fixes DORIS-27353. TeamCity #203693 exposed that agg_sync_mv still expected map_agg v1 NULL-key behavior after #65634 made the data load effective. Align the golden result with map_agg_v2, which preserves the nullable key.