### PR TITLE
branch-4.0: [fix] fix routine_load_jobs first_error_msg on non-master FE and flaky ann_index_basic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -100,8 +100,13 @@ public class SchemaScanNode extends ScanNode {
 
     @Override
     public void finalizeForNereids() throws UserException {
+        // "routine_load_jobs" carries in-memory state (ERROR_LOG_URLS / FIRST_ERROR_MSG and other
+        // transient fields) that is only maintained on the master FE, so a scan served by a follower
+        // returns empty error info. Route it to the master FE, same as "tables", so the result is
+        // consistent with SHOW ROUTINE LOAD (which forwards to the master).
         if (ConnectContext.get().getSessionVariable().enableSchemaScanFromMasterFe
-                && tableName.equalsIgnoreCase("tables")) {
+                && (tableName.equalsIgnoreCase("tables")
+                        || tableName.equalsIgnoreCase("routine_load_jobs"))) {
             frontendIP = Env.getCurrentEnv().getMasterHost();
             frontendPort = Env.getCurrentEnv().getMasterRpcPort();
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3152,8 +3152,9 @@ public class SessionVariable implements Serializable, Writable {
     // for getting version is memory operation in master node,
     // but it will slightly increase the pressure on the FE master.
     @VariableMgr.VarAttr(name = ENABLE_SCHEMA_SCAN_FROM_MASTER_FE, description = {
-            "在 follower 节点查询时，是否允许从 master 节点扫描 information_schema.tables 的结果",
-            "Whether to allow scanning information_schema.tables from the master node"
+            "在 follower 节点查询时，是否允许从 master 节点扫描 information_schema.tables"
+                    + " / routine_load_jobs 的结果",
+            "Whether to allow scanning information_schema.tables / routine_load_jobs from the master node"
     })
     public boolean enableSchemaScanFromMasterFe = true;
 

--- a/regression-test/suites/ann_index_p0/ann_index_basic.groovy
+++ b/regression-test/suites/ann_index_p0/ann_index_basic.groovy
@@ -21,6 +21,16 @@
 suite ("ann_index_basic") {
 		sql "set enable_common_expr_pushdown=true;"
 
+		// After an INSERT the ANN index can become queryable slightly before the freshly written
+		// raw rows are visible to a plain (brute-force) scan. Queries that cannot be evaluated by the
+		// ANN index fall back to a brute-force scan (Asc inner_product / Desc l2 topn, small-predicate
+		// topn) and may then intermittently see an empty table right after the load. Gate on scan
+		// visibility (a real row read, not count(*) metadata) after each INSERT to keep the ordered
+		// queries deterministic.
+		def waitRowsVisible = { String tbl, int expected ->
+			awaitUntil(30) { sql("select id from ${tbl}").size() == expected }
+		}
+
 		// 1) Basic L2 ANN table: dim=3
 		sql "drop table if exists tbl_ann_l2"
 		sql """
@@ -44,6 +54,8 @@ suite ("ann_index_basic") {
 		(2, [0.5, 2.1, 2.9]),
 		(3, [10.0, 10.0, 10.0]);
 		"""
+
+		waitRowsVisible("tbl_ann_l2", 3)
 
 		// Query: l2 distance ascending (closest first)
 		qt_sql_l2_query "select id, l2_distance_approximate(embedding, [1.0,2.0,3.0]) as dist from tbl_ann_l2 order by dist limit 3;"
@@ -71,6 +83,8 @@ suite ("ann_index_basic") {
 		(2, [0.5, 0.6, 0.7, 0.8]),
 		(3, [1.0, 1.0, 1.0, 1.0]);
 		"""
+
+		waitRowsVisible("tbl_ann_ip", 3)
 
 		// Query: inner product descending (higher score first)
 		qt_sql_ip_query "select id from tbl_ann_ip order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc limit 3;"
@@ -112,6 +126,8 @@ suite ("ann_index_basic") {
         }
         sql "INSERT INTO tbl_ann_l2_large VALUES ${values.join(',')};"
 
+        waitRowsVisible("tbl_ann_l2_large", 50)
+
         // topn with small predicate (id < 5) -> selects 4/50 = 8% (<30%), should exercise "will not use ann index" path
         qt_sql_l2_small_pred "select id from tbl_ann_l2_large where id < 5 order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) limit 5;"
 
@@ -137,6 +153,8 @@ suite ("ann_index_basic") {
         """
 
         sql "INSERT INTO ann_compound VALUES (1, [1.0,2.0,3.0], 'quick brown fox'), (2, [2.0,3.0,4.0], 'lazy dog fox'), (3, [10.0,10.0,10.0], 'unrelated text');"
+
+        waitRowsVisible("ann_compound", 3)
 
         qt_sql_compound "select id from ann_compound where txt match_any 'fox' order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) limit 3;"
 }


### PR DESCRIPTION
## What this PR does

Two independent fixes for P0 regression failures on branch-4.0 (surfaced in internal CI build 203615).

### 1. `information_schema.routine_load_jobs` returns empty error columns on a non-master FE (product fix)

`FIRST_ERROR_MSG` / `ERROR_LOG_URLS` of a routine load job are transient, in-memory fields maintained **only on the master FE** (set in `RoutineLoadJob.executeTaskOnTxnStatusChanged` on task-txn commit; the follower replay path never sets them).

`information_schema.routine_load_jobs` is served by the local (coordinating) FE, so on a non-master FE these columns come back empty, while `SHOW ROUTINE LOAD` (forwarded to the master) shows them. In a multi-FE cluster the two views are inconsistent, which made `test_routine_load_first_error_msg` fail (~4/5 runs).

**Fix:** route the `routine_load_jobs` scan to the master FE, the same way `information_schema.tables` is already routed, gated by the existing `enable_schema_scan_from_master_fe` session variable (default `true`). No BE change, no test change needed.

### 2. Flaky `ann_index_basic` — `sql_ip_asc` empty result (test fix)

Queries whose top-n cannot be evaluated by the ANN index (Asc `inner_product`, Desc `l2`, small-predicate top-n) fall back to a brute-force scan. Right after an INSERT the freshly written raw rows can be briefly invisible to that scan, so the ordered query intermittently returns nothing.

**Fix:** add a scan-visibility gate after each INSERT that waits until a real row read (`select id`, not `count(*)` which may take a metadata shortcut) returns the expected number of rows. `.out` and `qt_` tags are unchanged.

## Verification

- FE change is minimal and type-checked; not built/e2e-locally — relying on PR CI.
- Root causes confirmed by code path + CI history (routine_load 4/5 fail, ann_index ~2/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
