### PR TITLE
[improvement](be) Add instance ID to hash join profiles

### DIFF
--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -56,6 +56,7 @@ Status HashJoinBuildSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo
     _task_idx = info.task_idx;
     auto& p = _parent->cast<HashJoinBuildSinkOperatorX>();
     _shared_state->join_op_variants = p._join_op_variants;
+    custom_profile()->add_info_string("InstanceID", print_id(state->fragment_instance_id()));
 
     _build_expr_ctxs.resize(p._build_expr_ctxs.size());
     for (size_t i = 0; i < _build_expr_ctxs.size(); i++) {

--- a/be/src/exec/operator/hashjoin_probe_operator.cpp
+++ b/be/src/exec/operator/hashjoin_probe_operator.cpp
@@ -30,6 +30,7 @@
 #include "core/data_type/data_type_nullable.h"
 #include "exec/operator/operator.h"
 #include "runtime/descriptors.h"
+#include "util/uid_util.h"
 
 namespace doris {
 HashJoinProbeLocalState::HashJoinProbeLocalState(RuntimeState* state, OperatorXBase* parent)
@@ -42,6 +43,7 @@ Status HashJoinProbeLocalState::init(RuntimeState* state, LocalStateInfo& info) 
     SCOPED_TIMER(_init_timer);
     _task_idx = info.task_idx;
     auto& p = _parent->cast<HashJoinProbeOperatorX>();
+    custom_profile()->add_info_string("InstanceID", print_id(state->fragment_instance_id()));
     _probe_expr_ctxs.resize(p._probe_expr_ctxs.size());
     for (size_t i = 0; i < _probe_expr_ctxs.size(); i++) {
         RETURN_IF_ERROR(p._probe_expr_ctxs[i]->clone(state, _probe_expr_ctxs[i]));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65761

Problem Summary:

This forward-ports #65761 from `opt_perf_4.1` to `master`.

Shuffle hash join build and probe operators run in separate pipelines, so their per-instance profiles are difficult to correlate. Add the fragment instance ID to both hash join build and probe custom profiles. Profiles with the same join node ID and `InstanceID` now identify the corresponding build/probe pair without relying on process-local hash table addresses.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test or manual test. The change only adds profile metadata.
        - `build-support/clang-format.sh` (passed)
        - `build-support/check-format.sh` (passed)
        - `git diff --check origin/master...HEAD` (passed)
        - `BUILD_TYPE=ASAN ./build.sh --be` (attempted; CMake configured successfully, but Ninja was blocked before compilation because this worktree lacks `thirdparty/installed/lib64/liblance_c.a`)
        - `thirdparty/build-thirdparty.sh lance_c` (attempted; blocked because the required Rust/Cargo 1.91 toolchain is unavailable)
        - `build-support/run-clang-tidy.sh --base origin/master --build-dir be/build_ASAN` (attempted; blocked by the existing `core/types.h` unmatched `NOLINTEND` and missing system `stddef.h`; no diagnostic identified on the added lines)
- [ ] This is a refactor/code format and no logic has been changed.
- Behavior changed:
    - [ ] No.
    - [x] Yes. Hash join build and probe profiles include `InstanceID`.
- Does this need documentation?
    - [x] No.
    - [ ] Yes.
