### PR TITLE
[branch-4.1][fix](test) Extend JDBC catalog sync timeout

### DIFF
--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_show_and_select.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_show_and_select.groovy
@@ -30,12 +30,12 @@ suite("test_lower_case_meta_with_lower_table_conf_show_and_select", "p0,external
     // String driver_url = "mysql-connector-j-8.4.0.jar"
 
     def wait_table_sync = { String db ->
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until{
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until{
             try {
                 def res = sql "show tables from ${db}"
                 return res.size() > 0;
             } catch (Exception e) {
-                e.printStackTrace();
+                logger.warn("Waiting for JDBC catalog tables from ${db} failed", e)
                 return false;
             }
         }


### PR DESCRIPTION
## Proposed changes

- extend the bounded JDBC catalog table-sync wait from 10 seconds to 60 seconds
- log the catalog/database name and last SQL exception through the suite logger while polling

## Root cause

S3 P0 build 203802 created the JDBC catalog successfully, but the first metadata discovery did not expose tables within the fixed 10-second window. A sibling lower-case catalog test succeeded in the same cluster, so this is a case-level cold metadata/driver timing issue rather than a cluster-wide outage.

## Validation

- git diff --check
- scoped to one regression case; product behavior and assertions are unchanged

Jira: DORIS-27397
TeamCity: http://172.20.48.17:8111/buildConfiguration/Doris_Doris_x64_branch41_S3_Regression_P0/203802
Occurrence: build:(id:203802),id:2000001232