### PR TITLE
fix(test): isolate backup restore retention config

### DIFF
--- a/regression-test/suites/backup_restore/test_backup_restore_retention_count.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_retention_count.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_backup_restore_retention_count", "backup_restore") {
+suite("test_backup_restore_retention_count", "backup_restore,nonConcurrent") {
     String suiteName = "test_backup_restore_retention_count"
     String dbName = "${suiteName}_db"
     String snapshotName = "${suiteName}_snapshot"
@@ -83,16 +83,24 @@ suite("test_backup_restore_retention_count", "backup_restore") {
     assertTrue(res[0][1].contains('"partition.retention_count" = "4"'))
 
     // Trigger recycle to verify retention_count works after restore
-    sql "admin set frontend config ('dynamic_partition_check_interval_seconds' = '1')"
-    sleep(8000)
+    def originalCheckInterval = getFeConfig("dynamic_partition_check_interval_seconds")
+    try {
+        sql "admin set frontend config ('dynamic_partition_check_interval_seconds' = '1')"
 
-    res = sql "SHOW PARTITIONS FROM ${dbName}.${tableName}"
-    assertEquals(4, res.size())
+        res = sql "SHOW PARTITIONS FROM ${dbName}.${tableName}"
+        for (int retry = 0; retry < 30 && res.size() != 4; retry++) {
+            logger.info("wait for partition retention, sleep 1s")
+            sleep(1000)
+            res = sql "SHOW PARTITIONS FROM ${dbName}.${tableName}"
+        }
+        assertEquals(4, res.size())
 
-    qt_select "SELECT * FROM ${dbName}.${tableName} ORDER BY k0"
+        qt_select "SELECT * FROM ${dbName}.${tableName} ORDER BY k0"
+    } finally {
+        sql "admin set frontend config ('dynamic_partition_check_interval_seconds' = '${originalCheckInterval}')"
+    }
 
     // Cleanup
-    sql "admin set frontend config ('dynamic_partition_check_interval_seconds' = '600')"
     sql "DROP TABLE ${dbName}.${tableName} FORCE"
     sql "DROP DATABASE ${dbName} FORCE"
     sql "DROP REPOSITORY `${repoName}`"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65282

Problem Summary:

`test_backup_restore_retention_count` changes the master FE process-wide
`dynamic_partition_check_interval_seconds` while running as an ordinary
parallel suite. A failure after that change leaves the interval at one second,
and the successful path overwrites the previous value with a hard-coded 600.
The fixed eight-second sleep also makes scheduler timing part of the oracle.

This PR moves the suite to the `nonConcurrent` executor, captures and restores
the actual previous FE value in `finally`, and polls for the expected four
retained partitions for up to 30 seconds. The existing partition-count and
golden-row assertions are unchanged.

This is case isolation hardening. It does not replace the product-side
`createPartition` race fix tracked by #65282.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Groovy parsing and `git diff --check` pass locally. The exact S3
backup/restore case will run in CI.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
