### PR TITLE
[branch-4.1][fix](docker) initialize external MS argument

### DIFF
--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -657,6 +657,7 @@ class UpCommand(Command):
                 args.add_be_num = 3
 
             cloud_store_config = {}
+            external_ms_cluster = getattr(args, 'external_ms', None)
             if args.cloud:
                 add_fdb_num = 1
                 if not args.add_ms_num:


### PR DESCRIPTION
### What problem does this PR solve?

TeamCity S3 Docker build #203806 reran branch-4.1 after #64623 and exposed the next first error shared by all 192 failed suites:

```text
NameError: name 'external_ms_cluster' is not defined
```

This is a partial-backport gap. branch-4.1 already contains the `--external-ms` argument and passes `external_ms_cluster` to `Cluster.new`, but missed the corresponding local-variable assignment from #57236.

Jira: DORIS-26392  
Build: http://172.20.48.17:8111/build/203806  
Reference: #57236

### What is changed?

Initialize `external_ms_cluster` from `args.external_ms` before the cloud/non-cloud branch.

This PR intentionally does not backport the full multi-cluster feature or add new validation behavior. It only restores the missing assignment while preserving the existing branch-4.1 behavior.

### Check List

- [x] Diff against branch-4.1 is exactly one added line.
- [x] `git diff --check`
- [x] `python3 -m py_compile docker/runtime/doris-compose/command.py docker/runtime/doris-compose/cluster.py`
- [x] AST check confirms the variable is bound before `Cluster.new` uses it.
- [ ] After merge, rerun branch-4.1 Compile and S3 Docker; all #203806 occurrences must create their clusters and reach their own assertions.