### PR TITLE
[opt](repeat) deduplicate grouping scalar functions from projetion inrepeat

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
@@ -129,8 +129,7 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
     }
 
     private static void checkGroupingSetsSize(LogicalRepeat<Plan> repeat) {
-        Set<Expression> flattenGroupingSetExpr = ImmutableSet.copyOf(
-                ExpressionUtils.flatExpressions(repeat.getGroupingSets()));
+        Set<Expression> flattenGroupingSetExpr = ExpressionUtils.flatExpressions(repeat.getGroupingSets());
         if (flattenGroupingSetExpr.size() > LogicalRepeat.MAX_GROUPING_SETS_NUM) {
             throw new AnalysisException(
                     "Too many sets in GROUP BY clause, the max grouping sets item is "
@@ -139,7 +138,9 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
     }
 
     private static LogicalAggregate<Plan> normalizeRepeat(LogicalRepeat<Plan> repeat) {
-        Set<Expression> needToSlotsGroupingExpr = collectNeedToSlotGroupingExpr(repeat);
+        // grouping sets should be pushed down, e.g. grouping sets((k + 1)),
+        // we should push down the `k + 1` to the bottom plan
+        Set<Expression> needToSlotsGroupingExpr = ExpressionUtils.flatExpressions(repeat.getGroupingSets());
         NormalizeToSlotContext groupingExprContext = buildContext(repeat, needToSlotsGroupingExpr);
         Map<Expression, NormalizeToSlotTriplet> groupingExprMap = groupingExprContext.getNormalizeToSlotMap();
         Map<Expression, Alias> existsAlias = getExistsAlias(repeat, groupingExprMap);
@@ -159,7 +160,8 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
         // rewrite grouping scalar function to virtual slots
         // rewrite the arguments of agg function to slots
         List<NamedExpression> normalizedAggOutput = Lists.newArrayList();
-        List<NamedExpression> groupingFunctions = Lists.newArrayList();
+        // use a map to deduplicate grouping scalar functions in projection
+        Map<GroupingScalarFunction, NamedExpression> groupingFunctions = Maps.newHashMap();
         for (Expression expr : repeat.getOutputExpressions()) {
             Expression rewrittenExpr = expr.rewriteDownShortCircuit(
                     e -> normalizeAggFuncChildrenAndGroupingScalarFunc(argsContext, e, groupingFunctions));
@@ -172,17 +174,16 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
         Set<SlotReference> aggUsedSlots = ExpressionUtils.collect(
                 normalizedAggOutput, expr -> expr.getClass().equals(SlotReference.class));
 
-        Set<Slot> groupingSetsUsedSlot = ImmutableSet.copyOf(
-                ExpressionUtils.flatExpressions(normalizedGroupingSets));
+        Set<Slot> groupingSetsUsedSlot = ExpressionUtils.flatExpressions(normalizedGroupingSets);
 
         SetView<SlotReference> aggUsedSlotNotInGroupBy
-                = Sets.difference(Sets.difference(aggUsedSlots, groupingFunctions.stream()
+                = Sets.difference(Sets.difference(aggUsedSlots, groupingFunctions.values().stream()
                 .map(NamedExpression::toSlot).collect(Collectors.toSet())), groupingSetsUsedSlot);
 
         List<NamedExpression> normalizedRepeatOutput = ImmutableList.<NamedExpression>builder()
                 .addAll(groupingSetsUsedSlot)
                 .addAll(aggUsedSlotNotInGroupBy)
-                .addAll(groupingFunctions)
+                .addAll(groupingFunctions.values())
                 .build();
 
         // 3 parts need push down:
@@ -218,20 +219,13 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
 
         List<Expression> normalizedAggGroupBy = ImmutableList.<Expression>builder()
                 .addAll(groupingSetsUsedSlot)
-                .addAll(groupingFunctions.stream().map(NamedExpression::toSlot).collect(Collectors.toList()))
+                .addAll(groupingFunctions.values().stream().map(NamedExpression::toSlot).collect(Collectors.toList()))
                 .add(groupingId)
                 .build();
 
         normalizedAggOutput = getExprIdUnchangedNormalizedAggOutput(normalizedAggOutput, repeat.getOutputExpressions());
         return new LogicalAggregate<>(normalizedAggGroupBy, (List) normalizedAggOutput,
                 Optional.of(normalizedRepeat), normalizedRepeat);
-    }
-
-    private static Set<Expression> collectNeedToSlotGroupingExpr(LogicalRepeat<Plan> repeat) {
-        // grouping sets should be pushed down, e.g. grouping sets((k + 1)),
-        // we should push down the `k + 1` to the bottom plan
-        return ImmutableSet.copyOf(
-                ExpressionUtils.flatExpressions(repeat.getGroupingSets()));
     }
 
     private static Set<Expression> collectNeedToSlotArgsOfGroupingScalarFuncAndAggFunc(LogicalRepeat<Plan> repeat) {
@@ -300,7 +294,7 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
 
     private static NormalizeToSlotContext buildContextWithAlias(Repeat<? extends Plan> repeat,
             Map<Expression, Alias> existsAliasMap, Collection<? extends Expression> sourceExpressions) {
-        List<Expression> groupingSetExpressions = ExpressionUtils.flatExpressions(repeat.getGroupingSets());
+        Set<Expression> groupingSetExpressions = ExpressionUtils.flatExpressions(repeat.getGroupingSets());
         Map<Expression, NormalizeToSlotTriplet> normalizeToSlotMap = Maps.newLinkedHashMap();
         for (Expression expression : sourceExpressions) {
             Optional<NormalizeToSlotTriplet> pushDownTriplet;
@@ -325,7 +319,7 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
     }
 
     private static Expression normalizeAggFuncChildrenAndGroupingScalarFunc(NormalizeToSlotContext context,
-            Expression expr, List<NamedExpression> groupingSetExpressions) {
+            Expression expr, Map<GroupingScalarFunction, NamedExpression> groupingSetExpressions) {
         if (expr instanceof AggregateFunction) {
             AggregateFunction function = (AggregateFunction) expr;
             List<Expression> normalizedRealExpressions = context.normalizeToUseSlotRef(function.getArguments());
@@ -336,8 +330,8 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
             List<Expression> normalizedRealExpressions = context.normalizeToUseSlotRef(function.getArguments());
             function = function.withChildren(normalizedRealExpressions);
             // eliminate GroupingScalarFunction and replace to VirtualSlotReference
-            Alias alias = new Alias(function, Repeat.generateVirtualSlotName(function));
-            groupingSetExpressions.add(alias);
+            NamedExpression alias = groupingSetExpressions.computeIfAbsent(function,
+                    f -> new Alias(f, Repeat.generateVirtualSlotName(f)));
             return alias.toSlot();
         } else {
             return expr;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/Repeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/Repeat.java
@@ -51,7 +51,7 @@ public interface Repeat<CHILD_PLAN extends Plan> extends Aggregate<CHILD_PLAN> {
 
     @Override
     default List<Expression> getGroupByExpressions() {
-        return ExpressionUtils.flatExpressions(getGroupingSets());
+        return ImmutableList.copyOf(ExpressionUtils.flatExpressions(getGroupingSets()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -851,13 +851,13 @@ public class ExpressionUtils {
     }
 
     /** flatExpressions */
-    public static <E extends Expression> List<E> flatExpressions(List<List<E>> expressionLists) {
+    public static <E extends Expression> Set<E> flatExpressions(List<List<E>> expressionLists) {
         int num = 0;
         for (List<E> expressionList : expressionLists) {
             num += expressionList.size();
         }
 
-        ImmutableList.Builder<E> flatten = ImmutableList.builderWithExpectedSize(num);
+        ImmutableSet.Builder<E> flatten = ImmutableSet.builderWithExpectedSize(num);
         for (List<E> expressionList : expressionLists) {
             flatten.addAll(expressionList);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeatTest.java
@@ -21,8 +21,10 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingId;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Repeat.RepeatType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
@@ -31,6 +33,7 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class NormalizeRepeatTest implements MemoPatternMatchSupported {
@@ -91,5 +94,32 @@ public class NormalizeRepeatTest implements MemoPatternMatchSupported {
                 .matchesFromRoot(
                         logicalAggregate(logicalRepeat(logicalOlapScan()))
                 );
+    }
+
+    @Test
+    public void testDeduplicateGroupingScalarFunctions() {
+        Slot id = scan1.getOutput().get(0);
+        Slot name = scan1.getOutput().get(1);
+        Alias firstGroupingId = new Alias(new GroupingId(name), "first_grouping_id");
+        Alias secondGroupingId = new Alias(new GroupingId(name), "second_grouping_id");
+        LogicalRepeat<Plan> repeat = new LogicalRepeat<>(
+                ImmutableList.of(ImmutableList.of(id)),
+                ImmutableList.of(id, firstGroupingId, secondGroupingId),
+                RepeatType.GROUPING_SETS,
+                scan1
+        );
+
+        LogicalAggregate<Plan> normalizedAggregate = NormalizeRepeat.doNormalize(repeat);
+        LogicalRepeat<Plan> normalizedRepeat = (LogicalRepeat<Plan>) normalizedAggregate.child();
+        long groupingFunctionCount = normalizedRepeat.getOutputExpressions().stream()
+                .filter(expression -> expression instanceof Alias
+                        && ((Alias) expression).child() instanceof GroupingScalarFunction)
+                .count();
+
+        Assertions.assertEquals(1, groupingFunctionCount);
+        Assertions.assertEquals(3, normalizedAggregate.getOutputExpressions().size());
+        Assertions.assertEquals(
+                ((Alias) normalizedAggregate.getOutputExpressions().get(1)).child(),
+                ((Alias) normalizedAggregate.getOutputExpressions().get(2)).child());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #34196

Problem Summary:

when normalize repeat, we maybe generate duplicate grouping functions because the same grouping functions appear in projection more than once.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

