### PR TITLE
[fix](cloud) normalize SHOW PARTITIONS display for storage and replica (#60871)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -104,6 +104,7 @@ import java.util.stream.Collectors;
  */
 public class PartitionsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(PartitionsProcDir.class);
+    static final String CLOUD_STORAGE_MEDIUM_DISPLAY = "OBJECT_STORAGE";
 
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("PartitionId").add("PartitionName")
@@ -408,6 +409,14 @@ public class PartitionsProcDir implements ProcDirInterface {
         return partitionInfosInrernal.stream().map(pair -> pair.second).collect(Collectors.toList());
     }
 
+    public static String getStorageMediumDisplay(String storageMedium) {
+        return Config.isCloudMode() ? CLOUD_STORAGE_MEDIUM_DISPLAY : storageMedium;
+    }
+
+    public static String getReplicaAllocationDisplay(String replicaAllocation) {
+        return Config.isCloudMode() ? FeConstants.null_string : replicaAllocation;
+    }
+
     private List<Long> getPartitionVersions(OlapTable olapTable, List<Long> partitionIds)
             throws AnalysisException {
         List<Long> partitionVersions;
@@ -579,8 +588,9 @@ public class PartitionsProcDir implements ProcDirInterface {
                 trow.addToColumnValue(new TCell().setIntVal(totalReplicaNum));
 
                 DataProperty dataProperty = tblPartitionInfo.getDataProperty(partitionId);
-                partitionInfo.add(dataProperty.getStorageMedium().name());
-                trow.addToColumnValue(new TCell().setStringVal(dataProperty.getStorageMedium().name()));
+                String storageMedium = getStorageMediumDisplay(dataProperty.getStorageMedium().name());
+                partitionInfo.add(storageMedium);
+                trow.addToColumnValue(new TCell().setStringVal(storageMedium));
                 String cooldownTimeStr = TimeUtils.longToTimeString(dataProperty.getCooldownTimeMs());
                 partitionInfo.add(cooldownTimeStr);
                 trow.addToColumnValue(new TCell().setStringVal(cooldownTimeStr));
@@ -599,7 +609,8 @@ public class PartitionsProcDir implements ProcDirInterface {
                 partitionInfo.add(isInMemory);
                 trow.addToColumnValue(new TCell().setBoolVal(isInMemory));
                 // replica allocation
-                String replica = tblPartitionInfo.getReplicaAllocation(partitionId).toCreateStmt();
+                String replica = getReplicaAllocationDisplay(
+                        tblPartitionInfo.getReplicaAllocation(partitionId).toCreateStmt());
                 partitionInfo.add(replica);
                 trow.addToColumnValue(new TCell().setStringVal(replica));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -1862,15 +1862,17 @@ public class MetadataGenerator {
                             + sizePair.second;
                     trow.addToColumnValue(new TCell().setStringVal(readableDateSize)); // REMOTE_DATA_SIZE
                     trow.addToColumnValue(new TCell().setStringVal(partition.getState().toString())); // STATE
-                    trow.addToColumnValue(new TCell().setStringVal(partitionInfo.getReplicaAllocation(partitionId)
-                            .toCreateStmt())); // REPLICA_ALLOCATION
+                    String replicaAllocation = PartitionsProcDir.getReplicaAllocationDisplay(
+                            partitionInfo.getReplicaAllocation(partitionId).toCreateStmt());
+                    trow.addToColumnValue(new TCell().setStringVal(replicaAllocation)); // REPLICA_ALLOCATION
                     trow.addToColumnValue(new TCell().setIntVal(partitionInfo.getReplicaAllocation(partitionId)
                             .getTotalReplicaNum())); // REPLICA_NUM
                     trow.addToColumnValue(new TCell().setStringVal(partitionInfo
                             .getStoragePolicy(partitionId))); // STORAGE_POLICY
                     DataProperty dataProperty = partitionInfo.getDataProperty(partitionId);
-                    trow.addToColumnValue(new TCell().setStringVal(dataProperty.getStorageMedium()
-                            .name())); // STORAGE_MEDIUM
+                    String storageMedium = PartitionsProcDir
+                            .getStorageMediumDisplay(dataProperty.getStorageMedium().name());
+                    trow.addToColumnValue(new TCell().setStringVal(storageMedium)); // STORAGE_MEDIUM
                     trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(dataProperty
                             .getCooldownTimeMs()))); // COOLDOWN_TIME_MS
                     trow.addToColumnValue(new TCell().setStringVal(TimeUtils.longToTimeString(partition

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/PartitionsProcDirTest.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PartitionsProcDirTest {
+    private String originDeployMode;
+    private String originCloudUniqueId;
+
+    @Before
+    public void setUp() {
+        originDeployMode = Config.deploy_mode;
+        originCloudUniqueId = Config.cloud_unique_id;
+        Config.deploy_mode = "";
+        Config.cloud_unique_id = "";
+    }
+
+    @After
+    public void tearDown() {
+        Config.deploy_mode = originDeployMode;
+        Config.cloud_unique_id = originCloudUniqueId;
+    }
+
+    @Test
+    public void testDisplayInNonCloudMode() {
+        Assert.assertEquals("HDD", PartitionsProcDir.getStorageMediumDisplay("HDD"));
+        Assert.assertEquals("tag.location.default: 1",
+                PartitionsProcDir.getReplicaAllocationDisplay("tag.location.default: 1"));
+    }
+
+    @Test
+    public void testDisplayInCloudMode() {
+        Config.deploy_mode = "cloud";
+        Assert.assertEquals(PartitionsProcDir.CLOUD_STORAGE_MEDIUM_DISPLAY,
+                PartitionsProcDir.getStorageMediumDisplay("HDD"));
+        Assert.assertEquals(FeConstants.null_string,
+                PartitionsProcDir.getReplicaAllocationDisplay("tag.location.default: 1"));
+    }
+}


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/60871

In cloud mode, SHOW PARTITIONS now displays StorageMedium as OBJECT_STORAGE and ReplicaAllocation as <null>. Also add PartitionsProcDirTest to cover cloud/non-cloud display behavior.

<img width="462" height="312" alt="image"
src="https://github.com/user-attachments/assets/f5ac8ab8-3ffd-468c-a2ea-9a957e7e385a" />

(cherry picked from commit 9688e57f280da153268779603f0470c5c340960d)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

