### PR TITLE
[fix](regression) Skip mirrored CSV header in HTTP TVF

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -327,7 +327,8 @@ suite("test_http_tvf", "p2") {
         select count(*) from
         http(
             "uri" = "${stableRemoteDataUrl}/awesome-chatgpt-prompts/61229c8c07ea12c6e219b2b2b728f23f2842901b/prompts.csv",
-            "format" = "csv"
+            "format" = "csv",
+            "skip_lines" = "1"
         );
     """
 
@@ -335,7 +336,8 @@ suite("test_http_tvf", "p2") {
         select count(*) from
         http(
             "uri" = "${stableRemoteDataUrl}/awesome-chatgpt-prompts/61229c8c07ea12c6e219b2b2b728f23f2842901b/prompts.csv",
-            "format" = "csv"
+            "format" = "csv",
+            "skip_lines" = "1"
         );
     """
     
@@ -343,7 +345,8 @@ suite("test_http_tvf", "p2") {
         desc function
         http(
             "uri" = "${stableRemoteDataUrl}/awesome-chatgpt-prompts/61229c8c07ea12c6e219b2b2b728f23f2842901b/prompts.csv",
-            "format" = "csv"
+            "format" = "csv",
+            "skip_lines" = "1"
         );
     """
 


### PR DESCRIPTION
## Proposed changes

Follow-up for DORIS-27400 after #66013 replaced unstable HuggingFace URLs with immutable OSS fixtures.

Post-merge exact S3 P2 build #204256 reached the mirrored `prompts.csv`, proving that the original network timeout is gone, but `qt_sql15` failed with expected 204 / actual 205. The mirrored CSV is byte-identical to the pinned dataset revision we captured and contains one header record plus 204 data records. Direct HTTP CSV TVF reads the header as data, while the previous HuggingFace path exposed the 204 dataset rows.

This case-only follow-up adds `skip_lines = 1` to the three `prompts.csv` HTTP TVF calls (`qt_sql15`, `qt_sql16`, and `qt_sql17`) so the mirrored path preserves the existing 204-row semantics and schema assertion.

## Validation

- #204256 terminal first error: `sql15` expected 204, actual 205; the OSS URL was reachable and the target executed
- Mirrored CSV: 205 physical CSV records = 1 header + 204 data records
- `git diff --check`: passed
- Groovy 4.0.19 compilation: passed
- Suite discover/load identity: exactly one `test_http_tvf`, group `p2`; no framework/tool/build changes

A post-merge exact `external_table_p0/tvf/test_http_tvf` run is still required before closing DORIS-27400.