### PR TITLE
[fix](build) Let ScopedLSANDisabler compile without a sanitizer

### DIFF
--- a/be/src/util/debug/leak_annotations.h
+++ b/be/src/util/debug/leak_annotations.h
@@ -79,10 +79,26 @@ int __lsan_do_recoverable_leak_check();
 
 namespace doris::debug {
 
+// Suppresses leak reports for allocations made in this scope.
+//
+// The __lsan_* functions above are only declared here; they are defined by the LeakSanitizer
+// runtime. Without -fsanitize=address (or =leak) nothing provides them, so calling them
+// unconditionally left every translation unit that instantiates this class with an undefined
+// reference, and doris_be_test could only be linked as an ASAN build. There is nothing to suppress
+// when no sanitizer is present, so the guard below degrades to a no-op -- the same reasoning
+// ANNOTATE_LEAKING_OBJECT_PTR already uses.
 class ScopedLSANDisabler {
 public:
+#if defined(DORIS_LSAN_ENABLED)
     ScopedLSANDisabler() { __lsan_disable(); }
     ~ScopedLSANDisabler() { __lsan_enable(); }
+#else
+    // Deliberately user-provided and not `= default`: a defaulted constructor makes the type
+    // trivial, and every `ScopedLSANDisabler guard;` then trips -Werror,-Wunused-variable. An
+    // empty user-provided body keeps the guard a no-op while remaining a real RAII object.
+    ScopedLSANDisabler() {}
+    ~ScopedLSANDisabler() {}
+#endif
 };
 
 } // namespace doris::debug


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`doris_be_test` can only be linked as an ASAN build. `BUILD_TYPE_UT=DEBUG` and `BUILD_TYPE_UT=RELEASE`
both fail at link:

```
ld.lld: error: undefined symbol: __lsan_disable
>>> referenced by leak_annotations.h:84
>>>               cached_remote_file_reader_peer_test.cpp.o:(doris::debug::ScopedLSANDisabler::ScopedLSANDisabler())
```

`be/src/util/debug/leak_annotations.h` computes `DORIS_LSAN_ENABLED` and uses it to guard
`ANNOTATE_LEAKING_OBJECT_PTR`, but `ScopedLSANDisabler` sits outside every `#if`:

```cpp
class ScopedLSANDisabler {
public:
    ScopedLSANDisabler()  { __lsan_disable(); }
    ~ScopedLSANDisabler() { __lsan_enable();  }
};
```

`__lsan_disable` / `__lsan_enable` are only declared in that header; they are defined by the
LeakSanitizer runtime. Without `-fsanitize=address` (or `=leak`) nothing provides them, so every
translation unit that instantiates the class emits an undefined reference. Two do —
`be/src/util/debug/leakcheck_disabler.h` and `be/test/io/cache/cached_remote_file_reader_peer_test.cpp`.

This matters beyond tidiness: it means there is no way to produce an optimized, un-instrumented unit
test binary, so unit tests cannot be used for any timing work — ASAN's allocator instrumentation and
`-O0` dominate whatever is being measured.

The guard is extended to cover the class. With no LeakSanitizer there is nothing to suppress, so it
degrades to a no-op, which is the same reasoning `ANNOTATE_LEAKING_OBJECT_PTR` already applies.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)

      Compiled a translation unit that instantiates `ScopedLSANDisabler` both ways and inspected the
      undefined symbols, which isolates the change from everything else in the binary:

      ```
      # master header, no sanitizer -> the undefined references that break the link
      $ nm -u probe_orig.o | grep lsan
                       U __lsan_disable
                       U __lsan_enable

      # this PR, no sanitizer -> none
      $ nm -u probe_fixed.o | grep lsan     # (no output)

      # this PR, -fsanitize=address -> still emitted, suppression behaviour unchanged
      $ nm -u probe_asan.o | grep lsan
                       U __lsan_disable
                       U __lsan_enable
      ```

      Then built the unit test binary with `BUILD_TYPE_UT=RELEASE sh run-be-ut.sh`. On master it
      fails with the undefined `__lsan_disable`; with this change all translation units compile and
      the `-O3 -DNDEBUG` binary links.

      Note the no-op constructor is written out rather than `= default`: a defaulted constructor
      makes the type trivial, and the RELEASE build then fails with
      `error: unused variable 'lsan_disabler' [-Werror,-Wunused-variable]` at the two use sites.

    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes.

      Under a sanitizer build nothing changes — the calls are still emitted. Without a sanitizer the
      scope guard becomes a no-op instead of failing to link, which is the only behaviour it can
      meaningfully have when there is no LeakSanitizer runtime to talk to.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
