### PR TITLE
[fix](cloud) Skip BE rowset promotion for incomplete lazy commits

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -1641,7 +1641,6 @@ Status CloudMetaMgr::commit_txn(const StreamLoadContext& ctx, bool is_2pc) {
     req.set_txn_id(ctx.txn_id);
     req.set_is_2pc(is_2pc);
     req.set_enable_txn_lazy_commit(config::enable_cloud_txn_lazy_commit);
-    req.set_supports_incomplete_lazy_commit_response(true);
     auto st = retry_rpc(MetaServiceRPC::COMMIT_TXN, req, &res, &MetaService_Stub::commit_txn,
                         {
                                 .host_limiters = host_level_ms_rpc_rate_limiters_,

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -1641,6 +1641,7 @@ Status CloudMetaMgr::commit_txn(const StreamLoadContext& ctx, bool is_2pc) {
     req.set_txn_id(ctx.txn_id);
     req.set_is_2pc(is_2pc);
     req.set_enable_txn_lazy_commit(config::enable_cloud_txn_lazy_commit);
+    req.set_supports_incomplete_lazy_commit_response(true);
     auto st = retry_rpc(MetaServiceRPC::COMMIT_TXN, req, &res, &MetaService_Stub::commit_txn,
                         {
                                 .host_limiters = host_level_ms_rpc_rate_limiters_,

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -1648,6 +1648,9 @@ Status CloudMetaMgr::commit_txn(const StreamLoadContext& ctx, bool is_2pc) {
                         });
 
     if (st.ok()) {
+        VLOG_DEBUG << "commit txn succeeded, db_id: " << ctx.db_id << ", txn_id: " << ctx.txn_id
+                   << ", label: " << ctx.label << ", is_lazy_commit: " << res.is_lazy_commit()
+                   << ", is_lazy_commit_incomplete: " << res.is_lazy_commit_incomplete();
         std::vector<int64_t> tablet_ids;
         for (auto& commit_info : ctx.commit_infos) {
             tablet_ids.emplace_back(commit_info.tabletId);

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -185,6 +185,8 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, const Reques
     if constexpr (std::is_same_v<Response, CommitTxnResponse>) {
         LOG(INFO) << "finish " << func_name << " remote_caller=" << ctrl->remote_side()
                   << " original_client_ip=" << req->request_ip()
+                  << " is_lazy_commit=" << res->is_lazy_commit()
+                  << " is_lazy_commit_incomplete=" << res->is_lazy_commit_incomplete()
                   << " response=" << res->ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetRowsetResponse>) {
         LOG_IF(INFO, res->status().code() != MetaServiceCode::OK)

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -185,8 +185,6 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, const Reques
     if constexpr (std::is_same_v<Response, CommitTxnResponse>) {
         LOG(INFO) << "finish " << func_name << " remote_caller=" << ctrl->remote_side()
                   << " original_client_ip=" << req->request_ip()
-                  << " is_lazy_commit=" << res->is_lazy_commit()
-                  << " is_lazy_commit_incomplete=" << res->is_lazy_commit_incomplete()
                   << " response=" << res->ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetRowsetResponse>) {
         LOG_IF(INFO, res->status().code() != MetaServiceCode::OK)

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2620,6 +2620,8 @@ void MetaServiceImpl::commit_txn_eventually(
             return;
         }
 
+        response->set_is_partial_commit(true);
+
         // set table versions in response
         if (is_versioned_read) {
             Versionstamp vs;
@@ -2649,6 +2651,8 @@ void MetaServiceImpl::commit_txn_eventually(
         if (ret.first != MetaServiceCode::OK) {
             LOG(WARNING) << "txn lazy commit failed txn_id=" << txn_id << " code=" << ret.first
                          << " msg=" << ret.second;
+        } else {
+            response->clear_is_partial_commit();
         }
 
         std::unordered_map<int64_t, TabletStats> tablet_stats; // tablet_id -> stats

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2652,7 +2652,7 @@ void MetaServiceImpl::commit_txn_eventually(
             LOG(WARNING) << "txn lazy commit failed txn_id=" << txn_id << " code=" << ret.first
                          << " msg=" << ret.second;
         } else {
-            response->clear_is_lazy_commit_incomplete();
+            response->set_is_lazy_commit_incomplete(false);
         }
 
         std::unordered_map<int64_t, TabletStats> tablet_stats; // tablet_id -> stats
@@ -3286,6 +3286,7 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
                                  const CommitTxnRequest* request, CommitTxnResponse* response,
                                  ::google::protobuf::Closure* done) {
     RPC_PREPROCESS(commit_txn, get, put, del);
+    response->set_is_lazy_commit_incomplete(false);
     if (!request->has_txn_id()) {
         code = MetaServiceCode::INVALID_ARGUMENT;
         msg = "invalid argument, missing txn id";
@@ -3323,13 +3324,17 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
     }
 
     TxnErrorCode err = TxnErrorCode::TXN_OK;
-    bool enable_txn_lazy_commit_feature =
+    const bool supports_incomplete_lazy_commit_response =
+            request->has_supports_incomplete_lazy_commit_response() &&
+            request->supports_incomplete_lazy_commit_response();
+    const bool enable_txn_lazy_commit_feature =
             (request->has_is_2pc() && !request->is_2pc() && request->has_enable_txn_lazy_commit() &&
-             request->enable_txn_lazy_commit() && config::enable_cloud_txn_lazy_commit);
+             request->enable_txn_lazy_commit() && config::enable_cloud_txn_lazy_commit &&
+             supports_incomplete_lazy_commit_response);
 
     while ((!enable_txn_lazy_commit_feature ||
             (tmp_rowsets_meta.size() <= config::txn_lazy_commit_rowsets_thresold))) {
-        if (force_txn_lazy_commit()) {
+        if (enable_txn_lazy_commit_feature && force_txn_lazy_commit()) {
             LOG(INFO) << "fuzzy test force_txn_lazy_commit, txn_id=" << txn_id
                       << " force_posibility=" << config::cloud_txn_lazy_commit_fuzzy_possibility;
             break;

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2652,7 +2652,7 @@ void MetaServiceImpl::commit_txn_eventually(
             LOG(WARNING) << "txn lazy commit failed txn_id=" << txn_id << " code=" << ret.first
                          << " msg=" << ret.second;
         } else {
-            response->set_is_lazy_commit_incomplete(false);
+            response->clear_is_lazy_commit_incomplete();
         }
 
         std::unordered_map<int64_t, TabletStats> tablet_stats; // tablet_id -> stats
@@ -3286,7 +3286,6 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
                                  const CommitTxnRequest* request, CommitTxnResponse* response,
                                  ::google::protobuf::Closure* done) {
     RPC_PREPROCESS(commit_txn, get, put, del);
-    response->set_is_lazy_commit_incomplete(false);
     if (!request->has_txn_id()) {
         code = MetaServiceCode::INVALID_ARGUMENT;
         msg = "invalid argument, missing txn id";
@@ -3324,9 +3323,6 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
     }
 
     TxnErrorCode err = TxnErrorCode::TXN_OK;
-    const bool supports_incomplete_lazy_commit_response =
-            request->has_supports_incomplete_lazy_commit_response() &&
-            request->supports_incomplete_lazy_commit_response();
     bool enable_txn_lazy_commit_feature =
             (request->has_is_2pc() && !request->is_2pc() && request->has_enable_txn_lazy_commit() &&
              request->enable_txn_lazy_commit() && config::enable_cloud_txn_lazy_commit);
@@ -3371,13 +3367,6 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
     msg.clear();
     commit_txn_eventually(request, response, code, msg, instance_id, db_id, tmp_rowsets_meta,
                           stats);
-    if (!supports_incomplete_lazy_commit_response && response->is_lazy_commit_incomplete()) {
-        code = MetaServiceCode::KV_TXN_COMMIT_ERR;
-        msg = fmt::format(
-                "lazy commit is incomplete, txn_id={}, "
-                "caller does not support incomplete lazy commit responses",
-                txn_id);
-    }
 }
 
 void _abort_txn(const std::string& instance_id, const AbortTxnRequest* request, Transaction* txn,

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2620,7 +2620,7 @@ void MetaServiceImpl::commit_txn_eventually(
             return;
         }
 
-        response->set_is_partial_commit(true);
+        response->set_is_lazy_commit_incomplete(true);
 
         // set table versions in response
         if (is_versioned_read) {
@@ -2652,7 +2652,7 @@ void MetaServiceImpl::commit_txn_eventually(
             LOG(WARNING) << "txn lazy commit failed txn_id=" << txn_id << " code=" << ret.first
                          << " msg=" << ret.second;
         } else {
-            response->clear_is_partial_commit();
+            response->clear_is_lazy_commit_incomplete();
         }
 
         std::unordered_map<int64_t, TabletStats> tablet_stats; // tablet_id -> stats

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2194,6 +2194,7 @@ void MetaServiceImpl::commit_txn_eventually(
         std::string& msg, const std::string& instance_id, int64_t db_id,
         const std::vector<std::pair<std::string, doris::RowsetMetaCloudPB>>& tmp_rowsets_meta,
         KVStats& stats) {
+    response->set_is_lazy_commit(true);
     StopWatch sw;
     DORIS_CLOUD_DEFER {
         if (config::use_detailed_metrics && !instance_id.empty()) {
@@ -3286,6 +3287,7 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
                                  const CommitTxnRequest* request, CommitTxnResponse* response,
                                  ::google::protobuf::Closure* done) {
     RPC_PREPROCESS(commit_txn, get, put, del);
+    response->set_is_lazy_commit(false);
     if (!request->has_txn_id()) {
         code = MetaServiceCode::INVALID_ARGUMENT;
         msg = "invalid argument, missing txn id";

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2653,7 +2653,7 @@ void MetaServiceImpl::commit_txn_eventually(
             LOG(WARNING) << "txn lazy commit failed txn_id=" << txn_id << " code=" << ret.first
                          << " msg=" << ret.second;
         } else {
-            response->clear_is_lazy_commit_incomplete();
+            response->set_is_lazy_commit_incomplete(false);
         }
 
         std::unordered_map<int64_t, TabletStats> tablet_stats; // tablet_id -> stats

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -3327,14 +3327,13 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
     const bool supports_incomplete_lazy_commit_response =
             request->has_supports_incomplete_lazy_commit_response() &&
             request->supports_incomplete_lazy_commit_response();
-    const bool enable_txn_lazy_commit_feature =
+    bool enable_txn_lazy_commit_feature =
             (request->has_is_2pc() && !request->is_2pc() && request->has_enable_txn_lazy_commit() &&
-             request->enable_txn_lazy_commit() && config::enable_cloud_txn_lazy_commit &&
-             supports_incomplete_lazy_commit_response);
+             request->enable_txn_lazy_commit() && config::enable_cloud_txn_lazy_commit);
 
     while ((!enable_txn_lazy_commit_feature ||
             (tmp_rowsets_meta.size() <= config::txn_lazy_commit_rowsets_thresold))) {
-        if (enable_txn_lazy_commit_feature && force_txn_lazy_commit()) {
+        if (force_txn_lazy_commit()) {
             LOG(INFO) << "fuzzy test force_txn_lazy_commit, txn_id=" << txn_id
                       << " force_posibility=" << config::cloud_txn_lazy_commit_fuzzy_possibility;
             break;
@@ -3372,6 +3371,13 @@ void MetaServiceImpl::commit_txn(::google::protobuf::RpcController* controller,
     msg.clear();
     commit_txn_eventually(request, response, code, msg, instance_id, db_id, tmp_rowsets_meta,
                           stats);
+    if (!supports_incomplete_lazy_commit_response && response->is_lazy_commit_incomplete()) {
+        code = MetaServiceCode::KV_TXN_COMMIT_ERR;
+        msg = fmt::format(
+                "lazy commit is incomplete, txn_id={}, "
+                "caller does not support incomplete lazy commit responses",
+                txn_id);
+    }
 }
 
 void _abort_txn(const std::string& instance_id, const AbortTxnRequest* request, Transaction* txn,

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -3491,7 +3491,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         ASSERT_TRUE(res.has_is_lazy_commit());
         ASSERT_TRUE(res.is_lazy_commit());
-        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -1192,6 +1192,8 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         ASSERT_TRUE(commit_txn_immediatelly_hit);
+        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
     {
@@ -1205,6 +1207,81 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
             check_rowset_meta_exist(txn, tablet_id, 2);
         }
     }
+}
+
+TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
+    auto txn_kv = get_mem_txn_kv();
+
+    int64_t db_id = 67935421;
+    int64_t table_id = 97432015;
+    int64_t index_id = 468213;
+    int64_t partition_id = 753129;
+    int64_t tablet_id = 86421357;
+    std::string label = "test_failed_lazy_commit_task";
+
+    auto meta_service = get_meta_service(txn_kv, true);
+    brpc::Controller cntl;
+    BeginTxnRequest req;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    TxnInfoPB txn_info_pb;
+    txn_info_pb.set_db_id(db_id);
+    txn_info_pb.set_label(label);
+    txn_info_pb.add_table_ids(table_id);
+    txn_info_pb.set_timeout_ms(36000);
+    req.mutable_txn_info()->CopyFrom(txn_info_pb);
+    BeginTxnResponse res;
+    meta_service->begin_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res,
+                            nullptr);
+    ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    int64_t txn_id = res.txn_id();
+
+    create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
+                             tablet_id);
+    auto tmp_rowset = create_rowset(txn_id, tablet_id, index_id, partition_id);
+    CreateRowsetResponse rowset_res;
+    prepare_rowset(meta_service.get(), tmp_rowset, rowset_res);
+    ASSERT_EQ(rowset_res.status().code(), MetaServiceCode::OK);
+    commit_rowset(meta_service.get(), tmp_rowset, rowset_res);
+    ASSERT_EQ(rowset_res.status().code(), MetaServiceCode::OK);
+
+    int32_t original_fuzzy_possibility = config::cloud_txn_lazy_commit_fuzzy_possibility;
+    config::cloud_txn_lazy_commit_fuzzy_possibility = 100;
+    std::atomic_bool failure_injected = false;
+    auto sp = SyncPoint::get_instance();
+    sp->set_call_back("convert_tmp_rowsets::before_commit", [&](auto&& args) {
+        auto* code = try_any_cast<MetaServiceCode*>(args[0]);
+        *code = MetaServiceCode::UNDEFINED_ERR;
+        auto* pred = try_any_cast<bool*>(args.back());
+        *pred = true;
+        failure_injected = true;
+    });
+    sp->enable_processing();
+    DORIS_CLOUD_DEFER {
+        config::cloud_txn_lazy_commit_fuzzy_possibility = original_fuzzy_possibility;
+        sp->clear_all_call_backs();
+        sp->clear_trace();
+        sp->disable_processing();
+    };
+
+    CommitTxnRequest commit_req;
+    commit_req.set_cloud_unique_id("test_cloud_unique_id");
+    commit_req.set_db_id(db_id);
+    commit_req.set_txn_id(txn_id);
+    commit_req.set_is_2pc(false);
+    commit_req.set_enable_txn_lazy_commit(true);
+    CommitTxnResponse commit_res;
+    meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                             &commit_req, &commit_res, nullptr);
+    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::OK);
+    ASSERT_TRUE(failure_injected.load());
+    ASSERT_TRUE(commit_res.has_is_lazy_commit_incomplete());
+    ASSERT_TRUE(commit_res.is_lazy_commit_incomplete());
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    check_txn_committed(txn, db_id, txn_id, label);
+    check_tmp_rowset_exist(txn, tablet_id, txn_id);
+    check_rowset_meta_not_exist(txn, tablet_id, 2);
 }
 
 TEST(TxnLazyCommitTest, NotFallThroughCommitTxnEventuallyTest) {
@@ -2224,7 +2301,8 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase4Test) {
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
             ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-            ASSERT_TRUE(res.is_partial_commit());
+            ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
+            ASSERT_TRUE(res.is_lazy_commit_incomplete());
         }
     }
 
@@ -3405,7 +3483,28 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-        ASSERT_FALSE(res.is_partial_commit());
+        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.is_lazy_commit_incomplete());
+    }
+
+    {
+        brpc::Controller cntl;
+        CommitTxnRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_db_id(db_id);
+        req.set_txn_id(txn_id);
+        req.set_is_2pc(false);
+        req.set_enable_txn_lazy_commit(true);
+        for (int i = 0; i < 2001; ++i) {
+            int64_t tablet_id = tablet_id_base + i;
+            req.add_base_tablet_ids(tablet_id);
+        }
+        CommitTxnResponse res;
+        meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
+                                 &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
     {

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -135,11 +135,6 @@ std::unique_ptr<MetaServiceProxy> get_meta_service(std::shared_ptr<TxnKv> txn_kv
     return std::make_unique<MetaServiceProxy>(std::move(meta_service));
 }
 
-static void enable_lazy_commit_for_capable_client(CommitTxnRequest& request) {
-    request.set_enable_txn_lazy_commit(true);
-    request.set_supports_incomplete_lazy_commit_response(true);
-}
-
 static std::string next_rowset_id() {
     static int cnt = 0;
     return std::to_string(++cnt);
@@ -642,7 +637,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithoutDbIdTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         for (int i = 0; i < 2999; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -740,7 +735,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortedTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -834,7 +829,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithDbIdTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -945,7 +940,7 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -1097,7 +1092,7 @@ TEST(TxnLazyCommitVersionedReadTest, DISABLED_CommitTxnEventuallyWithoutDbIdTest
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -1191,13 +1186,13 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         ASSERT_TRUE(commit_txn_immediatelly_hit);
-        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
@@ -1214,7 +1209,7 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
     }
 }
 
-TEST(TxnLazyCommitTest, LegacyClientGetsErrorForFailedLazyCommitTaskTest) {
+TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
     auto txn_kv = get_mem_txn_kv();
 
     int64_t db_id = 67935421;
@@ -1277,7 +1272,7 @@ TEST(TxnLazyCommitTest, LegacyClientGetsErrorForFailedLazyCommitTaskTest) {
     CommitTxnResponse commit_res;
     meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                              &commit_req, &commit_res, nullptr);
-    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::KV_TXN_COMMIT_ERR);
+    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::OK);
     ASSERT_TRUE(failure_injected.load());
     ASSERT_TRUE(commit_res.has_is_lazy_commit_incomplete());
     ASSERT_TRUE(commit_res.is_lazy_commit_incomplete());
@@ -1289,7 +1284,7 @@ TEST(TxnLazyCommitTest, LegacyClientGetsErrorForFailedLazyCommitTaskTest) {
     check_rowset_meta_not_exist(txn, tablet_id, 2);
 }
 
-TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
+TEST(TxnLazyCommitTest, NotFallThroughCommitTxnEventuallyTest) {
     auto txn_kv = get_mem_txn_kv();
     int64_t db_id = 415413556;
     int64_t table_id = 34184234;
@@ -1297,8 +1292,6 @@ TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
     int64_t partition_id = 8934984;
     bool commit_txn_immediatelly_hit = false;
     bool commit_txn_eventually_finish_hit = false;
-    int32_t original_fuzzy_possibility = config::cloud_txn_lazy_commit_fuzzy_possibility;
-    config::cloud_txn_lazy_commit_fuzzy_possibility = 0;
 
     auto sp = SyncPoint::get_instance();
     sp->set_call_back("commit_txn_immediately::before_commit", [&](auto&& args) {
@@ -1320,7 +1313,6 @@ TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
     });
     sp->enable_processing();
     DORIS_CLOUD_DEFER {
-        config::cloud_txn_lazy_commit_fuzzy_possibility = original_fuzzy_possibility;
         sp->clear_all_call_backs();
         sp->clear_trace();
         sp->disable_processing();
@@ -1332,7 +1324,7 @@ TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
     req.set_cloud_unique_id("test_cloud_unique_id");
     TxnInfoPB txn_info_pb;
     txn_info_pb.set_db_id(db_id);
-    txn_info_pb.set_label("test_label_legacy_client_still_uses_lazy_commit");
+    txn_info_pb.set_label("test_label_not_fallthrough_commit_txn_eventually");
     txn_info_pb.add_table_ids(table_id);
     txn_info_pb.set_timeout_ms(36000);
     req.mutable_txn_info()->CopyFrom(txn_info_pb);
@@ -1344,7 +1336,7 @@ TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
 
     // mock rowset and tablet
     int64_t tablet_id_base = 783426908;
-    for (int i = 0; i <= config::txn_lazy_commit_rowsets_thresold; ++i) {
+    for (int i = 0; i < config::txn_lazy_commit_rowsets_thresold; ++i) {
         create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
                                  tablet_id_base + i);
         auto tmp_rowset = create_rowset(txn_id, tablet_id_base + i, index_id, partition_id);
@@ -1362,25 +1354,22 @@ TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-        ASSERT_FALSE(commit_txn_immediatelly_hit);
-        ASSERT_TRUE(commit_txn_eventually_finish_hit);
-        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
-        ASSERT_FALSE(res.is_lazy_commit_incomplete());
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+        ASSERT_TRUE(commit_txn_immediatelly_hit);
+        ASSERT_FALSE(commit_txn_eventually_finish_hit);
     }
 
     {
         std::unique_ptr<Transaction> txn;
         ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
-        for (int i = 0; i <= config::txn_lazy_commit_rowsets_thresold; ++i) {
+        for (int i = 0; i < config::txn_lazy_commit_rowsets_thresold; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             check_tablet_idx_db_id(txn, db_id, tablet_id);
-            check_tmp_rowset_not_exist(txn, tablet_id, txn_id);
-            check_rowset_meta_exist(txn, tablet_id, 2);
+            check_tmp_rowset_exist(txn, tablet_id, txn_id);
+            check_rowset_meta_not_exist(txn, tablet_id, 2);
         }
     }
 }
@@ -1456,7 +1445,7 @@ TEST(TxnLazyCommitTest, FallThroughCommitTxnEventuallyTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -1619,7 +1608,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase1Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -1673,7 +1662,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase1Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id2);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -1877,7 +1866,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase2Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2037,7 +2026,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase3Test) {
             req.set_db_id(db_id);
             req.set_txn_id(tmp_txn_id);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2153,7 +2142,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase3Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2307,7 +2296,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase4Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2491,7 +2480,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase5Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2678,7 +2667,7 @@ TEST(TxnLazyCommitTest, RowsetMetaSizeExceedTest) {
             req.set_db_id(db_id);
             req.set_txn_id(tmp_txn_id);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2849,7 +2838,7 @@ TEST(TxnLazyCommitTest, RecyclePartitions) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2998,7 +2987,7 @@ TEST(TxnLazyCommitTest, RecycleIndexes) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -3114,7 +3103,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithMultiTableTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -3217,7 +3206,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithHugeRowsetMetaTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -3354,7 +3343,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithSchemaChangeTest) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            enable_lazy_commit_for_capable_client(req);
+            req.set_enable_txn_lazy_commit(true);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -3485,7 +3474,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -3494,7 +3483,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
@@ -3505,7 +3494,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -3514,7 +3503,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
@@ -3597,7 +3586,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithManyPartitions) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        enable_lazy_commit_for_capable_client(req);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -135,6 +135,11 @@ std::unique_ptr<MetaServiceProxy> get_meta_service(std::shared_ptr<TxnKv> txn_kv
     return std::make_unique<MetaServiceProxy>(std::move(meta_service));
 }
 
+static void enable_lazy_commit_for_capable_client(CommitTxnRequest& request) {
+    request.set_enable_txn_lazy_commit(true);
+    request.set_supports_incomplete_lazy_commit_response(true);
+}
+
 static std::string next_rowset_id() {
     static int cnt = 0;
     return std::to_string(++cnt);
@@ -637,7 +642,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithoutDbIdTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         for (int i = 0; i < 2999; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -735,7 +740,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortedTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -829,7 +834,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithDbIdTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -940,7 +945,7 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -1092,7 +1097,7 @@ TEST(TxnLazyCommitVersionedReadTest, DISABLED_CommitTxnEventuallyWithoutDbIdTest
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -1186,13 +1191,13 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         ASSERT_TRUE(commit_txn_immediatelly_hit);
-        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
@@ -1268,7 +1273,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
     commit_req.set_db_id(db_id);
     commit_req.set_txn_id(txn_id);
     commit_req.set_is_2pc(false);
-    commit_req.set_enable_txn_lazy_commit(true);
+    enable_lazy_commit_for_capable_client(commit_req);
     CommitTxnResponse commit_res;
     meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                              &commit_req, &commit_res, nullptr);
@@ -1284,7 +1289,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
     check_rowset_meta_not_exist(txn, tablet_id, 2);
 }
 
-TEST(TxnLazyCommitTest, NotFallThroughCommitTxnEventuallyTest) {
+TEST(TxnLazyCommitTest, LegacyClientDoesNotFallThroughCommitTxnEventuallyTest) {
     auto txn_kv = get_mem_txn_kv();
     int64_t db_id = 415413556;
     int64_t table_id = 34184234;
@@ -1292,6 +1297,8 @@ TEST(TxnLazyCommitTest, NotFallThroughCommitTxnEventuallyTest) {
     int64_t partition_id = 8934984;
     bool commit_txn_immediatelly_hit = false;
     bool commit_txn_eventually_finish_hit = false;
+    int32_t original_fuzzy_possibility = config::cloud_txn_lazy_commit_fuzzy_possibility;
+    config::cloud_txn_lazy_commit_fuzzy_possibility = 100;
 
     auto sp = SyncPoint::get_instance();
     sp->set_call_back("commit_txn_immediately::before_commit", [&](auto&& args) {
@@ -1313,6 +1320,7 @@ TEST(TxnLazyCommitTest, NotFallThroughCommitTxnEventuallyTest) {
     });
     sp->enable_processing();
     DORIS_CLOUD_DEFER {
+        config::cloud_txn_lazy_commit_fuzzy_possibility = original_fuzzy_possibility;
         sp->clear_all_call_backs();
         sp->clear_trace();
         sp->disable_processing();
@@ -1354,6 +1362,7 @@ TEST(TxnLazyCommitTest, NotFallThroughCommitTxnEventuallyTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
+        req.set_enable_txn_lazy_commit(true);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -1445,7 +1454,7 @@ TEST(TxnLazyCommitTest, FallThroughCommitTxnEventuallyTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -1608,7 +1617,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase1Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -1662,7 +1671,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase1Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id2);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -1866,7 +1875,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase2Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2026,7 +2035,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase3Test) {
             req.set_db_id(db_id);
             req.set_txn_id(tmp_txn_id);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2142,7 +2151,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase3Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2296,7 +2305,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase4Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2480,7 +2489,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase5Test) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id1);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2667,7 +2676,7 @@ TEST(TxnLazyCommitTest, RowsetMetaSizeExceedTest) {
             req.set_db_id(db_id);
             req.set_txn_id(tmp_txn_id);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2838,7 +2847,7 @@ TEST(TxnLazyCommitTest, RecyclePartitions) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -2987,7 +2996,7 @@ TEST(TxnLazyCommitTest, RecycleIndexes) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -3103,7 +3112,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithMultiTableTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -3206,7 +3215,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithHugeRowsetMetaTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
@@ -3343,7 +3352,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithSchemaChangeTest) {
             req.set_db_id(db_id);
             req.set_txn_id(txn_id);
             req.set_is_2pc(false);
-            req.set_enable_txn_lazy_commit(true);
+            enable_lazy_commit_for_capable_client(req);
             CommitTxnResponse res;
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -3474,7 +3483,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -3483,7 +3492,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
@@ -3494,7 +3503,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         for (int i = 0; i < 2001; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             req.add_base_tablet_ids(tablet_id);
@@ -3503,7 +3512,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-        ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
+        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
@@ -3586,7 +3595,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithManyPartitions) {
         req.set_db_id(db_id);
         req.set_txn_id(txn_id);
         req.set_is_2pc(false);
-        req.set_enable_txn_lazy_commit(true);
+        enable_lazy_commit_for_capable_client(req);
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -1214,7 +1214,7 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
     }
 }
 
-TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
+TEST(TxnLazyCommitTest, LegacyClientGetsErrorForFailedLazyCommitTaskTest) {
     auto txn_kv = get_mem_txn_kv();
 
     int64_t db_id = 67935421;
@@ -1273,11 +1273,11 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
     commit_req.set_db_id(db_id);
     commit_req.set_txn_id(txn_id);
     commit_req.set_is_2pc(false);
-    enable_lazy_commit_for_capable_client(commit_req);
+    commit_req.set_enable_txn_lazy_commit(true);
     CommitTxnResponse commit_res;
     meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                              &commit_req, &commit_res, nullptr);
-    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::OK);
+    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::KV_TXN_COMMIT_ERR);
     ASSERT_TRUE(failure_injected.load());
     ASSERT_TRUE(commit_res.has_is_lazy_commit_incomplete());
     ASSERT_TRUE(commit_res.is_lazy_commit_incomplete());
@@ -1289,7 +1289,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
     check_rowset_meta_not_exist(txn, tablet_id, 2);
 }
 
-TEST(TxnLazyCommitTest, LegacyClientDoesNotFallThroughCommitTxnEventuallyTest) {
+TEST(TxnLazyCommitTest, LegacyClientStillUsesLazyCommitTest) {
     auto txn_kv = get_mem_txn_kv();
     int64_t db_id = 415413556;
     int64_t table_id = 34184234;
@@ -1298,7 +1298,7 @@ TEST(TxnLazyCommitTest, LegacyClientDoesNotFallThroughCommitTxnEventuallyTest) {
     bool commit_txn_immediatelly_hit = false;
     bool commit_txn_eventually_finish_hit = false;
     int32_t original_fuzzy_possibility = config::cloud_txn_lazy_commit_fuzzy_possibility;
-    config::cloud_txn_lazy_commit_fuzzy_possibility = 100;
+    config::cloud_txn_lazy_commit_fuzzy_possibility = 0;
 
     auto sp = SyncPoint::get_instance();
     sp->set_call_back("commit_txn_immediately::before_commit", [&](auto&& args) {
@@ -1332,7 +1332,7 @@ TEST(TxnLazyCommitTest, LegacyClientDoesNotFallThroughCommitTxnEventuallyTest) {
     req.set_cloud_unique_id("test_cloud_unique_id");
     TxnInfoPB txn_info_pb;
     txn_info_pb.set_db_id(db_id);
-    txn_info_pb.set_label("test_label_not_fallthrough_commit_txn_eventually");
+    txn_info_pb.set_label("test_label_legacy_client_still_uses_lazy_commit");
     txn_info_pb.add_table_ids(table_id);
     txn_info_pb.set_timeout_ms(36000);
     req.mutable_txn_info()->CopyFrom(txn_info_pb);
@@ -1344,7 +1344,7 @@ TEST(TxnLazyCommitTest, LegacyClientDoesNotFallThroughCommitTxnEventuallyTest) {
 
     // mock rowset and tablet
     int64_t tablet_id_base = 783426908;
-    for (int i = 0; i < config::txn_lazy_commit_rowsets_thresold; ++i) {
+    for (int i = 0; i <= config::txn_lazy_commit_rowsets_thresold; ++i) {
         create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
                                  tablet_id_base + i);
         auto tmp_rowset = create_rowset(txn_id, tablet_id_base + i, index_id, partition_id);
@@ -1366,19 +1366,21 @@ TEST(TxnLazyCommitTest, LegacyClientDoesNotFallThroughCommitTxnEventuallyTest) {
         CommitTxnResponse res;
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
-        ASSERT_TRUE(commit_txn_immediatelly_hit);
-        ASSERT_FALSE(commit_txn_eventually_finish_hit);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_FALSE(commit_txn_immediatelly_hit);
+        ASSERT_TRUE(commit_txn_eventually_finish_hit);
+        ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
+        ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
 
     {
         std::unique_ptr<Transaction> txn;
         ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
-        for (int i = 0; i < config::txn_lazy_commit_rowsets_thresold; ++i) {
+        for (int i = 0; i <= config::txn_lazy_commit_rowsets_thresold; ++i) {
             int64_t tablet_id = tablet_id_base + i;
             check_tablet_idx_db_id(txn, db_id, tablet_id);
-            check_tmp_rowset_exist(txn, tablet_id, txn_id);
-            check_rowset_meta_not_exist(txn, tablet_id, 2);
+            check_tmp_rowset_not_exist(txn, tablet_id, txn_id);
+            check_rowset_meta_exist(txn, tablet_id, 2);
         }
     }
 }

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -2224,6 +2224,7 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase4Test) {
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
             ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+            ASSERT_TRUE(res.is_partial_commit());
         }
     }
 
@@ -3404,6 +3405,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_FALSE(res.is_partial_commit());
     }
 
     {

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -1192,6 +1192,8 @@ TEST(TxnLazyCommitTest, CommitTxnImmediatelyTest) {
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         ASSERT_TRUE(commit_txn_immediatelly_hit);
+        ASSERT_TRUE(res.has_is_lazy_commit());
+        ASSERT_FALSE(res.is_lazy_commit());
         ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
@@ -1274,6 +1276,8 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithFailedLazyCommitTaskTest) {
                              &commit_req, &commit_res, nullptr);
     ASSERT_EQ(commit_res.status().code(), MetaServiceCode::OK);
     ASSERT_TRUE(failure_injected.load());
+    ASSERT_TRUE(commit_res.has_is_lazy_commit());
+    ASSERT_TRUE(commit_res.is_lazy_commit());
     ASSERT_TRUE(commit_res.has_is_lazy_commit_incomplete());
     ASSERT_TRUE(commit_res.is_lazy_commit_incomplete());
 
@@ -2301,6 +2305,8 @@ TEST(TxnLazyCommitTest, ConcurrentCommitTxnEventuallyCase4Test) {
             meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
             ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+            ASSERT_TRUE(res.has_is_lazy_commit());
+            ASSERT_TRUE(res.is_lazy_commit());
             ASSERT_TRUE(res.has_is_lazy_commit_incomplete());
             ASSERT_TRUE(res.is_lazy_commit_incomplete());
         }
@@ -3483,6 +3489,8 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_TRUE(res.has_is_lazy_commit());
+        ASSERT_TRUE(res.is_lazy_commit());
         ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }
@@ -3503,6 +3511,8 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithAbortAfterCommitTest) {
         meta_service->commit_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
                                  &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_TRUE(res.has_is_lazy_commit());
+        ASSERT_FALSE(res.is_lazy_commit());
         ASSERT_FALSE(res.has_is_lazy_commit_incomplete());
         ASSERT_FALSE(res.is_lazy_commit_incomplete());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -2787,8 +2787,8 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
      */
     private void notifyBesMakeTmpRsVisible(CommitTxnResponse commitTxnResponse,
                                            List<TabletCommitInfo> tabletCommitInfos) {
-        if (commitTxnResponse.getIsPartialCommit()) {
-            LOG.info("skip make cloud tmp rowsets visible for partial commit, txn_id: {}",
+        if (commitTxnResponse.getIsLazyCommitIncomplete()) {
+            LOG.info("skip make cloud tmp rowsets visible for incomplete lazy commit, txn_id: {}",
                     commitTxnResponse.getTxnInfo().getTxnId());
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -831,9 +831,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 }
                 commitTxnResponse = MetaServiceProxy.getInstance().commitTxn(commitTxnRequest);
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("retryTime:{}, isLazyCommit:{}, isLazyCommitIncomplete:{}, commitTxnResponse:{}",
-                            retryTime, commitTxnResponse.getIsLazyCommit(),
-                            commitTxnResponse.getIsLazyCommitIncomplete(), commitTxnResponse);
+                    LOG.debug("retryTime:{}, commitTxnResponse:{}", retryTime, commitTxnResponse);
                 }
                 if (commitTxnResponse.getStatus().getCode() != MetaServiceCode.KV_TXN_CONFLICT) {
                     break;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -704,7 +704,8 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 .setIs2Pc(is2PC)
                 .setCloudUniqueId(Config.cloud_unique_id)
                 .addAllBaseTabletIds(getBaseTabletsFromTables(tableList, tabletCommitInfos))
-                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit);
+                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit)
+                .setSupportsIncompleteLazyCommitResponse(true);
         for (OlapTable olapTable : mowTableList) {
             builder.addMowTableIds(olapTable.getId());
         }
@@ -1651,7 +1652,8 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 .setIs2Pc(false)
                 .setCloudUniqueId(Config.cloud_unique_id)
                 .setIsTxnLoad(true)
-                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit);
+                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit)
+                .setSupportsIncompleteLazyCommitResponse(true);
         for (OlapTable olapTable : mowTableList) {
             builder.addMowTableIds(olapTable.getId());
         }
@@ -2787,13 +2789,15 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
      */
     private void notifyBesMakeTmpRsVisible(CommitTxnResponse commitTxnResponse,
                                            List<TabletCommitInfo> tabletCommitInfos) {
-        if (commitTxnResponse.getIsLazyCommitIncomplete()) {
-            LOG.info("skip make cloud tmp rowsets visible for incomplete lazy commit, txn_id: {}",
-                    commitTxnResponse.getTxnInfo().getTxnId());
-            return;
-        }
         if (tabletCommitInfos == null || tabletCommitInfos.isEmpty()
                 || !Config.enable_notify_be_after_load_txn_commit) {
+            return;
+        }
+        if (!commitTxnResponse.hasIsLazyCommitIncomplete()
+                || commitTxnResponse.getIsLazyCommitIncomplete()) {
+            LOG.info("skip make cloud tmp rowsets visible because lazy commit completion is "
+                            + "unconfirmed or incomplete, txn_id: {}",
+                    commitTxnResponse.getTxnInfo().getTxnId());
             return;
         }
         long txnId = commitTxnResponse.getTxnInfo().getTxnId();

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -831,7 +831,9 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 }
                 commitTxnResponse = MetaServiceProxy.getInstance().commitTxn(commitTxnRequest);
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("retryTime:{}, commitTxnResponse:{}", retryTime, commitTxnResponse);
+                    LOG.debug("retryTime:{}, isLazyCommit:{}, isLazyCommitIncomplete:{}, commitTxnResponse:{}",
+                            retryTime, commitTxnResponse.getIsLazyCommit(),
+                            commitTxnResponse.getIsLazyCommitIncomplete(), commitTxnResponse);
                 }
                 if (commitTxnResponse.getStatus().getCode() != MetaServiceCode.KV_TXN_CONFLICT) {
                     break;
@@ -2787,7 +2789,8 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
      */
     private void notifyBesMakeTmpRsVisible(CommitTxnResponse commitTxnResponse,
                                            List<TabletCommitInfo> tabletCommitInfos) {
-        if (commitTxnResponse.getIsLazyCommitIncomplete()) {
+        if (commitTxnResponse.getIsLazyCommit()
+                && commitTxnResponse.getIsLazyCommitIncomplete()) {
             LOG.info("skip make cloud tmp rowsets visible for incomplete lazy commit, txn_id: {}",
                     commitTxnResponse.getTxnInfo().getTxnId());
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -2787,6 +2787,11 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
      */
     private void notifyBesMakeTmpRsVisible(CommitTxnResponse commitTxnResponse,
                                            List<TabletCommitInfo> tabletCommitInfos) {
+        if (commitTxnResponse.getIsPartialCommit()) {
+            LOG.info("skip make cloud tmp rowsets visible for partial commit, txn_id: {}",
+                    commitTxnResponse.getTxnInfo().getTxnId());
+            return;
+        }
         if (tabletCommitInfos == null || tabletCommitInfos.isEmpty()
                 || !Config.enable_notify_be_after_load_txn_commit) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -704,8 +704,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 .setIs2Pc(is2PC)
                 .setCloudUniqueId(Config.cloud_unique_id)
                 .addAllBaseTabletIds(getBaseTabletsFromTables(tableList, tabletCommitInfos))
-                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit)
-                .setSupportsIncompleteLazyCommitResponse(true);
+                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit);
         for (OlapTable olapTable : mowTableList) {
             builder.addMowTableIds(olapTable.getId());
         }
@@ -1652,8 +1651,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 .setIs2Pc(false)
                 .setCloudUniqueId(Config.cloud_unique_id)
                 .setIsTxnLoad(true)
-                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit)
-                .setSupportsIncompleteLazyCommitResponse(true);
+                .setEnableTxnLazyCommit(Config.enable_cloud_txn_lazy_commit);
         for (OlapTable olapTable : mowTableList) {
             builder.addMowTableIds(olapTable.getId());
         }
@@ -2789,15 +2787,13 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
      */
     private void notifyBesMakeTmpRsVisible(CommitTxnResponse commitTxnResponse,
                                            List<TabletCommitInfo> tabletCommitInfos) {
-        if (tabletCommitInfos == null || tabletCommitInfos.isEmpty()
-                || !Config.enable_notify_be_after_load_txn_commit) {
+        if (commitTxnResponse.getIsLazyCommitIncomplete()) {
+            LOG.info("skip make cloud tmp rowsets visible for incomplete lazy commit, txn_id: {}",
+                    commitTxnResponse.getTxnInfo().getTxnId());
             return;
         }
-        if (!commitTxnResponse.hasIsLazyCommitIncomplete()
-                || commitTxnResponse.getIsLazyCommitIncomplete()) {
-            LOG.info("skip make cloud tmp rowsets visible because lazy commit completion is "
-                            + "unconfirmed or incomplete, txn_id: {}",
-                    commitTxnResponse.getTxnInfo().getTxnId());
+        if (tabletCommitInfos == null || tabletCommitInfos.isEmpty()
+                || !Config.enable_notify_be_after_load_txn_commit) {
             return;
         }
         long txnId = commitTxnResponse.getTxnInfo().getTxnId();

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -37,7 +37,9 @@ import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.load.routineload.RLTaskTxnCommitAttachment;
+import org.apache.doris.thrift.TTabletCommitInfo;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TabletCommitInfo;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TxnStateChangeCallback;
 
@@ -51,6 +53,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CloudGlobalTransactionMgrTest {
@@ -200,6 +206,43 @@ public class CloudGlobalTransactionMgrTest {
                     .getTableOrMetaException(CatalogTestUtil.testTableId1);
             masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
                     transactionId, null, null);
+        }
+    }
+
+    @Test
+    public void testSkipMakeTmpRsVisibleForPartialCommit() throws Exception {
+        boolean originalEnableNotify = Config.enable_notify_be_after_load_txn_commit;
+        try {
+            Config.enable_notify_be_after_load_txn_commit = true;
+            AtomicBoolean notified = new AtomicBoolean(false);
+            CloudGlobalTransactionMgr transactionMgr = new CloudGlobalTransactionMgr() {
+                @Override
+                public void sendMakeCloudTmpRsVisibleTasks(long txnId,
+                        List<TTabletCommitInfo> commitInfos, Map<Long, Long> partitionVersionMap,
+                        long updateVersionVisibleTime) {
+                    notified.set(true);
+                }
+            };
+            Method notifyMethod = CloudGlobalTransactionMgr.class.getDeclaredMethod(
+                    "notifyBesMakeTmpRsVisible", CommitTxnResponse.class, List.class);
+            notifyMethod.setAccessible(true);
+
+            TxnInfoPB txnInfo = TxnInfoPB.newBuilder().setTxnId(12345L).build();
+            CommitTxnResponse partialCommitResponse = CommitTxnResponse.newBuilder()
+                    .setTxnInfo(txnInfo)
+                    .setIsPartialCommit(true)
+                    .build();
+            List<TabletCommitInfo> tabletCommitInfos =
+                    Lists.newArrayList(new TabletCommitInfo(10001L, 10002L));
+
+            notifyMethod.invoke(transactionMgr, partialCommitResponse, tabletCommitInfos);
+            Assert.assertFalse(notified.get());
+
+            notifyMethod.invoke(transactionMgr,
+                    partialCommitResponse.toBuilder().clearIsPartialCommit().build(), tabletCommitInfos);
+            Assert.assertTrue(notified.get());
+        } finally {
+            Config.enable_notify_be_after_load_txn_commit = originalEnableNotify;
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -206,11 +206,15 @@ public class CloudGlobalTransactionMgrTest {
                     .getTableOrMetaException(CatalogTestUtil.testTableId1);
             masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
                     transactionId, null, null);
+            ArgumentCaptor<Cloud.CommitTxnRequest> requestCaptor =
+                    ArgumentCaptor.forClass(Cloud.CommitTxnRequest.class);
+            Mockito.verify(mockProxy).commitTxn(requestCaptor.capture());
+            Assert.assertTrue(requestCaptor.getValue().getSupportsIncompleteLazyCommitResponse());
         }
     }
 
     @Test
-    public void testSkipMakeTmpRsVisibleForIncompleteLazyCommit() throws Exception {
+    public void testMakeTmpRsVisibleRequiresConfirmedCompleteLazyCommit() throws Exception {
         boolean originalEnableNotify = Config.enable_notify_be_after_load_txn_commit;
         try {
             Config.enable_notify_be_after_load_txn_commit = true;
@@ -240,6 +244,11 @@ public class CloudGlobalTransactionMgrTest {
 
             notifyMethod.invoke(transactionMgr,
                     incompleteLazyCommitResponse.toBuilder().clearIsLazyCommitIncomplete().build(),
+                    tabletCommitInfos);
+            Assert.assertFalse(notified.get());
+
+            notifyMethod.invoke(transactionMgr,
+                    incompleteLazyCommitResponse.toBuilder().setIsLazyCommitIncomplete(false).build(),
                     tabletCommitInfos);
             Assert.assertTrue(notified.get());
         } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -211,6 +211,49 @@ public class CloudGlobalTransactionMgrTest {
 
     @Test
     public void testSkipMakeTmpRsVisibleForIncompleteLazyCommit() throws Exception {
+        CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                .setTxnInfo(TxnInfoPB.newBuilder().setTxnId(12345L).build())
+                .setIsLazyCommit(true)
+                .setIsLazyCommitIncomplete(true)
+                .build();
+
+        Assert.assertFalse(invokeNotifyBesMakeTmpRsVisible(response));
+    }
+
+    @Test
+    public void testMakeTmpRsVisibleForNonLazyCommitWithIncompleteFlag() throws Exception {
+        CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                .setTxnInfo(TxnInfoPB.newBuilder().setTxnId(12346L).build())
+                .setIsLazyCommit(false)
+                .setIsLazyCommitIncomplete(true)
+                .build();
+
+        Assert.assertTrue(invokeNotifyBesMakeTmpRsVisible(response));
+    }
+
+    @Test
+    public void testMakeTmpRsVisibleForCompletedLazyCommit() throws Exception {
+        CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                .setTxnInfo(TxnInfoPB.newBuilder().setTxnId(12347L).build())
+                .setIsLazyCommit(true)
+                .setIsLazyCommitIncomplete(false)
+                .build();
+
+        Assert.assertTrue(invokeNotifyBesMakeTmpRsVisible(response));
+    }
+
+    @Test
+    public void testMakeTmpRsVisibleForNonLazyCommit() throws Exception {
+        CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                .setTxnInfo(TxnInfoPB.newBuilder().setTxnId(12348L).build())
+                .setIsLazyCommit(false)
+                .setIsLazyCommitIncomplete(false)
+                .build();
+
+        Assert.assertTrue(invokeNotifyBesMakeTmpRsVisible(response));
+    }
+
+    private boolean invokeNotifyBesMakeTmpRsVisible(CommitTxnResponse response) throws Exception {
         boolean originalEnableNotify = Config.enable_notify_be_after_load_txn_commit;
         try {
             Config.enable_notify_be_after_load_txn_commit = true;
@@ -227,37 +270,11 @@ public class CloudGlobalTransactionMgrTest {
                     "notifyBesMakeTmpRsVisible", CommitTxnResponse.class, List.class);
             notifyMethod.setAccessible(true);
 
-            TxnInfoPB txnInfo = TxnInfoPB.newBuilder().setTxnId(12345L).build();
-            CommitTxnResponse incompleteLazyCommitResponse = CommitTxnResponse.newBuilder()
-                    .setTxnInfo(txnInfo)
-                    .setIsLazyCommit(true)
-                    .setIsLazyCommitIncomplete(true)
-                    .build();
             List<TabletCommitInfo> tabletCommitInfos =
                     Lists.newArrayList(new TabletCommitInfo(10001L, 10002L));
 
-            notifyMethod.invoke(transactionMgr, incompleteLazyCommitResponse, tabletCommitInfos);
-            Assert.assertFalse(notified.get());
-
-            notifyMethod.invoke(transactionMgr,
-                    incompleteLazyCommitResponse.toBuilder().setIsLazyCommit(false).build(),
-                    tabletCommitInfos);
-            Assert.assertTrue(notified.get());
-
-            notified.set(false);
-            notifyMethod.invoke(transactionMgr,
-                    incompleteLazyCommitResponse.toBuilder().setIsLazyCommitIncomplete(false).build(),
-                    tabletCommitInfos);
-            Assert.assertTrue(notified.get());
-
-            notified.set(false);
-            notifyMethod.invoke(transactionMgr,
-                    incompleteLazyCommitResponse.toBuilder()
-                            .setIsLazyCommit(false)
-                            .setIsLazyCommitIncomplete(false)
-                            .build(),
-                    tabletCommitInfos);
-            Assert.assertTrue(notified.get());
+            notifyMethod.invoke(transactionMgr, response, tabletCommitInfos);
+            return notified.get();
         } finally {
             Config.enable_notify_be_after_load_txn_commit = originalEnableNotify;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -246,15 +246,15 @@ public class CloudGlobalTransactionMgrTest {
 
             notified.set(false);
             notifyMethod.invoke(transactionMgr,
-                    incompleteLazyCommitResponse.toBuilder().clearIsLazyCommitIncomplete().build(),
+                    incompleteLazyCommitResponse.toBuilder().setIsLazyCommitIncomplete(false).build(),
                     tabletCommitInfos);
             Assert.assertTrue(notified.get());
 
             notified.set(false);
             notifyMethod.invoke(transactionMgr,
                     incompleteLazyCommitResponse.toBuilder()
-                            .clearIsLazyCommit()
-                            .clearIsLazyCommitIncomplete()
+                            .setIsLazyCommit(false)
+                            .setIsLazyCommitIncomplete(false)
                             .build(),
                     tabletCommitInfos);
             Assert.assertTrue(notified.get());

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -206,15 +206,11 @@ public class CloudGlobalTransactionMgrTest {
                     .getTableOrMetaException(CatalogTestUtil.testTableId1);
             masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
                     transactionId, null, null);
-            ArgumentCaptor<Cloud.CommitTxnRequest> requestCaptor =
-                    ArgumentCaptor.forClass(Cloud.CommitTxnRequest.class);
-            Mockito.verify(mockProxy).commitTxn(requestCaptor.capture());
-            Assert.assertTrue(requestCaptor.getValue().getSupportsIncompleteLazyCommitResponse());
         }
     }
 
     @Test
-    public void testMakeTmpRsVisibleRequiresConfirmedCompleteLazyCommit() throws Exception {
+    public void testSkipMakeTmpRsVisibleForIncompleteLazyCommit() throws Exception {
         boolean originalEnableNotify = Config.enable_notify_be_after_load_txn_commit;
         try {
             Config.enable_notify_be_after_load_txn_commit = true;
@@ -244,11 +240,6 @@ public class CloudGlobalTransactionMgrTest {
 
             notifyMethod.invoke(transactionMgr,
                     incompleteLazyCommitResponse.toBuilder().clearIsLazyCommitIncomplete().build(),
-                    tabletCommitInfos);
-            Assert.assertFalse(notified.get());
-
-            notifyMethod.invoke(transactionMgr,
-                    incompleteLazyCommitResponse.toBuilder().setIsLazyCommitIncomplete(false).build(),
                     tabletCommitInfos);
             Assert.assertTrue(notified.get());
         } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -230,6 +230,7 @@ public class CloudGlobalTransactionMgrTest {
             TxnInfoPB txnInfo = TxnInfoPB.newBuilder().setTxnId(12345L).build();
             CommitTxnResponse incompleteLazyCommitResponse = CommitTxnResponse.newBuilder()
                     .setTxnInfo(txnInfo)
+                    .setIsLazyCommit(true)
                     .setIsLazyCommitIncomplete(true)
                     .build();
             List<TabletCommitInfo> tabletCommitInfos =
@@ -239,7 +240,22 @@ public class CloudGlobalTransactionMgrTest {
             Assert.assertFalse(notified.get());
 
             notifyMethod.invoke(transactionMgr,
+                    incompleteLazyCommitResponse.toBuilder().setIsLazyCommit(false).build(),
+                    tabletCommitInfos);
+            Assert.assertTrue(notified.get());
+
+            notified.set(false);
+            notifyMethod.invoke(transactionMgr,
                     incompleteLazyCommitResponse.toBuilder().clearIsLazyCommitIncomplete().build(),
+                    tabletCommitInfos);
+            Assert.assertTrue(notified.get());
+
+            notified.set(false);
+            notifyMethod.invoke(transactionMgr,
+                    incompleteLazyCommitResponse.toBuilder()
+                            .clearIsLazyCommit()
+                            .clearIsLazyCommitIncomplete()
+                            .build(),
                     tabletCommitInfos);
             Assert.assertTrue(notified.get());
         } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -210,7 +210,7 @@ public class CloudGlobalTransactionMgrTest {
     }
 
     @Test
-    public void testSkipMakeTmpRsVisibleForPartialCommit() throws Exception {
+    public void testSkipMakeTmpRsVisibleForIncompleteLazyCommit() throws Exception {
         boolean originalEnableNotify = Config.enable_notify_be_after_load_txn_commit;
         try {
             Config.enable_notify_be_after_load_txn_commit = true;
@@ -228,18 +228,19 @@ public class CloudGlobalTransactionMgrTest {
             notifyMethod.setAccessible(true);
 
             TxnInfoPB txnInfo = TxnInfoPB.newBuilder().setTxnId(12345L).build();
-            CommitTxnResponse partialCommitResponse = CommitTxnResponse.newBuilder()
+            CommitTxnResponse incompleteLazyCommitResponse = CommitTxnResponse.newBuilder()
                     .setTxnInfo(txnInfo)
-                    .setIsPartialCommit(true)
+                    .setIsLazyCommitIncomplete(true)
                     .build();
             List<TabletCommitInfo> tabletCommitInfos =
                     Lists.newArrayList(new TabletCommitInfo(10001L, 10002L));
 
-            notifyMethod.invoke(transactionMgr, partialCommitResponse, tabletCommitInfos);
+            notifyMethod.invoke(transactionMgr, incompleteLazyCommitResponse, tabletCommitInfos);
             Assert.assertFalse(notified.get());
 
             notifyMethod.invoke(transactionMgr,
-                    partialCommitResponse.toBuilder().clearIsPartialCommit().build(), tabletCommitInfos);
+                    incompleteLazyCommitResponse.toBuilder().clearIsLazyCommitIncomplete().build(),
+                    tabletCommitInfos);
             Assert.assertTrue(notified.get());
         } finally {
             Config.enable_notify_be_after_load_txn_commit = originalEnableNotify;

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1046,6 +1046,9 @@ message CommitTxnResponse {
     repeated int64 versions = 5;
     repeated TableStatsPB table_stats = 6;
     optional int64 version_update_time_ms = 7;
+    // The lazy commit has only completed its first phase. FE must not notify BE to make
+    // temporary rowsets visible until BE observes the final metadata from meta-service.
+    optional bool is_partial_commit = 8;
 }
 
 message AbortTxnRequest {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1046,11 +1046,11 @@ message CommitTxnResponse {
     repeated int64 versions = 5;
     repeated TableStatsPB table_stats = 6;
     optional int64 version_update_time_ms = 7;
+    // Whether this commit request used the lazy commit path.
+    optional bool is_lazy_commit = 8;
     // The lazy commit has only completed its first phase. FE must not notify BE to make
     // temporary rowsets visible until BE observes the final metadata from meta-service.
-    optional bool is_lazy_commit_incomplete = 8;
-    // Whether this commit request used the lazy commit path.
-    optional bool is_lazy_commit = 9;
+    optional bool is_lazy_commit_incomplete = 9;
 }
 
 message AbortTxnRequest {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1021,8 +1021,6 @@ message CommitTxnRequest {
     repeated SubTxnInfo sub_txn_infos = 10;
     optional bool enable_txn_lazy_commit = 11;
     optional string request_ip = 12;
-    // The caller can safely handle an OK response while lazy commit is incomplete.
-    optional bool supports_incomplete_lazy_commit_response = 13;
 }
 
 message SubTxnInfo {
@@ -1048,8 +1046,8 @@ message CommitTxnResponse {
     repeated int64 versions = 5;
     repeated TableStatsPB table_stats = 6;
     optional int64 version_update_time_ms = 7;
-    // Present when meta-service supports reporting lazy commit completion. Callers must not
-    // promote temporary rowsets when this field is absent or true.
+    // The lazy commit has only completed its first phase. FE must not notify BE to make
+    // temporary rowsets visible until BE observes the final metadata from meta-service.
     optional bool is_lazy_commit_incomplete = 8;
 }
 

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1021,6 +1021,8 @@ message CommitTxnRequest {
     repeated SubTxnInfo sub_txn_infos = 10;
     optional bool enable_txn_lazy_commit = 11;
     optional string request_ip = 12;
+    // The caller can safely handle an OK response while lazy commit is incomplete.
+    optional bool supports_incomplete_lazy_commit_response = 13;
 }
 
 message SubTxnInfo {
@@ -1046,8 +1048,8 @@ message CommitTxnResponse {
     repeated int64 versions = 5;
     repeated TableStatsPB table_stats = 6;
     optional int64 version_update_time_ms = 7;
-    // The lazy commit has only completed its first phase. FE must not notify BE to make
-    // temporary rowsets visible until BE observes the final metadata from meta-service.
+    // Present when meta-service supports reporting lazy commit completion. Callers must not
+    // promote temporary rowsets when this field is absent or true.
     optional bool is_lazy_commit_incomplete = 8;
 }
 

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1048,7 +1048,7 @@ message CommitTxnResponse {
     optional int64 version_update_time_ms = 7;
     // The lazy commit has only completed its first phase. FE must not notify BE to make
     // temporary rowsets visible until BE observes the final metadata from meta-service.
-    optional bool is_partial_commit = 8;
+    optional bool is_lazy_commit_incomplete = 8;
 }
 
 message AbortTxnRequest {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1049,6 +1049,8 @@ message CommitTxnResponse {
     // The lazy commit has only completed its first phase. FE must not notify BE to make
     // temporary rowsets visible until BE observes the final metadata from meta-service.
     optional bool is_lazy_commit_incomplete = 8;
+    // Whether this commit request used the lazy commit path.
+    optional bool is_lazy_commit = 9;
 }
 
 message AbortTxnRequest {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: https://github.com/apache/doris/pull/59754

Problem Summary: During a large cloud load, lazy commit can finish its first metadata phase but fail to complete the background promotion before the commit RPC returns. FE previously treated this response like a fully published transaction and notified BEs to make temporary rowsets visible immediately. A BE compaction could then consume rowsets that were not yet visible in meta-service, racing the lazy commit metadata update.

This change adds `is_lazy_commit` and `is_lazy_commit_incomplete` to the commit response. `is_lazy_commit` is false for an immediate commit and true when the current commit RPC enters the lazy commit path. Meta-service sets `is_lazy_commit_incomplete=true` after lazy commit phase one and explicitly sets it to false after lazy commit completes. FE skips the BE fast-path rowset promotion only when both fields are true, allowing BEs to observe the final rowset metadata from meta-service.

An idempotent retry handled by the immediate path reports `is_lazy_commit=false`. Existing FE debug and meta-service info logs retain the complete protobuf response, which already contains both fields. The BE direct-to-meta-service commit path adds a post-success debug log with both lazy commit states.

The lazy commit enable condition, rowset threshold, fuzzy forcing, immediate path, fallback behavior, and RPC status remain unchanged. Mixed-version rolling-upgrade compatibility is outside the scope of this PR.

### Release note

Fix a cloud metadata consistency issue between large transaction lazy commit and BE compaction.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test

Test commands:

```shell
./run-fe-ut.sh --run org.apache.doris.cloud.transaction.CloudGlobalTransactionMgrTest
BUILD_TYPE=ASAN ./run-cloud-ut.sh --run --filter=txn_lazy_commit_test:TxnLazyCommitTest.CommitTxnEventuallyWithFailedLazyCommitTaskTest -j 100
BUILD_TYPE=ASAN ./run-cloud-ut.sh --run --filter=txn_lazy_commit_test:TxnLazyCommitTest.CommitTxnImmediatelyTest -j 100
BUILD_TYPE=ASAN ./run-cloud-ut.sh --run --filter=txn_lazy_commit_test:TxnLazyCommitTest.ConcurrentCommitTxnEventuallyCase4Test -j 100
BUILD_TYPE=ASAN ./run-cloud-ut.sh --run --filter=txn_lazy_commit_test:TxnLazyCommitTest.CommitTxnEventuallyWithAbortAfterCommitTest -j 100
BUILD_TYPE=ASAN ./run-cloud-ut.sh --run --filter=txn_lazy_commit_test:TxnLazyCommitTest.NotFallThroughCommitTxnEventuallyTest -j 100
./build.sh --be -j 100
build-support/clang-format.sh
build-support/check-format.sh
```

The unit tests cover:

- immediate commit: `is_lazy_commit=false`, incomplete state is absent/default false, and BE promotion remains enabled
- lazy commit task failure: `is_lazy_commit=true`, response is OK with incomplete=true, transaction is committed, and temporary rowsets remain unpromoted
- interruption after lazy commit phase one: `is_lazy_commit=true` and response is OK with incomplete=true
- successful lazy commit: `is_lazy_commit=true` and `is_lazy_commit_incomplete` is explicitly present and false
- idempotent retry after lazy commit success: the immediate retry reports `is_lazy_commit=false` and incomplete state remains false
- lazy commit disabled: the original immediate/fallback behavior is unchanged
- FE handling: only `is_lazy_commit=true && is_lazy_commit_incomplete=true` skips BE promotion; all other tested field combinations permit the original fast path

- Behavior changed:
    - [ ] No
    - [x] Yes. FE skips BE rowset promotion while the current meta-service response reports an incomplete lazy commit.

- Does this need documentation?
    - [x] No
    - [ ] Yes
