### PR TITLE
[fix](be) return empty collection for empty array/map field in Hive text

### DIFF
--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -160,7 +160,12 @@ Status DataTypeArraySerDe::deserialize_one_cell_from_hive_text(
         IColumn& column, Slice& slice, const FormatOptions& options,
         int hive_text_complex_type_delimiter_level) const {
     if (slice.empty()) {
-        return Status::InvalidArgument("slice is empty!");
+        // An empty Hive-text field is an empty array ([]), matching Spark/Hive semantics,
+        // rather than an error (which the nullable serde would otherwise turn into a NULL).
+        auto& array_column = assert_cast<ColumnArray&>(column);
+        auto& offsets = array_column.get_offsets();
+        offsets.push_back(offsets.back());
+        return Status::OK();
     }
     auto& array_column = assert_cast<ColumnArray&>(column);
     auto& offsets = array_column.get_offsets();

--- a/be/src/core/data_type_serde/data_type_map_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_map_serde.cpp
@@ -73,7 +73,12 @@ Status DataTypeMapSerDe::deserialize_one_cell_from_hive_text(
         IColumn& column, Slice& slice, const FormatOptions& options,
         int hive_text_complex_type_delimiter_level) const {
     if (slice.empty()) {
-        return Status::InvalidArgument("slice is empty!");
+        // An empty Hive-text field is an empty map ({}), matching Spark/Hive semantics,
+        // rather than an error (which the nullable serde would otherwise turn into a NULL).
+        auto& map_column = assert_cast<ColumnMap&>(column);
+        auto& offsets = map_column.get_offsets();
+        offsets.push_back(offsets.back());
+        return Status::OK();
     }
     auto& array_column = assert_cast<ColumnMap&>(column);
     auto& offsets = array_column.get_offsets();

--- a/be/test/core/data_type_serde/empty_complex_type_hive_text_test.cpp
+++ b/be/test/core/data_type_serde/empty_complex_type_hive_text_test.cpp
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "core/column/column_array.h"
+#include "core/column/column_map.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_map.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type_serde/data_type_serde.h"
+
+namespace doris {
+
+// Test that deserializing an empty slice (as in CSV/Hive Text format)
+// for array/map types produces an empty collection ([]/{}) instead of null,
+// matching Spark's behavior.
+class EmptyComplexTypeHiveTextTest : public ::testing::Test {
+protected:
+    DataTypeSerDe::FormatOptions options;
+};
+
+TEST_F(EmptyComplexTypeHiveTextTest, EmptyArrayFromHiveText) {
+    // array<int>
+    auto array_type =
+            std::make_shared<DataTypeArray>(make_nullable(std::make_shared<DataTypeInt32>()));
+    auto serde = array_type->get_serde(1);
+    auto column = array_type->create_column();
+
+    // Deserialize empty slice -- should produce empty array, not error
+    Slice empty_slice("");
+    auto st = serde->deserialize_one_cell_from_hive_text(*column, empty_slice, options);
+    EXPECT_TRUE(st.ok()) << "deserialize empty array failed: " << st.to_string();
+    ASSERT_EQ(column->size(), 1u);
+
+    // Verify the result is [] (empty array)
+    const auto& array_col = assert_cast<const ColumnArray&>(*column);
+    const auto& offsets = array_col.get_offsets();
+    EXPECT_EQ(offsets[0], 0u) << "empty array should have offset 0";
+}
+
+TEST_F(EmptyComplexTypeHiveTextTest, EmptyMapFromHiveText) {
+    // map<int, int>
+    auto map_type = std::make_shared<DataTypeMap>(make_nullable(std::make_shared<DataTypeInt32>()),
+                                                  make_nullable(std::make_shared<DataTypeInt32>()));
+    auto serde = map_type->get_serde(1);
+    auto column = map_type->create_column();
+
+    // Deserialize empty slice -- should produce empty map, not error
+    Slice empty_slice("");
+    auto st = serde->deserialize_one_cell_from_hive_text(*column, empty_slice, options);
+    EXPECT_TRUE(st.ok()) << "deserialize empty map failed: " << st.to_string();
+    ASSERT_EQ(column->size(), 1u);
+
+    // Verify the result is {} (empty map)
+    const auto& map_col = assert_cast<const ColumnMap&>(*column);
+    const auto& offsets = map_col.get_offsets();
+    EXPECT_EQ(offsets[0], 0u) << "empty map should have offset 0";
+}
+
+TEST_F(EmptyComplexTypeHiveTextTest, NonEmptyArrayFromHiveText) {
+    // Ensure non-empty array still works correctly
+    auto array_type =
+            std::make_shared<DataTypeArray>(make_nullable(std::make_shared<DataTypeInt32>()));
+    auto serde = array_type->get_serde(1);
+    auto column = array_type->create_column();
+
+    // Standard hive text uses Ctrl-B (\002) as the collection delimiter at level 1
+    options.collection_delim = '\002';
+    Slice data_slice("1\0022\0023");
+    auto st = serde->deserialize_one_cell_from_hive_text(*column, data_slice, options);
+    EXPECT_TRUE(st.ok()) << "deserialize non-empty array failed: " << st.to_string();
+    ASSERT_EQ(column->size(), 1u);
+
+    const auto& array_col = assert_cast<const ColumnArray&>(*column);
+    const auto& offsets = array_col.get_offsets();
+    EXPECT_EQ(offsets[0], 3u) << "array should have 3 elements";
+}
+
+TEST_F(EmptyComplexTypeHiveTextTest, NullableEmptyArrayFromHiveText) {
+    // Test nullable(array<int>) -- empty string should produce empty array, not null
+    auto array_type =
+            std::make_shared<DataTypeArray>(make_nullable(std::make_shared<DataTypeInt32>()));
+    auto nullable_array_type = make_nullable(array_type);
+    auto serde = nullable_array_type->get_serde(1);
+    auto column = nullable_array_type->create_column();
+
+    // Deserialize empty slice -- should produce NOT NULL empty array
+    Slice empty_slice("");
+    auto st = serde->deserialize_one_cell_from_hive_text(*column, empty_slice, options);
+    EXPECT_TRUE(st.ok()) << "deserialize nullable empty array failed: " << st.to_string();
+    ASSERT_EQ(column->size(), 1u);
+
+    // The top-level nullable column should NOT be null
+    const auto& nullable_col = assert_cast<const ColumnNullable&>(*column);
+    EXPECT_FALSE(nullable_col.is_null_at(0))
+            << "empty array in nullable wrapper should not be null";
+}
+
+TEST_F(EmptyComplexTypeHiveTextTest, NullableEmptyMapFromHiveText) {
+    // Test nullable(map<int,int>) -- empty string should produce empty map, not null
+    auto map_type = std::make_shared<DataTypeMap>(make_nullable(std::make_shared<DataTypeInt32>()),
+                                                  make_nullable(std::make_shared<DataTypeInt32>()));
+    auto nullable_map_type = make_nullable(map_type);
+    auto serde = nullable_map_type->get_serde(1);
+    auto column = nullable_map_type->create_column();
+
+    // Deserialize empty slice -- should produce NOT NULL empty map
+    Slice empty_slice("");
+    auto st = serde->deserialize_one_cell_from_hive_text(*column, empty_slice, options);
+    EXPECT_TRUE(st.ok()) << "deserialize nullable empty map failed: " << st.to_string();
+    ASSERT_EQ(column->size(), 1u);
+
+    // The top-level nullable column should NOT be null
+    const auto& nullable_col = assert_cast<const ColumnNullable&>(*column);
+    EXPECT_FALSE(nullable_col.is_null_at(0)) << "empty map in nullable wrapper should not be null";
+}
+
+TEST_F(EmptyComplexTypeHiveTextTest, ExplicitNullArrayFromHiveText) {
+    // An explicit null field (\N, the default FormatOptions::null_format) must still
+    // deserialize to NULL -- the empty-collection change only affects empty fields.
+    auto array_type =
+            std::make_shared<DataTypeArray>(make_nullable(std::make_shared<DataTypeInt32>()));
+    auto nullable_array_type = make_nullable(array_type);
+    auto serde = nullable_array_type->get_serde(1);
+    auto column = nullable_array_type->create_column();
+
+    Slice null_slice("\\N");
+    auto st = serde->deserialize_one_cell_from_hive_text(*column, null_slice, options);
+    EXPECT_TRUE(st.ok()) << "deserialize \\N array failed: " << st.to_string();
+    ASSERT_EQ(column->size(), 1u);
+
+    const auto& nullable_col = assert_cast<const ColumnNullable&>(*column);
+    EXPECT_TRUE(nullable_col.is_null_at(0)) << "\\N field should deserialize to null";
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66039

Problem Summary:
When reading Hive text (and CSV) data, `DataTypeArraySerDe::deserialize_one_cell_from_hive_text`
and `DataTypeMapSerDe::deserialize_one_cell_from_hive_text` returned
`Status::InvalidArgument("slice is empty!")` for an empty field. This is wrong for a Hive-text
empty field, which should map to an empty collection (`[]` / `{}`) to match Spark/Hive semantics.

For a non-nullable array/map column this surfaced as a load/read error. For a nullable column the
`InvalidArgument` was silently swallowed by `DataTypeNullableSerDe` (which fills NULL on any nested
error), so an empty field became NULL instead of an empty collection.

The fix makes both serdes append an empty collection (advance offsets by 0) and return
`Status::OK()` when the input slice is empty.

Observable behavior change: an empty array/map field in Hive text is now read as an empty
collection (`[]` / `{}`) instead of NULL (nullable columns) or a read error (non-nullable columns).
An explicit NULL field (`\N`, the default `null_format`) is unchanged and still deserializes to NULL.

Struct serde is intentionally left unchanged (empty-struct semantics are ambiguous, tracked
separately).

### Release note

An empty array/map field in Hive text format is now read as an empty collection instead of NULL
(or a load error for non-nullable columns). An explicit NULL (`\N`) is unchanged.

### Check List (For Author)

- Test: Unit Test
    - Added `be/test/core/data_type_serde/empty_complex_type_hive_text_test.cpp` with 6 cases
      (empty array/map, non-empty array, nullable empty array/map, explicit `\N` -> NULL).
      All 6 pass under ASAN: `[  PASSED  ] 6 tests.`
    - clang-format (v16) clean on all 3 changed files.
- Behavior changed: Yes (empty nullable array/map field now reads as empty collection instead of
  NULL; `\N` still means NULL).
- Does this need documentation: No

