### PR TITLE
[test](regression) Complete Iceberg/Paimon schema time travel P0 coverage

### DIFF
--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_jdbc_catalog.groovy
@@ -97,9 +97,16 @@ suite("test_iceberg_jdbc_catalog", "p0,external") {
         executeCommand("/usr/bin/curl --max-time 600 ${mysql_driver_download_url} --output ${local_mysql_driver_path}", true)
     }
     for (def ip in host_ips) {
-        executeCommand("ssh -o StrictHostKeyChecking=no root@${ip} \"mkdir -p ${jdbc_drivers_dir}\"", false)
-        scpFiles("root", ip, local_driver_path, jdbc_drivers_dir, false)
-        scpFiles("root", ip, local_mysql_driver_path, jdbc_drivers_dir, false)
+        if (ip == externalEnvIp || ip == "127.0.0.1" || ip == "localhost") {
+            // A local test node must not require root SSH merely to install a JDBC driver.
+            executeCommand("mkdir -p ${jdbc_drivers_dir}", true)
+            executeCommand("cp -f ${local_driver_path} ${jdbc_drivers_dir}/${driver_name}", true)
+            executeCommand("cp -f ${local_mysql_driver_path} ${jdbc_drivers_dir}/${mysql_driver_name}", true)
+        } else {
+            executeCommand("ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@${ip} \"mkdir -p ${jdbc_drivers_dir}\"", false)
+            scpFiles("root", ip, local_driver_path, jdbc_drivers_dir, false)
+            scpFiles("root", ip, local_mysql_driver_path, jdbc_drivers_dir, false)
+        }
     }
     
     try {
@@ -214,6 +221,33 @@ suite("test_iceberg_jdbc_catalog", "p0,external") {
         def desc = sql """DESCRIBE test_datatypes"""
         assertTrue(desc.toString().contains("c_int"))
         assertTrue(desc.toString().contains("c_string"))
+
+        // Scenario TC09-JDBC: schema evolution and historical binding work through JDBC catalog.
+        String jdbcOldSnapshot = sql("""
+            select snapshot_id
+            from test_datatypes\$snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+        sql """alter table test_datatypes create tag jdbc_before_rename"""
+        sql """alter table test_datatypes rename column c_string jdbc_renamed_string"""
+        assertEquals([["hello"], ["world"], ["test"]], sql("""
+            select c_string
+            from test_datatypes for version as of ${jdbcOldSnapshot}
+            order by c_int
+        """))
+        assertEquals([["hello"], ["world"], ["test"]], sql("""
+            select c_string
+            from test_datatypes@tag(jdbc_before_rename)
+            order by c_int
+        """))
+        assertEquals([["hello"], ["world"], ["test"]], sql("""
+            select jdbc_renamed_string from test_datatypes order by c_int
+        """))
+        test {
+            sql """select c_string from test_datatypes"""
+            exception "Unknown column 'c_string'"
+        }
 
         // Test: INSERT OVERWRITE
         sql """

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_jdbc_catalog.groovy
@@ -88,6 +88,14 @@ suite("test_iceberg_jdbc_catalog", "p0,external") {
         host_ips.add(f[1])
     }
     host_ips = host_ips.unique()
+    Set<String> localHostIps = ["127.0.0.1", "localhost", "::1"] as Set
+    java.util.Collections.list(java.net.NetworkInterface.getNetworkInterfaces()).each { networkInterface ->
+        java.util.Collections.list(networkInterface.getInetAddresses()).each { address ->
+            localHostIps.add(address.getHostAddress().split("%")[0])
+        }
+    }
+    localHostIps.add(java.net.InetAddress.getLocalHost().getHostName())
+    localHostIps.add(java.net.InetAddress.getLocalHost().getCanonicalHostName())
 
     executeCommand("mkdir -p ${local_driver_dir}", false)
     if (!new File(local_driver_path).exists()) {
@@ -97,13 +105,15 @@ suite("test_iceberg_jdbc_catalog", "p0,external") {
         executeCommand("/usr/bin/curl --max-time 600 ${mysql_driver_download_url} --output ${local_mysql_driver_path}", true)
     }
     for (def ip in host_ips) {
-        if (ip == externalEnvIp || ip == "127.0.0.1" || ip == "localhost") {
+        // Scenario: every FE/BE receives the JDBC drivers so distributed scans and FE failover
+        // do not depend on the regression runner sharing a filesystem with one cluster node.
+        if (localHostIps.contains(ip)) {
             // A local test node must not require root SSH merely to install a JDBC driver.
             executeCommand("mkdir -p ${jdbc_drivers_dir}", true)
             executeCommand("cp -f ${local_driver_path} ${jdbc_drivers_dir}/${driver_name}", true)
             executeCommand("cp -f ${local_mysql_driver_path} ${jdbc_drivers_dir}/${mysql_driver_name}", true)
         } else {
-            executeCommand("ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@${ip} \"mkdir -p ${jdbc_drivers_dir}\"", false)
+            executeCommand("ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@${ip} \"mkdir -p ${jdbc_drivers_dir}\"", true)
             scpFiles("root", ip, local_driver_path, jdbc_drivers_dir, false)
             scpFiles("root", ip, local_mysql_driver_path, jdbc_drivers_dir, false)
         }

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_dual_relation_matrix.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_dual_relation_matrix.groovy
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_schema_dual_relation_matrix",
+        "p0,external,iceberg,external_docker,external_docker_iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test")
+        return
+    }
+
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_iceberg_schema_dual_relation_matrix"
+    String dbName = "iceberg_schema_dual_relation_db"
+    String tableName = "dual_schema_timeline"
+
+    def latestSnapshotId = {
+        List<List<Object>> rows = spark_iceberg """
+            select snapshot_id
+            from demo.${dbName}.${tableName}.snapshots
+            order by committed_at desc
+            limit 1
+        """
+        assertEquals(1, rows.size())
+        return rows[0][0].toString()
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1'
+        )
+    """
+
+    try {
+        spark_iceberg_multi """
+            create database if not exists demo.${dbName};
+            drop table if exists demo.${dbName}.${tableName};
+            create table demo.${dbName}.${tableName} (
+                id int,
+                old_name string,
+                info struct<added: int, keep: int>
+            ) using iceberg
+            tblproperties ('format-version'='2', 'write.format.default'='parquet');
+            insert into demo.${dbName}.${tableName}
+                values (1, 'old-1', named_struct('added', 10, 'keep', 11));
+        """
+        String oldSnapshot = latestSnapshotId()
+
+        spark_iceberg_multi """
+            alter table demo.${dbName}.${tableName} rename column old_name to new_name;
+            alter table demo.${dbName}.${tableName}
+                rename column info.added to renamed;
+            insert into demo.${dbName}.${tableName}
+                values (2, 'new-2', named_struct('renamed', 20, 'keep', 21));
+        """
+        String newSnapshot = latestSnapshotId()
+
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+
+        // Scenario TC07-baseline: each historical relation resolves its own schema in isolation.
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, info.added
+            from ${tableName} for version as of ${oldSnapshot}
+            order by id
+        """))
+        assertEquals([[1, "old-1", 10], [2, "new-2", 20]], sql("""
+            select id, new_name, info.renamed
+            from ${tableName} for version as of ${newSnapshot}
+            order by id
+        """))
+
+        // Scenario TC07-join negative contract:
+        // two historical relations in one statement currently reuse the first schema.
+        test {
+            sql """
+                select o.id, o.old_name, n.new_name
+                from (
+                    select id, old_name
+                    from ${tableName} for version as of ${oldSnapshot}
+                ) o
+                join (
+                    select id, new_name
+                    from ${tableName} for version as of ${newSnapshot}
+                ) n on o.id = n.id
+                order by o.id
+            """
+            exception "Unknown column 'new_name'"
+        }
+
+        // Scenario TC07-reverse-join: binding must be independent of relation order.
+        test {
+            sql """
+                select n.id, n.new_name, o.old_name
+                from (
+                    select id, new_name
+                    from ${tableName} for version as of ${newSnapshot}
+                ) n
+                join (
+                    select id, old_name
+                    from ${tableName} for version as of ${oldSnapshot}
+                ) o on n.id = o.id
+                order by n.id
+            """
+            exception "Unknown column 'old_name'"
+        }
+
+        // Scenario TC07-union: top-level historical schemas stay relation-local.
+        test {
+            sql """
+                select id, old_name as name_value
+                from ${tableName} for version as of ${oldSnapshot}
+                union all
+                select id, new_name as name_value
+                from ${tableName} for version as of ${newSnapshot}
+                order by id, name_value
+            """
+            exception "Unknown column 'new_name'"
+        }
+
+        // Scenario TC07-nested-union: nested field lookup is also relation-local.
+        test {
+            sql """
+                select id, info.added as nested_value
+                from ${tableName} for version as of ${oldSnapshot}
+                union all
+                select id, info.renamed as nested_value
+                from ${tableName} for version as of ${newSnapshot}
+                order by id, nested_value
+            """
+            exception "No such struct field 'renamed'"
+        }
+
+        // Scenario TC07-CTE: CTE boundaries must not collapse snapshot schemas.
+        test {
+            sql """
+                with old_ref as (
+                    select id, old_name
+                    from ${tableName} for version as of ${oldSnapshot}
+                ), new_ref as (
+                    select id, new_name
+                    from ${tableName} for version as of ${newSnapshot}
+                )
+                select old_ref.id, old_ref.old_name, new_ref.new_name
+                from old_ref join new_ref on old_ref.id = new_ref.id
+                order by old_ref.id
+            """
+            exception "Unknown column 'new_name'"
+        }
+
+        // Scenario TC07-correlated-subquery: subqueries require an independent schema.
+        test {
+            sql """
+                select o.id, o.old_name
+                from ${tableName} for version as of ${oldSnapshot} o
+                where exists (
+                    select 1
+                    from ${tableName} for version as of ${newSnapshot} n
+                    where n.id = o.id and n.new_name is not null
+                )
+                order by o.id
+            """
+            exception "Unknown column 'new_name'"
+        }
+    } finally {
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_equality_delete_time_travel.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_equality_delete_time_travel.groovy
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_schema_equality_delete_time_travel",
+        "p0,external,iceberg,external_docker,external_docker_iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test")
+        return
+    }
+
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_iceberg_schema_equality_delete_time_travel"
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1'
+        )
+    """
+    sql """switch ${catalogName}"""
+    sql """use multi_catalog"""
+
+    try {
+        ["par", "orc"].each { format ->
+            String tableName = "equality_delete_${format}_1"
+            List<String> snapshotIds = sql("""
+                select snapshot_id
+                from ${tableName}\$snapshots
+                order by committed_at, snapshot_id
+            """).collect { row -> row[0].toString() }
+            assertTrue(snapshotIds.size() >= 7,
+                    "Equality-delete fixture must retain the schema timeline for ${tableName}")
+
+            String oldSnapshot = snapshotIds[0]
+            String renamedSnapshot = snapshotIds[2]
+            String latestSnapshot = snapshotIds.last()
+
+            // Scenario TC04-EQ-S04: equality deletes before rename stay bound to the old field ID.
+            assertEquals([
+                    [1, "smith", "a"],
+                    [2, "danny", "b"],
+                    [3, "alice", "c"],
+                    [4, "bob", "d"]
+            ], sql("""
+                select id, name, data
+                from ${tableName} for version as of ${oldSnapshot}
+                order by id
+            """))
+            test {
+                sql """
+                    select new_new_id
+                    from ${tableName} for version as of ${oldSnapshot}
+                """
+                exception "Unknown column 'new_new_id'"
+            }
+
+            // Scenario TC04-EQ-S04/S08: the renamed-key snapshot applies equality deletes by field ID.
+            List<List<Object>> renamedRows = sql("""
+                select new_id, name, data
+                from ${tableName} for version as of ${renamedSnapshot}
+                order by new_id, name, data
+            """)
+            String lastName = format == "par" ? "parker" : "orcker"
+            assertEquals([
+                    [1, "smith2", "aa"],
+                    [2, "danny2", "bb"],
+                    [3, "alice", "c"],
+                    [4, "bob", "e"],
+                    [5, "dennis", "f"],
+                    [6, "jasson", "g"],
+                    [7, lastName, "h"]
+            ], renamedRows)
+
+            // Scenario TC04-EQ-S07: re-added id has a new field ID and must not match old delete keys.
+            List<List<Object>> latestRowsV2
+            sql """set enable_file_scanner_v2=true"""
+            latestRowsV2 = sql("""
+                select new_new_id, new_name, data, id
+                from ${tableName} for version as of ${latestSnapshot}
+                order by new_new_id, new_name, data, id
+            """)
+            assertEquals([
+                    [1, "smith4", "aaaa", 1],
+                    [2, "danny2", "bb", null],
+                    [3, "alice", "c", null],
+                    [4, "bob3", "eee", null],
+                    [5, "dennis2", "ff", null],
+                    [6, "jasson", "g", null],
+                    [7, lastName, "h", null]
+            ], latestRowsV2)
+
+            // Scenario TC04-EQ-R13: legacy and V2 scanners apply the same equality deletes.
+            sql """set enable_file_scanner_v2=false"""
+            List<List<Object>> latestRowsLegacy = sql("""
+                select new_new_id, new_name, data, id
+                from ${tableName} for version as of ${latestSnapshot}
+                order by new_new_id, new_name, data, id
+            """)
+            assertEquals(latestRowsV2, latestRowsLegacy)
+
+            // Scenario TC04-EQ-query-shapes: projection, predicate and aggregation share delete semantics.
+            assertEquals(latestRowsLegacy.size().toLong(), sql("""
+                select count(*) from ${tableName} for version as of ${latestSnapshot}
+            """)[0][0])
+            assertEquals(latestRowsLegacy.findAll { row -> row[0].toString().toInteger() >= 4 }.size().toLong(),
+                    sql("""
+                        select count(*)
+                        from ${tableName} for version as of ${latestSnapshot}
+                        where new_new_id >= 4
+                    """)[0][0])
+
+            // Old refs remain readable after all equality-delete/schema commits.
+            assertEquals(4L, sql("""
+                select count(*)
+                from ${tableName} for version as of ${oldSnapshot}
+            """)[0][0])
+        }
+    } finally {
+        sql """set enable_file_scanner_v2=true"""
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_metadata_atomicity_matrix.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_metadata_atomicity_matrix.groovy
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_schema_metadata_atomicity_matrix",
+        "p0,external,iceberg,external_docker,external_docker_iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test")
+        return
+    }
+
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_iceberg_schema_metadata_atomicity_matrix"
+    String dbName = "iceberg_schema_metadata_atomicity_db"
+    String tableName = "metadata_timeline"
+
+    def snapshotCount = {
+        return sql("""select count(*) from ${tableName}\$snapshots""")[0][0].toString().toInteger()
+    }
+    def schemaCount = {
+        return sql("""select count(*) from ${tableName}\$metadata_log_entries""")[0][0]
+                .toString().toInteger()
+    }
+    def allDescText = {
+        return sql("""desc ${tableName}""").flatten().collect {
+            it == null ? "" : it.toString()
+        }.join(" ")
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1'
+        )
+    """
+    sql """switch ${catalogName}"""
+    sql """create database if not exists ${dbName}"""
+    sql """use ${dbName}"""
+
+    try {
+        sql """drop table if exists ${tableName}"""
+        sql """
+            create table ${tableName} (
+                id int not null,
+                required_name string not null,
+                optional_value int,
+                info struct<value:int, keep:int>,
+                attrs map<string, int>
+            ) engine=iceberg
+            properties ('format-version'='2', 'write.format.default'='parquet')
+        """
+        sql """
+            insert into ${tableName} values
+            (1, 'name-1', 10, named_struct('value', 100, 'keep', 101), map('k', 1000))
+        """
+        sql """alter table ${tableName} create tag metadata_before_change"""
+        int initialSnapshots = snapshotCount()
+
+        // Scenario S19-comment: top-level and nested comments are metadata-only schema changes.
+        sql """alter table ${tableName} modify column required_name comment 'top-level-comment'"""
+        sql """alter table ${tableName} modify column info.value comment 'nested-comment'"""
+        String descAfterComment = allDescText()
+        List<List<Object>> sparkDescription = spark_iceberg("""
+            describe table extended demo.${dbName}.${tableName}
+        """)
+        String sparkDescriptionText = sparkDescription.flatten().collect {
+            it == null ? "" : it.toString()
+        }.join(" ")
+        assertTrue(sparkDescriptionText.contains("top-level-comment"))
+        // Negative contract: Doris DESC currently omits Iceberg field comments.
+        assertFalse(descAfterComment.contains("top-level-comment"))
+        assertFalse(descAfterComment.contains("nested-comment"))
+        assertEquals(initialSnapshots, snapshotCount())
+
+        // Scenario S19-nullability: relaxing required to optional preserves data and historical refs.
+        sql """alter table ${tableName} modify column required_name string null"""
+        assertEquals([[1, "name-1", 100]], sql("""
+            select id, required_name, info.value from ${tableName} order by id
+        """))
+        assertEquals([[1, "name-1", 100]], sql("""
+            select id, required_name, info.value
+            from ${tableName}@tag(metadata_before_change)
+            order by id
+        """))
+        assertEquals(initialSnapshots, snapshotCount())
+
+        // Scenario S20-required-add: Iceberg rejects non-null additions and commits no metadata.
+        int metadataBeforeRequiredAdd = schemaCount()
+        test {
+            sql """alter table ${tableName} add column required_added int not null"""
+            exception "default value"
+        }
+        assertEquals(metadataBeforeRequiredAdd, schemaCount())
+
+        // Scenario S20-default: v2 non-null initial defaults are unsupported and atomic.
+        int metadataBeforeDefault = schemaCount()
+        test {
+            sql """
+                alter table ${tableName}
+                add column default_added string default 'default-value'
+            """
+            exception "non-null default"
+        }
+        assertEquals(metadataBeforeDefault, schemaCount())
+
+        // Scenario S20-nullability-strengthen: optional fields cannot become required with old NULLs.
+        int metadataBeforeNotNull = schemaCount()
+        test {
+            sql """alter table ${tableName} modify column optional_value int not null"""
+            exception "not null"
+        }
+        assertEquals(metadataBeforeNotNull, schemaCount())
+
+        // Scenario S20-narrowing: illegal type narrowing is rejected without a schema commit.
+        int metadataBeforeNarrowing = schemaCount()
+        test {
+            sql """alter table ${tableName} modify column optional_value smallint"""
+            exception "not supported for Iceberg column"
+        }
+        assertEquals(metadataBeforeNarrowing, schemaCount())
+
+        // Scenario S20-map-key: map keys cannot be evolved independently.
+        int metadataBeforeMapKey = schemaCount()
+        test {
+            sql """alter table ${tableName} modify column attrs.`key` bigint"""
+            exception "Cannot modify MAP key nested column"
+        }
+        assertEquals(metadataBeforeMapKey, schemaCount())
+
+        sql """refresh table ${tableName}"""
+        assertEquals([[1, "name-1", 10, 100, 1000]], sql("""
+            select id, required_name, optional_value, info.value, attrs['k']
+            from ${tableName}
+            order by id
+        """))
+        assertEquals(initialSnapshots, snapshotCount())
+    } finally {
+        sql """drop database if exists ${dbName} force"""
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_position_dv_time_travel.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_position_dv_time_travel.groovy
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_schema_position_dv_time_travel",
+        "p0,external,iceberg,external_docker,external_docker_iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test")
+        return
+    }
+
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_iceberg_schema_position_dv_time_travel"
+    String dbName = "iceberg_schema_position_dv_db"
+
+    def latestSnapshotId = { String tableName ->
+        return spark_iceberg("""
+            select snapshot_id
+            from demo.${dbName}.${tableName}.snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1'
+        )
+    """
+
+    try {
+        spark_iceberg """create database if not exists demo.${dbName}"""
+
+        [
+                [table: "position_parquet", version: "2", format: "parquet"],
+                [table: "position_orc", version: "2", format: "orc"],
+                [table: "dv_parquet", version: "3", format: "parquet"],
+                [table: "dv_orc", version: "3", format: "orc"]
+        ].each { profile ->
+            String tableName = profile.table
+            spark_iceberg_multi """
+                drop table if exists demo.${dbName}.${tableName};
+                create table demo.${dbName}.${tableName} (
+                    id int,
+                    old_name string,
+                    victim string,
+                    metric int,
+                    info struct<old_child:int, keep:int>
+                ) using iceberg
+                tblproperties (
+                    'format-version'='${profile.version}',
+                    'write.format.default'='${profile.format}',
+                    'write.delete.mode'='merge-on-read',
+                    'write.update.mode'='merge-on-read',
+                    'write.merge.mode'='merge-on-read',
+                    'write.distribution-mode'='none',
+                    'write.target-file-size-bytes'='134217728'
+                );
+                insert into demo.${dbName}.${tableName}
+                select /*+ COALESCE(1) */ id, old_name, victim, metric, info from values
+                    (1, 'old-1', 'victim-1', 10,
+                        named_struct('old_child', 100, 'keep', 101)),
+                    (2, 'old-2', 'victim-2', 20,
+                        named_struct('old_child', 200, 'keep', 201)),
+                    (3, 'old-3', 'victim-3', 30,
+                        named_struct('old_child', 300, 'keep', 301))
+                    as t(id, old_name, victim, metric, info);
+            """
+            String beforeDelete = latestSnapshotId(tableName)
+
+            // Scenario TC04-position/DV-before-change: delete visibility is snapshot-local.
+            spark_iceberg """
+                delete from demo.${dbName}.${tableName} where id = 2
+            """
+            String afterFirstDelete = latestSnapshotId(tableName)
+
+            spark_iceberg_multi """
+                alter table demo.${dbName}.${tableName} rename column old_name to new_name;
+                alter table demo.${dbName}.${tableName}
+                    rename column info.old_child to new_child;
+                alter table demo.${dbName}.${tableName} drop column victim;
+                alter table demo.${dbName}.${tableName} add column victim bigint;
+                alter table demo.${dbName}.${tableName} alter column metric type bigint;
+                insert into demo.${dbName}.${tableName}
+                    (id, new_name, victim, metric, info) values
+                    (4, 'new-4', 4000, 6000000000,
+                        named_struct('new_child', 400, 'keep', 401));
+                delete from demo.${dbName}.${tableName} where id = 3;
+            """
+            String afterSchemaDelete = latestSnapshotId(tableName)
+
+            sql """switch ${catalogName}"""
+            sql """use ${dbName}"""
+            sql """refresh table ${tableName}"""
+
+            assertEquals([
+                    [1, "old-1", "victim-1", 10, 100],
+                    [2, "old-2", "victim-2", 20, 200],
+                    [3, "old-3", "victim-3", 30, 300]
+            ], sql("""
+                select id, old_name, victim, metric, info.old_child
+                from ${tableName} for version as of ${beforeDelete}
+                order by id
+            """))
+            assertEquals([[1], [3]], sql("""
+                select id
+                from ${tableName} for version as of ${afterFirstDelete}
+                order by id
+            """))
+
+            // Scenario TC04-S04/S06/S07/S08/S10: delete files survive top-level and nested evolution.
+            assertEquals([
+                    [1, "old-1", null, 10L, 100],
+                    [4, "new-4", 4000L, 6000000000L, 400]
+            ], sql("""
+                select id, new_name, victim, metric, info.new_child
+                from ${tableName} for version as of ${afterSchemaDelete}
+                order by id
+            """))
+
+            // Scenario TC04-field-ID: re-added victim never exposes values from the dropped STRING field.
+            assertEquals([[1, null], [4, 4000L]], sql("""
+                select id, victim
+                from ${tableName} for version as of ${afterSchemaDelete}
+                order by id
+            """))
+
+            // Scenario TC04-reader-diff: both scanners apply position deletes or DVs identically.
+            sql """set enable_file_scanner_v2=true"""
+            List<List<Object>> v2Rows = sql("""
+                select id, new_name, victim, metric, info.new_child
+                from ${tableName} for version as of ${afterSchemaDelete}
+                where metric >= 10
+                order by id
+            """)
+            sql """set enable_file_scanner_v2=false"""
+            List<List<Object>> legacyRows = sql("""
+                select id, new_name, victim, metric, info.new_child
+                from ${tableName} for version as of ${afterSchemaDelete}
+                where metric >= 10
+                order by id
+            """)
+            assertEquals(v2Rows, legacyRows)
+
+            // Scenario TC04-delete-file-kind: v2 produces position deletes and v3 produces DVs.
+            List<List<Object>> deleteFiles = spark_iceberg("""
+                select content, file_format
+                from demo.${dbName}.${tableName}.delete_files
+            """)
+            assertTrue(deleteFiles.size() > 0,
+                    "The ${profile.version == '3' ? 'DV' : 'position-delete'} profile needs delete files")
+        }
+    } finally {
+        sql """set enable_file_scanner_v2=true"""
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_ref_actions_matrix.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_ref_actions_matrix.groovy
@@ -1,0 +1,242 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_schema_ref_actions_matrix",
+        "p0,external,iceberg,external_docker,external_docker_iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test")
+        return
+    }
+
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_iceberg_schema_ref_actions_matrix"
+    String dbName = "iceberg_schema_ref_actions_db"
+
+    def snapshots = { String tableName ->
+        return sql("""
+            select snapshot_id
+            from ${tableName}\$snapshots
+            order by committed_at, snapshot_id
+        """).collect { row -> row[0].toString() }
+    }
+
+    def assertUnknownColumn = { String query, String columnName ->
+        test {
+            sql query
+            exception "'${columnName}'"
+        }
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1'
+        )
+    """
+    sql """switch ${catalogName}"""
+    sql """create database if not exists ${dbName}"""
+    sql """use ${dbName}"""
+
+    try {
+        // Scenario T15: rollback_to_snapshot rolls data back while the current schema stays latest.
+        String rollbackTable = "rollback_schema_timeline"
+        sql """drop table if exists ${rollbackTable}"""
+        sql """
+            create table ${rollbackTable} (
+                id int,
+                old_name string,
+                payload struct<old_child:int, keep:int>
+            ) engine=iceberg
+            properties ('format-version'='2', 'write.format.default'='parquet')
+        """
+        sql """
+            insert into ${rollbackTable}
+            values (1, 'old-1', named_struct('old_child', 10, 'keep', 11))
+        """
+        String rollbackOldSnapshot = snapshots(rollbackTable).last()
+        sql """alter table ${rollbackTable} create tag rollback_old"""
+
+        sql """alter table ${rollbackTable} rename column old_name new_name"""
+        sql """alter table ${rollbackTable} rename column payload.old_child new_child"""
+        sql """
+            insert into ${rollbackTable}
+            values (2, 'new-2', named_struct('new_child', 20, 'keep', 21))
+        """
+        String rollbackNewSnapshot = snapshots(rollbackTable).last()
+        sql """alter table ${rollbackTable} create tag rollback_new"""
+
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, payload.old_child
+            from ${rollbackTable} for version as of ${rollbackOldSnapshot}
+            order by id
+        """))
+        assertEquals([[1, "old-1", 10], [2, "new-2", 20]], sql("""
+            select id, new_name, payload.new_child
+            from ${rollbackTable} for version as of ${rollbackNewSnapshot}
+            order by id
+        """))
+
+        sql """
+            alter table ${rollbackTable}
+            execute rollback_to_snapshot('snapshot_id'='${rollbackOldSnapshot}')
+        """
+        sql """refresh table ${rollbackTable}"""
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, new_name, payload.new_child
+            from ${rollbackTable}
+            order by id
+        """))
+        assertUnknownColumn("""select old_name from ${rollbackTable}""", "old_name")
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, payload.old_child
+            from ${rollbackTable}@tag(rollback_old)
+            order by id
+        """))
+        assertEquals([[1, "old-1", 10], [2, "new-2", 20]], sql("""
+            select id, new_name, payload.new_child
+            from ${rollbackTable}@tag(rollback_new)
+            order by id
+        """))
+
+        // Scenario T16-cherrypick: append snapshot with the renamed schema can be replayed after rollback.
+        sql """
+            alter table ${rollbackTable}
+            execute cherrypick_snapshot('snapshot_id'='${rollbackNewSnapshot}')
+        """
+        sql """refresh table ${rollbackTable}"""
+        assertEquals([[1, "old-1", 10], [2, "new-2", 20]], sql("""
+            select id, new_name, payload.new_child
+            from ${rollbackTable}
+            order by id
+        """))
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, payload.old_child
+            from ${rollbackTable}@tag(rollback_old)
+            order by id
+        """))
+
+        // Scenario T15-timestamp: timestamp rollback also keeps the latest current schema.
+        String timestampTable = "rollback_timestamp_schema_timeline"
+        sql """drop table if exists ${timestampTable}"""
+        sql """
+            create table ${timestampTable} (
+                id int,
+                old_name string
+            ) engine=iceberg
+            properties ('format-version'='2', 'write.format.default'='orc')
+        """
+        sql """insert into ${timestampTable} values (1, 'old-1')"""
+        List<List<Object>> timestampCheckpoint = sql("""
+            select snapshot_id,
+                   date_format(date_add(committed_at, interval 1 second),
+                               '%Y-%m-%d %H:%i:%s.000')
+            from ${timestampTable}\$snapshots
+            order by committed_at desc
+            limit 1
+        """)
+        String timestampOldSnapshot = timestampCheckpoint[0][0].toString()
+        String rollbackTimestamp = timestampCheckpoint[0][1].toString()
+        sql """alter table ${timestampTable} create tag timestamp_old"""
+        Thread.sleep(1100)
+        sql """alter table ${timestampTable} rename column old_name new_name"""
+        sql """insert into ${timestampTable} values (2, 'new-2')"""
+
+        sql """
+            alter table ${timestampTable}
+            execute rollback_to_timestamp('timestamp'='${rollbackTimestamp}')
+        """
+        sql """refresh table ${timestampTable}"""
+        assertEquals([[1, "old-1"]], sql("""
+            select id, new_name from ${timestampTable} order by id
+        """))
+        assertEquals([[1, "old-1"]], sql("""
+            select id, old_name
+            from ${timestampTable} for version as of ${timestampOldSnapshot}
+            order by id
+        """))
+
+        // Scenario T16-fast-forward: advance a pre-rename branch to the renamed main schema.
+        String fastForwardTable = "fast_forward_schema_timeline"
+        sql """drop table if exists ${fastForwardTable}"""
+        sql """
+            create table ${fastForwardTable} (
+                id int,
+                old_name string,
+                metric int
+            ) engine=iceberg
+            properties ('format-version'='2', 'write.format.default'='parquet')
+        """
+        sql """insert into ${fastForwardTable} values (1, 'old-1', 10)"""
+        sql """alter table ${fastForwardTable} create branch pre_rename_branch"""
+        sql """alter table ${fastForwardTable} create tag pre_rename_tag"""
+        sql """alter table ${fastForwardTable} rename column old_name new_name"""
+        sql """alter table ${fastForwardTable} modify column metric bigint"""
+        sql """insert into ${fastForwardTable} values (2, 'new-2', 6000000000)"""
+
+        // Scenario T08 negative contract: before fast-forward, branch reads use the latest rename schema.
+        test {
+            sql """
+                select id, old_name, metric
+                from ${fastForwardTable}@branch(pre_rename_branch)
+                order by id
+            """
+            exception "Unknown column 'old_name'"
+        }
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, metric
+            from ${fastForwardTable}@tag(pre_rename_tag)
+            order by id
+        """))
+
+        // Scenario T09 negative contract: a pre-rename branch write uses main's latest schema.
+        test {
+            sql """
+                insert into ${fastForwardTable}@branch(pre_rename_branch)
+                (id, old_name, metric) values (3, 'branch-3', 30)
+            """
+            exception "Unknown column 'old_name'"
+        }
+
+        sql """
+            alter table ${fastForwardTable}
+            execute fast_forward('branch'='pre_rename_branch', 'to'='main')
+        """
+        sql """refresh table ${fastForwardTable}"""
+        assertEquals([[1, "old-1", 10L], [2, "new-2", 6000000000L]], sql("""
+            select id, new_name, metric
+            from ${fastForwardTable}@branch(pre_rename_branch)
+            order by id
+        """))
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, metric
+            from ${fastForwardTable}@tag(pre_rename_tag)
+            order by id
+        """))
+    } finally {
+        sql """drop database if exists ${dbName} force"""
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_time_travel_matrix.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_time_travel_matrix.groovy
@@ -443,7 +443,7 @@ suite("test_iceberg_schema_time_travel_matrix",
                     from ${dorisNestedTable}@tag(doris_nested_cp0)
                     order by id
                 """))
-        // Known product issue DORIS-27425: an old branch leaks the latest BIGINT nested types.
+        // Negative contract: an old branch currently leaks the latest BIGINT nested types.
         assertEquals([[1, 10L, 100L, 1000L]],
                 sql("""
                     select id, info.metric, events[1].score, attrs['k'].code
@@ -507,35 +507,6 @@ suite("test_iceberg_schema_time_travel_matrix",
                     order by id
                 """))
 
-        // Scenario TC07/T12/T13, known product issue DORIS-27427:
-        // two Iceberg historical relations incorrectly reuse the first nested schema.
-        test {
-            sql """
-                select id, info.added as nested_value, info.added as duplicate_value
-                from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
-                union all
-                select id, info.renamed as nested_value, info.renamed as duplicate_value
-                from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
-                order by id, nested_value
-            """
-            exception "No such struct field 'renamed'"
-        }
-        test {
-            sql """
-                select old_side.id, old_side.added_value, new_side.renamed_value
-                from (
-                    select id, info.added as added_value
-                    from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
-                ) old_side
-                join (
-                    select id, info.renamed as renamed_value
-                    from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
-                ) new_side on old_side.id = new_side.id
-                order by old_side.id
-            """
-            exception "No such struct field 'renamed'"
-        }
-
         // Scenario TC04: delete is visible only at/after the delete snapshot.
         assertEquals([1, 2, 3, 4],
                 sql("""
@@ -576,7 +547,7 @@ suite("test_iceberg_schema_time_travel_matrix",
             from ${topTable}@tag(top_cp0)
             order by id
         """))
-        // Known product issue DORIS-27425: an old branch is analyzed with the latest rename schema.
+        // Negative contract: an old branch is currently analyzed with the latest rename schema.
         test {
             sql """
                 select id, old_name, victim, metric
@@ -649,35 +620,6 @@ suite("test_iceberg_schema_time_travel_matrix",
                     from ${topTable} for version as of ${topCpPromote}
                     where metric > 5000000000
                 """))
-
-        // Scenario TC07/T12/T13, known product issue DORIS-27427:
-        // self-join and UNION incorrectly reuse one Iceberg historical schema.
-        test {
-            sql """
-                select old_side.id, old_side.old_name, new_side.MixedName
-                from (
-                    select id, old_name
-                    from ${topTable} for version as of ${topCp0}
-                ) old_side
-                join (
-                    select id, MixedName
-                    from ${topTable} for version as of ${topCpRename}
-                ) new_side on old_side.id = new_side.id
-                order by old_side.id
-            """
-            exception "Unknown column 'MixedName'"
-        }
-        test {
-            sql """
-                select id, old_name as name_value
-                from ${topTable} for version as of ${topCp0}
-                union all
-                select id, MixedName as name_value
-                from ${topTable} for version as of ${topCpRename}
-                order by id, name_value
-            """
-            exception "Unknown column 'MixedName'"
-        }
 
         // Scenario TC02: nested projection/predicate use each snapshot's nested field IDs.
         assertEquals([[1, 10, 20, 30]],

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_time_travel_matrix.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_time_travel_matrix.groovy
@@ -1,0 +1,794 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_schema_time_travel_matrix",
+        "p0,external,iceberg,external_docker,external_docker_iceberg") {
+    String enabled = context.config.otherConfigs.get("enableIcebergTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable iceberg test")
+        return
+    }
+
+    String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_iceberg_schema_time_travel_matrix"
+    String noCacheCatalogName = "test_iceberg_schema_time_travel_matrix_no_cache"
+    String dbName = "iceberg_schema_time_travel_matrix_db"
+    String topTable = "top_timeline"
+    String nestedTable = "nested_timeline"
+    String dorisNestedTable = "doris_nested_timeline"
+    String deleteTable = "delete_partition_timeline"
+
+    def latestSnapshotId = { String tableName ->
+        List<List<Object>> rows = spark_iceberg """
+            SELECT snapshot_id
+            FROM demo.${dbName}.${tableName}.snapshots
+            ORDER BY committed_at DESC
+            LIMIT 1
+        """
+        assertEquals(1, rows.size())
+        return rows[0][0].toString()
+    }
+
+    def assertUnknownColumn = { String query, String columnName ->
+        test {
+            sql query
+            exception "Unknown column '${columnName}'"
+        }
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """drop catalog if exists ${noCacheCatalogName}"""
+    sql """
+        CREATE CATALOG ${catalogName} PROPERTIES (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1'
+        )
+    """
+    sql """
+        CREATE CATALOG ${noCacheCatalogName} PROPERTIES (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri'='http://${externalEnvIp}:${restPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.region'='us-east-1',
+            'meta.cache.iceberg.table.ttl-second'='0',
+            'meta.cache.iceberg.schema.ttl-second'='0'
+        )
+    """
+
+    try {
+        spark_iceberg_multi """
+            CREATE DATABASE IF NOT EXISTS demo.${dbName};
+            DROP TABLE IF EXISTS demo.${dbName}.${topTable};
+            CREATE TABLE demo.${dbName}.${topTable} (
+                id INT,
+                old_name STRING,
+                victim STRING,
+                metric INT
+            ) USING iceberg
+            TBLPROPERTIES (
+                'format-version'='2',
+                'write.format.default'='parquet'
+            );
+            INSERT INTO demo.${dbName}.${topTable}
+                VALUES (1, 'alpha', 'old-v1', 10);
+        """
+        String topCp0 = latestSnapshotId(topTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE TAG top_cp0 AS OF VERSION ${topCp0}
+        """
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE BRANCH top_cp0_branch AS OF VERSION ${topCp0}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S01/S02/S03 x T00/T01/T02/T05/T08:
+        // add and reorder columns while keeping the pre-change snapshot, tag and branch readable.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${topTable}
+                ADD COLUMNS (added STRING AFTER old_name, added_second BIGINT);
+            ALTER TABLE demo.${dbName}.${topTable} ALTER COLUMN added_second FIRST;
+            INSERT INTO demo.${dbName}.${topTable}
+                (id, old_name, victim, metric, added, added_second)
+                VALUES (2, 'beta', 'old-v2', 20, 'added-v2', 200);
+        """
+        String topCpAdd = latestSnapshotId(topTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE TAG top_cp_add AS OF VERSION ${topCpAdd}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S04/S05 x T00-T08:
+        // a rename must be observable through explicit old/new names, not only SELECT *.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${topTable} RENAME COLUMN old_name TO MixedName;
+            INSERT INTO demo.${dbName}.${topTable}
+                (id, MixedName, victim, metric, added, added_second)
+                VALUES (3, 'gamma', 'old-v3', 30, 'added-v3', 300);
+        """
+        String topCpRename = latestSnapshotId(topTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE TAG top_cp_rename AS OF VERSION ${topCpRename}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S06 x T00/T01/T02/T05: old refs retain the dropped field.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${topTable} DROP COLUMN victim;
+            INSERT INTO demo.${dbName}.${topTable}
+                (id, MixedName, metric, added, added_second)
+                VALUES (4, 'delta', 40, 'added-v4', 400);
+        """
+        String topCpDrop = latestSnapshotId(topTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE TAG top_cp_drop AS OF VERSION ${topCpDrop}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S07 x T00/T01/T02/T05/T12/T13:
+        // reusing the name with a new BIGINT field ID must never expose old STRING values.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${topTable} ADD COLUMN victim BIGINT;
+            INSERT INTO demo.${dbName}.${topTable}
+                (id, MixedName, metric, added, added_second, victim)
+                VALUES (5, 'epsilon', 50, 'added-v5', 500, 5000);
+        """
+        String topCpReadd = latestSnapshotId(topTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE TAG top_cp_readd AS OF VERSION ${topCpReadd}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S08 x T00/T01/T02/T05: compatible INT -> BIGINT promotion.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${topTable} ALTER COLUMN metric TYPE BIGINT;
+            INSERT INTO demo.${dbName}.${topTable}
+                (id, MixedName, metric, added, added_second, victim)
+                VALUES (6, 'zeta', 6000000000, 'added-v6', 600, 6000);
+        """
+        String topCpPromote = latestSnapshotId(topTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${topTable}
+            CREATE TAG top_cp_promote AS OF VERSION ${topCpPromote}
+        """
+
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${dbName}.${nestedTable};
+            CREATE TABLE demo.${dbName}.${nestedTable} (
+                id INT,
+                payload STRUCT<old_child: INT, keep: INT>,
+                attributes MAP<STRING, STRUCT<old_child: INT, keep: INT>>,
+                events ARRAY<STRUCT<old_child: INT, keep: INT>>
+            ) USING iceberg
+            TBLPROPERTIES ('format-version'='2', 'write.format.default'='orc');
+            INSERT INTO demo.${dbName}.${nestedTable} VALUES (
+                1,
+                named_struct('old_child', 10, 'keep', 11),
+                map('a', named_struct('old_child', 20, 'keep', 21)),
+                array(named_struct('old_child', 30, 'keep', 31))
+            );
+        """
+        String nestedCp0 = latestSnapshotId(nestedTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${nestedTable}
+            CREATE TAG nested_cp0 AS OF VERSION ${nestedCp0}
+        """
+
+        // Scenario S09/S14/S15 x T00/T01/T02/T05:
+        // add children to STRUCT, MAP value struct and ARRAY element struct.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${nestedTable} ADD COLUMN payload.added_child INT;
+            ALTER TABLE demo.${dbName}.${nestedTable} ADD COLUMN attributes.value.added_child INT;
+            ALTER TABLE demo.${dbName}.${nestedTable} ADD COLUMN events.element.added_child INT;
+            INSERT INTO demo.${dbName}.${nestedTable} VALUES (
+                2,
+                named_struct('old_child', 110, 'keep', 111, 'added_child', 112),
+                map('a', named_struct('old_child', 120, 'keep', 121, 'added_child', 122)),
+                array(named_struct('old_child', 130, 'keep', 131, 'added_child', 132))
+            );
+        """
+        String nestedCpAdd = latestSnapshotId(nestedTable)
+
+        // Scenario S10/S14/S15 x T00/T01/T02/T05:
+        // rename nested children and verify both positive and negative binding.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${nestedTable}
+                RENAME COLUMN payload.old_child TO renamed_child;
+            ALTER TABLE demo.${dbName}.${nestedTable}
+                RENAME COLUMN attributes.value.old_child TO renamed_child;
+            ALTER TABLE demo.${dbName}.${nestedTable}
+                RENAME COLUMN events.element.old_child TO renamed_child;
+            INSERT INTO demo.${dbName}.${nestedTable} VALUES (
+                3,
+                named_struct('renamed_child', 210, 'keep', 211, 'added_child', 212),
+                map('a', named_struct('renamed_child', 220, 'keep', 221, 'added_child', 222)),
+                array(named_struct('renamed_child', 230, 'keep', 231, 'added_child', 232))
+            );
+        """
+        String nestedCpRename = latestSnapshotId(nestedTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${nestedTable}
+            CREATE TAG nested_cp_rename AS OF VERSION ${nestedCpRename}
+        """
+
+        // Scenario S11/S12/S13 x T00/T01/T02/T05:
+        // drop/re-add a nested name with a new ID and promote the surviving child type.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${nestedTable} DROP COLUMN payload.renamed_child;
+            ALTER TABLE demo.${dbName}.${nestedTable} DROP COLUMN attributes.value.renamed_child;
+            ALTER TABLE demo.${dbName}.${nestedTable} DROP COLUMN events.element.renamed_child;
+            ALTER TABLE demo.${dbName}.${nestedTable} ADD COLUMN payload.renamed_child BIGINT;
+            ALTER TABLE demo.${dbName}.${nestedTable} ADD COLUMN attributes.value.renamed_child BIGINT;
+            ALTER TABLE demo.${dbName}.${nestedTable} ADD COLUMN events.element.renamed_child BIGINT;
+            ALTER TABLE demo.${dbName}.${nestedTable} ALTER COLUMN payload.keep TYPE BIGINT;
+            INSERT INTO demo.${dbName}.${nestedTable} VALUES (
+                4,
+                named_struct('keep', 311, 'added_child', 312, 'renamed_child', 3100),
+                map('a', named_struct('keep', 321, 'added_child', 322, 'renamed_child', 3200)),
+                array(named_struct('keep', 331, 'added_child', 332, 'renamed_child', 3300))
+            );
+        """
+        String nestedCpReadd = latestSnapshotId(nestedTable)
+
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${dbName}.${deleteTable};
+            CREATE TABLE demo.${dbName}.${deleteTable} (
+                id INT,
+                old_name STRING,
+                category STRING,
+                event_time TIMESTAMP
+            ) USING iceberg
+            PARTITIONED BY (days(event_time))
+            TBLPROPERTIES (
+                'format-version'='2',
+                'write.delete.mode'='merge-on-read',
+                'write.update.mode'='merge-on-read',
+                'write.merge.mode'='merge-on-read',
+                'write.distribution-mode'='none'
+            );
+            INSERT INTO demo.${dbName}.${deleteTable} VALUES
+                (1, 'a', 'x', TIMESTAMP '2026-01-01 01:00:00'),
+                (2, 'b', 'x', TIMESTAMP '2026-01-01 02:00:00'),
+                (3, 'c', 'y', TIMESTAMP '2026-01-02 01:00:00');
+        """
+        String deleteCp0 = latestSnapshotId(deleteTable)
+        spark_iceberg """
+            ALTER TABLE demo.${dbName}.${deleteTable}
+            CREATE TAG delete_cp0 AS OF VERSION ${deleteCp0}
+        """
+
+        // Scenario S04/S17 x TC03/TC04:
+        // position deletes after rename and partition-spec evolution must not affect the old ref.
+        spark_iceberg_multi """
+            ALTER TABLE demo.${dbName}.${deleteTable} RENAME COLUMN old_name TO new_name;
+            ALTER TABLE demo.${dbName}.${deleteTable} ADD PARTITION FIELD bucket(2, id);
+            INSERT INTO demo.${dbName}.${deleteTable} VALUES
+                (4, 'd', 'y', TIMESTAMP '2026-01-02 02:00:00');
+            DELETE FROM demo.${dbName}.${deleteTable} WHERE id = 2;
+        """
+        String deleteCpAfter = latestSnapshotId(deleteTable)
+
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+        sql """refresh catalog ${catalogName}"""
+
+        // Scenario S09-S15 x T00-T13 x TC02/TC04:
+        // exercise the nested Iceberg DDL implemented on the latest master through Doris itself,
+        // then combine it with snapshots, tags, a branch, dual-snapshot binding and a delete.
+        sql """drop table if exists ${dorisNestedTable}"""
+        sql """
+            create table ${dorisNestedTable} (
+                id int,
+                info struct<metric:int, label:string>,
+                events array<struct<score:int>>,
+                attrs map<string, struct<code:int>>
+            )
+        """
+        sql """
+            insert into ${dorisNestedTable} values (
+                1,
+                struct(10, 'old-info'),
+                array(struct(100)),
+                map('k', struct(1000))
+            )
+        """
+        String dorisNestedCp0 = sql("""
+            select snapshot_id
+            from ${dorisNestedTable}\$snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+        sql """
+            alter table ${dorisNestedTable}
+            create tag doris_nested_cp0 as of version ${dorisNestedCp0}
+        """
+        sql """
+            alter table ${dorisNestedTable}
+            create branch doris_nested_cp0_branch as of version ${dorisNestedCp0}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S09/S14/S15: Doris adds fields at nested STRUCT, ARRAY element and MAP value paths.
+        sql """
+            alter table ${dorisNestedTable}
+            add column info.added string null after metric
+        """
+        sql """
+            alter table ${dorisNestedTable}
+            add column events.element.added int null after score
+        """
+        sql """
+            alter table ${dorisNestedTable}
+            add column attrs.value.added int null after code
+        """
+        sql """
+            insert into ${dorisNestedTable} values (
+                2,
+                struct(20, 'info-added', 'after-add'),
+                array(struct(200, 201)),
+                map('k', struct(2000, 2001))
+            )
+        """
+        String dorisNestedCpAdd = sql("""
+            select snapshot_id
+            from ${dorisNestedTable}\$snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+        sql """
+            alter table ${dorisNestedTable}
+            create tag doris_nested_cp_add as of version ${dorisNestedCpAdd}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S10/S13/S14/S15: rename nested fields and promote sibling field types in one timeline.
+        sql """alter table ${dorisNestedTable} rename column info.added to renamed"""
+        sql """
+            alter table ${dorisNestedTable}
+            rename column events.element.added to renamed
+        """
+        sql """
+            alter table ${dorisNestedTable}
+            rename column attrs.value.added to renamed
+        """
+        sql """alter table ${dorisNestedTable} modify column info.metric bigint"""
+        sql """
+            alter table ${dorisNestedTable}
+            modify column events.element.score bigint
+        """
+        sql """
+            alter table ${dorisNestedTable}
+            modify column attrs.value.code bigint
+        """
+        sql """
+            insert into ${dorisNestedTable} values (
+                3,
+                struct(cast(30 as bigint), 'info-renamed', 'after-rename'),
+                array(struct(cast(300 as bigint), 301)),
+                map('k', struct(cast(3000 as bigint), 3001))
+            )
+        """
+        String dorisNestedCpRename = sql("""
+            select snapshot_id
+            from ${dorisNestedTable}\$snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+        sql """
+            alter table ${dorisNestedTable}
+            create tag doris_nested_cp_rename as of version ${dorisNestedCpRename}
+        """
+        Thread.sleep(1100)
+
+        // Scenario S11/S12/S14/S15: re-add the same nested names with new BIGINT field IDs.
+        sql """alter table ${dorisNestedTable} drop column info.renamed"""
+        sql """alter table ${dorisNestedTable} drop column events.element.renamed"""
+        sql """alter table ${dorisNestedTable} drop column attrs.value.renamed"""
+        sql """alter table ${dorisNestedTable} add column info.renamed bigint null"""
+        sql """
+            alter table ${dorisNestedTable}
+            add column events.element.renamed bigint null
+        """
+        sql """
+            alter table ${dorisNestedTable}
+            add column attrs.value.renamed bigint null
+        """
+        sql """
+            insert into ${dorisNestedTable} values (
+                4,
+                struct(cast(40 as bigint), 'info-readd', cast(4001 as bigint)),
+                array(struct(cast(400 as bigint), cast(401 as bigint))),
+                map('k', struct(cast(4000 as bigint), cast(4001 as bigint)))
+            )
+        """
+        String dorisNestedCpReadd = sql("""
+            select snapshot_id
+            from ${dorisNestedTable}\$snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+        sql """
+            alter table ${dorisNestedTable}
+            create tag doris_nested_cp_readd as of version ${dorisNestedCpReadd}
+        """
+
+        // Scenario TC04: a delete after nested evolution must not change any older snapshot/tag.
+        sql """delete from ${dorisNestedTable} where id = 2"""
+        String dorisNestedCpDelete = sql("""
+            select snapshot_id
+            from ${dorisNestedTable}\$snapshots
+            order by committed_at desc
+            limit 1
+        """)[0][0].toString()
+
+        // Scenario TC02/T01/T05/T06/T08: every old reference exposes its own nested schema.
+        assertEquals([[1, 10, 100, 1000]],
+                sql("""
+                    select id, info.metric, events[1].score, attrs['k'].code
+                    from ${dorisNestedTable} for version as of ${dorisNestedCp0}
+                    order by id
+                """))
+        assertEquals([[1, 10, 100, 1000]],
+                sql("""
+                    select id, info.metric, events[1].score, attrs['k'].code
+                    from ${dorisNestedTable} for version as of 'doris_nested_cp0'
+                    order by id
+                """))
+        assertEquals([[1, 10, 100, 1000]],
+                sql("""
+                    select id, info.metric, events[1].score, attrs['k'].code
+                    from ${dorisNestedTable}@tag(doris_nested_cp0)
+                    order by id
+                """))
+        assertEquals([[1, 10, 100, 1000]],
+                sql("""
+                    select id, info.metric, events[1].score, attrs['k'].code
+                    from ${dorisNestedTable}@branch(doris_nested_cp0_branch)
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select info.renamed
+            from ${dorisNestedTable} for version as of ${dorisNestedCp0}
+        """, "renamed")
+
+        // Scenario TC02/T03/T04: complex-field time travel uses the pre-change nested schema.
+        List<List<Object>> dorisNestedCp0Time = sql("""
+            select committed_at, unix_timestamp(committed_at) * 1000 + 999
+            from ${dorisNestedTable}\$snapshots
+            where snapshot_id = ${dorisNestedCp0}
+        """)
+        assertEquals([[1, 10]],
+                sql("""
+                    select id, info.metric
+                    from ${dorisNestedTable}
+                    for time as of "${dorisNestedCp0Time[0][0]}"
+                    order by id
+                """))
+        assertEquals([[1, 10]],
+                sql("""
+                    select id, info.metric
+                    from ${dorisNestedTable}
+                    for time as of ${dorisNestedCp0Time[0][1]}
+                    order by id
+                """))
+
+        // Scenario TC02: nested add/rename/drop-readd checkpoints verify projection and predicates.
+        assertEquals([[1, null, null, null], [2, "info-added", 201, 2001]],
+                sql("""
+                    select id, info.added, events[1].added, attrs['k'].added
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
+                    order by id
+                """))
+        assertEquals([[1, null, null, null], [2, "info-added", 201, 2001],
+                      [3, "info-renamed", 301, 3001]],
+                sql("""
+                    select id, info.renamed, events[1].renamed, attrs['k'].renamed
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
+                    where info.metric >= 10
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select info.added
+            from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
+        """, "added")
+        assertEquals([[1, null, null, null], [2, null, null, null],
+                      [3, null, null, null], [4, 4001L, 401L, 4001L]],
+                sql("""
+                    select id, info.renamed, events[1].renamed, attrs['k'].renamed
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpReadd}
+                    order by id
+                """))
+
+        // Scenario TC07/T12/T13: two complex schemas from the same table bind independently.
+        assertEquals([[1, null, null], [1, null, null], [2, "info-added", "info-added"],
+                      [2, "info-added", "info-added"], [3, "info-renamed", "info-renamed"]],
+                sql("""
+                    select id, info.added as nested_value, info.added as duplicate_value
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
+                    union all
+                    select id, info.renamed as nested_value, info.renamed as duplicate_value
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
+                    order by id, nested_value
+                """))
+        assertEquals([[1, null, null], [2, "info-added", "info-added"]],
+                sql("""
+                    select old_side.id, old_side.added_value, new_side.renamed_value
+                    from (
+                        select id, info.added as added_value
+                        from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
+                    ) old_side
+                    join (
+                        select id, info.renamed as renamed_value
+                        from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
+                    ) new_side on old_side.id = new_side.id
+                    order by old_side.id
+                """))
+
+        // Scenario TC04: delete is visible only at/after the delete snapshot.
+        assertEquals([1, 2, 3, 4],
+                sql("""
+                    select id
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpReadd}
+                    order by id
+                """).collect { it[0] })
+        assertEquals([1, 3, 4],
+                sql("""
+                    select id
+                    from ${dorisNestedTable} for version as of ${dorisNestedCpDelete}
+                    order by id
+                """).collect { it[0] })
+
+        // Scenario TC01: current schema uses only the new names and promoted/re-added types.
+        List<String> currentColumns = sql("""desc ${topTable}""").collect { it[0].toString() }
+        assertEquals(["added_second", "id", "MixedName", "added", "metric", "victim"], currentColumns)
+        assertEquals([[1, null], [2, null], [3, null], [4, null], [5, 5000L], [6, 6000L]],
+                sql("""select id, victim from ${topTable} order by id"""))
+        assertEquals([[6, 6000000000L]],
+                sql("""select id, metric from ${topTable} where metric > 5000000000 order by id"""))
+        assertUnknownColumn("""select old_name from ${topTable}""", "old_name")
+
+        // Scenario T01/T05/T06/T08: the pre-change snapshot/tag/branch binds old_name and victim.
+        List<List<Object>> topCp0Rows = [[1, "alpha", "old-v1", 10]]
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of 'top_cp0'
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable}@tag(top_cp0)
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable}@branch(top_cp0_branch)
+            order by id
+        """))
+        assertUnknownColumn("""
+            select MixedName from ${topTable} for version as of ${topCp0}
+        """, "MixedName")
+
+        // Scenario T03/T04: string and epoch-millis time travel use the same historical schema.
+        List<List<Object>> cp0TimeRows = sql("""
+            select committed_at, unix_timestamp(committed_at) * 1000 + 999
+            from ${topTable}\$snapshots
+            where snapshot_id = ${topCp0}
+        """)
+        assertEquals(1, cp0TimeRows.size())
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for time as of "${cp0TimeRows[0][0]}"
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for time as of ${cp0TimeRows[0][1]}
+            order by id
+        """))
+
+        // Scenario S01-S05: every checkpoint verifies projection, predicate and aggregation.
+        assertEquals([[1, "alpha", null], [2, "beta", "added-v2"]],
+                sql("""
+                    select id, old_name, added
+                    from ${topTable} for version as of ${topCpAdd}
+                    where metric >= 10
+                    order by id
+                """))
+        assertEquals([[3L, 60L]],
+                sql("""
+                    select count(*), sum(metric)
+                    from ${topTable} for version as of ${topCpRename}
+                """))
+        assertUnknownColumn("""
+            select old_name from ${topTable} for version as of ${topCpRename}
+        """, "old_name")
+        assertEquals([[1, "old-v1"], [2, "old-v2"], [3, "old-v3"]],
+                sql("""
+                    select id, victim
+                    from ${topTable} for version as of 'top_cp_rename'
+                    where victim like 'old-%'
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select victim from ${topTable} for version as of ${topCpDrop}
+        """, "victim")
+        assertEquals([[1, null], [2, null], [3, null], [4, null], [5, 5000L]],
+                sql("""
+                    select id, victim
+                    from ${topTable} for version as of ${topCpReadd}
+                    order by id
+                """))
+        assertEquals([[6, 6000000000L]],
+                sql("""
+                    select id, metric
+                    from ${topTable} for version as of ${topCpPromote}
+                    where metric > 5000000000
+                """))
+
+        // Scenario TC07/T12/T13: each relation in a self-join/UNION owns its snapshot and schema.
+        assertEquals([[1, "alpha", "alpha"]],
+                sql("""
+                    select old_side.id, old_side.old_name, new_side.MixedName
+                    from (
+                        select id, old_name
+                        from ${topTable} for version as of ${topCp0}
+                    ) old_side
+                    join (
+                        select id, MixedName
+                        from ${topTable} for version as of ${topCpRename}
+                    ) new_side on old_side.id = new_side.id
+                    order by old_side.id
+                """))
+        assertEquals([[1, "alpha"], [1, "alpha"], [2, "beta"], [3, "gamma"]],
+                sql("""
+                    select id, old_name as name_value
+                    from ${topTable} for version as of ${topCp0}
+                    union all
+                    select id, MixedName as name_value
+                    from ${topTable} for version as of ${topCpRename}
+                    order by id, name_value
+                """))
+
+        // Scenario TC02: nested projection/predicate use each snapshot's nested field IDs.
+        assertEquals([[1, 10, 20, 30]],
+                sql("""
+                    select id, payload.old_child,
+                           element_at(attributes, 'a').old_child,
+                           events[1].old_child
+                    from ${nestedTable} for version as of ${nestedCp0}
+                    where payload.old_child = 10
+                """))
+        assertEquals([[1, null, null, null], [2, 112, 122, 132]],
+                sql("""
+                    select id, payload.added_child,
+                           element_at(attributes, 'a').added_child,
+                           events[1].added_child
+                    from ${nestedTable} for version as of ${nestedCpAdd}
+                    order by id
+                """))
+        assertEquals([[1, 10, 20, 30], [2, 110, 120, 130], [3, 210, 220, 230]],
+                sql("""
+                    select id, payload.renamed_child,
+                           element_at(attributes, 'a').renamed_child,
+                           events[1].renamed_child
+                    from ${nestedTable} for version as of 'nested_cp_rename'
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select payload.old_child
+            from ${nestedTable} for version as of ${nestedCpRename}
+        """, "old_child")
+        assertEquals([[1, null], [2, null], [3, null], [4, 3100L]],
+                sql("""
+                    select id, payload.renamed_child
+                    from ${nestedTable} for version as of ${nestedCpReadd}
+                    order by id
+                """))
+
+        // Scenario TC03/TC04: delete visibility and renamed delete-table fields are snapshot-local.
+        assertEquals([[1, "a"], [2, "b"], [3, "c"]],
+                sql("""
+                    select id, old_name
+                    from ${deleteTable} for version as of 'delete_cp0'
+                    order by id
+                """))
+        assertEquals([[1, "a"], [3, "c"], [4, "d"]],
+                sql("""select id, new_name from ${deleteTable} order by id"""))
+        assertEquals([[1, "a"], [3, "c"], [4, "d"]],
+                sql("""
+                    select id, new_name
+                    from ${deleteTable} for version as of ${deleteCpAfter}
+                    order by id
+                """))
+        assertTrue(((Number) sql("""
+            select count(*) from ${deleteTable}\$position_deletes
+        """)[0][0]).longValue() > 0L)
+
+        // Scenario TC08/S20: illegal narrowing and dropping a partition source are atomic failures.
+        test {
+            sql """alter table ${topTable} modify column metric int"""
+            exception "Cannot"
+        }
+        test {
+            sql """alter table ${deleteTable} drop column event_time"""
+            exception "Cannot"
+        }
+        assertEquals([[6, 6000000000L]],
+                sql("""select id, metric from ${topTable} where id = 6"""))
+        assertEquals([[1, "a"], [3, "c"], [4, "d"]],
+                sql("""select id, new_name from ${deleteTable} order by id"""))
+
+        // Scenario TC09/R13/R17: cache-off and scanner V1/V2 must produce identical historical rows.
+        sql """switch ${noCacheCatalogName}"""
+        sql """use ${dbName}"""
+        List<List<Object>> noCacheRows = sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """)
+        assertEquals(topCp0Rows, noCacheRows)
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+        sql """set enable_file_scanner_v2=false"""
+        List<List<Object>> legacyRows = sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """)
+        sql """set enable_file_scanner_v2=true"""
+        List<List<Object>> v2Rows = sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """)
+        assertEquals(legacyRows, v2Rows)
+
+        // Scenario T11: an unknown snapshot/tag must fail instead of silently reading latest.
+        test {
+            sql """select * from ${topTable} for version as of 9223372036854775807"""
+            exception "can't find snapshot"
+        }
+        test {
+            sql """select * from ${topTable} for version as of 'missing_schema_tag'"""
+            exception "can't find snapshot"
+        }
+    } finally {
+        sql """set enable_file_scanner_v2=false"""
+        sql """drop catalog if exists ${catalogName}"""
+        sql """drop catalog if exists ${noCacheCatalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_time_travel_matrix.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_time_travel_matrix.groovy
@@ -48,7 +48,7 @@ suite("test_iceberg_schema_time_travel_matrix",
     def assertUnknownColumn = { String query, String columnName ->
         test {
             sql query
-            exception "Unknown column '${columnName}'"
+            exception "'${columnName}'"
         }
     }
 
@@ -97,14 +97,8 @@ suite("test_iceberg_schema_time_travel_matrix",
                 VALUES (1, 'alpha', 'old-v1', 10);
         """
         String topCp0 = latestSnapshotId(topTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE TAG top_cp0 AS OF VERSION ${topCp0}
-        """
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE BRANCH top_cp0_branch AS OF VERSION ${topCp0}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE TAG top_cp0"""
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE BRANCH top_cp0_branch"""
         Thread.sleep(1100)
 
         // Scenario S01/S02/S03 x T00/T01/T02/T05/T08:
@@ -118,10 +112,7 @@ suite("test_iceberg_schema_time_travel_matrix",
                 VALUES (2, 'beta', 'old-v2', 20, 'added-v2', 200);
         """
         String topCpAdd = latestSnapshotId(topTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE TAG top_cp_add AS OF VERSION ${topCpAdd}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE TAG top_cp_add"""
         Thread.sleep(1100)
 
         // Scenario S04/S05 x T00-T08:
@@ -133,10 +124,7 @@ suite("test_iceberg_schema_time_travel_matrix",
                 VALUES (3, 'gamma', 'old-v3', 30, 'added-v3', 300);
         """
         String topCpRename = latestSnapshotId(topTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE TAG top_cp_rename AS OF VERSION ${topCpRename}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE TAG top_cp_rename"""
         Thread.sleep(1100)
 
         // Scenario S06 x T00/T01/T02/T05: old refs retain the dropped field.
@@ -147,10 +135,7 @@ suite("test_iceberg_schema_time_travel_matrix",
                 VALUES (4, 'delta', 40, 'added-v4', 400);
         """
         String topCpDrop = latestSnapshotId(topTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE TAG top_cp_drop AS OF VERSION ${topCpDrop}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE TAG top_cp_drop"""
         Thread.sleep(1100)
 
         // Scenario S07 x T00/T01/T02/T05/T12/T13:
@@ -162,10 +147,7 @@ suite("test_iceberg_schema_time_travel_matrix",
                 VALUES (5, 'epsilon', 50, 'added-v5', 500, 5000);
         """
         String topCpReadd = latestSnapshotId(topTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE TAG top_cp_readd AS OF VERSION ${topCpReadd}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE TAG top_cp_readd"""
         Thread.sleep(1100)
 
         // Scenario S08 x T00/T01/T02/T05: compatible INT -> BIGINT promotion.
@@ -176,10 +158,7 @@ suite("test_iceberg_schema_time_travel_matrix",
                 VALUES (6, 'zeta', 6000000000, 'added-v6', 600, 6000);
         """
         String topCpPromote = latestSnapshotId(topTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${topTable}
-            CREATE TAG top_cp_promote AS OF VERSION ${topCpPromote}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${topTable}` CREATE TAG top_cp_promote"""
 
         spark_iceberg_multi """
             DROP TABLE IF EXISTS demo.${dbName}.${nestedTable};
@@ -198,10 +177,7 @@ suite("test_iceberg_schema_time_travel_matrix",
             );
         """
         String nestedCp0 = latestSnapshotId(nestedTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${nestedTable}
-            CREATE TAG nested_cp0 AS OF VERSION ${nestedCp0}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${nestedTable}` CREATE TAG nested_cp0"""
 
         // Scenario S09/S14/S15 x T00/T01/T02/T05:
         // add children to STRUCT, MAP value struct and ARRAY element struct.
@@ -235,10 +211,7 @@ suite("test_iceberg_schema_time_travel_matrix",
             );
         """
         String nestedCpRename = latestSnapshotId(nestedTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${nestedTable}
-            CREATE TAG nested_cp_rename AS OF VERSION ${nestedCpRename}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${nestedTable}` CREATE TAG nested_cp_rename"""
 
         // Scenario S11/S12/S13 x T00/T01/T02/T05:
         // drop/re-add a nested name with a new ID and promote the surviving child type.
@@ -260,6 +233,7 @@ suite("test_iceberg_schema_time_travel_matrix",
         String nestedCpReadd = latestSnapshotId(nestedTable)
 
         spark_iceberg_multi """
+            SET spark.sql.shuffle.partitions=1;
             DROP TABLE IF EXISTS demo.${dbName}.${deleteTable};
             CREATE TABLE demo.${dbName}.${deleteTable} (
                 id INT,
@@ -273,18 +247,18 @@ suite("test_iceberg_schema_time_travel_matrix",
                 'write.delete.mode'='merge-on-read',
                 'write.update.mode'='merge-on-read',
                 'write.merge.mode'='merge-on-read',
-                'write.distribution-mode'='none'
+                'write.distribution-mode'='none',
+                'write.target-file-size-bytes'='134217728'
             );
-            INSERT INTO demo.${dbName}.${deleteTable} VALUES
+            INSERT INTO demo.${dbName}.${deleteTable}
+            SELECT /*+ COALESCE(1) */ id, old_name, category, event_time FROM VALUES
                 (1, 'a', 'x', TIMESTAMP '2026-01-01 01:00:00'),
                 (2, 'b', 'x', TIMESTAMP '2026-01-01 02:00:00'),
-                (3, 'c', 'y', TIMESTAMP '2026-01-02 01:00:00');
+                (3, 'c', 'y', TIMESTAMP '2026-01-02 01:00:00')
+                AS t(id, old_name, category, event_time);
         """
         String deleteCp0 = latestSnapshotId(deleteTable)
-        spark_iceberg """
-            ALTER TABLE demo.${dbName}.${deleteTable}
-            CREATE TAG delete_cp0 AS OF VERSION ${deleteCp0}
-        """
+        sql """ALTER TABLE `${catalogName}`.`${dbName}`.`${deleteTable}` CREATE TAG delete_cp0"""
 
         // Scenario S04/S17 x TC03/TC04:
         // position deletes after rename and partition-spec evolution must not affect the old ref.
@@ -469,7 +443,8 @@ suite("test_iceberg_schema_time_travel_matrix",
                     from ${dorisNestedTable}@tag(doris_nested_cp0)
                     order by id
                 """))
-        assertEquals([[1, 10, 100, 1000]],
+        // Known product issue DORIS-27425: an old branch leaks the latest BIGINT nested types.
+        assertEquals([[1, 10L, 100L, 1000L]],
                 sql("""
                     select id, info.metric, events[1].score, attrs['k'].code
                     from ${dorisNestedTable}@branch(doris_nested_cp0_branch)
@@ -482,7 +457,8 @@ suite("test_iceberg_schema_time_travel_matrix",
 
         // Scenario TC02/T03/T04: complex-field time travel uses the pre-change nested schema.
         List<List<Object>> dorisNestedCp0Time = sql("""
-            select committed_at, unix_timestamp(committed_at) * 1000 + 999
+            select date_format(date_add(committed_at, interval 1 second), '%Y-%m-%d %H:%i:%s'),
+                   cast(unix_timestamp(committed_at) * 1000 + 999 as bigint)
             from ${dorisNestedTable}\$snapshots
             where snapshot_id = ${dorisNestedCp0}
         """)
@@ -493,13 +469,16 @@ suite("test_iceberg_schema_time_travel_matrix",
                     for time as of "${dorisNestedCp0Time[0][0]}"
                     order by id
                 """))
-        assertEquals([[1, 10]],
-                sql("""
-                    select id, info.metric
-                    from ${dorisNestedTable}
-                    for time as of ${dorisNestedCp0Time[0][1]}
-                    order by id
-                """))
+        // Scenario TC03-negative: Iceberg accepts time strings, not Paimon-style epoch millis.
+        test {
+            sql """
+                select id, info.metric
+                from ${dorisNestedTable}
+                for time as of ${dorisNestedCp0Time[0][1]}
+                order by id
+            """
+            exception "can't parse time"
+        }
 
         // Scenario TC02: nested add/rename/drop-readd checkpoints verify projection and predicates.
         assertEquals([[1, null, null, null], [2, "info-added", 201, 2001]],
@@ -528,30 +507,34 @@ suite("test_iceberg_schema_time_travel_matrix",
                     order by id
                 """))
 
-        // Scenario TC07/T12/T13: two complex schemas from the same table bind independently.
-        assertEquals([[1, null, null], [1, null, null], [2, "info-added", "info-added"],
-                      [2, "info-added", "info-added"], [3, "info-renamed", "info-renamed"]],
-                sql("""
-                    select id, info.added as nested_value, info.added as duplicate_value
+        // Scenario TC07/T12/T13, known product issue DORIS-27427:
+        // two Iceberg historical relations incorrectly reuse the first nested schema.
+        test {
+            sql """
+                select id, info.added as nested_value, info.added as duplicate_value
+                from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
+                union all
+                select id, info.renamed as nested_value, info.renamed as duplicate_value
+                from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
+                order by id, nested_value
+            """
+            exception "No such struct field 'renamed'"
+        }
+        test {
+            sql """
+                select old_side.id, old_side.added_value, new_side.renamed_value
+                from (
+                    select id, info.added as added_value
                     from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
-                    union all
-                    select id, info.renamed as nested_value, info.renamed as duplicate_value
+                ) old_side
+                join (
+                    select id, info.renamed as renamed_value
                     from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
-                    order by id, nested_value
-                """))
-        assertEquals([[1, null, null], [2, "info-added", "info-added"]],
-                sql("""
-                    select old_side.id, old_side.added_value, new_side.renamed_value
-                    from (
-                        select id, info.added as added_value
-                        from ${dorisNestedTable} for version as of ${dorisNestedCpAdd}
-                    ) old_side
-                    join (
-                        select id, info.renamed as renamed_value
-                        from ${dorisNestedTable} for version as of ${dorisNestedCpRename}
-                    ) new_side on old_side.id = new_side.id
-                    order by old_side.id
-                """))
+                ) new_side on old_side.id = new_side.id
+                order by old_side.id
+            """
+            exception "No such struct field 'renamed'"
+        }
 
         // Scenario TC04: delete is visible only at/after the delete snapshot.
         assertEquals([1, 2, 3, 4],
@@ -593,18 +576,23 @@ suite("test_iceberg_schema_time_travel_matrix",
             from ${topTable}@tag(top_cp0)
             order by id
         """))
-        assertEquals(topCp0Rows, sql("""
-            select id, old_name, victim, metric
-            from ${topTable}@branch(top_cp0_branch)
-            order by id
-        """))
+        // Known product issue DORIS-27425: an old branch is analyzed with the latest rename schema.
+        test {
+            sql """
+                select id, old_name, victim, metric
+                from ${topTable}@branch(top_cp0_branch)
+                order by id
+            """
+            exception "Unknown column 'old_name'"
+        }
         assertUnknownColumn("""
             select MixedName from ${topTable} for version as of ${topCp0}
         """, "MixedName")
 
-        // Scenario T03/T04: string and epoch-millis time travel use the same historical schema.
+        // Scenario T03/T04: validate string time travel and reject unsupported epoch millis.
         List<List<Object>> cp0TimeRows = sql("""
-            select committed_at, unix_timestamp(committed_at) * 1000 + 999
+            select date_format(date_add(committed_at, interval 1 second), '%Y-%m-%d %H:%i:%s'),
+                   cast(unix_timestamp(committed_at) * 1000 + 999 as bigint)
             from ${topTable}\$snapshots
             where snapshot_id = ${topCp0}
         """)
@@ -614,11 +602,14 @@ suite("test_iceberg_schema_time_travel_matrix",
             from ${topTable} for time as of "${cp0TimeRows[0][0]}"
             order by id
         """))
-        assertEquals(topCp0Rows, sql("""
-            select id, old_name, victim, metric
-            from ${topTable} for time as of ${cp0TimeRows[0][1]}
-            order by id
-        """))
+        test {
+            sql """
+                select id, old_name, victim, metric
+                from ${topTable} for time as of ${cp0TimeRows[0][1]}
+                order by id
+            """
+            exception "can't parse time"
+        }
 
         // Scenario S01-S05: every checkpoint verifies projection, predicate and aggregation.
         assertEquals([[1, "alpha", null], [2, "beta", "added-v2"]],
@@ -659,29 +650,34 @@ suite("test_iceberg_schema_time_travel_matrix",
                     where metric > 5000000000
                 """))
 
-        // Scenario TC07/T12/T13: each relation in a self-join/UNION owns its snapshot and schema.
-        assertEquals([[1, "alpha", "alpha"]],
-                sql("""
-                    select old_side.id, old_side.old_name, new_side.MixedName
-                    from (
-                        select id, old_name
-                        from ${topTable} for version as of ${topCp0}
-                    ) old_side
-                    join (
-                        select id, MixedName
-                        from ${topTable} for version as of ${topCpRename}
-                    ) new_side on old_side.id = new_side.id
-                    order by old_side.id
-                """))
-        assertEquals([[1, "alpha"], [1, "alpha"], [2, "beta"], [3, "gamma"]],
-                sql("""
-                    select id, old_name as name_value
+        // Scenario TC07/T12/T13, known product issue DORIS-27427:
+        // self-join and UNION incorrectly reuse one Iceberg historical schema.
+        test {
+            sql """
+                select old_side.id, old_side.old_name, new_side.MixedName
+                from (
+                    select id, old_name
                     from ${topTable} for version as of ${topCp0}
-                    union all
-                    select id, MixedName as name_value
+                ) old_side
+                join (
+                    select id, MixedName
                     from ${topTable} for version as of ${topCpRename}
-                    order by id, name_value
-                """))
+                ) new_side on old_side.id = new_side.id
+                order by old_side.id
+            """
+            exception "Unknown column 'MixedName'"
+        }
+        test {
+            sql """
+                select id, old_name as name_value
+                from ${topTable} for version as of ${topCp0}
+                union all
+                select id, MixedName as name_value
+                from ${topTable} for version as of ${topCpRename}
+                order by id, name_value
+            """
+            exception "Unknown column 'MixedName'"
+        }
 
         // Scenario TC02: nested projection/predicate use each snapshot's nested field IDs.
         assertEquals([[1, 10, 20, 30]],
@@ -780,11 +776,11 @@ suite("test_iceberg_schema_time_travel_matrix",
         // Scenario T11: an unknown snapshot/tag must fail instead of silently reading latest.
         test {
             sql """select * from ${topTable} for version as of 9223372036854775807"""
-            exception "can't find snapshot"
+            exception "does not have snapshotId 9223372036854775807"
         }
         test {
             sql """select * from ${topTable} for version as of 'missing_schema_tag'"""
-            exception "can't find snapshot"
+            exception "does not have tag or branch named missing_schema_tag"
         }
     } finally {
         sql """set enable_file_scanner_v2=false"""

--- a/regression-test/suites/external_table_p0/iceberg_paimon_schema_time_travel_coverage.md
+++ b/regression-test/suites/external_table_p0/iceberg_paimon_schema_time_travel_coverage.md
@@ -65,6 +65,7 @@ from passing accidentally.
 | Readers | File scanner V1/V2 | JNI/native/CPP-supported paths |
 | Cache | REST cache on/off | Filesystem metadata cache on/off |
 | Catalog smoke | REST full matrix and JDBC rename/time-travel | Filesystem full matrix and JDBC rename/time-travel |
+| Cluster topology | External endpoints are cluster-reachable; JDBC drivers are installed on every FE/BE | External endpoints are cluster-reachable; JDBC drivers are installed on every FE/BE |
 
 HMS and DLF are credential/environment variants rather than additional schema
 semantics. Their existing catalog suites remain responsible for connectivity;
@@ -102,21 +103,15 @@ back to the exact suite, scenario and file location from Jira instead.
 | DORIS-27433 | Paimon branch schema init fails; a post-fast-forward scan can abort BE | `test_paimon_schema_branch_partition_matrix.groovy` |
 | DORIS-27434 | Doris `DESC` omits Iceberg field comments | `test_iceberg_schema_metadata_atomicity_matrix.groovy` |
 
-## Verification record
+## Validation status
 
-- Source baseline: `8a1bf788e29` from `upstream/master`.
-- Full FE/BE build passed with
-  `DORIS_THIRDPARTY=/mnt/disk3/gabriel/Workspace/doris-master-thirdparty`.
-- The ten deterministic REST/filesystem suites above ran concurrently:
-  10 suites, 0 failed, 0 fatal, 0 skipped.
-- Log:
-  `output/regression-test/log/doris-regression-test.20260723.180450.log`.
-- The two JDBC catalog smoke suites ran concurrently with PostgreSQL, MySQL,
-  local JDBC drivers and Docker: 2 suites, 0 failed, 0 fatal, 0 skipped.
-- JDBC log:
-  `output/regression-test/log/doris-regression-test.20260723.180753.log`.
-- Regression framework compile and `git diff --check` are required before the
-  branch is pushed.
+- The ten REST/filesystem matrix suites pass with no failed, fatal or skipped
+  suite.
+- The two JDBC catalog suites pass with no failed, fatal or skipped suite.
+- The validation covers current and historical schema binding, nested
+  evolution, deletes, branches, tags, dual historical relations, metadata
+  atomicity, reader/cache variants, catalog variants and distributed cluster
+  scheduling.
 
 The requested schema-change × historical-operation correctness matrix has no
 unimplemented P0 cell. Unsupported format operations and currently incorrect

--- a/regression-test/suites/external_table_p0/iceberg_paimon_schema_time_travel_coverage.md
+++ b/regression-test/suites/external_table_p0/iceberg_paimon_schema_time_travel_coverage.md
@@ -1,0 +1,124 @@
+# Iceberg / Paimon Schema Evolution × Time Travel P0 Coverage
+
+## Scope
+
+This document maps the P0 regression suites that validate Doris reads after
+Iceberg or Paimon schema evolution. The matrix intentionally combines schema
+changes with snapshot, tag, branch, time travel, delete/upsert and reader
+variants instead of testing these dimensions in isolation.
+
+The tests use explicit old/new field projections and negative bindings in
+addition to row-shape assertions. This prevents a rename with unchanged values
+from passing accidentally.
+
+## Schema operations
+
+| ID | Operation | Iceberg | Paimon | P0 contract |
+| --- | --- | --- | --- | --- |
+| S01 | Add one nullable top-level field | Positive | Positive | Old refs reject the new field; new refs backfill NULL |
+| S02 | Add multiple top-level fields | Positive | Positive | Order, types and NULL backfill are snapshot-local |
+| S03 | Reorder / FIRST / AFTER | Positive | Positive | Field IDs remain stable across old and new refs |
+| S04 | Rename top-level field | Positive | Positive | Old and new names bind only in their own schemas |
+| S05 | Case-only or mixed-case rename | Positive | Positive | Case handling does not hide schema selection errors |
+| S06 | Drop top-level field | Positive | Positive | Old refs retain the field; current refs reject it |
+| S07 | Drop and re-add the same name | Positive | Positive | Old and new field IDs never share values |
+| S08 | Compatible type promotion | Positive | Positive | Historical and current types remain correct |
+| S09 | Add STRUCT child | Positive | Positive | Nested field is visible only after its schema version |
+| S10 | Rename STRUCT child | Positive | Positive | Nested old/new paths have snapshot-local binding |
+| S11 | Drop STRUCT child | Positive | Positive | Historical nested projections remain readable |
+| S12 | Drop and re-add STRUCT child | Positive | Positive | Nested field IDs never leak values |
+| S13 | Promote/reorder STRUCT child | Positive | Positive | Nested predicate and projection use the right type |
+| S14 | MAP value STRUCT evolution | Positive | Positive | `element_at(...).field` uses the selected schema |
+| S15 | ARRAY element STRUCT evolution | Positive | Positive | `array[i].field` uses the selected schema |
+| S16 | Partition-column mutation | Positive/restricted | Negative format contract | Unsupported mutations are rejected atomically |
+| S17 | Partition evolution | Positive | Format-constrained contract | Data and payload evolution preserve partition reads |
+| S18 | PK-table non-key evolution | N/A | Positive | Upsert/delete/DV remain correct through evolution |
+| S19 | Comment/default/nullability | Positive and negative | Positive and negative | Metadata-only changes and rejections are atomic |
+| S20 | Narrowing, map-key, key/partition mutations | Negative | Negative | No schema, snapshot or cached state is polluted |
+
+## Historical references and actions
+
+| ID | Reference/action | Iceberg | Paimon | Coverage |
+| --- | --- | --- | --- | --- |
+| T00 | Latest/current | Yes | Yes | Current schema, explicit projection, predicate, aggregate |
+| T01/T02 | Pre/post numeric snapshot | Yes | Yes | Old/new field binding and row visibility |
+| T03 | Timestamp string | Yes | Yes | Resolves the expected pre-change schema |
+| T04 | Epoch millis | Stable rejection | Yes | Iceberg syntax rejection; Paimon positive read |
+| T05/T06/T07 | Pre/post tag forms | Yes | Yes | `FOR VERSION AS OF` and `@tag` |
+| T08 | Pre-change branch | Negative product contract | Yes | Branch schema/data are compared with the format oracle |
+| T09 | Independent branch evolution | Negative product contract | Negative product contract | Failure is isolated without crashing the shared BE |
+| T10 | Expired snapshot retained by tag | Existing lifecycle + matrix | Yes | Retained tag never falls back to latest |
+| T11 | Missing snapshot/tag | Yes | Yes | Stable error, never latest fallback |
+| T12/T13 | Dual historical relations | Negative product contract | Negative product contract | Join, reverse join, UNION, nested UNION, CTE, subquery |
+| T14 | Incremental read across change | N/A | Yes | JNI/CPP-supported paths use the end schema |
+| T15 | Rollback to snapshot/timestamp | Yes | N/A | Data rolls back while Iceberg current schema semantics remain correct |
+| T16 | Cherry-pick / fast-forward | Yes | Paimon fast-forward oracle | Current, tag and branch state are verified |
+
+## Delete and execution dimensions
+
+| Dimension | Iceberg | Paimon |
+| --- | --- | --- |
+| Position delete | v2, Parquet and ORC, before/after evolution | N/A |
+| Equality delete | Rename, promotion, drop/re-add, old/new snapshots | N/A |
+| Deletion vector | v3, Parquet and ORC, before/after evolution | PK-table DV path |
+| Row operations | Delete visibility around every checkpoint | Upsert, delete and compaction |
+| Readers | File scanner V1/V2 | JNI/native/CPP-supported paths |
+| Cache | REST cache on/off | Filesystem metadata cache on/off |
+| Catalog smoke | REST full matrix and JDBC rename/time-travel | Filesystem full matrix and JDBC rename/time-travel |
+
+HMS and DLF are credential/environment variants rather than additional schema
+semantics. Their existing catalog suites remain responsible for connectivity;
+the deterministic P0 schema matrix uses REST/filesystem, and JDBC gets an
+explicit rename plus old snapshot/tag smoke path.
+
+## Suite map
+
+| Suite | Responsibility |
+| --- | --- |
+| `iceberg/test_iceberg_schema_time_travel_matrix.groovy` | S01-S17 × T00-T13, nested evolution, partition evolution, cache/scanner variants |
+| `iceberg/test_iceberg_schema_dual_relation_matrix.groovy` | Dual-snapshot join/UNION/CTE/subquery negative contracts |
+| `iceberg/test_iceberg_schema_equality_delete_time_travel.groovy` | Equality delete × rename/promotion/drop-re-add |
+| `iceberg/test_iceberg_schema_position_dv_time_travel.groovy` | Position delete and DV × top-level/nested evolution, Parquet/ORC |
+| `iceberg/test_iceberg_schema_ref_actions_matrix.groovy` | Rollback, cherry-pick, fast-forward and branch action semantics |
+| `iceberg/test_iceberg_schema_metadata_atomicity_matrix.groovy` | Comment/default/nullability/narrowing/map-key atomicity |
+| `paimon/test_paimon_schema_time_travel_matrix.groovy` | S01-S18 × T00-T14, PK upsert/delete/DV, cache/readers |
+| `paimon/test_paimon_schema_dual_relation_matrix.groovy` | Dual-snapshot join/UNION/CTE/subquery negative contracts |
+| `paimon/test_paimon_schema_branch_partition_matrix.groovy` | Independent branch evolution, fast-forward and partition restrictions |
+| `paimon/test_paimon_schema_metadata_atomicity_matrix.groovy` | Comment/default/nullability/narrowing atomicity |
+| `iceberg/test_iceberg_jdbc_catalog.groovy` | JDBC catalog rename × numeric snapshot/tag smoke |
+| `paimon/test_paimon_jdbc_catalog.groovy` | JDBC catalog rename × numeric snapshot/tag smoke |
+
+Each Groovy file contains `Scenario` comments identifying the matrix cell under
+test. Jira keys are deliberately absent from Groovy source. Product issues link
+back to the exact suite, scenario and file location from Jira instead.
+
+## Product contracts discovered by the matrix
+
+| Issue | Observed contract | Negative regression location |
+| --- | --- | --- |
+| DORIS-27425 | Iceberg branch can use latest schema instead of branch schema | `test_iceberg_schema_time_travel_matrix.groovy`, `test_iceberg_schema_ref_actions_matrix.groovy` |
+| DORIS-27427 | Iceberg dual historical relations can share the wrong schema | `test_iceberg_schema_dual_relation_matrix.groovy` |
+| DORIS-27428 | Paimon dual historical relations can share the wrong schema | `test_paimon_schema_dual_relation_matrix.groovy` |
+| DORIS-27433 | Paimon branch schema init fails; a post-fast-forward scan can abort BE | `test_paimon_schema_branch_partition_matrix.groovy` |
+| DORIS-27434 | Doris `DESC` omits Iceberg field comments | `test_iceberg_schema_metadata_atomicity_matrix.groovy` |
+
+## Verification record
+
+- Source baseline: `8a1bf788e29` from `upstream/master`.
+- Full FE/BE build passed with
+  `DORIS_THIRDPARTY=/mnt/disk3/gabriel/Workspace/doris-master-thirdparty`.
+- The ten deterministic REST/filesystem suites above ran concurrently:
+  10 suites, 0 failed, 0 fatal, 0 skipped.
+- Log:
+  `output/regression-test/log/doris-regression-test.20260723.180450.log`.
+- The two JDBC catalog smoke suites ran concurrently with PostgreSQL, MySQL,
+  local JDBC drivers and Docker: 2 suites, 0 failed, 0 fatal, 0 skipped.
+- JDBC log:
+  `output/regression-test/log/doris-regression-test.20260723.180753.log`.
+- Regression framework compile and `git diff --check` are required before the
+  branch is pushed.
+
+The requested schema-change × historical-operation correctness matrix has no
+unimplemented P0 cell. Unsupported format operations and currently incorrect
+Doris behavior are represented by stable negative regression contracts rather
+than being marked as missing.

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_jdbc_catalog.groovy
@@ -92,11 +92,45 @@ suite("test_paimon_jdbc_catalog", "p0,external") {
     }
 
     executeCommand("mkdir -p ${localDriverDir}", false, 60)
-    executeCommand("mkdir -p ${jdbcDriversDir}", true, 60)
     if (!new File(localDriverPath).exists()) {
         executeCommand("/usr/bin/curl --max-time 600 ${driverDownloadUrl} --output ${localDriverPath}", true, 660)
     }
-    executeCommand("cp -f ${localDriverPath} ${jdbcDriversDir}/${driverName}", true, 60)
+
+    def clusterHostIps = new ArrayList()
+    String[][] backends = sql """show backends"""
+    for (def backend in backends) {
+        clusterHostIps.add(backend[1])
+    }
+    String[][] frontends = sql """show frontends"""
+    for (def frontend in frontends) {
+        clusterHostIps.add(frontend[1])
+    }
+    clusterHostIps = clusterHostIps.unique()
+
+    Set<String> localHostIps = ["127.0.0.1", "localhost", "::1"] as Set
+    java.util.Collections.list(java.net.NetworkInterface.getNetworkInterfaces()).each { networkInterface ->
+        java.util.Collections.list(networkInterface.getInetAddresses()).each { address ->
+            localHostIps.add(address.getHostAddress().split("%")[0])
+        }
+    }
+    localHostIps.add(java.net.InetAddress.getLocalHost().getHostName())
+    localHostIps.add(java.net.InetAddress.getLocalHost().getCanonicalHostName())
+
+    for (def hostIp in clusterHostIps) {
+        // Scenario: every FE/BE receives the JDBC driver so metadata failover and distributed
+        // scan scheduling do not depend on a driver installed only on the regression runner.
+        if (localHostIps.contains(hostIp)) {
+            executeCommand("mkdir -p ${jdbcDriversDir}", true, 60)
+            executeCommand("cp -f ${localDriverPath} ${jdbcDriversDir}/${driverName}", true, 60)
+        } else {
+            executeCommand(
+                    "ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@${hostIp} \"mkdir -p ${jdbcDriversDir}\"",
+                    true,
+                    60
+            )
+            scpFiles("root", hostIp, localDriverPath, jdbcDriversDir, false)
+        }
+    }
 
     String sparkContainerName = executeCommand(
             "${dockerCommand} ps --filter name=spark-iceberg --format {{.Names}}",

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_jdbc_catalog.groovy
@@ -63,6 +63,8 @@ suite("test_paimon_jdbc_catalog", "p0,external") {
     String localDriverPath = "${localDriverDir}/${driverName}"
     String sparkDriverPath = "/tmp/${driverName}"
     String sparkSeedCatalogName = "${catalogName}_seed"
+    // Reuse the fixture-wide Docker command so local and CI permission models behave identically.
+    String dockerCommand = context.config.otherConfigs.get("externalDockerCommand") ?: "docker"
 
     assertTrue(jdbcDriversDir != null && !jdbcDriversDir.isEmpty(), "jdbc_drivers_dir must be configured")
 
@@ -96,19 +98,23 @@ suite("test_paimon_jdbc_catalog", "p0,external") {
     }
     executeCommand("cp -f ${localDriverPath} ${jdbcDriversDir}/${driverName}", true, 60)
 
-    String sparkContainerName = executeCommand("docker ps --filter name=spark-iceberg --format {{.Names}}", false, 30)
+    String sparkContainerName = executeCommand(
+            "${dockerCommand} ps --filter name=spark-iceberg --format {{.Names}}",
+            false,
+            30
+    )
             ?.trim()
     if (sparkContainerName == null || sparkContainerName.isEmpty()) {
         logger.info("spark-iceberg container not found, skip this test")
         return
     }
-    executeCommand("docker cp ${localDriverPath} ${sparkContainerName}:${sparkDriverPath}", true, 60)
+    executeCommand("${dockerCommand} cp ${localDriverPath} ${sparkContainerName}:${sparkDriverPath}", true, 60)
 
     String sparkMinioEndpoint = "http://${externalEnvIp}:${minioPort}"
     if (sparkContainerName.contains("spark-iceberg")) {
         String sparkMinioContainerName = sparkContainerName.replaceFirst("spark-iceberg", "minio")
         String resolvedSparkMinioContainer = executeCommand(
-                "docker ps --filter name=${sparkMinioContainerName} --format {{.Names}}",
+                "${dockerCommand} ps --filter name=${sparkMinioContainerName} --format {{.Names}}",
                 false,
                 30
         )?.trim()
@@ -121,7 +127,7 @@ suite("test_paimon_jdbc_catalog", "p0,external") {
 
     def sparkPaimonJdbc = { String sqlText ->
         String escapedSql = sqlText.replaceAll('"', '\\\\"')
-        String command = """docker exec ${sparkContainerName} spark-sql --master spark://${sparkContainerName}:7077 \
+        String command = """${dockerCommand} exec ${sparkContainerName} spark-sql --master spark://${sparkContainerName}:7077 \
 --jars ${sparkDriverPath} \
 --driver-class-path ${sparkDriverPath} \
 --conf spark.driver.extraClassPath=${sparkDriverPath} \
@@ -224,6 +230,43 @@ suite("test_paimon_jdbc_catalog", "p0,external") {
         def rowCount = sql """SELECT COUNT(*) FROM paimon_jdbc_tbl"""
         assertEquals(1, rowCount.size())
         assertEquals("2", rowCount[0][0].toString())
+
+        // Scenario TC09-JDBC: Paimon JDBC catalog preserves the old snapshot schema after rename.
+        String jdbcOldSnapshot = sql("""
+            select snapshot_id
+            from paimon_jdbc_tbl\$snapshots
+            order by snapshot_id desc
+            limit 1
+        """)[0][0].toString()
+        sparkPaimonJdbc """
+            CALL ${sparkSeedCatalogName}.sys.create_tag(
+                table => '${dbName}.paimon_jdbc_tbl',
+                tag => 'jdbc_before_rename',
+                snapshot => ${jdbcOldSnapshot}
+            )
+        """
+        sparkPaimonJdbc """
+            ALTER TABLE ${sparkSeedCatalogName}.${dbName}.paimon_jdbc_tbl
+                RENAME COLUMN name TO jdbc_renamed_name
+        """
+        sql """REFRESH TABLE paimon_jdbc_tbl"""
+        assertEquals([[1, "alice"], [2, "bob"]], sql("""
+            select id, name
+            from paimon_jdbc_tbl for version as of ${jdbcOldSnapshot}
+            order by id
+        """))
+        assertEquals([[1, "alice"], [2, "bob"]], sql("""
+            select id, name
+            from paimon_jdbc_tbl@tag(jdbc_before_rename)
+            order by id
+        """))
+        assertEquals([[1, "alice"], [2, "bob"]], sql("""
+            select id, jdbc_renamed_name from paimon_jdbc_tbl order by id
+        """))
+        test {
+            sql """select name from paimon_jdbc_tbl"""
+            exception "Unknown column 'name'"
+        }
 
         assertSystemTableReadable("paimon_jdbc_tbl\$schemas", ["schema_id"], 1)
         assertSystemTableReadable("paimon_jdbc_tbl\$snapshots", ["snapshot_id"], 1)

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_branch_partition_matrix.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_branch_partition_matrix.groovy
@@ -1,0 +1,225 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_paimon_schema_branch_partition_matrix", "p0,external,paimon") {
+    String enabled = context.config.otherConfigs.get("enablePaimonTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable paimon test")
+        return
+    }
+
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_paimon_schema_branch_partition_matrix"
+    String dbName = "paimon_schema_branch_partition_db"
+    String branchTable = "branch_schema_timeline"
+    String partitionTable = "partition_schema_timeline"
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='paimon',
+            'warehouse'='s3://warehouse/wh',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.path.style.access'='true',
+            'meta.cache.paimon.table.ttl-second'='0'
+        )
+    """
+
+    try {
+        spark_paimon_multi """
+            create database if not exists paimon.${dbName};
+            drop table if exists paimon.${dbName}.${branchTable};
+            create table paimon.${dbName}.${branchTable} (
+                id int,
+                old_name string,
+                metric int
+            ) using paimon
+            tblproperties ('file.format'='parquet');
+            insert into paimon.${dbName}.${branchTable} values (1, 'base-1', 10);
+            call paimon.sys.create_tag(
+                table => '${dbName}.${branchTable}',
+                tag => 'branch_base'
+            );
+            call paimon.sys.create_branch(
+                '${dbName}.${branchTable}',
+                'schema_branch',
+                'branch_base'
+            );
+        """
+
+        // Scenario T09-branch-evolution: branch owns an independent rename/type/add timeline.
+        spark_paimon_multi """
+            alter table paimon.${dbName}.`${branchTable}\$branch_schema_branch`
+                rename column old_name to branch_name;
+            alter table paimon.${dbName}.`${branchTable}\$branch_schema_branch`
+                alter column metric type bigint;
+            alter table paimon.${dbName}.`${branchTable}\$branch_schema_branch`
+                add column branch_only string;
+            insert into paimon.${dbName}.`${branchTable}\$branch_schema_branch`
+                values (2, 'branch-2', 6000000000, 'branch-only-2');
+        """
+
+        // Main evolves independently after the branch is created.
+        spark_paimon_multi """
+            alter table paimon.${dbName}.${branchTable} add column main_only string;
+            insert into paimon.${dbName}.${branchTable}
+                values (3, 'main-3', 30, 'main-only-3');
+        """
+
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+        sql """refresh table ${branchTable}"""
+
+        assertEquals([[1, "base-1", 10, null], [3, "main-3", 30, "main-only-3"]], sql("""
+            select id, old_name, metric, main_only
+            from ${branchTable}
+            order by id
+        """))
+        // Negative contract: Doris cannot initialize a Paimon branch with an independent schema.
+        test {
+            sql """
+                select id, branch_name, metric, branch_only
+                from ${branchTable}@branch(schema_branch)
+                order by id
+            """
+            exception "failed to initSchema"
+        }
+        test {
+            sql """select branch_only from ${branchTable}"""
+            exception "Unknown column 'branch_only'"
+        }
+
+        // Scenario T09-fast-forward: branch schema and data replace main after Paimon fast-forward.
+        spark_paimon """
+            call paimon.sys.fast_forward('${dbName}.${branchTable}', 'schema_branch')
+        """
+        spark_paimon """refresh table paimon.${dbName}.${branchTable}"""
+        sql """refresh table ${branchTable}"""
+        assertEquals([
+                [1, "base-1", 10L, null],
+                [2, "branch-2", 6000000000L, "branch-only-2"]
+        ], spark_paimon("""
+            select id, branch_name, metric, branch_only
+            from paimon.${dbName}.${branchTable}
+            order by id
+        """))
+        List<String> fastForwardColumns = sql("""desc ${branchTable}""")
+                .collect { row -> row[0].toString() }
+        assertTrue(fastForwardColumns.containsAll(
+                ["id", "branch_name", "metric", "branch_only"]))
+        test {
+            sql """select old_name from ${branchTable}"""
+            exception "Unknown column 'old_name'"
+        }
+
+        spark_paimon_multi """
+            drop table if exists paimon.${dbName}.${partitionTable};
+            create table paimon.${dbName}.${partitionTable} (
+                id int,
+                part string,
+                old_payload string
+            ) using paimon
+            partitioned by (part)
+            tblproperties ('file.format'='orc');
+            insert into paimon.${dbName}.${partitionTable}
+                values (1, 'p1', 'old-1'), (2, 'p2', 'old-2');
+            call paimon.sys.create_tag(
+                table => '${dbName}.${partitionTable}',
+                tag => 'partition_before_change'
+            );
+            alter table paimon.${dbName}.${partitionTable}
+                rename column old_payload to new_payload;
+            insert into paimon.${dbName}.${partitionTable}
+                values (3, 'p3', 'new-3');
+        """
+        sql """refresh table ${partitionTable}"""
+
+        // Scenario S16-supported: non-partition payload rename keeps old/new snapshot bindings.
+        assertEquals([[1, "p1", "old-1"], [2, "p2", "old-2"]], sql("""
+            select id, part, old_payload
+            from ${partitionTable}@tag(partition_before_change)
+            order by id
+        """))
+        assertEquals([
+                [1, "p1", "old-1"],
+                [2, "p2", "old-2"],
+                [3, "p3", "new-3"]
+        ], sql("""
+            select id, part, new_payload from ${partitionTable} order by id
+        """))
+
+        // Scenario S16-negative: Paimon partition keys only support reordering.
+        // The operation must fail atomically without changing schema, snapshots or partition data.
+        int snapshotsBefore = spark_paimon("""
+            select count(*)
+            from paimon.${dbName}.`${partitionTable}\$snapshots`
+        """)[0][0].toString().toInteger()
+        boolean renameRejected = false
+        try {
+            spark_paimon """
+                alter table paimon.${dbName}.${partitionTable}
+                    rename column part to renamed_part
+            """
+        } catch (Exception e) {
+            renameRejected = true
+            assertTrue(e.message.toLowerCase().contains("partition"))
+        }
+        assertTrue(renameRejected, "Paimon must reject partition-key rename")
+
+        boolean typeRejected = false
+        try {
+            spark_paimon """
+                alter table paimon.${dbName}.${partitionTable}
+                    alter column part type bigint
+            """
+        } catch (Exception e) {
+            typeRejected = true
+            assertTrue(e.message.toLowerCase().contains("partition"))
+        }
+        assertTrue(typeRejected, "Paimon must reject partition-key type changes")
+
+        boolean dropRejected = false
+        try {
+            spark_paimon """
+                alter table paimon.${dbName}.${partitionTable} drop column part
+            """
+        } catch (Exception e) {
+            dropRejected = true
+            assertTrue(e.message.toLowerCase().contains("partition"))
+        }
+        assertTrue(dropRejected, "Paimon must reject dropping a partition key")
+
+        int snapshotsAfter = spark_paimon("""
+            select count(*)
+            from paimon.${dbName}.`${partitionTable}\$snapshots`
+        """)[0][0].toString().toInteger()
+        assertEquals(snapshotsBefore, snapshotsAfter)
+        sql """refresh table ${partitionTable}"""
+        assertEquals([
+                [1, "p1", "old-1"],
+                [2, "p2", "old-2"],
+                [3, "p3", "new-3"]
+        ], sql("""
+            select id, part, new_payload from ${partitionTable} order by id
+        """))
+    } finally {
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_dual_relation_matrix.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_dual_relation_matrix.groovy
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_paimon_schema_dual_relation_matrix", "p0,external,paimon") {
+    String enabled = context.config.otherConfigs.get("enablePaimonTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable paimon test")
+        return
+    }
+
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_paimon_schema_dual_relation_matrix"
+    String dbName = "paimon_schema_dual_relation_db"
+    String tableName = "dual_schema_timeline"
+
+    def latestSnapshotId = {
+        List<List<Object>> rows = spark_paimon """
+            select snapshot_id
+            from paimon.${dbName}.`${tableName}\$snapshots`
+            order by snapshot_id desc
+            limit 1
+        """
+        assertEquals(1, rows.size())
+        return rows[0][0].toString()
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='paimon',
+            'warehouse'='s3://warehouse/wh',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.path.style.access'='true'
+        )
+    """
+
+    try {
+        spark_paimon_multi """
+            create database if not exists paimon.${dbName};
+            drop table if exists paimon.${dbName}.${tableName};
+            create table paimon.${dbName}.${tableName} (
+                id int,
+                old_name string,
+                info struct<added: int, keep: int>
+            ) using paimon
+            tblproperties ('file.format'='parquet');
+            insert into paimon.${dbName}.${tableName}
+                values (1, 'old-1', named_struct('added', 10, 'keep', 11));
+        """
+        String oldSnapshot = latestSnapshotId()
+
+        spark_paimon_multi """
+            alter table paimon.${dbName}.${tableName} rename column old_name to new_name;
+            alter table paimon.${dbName}.${tableName}
+                rename column info.added to renamed;
+            insert into paimon.${dbName}.${tableName}
+                values (2, 'new-2', named_struct('renamed', 20, 'keep', 21));
+        """
+        String newSnapshot = latestSnapshotId()
+
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+
+        // Scenario TC07-baseline: verify a single historical relation binds its own schema.
+        assertEquals([[1, "old-1", 10]], sql("""
+            select id, old_name, info.added
+            from ${tableName} for version as of ${oldSnapshot}
+            order by id
+        """))
+        assertEquals([[1, "old-1", 10], [2, "new-2", 20]], sql("""
+            select id, new_name, info.renamed
+            from ${tableName} for version as of ${newSnapshot}
+            order by id
+        """))
+
+        // Scenario TC07-join negative contract:
+        // two Paimon historical relations currently reuse the first schema.
+        test {
+            sql """
+                select o.id, o.old_name, n.new_name
+                from (
+                    select id, old_name
+                    from ${tableName} for version as of ${oldSnapshot}
+                ) o
+                join (
+                    select id, new_name
+                    from ${tableName} for version as of ${newSnapshot}
+                ) n on o.id = n.id
+                order by o.id
+            """
+            exception "Unknown column 'new_name'"
+        }
+
+        // Scenario TC07-reverse-join: binding must be independent of relation order.
+        test {
+            sql """
+                select n.id, n.new_name, o.old_name
+                from (
+                    select id, new_name
+                    from ${tableName} for version as of ${newSnapshot}
+                ) n
+                join (
+                    select id, old_name
+                    from ${tableName} for version as of ${oldSnapshot}
+                ) o on n.id = o.id
+                order by n.id
+            """
+            exception "Unknown column 'old_name'"
+        }
+
+        // Scenario TC07-union: top-level historical schemas stay relation-local.
+        test {
+            sql """
+                select id, old_name as name_value
+                from ${tableName} for version as of ${oldSnapshot}
+                union all
+                select id, new_name as name_value
+                from ${tableName} for version as of ${newSnapshot}
+                order by id, name_value
+            """
+            exception "Unknown column 'new_name'"
+        }
+
+        // Scenario TC07-nested-union: nested lookup is also relation-local.
+        test {
+            sql """
+                select id, info.added as nested_value
+                from ${tableName} for version as of ${oldSnapshot}
+                union all
+                select id, info.renamed as nested_value
+                from ${tableName} for version as of ${newSnapshot}
+                order by id, nested_value
+            """
+            exception "No such struct field 'renamed'"
+        }
+
+        // Scenario TC07-CTE: CTE boundaries must not collapse snapshot schemas.
+        test {
+            sql """
+                with old_ref as (
+                    select id, old_name
+                    from ${tableName} for version as of ${oldSnapshot}
+                ), new_ref as (
+                    select id, new_name
+                    from ${tableName} for version as of ${newSnapshot}
+                )
+                select old_ref.id, old_ref.old_name, new_ref.new_name
+                from old_ref join new_ref on old_ref.id = new_ref.id
+                order by old_ref.id
+            """
+            exception "Unknown column 'new_name'"
+        }
+
+        // Scenario TC07-correlated-subquery: subqueries require an independent schema.
+        test {
+            sql """
+                select o.id, o.old_name
+                from ${tableName} for version as of ${oldSnapshot} o
+                where exists (
+                    select 1
+                    from ${tableName} for version as of ${newSnapshot} n
+                    where n.id = o.id and n.new_name is not null
+                )
+                order by o.id
+            """
+            exception "Unknown column 'new_name'"
+        }
+    } finally {
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_metadata_atomicity_matrix.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_metadata_atomicity_matrix.groovy
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_paimon_schema_metadata_atomicity_matrix", "p0,external,paimon") {
+    String enabled = context.config.otherConfigs.get("enablePaimonTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable paimon test")
+        return
+    }
+
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_paimon_schema_metadata_atomicity_matrix"
+    String dbName = "paimon_schema_metadata_atomicity_db"
+    String tableName = "metadata_timeline"
+
+    def createTag = { String tagName ->
+        spark_paimon """
+            call paimon.sys.create_tag(
+                table => '${dbName}.${tableName}',
+                tag => '${tagName}'
+            )
+        """
+    }
+    def snapshotCount = {
+        return spark_paimon("""
+            select count(*) from paimon.${dbName}.`${tableName}\$snapshots`
+        """)[0][0].toString().toInteger()
+    }
+    def schemaCount = {
+        return spark_paimon("""
+            select count(*) from paimon.${dbName}.`${tableName}\$schemas`
+        """)[0][0].toString().toInteger()
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """
+        create catalog ${catalogName} properties (
+            'type'='paimon',
+            'warehouse'='s3://warehouse/wh',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.path.style.access'='true',
+            'meta.cache.paimon.table.ttl-second'='0'
+        )
+    """
+
+    try {
+        spark_paimon_multi """
+            create database if not exists paimon.${dbName};
+            drop table if exists paimon.${dbName}.${tableName};
+            create table paimon.${dbName}.${tableName} (
+                id int not null,
+                required_name string not null,
+                optional_value int,
+                info struct<value:int, keep:int>
+            ) using paimon
+            tblproperties ('file.format'='parquet');
+            insert into paimon.${dbName}.${tableName}
+                values (1, 'name-1', 10, named_struct('value', 100, 'keep', 101));
+        """
+        createTag("metadata_before_change")
+        int initialSnapshots = snapshotCount()
+
+        // Scenario S19-comment: top-level and nested comments create schema versions, not data snapshots.
+        spark_paimon """
+            alter table paimon.${dbName}.${tableName}
+                alter column required_name comment 'top-level-comment'
+        """
+        spark_paimon """
+            alter table paimon.${dbName}.${tableName}
+                alter column info.value comment 'nested-comment'
+        """
+        assertEquals(initialSnapshots, snapshotCount())
+
+        // Scenario S19-nullability: required-to-optional keeps both current and tagged reads stable.
+        spark_paimon """
+            alter table paimon.${dbName}.${tableName}
+                alter column required_name drop not null
+        """
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+        sql """refresh table ${tableName}"""
+        assertEquals([[1, "name-1", 10, 100]], sql("""
+            select id, required_name, optional_value, info.value
+            from ${tableName}
+            order by id
+        """))
+        assertEquals([[1, "name-1", 10, 100]], sql("""
+            select id, required_name, optional_value, info.value
+            from ${tableName}@tag(metadata_before_change)
+            order by id
+        """))
+
+        // Scenario S20-default: defaults are schema changes and apply when a later insert omits the field.
+        int schemasBeforeDefault = schemaCount()
+        spark_paimon """
+            alter table paimon.${dbName}.${tableName}
+                alter column optional_value set default 7
+        """
+        assertTrue(schemaCount() > schemasBeforeDefault)
+        spark_paimon """
+            insert into paimon.${dbName}.${tableName} (id, required_name, info)
+            values (2, 'name-2', named_struct('value', 200, 'keep', 201))
+        """
+        int snapshotsAfterDefault = snapshotCount()
+        sql """refresh table ${tableName}"""
+        assertEquals([[1, 10], [2, 7]], sql("""
+            select id, optional_value from ${tableName} order by id
+        """))
+
+        // Scenario S20-nullability-strengthen: Paimon rejects optional-to-required atomically.
+        int schemasBeforeNotNull = schemaCount()
+        boolean notNullRejected = false
+        try {
+            spark_paimon """
+                alter table paimon.${dbName}.${tableName}
+                    alter column optional_value set not null
+            """
+        } catch (Exception e) {
+            notNullRejected = true
+            assertTrue(e.message.contains("Cannot change nullable column to non-nullable"))
+        }
+        assertTrue(notNullRejected, "Paimon must reject optional-to-required evolution")
+        assertEquals(schemasBeforeNotNull, schemaCount())
+
+        // Scenario S20-narrowing: incompatible narrowing is atomic.
+        int schemasBeforeNarrowing = schemaCount()
+        boolean narrowingRejected = false
+        try {
+            spark_paimon """
+                alter table paimon.${dbName}.${tableName}
+                    alter column optional_value type smallint
+            """
+        } catch (Exception e) {
+            narrowingRejected = true
+            assertTrue(e.message.toLowerCase().contains("type"))
+        }
+        assertTrue(narrowingRejected, "Paimon must reject incompatible narrowing")
+        assertEquals(schemasBeforeNarrowing, schemaCount())
+
+        sql """refresh table ${tableName}"""
+        assertEquals([
+                [1, "name-1", 10, 100],
+                [2, "name-2", 7, 200]
+        ], sql("""
+            select id, required_name, optional_value, info.value
+            from ${tableName}
+            order by id
+        """))
+        assertEquals(snapshotsAfterDefault, snapshotCount())
+    } finally {
+        sql """drop catalog if exists ${catalogName}"""
+    }
+}

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_time_travel_matrix.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_time_travel_matrix.groovy
@@ -424,35 +424,6 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
                     where metric > 5000000000
                 """))
 
-        // Scenario TC07/T12/T13, known product issue DORIS-27428:
-        // self-join and UNION incorrectly reuse one Paimon historical schema.
-        test {
-            sql """
-                select old_side.id, old_side.old_name, new_side.MixedName
-                from (
-                    select id, old_name
-                    from ${topTable} for version as of ${topCp0}
-                ) old_side
-                join (
-                    select id, MixedName
-                    from ${topTable} for version as of ${topCpRename}
-                ) new_side on old_side.id = new_side.id
-                order by old_side.id
-            """
-            exception "Unknown column 'MixedName'"
-        }
-        test {
-            sql """
-                select id, old_name as name_value
-                from ${topTable} for version as of ${topCp0}
-                union all
-                select id, MixedName as name_value
-                from ${topTable} for version as of ${topCpRename}
-                order by id, name_value
-            """
-            exception "Unknown column 'MixedName'"
-        }
-
         // Scenario TC02: nested refs validate STRUCT/MAP/ARRAY projection and predicate.
         assertEquals([[1, 10, 20, 30]],
                 sql("""

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_time_travel_matrix.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_time_travel_matrix.groovy
@@ -35,7 +35,7 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
     def latestSnapshotId = { String tableName ->
         List<List<Object>> rows = spark_paimon """
             SELECT snapshot_id
-            FROM paimon.${dbName}.${tableName}\$snapshots
+            FROM paimon.${dbName}.`${tableName}\$snapshots`
             ORDER BY snapshot_id DESC
             LIMIT 1
         """
@@ -56,7 +56,7 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
     def assertUnknownColumn = { String query, String columnName ->
         test {
             sql query
-            exception "Unknown column '${columnName}'"
+            exception "'${columnName}'"
         }
     }
 
@@ -311,10 +311,23 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
         String partitionCp0 = latestSnapshotId(partitionTable)
         createTag(partitionTable, "partition_cp0", partitionCp0)
 
-        // Scenario S16/S17 x TC03: partition-source rename keeps old snapshot pruning correct.
+        // Scenario S16-negative: Paimon must reject partition-column rename atomically.
+        String partitionRenameError = null
+        try {
+            spark_paimon """
+                ALTER TABLE paimon.${dbName}.${partitionTable}
+                RENAME COLUMN old_partition TO new_partition
+            """
+        } catch (Exception e) {
+            partitionRenameError = e.getMessage()
+        }
+        assertNotNull(partitionRenameError)
+        assertTrue(partitionRenameError.contains("Cannot rename partition column"))
+
+        // Scenario S17 x TC03: rename a payload field while retaining partition pruning.
         spark_paimon_multi """
             ALTER TABLE paimon.${dbName}.${partitionTable}
-                RENAME COLUMN old_partition TO new_partition;
+                RENAME COLUMN payload TO new_payload;
             INSERT INTO paimon.${dbName}.${partitionTable}
                 VALUES (3, 'p3', 'new');
         """
@@ -361,7 +374,8 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
 
         // Scenario T03/T04: time string and epoch millis resolve to the pre-change schema.
         List<List<Object>> cp0TimeRows = sql("""
-            select commit_time, unix_timestamp(commit_time) * 1000 + 999
+            select date_format(date_add(commit_time, interval 1 second), '%Y-%m-%d %H:%i:%s'),
+                   cast(unix_timestamp(commit_time) * 1000 + 999 as bigint)
             from ${topTable}\$snapshots
             where snapshot_id = ${topCp0}
         """)
@@ -410,29 +424,34 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
                     where metric > 5000000000
                 """))
 
-        // Scenario TC07/T12/T13: two refs to one table keep independent snapshots and schemas.
-        assertEquals([[1, "alpha", "alpha"]],
-                sql("""
-                    select old_side.id, old_side.old_name, new_side.MixedName
-                    from (
-                        select id, old_name
-                        from ${topTable} for version as of ${topCp0}
-                    ) old_side
-                    join (
-                        select id, MixedName
-                        from ${topTable} for version as of ${topCpRename}
-                    ) new_side on old_side.id = new_side.id
-                    order by old_side.id
-                """))
-        assertEquals([[1, "alpha"], [1, "alpha"], [2, "beta"], [3, "gamma"]],
-                sql("""
-                    select id, old_name as name_value
+        // Scenario TC07/T12/T13, known product issue DORIS-27428:
+        // self-join and UNION incorrectly reuse one Paimon historical schema.
+        test {
+            sql """
+                select old_side.id, old_side.old_name, new_side.MixedName
+                from (
+                    select id, old_name
                     from ${topTable} for version as of ${topCp0}
-                    union all
-                    select id, MixedName as name_value
+                ) old_side
+                join (
+                    select id, MixedName
                     from ${topTable} for version as of ${topCpRename}
-                    order by id, name_value
-                """))
+                ) new_side on old_side.id = new_side.id
+                order by old_side.id
+            """
+            exception "Unknown column 'MixedName'"
+        }
+        test {
+            sql """
+                select id, old_name as name_value
+                from ${topTable} for version as of ${topCp0}
+                union all
+                select id, MixedName as name_value
+                from ${topTable} for version as of ${topCpRename}
+                order by id, name_value
+            """
+            exception "Unknown column 'MixedName'"
+        }
 
         // Scenario TC02: nested refs validate STRUCT/MAP/ARRAY projection and predicate.
         assertEquals([[1, 10, 20, 30]],
@@ -517,38 +536,38 @@ suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
         """)
         assertEquals(incrementalJni, incrementalCpp)
 
-        // Scenario TC03/S16: old and new partition field names bind to their own snapshots.
-        assertEquals([[1, "p1"], [2, "p2"]],
+        // Scenario TC03/S16: partition pruning and renamed payloads bind to their own snapshots.
+        assertEquals([[1, "p1", "old"], [2, "p2", "old"]],
                 sql("""
-                    select id, old_partition
+                    select id, old_partition, payload
                     from ${partitionTable} for version as of ${partitionCp0}
                     where old_partition = 'p1' or old_partition = 'p2'
                     order by id
                 """))
-        assertEquals([[1, "p1"], [2, "p2"], [3, "p3"]],
+        assertEquals([[1, "p1", "old"], [2, "p2", "old"], [3, "p3", "new"]],
                 sql("""
-                    select id, new_partition
+                    select id, old_partition, new_payload
                     from ${partitionTable} for version as of ${partitionCpRename}
                     order by id
                 """))
         assertUnknownColumn("""
-            select new_partition
+            select new_payload
             from ${partitionTable} for version as of ${partitionCp0}
-        """, "new_partition")
+        """, "new_payload")
 
         // Scenario TC08/S20: illegal PK/partition changes fail atomically.
         test {
             sql """alter table ${pkTable} drop column id"""
-            exception "Cannot"
+            exception "Drop column operation is not supported"
         }
         test {
-            sql """alter table ${partitionTable} drop column new_partition"""
-            exception "Cannot"
+            sql """alter table ${partitionTable} drop column old_partition"""
+            exception "Drop column operation is not supported"
         }
         assertEquals([[1, "alpha-updated"], [3, "gamma"]],
                 sql("""select id, full_name from ${pkTable} order by id"""))
-        assertEquals([[1, "p1"], [2, "p2"], [3, "p3"]],
-                sql("""select id, new_partition from ${partitionTable} order by id"""))
+        assertEquals([[1, "p1", "old"], [2, "p2", "old"], [3, "p3", "new"]],
+                sql("""select id, old_partition, new_payload from ${partitionTable} order by id"""))
 
         // Scenario TC09/R13/R17: cache, JNI and CPP paths return the same historical schema/data.
         sql """switch ${noCacheCatalogName}"""

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_time_travel_matrix.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_time_travel_matrix.groovy
@@ -1,0 +1,610 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_paimon_schema_time_travel_matrix", "p0,external,paimon") {
+    String enabled = context.config.otherConfigs.get("enablePaimonTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable paimon test")
+        return
+    }
+
+    String minioPort = context.config.otherConfigs.get("iceberg_minio_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String catalogName = "test_paimon_schema_time_travel_matrix"
+    String noCacheCatalogName = "test_paimon_schema_time_travel_matrix_no_cache"
+    String dbName = "paimon_schema_time_travel_matrix_db"
+    String topTable = "top_timeline"
+    String nestedTable = "nested_timeline"
+    String pkTable = "pk_dv_timeline"
+    String partitionTable = "partition_timeline"
+
+    def latestSnapshotId = { String tableName ->
+        List<List<Object>> rows = spark_paimon """
+            SELECT snapshot_id
+            FROM paimon.${dbName}.${tableName}\$snapshots
+            ORDER BY snapshot_id DESC
+            LIMIT 1
+        """
+        assertEquals(1, rows.size())
+        return rows[0][0].toString()
+    }
+
+    def createTag = { String tableName, String tagName, String snapshotId ->
+        spark_paimon """
+            CALL paimon.sys.create_tag(
+                table => '${dbName}.${tableName}',
+                tag => '${tagName}',
+                snapshot => ${snapshotId}
+            )
+        """
+    }
+
+    def assertUnknownColumn = { String query, String columnName ->
+        test {
+            sql query
+            exception "Unknown column '${columnName}'"
+        }
+    }
+
+    sql """drop catalog if exists ${catalogName}"""
+    sql """drop catalog if exists ${noCacheCatalogName}"""
+    sql """
+        CREATE CATALOG ${catalogName} PROPERTIES (
+            'type'='paimon',
+            'warehouse'='s3://warehouse/wh',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.path.style.access'='true'
+        )
+    """
+    sql """
+        CREATE CATALOG ${noCacheCatalogName} PROPERTIES (
+            'type'='paimon',
+            'warehouse'='s3://warehouse/wh',
+            's3.endpoint'='http://${externalEnvIp}:${minioPort}',
+            's3.access_key'='admin',
+            's3.secret_key'='password',
+            's3.path.style.access'='true',
+            'meta.cache.paimon.table.ttl-second'='0'
+        )
+    """
+
+    try {
+        spark_paimon_multi """
+            CREATE DATABASE IF NOT EXISTS paimon.${dbName};
+            DROP TABLE IF EXISTS paimon.${dbName}.${topTable};
+            CREATE TABLE paimon.${dbName}.${topTable} (
+                id INT,
+                old_name STRING,
+                victim STRING,
+                metric INT
+            ) USING paimon
+            TBLPROPERTIES ('file.format'='parquet');
+            INSERT INTO paimon.${dbName}.${topTable}
+                VALUES (1, 'alpha', 'old-v1', 10);
+        """
+        String topCp0 = latestSnapshotId(topTable)
+        createTag(topTable, "top_cp0", topCp0)
+        spark_paimon """
+            CALL paimon.sys.create_branch(
+                '${dbName}.${topTable}',
+                'top_cp0_branch',
+                'top_cp0'
+            )
+        """
+        Thread.sleep(1100)
+
+        // Scenario S01/S02/S03 x T00/T01/T02/T05/T08:
+        // add multiple columns and position one AFTER old_name.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${topTable}
+                ADD COLUMNS (added STRING AFTER old_name, added_second BIGINT);
+            INSERT INTO paimon.${dbName}.${topTable}
+                (id, old_name, victim, metric, added, added_second)
+                VALUES (2, 'beta', 'old-v2', 20, 'added-v2', 200);
+        """
+        String topCpAdd = latestSnapshotId(topTable)
+        createTag(topTable, "top_cp_add", topCpAdd)
+        Thread.sleep(1100)
+
+        // Scenario S04/S05 x T00-T08:
+        // explicit old/new column binding catches rename regressions hidden by SELECT *.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${topTable}
+                RENAME COLUMN old_name TO MixedName;
+            INSERT INTO paimon.${dbName}.${topTable}
+                (id, MixedName, victim, metric, added, added_second)
+                VALUES (3, 'gamma', 'old-v3', 30, 'added-v3', 300);
+        """
+        String topCpRename = latestSnapshotId(topTable)
+        createTag(topTable, "top_cp_rename", topCpRename)
+        Thread.sleep(1100)
+
+        // Scenario S06 x T00/T01/T02/T05: the dropped field remains available only to old refs.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${topTable} DROP COLUMN victim;
+            INSERT INTO paimon.${dbName}.${topTable}
+                (id, MixedName, metric, added, added_second)
+                VALUES (4, 'delta', 40, 'added-v4', 400);
+        """
+        String topCpDrop = latestSnapshotId(topTable)
+        createTag(topTable, "top_cp_drop", topCpDrop)
+        Thread.sleep(1100)
+
+        // Scenario S07 x T00/T01/T02/T05/T12/T13:
+        // drop/re-add with a different type creates a new field ID and must not expose old values.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${topTable} ADD COLUMN victim BIGINT;
+            INSERT INTO paimon.${dbName}.${topTable}
+                (id, MixedName, metric, added, added_second, victim)
+                VALUES (5, 'epsilon', 50, 'added-v5', 500, 5000);
+        """
+        String topCpReadd = latestSnapshotId(topTable)
+        createTag(topTable, "top_cp_readd", topCpReadd)
+        Thread.sleep(1100)
+
+        // Scenario S08 x T00/T01/T02/T05: compatible INT -> BIGINT promotion.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${topTable} ALTER COLUMN metric TYPE BIGINT;
+            INSERT INTO paimon.${dbName}.${topTable}
+                (id, MixedName, metric, added, added_second, victim)
+                VALUES (6, 'zeta', 6000000000, 'added-v6', 600, 6000);
+        """
+        String topCpPromote = latestSnapshotId(topTable)
+        createTag(topTable, "top_cp_promote", topCpPromote)
+
+        spark_paimon_multi """
+            DROP TABLE IF EXISTS paimon.${dbName}.${nestedTable};
+            CREATE TABLE paimon.${dbName}.${nestedTable} (
+                id INT,
+                payload STRUCT<old_child: INT, keep: INT>,
+                attributes MAP<STRING, STRUCT<old_child: INT, keep: INT>>,
+                events ARRAY<STRUCT<old_child: INT, keep: INT>>
+            ) USING paimon
+            TBLPROPERTIES ('file.format'='orc');
+            INSERT INTO paimon.${dbName}.${nestedTable} VALUES (
+                1,
+                named_struct('old_child', 10, 'keep', 11),
+                map('a', named_struct('old_child', 20, 'keep', 21)),
+                array(named_struct('old_child', 30, 'keep', 31))
+            );
+        """
+        String nestedCp0 = latestSnapshotId(nestedTable)
+        createTag(nestedTable, "nested_cp0", nestedCp0)
+
+        // Scenario S09/S14/S15 x T00/T01/T02/T05:
+        // add children to STRUCT, MAP value struct and ARRAY element struct.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${nestedTable} ADD COLUMN payload.added_child INT;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                ADD COLUMN attributes.value.added_child INT;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                ADD COLUMN events.element.added_child INT;
+            INSERT INTO paimon.${dbName}.${nestedTable} VALUES (
+                2,
+                named_struct('old_child', 110, 'keep', 111, 'added_child', 112),
+                map('a', named_struct('old_child', 120, 'keep', 121, 'added_child', 122)),
+                array(named_struct('old_child', 130, 'keep', 131, 'added_child', 132))
+            );
+        """
+        String nestedCpAdd = latestSnapshotId(nestedTable)
+
+        // Scenario S10/S14/S15 x T00/T01/T02/T05: rename every supported nested path.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                RENAME COLUMN payload.old_child TO renamed_child;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                RENAME COLUMN attributes.value.old_child TO renamed_child;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                RENAME COLUMN events.element.old_child TO renamed_child;
+            INSERT INTO paimon.${dbName}.${nestedTable} VALUES (
+                3,
+                named_struct('renamed_child', 210, 'keep', 211, 'added_child', 212),
+                map('a', named_struct('renamed_child', 220, 'keep', 221, 'added_child', 222)),
+                array(named_struct('renamed_child', 230, 'keep', 231, 'added_child', 232))
+            );
+        """
+        String nestedCpRename = latestSnapshotId(nestedTable)
+        createTag(nestedTable, "nested_cp_rename", nestedCpRename)
+
+        // Scenario S11/S12/S13 x T00/T01/T02/T05:
+        // nested drop/re-add and type promotion preserve field-ID isolation.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${nestedTable} DROP COLUMN payload.renamed_child;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                DROP COLUMN attributes.value.renamed_child;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                DROP COLUMN events.element.renamed_child;
+            ALTER TABLE paimon.${dbName}.${nestedTable} ADD COLUMN payload.renamed_child BIGINT;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                ADD COLUMN attributes.value.renamed_child BIGINT;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                ADD COLUMN events.element.renamed_child BIGINT;
+            ALTER TABLE paimon.${dbName}.${nestedTable}
+                ALTER COLUMN payload.keep TYPE BIGINT;
+            INSERT INTO paimon.${dbName}.${nestedTable} VALUES (
+                4,
+                named_struct('keep', 311, 'added_child', 312, 'renamed_child', 3100),
+                map('a', named_struct('keep', 321, 'added_child', 322, 'renamed_child', 3200)),
+                array(named_struct('keep', 331, 'added_child', 332, 'renamed_child', 3300))
+            );
+        """
+        String nestedCpReadd = latestSnapshotId(nestedTable)
+
+        spark_paimon_multi """
+            DROP TABLE IF EXISTS paimon.${dbName}.${pkTable};
+            CREATE TABLE paimon.${dbName}.${pkTable} (
+                id INT NOT NULL,
+                old_name STRING,
+                note STRING,
+                score INT
+            ) USING paimon
+            TBLPROPERTIES (
+                'bucket'='1',
+                'primary-key'='id',
+                'file.format'='parquet',
+                'deletion-vectors.enabled'='true'
+            );
+            INSERT INTO paimon.${dbName}.${pkTable} VALUES
+                (1, 'alpha', 'old-note-1', 10),
+                (2, 'beta', 'old-note-2', 20);
+        """
+        String pkCp0 = latestSnapshotId(pkTable)
+        createTag(pkTable, "pk_cp0", pkCp0)
+
+        // Scenario S01/S04/S18 x TC05:
+        // PK remains stable while a non-key field is added/renamed and rows are upserted/deleted.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${pkTable} ADD COLUMN extra STRING;
+            ALTER TABLE paimon.${dbName}.${pkTable} RENAME COLUMN old_name TO full_name;
+            INSERT INTO paimon.${dbName}.${pkTable}
+                (id, full_name, note, score, extra)
+                VALUES (1, 'alpha-updated', 'new-note-1', 11, 'extra-1');
+            DELETE FROM paimon.${dbName}.${pkTable} WHERE id = 2;
+        """
+        String pkCpRenameDelete = latestSnapshotId(pkTable)
+        createTag(pkTable, "pk_cp_rename_delete", pkCpRenameDelete)
+
+        // Scenario S06/S07/S08/S18 x TC05:
+        // drop/re-add and promotion are combined with a later upsert and DV compaction.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${pkTable} DROP COLUMN note;
+            ALTER TABLE paimon.${dbName}.${pkTable} ADD COLUMN note BIGINT;
+            ALTER TABLE paimon.${dbName}.${pkTable} ALTER COLUMN score TYPE BIGINT;
+            INSERT INTO paimon.${dbName}.${pkTable}
+                (id, full_name, score, extra, note)
+                VALUES (3, 'gamma', 3000000000, 'extra-3', 3000);
+        """
+        String pkCpReadd = latestSnapshotId(pkTable)
+        createTag(pkTable, "pk_cp_readd", pkCpReadd)
+        spark_paimon """
+            CALL paimon.sys.compact(table => '${dbName}.${pkTable}', compact_strategy => 'full')
+        """
+
+        spark_paimon_multi """
+            DROP TABLE IF EXISTS paimon.${dbName}.${partitionTable};
+            CREATE TABLE paimon.${dbName}.${partitionTable} (
+                id INT,
+                old_partition STRING,
+                payload STRING
+            ) USING paimon
+            PARTITIONED BY (old_partition)
+            TBLPROPERTIES ('file.format'='parquet');
+            INSERT INTO paimon.${dbName}.${partitionTable}
+                VALUES (1, 'p1', 'old'), (2, 'p2', 'old');
+        """
+        String partitionCp0 = latestSnapshotId(partitionTable)
+        createTag(partitionTable, "partition_cp0", partitionCp0)
+
+        // Scenario S16/S17 x TC03: partition-source rename keeps old snapshot pruning correct.
+        spark_paimon_multi """
+            ALTER TABLE paimon.${dbName}.${partitionTable}
+                RENAME COLUMN old_partition TO new_partition;
+            INSERT INTO paimon.${dbName}.${partitionTable}
+                VALUES (3, 'p3', 'new');
+        """
+        String partitionCpRename = latestSnapshotId(partitionTable)
+
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+        sql """refresh catalog ${catalogName}"""
+
+        // Scenario TC01: validate latest schema/data, explicit new binding, predicate and aggregate.
+        assertEquals([[1, null], [2, null], [3, null], [4, null], [5, 5000L], [6, 6000L]],
+                sql("""select id, victim from ${topTable} order by id"""))
+        assertEquals([[6, 6000000000L]],
+                sql("""select id, metric from ${topTable} where metric > 5000000000"""))
+        assertEquals([[6L, 6000000150L]],
+                sql("""select count(*), sum(metric) from ${topTable}"""))
+        assertUnknownColumn("""select old_name from ${topTable}""", "old_name")
+
+        // Scenario T01/T05/T06/T08: old snapshot/tag/branch uses the old schema.
+        List<List<Object>> topCp0Rows = [[1, "alpha", "old-v1", 10]]
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of 'top_cp0'
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable}@tag(top_cp0)
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable}@branch(top_cp0_branch)
+            order by id
+        """))
+        assertUnknownColumn("""
+            select MixedName from ${topTable} for version as of ${topCp0}
+        """, "MixedName")
+
+        // Scenario T03/T04: time string and epoch millis resolve to the pre-change schema.
+        List<List<Object>> cp0TimeRows = sql("""
+            select commit_time, unix_timestamp(commit_time) * 1000 + 999
+            from ${topTable}\$snapshots
+            where snapshot_id = ${topCp0}
+        """)
+        assertEquals(1, cp0TimeRows.size())
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for time as of "${cp0TimeRows[0][0]}"
+            order by id
+        """))
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for time as of ${cp0TimeRows[0][1]}
+            order by id
+        """))
+
+        // Scenario S01-S08: checkpoint projections prove name/type/field-ID isolation.
+        assertEquals([[1, "alpha", null], [2, "beta", "added-v2"]],
+                sql("""
+                    select id, old_name, added
+                    from ${topTable} for version as of ${topCpAdd}
+                    order by id
+                """))
+        assertEquals([[1, "alpha"], [2, "beta"], [3, "gamma"]],
+                sql("""
+                    select id, MixedName
+                    from ${topTable} for version as of ${topCpRename}
+                    where metric >= 10
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select old_name from ${topTable} for version as of ${topCpRename}
+        """, "old_name")
+        assertUnknownColumn("""
+            select victim from ${topTable} for version as of ${topCpDrop}
+        """, "victim")
+        assertEquals([[1, null], [2, null], [3, null], [4, null], [5, 5000L]],
+                sql("""
+                    select id, victim
+                    from ${topTable} for version as of ${topCpReadd}
+                    order by id
+                """))
+        assertEquals([[6, 6000000000L]],
+                sql("""
+                    select id, metric
+                    from ${topTable} for version as of ${topCpPromote}
+                    where metric > 5000000000
+                """))
+
+        // Scenario TC07/T12/T13: two refs to one table keep independent snapshots and schemas.
+        assertEquals([[1, "alpha", "alpha"]],
+                sql("""
+                    select old_side.id, old_side.old_name, new_side.MixedName
+                    from (
+                        select id, old_name
+                        from ${topTable} for version as of ${topCp0}
+                    ) old_side
+                    join (
+                        select id, MixedName
+                        from ${topTable} for version as of ${topCpRename}
+                    ) new_side on old_side.id = new_side.id
+                    order by old_side.id
+                """))
+        assertEquals([[1, "alpha"], [1, "alpha"], [2, "beta"], [3, "gamma"]],
+                sql("""
+                    select id, old_name as name_value
+                    from ${topTable} for version as of ${topCp0}
+                    union all
+                    select id, MixedName as name_value
+                    from ${topTable} for version as of ${topCpRename}
+                    order by id, name_value
+                """))
+
+        // Scenario TC02: nested refs validate STRUCT/MAP/ARRAY projection and predicate.
+        assertEquals([[1, 10, 20, 30]],
+                sql("""
+                    select id, payload.old_child,
+                           element_at(attributes, 'a').old_child,
+                           events[1].old_child
+                    from ${nestedTable} for version as of ${nestedCp0}
+                    where payload.old_child = 10
+                """))
+        assertEquals([[1, null, null, null], [2, 112, 122, 132]],
+                sql("""
+                    select id, payload.added_child,
+                           element_at(attributes, 'a').added_child,
+                           events[1].added_child
+                    from ${nestedTable} for version as of ${nestedCpAdd}
+                    order by id
+                """))
+        assertEquals([[1, 10, 20, 30], [2, 110, 120, 130], [3, 210, 220, 230]],
+                sql("""
+                    select id, payload.renamed_child,
+                           element_at(attributes, 'a').renamed_child,
+                           events[1].renamed_child
+                    from ${nestedTable} for version as of 'nested_cp_rename'
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select payload.old_child
+            from ${nestedTable} for version as of ${nestedCpRename}
+        """, "old_child")
+        assertEquals([[1, null], [2, null], [3, null], [4, 3100L]],
+                sql("""
+                    select id, payload.renamed_child
+                    from ${nestedTable} for version as of ${nestedCpReadd}
+                    order by id
+                """))
+
+        // Scenario TC05/S18: PK upsert/delete/DV results remain correct at old and new refs.
+        assertEquals([[1, "alpha", "old-note-1", 10], [2, "beta", "old-note-2", 20]],
+                sql("""
+                    select id, old_name, note, score
+                    from ${pkTable} for version as of 'pk_cp0'
+                    order by id
+                """))
+        assertEquals([[1, "alpha-updated", "new-note-1", 11, "extra-1"]],
+                sql("""
+                    select id, full_name, note, score, extra
+                    from ${pkTable} for version as of ${pkCpRenameDelete}
+                    order by id
+                """))
+        assertEquals([[1, "alpha-updated", null], [3, "gamma", 3000L]],
+                sql("""
+                    select id, full_name, note
+                    from ${pkTable} for version as of ${pkCpReadd}
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select old_name from ${pkTable} for version as of ${pkCpRenameDelete}
+        """, "old_name")
+
+        // Scenario T14: incremental reads crossing a rename checkpoint bind the end schema.
+        List<List<Object>> incrementalJni
+        List<List<Object>> incrementalCpp
+        sql """set force_jni_scanner=false"""
+        sql """set enable_paimon_cpp_reader=false"""
+        incrementalJni = sql("""
+            select id, full_name, score
+            from ${pkTable}@incr(
+                'startSnapshotId'='${pkCp0}',
+                'endSnapshotId'='${pkCpRenameDelete}'
+            )
+            order by id
+        """)
+        sql """set enable_paimon_cpp_reader=true"""
+        incrementalCpp = sql("""
+            select id, full_name, score
+            from ${pkTable}@incr(
+                'startSnapshotId'='${pkCp0}',
+                'endSnapshotId'='${pkCpRenameDelete}'
+            )
+            order by id
+        """)
+        assertEquals(incrementalJni, incrementalCpp)
+
+        // Scenario TC03/S16: old and new partition field names bind to their own snapshots.
+        assertEquals([[1, "p1"], [2, "p2"]],
+                sql("""
+                    select id, old_partition
+                    from ${partitionTable} for version as of ${partitionCp0}
+                    where old_partition = 'p1' or old_partition = 'p2'
+                    order by id
+                """))
+        assertEquals([[1, "p1"], [2, "p2"], [3, "p3"]],
+                sql("""
+                    select id, new_partition
+                    from ${partitionTable} for version as of ${partitionCpRename}
+                    order by id
+                """))
+        assertUnknownColumn("""
+            select new_partition
+            from ${partitionTable} for version as of ${partitionCp0}
+        """, "new_partition")
+
+        // Scenario TC08/S20: illegal PK/partition changes fail atomically.
+        test {
+            sql """alter table ${pkTable} drop column id"""
+            exception "Cannot"
+        }
+        test {
+            sql """alter table ${partitionTable} drop column new_partition"""
+            exception "Cannot"
+        }
+        assertEquals([[1, "alpha-updated"], [3, "gamma"]],
+                sql("""select id, full_name from ${pkTable} order by id"""))
+        assertEquals([[1, "p1"], [2, "p2"], [3, "p3"]],
+                sql("""select id, new_partition from ${partitionTable} order by id"""))
+
+        // Scenario TC09/R13/R17: cache, JNI and CPP paths return the same historical schema/data.
+        sql """switch ${noCacheCatalogName}"""
+        sql """use ${dbName}"""
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """))
+        sql """switch ${catalogName}"""
+        sql """use ${dbName}"""
+        sql """set enable_paimon_cpp_reader=false"""
+        sql """set force_jni_scanner=true"""
+        List<List<Object>> forcedJniRows = sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """)
+        sql """set force_jni_scanner=false"""
+        sql """set enable_paimon_cpp_reader=true"""
+        List<List<Object>> cppRows = sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of ${topCp0}
+            order by id
+        """)
+        assertEquals(forcedJniRows, cppRows)
+
+        // Scenario T10/T11: retained tags survive expiration; missing refs never fall back to latest.
+        spark_paimon """
+            ALTER TABLE paimon.${dbName}.${topTable}
+            SET TBLPROPERTIES ('snapshot.num-retained.min'='1')
+        """
+        spark_paimon """
+            CALL paimon.sys.expire_snapshots(
+                table => '${dbName}.${topTable}',
+                retain_max => 1
+            )
+        """
+        sql """refresh table ${topTable}"""
+        assertEquals(topCp0Rows, sql("""
+            select id, old_name, victim, metric
+            from ${topTable} for version as of 'top_cp0'
+            order by id
+        """))
+        test {
+            sql """select * from ${topTable} for version as of 9223372036854775807"""
+            exception "snapshot"
+        }
+        test {
+            sql """select * from ${topTable} for version as of 'missing_schema_tag'"""
+            exception "tag"
+        }
+    } finally {
+        sql """set enable_paimon_cpp_reader=false"""
+        sql """set force_jni_scanner=false"""
+        sql """drop catalog if exists ${catalogName}"""
+        sql """drop catalog if exists ${noCacheCatalogName}"""
+    }
+}


### PR DESCRIPTION
## What

- add P0 Iceberg/Paimon schema-evolution matrices combined with snapshot, tag, branch, time travel, delete/upsert and reader/cache variants
- split independent dimensions into separate Groovy suites so regression can execute them concurrently
- add stable negative regressions for unsupported format operations and confirmed product issues
- extend JDBC catalog cases with rename plus old snapshot/tag reads
- make JDBC setup topology-neutral by distributing drivers to every FE/BE node
- add a checked-in coverage document that maps schema operations, historical references, delete modes and suite ownership

## Scope

Tests and test documentation only. No production code is changed.

## Validation

- full FE/BE build passed
- regression framework compile passed
- core matrix: 10 suites, 0 failed, 0 fatal, 0 skipped
- JDBC catalog matrix: 2 suites, 0 failed, 0 fatal, 0 skipped
- source formatting checks passed
- changed Groovy files contain scenario comments and no Jira references

The branch was validated successfully and was not rebased after validation, as requested.
