### PR TITLE
[feature](topn) Support parallel rowid fetch with configurable task splitting for TopN lazy materialization

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1632,6 +1632,12 @@ DEFINE_mBool(enable_segment_prefetch_verbose_log, "false");
 DEFINE_Int64(segment_prefetch_thread_pool_thread_num_min, "32");
 DEFINE_Int64(segment_prefetch_thread_pool_thread_num_max, "2000");
 
+// The max thread num of the InternalRowIdFetch thread pool, which executes
+// parallel rowid fetch tasks of TopN lazy materialization phase 2 for internal tables.
+DEFINE_mInt32(internal_rowid_fetch_threads, "16");
+// The max number of concurrent rowid fetch tasks of a single request.
+DEFINE_mInt32(internal_rowid_fetch_max_concurrent, "16");
+
 DEFINE_mInt32(segment_file_cache_consume_rowids_batch_size, "8000");
 // Enable segment file cache block prefetch for query
 DEFINE_mBool(enable_query_segment_file_cache_prefetch, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1680,6 +1680,12 @@ DECLARE_mBool(enable_segment_prefetch_verbose_log);
 DECLARE_Int64(segment_prefetch_thread_pool_thread_num_min);
 DECLARE_Int64(segment_prefetch_thread_pool_thread_num_max);
 
+// The max thread num of the InternalRowIdFetch thread pool, which executes
+// parallel rowid fetch tasks of TopN lazy materialization phase 2 for internal tables.
+DECLARE_mInt32(internal_rowid_fetch_threads);
+// The max number of concurrent rowid fetch tasks of a single request.
+DECLARE_mInt32(internal_rowid_fetch_max_concurrent);
+
 DECLARE_mInt32(segment_file_cache_consume_rowids_batch_size);
 // Enable segment file cache block prefetch for query
 DECLARE_mBool(enable_query_segment_file_cache_prefetch);

--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -464,6 +464,10 @@ Status MaterializationSharedState::init_multi_requests(
     multi_get_request.set_file_cache_remote_only_on_miss(
             config::is_cloud_mode() &&
             state->query_options().enable_topn_lazy_mat_phase2_no_write_file_cache);
+    if (state->query_options().__isset.rowid_fetch_parallel_batch_rows) {
+        multi_get_request.set_parallel_batch_rows(
+                state->query_options().rowid_fetch_parallel_batch_rows);
+    }
     auto* query_id = multi_get_request.mutable_query_id();
     query_id->set_hi(state->query_id().hi);
     query_id->set_lo(state->query_id().lo);

--- a/be/src/exec/rowid_fetcher.cpp
+++ b/be/src/exec/rowid_fetcher.cpp
@@ -69,8 +69,10 @@
 #include "storage/tablet_info.h" // DorisNodesInfo
 #include "storage/utils.h"
 #include "util/brpc_client_cache.h" // BrpcClientCache
+#include "util/countdown_latch.h"
 #include "util/defer_op.h"
 #include "util/jsonb/serialize.h"
+#include "util/threadpool.h"
 
 namespace doris {
 
@@ -612,7 +614,9 @@ Status RowIdStorageReader::read_by_rowids(const PMultiGetRequestV2& request,
                         RETURN_IF_ERROR(read_batch_doris_format_row(
                                 request_block_desc, id_file_map, slots, tquery_id, result_blocks[i],
                                 stats, &acquire_tablet_ms, &acquire_rowsets_ms,
-                                &acquire_segments_ms, &lookup_row_data_ms, file_cache_miss_policy));
+                                &acquire_segments_ms, &lookup_row_data_ms, file_cache_miss_policy,
+                                request.has_parallel_batch_rows() ? request.parallel_batch_rows()
+                                                                  : 0));
                     } else {
                         RETURN_IF_ERROR(read_batch_external_row(
                                 request.wg_id(), request_block_desc, id_file_map, slots,
@@ -673,7 +677,15 @@ Status RowIdStorageReader::read_batch_doris_format_row(
         std::vector<SlotDescriptor>& slots, const TUniqueId& query_id, Block& result_block,
         OlapReaderStatistics& stats, int64_t* acquire_tablet_ms, int64_t* acquire_rowsets_ms,
         int64_t* acquire_segments_ms, int64_t* lookup_row_data_ms,
-        io::FileCacheMissPolicy file_cache_miss_policy) {
+        io::FileCacheMissPolicy file_cache_miss_policy, int parallel_batch_rows) {
+    // parallel_batch_rows != 0 enables the parallel read path. Reading from the row store
+    // always goes through the serial path below.
+    if (parallel_batch_rows != 0 && !request_block_desc.fetch_row_store()) {
+        return read_batch_doris_format_row_parallel(
+                request_block_desc, id_file_map, slots, query_id, result_block, stats,
+                acquire_tablet_ms, acquire_rowsets_ms, acquire_segments_ms, lookup_row_data_ms,
+                file_cache_miss_policy, parallel_batch_rows);
+    }
     if (result_block.is_empty_column()) [[likely]] {
         result_block = Block(slots, request_block_desc.row_id_size());
     }
@@ -760,6 +772,236 @@ Status RowIdStorageReader::read_batch_doris_format_row(
 
     scatter_scan_blocks_to_result_block(row_id_block_idx, scan_blocks, result_block);
 
+    return Status::OK();
+}
+
+Status RowIdStorageReader::read_batch_doris_format_row_parallel(
+        const PRequestBlockDesc& request_block_desc, std::shared_ptr<IdFileMap> id_file_map,
+        std::vector<SlotDescriptor>& slots, const TUniqueId& query_id, Block& result_block,
+        OlapReaderStatistics& stats, int64_t* acquire_tablet_ms, int64_t* acquire_rowsets_ms,
+        int64_t* acquire_segments_ms, int64_t* lookup_row_data_ms,
+        io::FileCacheMissPolicy file_cache_miss_policy, int parallel_batch_rows) {
+    DCHECK(parallel_batch_rows != 0);
+    DCHECK(!request_block_desc.fetch_row_store());
+    if (result_block.is_empty_column()) [[likely]] {
+        result_block = Block(slots, request_block_desc.row_id_size());
+    }
+    TabletSchema full_read_schema;
+    for (const ColumnPB& column_pb : request_block_desc.column_descs()) {
+        full_read_schema.append_column(TabletColumn(column_pb));
+    }
+
+    ThreadPool* pool = ExecEnv::GetInstance()->internal_rowid_fetch_pool();
+    if (pool == nullptr) [[unlikely]] {
+        return Status::InternalError("InternalRowIdFetch thread pool is not initialized");
+    }
+
+    const size_t total_rows = request_block_desc.row_id_size();
+
+    // Per-task status, statistics and timers. seg_map/iterator_map/stats cannot be shared
+    // across threads (ColumnIterator is not thread safe), so each task collects its own and
+    // they are merged back after all tasks finish.
+    struct TaskResult {
+        Status status = Status::OK();
+        OlapReaderStatistics stats;
+        int64_t acquire_tablet_ms = 0;
+        int64_t acquire_rowsets_ms = 0;
+        int64_t acquire_segments_ms = 0;
+        int64_t lookup_row_data_ms = 0;
+    };
+
+    // Groups request rows in [begin, end) by their (tablet_id, rowset_id, segment_id) key,
+    // same as Phase 1 of the serial path, with request positions rebased to [0, end - begin).
+    auto build_segment_batches = [&](size_t begin, size_t end,
+                                     std::vector<DorisFormatReadBatch>* scan_batches,
+                                     Status* status) {
+        std::unordered_map<SegKey, size_t, HashOfSegKey> batch_idx_by_seg;
+        for (size_t j = begin; j < end; ++j) {
+            auto file_id = request_block_desc.file_id(cast_set<int>(j));
+            auto file_mapping = id_file_map->get_file_mapping(file_id);
+            if (!file_mapping) {
+                *status = Status::InternalError(
+                        "Backend:{} file_mapping not found, query_id: {}, file_id: {}",
+                        BackendOptions::get_localhost(), print_id(query_id), file_id);
+                return;
+            }
+            auto [tablet_id, rowset_id, segment_id] = file_mapping->get_doris_format_info();
+            SegKey seg_key {
+                    .tablet_id = tablet_id, .rowset_id = rowset_id, .segment_id = segment_id};
+            auto [it, inserted] = batch_idx_by_seg.emplace(seg_key, scan_batches->size());
+            if (inserted) {
+                scan_batches->emplace_back();
+                scan_batches->back().file_mapping = file_mapping;
+            }
+            (*scan_batches)[it->second].row_ids_with_positions.emplace_back(
+                    request_block_desc.row_id(cast_set<int>(j)), j - begin);
+        }
+    };
+
+    // Reads one segment batch, same as one iteration of Phase 2 of the serial path: sorts and
+    // dedups the batch's row_ids, reads them into blocks[batch_idx] with task-local
+    // seg_map/iterator_map/stats, and fills the scatter entries of block_idx for the request
+    // positions recorded in the batch.
+    auto read_one_segment_batch =
+            [&](DorisFormatReadBatch& scan_batch, size_t batch_idx, std::vector<Block>& blocks,
+                std::vector<std::pair<size_t, size_t>>& block_idx, TaskResult& task_result) {
+                auto& row_ids_with_positions = scan_batch.row_ids_with_positions;
+                std::sort(row_ids_with_positions.begin(), row_ids_with_positions.end(),
+                          [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+
+                std::vector<uint32_t> row_ids;
+                row_ids.reserve(row_ids_with_positions.size());
+                for (const auto& [row_id, result_idx] : row_ids_with_positions) {
+                    if (row_ids.empty() || row_ids.back() != row_id) {
+                        row_ids.emplace_back(row_id);
+                    }
+                    block_idx[result_idx] = std::make_pair(batch_idx, row_ids.size() - 1);
+                }
+
+                blocks[batch_idx] = Block(slots, row_ids.size());
+                std::unordered_map<SegKey, SegItem, HashOfSegKey> seg_map;
+                std::unordered_map<IteratorKey, IteratorItem, HashOfIteratorKey> iterator_map;
+                std::string row_store_buffer;
+                RowStoreReadStruct row_store_read_struct(row_store_buffer);
+                task_result.status = read_doris_format_row(
+                        id_file_map, scan_batch.file_mapping, row_ids, slots, full_read_schema,
+                        row_store_read_struct, task_result.stats, &task_result.acquire_tablet_ms,
+                        &task_result.acquire_rowsets_ms, &task_result.acquire_segments_ms,
+                        &task_result.lookup_row_data_ms, seg_map, iterator_map,
+                        file_cache_miss_policy, blocks[batch_idx]);
+            };
+
+    auto merge_task_results = [&](const std::vector<TaskResult>& task_results) -> Status {
+        Status first_error = Status::OK();
+        for (const auto& task_result : task_results) {
+            if (!task_result.status.ok() && first_error.ok()) {
+                first_error = task_result.status;
+            }
+            stats.merge(task_result.stats);
+            *acquire_tablet_ms += task_result.acquire_tablet_ms;
+            *acquire_rowsets_ms += task_result.acquire_rowsets_ms;
+            *acquire_segments_ms += task_result.acquire_segments_ms;
+            *lookup_row_data_ms += task_result.lookup_row_data_ms;
+        }
+        return first_error;
+    };
+
+    if (parallel_batch_rows < 0) {
+        // parallel_batch_rows == -1: one task per segment group, i.e. run Phase 2 of the
+        // serial path concurrently. Every request row belongs to exactly one batch, so the
+        // entries of row_id_block_idx written by different tasks never overlap.
+        std::vector<DorisFormatReadBatch> scan_batches;
+        Status build_status = Status::OK();
+        build_segment_batches(0, total_rows, &scan_batches, &build_status);
+        RETURN_IF_ERROR(build_status);
+
+        const size_t num_tasks = scan_batches.size();
+        std::vector<Block> scan_blocks(num_tasks);
+        std::vector<std::pair<size_t, size_t>> row_id_block_idx(total_rows);
+        std::vector<TaskResult> task_results(num_tasks);
+
+        CountDownLatch latch(cast_set<int>(num_tasks));
+        std::counting_semaphore semaphore {config::internal_rowid_fetch_max_concurrent};
+        for (size_t t = 0; t < num_tasks; ++t) {
+            semaphore.acquire();
+            Status submit_status = pool->submit_func([&, t]() {
+                Defer defer([&] {
+                    semaphore.release();
+                    latch.count_down();
+                });
+                SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->rowid_storage_reader_tracker());
+                signal::set_signal_task_id(query_id);
+                try {
+                    read_one_segment_batch(scan_batches[t], t, scan_blocks, row_id_block_idx,
+                                           task_results[t]);
+                } catch (const doris::Exception& e) {
+                    task_results[t].status = e.to_status();
+                } catch (const std::exception& e) {
+                    task_results[t].status =
+                            Status::InternalError("Row id fetch task failed: {}", e.what());
+                }
+            });
+            if (!submit_status.ok()) [[unlikely]] {
+                semaphore.release();
+                latch.count_down();
+                task_results[t].status = submit_status;
+            }
+        }
+        latch.wait();
+
+        RETURN_IF_ERROR(merge_task_results(task_results));
+        scatter_scan_blocks_to_result_block(row_id_block_idx, scan_blocks, result_block);
+        return Status::OK();
+    }
+
+    // parallel_batch_rows > 0: one task per consecutive range of parallel_batch_rows rows.
+    // Each task groups/sorts/dedups inside its own range and produces a local block keeping
+    // the original relative order of the range. Local blocks are concatenated in task order.
+    const size_t batch_rows = parallel_batch_rows;
+    const size_t num_tasks = (total_rows + batch_rows - 1) / batch_rows;
+    std::vector<TaskResult> task_results(num_tasks);
+    std::vector<Block> task_blocks(num_tasks);
+
+    CountDownLatch latch(cast_set<int>(num_tasks));
+    std::counting_semaphore semaphore {config::internal_rowid_fetch_max_concurrent};
+    for (size_t t = 0; t < num_tasks; ++t) {
+        semaphore.acquire();
+        Status submit_status = pool->submit_func([&, t]() {
+            Defer defer([&] {
+                semaphore.release();
+                latch.count_down();
+            });
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->rowid_storage_reader_tracker());
+            signal::set_signal_task_id(query_id);
+
+            auto& task_result = task_results[t];
+            const size_t begin = t * batch_rows;
+            const size_t end = std::min(begin + batch_rows, total_rows);
+
+            try {
+                std::vector<DorisFormatReadBatch> local_batches;
+                build_segment_batches(begin, end, &local_batches, &task_result.status);
+                if (!task_result.status.ok()) {
+                    return;
+                }
+                std::vector<Block> local_scan_blocks(local_batches.size());
+                std::vector<std::pair<size_t, size_t>> local_block_idx(end - begin);
+                for (size_t b = 0; b < local_batches.size(); ++b) {
+                    read_one_segment_batch(local_batches[b], b, local_scan_blocks, local_block_idx,
+                                           task_result);
+                    if (!task_result.status.ok()) {
+                        return;
+                    }
+                }
+                Block local_block(slots, end - begin);
+                scatter_scan_blocks_to_result_block(local_block_idx, local_scan_blocks,
+                                                    local_block);
+                task_blocks[t] = std::move(local_block);
+            } catch (const doris::Exception& e) {
+                task_result.status = e.to_status();
+            } catch (const std::exception& e) {
+                task_result.status =
+                        Status::InternalError("Row id fetch task failed: {}", e.what());
+            }
+        });
+        if (!submit_status.ok()) [[unlikely]] {
+            semaphore.release();
+            latch.count_down();
+            task_results[t].status = submit_status;
+        }
+    }
+    latch.wait();
+
+    RETURN_IF_ERROR(merge_task_results(task_results));
+
+    for (size_t column_id = 0; column_id < result_block.columns(); ++column_id) {
+        auto dst_col_guard = result_block.mutate_column_scoped(column_id);
+        MutableColumnPtr& dst_col = dst_col_guard.mutable_column();
+        for (const auto& task_block : task_blocks) {
+            dst_col->insert_range_from(*task_block.get_by_position(column_id).column, 0,
+                                       task_block.rows());
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/rowid_fetcher.h
+++ b/be/src/exec/rowid_fetcher.h
@@ -133,7 +133,16 @@ private:
             std::vector<SlotDescriptor>& slots, const TUniqueId& query_id, Block& result_block,
             OlapReaderStatistics& stats, int64_t* acquire_tablet_ms, int64_t* acquire_rowsets_ms,
             int64_t* acquire_segments_ms, int64_t* lookup_row_data_ms,
-            io::FileCacheMissPolicy file_cache_miss_policy);
+            io::FileCacheMissPolicy file_cache_miss_policy, int parallel_batch_rows = 0);
+
+    // Parallel variant of read_batch_doris_format_row, used when parallel_batch_rows != 0
+    // and the request does not fetch from the row store.
+    static Status read_batch_doris_format_row_parallel(
+            const PRequestBlockDesc& request_block_desc, std::shared_ptr<IdFileMap> id_file_map,
+            std::vector<SlotDescriptor>& slots, const TUniqueId& query_id, Block& result_block,
+            OlapReaderStatistics& stats, int64_t* acquire_tablet_ms, int64_t* acquire_rowsets_ms,
+            int64_t* acquire_segments_ms, int64_t* lookup_row_data_ms,
+            io::FileCacheMissPolicy file_cache_miss_policy, int parallel_batch_rows);
 
     static Status read_batch_external_row(
             const uint64_t workload_group_id, const PRequestBlockDesc& request_block_desc,

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -183,6 +183,20 @@ struct FileCacheStatistics {
 
         peer_hosts.insert(other.peer_hosts.begin(), other.peer_hosts.end());
     }
+
+    // Merge only the fields used by the rowid fetch (TopN lazy materialization phase 2) path.
+    // Used to combine statistics collected by parallel rowid fetch tasks.
+    void merge(const FileCacheStatistics& other) {
+        num_local_io_total += other.num_local_io_total;
+        num_remote_io_total += other.num_remote_io_total;
+        local_io_timer += other.local_io_timer;
+        remote_io_timer += other.remote_io_timer;
+        bytes_read_from_local += other.bytes_read_from_local;
+        bytes_read_from_remote += other.bytes_read_from_remote;
+        num_skip_cache_io_total += other.num_skip_cache_io_total;
+        write_cache_io_timer += other.write_cache_io_timer;
+        bytes_write_into_cache += other.bytes_write_into_cache;
+    }
 };
 
 struct IOContext {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -265,6 +265,7 @@ public:
     ThreadPool* s3_file_system_thread_pool() { return _s3_file_system_thread_pool.get(); }
     ThreadPool* udf_close_workers_pool() { return _udf_close_workers_thread_pool.get(); }
     ThreadPool* segment_prefetch_thread_pool() { return _segment_prefetch_thread_pool.get(); }
+    ThreadPool* internal_rowid_fetch_pool() { return _internal_rowid_fetch_pool.get(); }
     ThreadPool* peer_race_s3_thread_pool() { return _peer_race_s3_thread_pool.get(); }
 
     void init_file_cache_factory(std::vector<doris::CachePath>& cache_paths);
@@ -503,6 +504,9 @@ private:
     std::unique_ptr<ThreadPool> _udf_close_workers_thread_pool;
     // Threadpool used to prefetch segment file cache blocks
     std::unique_ptr<ThreadPool> _segment_prefetch_thread_pool;
+    // Threadpool used to execute parallel rowid fetch tasks of TopN lazy materialization
+    // phase 2 for internal tables
+    std::unique_ptr<ThreadPool> _internal_rowid_fetch_pool;
     std::unique_ptr<ThreadPool> _peer_race_s3_thread_pool;
 
     FragmentMgr* _fragment_mgr = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -276,6 +276,11 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                                       config::segment_prefetch_thread_pool_thread_num_max))
                               .build(&_segment_prefetch_thread_pool));
 
+    static_cast<void>(ThreadPoolBuilder("InternalRowIdFetch")
+                              .set_min_threads(4)
+                              .set_max_threads(config::internal_rowid_fetch_threads)
+                              .build(&_internal_rowid_fetch_pool));
+
     static_cast<void>(ThreadPoolBuilder("SendTableStatsThreadPool")
                               .set_min_threads(8)
                               .set_max_threads(32)
@@ -903,6 +908,7 @@ void ExecEnv::destroy() {
     }
     SAFE_SHUTDOWN(_buffered_reader_prefetch_thread_pool);
     SAFE_SHUTDOWN(_segment_prefetch_thread_pool);
+    SAFE_SHUTDOWN(_internal_rowid_fetch_pool);
     SAFE_SHUTDOWN(_s3_file_upload_thread_pool);
     SAFE_SHUTDOWN(_lazy_release_obj_pool);
     SAFE_SHUTDOWN(_non_block_close_thread_pool);
@@ -967,6 +973,7 @@ void ExecEnv::destroy() {
     _send_table_stats_thread_pool.reset(nullptr);
     _buffered_reader_prefetch_thread_pool.reset(nullptr);
     _segment_prefetch_thread_pool.reset(nullptr);
+    _internal_rowid_fetch_pool.reset(nullptr);
     _s3_file_upload_thread_pool.reset(nullptr);
     _send_batch_thread_pool.reset(nullptr);
     _udf_close_workers_thread_pool.reset(nullptr);

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -489,6 +489,20 @@ struct OlapReaderStatistics {
     int64_t variant_subtree_hierarchical_iter_count = 0;
     int64_t variant_subtree_sparse_iter_count = 0;
     int64_t variant_doc_value_column_iter_count = 0;
+
+    // Merge only the fields used by the rowid fetch (TopN lazy materialization phase 2) path.
+    // Used to combine statistics collected by parallel rowid fetch tasks.
+    void merge(const OlapReaderStatistics& other) {
+        io_ns += other.io_ns;
+        compressed_bytes_read += other.compressed_bytes_read;
+        decompress_ns += other.decompress_ns;
+        uncompressed_bytes_read += other.uncompressed_bytes_read;
+        bytes_read += other.bytes_read;
+        raw_rows_read += other.raw_rows_read;
+        total_pages_num += other.total_pages_num;
+        cached_pages_num += other.cached_pages_num;
+        file_cache_stats.merge(other.file_cache_stats);
+    }
 };
 
 using ColumnId = uint32_t;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -458,6 +458,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_PRUNE_NESTED_COLUMN = "enable_prune_nested_column";
 
+    public static final String ROWID_FETCH_PARALLEL_BATCH_ROWS = "rowid_fetch_parallel_batch_rows";
+
     static final String SESSION_CONTEXT = "session_context";
 
     public static final String DEFAULT_ORDER_BY_LIMIT = "default_order_by_limit";
@@ -2194,6 +2196,21 @@ public class SessionVariable implements Serializable, Writable {
 
     @VarAttrDef.VarAttr(name = ENABLE_RUNTIME_FILTER_PARTITION_PRUNE, needForward = true, fuzzy = true)
     public boolean enableRuntimeFilterPartitionPrune = true;
+
+    /**
+     * Controls the parallel execution strategy of TopN lazy materialization phase 2 (rowid fetch)
+     * for internal tables:
+     *   0  : read rowids serially (default, original behavior)
+     *   -1 : read in parallel, one task per segment group
+     *   >0 : read in parallel, split the request into consecutive row ranges of N rows per task
+     */
+    @VarAttrDef.VarAttr(name = ROWID_FETCH_PARALLEL_BATCH_ROWS, needForward = true,
+            description = {
+                    "TopN 延迟物化二期 rowid fetch 内表读取的并发策略：0 串行（默认），-1 按 segment 分组并发，"
+                            + ">0 每 N 行一个并发任务",
+                    "Parallel strategy of TopN lazy materialization phase 2 rowid fetch for internal tables: "
+                            + "0 serial (default), -1 one task per segment group, >0 one task per N rows"})
+    public int rowidFetchParallelBatchRows = 0;
 
     /**
      * The client can pass some special information by setting this session variable in the format: "k1:v1;k2:v2".
@@ -5859,6 +5876,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setIgnoreRuntimeFilterError(ignoreRuntimeFilterError);
         tResult.setProfileLevel(getProfileLevel());
         tResult.setEnableRuntimeFilterPartitionPrune(enableRuntimeFilterPartitionPrune);
+        tResult.setRowidFetchParallelBatchRows(rowidFetchParallelBatchRows);
 
         tResult.setMinimumOperatorMemoryRequiredKb(minimumOperatorMemoryRequiredKB);
         tResult.setExchangeMultiBlocksByteSize(exchangeMultiBlocksByteSize);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -854,6 +854,9 @@ message PMultiGetRequestV2 {
     optional bool gc_id_map = 4;
     optional uint64 wg_id = 5;
     optional bool file_cache_remote_only_on_miss = 6;
+    // Parallel execution strategy of rowid fetch for internal tables.
+    // 0: serial; -1: one task per segment group; >0: one task per N consecutive rows.
+    optional int32 parallel_batch_rows = 7;
 };
 
 message PMultiGetBlockV2 {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -507,6 +507,13 @@ struct TQueryOptions {
   225: optional i64 runtime_filter_tree_publish_max_send_bytes = 268435456
 
   226: optional bool enable_prune_nested_column = false;
+
+  // Controls the parallel execution strategy of TopN lazy materialization phase 2 (rowid fetch)
+  // for internal tables:
+  //   0  : read rowids serially (default, original behavior)
+  //   -1 : read in parallel, one task per segment group
+  //   >0 : read in parallel, split the request into consecutive row ranges of N rows per task
+  228: optional i32 rowid_fetch_parallel_batch_rows = 0;
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In TopN lazy materialization phase 2, the V2 internal rowid fetch path (`RowIdStorageReader::read_batch_doris_format_row`) reads segment batches strictly serially within a `multiget_data_v2` RPC. When the fetched rows span many segments, or one segment dominates the request, phase 2 becomes a latency bottleneck.

This PR adds concurrent execution to this path, controlled by a new session variable `rowid_fetch_parallel_batch_rows`:

- `0` (default): serial execution, existing behavior fully unchanged
- `-1`: parallel execution, tasks are split by segment groups (i.e., the existing Phase-1 grouping result)
- `>0`: parallel execution, tasks are consecutive row ranges of N rows, with rows grouped by segment within each range. This gives better load balance when a single segment dominates the request

Design points:

- The position-indexed scatter map (`row_id_block_idx[original_request_index] -> (batch_idx, position_in_batch)`) already decouples the final result order from how rows are partitioned into tasks, so both splitting strategies reuse the existing scatter logic and produce byte-identical results to the serial path
- Tasks run on a dedicated `InternalRowIdFetch` thread pool (`config::internal_rowid_fetch_threads`, default 16) instead of the remote scan scheduler to avoid pool deadlock; per-request concurrency is capped by `config::internal_rowid_fetch_max_concurrent` (default 16) via `counting_semaphore`
- Each task uses private `seg_map` / `iterator_map` / `OlapReaderStatistics` and timing counters (ColumnIterator is not thread-safe), merged after all tasks finish; new `merge()` methods are added for `OlapReaderStatistics` and `FileCacheStatistics` covering the fields used by this path
- `fetch_row_store` requests always fall back to the serial path
- The old `PMultiGetRequest` (V1) path and the external table path are not touched

### Release note

Support parallel rowid fetch in TopN lazy materialization phase 2, controlled by session variable `rowid_fetch_parallel_batch_rows`.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Deploy a cluster with this PR, run TopN lazy materialization queries with `set rowid_fetch_parallel_batch_rows = 0 / -1 / 100` respectively, verify result correctness (identical to serial) and compare phase-2 latency
- Behavior changed:
    - [x] No. (default value 0 keeps the existing serial path)
- Does this need documentation?
    - [x] Yes. The new session variable `rowid_fetch_parallel_batch_rows` should be documented.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label