### PR TITLE
[fix](be) avoid stale JNI exception poisoning pooled scan threads

### DIFF
--- a/be/src/format/jni/jni_reader.cpp
+++ b/be/src/format/jni/jni_reader.cpp
@@ -224,6 +224,15 @@ Status JniReader::close() {
                 COUNTER_UPDATE(_fill_block_time, _fill_block_watcher);
             }
 
+            // close() is best-effort cleanup that runs on a pooled scan thread. If a previous JNI
+            // call on this thread left an exception pending (the real scan error is already carried
+            // by the scan status), the early RETURN_ERROR_IF_EXC below would abort the
+            // resource-release calls and leak the Java scanner / off-heap table. Discard any
+            // residual exception up front so release/close always run on a clean thread state.
+            if (env->ExceptionCheck()) [[unlikely]] {
+                LOG(WARNING) << "discard stale pending JNI exception before closing JNI scanner: "
+                             << Jni::Env::GetJniExceptionMsg(env, false).to_string();
+            }
             RETURN_ERROR_IF_EXC(env);
             jlong _append = 0;
             RETURN_IF_ERROR(
@@ -395,6 +404,14 @@ Status JniReader::_fill_partition_columns(Block* block, size_t num_rows) {
 
 Status JniReader::_get_statistics(JNIEnv* env, std::map<std::string, std::string>* result) {
     result->clear();
+    // JNI exceptions are sticky per-thread until explicitly cleared. A stale exception left by
+    // an earlier JNI call on this pooled scan thread would make the JNI call below run under a
+    // pending exception (UB) and be misattributed here. The real scan error is already carried by
+    // the scan status, so discard any residual exception before touching the JVM again.
+    if (env->ExceptionCheck()) [[unlikely]] {
+        LOG(WARNING) << "discard stale pending JNI exception before collecting JNI scanner "
+                     << "statistics: " << Jni::Env::GetJniExceptionMsg(env, false).to_string();
+    }
     Jni::LocalObject metrics;
     RETURN_IF_ERROR(
             _jni_scanner_obj.call_object_method(env, _jni_scanner_get_statistics).call(&metrics));

--- a/be/src/format_v2/jni/jni_table_reader.cpp
+++ b/be/src/format_v2/jni/jni_table_reader.cpp
@@ -198,6 +198,14 @@ Status JniTableReader::finalize_jni_block(Block* jni_block, Block* output_block,
 Status JniTableReader::_get_statistics(JNIEnv* env, std::map<std::string, std::string>* result) {
     DORIS_CHECK(result != nullptr);
     result->clear();
+    // JNI exceptions are sticky per-thread until explicitly cleared. A stale exception left by
+    // an earlier JNI call on this pooled scan thread would make the JNI call below run under a
+    // pending exception (UB) and be misattributed here. The real scan error is already carried by
+    // the scan status, so discard any residual exception before touching the JVM again.
+    if (env->ExceptionCheck()) [[unlikely]] {
+        LOG(WARNING) << "discard stale pending JNI exception before collecting JNI scanner "
+                     << "statistics: " << Jni::Env::GetJniExceptionMsg(env, false).to_string();
+    }
     Jni::LocalObject metrics;
     RETURN_IF_ERROR(
             _jni_scanner_obj.call_object_method(env, _jni_scanner_get_statistics).call(&metrics));

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/JniScanner.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/JniScanner.java
@@ -100,9 +100,18 @@ public abstract class JniScanner {
         int numRows;
         try {
             numRows = getNext();
-        } catch (IOException e) {
+        } catch (Throwable t) {
+            // Catch Throwable, not just IOException: subclasses (and the libraries they call)
+            // routinely surface failures as unchecked RuntimeException/NPE. If such an exception
+            // escaped here, releaseTable() would be skipped (off-heap leak) and a bare pending JNI
+            // exception would be left on this pooled scan thread, later misattributed to an
+            // unrelated JNI call (e.g. getStatistics) and able to fail the whole query. Always
+            // release the table and normalize to a checked IOException so BE clears it cleanly.
             releaseTable();
-            throw e;
+            if (t instanceof IOException) {
+                throw (IOException) t;
+            }
+            throw new IOException("Failed to get next batch in JNI scanner: " + t.getMessage(), t);
         }
         if (numRows == 0) {
             releaseTable();

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/MockJniScanner.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/MockJniScanner.java
@@ -182,6 +182,9 @@ public class MockJniScanner extends JniScanner {
     private int mockRows;
     private int readRows = 0;
     private final MockColumnValue columnValue = new MockColumnValue();
+    // Test hook ("unchecked"/"io"/null): fail getNext() after real data is appended, so tests can
+    // verify getNextBatchMeta() releases the off-heap table and normalizes the failure.
+    private final String throwType;
 
     public MockJniScanner(int batchSize, Map<String, String> params) {
         mockRows = Integer.parseInt(params.get("mock_rows"));
@@ -191,6 +194,7 @@ public class MockJniScanner extends JniScanner {
         for (int i = 0; i < types.length; i++) {
             columnTypes[i] = ColumnType.parseType(requiredFields[i], types[i]);
         }
+        throwType = params.get("mock_throw_type");
         initTableInfo(columnTypes, requiredFields, batchSize);
     }
 
@@ -223,6 +227,12 @@ public class MockJniScanner extends JniScanner {
         }
         appendDataTime += System.nanoTime() - startTime;
         readRows += rows;
+        if (throwType != null) {
+            if ("io".equals(throwType)) {
+                throw new IOException("mock IO failure from getNext");
+            }
+            throw new IllegalStateException("mock unchecked failure from getNext");
+        }
         return rows;
     }
 }

--- a/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jni/JniScannerTest.java
+++ b/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jni/JniScannerTest.java
@@ -103,4 +103,45 @@ public class JniScannerTest {
         scanner.releaseTable();
         scanner.close();
     }
+
+    @Test
+    public void testGetNextBatchMetaReleasesTableWhenGetNextThrowsUnchecked() throws IOException {
+        OffHeap.setTesting();
+        MockJniScanner scanner = new MockJniScanner(32, new HashMap<String, String>() {
+            {
+                put("mock_rows", "128");
+                put("required_fields", "int");
+                put("columns_types", "int");
+                put("mock_throw_type", "unchecked");
+            }
+        });
+        scanner.open();
+        IOException thrown = Assert.assertThrows(IOException.class, scanner::getNextBatchMeta);
+        Assert.assertTrue("unchecked exception must be normalized to IOException with the original as cause",
+                thrown.getCause() instanceof IllegalStateException);
+        Assert.assertNull("off-heap vector table must be released (not leaked) when getNext throws",
+                scanner.getTable());
+        scanner.close();
+    }
+
+    @Test
+    public void testGetNextBatchMetaPreservesIOExceptionAndReleasesTable() throws IOException {
+        OffHeap.setTesting();
+        MockJniScanner scanner = new MockJniScanner(32, new HashMap<String, String>() {
+            {
+                put("mock_rows", "128");
+                put("required_fields", "int");
+                put("columns_types", "int");
+                put("mock_throw_type", "io");
+            }
+        });
+        scanner.open();
+        IOException thrown = Assert.assertThrows(IOException.class, scanner::getNextBatchMeta);
+        Assert.assertEquals("original IOException must be propagated, not re-wrapped",
+                "mock IO failure from getNext", thrown.getMessage());
+        Assert.assertNull("IOException must not be double-wrapped", thrown.getCause());
+        Assert.assertNull("off-heap vector table must be released (not leaked) when getNext throws",
+                scanner.getTable());
+        scanner.close();
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66037

Problem Summary:

JNI scan threads are pooled and reused across queries. A JNI exception is sticky per-thread: it stays pending until explicitly cleared. If one JNI call leaves an exception pending and it is not cleared, the next JNI call on that same reused thread runs under a pending exception (undefined behavior) and the error gets misattributed to an unrelated call, which can fail an otherwise healthy query. It also skips off-heap table release, leaking memory.

There are two sides to the bug:

- FE (`JniScanner.getNextBatchMeta`): the batch loop only caught `IOException` from `getNext()`. Scanner subclasses (and the libraries they call) routinely surface failures as unchecked `RuntimeException`/NPE. When such an exception escaped, `releaseTable()` was skipped (off-heap `VectorTable` leak) and a bare pending JNI exception was left on the pooled scan thread, later misattributed to an unrelated JNI call such as `getStatistics` and able to fail the whole query. The fix catches `Throwable`, always calls `releaseTable()`, and normalizes non-`IOException` throwables to a checked `IOException` (keeping the original as cause) so BE clears it cleanly.

- BE (`JniReader::_get_statistics` / `JniReader::close` and `JniTableReader::_get_statistics`): these best-effort methods ran JNI calls while a stale pending exception (left by an earlier call on the same pooled thread) could still be present. In `close()` the early `RETURN_ERROR_IF_EXC` aborted before the resource-release/close calls, leaking the Java scanner and off-heap table. The real scan error is already carried by the scan status, so each method now discards any residual pending exception up front (logging it) before touching the JVM again, so profile collection and release/close always run on a clean thread state.

### Release note

Fix off-heap memory leak and spurious query failures when a JNI scanner's getNext throws an unchecked exception.

### Check List (For Author)

- Test
    - [x] Unit Test: added `JniScannerTest.testGetNextBatchMetaReleasesTableWhenGetNextThrowsUnchecked` and `testGetNextBatchMetaPreservesIOExceptionAndReleasesTable`. They drive the real `MockJniScanner` (which allocates a real off-heap `VectorTable`), inject a failure in `getNext()` after data has been appended, and assert `getNextBatchMeta()` normalizes the throwable to `IOException` (unchecked kept as cause; existing `IOException` not re-wrapped) and releases the table (`getTable() == null`, i.e. no off-heap leak). BE: both changed translation units compile clean and `clang-format` is clean. No BE unit test for the stale-exception guard because reproducing it needs a live JVM and a reused pooled scan thread.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.
