### PR TITLE
[fix](hive) pass Hive view column aliases so outer query can resolve view columns

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -803,7 +803,21 @@ public class BindRelation extends OneAnalysisRuleFactory {
                         String ddlSql = pluginViewTable.getViewText();
                         Plan pluginViewPlan = parseAndAnalyzeExternalView(pluginViewTable,
                                 pluginCatalog, pluginDb, ddlSql, cascadesContext);
-                        return new LogicalSubQueryAlias<>(qualifiedTableName, pluginViewPlan);
+                        // The external view body's slot names may diverge from the declared view schema;
+                        // pass the schema as aliases so the outer query resolves columns by the view
+                        // definition instead of the view-body slot names.
+                        // getFullSchema() returns null when the schema cache is empty (e.g. after a
+                        // catalog drop / cache-lifecycle miss). Preserve the child fallback in that case:
+                        // an empty aliases Optional makes LogicalSubQueryAlias.computeOutput() fall back
+                        // to the analyzed view-body slot names instead of dereferencing a null schema.
+                        List<Column> viewSchema = pluginViewTable.getFullSchema();
+                        Optional<List<String>> columnAliases = (viewSchema == null || viewSchema.isEmpty())
+                                ? Optional.empty()
+                                : Optional.of(viewSchema.stream()
+                                        .map(Column::getName)
+                                        .collect(Collectors.toList()));
+                        return new LogicalSubQueryAlias<>(
+                                qualifiedTableName, columnAliases, pluginViewPlan);
                     }
                     return new LogicalFileScan(unboundRelation.getRelationId(), (ExternalTable) table,
                             qualifierWithoutTableName, ImmutableList.of(),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindRelationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindRelationTest.java
@@ -17,6 +17,15 @@
 
 package org.apache.doris.nereids.rules.analysis;
 
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.util.Util;
+import org.apache.doris.connector.api.Connector;
+import org.apache.doris.datasource.plugin.PluginDrivenExternalCatalog;
+import org.apache.doris.datasource.plugin.PluginDrivenExternalDatabase;
+import org.apache.doris.datasource.plugin.PluginDrivenExternalTable;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.pattern.GeneratedPlanPatterns;
@@ -25,6 +34,7 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
@@ -39,9 +49,12 @@ import org.apache.doris.utframe.TestWithFeService;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -65,6 +78,147 @@ class BindRelationTest extends TestWithFeService implements GeneratedPlanPattern
                 + "DISTRIBUTED BY random BUCKETS 3\n"
                 + "PROPERTIES (\"replication_num\"= \"1\");");
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+    }
+
+    @Test
+    void bindHiveViewPropagatesColumnAliases() throws Exception {
+        String catalogName = "plugin_view_catalog";
+        String dbName = "plugin_view_db";
+        String viewName = "plugin_view";
+
+        // The connector SPI is not exercised: every seam that would normally reach it
+        // (isView/getFullSchema/getViewText) is stubbed directly on the table spy below.
+        Connector connectorMock = Mockito.mock(Connector.class);
+        Map<String, String> props = new HashMap<>();
+        props.put("type", "hive");
+        TestPluginCatalog catalog = new TestPluginCatalog(
+                Env.getCurrentEnv().getNextId(), catalogName, props, connectorMock);
+        // addCatalog() is private: it is the minimal registration primitive (map insertion +
+        // resetToUninitialized) that createCatalogInternal() itself delegates to, without the
+        // SQL-parsing/checkProperties overhead that createCatalogInternal adds on top.
+        Deencapsulation.invoke(Env.getCurrentEnv().getCatalogMgr(), "addCatalog", catalog);
+        // addCatalog() resets the catalog to uninitialized; force it back so buildMetaCache()
+        // (invoked by addDatabaseForTest/addTableForTest below) is a no-op rather than a real
+        // metadata refresh against the (mocked) connector.
+        catalog.setInitializedForTest(true);
+
+        PluginDrivenExternalDatabase db = new PluginDrivenExternalDatabase(
+                catalog, Util.genIdByName(catalogName, dbName), dbName, dbName);
+        catalog.addDatabaseForTest(db);
+
+        // Declared view schema uses col1/col2; the view body deliberately uses different
+        // slot names (a/b) so alias propagation is observable in computeOutput().
+        List<Column> viewSchema = ImmutableList.of(
+                new Column("col1", PrimitiveType.INT),
+                new Column("col2", PrimitiveType.INT));
+
+        // The id must match ExternalDatabase.getTableNullable()'s expectedTableId
+        // (Util.genIdByName(catalogName, dbName, tableName)), or the id/name identity check on lookup fails.
+        PluginDrivenExternalTable pluginTable = Mockito.spy(new PluginDrivenExternalTable(
+                Util.genIdByName(catalogName, dbName, viewName), viewName, viewName, catalog, db));
+        // doReturn() stubs bypass the real method (and its makeSureInitialized() guard),
+        // so no live connector metadata call is made.
+        Mockito.doReturn(true).when(pluginTable).isView();
+        Mockito.doReturn(viewSchema).when(pluginTable).getFullSchema();
+        Mockito.doReturn("SELECT 1 AS a, 2 AS b").when(pluginTable).getViewText();
+        db.addTableForTest(pluginTable);
+
+        try {
+            Plan plan = PlanRewriter.bottomUpRewrite(new UnboundRelation(
+                    StatementScopeIdGenerator.newRelationId(),
+                    ImmutableList.of(catalogName, dbName, viewName)),
+                    connectContext, new BindRelation());
+
+            Assertions.assertInstanceOf(LogicalSubQueryAlias.class, plan);
+            LogicalSubQueryAlias<?> alias = (LogicalSubQueryAlias<?>) plan;
+            Assertions.assertTrue(alias.getColumnAliases().isPresent());
+            Assertions.assertEquals(ImmutableList.of("col1", "col2"), alias.getColumnAliases().get());
+
+            List<String> outputNames = alias.computeOutput().stream()
+                    .map(Slot::getName)
+                    .collect(Collectors.toList());
+            Assertions.assertEquals(ImmutableList.of("col1", "col2"), outputNames);
+        } finally {
+            // Mirror the original test's teardown, but via the same low-level primitive used to
+            // register the catalog (removeCatalog is the private counterpart of addCatalog; the
+            // public dropCatalog() expects a catalog created through the full SQL/edit-log path).
+            Deencapsulation.invoke(Env.getCurrentEnv().getCatalogMgr(), "removeCatalog", catalog.getId());
+        }
+    }
+
+    /**
+     * getFullSchema() returns null when the plugin table's schema cache is empty (e.g. after a
+     * catalog drop / cache-lifecycle miss). BindRelation must not dereference it: the alias list
+     * stays absent and LogicalSubQueryAlias falls back to the analyzed view-body slot names.
+     */
+    @Test
+    void bindHiveViewWithNullSchemaFallsBackToBodyNames() throws Exception {
+        String catalogName = "plugin_view_null_catalog";
+        String dbName = "plugin_view_null_db";
+        String viewName = "plugin_view_null";
+
+        Connector connectorMock = Mockito.mock(Connector.class);
+        Map<String, String> props = new HashMap<>();
+        props.put("type", "hive");
+        TestPluginCatalog catalog = new TestPluginCatalog(
+                Env.getCurrentEnv().getNextId(), catalogName, props, connectorMock);
+        Deencapsulation.invoke(Env.getCurrentEnv().getCatalogMgr(), "addCatalog", catalog);
+        catalog.setInitializedForTest(true);
+
+        PluginDrivenExternalDatabase db = new PluginDrivenExternalDatabase(
+                catalog, Util.genIdByName(catalogName, dbName), dbName, dbName);
+        catalog.addDatabaseForTest(db);
+
+        PluginDrivenExternalTable pluginTable = Mockito.spy(new PluginDrivenExternalTable(
+                Util.genIdByName(catalogName, dbName, viewName), viewName, viewName, catalog, db));
+        Mockito.doReturn(true).when(pluginTable).isView();
+        // Empty schema cache -> null schema, exactly as ExternalTable.getFullSchema() returns.
+        Mockito.doReturn(null).when(pluginTable).getFullSchema();
+        Mockito.doReturn("SELECT 1 AS a, 2 AS b").when(pluginTable).getViewText();
+        db.addTableForTest(pluginTable);
+
+        try {
+            Plan plan = PlanRewriter.bottomUpRewrite(new UnboundRelation(
+                    StatementScopeIdGenerator.newRelationId(),
+                    ImmutableList.of(catalogName, dbName, viewName)),
+                    connectContext, new BindRelation());
+
+            Assertions.assertInstanceOf(LogicalSubQueryAlias.class, plan);
+            LogicalSubQueryAlias<?> alias = (LogicalSubQueryAlias<?>) plan;
+            // No declared schema -> no aliases; output falls back to the view-body slot names.
+            Assertions.assertFalse(alias.getColumnAliases().isPresent());
+
+            List<String> outputNames = alias.computeOutput().stream()
+                    .map(Slot::getName)
+                    .collect(Collectors.toList());
+            Assertions.assertEquals(ImmutableList.of("a", "b"), outputNames);
+        } finally {
+            Deencapsulation.invoke(Env.getCurrentEnv().getCatalogMgr(), "removeCatalog", catalog.getId());
+        }
+    }
+
+    /**
+     * SPI-registered {@code ConnectorProvider} for the catalog's {@code type} property; no such provider
+     * is registered in the fe-core unit-test classpath (plugin connectors are separate, external JARs).
+     * {@code createConnectorFromProperties} is documented as "Extracted as a protected method so tests
+     * can override without depending on the static ConnectorFactory registry" -- this mirrors the same
+     * override used by {@code PluginDrivenExternalCatalogErrorMsgTest.TestErrorCatalog}: keep the connector
+     * injected via the constructor and skip the real (SPI-backed) local-object initialization entirely.
+     */
+    private static final class TestPluginCatalog extends PluginDrivenExternalCatalog {
+        TestPluginCatalog(long catalogId, String name, Map<String, String> props, Connector connector) {
+            super(catalogId, name, null, props, "", connector);
+        }
+
+        @Override
+        protected Connector createConnectorFromProperties() {
+            return null;
+        }
+
+        @Override
+        protected void initLocalObjectsImpl() {
+            // Connector is already injected via the constructor; nothing to build.
+        }
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66041

Problem Summary: When querying a Hive view through the Nereids optimizer, the
outer query could fail with a "find no column" error whenever the view's
declared column schema diverged from the slot names produced by the parsed
view body. The root cause is in `BindRelation.bindRelation` for the
`HMS_EXTERNAL_TABLE` case: the resulting `LogicalSubQueryAlias` was built
with the 2-arg constructor, which leaves `columnAliases` empty. Its
`computeOutput()` then fell back to the child (view-body) slot names instead
of the view's declared schema, so an outer query that referenced the view
columns by their declared names could not resolve them.

The fix passes the view's declared schema (from `HMSExternalTable.getFullSchema()`)
as `columnAliases` to the 3-arg `LogicalSubQueryAlias` constructor.
`computeOutput()` already honors `columnAliases` to rename the output slots,
so the outer query now resolves view columns by the view definition.

This is a hand-port of an internal fix; JD-only helpers (an internal auth
context and a view-SQL transformer) were intentionally dropped.

### Release note

Fixed a "find no column" error when querying certain Hive views whose declared column names differ from the view body slot names.

### Check List (For Author)

- Test: Unit Test
    - Added `BindRelationTest.bindHiveViewPropagatesColumnAliases`: drives the
      real `BindRelation` rule over a spied `HMSExternalTable` view whose
      declared schema (`col1,col2`) deliberately differs from the view body
      slot names (`a,b`), and asserts the resulting `LogicalSubQueryAlias`
      carries the schema as `columnAliases` and that `computeOutput()` slot
      names equal `[col1,col2]`.
    - Ran `run-fe-ut.sh --run BindRelationTest`: 7 tests run, 0 failures,
      0 errors, 0 skipped (locally green).
- Behavior changed: Yes — Hive view output columns are now renamed to match
  the view's declared schema (previously kept the view-body slot names).
- Does this need documentation: No

