### PR TITLE
[fix](fe) Support more hive types conversion to doris type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -643,6 +643,7 @@ public class HiveMetaStoreClientHelper {
             case "date":
                 return ScalarType.createDateV2Type();
             case "timestamp":
+            case "datetime":
                 return ScalarType.createDatetimeV2Type(timeScale);
             case "float":
                 return Type.FLOAT;
@@ -729,6 +730,21 @@ public class HiveMetaStoreClientHelper {
         if (lowerCaseType.startsWith("timestamp with local time zone")) {
             return enableMappingTimeStampTz ? ScalarType.createTimeStampTzType(timeScale)
                     : ScalarType.createDatetimeV2Type(timeScale);
+        }
+        if (lowerCaseType.startsWith("bigint")) {
+            return Type.BIGINT;
+        }
+        if (lowerCaseType.startsWith("int")) {
+            return Type.INT;
+        }
+        if (lowerCaseType.startsWith("tinyint")) {
+            return Type.TINYINT;
+        }
+        if (lowerCaseType.startsWith("smallint")) {
+            return Type.SMALLINT;
+        }
+        if (lowerCaseType.startsWith("timestamp")) {
+            return ScalarType.createDatetimeV2Type(timeScale);
         }
         return Type.UNSUPPORTED;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveTypeToDorisTypeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveTypeToDorisTypeTest.java
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import org.apache.doris.catalog.ArrayType;
+import org.apache.doris.catalog.MapType;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.StructField;
+import org.apache.doris.catalog.StructType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.types.VarBinaryType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+public class HiveTypeToDorisTypeTest {
+
+    @Test
+    public void testBasicTypes() {
+        Assertions.assertEquals(Type.BOOLEAN, hiveTypeToDorisType("boolean", 0));
+        Assertions.assertEquals(Type.TINYINT, hiveTypeToDorisType("tinyint", 0));
+        Assertions.assertEquals(Type.TINYINT, hiveTypeToDorisType("tinyint(3,0)", 0));
+        Assertions.assertEquals(Type.SMALLINT, hiveTypeToDorisType("smallint", 0));
+        Assertions.assertEquals(Type.INT, hiveTypeToDorisType("int", 0));
+        Assertions.assertEquals(Type.INT, hiveTypeToDorisType("int(10,0)", 0));
+        Assertions.assertEquals(Type.BIGINT, hiveTypeToDorisType("bigint", 0));
+        Assertions.assertEquals(Type.BIGINT, hiveTypeToDorisType("bigint(19,0)", 0));
+        Assertions.assertEquals(ScalarType.createDateV2Type(), hiveTypeToDorisType("date", 0));
+        Assertions.assertEquals(ScalarType.createDatetimeV2Type(3), hiveTypeToDorisType("timestamp", 3));
+        Assertions.assertEquals(ScalarType.createDatetimeV2Type(3), hiveTypeToDorisType("timestamp(19)", 3));
+        Assertions.assertEquals(ScalarType.createDatetimeV2Type(3), hiveTypeToDorisType("datetime", 3));
+        Assertions.assertEquals(Type.FLOAT, hiveTypeToDorisType("float", 0));
+        Assertions.assertEquals(Type.DOUBLE, hiveTypeToDorisType("double", 0));
+        Assertions.assertEquals(ScalarType.createStringType(), hiveTypeToDorisType("string", 0));
+        Assertions.assertEquals(ScalarType.createVarbinaryType(VarBinaryType.MAX_VARBINARY_LENGTH),
+                hiveTypeToDorisType("binary", 0));
+        Assertions.assertEquals(ScalarType.createStringType(),
+                HiveMetaStoreClientHelper.hiveTypeToDorisType("binary", 0, false, true));
+    }
+
+    @Test
+    public void testArrayType() {
+        Type expectedType = ArrayType.create(Type.INT, true);
+        Assertions.assertEquals(expectedType, hiveTypeToDorisType("array<int>", 0));
+    }
+
+    @Test
+    public void testMapType() {
+        Type expectedType = new MapType(Type.STRING, Type.INT);
+        Assertions.assertEquals(expectedType, hiveTypeToDorisType("map<string,int>", 0));
+    }
+
+    @Test
+    public void testStructType() {
+        ArrayList<StructField> fields = new ArrayList<>();
+        fields.add(new StructField("col1", Type.STRING));
+        fields.add(new StructField("col2", Type.INT));
+        Type expectedType = new StructType(fields);
+        Assertions.assertEquals(expectedType, hiveTypeToDorisType("struct<col1:string,col2:int>", 0));
+    }
+
+    @Test
+    public void testCharType() {
+        Assertions.assertEquals(ScalarType.createType(PrimitiveType.CHAR, 10, 0, 0),
+                hiveTypeToDorisType("char(10)", 0));
+        Assertions.assertEquals(ScalarType.createType(PrimitiveType.CHAR), hiveTypeToDorisType("char", 0));
+    }
+
+    @Test
+    public void testVarcharType() {
+        Assertions.assertEquals(ScalarType.createType(PrimitiveType.VARCHAR, 20, 0, 0),
+                hiveTypeToDorisType("varchar(20)", 0));
+        Assertions.assertEquals(ScalarType.createType(PrimitiveType.VARCHAR), hiveTypeToDorisType("varchar", 0));
+    }
+
+    @Test
+    public void testDecimalType() {
+        Assertions.assertEquals(ScalarType.createDecimalV3Type(10, 2),
+                hiveTypeToDorisType("decimal(10,2)", 0));
+        Assertions.assertEquals(
+                ScalarType.createDecimalV3Type(ScalarType.DEFAULT_PRECISION, ScalarType.DEFAULT_SCALE),
+                hiveTypeToDorisType("decimal", 0));
+    }
+
+    @Test
+    public void testUnsupportedType() {
+        Assertions.assertEquals(Type.UNSUPPORTED, hiveTypeToDorisType("unsupported_type", 0));
+    }
+
+    private Type hiveTypeToDorisType(String hiveType, int timeScale) {
+        return HiveMetaStoreClientHelper.hiveTypeToDorisType(hiveType, timeScale, true, true);
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65910

Problem Summary: Hive column types with explicit precision/length annotations (e.g. `tinyint(3,0)`, `smallint(5,0)`, `int(10,0)`, `bigint(19,0)`, `timestamp(19)`) and the Hive `datetime` type were not recognized by `HiveMetaStoreClientHelper.hiveTypeToDorisType`. They fell through to the `Type.UNSUPPORTED` fallback, which made the corresponding Hive columns unreadable from Doris Hive/HMS external catalogs.

This change:
- Adds a `case "datetime"` arm to the exact-match switch, mapping it to `datetimev2(timeScale)` (same as `timestamp`).
- Adds `startsWith` arms for `bigint`, `int`, `tinyint`, `smallint` and `timestamp` so the precision-annotated forms (e.g. `int(10,0)`) resolve to the same Doris type as their plain form. The `timestamp with local time zone` arm is kept ahead of the new `timestamp` arm so it is matched first.

End-to-end: Hive columns declared as `tinyint(3,0)`, `int(10,0)`, `bigint(19,0)`, `timestamp(19)` or `datetime` now resolve to the correct Doris type instead of `UNSUPPORTED`.

### Release note

Hive columns of types `datetime`, `tinyint(n,m)`, `smallint(n,m)`, `int(n,m)`, `bigint(n,m)` and `timestamp(n)` are now correctly mapped to the corresponding Doris types when reading Hive/HMS external tables.

### Check List (For Author)

- Test
    - [x] Unit Test — added `HiveTypeToDorisTypeTest` (`Tests run: 8, Failures: 0, Errors: 0, Skipped: 0`).
- Behavior changed:
    - [x] Yes — Hive types that previously resolved to `UNSUPPORTED` now resolve to a concrete Doris type, so previously unreadable Hive columns become readable.
- Does this need documentation?
    - [x] No.
