### PR TITLE
[improve](cloud) Skip non-MOW tablets for get_topn_tablet_delete_bitmap_score

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -1296,13 +1296,9 @@ void CloudStorageEngine::_check_tablet_delete_bitmap_score_callback() {
         uint64_t max_base_rowset_delete_bitmap_score = 0;
         tablet_mgr().get_topn_tablet_delete_bitmap_score(&max_delete_bitmap_score,
                                                          &max_base_rowset_delete_bitmap_score);
-        if (max_delete_bitmap_score > 0) {
-            _tablet_max_delete_bitmap_score_metrics->set_value(max_delete_bitmap_score);
-        }
-        if (max_base_rowset_delete_bitmap_score > 0) {
-            _tablet_max_base_rowset_delete_bitmap_score_metrics->set_value(
-                    max_base_rowset_delete_bitmap_score);
-        }
+        _tablet_max_delete_bitmap_score_metrics->set_value(max_delete_bitmap_score);
+        _tablet_max_base_rowset_delete_bitmap_score_metrics->set_value(
+                max_base_rowset_delete_bitmap_score);
     }
 }
 

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -581,7 +581,7 @@ void CloudTabletMgr::get_topn_tablet_delete_bitmap_score(
     buf.reserve(n + 1);
     auto handler = [&](const std::weak_ptr<CloudTablet>& tablet_wk) {
         auto t = tablet_wk.lock();
-        if (!t) return;
+        if (!t || !t->enable_unique_key_merge_on_write()) return;
         uint64_t delete_bitmap_count =
                 t.get()->tablet_meta()->delete_bitmap().get_delete_bitmap_count();
         total_delete_map_count += delete_bitmap_count;


### PR DESCRIPTION
Problem Summary: CloudTabletMgr included non-MOW tablets when calculating the top-N delete bitmap score. Skip non-MOW tablets before reading and aggregating delete bitmap counts so the reported score only represents MOW tables.