### PR TITLE
branch-4.1: [fix](multi-catalog) Preserve external partition metadata

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache;
@@ -69,6 +68,7 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 public class BrokerUtil {
     private static final Logger LOG = LogManager.getLogger(BrokerUtil.class);
@@ -155,7 +155,7 @@ public class BrokerUtil {
 
     public static List<String> parseColumnsFromPath(String filePath, List<String> columnsFromPath)
             throws UserException {
-        return parseColumnsFromPath(filePath, columnsFromPath, true, false);
+        return parseColumnsFromPathWithNullInfo(filePath, columnsFromPath, true, false).getValues();
     }
 
     public static List<String> parseColumnsFromPath(
@@ -164,23 +164,35 @@ public class BrokerUtil {
             boolean caseSensitive,
             boolean isACID)
             throws UserException {
+        return parseColumnsFromPathWithNullInfo(filePath, columnsFromPath, caseSensitive, isACID)
+                .getValues();
+    }
+
+    public static ParsedColumnsFromPath parseColumnsFromPathWithNullInfo(
+            String filePath,
+            List<String> columnsFromPath,
+            boolean caseSensitive,
+            boolean isACID)
+            throws UserException {
         if (columnsFromPath == null || columnsFromPath.isEmpty()) {
-            return Collections.emptyList();
+            return new ParsedColumnsFromPath(Collections.emptyList(), Collections.emptyList());
         }
         // if it is ACID, the path count is 3. The hdfs path is hdfs://xxx/table_name/par=xxx/delta(or base)_xxx/.
         int pathCount = isACID ? 3 : 2;
+        List<String> expectedColumns = columnsFromPath;
         if (!caseSensitive) {
-            for (int i = 0; i < columnsFromPath.size(); i++) {
-                String path = columnsFromPath.remove(i);
-                columnsFromPath.add(i, path.toLowerCase());
+            expectedColumns = new ArrayList<>(columnsFromPath.size());
+            for (String path : columnsFromPath) {
+                expectedColumns.add(path.toLowerCase(Locale.ROOT));
             }
         }
         String[] strings = filePath.split("/");
         if (strings.length < 2) {
             throw new UserException("Fail to parse columnsFromPath, expected: "
-                    + columnsFromPath + ", filePath: " + filePath);
+                    + expectedColumns + ", filePath: " + filePath);
         }
-        String[] columns = new String[columnsFromPath.size()];
+        String[] columns = new String[expectedColumns.size()];
+        Boolean[] columnsFromPathIsNull = new Boolean[expectedColumns.size()];
         int size = 0;
         boolean skipOnce = true;
         for (int i = strings.length - pathCount; i >= 0; i--) {
@@ -194,31 +206,33 @@ public class BrokerUtil {
                     continue;
                 }
                 throw new UserException("Fail to parse columnsFromPath, expected: "
-                        + columnsFromPath + ", filePath: " + filePath);
+                        + expectedColumns + ", filePath: " + filePath);
             }
             skipOnce = false;
             String[] pair = str.split("=", 2);
             if (pair.length != 2) {
                 throw new UserException("Fail to parse columnsFromPath, expected: "
-                        + columnsFromPath + ", filePath: " + filePath);
+                        + expectedColumns + ", filePath: " + filePath);
             }
-            String parsedColumnName = caseSensitive ? pair[0] : pair[0].toLowerCase();
-            int index = columnsFromPath.indexOf(parsedColumnName);
+            String parsedColumnName = caseSensitive ? pair[0] : pair[0].toLowerCase(Locale.ROOT);
+            int index = expectedColumns.indexOf(parsedColumnName);
             if (index == -1) {
                 continue;
             }
-            columns[index] = HiveExternalMetaCache.HIVE_DEFAULT_PARTITION.equals(pair[1])
-                ? FeConstants.null_string : pair[1];
+            boolean isNull = HiveExternalMetaCache.HIVE_DEFAULT_PARTITION.equals(pair[1]);
+            columns[index] = isNull ? "" : pair[1];
+            columnsFromPathIsNull[index] = isNull;
             size++;
-            if (size >= columnsFromPath.size()) {
+            if (size >= expectedColumns.size()) {
                 break;
             }
         }
-        if (size != columnsFromPath.size()) {
+        if (size != expectedColumns.size()) {
             throw new UserException("Fail to parse columnsFromPath, expected: "
-                    + columnsFromPath + ", filePath: " + filePath);
+                    + expectedColumns + ", filePath: " + filePath);
         }
-        return Lists.newArrayList(columns);
+        return new ParsedColumnsFromPath(
+                Lists.newArrayList(columns), Lists.newArrayList(columnsFromPathIsNull));
     }
 
     public static ParsedColumnsFromPath normalizeColumnsFromPath(List<String> columnsFromPath) {
@@ -228,8 +242,7 @@ public class BrokerUtil {
         List<String> values = new ArrayList<>(columnsFromPath.size());
         List<Boolean> isNull = new ArrayList<>(columnsFromPath.size());
         for (String value : columnsFromPath) {
-            boolean nullValue = value == null || FeConstants.null_string.equals(value)
-                    || HiveExternalMetaCache.HIVE_DEFAULT_PARTITION.equals(value);
+            boolean nullValue = value == null || HiveExternalMetaCache.HIVE_DEFAULT_PARTITION.equals(value);
             values.add(nullValue ? "" : value);
             isNull.add(nullValue);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache;
@@ -233,6 +234,25 @@ public class BrokerUtil {
         }
         return new ParsedColumnsFromPath(
                 Lists.newArrayList(columns), Lists.newArrayList(columnsFromPathIsNull));
+    }
+
+    public static ParsedColumnsFromPath parseColumnsFromPathWithNullInfoForLoad(
+            String filePath,
+            List<String> columnsFromPath,
+            boolean caseSensitive,
+            boolean isACID)
+            throws UserException {
+        ParsedColumnsFromPath parsed = parseColumnsFromPathWithNullInfo(
+                filePath, columnsFromPath, caseSensitive, isACID);
+        List<String> values = new ArrayList<>(parsed.getValues());
+        List<Boolean> isNull = new ArrayList<>(parsed.getIsNull());
+        for (int i = 0; i < values.size(); i++) {
+            if (FeConstants.null_string.equals(values.get(i))) {
+                values.set(i, "");
+                isNull.set(i, true);
+            }
+        }
+        return new ParsedColumnsFromPath(values, isNull);
     }
 
     public static ParsedColumnsFromPath normalizeColumnsFromPath(List<String> columnsFromPath) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileGroupInfo.java
@@ -266,11 +266,12 @@ public class FileGroupInfo {
                         Util.getOrInferCompressType(context.fileGroup.getFileFormatProperties().getCompressionType(),
                                 fileStatus.path);
                 context.params.setCompressType(compressType);
-                List<String> columnsFromPath = BrokerUtil.parseColumnsFromPath(fileStatus.path,
-                        context.fileGroup.getColumnNamesFromPath());
+                BrokerUtil.ParsedColumnsFromPath columnsFromPath =
+                        BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                                context.fileGroup.getColumnNamesFromPath(), true, false);
                 List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
-                TFileRangeDesc rangeDesc = createFileRangeDesc(0, fileStatus, fileStatus.size, columnsFromPath,
-                        columnsFromPathKeys);
+                TFileRangeDesc rangeDesc = createFileRangeDesc(0, fileStatus, fileStatus.size,
+                        columnsFromPath.getValues(), columnsFromPathKeys, columnsFromPath.getIsNull());
                 locations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
             }
             scanRangeLocations.add(locations);
@@ -312,15 +313,16 @@ public class FileGroupInfo {
                     Util.getOrInferCompressType(context.fileGroup.getFileFormatProperties().getCompressionType(),
                             fileStatus.path);
             context.params.setCompressType(compressType);
-            List<String> columnsFromPath = BrokerUtil.parseColumnsFromPath(fileStatus.path,
-                    context.fileGroup.getColumnNamesFromPath());
+            BrokerUtil.ParsedColumnsFromPath columnsFromPath =
+                    BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                            context.fileGroup.getColumnNamesFromPath(), true, false);
             List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
             // Assign scan range locations only for broker load.
             // stream load has only one file, and no need to set multi scan ranges.
             if (tmpBytes > bytesPerInstance && jobType != JobType.STREAM_LOAD) {
                 long rangeBytes = bytesPerInstance - curInstanceBytes;
                 TFileRangeDesc rangeDesc = createFileRangeDesc(curFileOffset, fileStatus, rangeBytes,
-                        columnsFromPath, columnsFromPathKeys);
+                        columnsFromPath.getValues(), columnsFromPathKeys, columnsFromPath.getIsNull());
                 curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
                 curFileOffset += rangeBytes;
 
@@ -329,8 +331,8 @@ public class FileGroupInfo {
                 curLocations = newLocations(context.params, brokerDesc, backendPolicy);
                 curInstanceBytes = 0;
             } else {
-                TFileRangeDesc rangeDesc = createFileRangeDesc(curFileOffset, fileStatus, leftBytes, columnsFromPath,
-                        columnsFromPathKeys);
+                TFileRangeDesc rangeDesc = createFileRangeDesc(curFileOffset, fileStatus, leftBytes,
+                        columnsFromPath.getValues(), columnsFromPathKeys, columnsFromPath.getIsNull());
                 curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
                 curFileOffset = 0;
                 curInstanceBytes += leftBytes;
@@ -401,7 +403,8 @@ public class FileGroupInfo {
     }
 
     private TFileRangeDesc createFileRangeDesc(long curFileOffset, TBrokerFileStatus fileStatus, long rangeBytes,
-            List<String> columnsFromPath, List<String> columnsFromPathKeys) {
+            List<String> columnsFromPath, List<String> columnsFromPathKeys,
+            List<Boolean> columnsFromPathIsNull) {
         TFileRangeDesc rangeDesc = new TFileRangeDesc();
         if (jobType == JobType.BULK_LOAD) {
             rangeDesc.setPath(fileStatus.path);
@@ -410,6 +413,7 @@ public class FileGroupInfo {
             rangeDesc.setFileSize(fileStatus.size);
             rangeDesc.setColumnsFromPath(columnsFromPath);
             rangeDesc.setColumnsFromPathKeys(columnsFromPathKeys);
+            rangeDesc.setColumnsFromPathIsNull(columnsFromPathIsNull);
             if (getFileType() == TFileType.FILE_HDFS) {
                 URI fileUri = new Path(fileStatus.path).toUri();
                 rangeDesc.setFsName(fileUri.getScheme() + "://" + fileUri.getAuthority());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileGroupInfo.java
@@ -267,7 +267,7 @@ public class FileGroupInfo {
                                 fileStatus.path);
                 context.params.setCompressType(compressType);
                 BrokerUtil.ParsedColumnsFromPath columnsFromPath =
-                        BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                        BrokerUtil.parseColumnsFromPathWithNullInfoForLoad(fileStatus.path,
                                 context.fileGroup.getColumnNamesFromPath(), true, false);
                 List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
                 TFileRangeDesc rangeDesc = createFileRangeDesc(0, fileStatus, fileStatus.size,
@@ -314,7 +314,7 @@ public class FileGroupInfo {
                             fileStatus.path);
             context.params.setCompressType(compressType);
             BrokerUtil.ParsedColumnsFromPath columnsFromPath =
-                    BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                    BrokerUtil.parseColumnsFromPathWithNullInfoForLoad(fileStatus.path,
                             context.fileGroup.getColumnNamesFromPath(), true, false);
             List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
             // Assign scan range locations only for broker load.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -501,11 +501,11 @@ public abstract class FileQueryScanNode extends FileScanNode {
             HiveSplit hiveSplit = (HiveSplit) fileSplit;
             isACID = hiveSplit.isACID();
         }
-        List<String> rawPartitionValues = fileSplit.getPartitionValues() == null
-                ? BrokerUtil.parseColumnsFromPath(fileSplit.getPathString(), pathPartitionKeys,
-                false, isACID) : fileSplit.getPartitionValues();
         BrokerUtil.ParsedColumnsFromPath partitionValues =
-                BrokerUtil.normalizeColumnsFromPath(rawPartitionValues);
+                fileSplit.getPartitionValues() == null
+                        ? BrokerUtil.parseColumnsFromPathWithNullInfo(
+                                fileSplit.getPathString(), pathPartitionKeys, false, isACID)
+                        : BrokerUtil.normalizeColumnsFromPath(fileSplit.getPartitionValues());
 
         TFileRangeDesc rangeDesc = createFileRangeDesc(fileSplit, partitionValues.getValues(),
                 pathPartitionKeys, partitionValues.getIsNull());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalMetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalMetaCache.java
@@ -28,7 +28,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.security.authentication.AuthenticationConfig;
 import org.apache.doris.common.security.authentication.HadoopAuthenticator;
@@ -436,9 +435,10 @@ public class HiveExternalMetaCache extends AbstractExternalMetaCache {
             try {
                 FileCacheValue result = getFileCache(catalog, finalLocation, key.inputFormat,
                         key.getPartitionValues(), directoryLister, table);
+                // Replace default hive partition with null to distinguish it from a literal "\N".
                 for (int i = 0; i < result.getValuesSize(); i++) {
                     if (HIVE_DEFAULT_PARTITION.equals(result.getPartitionValues().get(i))) {
-                        result.getPartitionValues().set(i, FeConstants.null_string);
+                        result.getPartitionValues().set(i, null);
                     }
                 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -27,6 +27,7 @@ import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.common.util.FileFormatUtils;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.ExternalTable;
@@ -330,8 +331,11 @@ public class HudiScanNode extends HiveScanNode {
                 formPathKeys.add(entry.getKey());
                 formPathValues.add(entry.getValue());
             }
+            BrokerUtil.ParsedColumnsFromPath parsedColumnsFromPath =
+                    BrokerUtil.normalizeColumnsFromPath(formPathValues);
             rangeDesc.setColumnsFromPathKeys(formPathKeys);
-            rangeDesc.setColumnsFromPath(formPathValues);
+            rangeDesc.setColumnsFromPath(parsedColumnsFromPath.getValues());
+            rangeDesc.setColumnsFromPathIsNull(parsedColumnsFromPath.getIsNull());
         }
         rangeDesc.setTableFormatParams(tableFormatFileDesc);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -815,6 +815,33 @@ public class IcebergUtils {
         return new ArrayList<>(partitionColumns);
     }
 
+    /**
+     * Get identity partition columns that exist in all partition specs.
+     * The legacy file scanner uses partition columns in the first scan range for all ranges,
+     * so only common identity partition columns can be used for partition pruning.
+     */
+    public static List<String> getCommonIdentityPartitionColumns(Table table) {
+        LinkedHashSet<Integer> commonSourceIds = new LinkedHashSet<>();
+        for (PartitionField field : table.spec().fields()) {
+            NestedField sourceField = table.schema().findField(field.sourceId());
+            if (field.transform().isIdentity() && sourceField != null
+                    && isSupportedPartitionValueType(sourceField.type().typeId())) {
+                commonSourceIds.add(field.sourceId());
+            }
+        }
+        for (PartitionSpec spec : table.specs().values()) {
+            Set<Integer> specIdentitySourceIds = spec.fields().stream()
+                    .filter(field -> field.transform().isIdentity())
+                    .map(PartitionField::sourceId)
+                    .collect(Collectors.toSet());
+            commonSourceIds.retainAll(specIdentitySourceIds);
+        }
+        return commonSourceIds.stream()
+                .map(table.schema()::findColumnName)
+                .filter(columnName -> columnName != null)
+                .collect(Collectors.toList());
+    }
+
     public static Map<String, String> getIdentityPartitionInfoMap(PartitionData partitionData,
             PartitionSpec partitionSpec, Table table, String timeZone) {
         Map<String, String> partitionInfoMap = Maps.newLinkedHashMap();
@@ -829,8 +856,7 @@ public class IcebergUtils {
             if (!partitionField.transform().isIdentity()) {
                 continue;
             }
-            TypeID partitionTypeId = field.type().typeId();
-            if (partitionTypeId == TypeID.BINARY || partitionTypeId == TypeID.FIXED) {
+            if (!isSupportedPartitionValueType(field.type().typeId())) {
                 continue;
             }
 
@@ -847,6 +873,10 @@ public class IcebergUtils {
             }
         }
         return partitionInfoMap;
+    }
+
+    private static boolean isSupportedPartitionValueType(TypeID typeId) {
+        return typeId != TypeID.BINARY && typeId != TypeID.FIXED;
     }
 
     public static List<String> getPartitionValues(PartitionData partitionData, PartitionSpec partitionSpec,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -800,10 +800,20 @@ public class IcebergUtils {
     }
 
     public static List<String> getIdentityPartitionColumns(Table table) {
+        return getIdentityPartitionColumns(table, false, false);
+    }
+
+    public static List<String> getIdentityPartitionColumns(Table table,
+            boolean enableMappingVarbinary, boolean enableMappingTimestampTz) {
         LinkedHashSet<String> partitionColumns = new LinkedHashSet<>();
         for (PartitionSpec spec : table.specs().values()) {
             for (PartitionField partitionField : spec.fields()) {
                 if (!partitionField.transform().isIdentity()) {
+                    continue;
+                }
+                NestedField sourceField = table.schema().findField(partitionField.sourceId());
+                if (sourceField == null || !isSupportedPartitionValueType(
+                        sourceField.type(), enableMappingVarbinary, enableMappingTimestampTz)) {
                     continue;
                 }
                 String columnName = table.schema().findColumnName(partitionField.sourceId());
@@ -821,11 +831,17 @@ public class IcebergUtils {
      * so only common identity partition columns can be used for partition pruning.
      */
     public static List<String> getCommonIdentityPartitionColumns(Table table) {
+        return getCommonIdentityPartitionColumns(table, false, false);
+    }
+
+    public static List<String> getCommonIdentityPartitionColumns(Table table,
+            boolean enableMappingVarbinary, boolean enableMappingTimestampTz) {
         LinkedHashSet<Integer> commonSourceIds = new LinkedHashSet<>();
         for (PartitionField field : table.spec().fields()) {
             NestedField sourceField = table.schema().findField(field.sourceId());
             if (field.transform().isIdentity() && sourceField != null
-                    && isSupportedPartitionValueType(sourceField.type().typeId())) {
+                    && isSupportedPartitionValueType(
+                            sourceField.type(), enableMappingVarbinary, enableMappingTimestampTz)) {
                 commonSourceIds.add(field.sourceId());
             }
         }
@@ -844,6 +860,12 @@ public class IcebergUtils {
 
     public static Map<String, String> getIdentityPartitionInfoMap(PartitionData partitionData,
             PartitionSpec partitionSpec, Table table, String timeZone) {
+        return getIdentityPartitionInfoMap(partitionData, partitionSpec, table, timeZone, false, false);
+    }
+
+    public static Map<String, String> getIdentityPartitionInfoMap(PartitionData partitionData,
+            PartitionSpec partitionSpec, Table table, String timeZone,
+            boolean enableMappingVarbinary, boolean enableMappingTimestampTz) {
         Map<String, String> partitionInfoMap = Maps.newLinkedHashMap();
         List<NestedField> fields = partitionData.getPartitionType().asNestedType().fields();
         List<PartitionField> partitionFields = partitionSpec.fields();
@@ -856,7 +878,8 @@ public class IcebergUtils {
             if (!partitionField.transform().isIdentity()) {
                 continue;
             }
-            if (!isSupportedPartitionValueType(field.type().typeId())) {
+            if (!isSupportedPartitionValueType(
+                    field.type(), enableMappingVarbinary, enableMappingTimestampTz)) {
                 continue;
             }
 
@@ -875,8 +898,17 @@ public class IcebergUtils {
         return partitionInfoMap;
     }
 
-    private static boolean isSupportedPartitionValueType(TypeID typeId) {
-        return typeId != TypeID.BINARY && typeId != TypeID.FIXED;
+    private static boolean isSupportedPartitionValueType(org.apache.iceberg.types.Type type,
+            boolean enableMappingVarbinary, boolean enableMappingTimestampTz) {
+        TypeID typeId = type.typeId();
+        if (typeId == TypeID.BINARY || typeId == TypeID.FIXED) {
+            return false;
+        }
+        if (enableMappingVarbinary && typeId == TypeID.UUID) {
+            return false;
+        }
+        return !enableMappingTimestampTz || typeId != TypeID.TIMESTAMP
+                || !((TimestampType) type).shouldAdjustToUTC();
     }
 
     public static List<String> getPartitionValues(PartitionData partitionData, PartitionSpec partitionSpec,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -157,6 +157,10 @@ public class IcebergScanNode extends FileQueryScanNode {
     // Used to avoid repeatedly calculating partition info map for the same
     // partition data and spec.
     private Map<Pair<Integer, PartitionData>, Map<String, String>> partitionMapInfos;
+    private List<String> orderedPathPartitionKeys;
+    private List<String> orderedPartitionMetadataKeys;
+    private boolean enableMappingVarbinaryForPartitionMetadata;
+    private boolean enableMappingTimestampTzForPartitionMetadata;
     private boolean isPartitionedTable;
     private int formatVersion;
     private ExecutionAuthenticator preExecutionAuthenticator;
@@ -253,6 +257,7 @@ public class IcebergScanNode extends FileQueryScanNode {
             icebergTable = source.getIcebergTable();
             icebergTable = useFrozenTableGeneration(icebergTable);
             partitionMapInfos = new HashMap<>();
+            initializePartitionMetadata();
             isPartitionedTable = icebergTable.spec().isPartitioned();
             // Metadata tables (system tables) are not BaseTable instances, so we need to handle this case
             if (icebergTable instanceof BaseTable) {
@@ -416,20 +421,39 @@ public class IcebergScanNode extends FileQueryScanNode {
     }
 
     private List<String> getOrderedPathPartitionKeys() {
-        if (isSystemTable || icebergTable == null) {
-            return Collections.emptyList();
+        if (orderedPathPartitionKeys == null) {
+            initializePartitionMetadata();
         }
-        return IcebergUtils.getCommonIdentityPartitionColumns(icebergTable);
+        return orderedPathPartitionKeys;
     }
 
     private List<String> getOrderedPartitionMetadataKeys() {
+        if (orderedPartitionMetadataKeys == null) {
+            initializePartitionMetadata();
+        }
+        return orderedPartitionMetadataKeys;
+    }
+
+    private void initializePartitionMetadata() {
         if (isSystemTable || icebergTable == null) {
-            return Collections.emptyList();
+            orderedPathPartitionKeys = Collections.emptyList();
+            orderedPartitionMetadataKeys = Collections.emptyList();
+            return;
         }
+        enableMappingVarbinaryForPartitionMetadata = getEnableMappingVarbinary();
+        enableMappingTimestampTzForPartitionMetadata = getEnableMappingTimestampTz();
+        orderedPathPartitionKeys = Collections.unmodifiableList(
+                IcebergUtils.getCommonIdentityPartitionColumns(icebergTable,
+                        enableMappingVarbinaryForPartitionMetadata,
+                        enableMappingTimestampTzForPartitionMetadata));
         if (sessionVariable.enableFileScannerV2) {
-            return IcebergUtils.getIdentityPartitionColumns(icebergTable);
+            orderedPartitionMetadataKeys = Collections.unmodifiableList(
+                    IcebergUtils.getIdentityPartitionColumns(icebergTable,
+                            enableMappingVarbinaryForPartitionMetadata,
+                            enableMappingTimestampTzForPartitionMetadata));
+        } else {
+            orderedPartitionMetadataKeys = orderedPathPartitionKeys;
         }
-        return getOrderedPathPartitionKeys();
     }
 
     @VisibleForTesting
@@ -1121,7 +1145,9 @@ public class IcebergScanNode extends FileQueryScanNode {
                         partitionData, partitionSpec, sessionVariable.getTimeZone()));
                 Map<String, String> partitionInfoMap = partitionMapInfos.computeIfAbsent(
                         Pair.of(specId, partitionData), k -> IcebergUtils.getIdentityPartitionInfoMap(
-                                partitionData, partitionSpec, icebergTable, sessionVariable.getTimeZone()));
+                                partitionData, partitionSpec, icebergTable, sessionVariable.getTimeZone(),
+                                enableMappingVarbinaryForPartitionMetadata,
+                                enableMappingTimestampTzForPartitionMetadata));
                 // A spec may mix identity and transformed fields. Keep its identity values so a
                 // runtime filter can prune that split without treating source columns as constants
                 // for files written under another evolved spec.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -422,29 +422,43 @@ public class IcebergScanNode extends FileQueryScanNode {
         return IcebergUtils.getCommonIdentityPartitionColumns(icebergTable);
     }
 
+    private List<String> getOrderedPartitionMetadataKeys() {
+        if (isSystemTable || icebergTable == null) {
+            return Collections.emptyList();
+        }
+        if (sessionVariable.enableFileScannerV2) {
+            return IcebergUtils.getIdentityPartitionColumns(icebergTable);
+        }
+        return getOrderedPathPartitionKeys();
+    }
+
     @VisibleForTesting
     void setPartitionValues(TFileRangeDesc rangeDesc, Map<String, String> partitionValues) {
         rangeDesc.unsetColumnsFromPathKeys();
         rangeDesc.unsetColumnsFromPath();
         rangeDesc.unsetColumnsFromPathIsNull();
 
-        List<String> orderedPartitionKeys = getOrderedPathPartitionKeys();
-        if (orderedPartitionKeys.isEmpty()) {
+        List<String> orderedPartitionKeys = getOrderedPartitionMetadataKeys();
+        if (orderedPartitionKeys.isEmpty() || partitionValues == null || partitionValues.isEmpty()) {
             return;
         }
-        Preconditions.checkState(partitionValues != null,
-                "Missing partition values for Iceberg identity-partitioned table");
 
+        List<String> fromPathKeys = new ArrayList<>(orderedPartitionKeys.size());
         List<String> fromPathValues = new ArrayList<>(orderedPartitionKeys.size());
         List<Boolean> fromPathIsNull = new ArrayList<>(orderedPartitionKeys.size());
         for (String partitionKey : orderedPartitionKeys) {
-            Preconditions.checkState(partitionValues.containsKey(partitionKey),
-                    "Missing partition value for Iceberg partition key: %s", partitionKey);
+            if (!partitionValues.containsKey(partitionKey)) {
+                continue;
+            }
             String partitionValue = partitionValues.get(partitionKey);
+            fromPathKeys.add(partitionKey);
             fromPathValues.add(partitionValue == null ? "" : partitionValue);
             fromPathIsNull.add(partitionValue == null);
         }
-        rangeDesc.setColumnsFromPathKeys(orderedPartitionKeys);
+        if (fromPathKeys.isEmpty()) {
+            return;
+        }
+        rangeDesc.setColumnsFromPathKeys(fromPathKeys);
         rangeDesc.setColumnsFromPath(fromPathValues);
         rangeDesc.setColumnsFromPathIsNull(fromPathIsNull);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
@@ -153,8 +154,9 @@ public class IcebergScanNode extends FileQueryScanNode {
     private long countFromSnapshot;
     private static final long COUNT_WITH_PARALLEL_SPLITS = 10000;
     private long targetSplitSize = 0;
-    // This is used to avoid repeatedly calculating partition info map for the same partition data.
-    private Map<PartitionData, Map<String, String>> partitionMapInfos;
+    // Used to avoid repeatedly calculating partition info map for the same
+    // partition data and spec.
+    private Map<Pair<Integer, PartitionData>, Map<String, String>> partitionMapInfos;
     private boolean isPartitionedTable;
     private int formatVersion;
     private ExecutionAuthenticator preExecutionAuthenticator;
@@ -409,21 +411,42 @@ public class IcebergScanNode extends FileQueryScanNode {
             deleteFilesDescByReferencedDataFile.put(icebergSplit.getOriginalPath(), nonEqualityDeleteFileDesc);
         }
         tableFormatFileDesc.setIcebergParams(fileDesc);
-        Map<String, String> partitionValues = icebergSplit.getIcebergPartitionValues();
-        if (partitionValues != null) {
-            List<String> fromPathKeys = new ArrayList<>();
-            List<String> fromPathValues = new ArrayList<>();
-            List<Boolean> fromPathIsNull = new ArrayList<>();
-            for (Map.Entry<String, String> entry : partitionValues.entrySet()) {
-                fromPathKeys.add(entry.getKey());
-                fromPathValues.add(entry.getValue() != null ? entry.getValue() : "");
-                fromPathIsNull.add(entry.getValue() == null);
-            }
-            rangeDesc.setColumnsFromPathKeys(fromPathKeys);
-            rangeDesc.setColumnsFromPath(fromPathValues);
-            rangeDesc.setColumnsFromPathIsNull(fromPathIsNull);
-        }
+        setPartitionValues(rangeDesc, icebergSplit.getIcebergPartitionValues());
         rangeDesc.setTableFormatParams(tableFormatFileDesc);
+    }
+
+    private List<String> getOrderedPathPartitionKeys() {
+        if (isSystemTable || icebergTable == null) {
+            return Collections.emptyList();
+        }
+        return IcebergUtils.getCommonIdentityPartitionColumns(icebergTable);
+    }
+
+    @VisibleForTesting
+    void setPartitionValues(TFileRangeDesc rangeDesc, Map<String, String> partitionValues) {
+        rangeDesc.unsetColumnsFromPathKeys();
+        rangeDesc.unsetColumnsFromPath();
+        rangeDesc.unsetColumnsFromPathIsNull();
+
+        List<String> orderedPartitionKeys = getOrderedPathPartitionKeys();
+        if (orderedPartitionKeys.isEmpty()) {
+            return;
+        }
+        Preconditions.checkState(partitionValues != null,
+                "Missing partition values for Iceberg identity-partitioned table");
+
+        List<String> fromPathValues = new ArrayList<>(orderedPartitionKeys.size());
+        List<Boolean> fromPathIsNull = new ArrayList<>(orderedPartitionKeys.size());
+        for (String partitionKey : orderedPartitionKeys) {
+            Preconditions.checkState(partitionValues.containsKey(partitionKey),
+                    "Missing partition value for Iceberg partition key: %s", partitionKey);
+            String partitionValue = partitionValues.get(partitionKey);
+            fromPathValues.add(partitionValue == null ? "" : partitionValue);
+            fromPathIsNull.add(partitionValue == null);
+        }
+        rangeDesc.setColumnsFromPathKeys(orderedPartitionKeys);
+        rangeDesc.setColumnsFromPath(fromPathValues);
+        rangeDesc.setColumnsFromPathIsNull(fromPathIsNull);
     }
 
     private void setIcebergPositionDeleteSysTableParams(TFileRangeDesc rangeDesc, IcebergSplit icebergSplit,
@@ -1082,10 +1105,8 @@ public class IcebergScanNode extends FileQueryScanNode {
                 split.setPartitionSpecId(specId);
                 split.setPartitionDataJson(IcebergUtils.getPartitionDataJson(
                         partitionData, partitionSpec, sessionVariable.getTimeZone()));
-            }
-            if (sessionVariable.isEnableRuntimeFilterPartitionPrune()) {
                 Map<String, String> partitionInfoMap = partitionMapInfos.computeIfAbsent(
-                        partitionData, k -> IcebergUtils.getIdentityPartitionInfoMap(
+                        Pair.of(specId, partitionData), k -> IcebergUtils.getIdentityPartitionInfoMap(
                                 partitionData, partitionSpec, icebergTable, sessionVariable.getTimeZone()));
                 // A spec may mix identity and transformed fields. Keep its identity values so a
                 // runtime filter can prune that split without treating source columns as constants
@@ -1094,7 +1115,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                     split.setIcebergPartitionValues(partitionInfoMap);
                 }
             } else {
-                partitionMapInfos.put(partitionData, null);
+                partitionMapInfos.put(Pair.of(specId, null), Collections.emptyMap());
             }
         }
         return split;
@@ -1538,20 +1559,7 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public List<String> getPathPartitionKeys() throws UserException {
-        // return icebergTable.spec().fields().stream().map(PartitionField::name).map(String::toLowerCase)
-        //         .collect(Collectors.toList());
-        /**First, iceberg partition columns are based on existing fields, which will be stored in the actual data file.
-         * Second, iceberg partition columns support Partition transforms. In this case, the path partition key is not
-         * equal to the column name of the partition column, so remove this code and get all the columns you want to
-         * read from the file.
-         * Related code:
-         *  be/src/vec/exec/scan/vfile_scanner.cpp:
-         *      VFileScanner::_init_expr_ctxes()
-         *          if (slot_info.is_file_slot) {
-         *              xxxx
-         *          }
-         */
-        return new ArrayList<>();
+        return getOrderedPathPartitionKeys();
     }
 
     private void recordManifestCacheAccess(boolean cacheHit) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsFileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsFileGroupInfo.java
@@ -279,11 +279,12 @@ public class NereidsFileGroupInfo {
                         context.fileGroup.getFileFormatProperties().getCompressionType(),
                         fileStatus.path);
                 context.params.setCompressType(compressType);
-                List<String> columnsFromPath = BrokerUtil.parseColumnsFromPath(fileStatus.path,
-                        context.fileGroup.getColumnNamesFromPath());
+                BrokerUtil.ParsedColumnsFromPath columnsFromPath =
+                        BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                                context.fileGroup.getColumnNamesFromPath(), true, false);
                 List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
-                TFileRangeDesc rangeDesc = createFileRangeDesc(0, fileStatus, fileStatus.size, columnsFromPath,
-                        columnsFromPathKeys);
+                TFileRangeDesc rangeDesc = createFileRangeDesc(0, fileStatus, fileStatus.size,
+                        columnsFromPath.getValues(), columnsFromPathKeys, columnsFromPath.getIsNull());
                 locations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
             }
             scanRangeLocations.add(locations);
@@ -331,15 +332,16 @@ public class NereidsFileGroupInfo {
                     context.fileGroup.getFileFormatProperties().getCompressionType(),
                     fileStatus.path);
             context.params.setCompressType(compressType);
-            List<String> columnsFromPath = BrokerUtil.parseColumnsFromPath(fileStatus.path,
-                    context.fileGroup.getColumnNamesFromPath());
+            BrokerUtil.ParsedColumnsFromPath columnsFromPath =
+                    BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                            context.fileGroup.getColumnNamesFromPath(), true, false);
             List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
             // Assign scan range locations only for broker load.
             // stream load has only one file, and no need to set multi scan ranges.
             if (tmpBytes > bytesPerInstance && jobType != FileGroupInfo.JobType.STREAM_LOAD) {
                 long rangeBytes = bytesPerInstance - curInstanceBytes;
                 TFileRangeDesc rangeDesc = createFileRangeDesc(curFileOffset, fileStatus, rangeBytes,
-                        columnsFromPath, columnsFromPathKeys);
+                        columnsFromPath.getValues(), columnsFromPathKeys, columnsFromPath.getIsNull());
                 curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
                 curFileOffset += rangeBytes;
 
@@ -348,8 +350,8 @@ public class NereidsFileGroupInfo {
                 curLocations = newLocations(context.params, brokerDesc, backendPolicy);
                 curInstanceBytes = 0;
             } else {
-                TFileRangeDesc rangeDesc = createFileRangeDesc(curFileOffset, fileStatus, leftBytes, columnsFromPath,
-                        columnsFromPathKeys);
+                TFileRangeDesc rangeDesc = createFileRangeDesc(curFileOffset, fileStatus, leftBytes,
+                        columnsFromPath.getValues(), columnsFromPathKeys, columnsFromPath.getIsNull());
                 curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
                 curFileOffset = 0;
                 curInstanceBytes += leftBytes;
@@ -420,7 +422,8 @@ public class NereidsFileGroupInfo {
     }
 
     private TFileRangeDesc createFileRangeDesc(long curFileOffset, TBrokerFileStatus fileStatus, long rangeBytes,
-            List<String> columnsFromPath, List<String> columnsFromPathKeys) {
+            List<String> columnsFromPath, List<String> columnsFromPathKeys,
+            List<Boolean> columnsFromPathIsNull) {
         TFileRangeDesc rangeDesc = new TFileRangeDesc();
         if (jobType == FileGroupInfo.JobType.BULK_LOAD) {
             rangeDesc.setPath(fileStatus.path);
@@ -429,6 +432,7 @@ public class NereidsFileGroupInfo {
             rangeDesc.setFileSize(fileStatus.size);
             rangeDesc.setColumnsFromPath(columnsFromPath);
             rangeDesc.setColumnsFromPathKeys(columnsFromPathKeys);
+            rangeDesc.setColumnsFromPathIsNull(columnsFromPathIsNull);
             if (getFileType() == TFileType.FILE_HDFS) {
                 URI fileUri = new Path(fileStatus.path).toUri();
                 rangeDesc.setFsName(fileUri.getScheme() + "://" + fileUri.getAuthority());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsFileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsFileGroupInfo.java
@@ -280,7 +280,7 @@ public class NereidsFileGroupInfo {
                         fileStatus.path);
                 context.params.setCompressType(compressType);
                 BrokerUtil.ParsedColumnsFromPath columnsFromPath =
-                        BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                        BrokerUtil.parseColumnsFromPathWithNullInfoForLoad(fileStatus.path,
                                 context.fileGroup.getColumnNamesFromPath(), true, false);
                 List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
                 TFileRangeDesc rangeDesc = createFileRangeDesc(0, fileStatus, fileStatus.size,
@@ -333,7 +333,7 @@ public class NereidsFileGroupInfo {
                     fileStatus.path);
             context.params.setCompressType(compressType);
             BrokerUtil.ParsedColumnsFromPath columnsFromPath =
-                    BrokerUtil.parseColumnsFromPathWithNullInfo(fileStatus.path,
+                    BrokerUtil.parseColumnsFromPathWithNullInfoForLoad(fileStatus.path,
                             context.fileGroup.getColumnNamesFromPath(), true, false);
             List<String> columnsFromPathKeys = context.fileGroup.getColumnNamesFromPath();
             // Assign scan range locations only for broker load.

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/BrokerUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/BrokerUtilTest.java
@@ -159,13 +159,37 @@ public class BrokerUtilTest {
     }
 
     @Test
+    public void parseColumnsFromPathPreservesNullMetadataAndInputKeys() throws Exception {
+        List<String> partitionKeys = Lists.newArrayList("region", "dt");
+        BrokerUtil.ParsedColumnsFromPath parsed = BrokerUtil.parseColumnsFromPathWithNullInfo(
+                "hdfs://host/table/Region=cn/Dt=" + HiveExternalMetaCache.HIVE_DEFAULT_PARTITION
+                        + "/data.parquet",
+                partitionKeys, false, false);
+
+        Assert.assertEquals(Lists.newArrayList("cn", ""), parsed.getValues());
+        Assert.assertEquals(Lists.newArrayList(false, true), parsed.getIsNull());
+        Assert.assertEquals(Lists.newArrayList("region", "dt"), partitionKeys);
+
+        parsed = BrokerUtil.parseColumnsFromPathWithNullInfo(
+                "hdfs://host/table/p=\\N/data.orc", Collections.singletonList("p"), true, false);
+        Assert.assertEquals(Collections.singletonList("\\N"), parsed.getValues());
+        Assert.assertEquals(Collections.singletonList(false), parsed.getIsNull());
+
+        parsed = BrokerUtil.parseColumnsFromPathWithNullInfo(
+                "hdfs://host/table/p=value/delta_1_1/bucket_00000",
+                Collections.singletonList("p"), true, true);
+        Assert.assertEquals(Collections.singletonList("value"), parsed.getValues());
+        Assert.assertEquals(Collections.singletonList(false), parsed.getIsNull());
+    }
+
+    @Test
     public void normalizeColumnsFromPathPreservesNullInfo() {
         BrokerUtil.ParsedColumnsFromPath parsed = BrokerUtil.normalizeColumnsFromPath(
                 Lists.newArrayList("p1", FeConstants.null_string,
                         HiveExternalMetaCache.HIVE_DEFAULT_PARTITION, null));
 
-        Assert.assertEquals(Lists.newArrayList("p1", "", "", ""), parsed.getValues());
-        Assert.assertEquals(Lists.newArrayList(false, true, true, true), parsed.getIsNull());
+        Assert.assertEquals(Lists.newArrayList("p1", "\\N", "", ""), parsed.getValues());
+        Assert.assertEquals(Lists.newArrayList(false, false, true, true), parsed.getIsNull());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/BrokerUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/BrokerUtilTest.java
@@ -193,6 +193,15 @@ public class BrokerUtilTest {
     }
 
     @Test
+    public void parseColumnsFromPathForLoadKeepsLegacyNullSemantics() throws Exception {
+        BrokerUtil.ParsedColumnsFromPath parsed = BrokerUtil.parseColumnsFromPathWithNullInfoForLoad(
+                "hdfs://host/table/p=\\N/data.orc", Collections.singletonList("p"), true, false);
+
+        Assert.assertEquals(Collections.singletonList(""), parsed.getValues());
+        Assert.assertEquals(Collections.singletonList(true), parsed.getIsNull());
+    }
+
+    @Test
     public void testReadFile(@Mocked TPaloBrokerService.Client client, @Mocked Env env,
                              @Injectable BrokerMgr brokerMgr)
             throws TException, UserException, UnsupportedEncodingException {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
@@ -522,6 +522,36 @@ public class IcebergUtilsTest {
     }
 
     @Test
+    public void testMappedTypesAreExcludedFromPartitionMetadata() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "Dt", Types.StringType.get()),
+                Types.NestedField.required(2, "uuid_col", Types.UUIDType.get()),
+                Types.NestedField.required(3, "ts_tz", Types.TimestampType.withZone()));
+        PartitionSpec partitionSpec = PartitionSpec.builderFor(schema)
+                .identity("Dt")
+                .identity("uuid_col")
+                .identity("ts_tz")
+                .build();
+        PartitionData partitionData = new PartitionData(partitionSpec.partitionType());
+        partitionData.set(0, "2026-08-03");
+        partitionData.set(1, UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+        partitionData.set(2, 0L);
+
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.schema()).thenReturn(schema);
+        Mockito.when(table.spec()).thenReturn(partitionSpec);
+        Mockito.when(table.specs()).thenReturn(Collections.singletonMap(partitionSpec.specId(), partitionSpec));
+
+        Assert.assertEquals(Collections.singletonList("Dt"),
+                IcebergUtils.getIdentityPartitionColumns(table, true, true));
+        Assert.assertEquals(Collections.singletonList("Dt"),
+                IcebergUtils.getCommonIdentityPartitionColumns(table, true, true));
+        Assert.assertEquals(Collections.singletonMap("Dt", "2026-08-03"),
+                IcebergUtils.getIdentityPartitionInfoMap(
+                        partitionData, partitionSpec, table, "Asia/Shanghai", true, true));
+    }
+
+    @Test
     public void testGetIdentityPartitionInfoMapSupportsFloatingPointPartitions() {
         Schema schema = new Schema(
                 Types.NestedField.required(1, "float_partition", Types.FloatType.get()),

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
@@ -472,6 +472,35 @@ public class IcebergUtilsTest {
     }
 
     @Test
+    public void testGetCommonIdentityPartitionColumnsUsesSafeIntersection() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "Dt", Types.StringType.get()),
+                Types.NestedField.required(3, "ts", Types.TimestampType.withoutZone()));
+        PartitionSpec oldSpec = PartitionSpec.builderFor(schema)
+                .withSpecId(1)
+                .identity("id")
+                .identity("Dt")
+                .build();
+        PartitionSpec currentSpec = PartitionSpec.builderFor(schema)
+                .withSpecId(2)
+                .identity("Dt")
+                .day("ts")
+                .build();
+        Map<Integer, PartitionSpec> specs = new LinkedHashMap<>();
+        specs.put(oldSpec.specId(), oldSpec);
+        specs.put(currentSpec.specId(), currentSpec);
+
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.schema()).thenReturn(schema);
+        Mockito.when(table.spec()).thenReturn(currentSpec);
+        Mockito.when(table.specs()).thenReturn(specs);
+
+        Assert.assertEquals(Collections.singletonList("Dt"),
+                IcebergUtils.getCommonIdentityPartitionColumns(table));
+    }
+
+    @Test
     public void testGetIdentityPartitionInfoMapReturnsIdentityColumnsOnly() {
         Schema schema = new Schema(
                 Types.NestedField.required(1, "Dt", Types.StringType.get()),

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -119,19 +119,26 @@ public class IcebergScanNodeTest {
     private static class TestIcebergScanNode extends IcebergScanNode {
         private final boolean enableMappingVarbinary;
         private final boolean batchMode;
+        private final boolean enableMappingTimestampTz;
         private TableScan tableScan;
 
         TestIcebergScanNode(SessionVariable sv) {
-            this(sv, false, false);
+            this(sv, false, false, false);
         }
 
         TestIcebergScanNode(SessionVariable sv, boolean enableMappingVarbinary) {
-            this(sv, enableMappingVarbinary, false);
+            this(sv, enableMappingVarbinary, false, false);
         }
 
         TestIcebergScanNode(SessionVariable sv, boolean enableMappingVarbinary, boolean batchMode) {
+            this(sv, enableMappingVarbinary, false, batchMode);
+        }
+
+        TestIcebergScanNode(SessionVariable sv, boolean enableMappingVarbinary,
+                boolean enableMappingTimestampTz, boolean batchMode) {
             super(new PlanNodeId(0), new TupleDescriptor(new TupleId(0)), sv, ScanContext.EMPTY);
             this.enableMappingVarbinary = enableMappingVarbinary;
+            this.enableMappingTimestampTz = enableMappingTimestampTz;
             this.batchMode = batchMode;
         }
 
@@ -156,6 +163,11 @@ public class IcebergScanNodeTest {
         @Override
         protected boolean getEnableMappingVarbinary() {
             return enableMappingVarbinary;
+        }
+
+        @Override
+        protected boolean getEnableMappingTimestampTz() {
+            return enableMappingTimestampTz;
         }
 
         @Override
@@ -338,6 +350,46 @@ public class IcebergScanNodeTest {
         Assert.assertEquals(Collections.singletonList("Dt"), rangeDesc.getColumnsFromPathKeys());
         Assert.assertEquals(Collections.singletonList("2026-07-31"), rangeDesc.getColumnsFromPath());
         Assert.assertEquals(Collections.singletonList(false), rangeDesc.getColumnsFromPathIsNull());
+    }
+
+    @Test
+    public void testSetPartitionValuesSkipsValuesUnsupportedByMappedTypes() throws Exception {
+        for (boolean enableFileScannerV2 : Arrays.asList(false, true)) {
+            SessionVariable sessionVariable = new SessionVariable();
+            sessionVariable.enableFileScannerV2 = enableFileScannerV2;
+            sessionVariable.setTimeZone("Asia/Shanghai");
+            TestIcebergScanNode node = new TestIcebergScanNode(sessionVariable, true, true, false);
+            Schema schema = new Schema(
+                    Types.NestedField.required(1, "Dt", Types.StringType.get()),
+                    Types.NestedField.required(2, "uuid_col", Types.UUIDType.get()),
+                    Types.NestedField.required(3, "ts_tz", Types.TimestampType.withZone()));
+            PartitionSpec spec = PartitionSpec.builderFor(schema)
+                    .identity("Dt")
+                    .identity("uuid_col")
+                    .identity("ts_tz")
+                    .build();
+            Table table = Mockito.mock(Table.class);
+            Mockito.when(table.schema()).thenReturn(schema);
+            Mockito.when(table.spec()).thenReturn(spec);
+            Mockito.when(table.specs()).thenReturn(Collections.singletonMap(spec.specId(), spec));
+            setIcebergTable(node, table);
+
+            Map<String, String> partitionValues = new LinkedHashMap<>();
+            partitionValues.put("Dt", "2026-08-03");
+            partitionValues.put("uuid_col", "123e4567-e89b-12d3-a456-426614174000");
+            partitionValues.put("ts_tz", "2026-08-03T16:00:00");
+            TFileRangeDesc rangeDesc = new TFileRangeDesc();
+            node.setPartitionValues(rangeDesc, partitionValues);
+
+            Assert.assertEquals(Collections.singletonList("Dt"), rangeDesc.getColumnsFromPathKeys());
+            Assert.assertEquals(Collections.singletonList("2026-08-03"), rangeDesc.getColumnsFromPath());
+            Assert.assertEquals(Collections.singletonList(false), rangeDesc.getColumnsFromPathIsNull());
+
+            Mockito.clearInvocations(table);
+            node.setPartitionValues(new TFileRangeDesc(), partitionValues);
+            Mockito.verify(table, Mockito.never()).specs();
+            Mockito.verify(table, Mockito.never()).schema();
+        }
     }
 
     @Test
@@ -989,6 +1041,11 @@ public class IcebergScanNodeTest {
         Field icebergTableField = IcebergScanNode.class.getDeclaredField("icebergTable");
         icebergTableField.setAccessible(true);
         icebergTableField.set(node, table);
+        for (String fieldName : Arrays.asList("orderedPathPartitionKeys", "orderedPartitionMetadataKeys")) {
+            Field field = IcebergScanNode.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(node, null);
+        }
     }
 
     private static void setIcebergSource(IcebergScanNode node, IcebergSource source) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -90,7 +90,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -228,6 +231,35 @@ public class IcebergScanNodeTest {
                 .getFields().get(0).getFieldPtr().getName());
         Assert.assertEquals("payload", scanParams.getHistorySchemaInfo().get(0).getRootField()
                 .getFields().get(1).getFieldPtr().getName());
+    }
+
+    @Test
+    public void testSetPartitionValuesBuildsStableAlignedMetadata() throws Exception {
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable());
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "Region", Types.StringType.get()),
+                Types.NestedField.required(2, "Dt", Types.StringType.get()));
+        PartitionSpec spec = PartitionSpec.builderFor(schema)
+                .identity("Region")
+                .identity("Dt")
+                .build();
+        Map<Integer, PartitionSpec> specs = new LinkedHashMap<>();
+        specs.put(spec.specId(), spec);
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.schema()).thenReturn(schema);
+        Mockito.when(table.spec()).thenReturn(spec);
+        Mockito.when(table.specs()).thenReturn(specs);
+        setIcebergTable(node, table);
+
+        Map<String, String> partitionValues = new HashMap<>();
+        partitionValues.put("Dt", null);
+        partitionValues.put("Region", "cn");
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        node.setPartitionValues(rangeDesc, partitionValues);
+
+        Assert.assertEquals(Arrays.asList("Region", "Dt"), rangeDesc.getColumnsFromPathKeys());
+        Assert.assertEquals(Arrays.asList("cn", ""), rangeDesc.getColumnsFromPath());
+        Assert.assertEquals(Arrays.asList(false, true), rangeDesc.getColumnsFromPathIsNull());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -263,6 +263,84 @@ public class IcebergScanNodeTest {
     }
 
     @Test
+    public void testSetPartitionValuesUsesPerSpecMetadataWithFileScannerV2() throws Exception {
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.enableFileScannerV2 = true;
+        TestIcebergScanNode node = new TestIcebergScanNode(sessionVariable);
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "Region", Types.StringType.get()),
+                Types.NestedField.required(2, "Dt", Types.StringType.get()),
+                Types.NestedField.required(3, "Category", Types.StringType.get()));
+        PartitionSpec oldSpec = PartitionSpec.builderFor(schema)
+                .withSpecId(1)
+                .identity("Region")
+                .identity("Dt")
+                .build();
+        PartitionSpec currentSpec = PartitionSpec.builderFor(schema)
+                .withSpecId(2)
+                .identity("Dt")
+                .identity("Category")
+                .build();
+        Map<Integer, PartitionSpec> specs = new LinkedHashMap<>();
+        specs.put(oldSpec.specId(), oldSpec);
+        specs.put(currentSpec.specId(), currentSpec);
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.schema()).thenReturn(schema);
+        Mockito.when(table.spec()).thenReturn(currentSpec);
+        Mockito.when(table.specs()).thenReturn(specs);
+        setIcebergTable(node, table);
+
+        Map<String, String> partitionValues = new HashMap<>();
+        partitionValues.put("Category", "books");
+        partitionValues.put("Dt", null);
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        node.setPartitionValues(rangeDesc, partitionValues);
+
+        Assert.assertEquals(Arrays.asList("Dt", "Category"), rangeDesc.getColumnsFromPathKeys());
+        Assert.assertEquals(Arrays.asList("", "books"), rangeDesc.getColumnsFromPath());
+        Assert.assertEquals(Arrays.asList(true, false), rangeDesc.getColumnsFromPathIsNull());
+    }
+
+    @Test
+    public void testSetPartitionValuesKeepsCommonMetadataWithLegacyFileScanner() throws Exception {
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.enableFileScannerV2 = false;
+        TestIcebergScanNode node = new TestIcebergScanNode(sessionVariable);
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "Region", Types.StringType.get()),
+                Types.NestedField.required(2, "Dt", Types.StringType.get()),
+                Types.NestedField.required(3, "Category", Types.StringType.get()));
+        PartitionSpec oldSpec = PartitionSpec.builderFor(schema)
+                .withSpecId(1)
+                .identity("Region")
+                .identity("Dt")
+                .build();
+        PartitionSpec currentSpec = PartitionSpec.builderFor(schema)
+                .withSpecId(2)
+                .identity("Dt")
+                .identity("Category")
+                .build();
+        Map<Integer, PartitionSpec> specs = new LinkedHashMap<>();
+        specs.put(oldSpec.specId(), oldSpec);
+        specs.put(currentSpec.specId(), currentSpec);
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.schema()).thenReturn(schema);
+        Mockito.when(table.spec()).thenReturn(currentSpec);
+        Mockito.when(table.specs()).thenReturn(specs);
+        setIcebergTable(node, table);
+
+        Map<String, String> partitionValues = new HashMap<>();
+        partitionValues.put("Region", "cn");
+        partitionValues.put("Dt", "2026-07-31");
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        node.setPartitionValues(rangeDesc, partitionValues);
+
+        Assert.assertEquals(Collections.singletonList("Dt"), rangeDesc.getColumnsFromPathKeys());
+        Assert.assertEquals(Collections.singletonList("2026-07-31"), rangeDesc.getColumnsFromPath());
+        Assert.assertEquals(Collections.singletonList(false), rangeDesc.getColumnsFromPathIsNull());
+    }
+
+    @Test
     public void testExtractNameMappingDistinguishesAbsentAndEmpty() throws Exception {
         TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable());
         Table table = Mockito.mock(Table.class);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62821, #65581, #66010

Problem Summary: branch-4.1 already backported the Paimon and BE partition metadata changes through #65581, but Hive-style scans, Hudi, Iceberg, and file load paths still had incomplete FE metadata propagation. Hive default partitions were encoded as `\N`, which lost the distinction between NULL and a literal `\N`. Iceberg attached partition metadata only when runtime partition pruning was enabled, used unstable per-map ordering, and did not safely handle files written with different partition specs.

This change:

- propagates aligned partition values and explicit NULL flags through Hive-style scans, Hudi, and both legacy and Nereids file load paths;
- preserves a literal `\N` as data while representing Hive default partitions as NULL;
- sends stable Iceberg identity-partition metadata for every split, keyed by both spec ID and partition data;
- restricts Iceberg path partition keys to identity columns shared by all partition specs, which is safe for both FileScannerV2 and the legacy scanner's scan-level slot mapping.

### Release note

Fix partition-column materialization, NULL handling, and Iceberg partition evolution compatibility for external table scans and file loads on branch-4.1.

### Check List (For Author)

- Test: Unit Test
  - `./run-fe-ut.sh --run org.apache.doris.common.util.BrokerUtilTest,org.apache.doris.datasource.hive.source.HiveScanNodeTest,org.apache.doris.datasource.iceberg.IcebergUtilsTest,org.apache.doris.datasource.iceberg.source.IcebergScanNodeTest,org.apache.doris.datasource.paimon.source.PaimonScanNodeTest`
- Behavior changed: Yes. External partition metadata and NULL values are materialized consistently per split.
- Does this need documentation: No
