### PR TITLE
[fix](cloud) fix cloud ut failed to compile when BUILD_AZURE set as OFF

### DIFF
--- a/cloud/test/CMakeLists.txt
+++ b/cloud/test/CMakeLists.txt
@@ -83,9 +83,12 @@ add_executable(http_encode_key_test http_encode_key_test.cpp)
 
 add_executable(fdb_injection_test fdb_injection_test.cpp)
 
-add_executable(s3_accessor_test s3_accessor_test.cpp)
+option(BUILD_AZURE "Enable build azure" ON)
+if (BUILD_AZURE)
+    add_executable(s3_accessor_test s3_accessor_test.cpp)
 
-add_executable(s3_accessor_client_test s3_accessor_client_test.cpp)
+    add_executable(s3_accessor_client_test s3_accessor_client_test.cpp)
+endif()
 
 add_executable(s3_accessor_mock_test s3_accessor_mock_test.cpp)
 
@@ -164,9 +167,12 @@ target_link_libraries(rpc_kv_bvar_test ${TEST_LINK_LIBS})
 
 target_link_libraries(http_encode_key_test ${TEST_LINK_LIBS})
 
-target_link_libraries(s3_accessor_test ${TEST_LINK_LIBS})
+option(BUILD_AZURE "Enable build azure" ON)
+if (BUILD_AZURE)
+    target_link_libraries(s3_accessor_test ${TEST_LINK_LIBS})
 
-target_link_libraries(s3_accessor_client_test ${TEST_LINK_LIBS})
+    target_link_libraries(s3_accessor_client_test ${TEST_LINK_LIBS})
+endif()
 
 target_link_libraries(s3_accessor_mock_test ${TEST_LINK_LIBS})
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

docker run 
--network host 
--ulimit nofile=1048576:1048576 
-e CUSTOM_NPM_REGISTRY=https://registry.npmmirror.com 
-e TZ=Asia/Shanghai 
-e USE_UNWIND=OFF 
-e USE_AVX2=OFF 
-e ENABLE_PCH=OFF 
-e DISABLE_BUILD_AZURE=ON 
-v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime 
-v /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris:/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris 
-v /data01/maven/repo:/root/.m2/repository 
xxx 
/bin/bash -c "cd /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris && bash run-cloud-ut.sh --clean --run --fdb doris_cloud_cluster:UseWVxYQuWo7yrSczko35bhQt1aw0cOc@172.16.0.10:4500,172.16.0.11:4500,172.16.0.12:4500 -j 16"

When I use this command to run cloud ut by docker container，I set env DISABLE_BUILD_AZURE=ON，compile error occurred as below:
[113/158] Building CXX object test/CMakeFiles/s3_accessor_test.dir/s3_accessor_test.cpp.o
FAILED: [code=1] test/CMakeFiles/s3_accessor_test.dir/s3_accessor_test.cpp.o
ccache /var/local/ldb-toolchain/bin/clang++ -DBE_TEST -DENABLE_HDFS_STORAGE_VAULT -DFDB_API_VERSION=710 -DGLOG_CUSTOM_PREFIX_SUPPORT -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -DUSE_HADOOP_HDFS -I/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/src -I/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/test -I/usr/local/jdk/include -I/usr/local/jdk/include/linux -isystem /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/../gensrc/build -isystem /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/../common -isystem /var/local/thirdparty/installed/include -isystem /var/local/thirdparty/installed/gperftools/include -Wall -Wno-sign-compare -pthread -Werror -fstrict-aliasing -fno-omit-frame-pointer -std=gnu++20 -D__STDC_FORMAT_MACROS -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_SYSTEM_NO_DEPRECATED -DBRPC_ENABLE_CPU_PROFILER -faligned-new  -ggdb -Wno-unused-local-typedefs -gdwarf-5 -O0 -fsanitize=address -DADDRESS_SANITIZER  -DUNIT_TEST -fprofile-arcs -ftest-coverage -fno-access-control -DGTEST_USE_OWN_TR1_TUPLE=0   -D OS_LINUX -fcolor-diagnostics -MD -MT test/CMakeFiles/s3_accessor_test.dir/s3_accessor_test.cpp.o -MF test/CMakeFiles/s3_accessor_test.dir/s3_accessor_test.cpp.o.d -o test/CMakeFiles/s3_accessor_test.dir/s3_accessor_test.cpp.o -c /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/test/s3_accessor_test.cpp
/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/test/s3_accessor_test.cpp:26:10: fatal error: 'azure/storage/blobs/blob_options.hpp' file not found
26 | #include <azure/storage/blobs/blob_options.hpp>
|          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[118/158] Building CXX object test/CMakeFiles/s3_accessor_client_test.dir/s3_accessor_client_test.cpp.o
FAILED: [code=1] test/CMakeFiles/s3_accessor_client_test.dir/s3_accessor_client_test.cpp.o
ccache /var/local/ldb-toolchain/bin/clang++ -DBE_TEST -DENABLE_HDFS_STORAGE_VAULT -DFDB_API_VERSION=710 -DGLOG_CUSTOM_PREFIX_SUPPORT -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -DUSE_HADOOP_HDFS -I/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/src -I/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/test -I/usr/local/jdk/include -I/usr/local/jdk/include/linux -isystem /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/../gensrc/build -isystem /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/../common -isystem /var/local/thirdparty/installed/include -isystem /var/local/thirdparty/installed/gperftools/include -Wall -Wno-sign-compare -pthread -Werror -fstrict-aliasing -fno-omit-frame-pointer -std=gnu++20 -D__STDC_FORMAT_MACROS -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_SYSTEM_NO_DEPRECATED -DBRPC_ENABLE_CPU_PROFILER -faligned-new  -ggdb -Wno-unused-local-typedefs -gdwarf-5 -O0 -fsanitize=address -DADDRESS_SANITIZER  -DUNIT_TEST -fprofile-arcs -ftest-coverage -fno-access-control -DGTEST_USE_OWN_TR1_TUPLE=0   -D OS_LINUX -fcolor-diagnostics -MD -MT test/CMakeFiles/s3_accessor_client_test.dir/s3_accessor_client_test.cpp.o -MF test/CMakeFiles/s3_accessor_client_test.dir/s3_accessor_client_test.cpp.o.d -o test/CMakeFiles/s3_accessor_client_test.dir/s3_accessor_client_test.cpp.o -c /data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/test/s3_accessor_client_test.cpp
/data01/srdcloud/sourcecode/4.1-fix-cloud-compile-unwind-issue/doris/cloud/test/s3_accessor_client_test.cpp:25:10: fatal error: 'azure/storage/blobs/blob_options.hpp' file not found
25 | #include <azure/storage/blobs/blob_options.hpp>
|          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    cloud ut successful result when BUILD_AZURE set as OFF : 
[87c34b7cc7c4.log](https://github.com/user-attachments/files/30342124/87c34b7cc7c4.log)

    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

