### PR TITLE
[fix](test) Retry internal copy until upload is visible

### DIFF
--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_internal_copy.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_internal_copy.groovy
@@ -59,11 +59,23 @@ suite("test_recycler_with_internal_copy") {
         DISTRIBUTED BY HASH(C_CUSTKEY) BUCKETS 1
     """
 
-    def result = sql " copy into ${tableName} from @~('${fileName}') properties ('file.type' = 'csv', 'file.column_separator' = '|', 'copy.async' = 'false'); "
-    logger.info("copy result: " + result)
-    assertTrue(result.size() == 1)
-    assertTrue(result[0].size() == 8)
-    assertTrue(result[0][1].equals("FINISHED"), "Finish copy into, state=" + result[0][1] + ", expected state=FINISHED")
+    int retry = 15
+    boolean success = false
+    def result
+    do {
+        result = sql " copy into ${tableName} from @~('${fileName}') properties ('file.type' = 'csv', 'file.column_separator' = '|', 'copy.async' = 'false'); "
+        logger.info("copy result: " + result)
+        assertTrue(result.size() == 1)
+        assertTrue(result[0].size() == 8)
+        if (result[0][1].equals("FINISHED")) {
+            success = true
+            break
+        }
+        assertTrue(result[0][1].equals("CANCELLED") && result[0][3].contains("No files can be copied"),
+                "Finish copy into, state=" + result[0][1] + ", expected state=FINISHED")
+        Thread.sleep(20000) // wait uploaded file visible to copy
+    } while (retry--)
+    assertTrue(success)
     qt_sql " SELECT COUNT(*) FROM ${tableName}; "
 
     result = sql " copy into ${tableName} from @~('${fileName}') properties ('file.type' = 'csv', 'file.column_separator' = '|', 'copy.async' = 'false'); "
@@ -74,8 +86,8 @@ suite("test_recycler_with_internal_copy") {
     qt_sql " SELECT COUNT(*) FROM ${tableName}; "
 
 
-    int retry = 15
-    boolean success = false
+    retry = 15
+    success = false
     // recycle data
     do {
         triggerRecycle(token, instanceId)


### PR DESCRIPTION
### What changed

- Retry the initial internal-stage `COPY INTO` while the uploaded file is not yet visible.
- Keep the retry limited to the known transient `CANCELLED` result containing `No files can be copied`.
- Preserve immediate failure for every other unexpected state.

### Why

The Recycler Check pipeline uploads the file successfully and immediately starts `COPY INTO`. Internal-stage metadata can become visible shortly after the upload response, so the first copy may transiently return `CANCELLED` with no matched files. The same test already uses this bounded retry after recycling and re-uploading; the initial copy now follows the same rule.

### Validation

- `git diff --check`
- Groovy 4.0.19 syntax parse of the changed suite
- Java 17 regression-framework dependency resolution succeeded
- Full local framework packaging was attempted but is blocked on this macOS checkout because `thirdparty/installed/bin/thrift` is unavailable

### Pipeline evidence

- Recycler Check build #280 passed framework compilation and entered Recycler tests with Java 17.
- The affected test failed because the first copy returned `CANCELLED` with `No files can be copied`.
- The same failure was observed previously in build #271.
