### PR TITLE
branch-4.0: [fix](regression) use JDK 17 for Java UDF builds

### DIFF
--- a/regression-test/java-udf-src/pom.xml
+++ b/regression-test/java-udf-src/pom.xml
@@ -26,8 +26,7 @@ under the License.
     <name>Java UDF Case</name>
     <url>https://doris.apache.org/</url>
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <hive.version>3.1.3</hive.version>
     </properties>
 
@@ -85,10 +84,6 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/regression-test/suites/vault_p0/create/test_nereids_show_create_storage_vault.groovy
+++ b/regression-test/suites/vault_p0/create/test_nereids_show_create_storage_vault.groovy
@@ -83,11 +83,11 @@ suite("test_show_create_storage_vault_command") {
     def hdfsVaultInfo = try_sql """SHOW CREATE STORAGE VAULT ${hdfsVaultName}"""
     def s3VaultInfo = try_sql """SHOW CREATE STORAGE VAULT ${s3VaultName}"""
 
-    if (hdfsVaultInfo.size == 1) {
+    if (hdfsVaultInfo.size() == 1) {
         hdfsVaultExist = true
     }
 
-    if (s3VaultInfo.size == 1) {
+    if (s3VaultInfo.size() == 1) {
         s3VaultExist = true
     }
 
@@ -96,4 +96,3 @@ suite("test_show_create_storage_vault_command") {
 
 
 }
-

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -23,6 +23,61 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 DORIS_HOME="${ROOT}"
 
+java_major_version() {
+    local java_cmd="$1"
+    local spec_version
+
+    spec_version="$("${java_cmd}" -XshowSettings:properties -version 2>&1 \
+        | awk -F'= ' '/java.specification.version =/ {print $2; exit}')"
+    if [[ "${spec_version}" == 1.* ]]; then
+        spec_version="${spec_version#1.}"
+    fi
+    echo "${spec_version%%.*}"
+}
+
+is_jdk17_home() {
+    local java_home="$1"
+    [[ -n "${java_home}" ]] && [[ -x "${java_home}/bin/java" ]] \
+        && [[ -x "${java_home}/bin/javac" ]] \
+        && [[ "$(java_major_version "${java_home}/bin/java")" == "17" ]]
+}
+
+find_jdk17_home() {
+    local candidate
+
+    for candidate in "${JAVA_HOME:-}" "${JDK_17:-}"; do
+        if is_jdk17_home "${candidate}"; then
+            echo "${candidate}"
+            return 0
+        fi
+    done
+
+    if [[ "$(uname -s)" == "Darwin" ]] && [[ -x /usr/libexec/java_home ]]; then
+        candidate="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+        if is_jdk17_home "${candidate}"; then
+            echo "${candidate}"
+            return 0
+        fi
+    elif [[ -d /usr/lib/jvm ]]; then
+        while IFS= read -r candidate; do
+            if is_jdk17_home "${candidate}"; then
+                echo "${candidate}"
+                return 0
+            fi
+        done < <(find /usr/lib/jvm -mindepth 1 -maxdepth 1 \( -type d -o -type l \) 2>/dev/null | sort)
+    fi
+
+    echo "Error: JDK 17 is required. Set JAVA_HOME or JDK_17, or install JDK 17." >&2
+    return 1
+}
+
+JAVA_HOME="$(find_jdk17_home)"
+export JAVA_HOME
+export PATH="${JAVA_HOME}/bin:${PATH}"
+export JAVA="${JAVA_HOME}/bin/java"
+JAVA_MAJOR_VERSION="$(java_major_version "${JAVA}")"
+echo "Using JDK ${JAVA_MAJOR_VERSION}: ${JAVA_HOME}"
+
 # Check args
 usage() {
     echo "
@@ -193,22 +248,6 @@ if ! test -f ${RUN_JAR:+${RUN_JAR}}; then
     cp target/java-udf-case-jar-with-dependencies.jar "${DORIS_HOME}"/output/fe/custom_lib/
     cp target/java-udf-case-jar-with-dependencies.jar "${DORIS_HOME}"/output/be/custom_lib/
     cd "${DORIS_HOME}"
-fi
-
-# check java home
-if [[ -z "${JAVA_HOME}" ]]; then
-    echo "Error: JAVA_HOME is not set"
-    exit 1
-fi
-
-# check java version
-export JAVA="${JAVA_HOME}/bin/java"
-JAVA_SPEC_VERSION="$("${JAVA}" -XshowSettings:properties -version 2>&1 \
-    | awk -F'= ' '/java.specification.version =/ {print $2; exit}')"
-JAVA_MAJOR_VERSION="${JAVA_SPEC_VERSION%%.*}"
-if [[ "${JAVA_SPEC_VERSION}" == 1.* ]]; then
-    JAVA_MAJOR_VERSION="${JAVA_SPEC_VERSION#1.}"
-    JAVA_MAJOR_VERSION="${JAVA_MAJOR_VERSION%%.*}"
 fi
 
 # Arrow Flight SQL JDBC needs java.nio opened when the regression framework runs on JDK 17+.


### PR DESCRIPTION
## What changed

- make `run-regression-test.sh` select and validate JDK 17 before invoking Maven
- prefer a valid `JAVA_HOME` or `JDK_17`, with Linux and macOS discovery fallbacks
- build the regression framework and Java UDF case jar with the same JDK 17
- compile `java-udf-src` with `maven.compiler.release=17`

## Why

The regression build depended on the caller to prepare `JAVA_HOME`, and newer branches also switched to JDK 8 only for the Java UDF module. This split ownership between CI and the Doris build script and could produce incomplete case artifacts when the framework required JDK 17.

Keeping Java selection in `run-regression-test.sh` makes local and CI builds follow the same contract and removes the Java 8-only UDF build path.

## Validation

- `bash -n run-regression-test.sh`
- `git diff --check`
- ran `./run-regression-test.sh --clean` while the incoming `JAVA_HOME` pointed to JDK 22; the script selected JDK 17 and Maven reported Java 17
- built `regression-test/java-udf-src` with JDK 17 successfully
- verified `Echo$EchoInt` has class major version 61 and the expected UDF classes are present in the assembled jar
