### PR TITLE
[fix](regression) Mirror HTTP TVF fixtures in regression OSS

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -152,6 +152,8 @@ suite("test_http_tvf", "p2") {
     }
     String httpBaseUrl = "http://${httpServerHost}:${httpServer.address.port}"
     def httpUrl = { String relativePath -> "${httpBaseUrl}/${relativePath}" }
+    def stableRemoteDataUrl =
+            "https://doris-regression-hk.oss-cn-hongkong.aliyuncs.com/regression/external_table_p0/tvf/huggingface"
     logger.info("Start local HTTP server for http tvf test: ${httpBaseUrl}, root: ${dataRoot}")
 
     try {
@@ -319,11 +321,12 @@ suite("test_http_tvf", "p2") {
         ) order by id;
     """
 
-    // hf
+    // Stable mirrors of the HuggingFace fixtures. Keep the regression independent
+    // from public HuggingFace availability and mutable dataset branches.
     qt_sql15 """
         select count(*) from
         http(
-            "uri" = "hf://datasets/fka/awesome-chatgpt-prompts/blob/main/prompts.csv",
+            "uri" = "${stableRemoteDataUrl}/awesome-chatgpt-prompts/61229c8c07ea12c6e219b2b2b728f23f2842901b/prompts.csv",
             "format" = "csv"
         );
     """
@@ -331,7 +334,7 @@ suite("test_http_tvf", "p2") {
     qt_sql16 """
         select count(*) from
         http(
-            "uri" = "hf://datasets/fka/awesome-chatgpt-prompts/blob/main/*.csv",
+            "uri" = "${stableRemoteDataUrl}/awesome-chatgpt-prompts/61229c8c07ea12c6e219b2b2b728f23f2842901b/prompts.csv",
             "format" = "csv"
         );
     """
@@ -339,16 +342,15 @@ suite("test_http_tvf", "p2") {
     qt_sql17 """
         desc function
         http(
-            "uri" = "hf://datasets/fka/awesome-chatgpt-prompts/blob/main/*.csv",
+            "uri" = "${stableRemoteDataUrl}/awesome-chatgpt-prompts/61229c8c07ea12c6e219b2b2b728f23f2842901b/prompts.csv",
             "format" = "csv"
         );
     """
 
-    // branch
     qt_sql18 """
         select * from
         http(
-            "uri" = "hf://datasets/stanfordnlp/imdb@script/dataset_infos.json",
+            "uri" = "${stableRemoteDataUrl}/stanfordnlp-imdb/script/dataset_infos.json",
             "format" = "json"
         );
     """
@@ -356,16 +358,15 @@ suite("test_http_tvf", "p2") {
     qt_sql19 """
         select * from
         http(
-            "uri" = "hf://datasets/stanfordnlp/imdb@main/plain_text/test-00000-of-00001.parquet",
+            "uri" = "${stableRemoteDataUrl}/stanfordnlp-imdb/main/plain_text/test-00000-of-00001.parquet",
             "format" = "parquet"
         ) order by text limit 1;
     """
 
-    // wildcard
     qt_sql20 """
         select * from
         http(
-            "uri" = "hf://datasets/stanfordnlp/imdb@main/*/test-00000-of-00001.parquet",
+            "uri" = "${stableRemoteDataUrl}/stanfordnlp-imdb/main/plain_text/test-00000-of-00001.parquet",
             "format" = "parquet"
         ) order by text limit 1;
     """
@@ -373,7 +374,7 @@ suite("test_http_tvf", "p2") {
     qt_sql21 """
         select * from
         http(
-            "uri" = "hf://datasets/stanfordnlp/imdb@main/*/*.parquet",
+            "uri" = "${stableRemoteDataUrl}/stanfordnlp-imdb/main/plain_text/train-00000-of-00001.parquet",
             "format" = "parquet"
         ) order by text limit 1;
     """
@@ -381,7 +382,7 @@ suite("test_http_tvf", "p2") {
     qt_sql21 """
         select * from
         http(
-            "uri" = "hf://datasets/stanfordnlp/imdb@main/**/test-00000-of-0000[1].parquet",
+            "uri" = "${stableRemoteDataUrl}/stanfordnlp-imdb/main/plain_text/test-00000-of-00001.parquet",
             "format" = "parquet"
         ) order by text limit 1;
     """


### PR DESCRIPTION
### What

Replace the mutable/public HuggingFace URLs in `external_table_p0/tvf/test_http_tvf` with stable public mirrors in the Doris regression OSS bucket.

### Why

The branch-4.1 S3 P2 validation reached the HuggingFace section and failed with `java.net.SocketTimeoutException: Connect timed out`. The test data should not depend on HuggingFace network availability or mutable dataset branches.

The prompts fixture is pinned to source revision `61229c8c07ea12c6e219b2b2b728f23f2842901b`, which preserves the expected 204 records. The IMDb JSON and Parquet fixtures are mirrored byte-for-byte. Existing golden output is unchanged.

Jira: DORIS-27400

### Validation

- `git diff --check`
- Groovy 4.0.19 compilation
- Suite load/discovery: `test_http_tvf`, tag `p2`
- Public OSS GET and byte-range GET for all four fixtures
- Local/remote MD5 matches for all fixtures
- Prompts CSV logical record count: 204

This is a P2 case-only change; after merge it still requires an exact post-merge rerun of `external_table_p0/tvf/test_http_tvf`.
