### PR TITLE
branch-3.1: [fix](regression) use JDK 17 for Java UDF builds

### DIFF
--- a/regression-test/java-udf-src/pom.xml
+++ b/regression-test/java-udf-src/pom.xml
@@ -26,8 +26,7 @@ under the License.
     <name>Java UDF Case</name>
     <url>https://doris.apache.org/</url>
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <hive.version>3.1.3</hive.version>
     </properties>
 
@@ -85,10 +84,6 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/regression-test/suites/auth_p0/test_master_slave_consistency_auth.groovy
+++ b/regression-test/suites/auth_p0/test_master_slave_consistency_auth.groovy
@@ -366,11 +366,11 @@ suite ("test_follower_consistent_auth","p0,auth") {
                  }
         connect(user, "${pwd}", url_tmp1) {
             def res = sql """SHOW RESOURCES;"""
-            assertTrue(res.size == 10)
+            assertTrue(res.size() == 10)
         }
         connect(user, "${pwd}", new_jdbc_url) {
             def res = sql """SHOW RESOURCES;"""
-            assertTrue(res.size == 10)
+            assertTrue(res.size() == 10)
         }
 
         try_sql("DROP USER ${user}")

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -285,11 +285,11 @@ suite("test_auto_partition_behavior") {
 
     sql """ insert into test_change values ("20201212"); """
     def part_result = sql " show tablets from test_change "
-    assertEquals(part_result.size, 2 * replicaNum)
+    assertEquals(part_result.size(), 2 * replicaNum)
     sql """ ALTER TABLE test_change MODIFY DISTRIBUTION DISTRIBUTED BY HASH(k0) BUCKETS 50; """
     sql """ insert into test_change values ("20001212"); """
     part_result = sql " show tablets from test_change "
-    assertEquals(part_result.size, 52 * replicaNum)
+    assertEquals(part_result.size(), 52 * replicaNum)
 
 
 

--- a/regression-test/suites/partition_p1/auto_partition/sql/multi_thread_load.groovy
+++ b/regression-test/suites/partition_p1/auto_partition/sql/multi_thread_load.groovy
@@ -91,7 +91,7 @@ suite("multi_thread_load", "p1,nonConcurrent") { // stress case should use resou
         }
 
         def table_exist = sql """select * from information_schema.tables where  TABLE_SCHEMA = "${realDb}" and TABLE_NAME = "${tableName}";"""
-        assertTrue(table_exist.size == 1)
+        assertTrue(table_exist.size() == 1)
         dir_file_exist("""${dirPath}/${part_type}""")
 
         for (int i = 0; i < data_count; i++) {

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -23,6 +23,61 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 DORIS_HOME="${ROOT}"
 
+java_major_version() {
+    local java_cmd="$1"
+    local spec_version
+
+    spec_version="$("${java_cmd}" -XshowSettings:properties -version 2>&1 \
+        | awk -F'= ' '/java.specification.version =/ {print $2; exit}')"
+    if [[ "${spec_version}" == 1.* ]]; then
+        spec_version="${spec_version#1.}"
+    fi
+    echo "${spec_version%%.*}"
+}
+
+is_jdk17_home() {
+    local java_home="$1"
+    [[ -n "${java_home}" ]] && [[ -x "${java_home}/bin/java" ]] \
+        && [[ -x "${java_home}/bin/javac" ]] \
+        && [[ "$(java_major_version "${java_home}/bin/java")" == "17" ]]
+}
+
+find_jdk17_home() {
+    local candidate
+
+    for candidate in "${JAVA_HOME:-}" "${JDK_17:-}"; do
+        if is_jdk17_home "${candidate}"; then
+            echo "${candidate}"
+            return 0
+        fi
+    done
+
+    if [[ "$(uname -s)" == "Darwin" ]] && [[ -x /usr/libexec/java_home ]]; then
+        candidate="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+        if is_jdk17_home "${candidate}"; then
+            echo "${candidate}"
+            return 0
+        fi
+    elif [[ -d /usr/lib/jvm ]]; then
+        while IFS= read -r candidate; do
+            if is_jdk17_home "${candidate}"; then
+                echo "${candidate}"
+                return 0
+            fi
+        done < <(find /usr/lib/jvm -mindepth 1 -maxdepth 1 \( -type d -o -type l \) 2>/dev/null | sort)
+    fi
+
+    echo "Error: JDK 17 is required. Set JAVA_HOME or JDK_17, or install JDK 17." >&2
+    return 1
+}
+
+JAVA_HOME="$(find_jdk17_home)"
+export JAVA_HOME
+export PATH="${JAVA_HOME}/bin:${PATH}"
+export JAVA="${JAVA_HOME}/bin/java"
+JAVA_MAJOR_VERSION="$(java_major_version "${JAVA}")"
+echo "Using JDK ${JAVA_MAJOR_VERSION}: ${JAVA_HOME}"
+
 # Check args
 usage() {
     echo "
@@ -194,15 +249,6 @@ if ! test -f ${RUN_JAR:+${RUN_JAR}}; then
     cp target/java-udf-case-jar-with-dependencies.jar "${DORIS_HOME}"/output/be/custom_lib/
     cd "${DORIS_HOME}"
 fi
-
-# check java home
-if [[ -z "${JAVA_HOME}" ]]; then
-    echo "Error: JAVA_HOME is not set"
-    exit 1
-fi
-
-# check java version
-export JAVA="${JAVA_HOME}/bin/java"
 
 REGRESSION_OPTIONS_PREFIX=''
 

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -261,7 +261,9 @@ fi
 
 echo "===== Run Regression Test ====="
 
-# if use jdk17, add java option "--add-opens=java.base/java.nio=ALL-UNNAMED"
+# Arrow Flight SQL uses direct access to java.nio buffers. JDK 17 requires this
+# package to be opened to the (shaded) Arrow client classes at runtime.
+JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.nio=ALL-UNNAMED"
 if [[ "${TEAMCITY}" -eq 1 ]]; then
     JAVA_OPTS="${JAVA_OPTS} -DstdoutAppenderType=teamcity -Xmx2048m"
 fi


### PR DESCRIPTION
## What changed

- make `run-regression-test.sh` select and validate JDK 17 before invoking Maven
- prefer a valid `JAVA_HOME` or `JDK_17`, with Linux and macOS discovery fallbacks
- build the regression framework and Java UDF case jar with the same JDK 17
- compile `java-udf-src` with `maven.compiler.release=17`

## Why

The regression build depended on the caller to prepare `JAVA_HOME`. This split ownership between CI and the Doris build script and could produce incomplete case artifacts when the build required JDK 17.

Keeping Java selection in `run-regression-test.sh` makes local and CI builds follow the same contract and removes the Java 8 UDF bytecode target from active branches.

## Validation

- `bash -n run-regression-test.sh`
- `git diff --check`
- ran `./run-regression-test.sh --clean` while the incoming `JAVA_HOME` pointed to JDK 22; the script selected JDK 17 and Maven reported Java 17
- built `regression-test/java-udf-src` with JDK 17 successfully
- verified `Echo$EchoInt` has class major version 61 and the expected UDF classes are present in the assembled jar
