### PR TITLE
[fix](cloud) Prevent replayed prepare from recycling committed metadata

### DIFF
--- a/cloud/src/meta-service/meta_service_partition.cpp
+++ b/cloud/src/meta-service/meta_service_partition.cpp
@@ -78,6 +78,24 @@ static TxnErrorCode index_exists(Transaction* txn, const std::string& instance_i
     return it->has_next() ? TxnErrorCode::TXN_OK : TxnErrorCode::TXN_KEY_NOT_FOUND;
 }
 
+static TxnErrorCode index_exists_with_versioned_fallback(
+        Transaction* txn, const std::string& instance_id, const IndexRequest* req, int64_t index_id,
+        CloneChainReader* reader, bool is_versioned_read, bool is_versioned_write) {
+    if (is_versioned_read) {
+        return reader->is_index_exists(txn, index_id);
+    }
+
+    TxnErrorCode err = index_exists(txn, instance_id, req);
+    if (err != TxnErrorCode::TXN_KEY_NOT_FOUND || !is_versioned_write) {
+        return err;
+    }
+
+    // In MULTI_VERSION_WRITE_ONLY, newly committed indexes only have versioned index keys
+    // before their tablets are created. A delayed prepare_index replay must still recognize
+    // the committed index, otherwise it recreates a PREPARED recycle marker.
+    return reader->is_index_exists(txn, index_id);
+}
+
 static TxnErrorCode check_recycle_key_exist(Transaction* txn, const std::string& key) {
     std::string val;
     return txn->get(key, &val);
@@ -110,12 +128,11 @@ void MetaServiceImpl::prepare_index(::google::protobuf::RpcController* controlle
         return;
     }
     bool is_versioned_read = is_version_read_enabled(instance_id);
+    bool is_versioned_write = is_version_write_enabled(instance_id);
     CloneChainReader reader(instance_id, resource_mgr_.get());
-    if (!is_versioned_read) {
-        err = index_exists(txn.get(), instance_id, request);
-    } else {
-        err = reader.is_index_exists(txn.get(), request->index_ids(0));
-    }
+    err = index_exists_with_versioned_fallback(txn.get(), instance_id, request,
+                                               request->index_ids(0), &reader, is_versioned_read,
+                                               is_versioned_write);
     // If index has existed, this might be a stale request
     if (err == TxnErrorCode::TXN_OK) {
         code = MetaServiceCode::ALREADY_EXISTED;
@@ -221,11 +238,9 @@ void MetaServiceImpl::commit_index(::google::protobuf::RpcController* controller
         std::string val;
         err = txn->get(key, &val);
         if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) { // UNKNOWN
-            if (!is_versioned_read) {
-                err = index_exists(txn.get(), instance_id, request);
-            } else {
-                err = reader.is_index_exists(txn.get(), index_id);
-            }
+            err = index_exists_with_versioned_fallback(txn.get(), instance_id, request, index_id,
+                                                       &reader, is_versioned_read,
+                                                       is_versioned_write);
             // If index has existed, this might be a duplicate request
             if (err == TxnErrorCode::TXN_OK) {
                 return; // Index committed, OK
@@ -552,6 +567,23 @@ static TxnErrorCode partition_exists(Transaction* txn, const std::string& instan
     return it->has_next() ? TxnErrorCode::TXN_OK : TxnErrorCode::TXN_KEY_NOT_FOUND;
 }
 
+static TxnErrorCode partition_exists_with_versioned_fallback(
+        Transaction* txn, const std::string& instance_id, const PartitionRequest* req,
+        int64_t partition_id, CloneChainReader* reader, bool is_versioned_read,
+        bool is_versioned_write) {
+    if (is_versioned_read) {
+        return reader->is_partition_exists(txn, partition_id);
+    }
+
+    TxnErrorCode err = partition_exists(txn, instance_id, req);
+    if (err != TxnErrorCode::TXN_KEY_NOT_FOUND || !is_versioned_write) {
+        return err;
+    }
+
+    // Keep delayed prepare/commit replays idempotent during the write-only migration phase.
+    return reader->is_partition_exists(txn, partition_id);
+}
+
 void MetaServiceImpl::prepare_partition(::google::protobuf::RpcController* controller,
                                         const PartitionRequest* request,
                                         PartitionResponse* response,
@@ -590,12 +622,11 @@ void MetaServiceImpl::prepare_partition(::google::protobuf::RpcController* contr
         return;
     }
     bool is_versioned_read = is_version_read_enabled(instance_id);
-    if (!is_versioned_read) {
-        err = partition_exists(txn.get(), instance_id, request);
-    } else {
-        CloneChainReader reader(instance_id, resource_mgr_.get());
-        err = reader.is_partition_exists(txn.get(), request->partition_ids(0));
-    }
+    bool is_versioned_write = is_version_write_enabled(instance_id);
+    CloneChainReader reader(instance_id, resource_mgr_.get());
+    err = partition_exists_with_versioned_fallback(txn.get(), instance_id, request,
+                                                   request->partition_ids(0), &reader,
+                                                   is_versioned_read, is_versioned_write);
     // If index has existed, this might be a stale request
     if (err == TxnErrorCode::TXN_OK) {
         code = MetaServiceCode::ALREADY_EXISTED;
@@ -765,11 +796,9 @@ void MetaServiceImpl::commit_partition_internal(const PartitionRequest* request,
         if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) { // UNKNOWN
             // Compatible with requests without `index_ids`
             if (!request->index_ids().empty()) {
-                if (!is_versioned_read) {
-                    err = partition_exists(txn.get(), instance_id, request);
-                } else {
-                    err = reader.is_partition_exists(txn.get(), part_id);
-                }
+                err = partition_exists_with_versioned_fallback(txn.get(), instance_id, request,
+                                                               part_id, &reader, is_versioned_read,
+                                                               is_versioned_write);
                 // If partition has existed, this might be a duplicate request
                 if (err == TxnErrorCode::TXN_OK) {
                     // Partition committed, OK

--- a/cloud/test/meta_service_operation_log_test.cpp
+++ b/cloud/test/meta_service_operation_log_test.cpp
@@ -163,6 +163,7 @@ TEST(MetaServiceOperationLogTest, CommitPartitionLog) {
 
         meta_service->resource_mgr()->refresh_instance(instance_id);
         ASSERT_TRUE(meta_service->resource_mgr()->is_version_write_enabled(instance_id));
+        ASSERT_FALSE(meta_service->resource_mgr()->is_version_read_enabled(instance_id));
     }
 
     {
@@ -192,6 +193,32 @@ TEST(MetaServiceOperationLogTest, CommitPartitionLog) {
     }
 
     auto txn_kv = meta_service->txn_kv();
+
+    {
+        // Replayed commit and a later prepare must not recreate a recycle marker while the
+        // instance is in MULTI_VERSION_WRITE_ONLY.
+        brpc::Controller ctrl;
+        PartitionRequest req;
+        PartitionResponse res;
+        req.set_db_id(db_id);
+        req.set_table_id(table_id);
+        req.add_index_ids(index_id);
+        req.add_partition_ids(partition_id);
+        meta_service->commit_partition(&ctrl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().DebugString();
+
+        res.Clear();
+        meta_service->prepare_partition(&ctrl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::ALREADY_EXISTED)
+                << res.status().DebugString();
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string value;
+        ASSERT_EQ(txn->get(recycle_partition_key({instance_id, partition_id}), &value),
+                  TxnErrorCode::TXN_KEY_NOT_FOUND);
+    }
+
     Versionstamp version1;
     {
         // Verify partition meta/index/inverted indexes are exists
@@ -441,6 +468,7 @@ TEST(MetaServiceOperationLogTest, CommitIndexLog) {
 
         meta_service->resource_mgr()->refresh_instance(instance_id);
         ASSERT_TRUE(meta_service->resource_mgr()->is_version_write_enabled(instance_id));
+        ASSERT_FALSE(meta_service->resource_mgr()->is_version_read_enabled(instance_id));
     }
 
     {
@@ -472,6 +500,32 @@ TEST(MetaServiceOperationLogTest, CommitIndexLog) {
     }
 
     auto txn_kv = meta_service->txn_kv();
+
+    {
+        // Replayed commit and a later prepare must not recreate a recycle marker while the
+        // instance is in MULTI_VERSION_WRITE_ONLY.
+        brpc::Controller ctrl;
+        IndexRequest req;
+        IndexResponse res;
+        req.set_db_id(db_id);
+        req.set_table_id(table_id);
+        req.add_index_ids(index_id);
+        req.set_is_new_table(true);
+        meta_service->commit_index(&ctrl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().DebugString();
+
+        res.Clear();
+        meta_service->prepare_index(&ctrl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::ALREADY_EXISTED)
+                << res.status().DebugString();
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string value;
+        ASSERT_EQ(txn->get(recycle_index_key({instance_id, index_id}), &value),
+                  TxnErrorCode::TXN_KEY_NOT_FOUND);
+    }
+
     Versionstamp version1;
     Versionstamp version2;
 


### PR DESCRIPTION
### What problem does this PR solve?

During `MULTI_VERSION_WRITE_ONLY`, `commit_index` and `commit_partition` write versioned
existence keys while reads still prefer legacy tablet metadata. If an idempotency retry replays
`prepare_index` or `prepare_partition` after the corresponding commit but before tablets are
created, the legacy existence check misses the committed object and recreates a `PREPARED`
recycle marker. Recycler can later consume that stale marker and delete active metadata.

### What is changed?

- Fall back to versioned index/partition existence keys when the legacy check misses during
  `MULTI_VERSION_WRITE_ONLY`.
- Apply the same existence check to duplicate commit handling.
- Add write-only tests covering `prepare -> commit -> replayed commit -> replayed prepare` and
  verify that no recycle marker is recreated.

### Check List

- [x] Code has been formatted with clang-format 16.
- [x] `git diff --check` passes.
- [ ] Cloud unit tests were not run locally because the full Cloud UT third-party toolchain is
  not installed in this workspace; the added tests are included for CI execution.
