### PR TITLE
[branch-4.1][fix](regression) Match Parquet TIME scanner errors

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
@@ -123,7 +123,13 @@ suite("test_hdfs_parquet_group5","external,hive,tvf,external_docker") {
                         "uri" = "${uri}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "parquet") limit 10; """
-                exception "The column type of 'timestamp' is not supported"
+                check { result, exception, startTime, endTime ->
+                    def message = exception?.toString()
+                    assertTrue("Unexpected Parquet TIME error: ${message}",
+                            message != null
+                                    && (message.contains("The column type of 'timestamp' is not supported")
+                                        || message.contains("Unsupported parquet column 'timestamp': Parquet TIME with isAdjustedToUTC=true is not supported")))
+                }
             }
 
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
@@ -123,7 +123,7 @@ suite("test_hdfs_parquet_group5","external,hive,tvf,external_docker") {
                         "uri" = "${uri}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "parquet") limit 10; """
-                exception "Parquet TIME with isAdjustedToUTC=true is not supported"
+                exception "The column type of 'timestamp' is not supported"
             }
 
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
@@ -125,10 +125,10 @@ suite("test_hdfs_parquet_group5","external,hive,tvf,external_docker") {
                         "format" = "parquet") limit 10; """
                 check { result, exception, startTime, endTime ->
                     def message = exception?.toString()
-                    assertTrue("Unexpected Parquet TIME error: ${message}",
-                            message != null
+                    assertTrue(message != null
                                     && (message.contains("The column type of 'timestamp' is not supported")
-                                        || message.contains("Unsupported parquet column 'timestamp': Parquet TIME with isAdjustedToUTC=true is not supported")))
+                                        || message.contains("Unsupported parquet column 'timestamp': Parquet TIME with isAdjustedToUTC=true is not supported")),
+                            "Unexpected Parquet TIME error: ${message}")
                 }
             }
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
@@ -429,10 +429,10 @@ suite("test_hdfs_parquet_group6","external,hive,tvf,external_docker") {
                         "format" = "parquet") limit 10; """
                 check { result, exception, startTime, endTime ->
                     def message = exception?.toString()
-                    assertTrue("Unexpected Parquet TIME error: ${message}",
-                            message != null
+                    assertTrue(message != null
                                     && (message.contains("The column type of 'time_millis' is not supported")
-                                        || message.contains("Unsupported parquet column 'time_millis': Parquet TIME with isAdjustedToUTC=true is not supported")))
+                                        || message.contains("Unsupported parquet column 'time_millis': Parquet TIME with isAdjustedToUTC=true is not supported")),
+                            "Unexpected Parquet TIME error: ${message}")
                 }
             }
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
@@ -427,7 +427,13 @@ suite("test_hdfs_parquet_group6","external,hive,tvf,external_docker") {
                         "uri" = "${uri}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "parquet") limit 10; """
-                exception "The column type of 'time_millis' is not supported"
+                check { result, exception, startTime, endTime ->
+                    def message = exception?.toString()
+                    assertTrue("Unexpected Parquet TIME error: ${message}",
+                            message != null
+                                    && (message.contains("The column type of 'time_millis' is not supported")
+                                        || message.contains("Unsupported parquet column 'time_millis': Parquet TIME with isAdjustedToUTC=true is not supported")))
+                }
             }
 
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
@@ -427,7 +427,7 @@ suite("test_hdfs_parquet_group6","external,hive,tvf,external_docker") {
                         "uri" = "${uri}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "parquet") limit 10; """
-                exception "Parquet TIME with isAdjustedToUTC=true is not supported"
+                exception "The column type of 'time_millis' is not supported"
             }
 
 


### PR DESCRIPTION
Internal External build 203691 used the branch-4.1 V1 scanner path and failed because the cases expected the FileScannerV2 Parquet TIME message. The first revision matched only the V1 messages, but terminal community External build 1004233 then proved that the current branch-4.1 merge runs the V2 path and the V1-only assertions fail in the opposite direction.

This test-only change now accepts exactly the two valid branch-4.1 scanner messages for each affected column:

- V1: `The column type of '<column>' is not supported`
- V2: `Unsupported parquet column '<column>': Parquet TIME with isAdjustedToUTC=true is not supported`

Unrelated exceptions are still rejected, and product behavior is unchanged.

Validation:

- `git diff --check`: passed
- Groovy 4.0.19 compilation: passed for both modified suites
- Suite discover/load: `test_hdfs_parquet_group5` and `test_hdfs_parquet_group6`, tags `external,hive,tvf,external_docker`
- Message gate: both V1/V2 signatures accepted for `timestamp` and `time_millis`; unrelated `connection refused` rejected
- Attempt 1 terminal evidence: External build 1004233 failed only because V1-only assertions met the current V2 messages
- Fresh Compile and External runtime validation are required for the new head before merge
