### PR TITLE
[fix](cloud) Skip unnecessary update tablet to ms when alter table property

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/alter/CloudSchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/alter/CloudSchemaChangeHandler.java
@@ -169,7 +169,6 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
                             groupCommitMode, olapTable.getGroupCommitMode());
                     return;
                 }
-                partitions.addAll(olapTable.getPartitions());
             } finally {
                 olapTable.readUnlock();
             }
@@ -184,7 +183,6 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
                             groupCommitIntervalMs, olapTable.getGroupCommitIntervalMs());
                     return;
                 }
-                partitions.addAll(olapTable.getPartitions());
             } finally {
                 olapTable.readUnlock();
             }
@@ -199,7 +197,6 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
                             groupCommitDataBytes, olapTable.getGroupCommitDataBytes());
                     return;
                 }
-                partitions.addAll(olapTable.getPartitions());
             } finally {
                 olapTable.readUnlock();
             }
@@ -362,7 +359,6 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
                     throw new UserException("enable_mow_light_delete property is "
                             + "not supported for unique merge-on-read table");
                 }
-                partitions.addAll(olapTable.getPartitions());
             } finally {
                 olapTable.readUnlock();
             }


### PR DESCRIPTION
Problem Summary: Altering group_commit_mode, group_commit_interval_ms, group_commit_data_bytes, or enable_mow_light_delete in cloud mode sent an updateTablet request for every tablet. Meta Service does not consume these properties from tablet metadata. Group commit properties are provided by FE when creating load plans, while MOW light delete is controlled by FE catalog metadata.
