### PR TITLE
[fix](bucket) Raise autobucket_min_buckets default from 1 to 3 (#63729)

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2841,7 +2841,7 @@ public class Config extends ConfigBase {
             "Auto Buckets 中最小的 buckets 数目",
             "min buckets of auto bucket"
     })
-    public static int autobucket_min_buckets = 1;
+    public static int autobucket_min_buckets = 3;
 
     @ConfField(mutable = true, masterOnly = true, description = {
         "Auto Buckets 中最大的 buckets 数目",

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -1835,7 +1835,7 @@ public class DynamicPartitionTableTest {
         partitions = Lists.newArrayList(table.getAllPartitions());
         partitions.sort(Comparator.comparing(Partition::getId));
         Assert.assertEquals(53, partitions.size());
-        Assert.assertEquals(1, partitions.get(partitions.size() - 1).getDistributionInfo().getBucketNum());
+        Assert.assertEquals(3, partitions.get(partitions.size() - 1).getDistributionInfo().getBucketNum());
         Config.autobucket_out_of_bounds_percent_threshold = 0.5;
 
         table.readLock();
@@ -1887,7 +1887,7 @@ public class DynamicPartitionTableTest {
                     if (i < 52) {
                         Assert.assertEquals(10, idx.getTablets().size());
                     } else if (i == 52) {
-                        Assert.assertEquals(1, idx.getTablets().size());
+                        Assert.assertEquals(3, idx.getTablets().size());
                     } else if (i == 53) {
                         Assert.assertEquals(20, idx.getTablets().size());
                     }

--- a/regression-test/suites/autobucket/test_autobucket.groovy
+++ b/regression-test/suites/autobucket/test_autobucket.groovy
@@ -62,7 +62,7 @@ suite("test_autobucket") {
     // XXX: buckets at pos(8), next maybe impl by sql meta
     assertEquals(5, Integer.valueOf(result.get(0).Buckets))
     // set back to default
-    sql "ADMIN SET FRONTEND CONFIG ('autobucket_min_buckets' = '1')"
+    sql "ADMIN SET FRONTEND CONFIG ('autobucket_min_buckets' = '3')"
     sql "drop table if exists autobucket_test_min_buckets"
 
     // set max to 1
@@ -84,7 +84,7 @@ suite("test_autobucket") {
     result = sql_return_maparray "show partitions from autobucket_test_max_buckets"
     logger.info("${result}")
     // XXX: buckets at pos(8), next maybe impl by sql meta
-    assertEquals(1, Integer.valueOf(result.get(0).Buckets)) //equals max bucket
+    assertEquals(3, Integer.valueOf(result.get(0).Buckets)) //equals max bucket
     // set back to default
     sql "ADMIN SET FRONTEND CONFIG ('autobucket_max_buckets' = '128')"
     sql "drop table if exists autobucket_test_max_buckets"


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/63729
Prevent the auto bucket algorithm from computing a bucket number that is too small. A minimum of 3 buckets provides a more reasonable lower bound for parallelism and data distribution under the auto bucket strategy.

(cherry picked from commit 1316d4bd633749e61adce3cbd1b88345fc00d9b3)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

