### PR TITLE
[test](feut) fix `testShouldWarmUpPerformanceRepeatedCycles200k`

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerTableFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerTableFilterTest.java
@@ -1041,8 +1041,8 @@ public class CacheHotspotManagerTableFilterTest {
 
         Assertions.assertEquals(200000 * iterations, totalMatched);
         System.out.println("[Perf] 200K tables × 5 cycles: total=" + totalMs + " ms, avg=" + avgMs + " ms/cycle");
-        Assertions.assertTrue(avgMs < 1000,
-                "Avg per refresh cycle for 200K tables should be < 1s, avg=" + avgMs + " ms");
+        Assertions.assertTrue(avgMs < 1500,
+                "Avg per refresh cycle for 200K tables should be < 1.5s, avg=" + avgMs + " ms");
     }
 
     private static class RecordingAppender extends AbstractAppender {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65153

Problem Summary: The repeated-cycle cache hotspot performance test used a 1-second average threshold even though the equivalent 200K-table single-cycle test allows 1.5 seconds. CI hosts occasionally exceeded 1 second while preserving correct matching results. This change aligns the repeated-cycle threshold with the existing 1.5-second allowance and updates the assertion message.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Test command:

```shell
./run-fe-ut.sh --run org.apache.doris.cloud.CacheHotspotManagerTableFilterTest#testShouldWarmUpPerformanceRepeatedCycles200k
```

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
