### PR TITLE
[fix](test) skip test_flight_record when the frontend is not on the regression runner

### DIFF
--- a/regression-test/suites/demo_p0/test_flight_record.groovy
+++ b/regression-test/suites/demo_p0/test_flight_record.groovy
@@ -27,12 +27,29 @@ suite("test_flight_record", "nonConcurrent") {
         return
     }
 
+    // flightRecord starts the java flight recorder by the local jps/jcmd, so it only works when the
+    // frontend runs on the same machine as the regression runner, e.g. a local development cluster.
+    // Skip this demo when the frontend is not here, otherwise flightRecord will fail the suite
+    String feProcessName = "DorisFE"
+    boolean feOnThisMachine = false
+    try {
+        feOnThisMachine = "jps".execute().text.readLines().any { it.contains(feProcessName) }
+    } catch (Throwable t) {
+        // jps is shipped with the jdk, it doesn't exist if this machine only installs a jre
+        logger.info("Can not execute jps: ${t.getMessage()}")
+    }
+    if (!feOnThisMachine) {
+        logger.info("Process ${feProcessName} is not running on this machine, this case requires the "
+                + "frontend and the regression runner deployed together, skip test")
+        return
+    }
+
     flightRecord {
         // whether delete jfr file after callback, default is true
         cleanUp true
 
         // the process name, default is DorisFE
-        processName "DorisFE"
+        processName feProcessName
 
         // the jcmd extra config, default is empty
         extraConfig(["jdk.ObjectAllocationSample#throttle=\"100 /ns\""])


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`flightRecord` starts the java flight recorder by running `jps` and `jcmd` **on the machine that
executes the regression suite**, so `demo_p0/test_flight_record` only works when the frontend and
the regression runner are deployed together, e.g. a local development cluster. The case never
verified that precondition.

On a runner without a local frontend the case failed with

```
java.lang.IllegalStateException: Can not found process: DorisFE
    at .../demo_p0/test_flight_record.groovy:30
```

and was reported as a product failure, although nothing was wrong with the product.

This PR checks the precondition in the case and returns early when the frontend is not running on
this machine, the same way the case already skips on jdk below 17:

```groovy
String feProcessName = "DorisFE"
boolean feOnThisMachine = false
try {
    feOnThisMachine = "jps".execute().text.readLines().any { it.contains(feProcessName) }
} catch (Throwable t) {
    logger.info("Can not execute jps: ${t.getMessage()}")
}
if (!feOnThisMachine) {
    logger.info("Process ${feProcessName} is not running on this machine, ... skip test")
    return
}
```

`FlightRecordAction` is deliberately left untouched: once the action is really invoked, failing
loudly is the right behavior, the precondition belongs to the case. The rest of the case is kept
as is, it still demonstrates the `flightRecord` api.

### Release note

None

### Check List (For Author)

- Test
    - [x] Manual test (add detailed scripts or steps below)

    Ran the real regression harness against a local cluster (jdk17), with
    `sh run-regression-test.sh --run -d demo_p0 -s test_flight_record -g nonConcurrent`.
    The "frontend not here" case is simulated by pointing the probed process name at a name that
    does not exist, which is what the action sees when the frontend is on another machine.

    | | frontend process | result |
    |---|---|---|
    | before this PR | not found | `java.lang.IllegalStateException: Can not found process: ...`, `failed 1 suites` |
    | after this PR | not found | `Process ... is not running on this machine, ... skip test`, `failed 0 suites` |
    | after this PR | found | `JFR.start` / 11x `select 100` / `JFR.stop` / parse ok, `allocation bytes: 2348624`, `.jfr` cleaned up, `failed 0 suites` |

- Behavior changed:
    - [x] Yes. `demo_p0/test_flight_record` now skips itself when no local frontend process is found,
      instead of failing. Regression test only, no product behavior change.

- Does this need documentation?
    - [x] No.
