### PR TITLE
[test](regression) Stabilize search score cache test

### DIFF
--- a/regression-test/suites/search/test_search_score_cache.groovy
+++ b/regression-test/suites/search/test_search_score_cache.groovy
@@ -43,6 +43,11 @@ suite("test_search_score_cache", "p0") {
         """)
     }
 
+    // Keep v.host materialized as an indexed scalar subcolumn so score() can collect BM25.
+    sql """ set default_variant_enable_doc_mode = false """
+    sql """ set default_variant_max_subcolumns_count = 0 """
+    sql """ set default_variant_doc_materialization_min_rows = 0 """
+
     sql "DROP TABLE IF EXISTS ${tableName}"
     sql """
         CREATE TABLE ${tableName} (


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:Fix fuzzy regression instability by pinning variant materialization settings for the score cache test. This keeps v.host materialized as an indexed scalar subcolumn so score() can collect BM25 instead of falling back to zero when doc mode stores the field only in doc-value buckets.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

