### PR TITLE
[fix](filecache) fix inode percentage division by zero on dynamic inode filesystems

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1828,7 +1828,8 @@ int disk_used_percentage(const std::string& path, std::pair<int, int>* percent) 
 
     unsigned long long inode_free = stat.f_ffree;
     unsigned long long inode_total = stat.f_files;
-    int inode_percentage = cast_set<int>(inode_free * 100 / inode_total);
+    // Some filesystems use dynamic inodes(e.g. btrfs) and stat.f_files are reported as zero.
+    int inode_percentage = inode_total > 0 ? cast_set<int>(inode_free * 100 / inode_total) : 100;
     percent->first = capacity_percentage;
     percent->second = 100 - inode_percentage;
 


### PR DESCRIPTION
### What problem does this PR solve?

On some filesystems that use dynamic inodes (e.g. btrfs), statfs reports f_files (total inodes) as 0. The original code will raise a arithmetic exception. 
This PR guard the division, when inode_total is zero, treat the inode usage percentage as 0.

Issue Number: close #65545

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

