### PR TITLE
[fix](job) Avoid adaptive batching for Kafka tasks with low lag

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
@@ -914,6 +914,25 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
     }
 
+    boolean isTaskLagGreaterThanMaxBatchRows(Map<Integer, Long> partitionIdToOffset) {
+        long remainingRows = Math.max(maxBatchRows, RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS);
+        for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
+            Long latestOffset = cachedPartitionWithLatestOffsets.get(entry.getKey());
+            if (latestOffset == null) {
+                continue;
+            }
+            long partitionLag = latestOffset - entry.getValue();
+            if (partitionLag <= 0) {
+                continue;
+            }
+            if (partitionLag > remainingRows) {
+                return true;
+            }
+            remainingRows -= partitionLag;
+        }
+        return false;
+    }
+
     // check if given partitions has more data to consume.
     // 'partitionIdToOffset' to the offset to be consumed.
     public boolean hasMoreDataToConsume(UUID taskId, Map<Integer, Long> partitionIdToOffset) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaTaskInfo.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.load.routineload.RLTaskTxnCommitAttachment;
 import org.apache.doris.load.routineload.RoutineLoadJob;
@@ -39,6 +40,7 @@ import org.apache.doris.thrift.TPipelineWorkloadGroup;
 import org.apache.doris.thrift.TPlanFragment;
 import org.apache.doris.thrift.TRoutineLoadTask;
 import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
@@ -56,9 +58,15 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
     private RoutineLoadManager routineLoadManager = Env.getCurrentEnv().getRoutineLoadManager();
 
     private static final Logger LOG = LogManager.getLogger(KafkaTaskInfo.class);
+    private static final long ADAPTIVE_BATCH_BYTES_THRESHOLD = 1024L * 1024 * 1024;
 
     // <partitionId, offset to be consumed>
     private Map<Integer, Long> partitionIdToOffset;
+
+    private long previousTaskBytes;
+    private long previousTaskExecutionTimeMs;
+    private int adaptiveMinBatchIntervalSnapshotS;
+    private boolean adaptiveMinBatchIntervalCaptured;
 
     public KafkaTaskInfo(UUID id, long jobId,
                          long timeoutMs, Map<Integer, Long> partitionIdToOffset, boolean isMultiTable,
@@ -72,10 +80,21 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 kafkaTaskInfo.getTimeoutMs(), kafkaTaskInfo.getBeId(), isMultiTable,
                 kafkaTaskInfo.getLastScheduledTime(), kafkaTaskInfo.getIsEof());
         this.partitionIdToOffset = partitionIdToOffset;
+        if (kafkaTaskInfo.canReuseAdaptiveBatchSample()) {
+            this.previousTaskBytes = kafkaTaskInfo.previousTaskBytes;
+            this.previousTaskExecutionTimeMs = kafkaTaskInfo.previousTaskExecutionTimeMs;
+        }
     }
 
     public List<Integer> getPartitions() {
         return new ArrayList<>(partitionIdToOffset.keySet());
+    }
+
+    @Override
+    public void handleTaskByTxnCommitAttachment(RLTaskTxnCommitAttachment rlTaskTxnCommitAttachment) {
+        super.handleTaskByTxnCommitAttachment(rlTaskTxnCommitAttachment);
+        previousTaskBytes = rlTaskTxnCommitAttachment.getReceivedBytes();
+        previousTaskExecutionTimeMs = rlTaskTxnCommitAttachment.getTaskExecutionTimeMs();
     }
 
     @Override
@@ -126,9 +145,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
 
     @Override
     public void updateAdaptiveTimeout(RoutineLoadJob routineLoadJob) {
-        if (!isEof) {
+        adaptiveMinBatchIntervalSnapshotS = Config.routine_load_adaptive_min_batch_interval_sec;
+        adaptiveMinBatchIntervalCaptured = true;
+        if (shouldUseAdaptiveBatch(routineLoadJob)) {
             long maxBatchIntervalS = Math.max(routineLoadJob.getMaxBatchIntervalS(),
-                    Config.routine_load_adaptive_min_batch_interval_sec);
+                    adaptiveMinBatchIntervalSnapshotS);
             long timeoutSec = maxBatchIntervalS * Config.routine_load_task_timeout_multiplier;
             long realTimeoutSec = Math.max(timeoutSec, Config.routine_load_task_min_timeout_sec);
             this.timeoutMs = realTimeoutSec * 1000;
@@ -141,14 +162,43 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         long maxBatchIntervalS = routineLoadJob.getMaxBatchIntervalS();
         long maxBatchRows = routineLoadJob.getMaxBatchRows();
         long maxBatchSize = routineLoadJob.getMaxBatchSizeBytes();
-        if (!isEof) {
-            maxBatchIntervalS = Math.max(maxBatchIntervalS, Config.routine_load_adaptive_min_batch_interval_sec);
+        if (shouldUseAdaptiveBatch(routineLoadJob)) {
+            maxBatchIntervalS = Math.max(maxBatchIntervalS, adaptiveMinBatchIntervalSnapshotS);
             maxBatchRows = Math.max(maxBatchRows, RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS);
             maxBatchSize = Math.max(maxBatchSize, RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE);
         }
         tRoutineLoadTask.setMaxIntervalS(maxBatchIntervalS);
         tRoutineLoadTask.setMaxBatchRows(maxBatchRows);
         tRoutineLoadTask.setMaxBatchSize(maxBatchSize);
+    }
+
+    private boolean shouldUseAdaptiveBatch(RoutineLoadJob routineLoadJob) {
+        if (!adaptiveMinBatchIntervalCaptured) {
+            throw new IllegalStateException(
+                    "adaptive batch interval must be captured before beginning the transaction");
+        }
+        if (isEof) {
+            return false;
+        }
+        if (DebugPointUtil.isEnable("KafkaTaskInfo.shouldUseAdaptiveBatch")) {
+            return true;
+        }
+        if (previousTaskExecutionTimeMs <= 0) {
+            return false;
+        }
+        long adaptiveBatchIntervalMs = Math.max(routineLoadJob.getMaxBatchIntervalS(),
+                adaptiveMinBatchIntervalSnapshotS) * 1000L;
+        // Estimate the data volume in an adaptive interval from the previous task throughput.
+        return reachesAdaptiveBytesThreshold(adaptiveBatchIntervalMs);
+    }
+
+    private boolean reachesAdaptiveBytesThreshold(long adaptiveBatchIntervalMs) {
+        return (double) previousTaskBytes * adaptiveBatchIntervalMs
+                >= (double) ADAPTIVE_BATCH_BYTES_THRESHOLD * previousTaskExecutionTimeMs;
+    }
+
+    private boolean canReuseAdaptiveBatchSample() {
+        return !isRunning() || txnStatus == TransactionStatus.COMMITTED || txnStatus == TransactionStatus.VISIBLE;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaTaskInfo.java
@@ -40,7 +40,6 @@ import org.apache.doris.thrift.TPipelineWorkloadGroup;
 import org.apache.doris.thrift.TPlanFragment;
 import org.apache.doris.thrift.TRoutineLoadTask;
 import org.apache.doris.thrift.TUniqueId;
-import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
@@ -58,15 +57,12 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
     private RoutineLoadManager routineLoadManager = Env.getCurrentEnv().getRoutineLoadManager();
 
     private static final Logger LOG = LogManager.getLogger(KafkaTaskInfo.class);
-    private static final long ADAPTIVE_BATCH_BYTES_THRESHOLD = 1024L * 1024 * 1024;
 
     // <partitionId, offset to be consumed>
     private Map<Integer, Long> partitionIdToOffset;
 
-    private long previousTaskBytes;
-    private long previousTaskExecutionTimeMs;
-    private int adaptiveMinBatchIntervalSnapshotS;
-    private boolean adaptiveMinBatchIntervalCaptured;
+    private int adaptiveMinBatchInterval;
+    private boolean isAdaptiveBatch;
 
     public KafkaTaskInfo(UUID id, long jobId,
                          long timeoutMs, Map<Integer, Long> partitionIdToOffset, boolean isMultiTable,
@@ -80,21 +76,10 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 kafkaTaskInfo.getTimeoutMs(), kafkaTaskInfo.getBeId(), isMultiTable,
                 kafkaTaskInfo.getLastScheduledTime(), kafkaTaskInfo.getIsEof());
         this.partitionIdToOffset = partitionIdToOffset;
-        if (kafkaTaskInfo.canReuseAdaptiveBatchSample()) {
-            this.previousTaskBytes = kafkaTaskInfo.previousTaskBytes;
-            this.previousTaskExecutionTimeMs = kafkaTaskInfo.previousTaskExecutionTimeMs;
-        }
     }
 
     public List<Integer> getPartitions() {
         return new ArrayList<>(partitionIdToOffset.keySet());
-    }
-
-    @Override
-    public void handleTaskByTxnCommitAttachment(RLTaskTxnCommitAttachment rlTaskTxnCommitAttachment) {
-        super.handleTaskByTxnCommitAttachment(rlTaskTxnCommitAttachment);
-        previousTaskBytes = rlTaskTxnCommitAttachment.getReceivedBytes();
-        previousTaskExecutionTimeMs = rlTaskTxnCommitAttachment.getTaskExecutionTimeMs();
     }
 
     @Override
@@ -145,11 +130,13 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
 
     @Override
     public void updateAdaptiveTimeout(RoutineLoadJob routineLoadJob) {
-        adaptiveMinBatchIntervalSnapshotS = Config.routine_load_adaptive_min_batch_interval_sec;
-        adaptiveMinBatchIntervalCaptured = true;
-        if (shouldUseAdaptiveBatch(routineLoadJob)) {
+        adaptiveMinBatchInterval = Config.routine_load_adaptive_min_batch_interval_sec;
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = (KafkaRoutineLoadJob) routineLoadJob;
+        isAdaptiveBatch = DebugPointUtil.isEnable("KafkaTaskInfo.shouldUseAdaptiveBatch")
+                || kafkaRoutineLoadJob.isTaskLagGreaterThanMaxBatchRows(partitionIdToOffset);
+        if (isAdaptiveBatch) {
             long maxBatchIntervalS = Math.max(routineLoadJob.getMaxBatchIntervalS(),
-                    adaptiveMinBatchIntervalSnapshotS);
+                    adaptiveMinBatchInterval);
             long timeoutSec = maxBatchIntervalS * Config.routine_load_task_timeout_multiplier;
             long realTimeoutSec = Math.max(timeoutSec, Config.routine_load_task_min_timeout_sec);
             this.timeoutMs = realTimeoutSec * 1000;
@@ -162,43 +149,14 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         long maxBatchIntervalS = routineLoadJob.getMaxBatchIntervalS();
         long maxBatchRows = routineLoadJob.getMaxBatchRows();
         long maxBatchSize = routineLoadJob.getMaxBatchSizeBytes();
-        if (shouldUseAdaptiveBatch(routineLoadJob)) {
-            maxBatchIntervalS = Math.max(maxBatchIntervalS, adaptiveMinBatchIntervalSnapshotS);
+        if (isAdaptiveBatch) {
+            maxBatchIntervalS = Math.max(maxBatchIntervalS, adaptiveMinBatchInterval);
             maxBatchRows = Math.max(maxBatchRows, RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS);
             maxBatchSize = Math.max(maxBatchSize, RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE);
         }
         tRoutineLoadTask.setMaxIntervalS(maxBatchIntervalS);
         tRoutineLoadTask.setMaxBatchRows(maxBatchRows);
         tRoutineLoadTask.setMaxBatchSize(maxBatchSize);
-    }
-
-    private boolean shouldUseAdaptiveBatch(RoutineLoadJob routineLoadJob) {
-        if (!adaptiveMinBatchIntervalCaptured) {
-            throw new IllegalStateException(
-                    "adaptive batch interval must be captured before beginning the transaction");
-        }
-        if (isEof) {
-            return false;
-        }
-        if (DebugPointUtil.isEnable("KafkaTaskInfo.shouldUseAdaptiveBatch")) {
-            return true;
-        }
-        if (previousTaskExecutionTimeMs <= 0) {
-            return false;
-        }
-        long adaptiveBatchIntervalMs = Math.max(routineLoadJob.getMaxBatchIntervalS(),
-                adaptiveMinBatchIntervalSnapshotS) * 1000L;
-        // Estimate the data volume in an adaptive interval from the previous task throughput.
-        return reachesAdaptiveBytesThreshold(adaptiveBatchIntervalMs);
-    }
-
-    private boolean reachesAdaptiveBytesThreshold(long adaptiveBatchIntervalMs) {
-        return (double) previousTaskBytes * adaptiveBatchIntervalMs
-                >= (double) ADAPTIVE_BATCH_BYTES_THRESHOLD * previousTaskExecutionTimeMs;
-    }
-
-    private boolean canReuseAdaptiveBatchSample() {
-        return !isRunning() || txnStatus == TransactionStatus.COMMITTED || txnStatus == TransactionStatus.VISIBLE;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -46,6 +46,8 @@ import org.apache.doris.nereids.trees.plans.commands.load.LoadProperty;
 import org.apache.doris.nereids.trees.plans.commands.load.LoadSeparator;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TResourceInfo;
+import org.apache.doris.thrift.TRoutineLoadTask;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -391,12 +393,227 @@ public class KafkaRoutineLoadJobTest {
     }
 
     @Test
+    public void testAdaptiveBatchUsesInternalThroughputThreshold() {
+        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+        Env env = Mockito.mock(Env.class);
+        int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            Config.routine_load_adaptive_min_batch_interval_sec = 360;
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+
+            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                    1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+            Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", 20L);
+            Deencapsulation.setField(routineLoadJob, "maxBatchRows", 200000L);
+            Deencapsulation.setField(routineLoadJob, "maxBatchSizeBytes", 100L * 1024 * 1024);
+            Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
+
+            Map<Integer, Long> taskProgress = Maps.newHashMap();
+            taskProgress.put(1, 10L);
+
+            KafkaTaskInfo initialTask = new KafkaTaskInfo(new UUID(1, 1), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            initialTask.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask initialThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(initialTask, "adaptiveBatchParam", initialThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, initialThriftTask.getMaxIntervalS());
+            Assert.assertEquals(200000L, initialThriftTask.getMaxBatchRows());
+            Assert.assertEquals(100L * 1024 * 1024, initialThriftTask.getMaxBatchSize());
+
+            KafkaTaskInfo lowThroughputTask = new KafkaTaskInfo(new UUID(1, 2), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            RLTaskTxnCommitAttachment lowThroughputAttachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(lowThroughputAttachment, "loadedRows", 100000L);
+            Deencapsulation.setField(lowThroughputAttachment, "receivedBytes", 4L * 1024 * 1024);
+            Deencapsulation.setField(lowThroughputAttachment, "taskExecutionTimeMs", 20000L);
+            lowThroughputTask.handleTaskByTxnCommitAttachment(lowThroughputAttachment);
+            KafkaTaskInfo nextLowThroughputTask = new KafkaTaskInfo(lowThroughputTask, taskProgress, false);
+            nextLowThroughputTask.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask lowThroughputThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(nextLowThroughputTask, "adaptiveBatchParam",
+                    lowThroughputThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, lowThroughputThriftTask.getMaxIntervalS());
+            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, nextLowThroughputTask.getTimeoutMs());
+
+            KafkaTaskInfo adaptiveLowThroughputTask = new KafkaTaskInfo(new UUID(1, 5), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            RLTaskTxnCommitAttachment adaptiveLowThroughputAttachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(adaptiveLowThroughputAttachment, "loadedRows", 162458L);
+            Deencapsulation.setField(adaptiveLowThroughputAttachment, "receivedBytes", 70045427L);
+            Deencapsulation.setField(adaptiveLowThroughputAttachment, "taskExecutionTimeMs", 360000L);
+            adaptiveLowThroughputTask.handleTaskByTxnCommitAttachment(adaptiveLowThroughputAttachment);
+            KafkaTaskInfo nextAdaptiveLowThroughputTask =
+                    new KafkaTaskInfo(adaptiveLowThroughputTask, taskProgress, false);
+            nextAdaptiveLowThroughputTask.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask adaptiveLowThroughputThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(nextAdaptiveLowThroughputTask, "adaptiveBatchParam",
+                    adaptiveLowThroughputThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, adaptiveLowThroughputThriftTask.getMaxIntervalS());
+
+            KafkaTaskInfo highRowsOnlyTask = new KafkaTaskInfo(new UUID(1, 3), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            RLTaskTxnCommitAttachment highRowsOnlyAttachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(highRowsOnlyAttachment, "loadedRows", 2000000L);
+            Deencapsulation.setField(highRowsOnlyAttachment, "receivedBytes", 1L);
+            Deencapsulation.setField(highRowsOnlyAttachment, "taskExecutionTimeMs", 20000L);
+            highRowsOnlyTask.handleTaskByTxnCommitAttachment(highRowsOnlyAttachment);
+            KafkaTaskInfo nextHighRowsOnlyTask = new KafkaTaskInfo(highRowsOnlyTask, taskProgress, false);
+            nextHighRowsOnlyTask.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask highRowsOnlyThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(nextHighRowsOnlyTask, "adaptiveBatchParam",
+                    highRowsOnlyThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, highRowsOnlyThriftTask.getMaxIntervalS());
+            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, nextHighRowsOnlyTask.getTimeoutMs());
+
+            KafkaTaskInfo highBytesThroughputTask = new KafkaTaskInfo(new UUID(1, 4), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            RLTaskTxnCommitAttachment highBytesThroughputAttachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(highBytesThroughputAttachment, "loadedRows", 1L);
+            Deencapsulation.setField(highBytesThroughputAttachment, "receivedBytes", 100L * 1024 * 1024);
+            Deencapsulation.setField(highBytesThroughputAttachment, "taskExecutionTimeMs", 20000L);
+            highBytesThroughputTask.handleTaskByTxnCommitAttachment(highBytesThroughputAttachment);
+            KafkaTaskInfo nextHighBytesThroughputTask =
+                    new KafkaTaskInfo(highBytesThroughputTask, taskProgress, false);
+            nextHighBytesThroughputTask.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask highBytesThroughputThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(nextHighBytesThroughputTask, "adaptiveBatchParam",
+                    highBytesThroughputThriftTask, routineLoadJob);
+            Assert.assertEquals(360L, highBytesThroughputThriftTask.getMaxIntervalS());
+            Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS,
+                    highBytesThroughputThriftTask.getMaxBatchRows());
+            Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE,
+                    highBytesThroughputThriftTask.getMaxBatchSize());
+            Assert.assertEquals(360L * Config.routine_load_task_timeout_multiplier * 1000,
+                    nextHighBytesThroughputTask.getTimeoutMs());
+        } finally {
+            Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
+        }
+    }
+
+    @Test
+    public void testAdaptiveBatchSnapshotAcrossConfigChange() {
+        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+        Env env = Mockito.mock(Env.class);
+        int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            Config.routine_load_adaptive_min_batch_interval_sec = 360;
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+
+            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                    1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+            Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", 30L);
+            Deencapsulation.setField(routineLoadJob, "maxBatchRows", 50000000L);
+            Deencapsulation.setField(routineLoadJob, "maxBatchSizeBytes", 10L * 1024 * 1024 * 1024);
+            Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
+
+            Map<Integer, Long> taskProgress = Maps.newHashMap();
+            taskProgress.put(1, 10L);
+
+            KafkaTaskInfo completedTask = new KafkaTaskInfo(new UUID(1, 6), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(attachment, "loadedRows", 1000000L);
+            Deencapsulation.setField(attachment, "receivedBytes", 64L * 1024 * 1024);
+            Deencapsulation.setField(attachment, "taskExecutionTimeMs", 30000L);
+            completedTask.handleTaskByTxnCommitAttachment(attachment);
+
+            KafkaTaskInfo scheduledTask = new KafkaTaskInfo(completedTask, taskProgress, false);
+            scheduledTask.updateAdaptiveTimeout(routineLoadJob);
+            long normalTimeoutMs = Math.max(30L * Config.routine_load_task_timeout_multiplier,
+                    Config.routine_load_task_min_timeout_sec) * 1000L;
+            Assert.assertEquals(normalTimeoutMs, scheduledTask.getTimeoutMs());
+
+            Config.routine_load_adaptive_min_batch_interval_sec = 720;
+            TRoutineLoadTask scheduledThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(scheduledTask, "adaptiveBatchParam", scheduledThriftTask, routineLoadJob);
+            Assert.assertEquals(30L, scheduledThriftTask.getMaxIntervalS());
+            Assert.assertEquals(50000000L, scheduledThriftTask.getMaxBatchRows());
+            Assert.assertEquals(10L * 1024 * 1024 * 1024, scheduledThriftTask.getMaxBatchSize());
+            Assert.assertEquals(normalTimeoutMs, scheduledTask.getTimeoutMs());
+
+            KafkaTaskInfo nextSchedulingAttempt = new KafkaTaskInfo(completedTask, taskProgress, false);
+            nextSchedulingAttempt.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask nextThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(nextSchedulingAttempt, "adaptiveBatchParam", nextThriftTask, routineLoadJob);
+            Assert.assertEquals(720L, nextThriftTask.getMaxIntervalS());
+            Assert.assertEquals(720L * Config.routine_load_task_timeout_multiplier * 1000L,
+                    nextSchedulingAttempt.getTimeoutMs());
+
+            for (int nonPositiveInterval : new int[] {0, -1}) {
+                Config.routine_load_adaptive_min_batch_interval_sec = nonPositiveInterval;
+                KafkaTaskInfo nonPositiveConfigTask = new KafkaTaskInfo(completedTask, taskProgress, false);
+                nonPositiveConfigTask.updateAdaptiveTimeout(routineLoadJob);
+                TRoutineLoadTask nonPositiveConfigThriftTask = new TRoutineLoadTask();
+                Deencapsulation.invoke(nonPositiveConfigTask, "adaptiveBatchParam",
+                        nonPositiveConfigThriftTask, routineLoadJob);
+                Assert.assertEquals(30L, nonPositiveConfigThriftTask.getMaxIntervalS());
+                Assert.assertEquals(normalTimeoutMs, nonPositiveConfigTask.getTimeoutMs());
+            }
+        } finally {
+            Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
+        }
+    }
+
+    @Test
+    public void testAdaptiveBatchSampleInheritanceOnRenew() {
+        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+        Env env = Mockito.mock(Env.class);
+        int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            Config.routine_load_adaptive_min_batch_interval_sec = 360;
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+
+            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                    1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+            Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", 20L);
+            Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
+
+            Map<Integer, Long> taskProgress = Maps.newHashMap();
+            taskProgress.put(1, 10L);
+
+            KafkaTaskInfo committedTask = new KafkaTaskInfo(new UUID(1, 7), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(attachment, "receivedBytes", 100L * 1024 * 1024);
+            Deencapsulation.setField(attachment, "taskExecutionTimeMs", 20000L);
+            committedTask.handleTaskByTxnCommitAttachment(attachment);
+            committedTask.setExecuteStartTimeMs(System.currentTimeMillis());
+            committedTask.setTxnStatus(TransactionStatus.COMMITTED);
+
+            KafkaTaskInfo taskAfterCommit = new KafkaTaskInfo(committedTask, taskProgress, false);
+            taskAfterCommit.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask thriftTaskAfterCommit = new TRoutineLoadTask();
+            Deencapsulation.invoke(taskAfterCommit, "adaptiveBatchParam", thriftTaskAfterCommit, routineLoadJob);
+            Assert.assertEquals(360L, thriftTaskAfterCommit.getMaxIntervalS());
+
+            taskAfterCommit.setExecuteStartTimeMs(System.currentTimeMillis());
+            taskAfterCommit.setTxnStatus(TransactionStatus.ABORTED);
+            KafkaTaskInfo taskAfterAbort = new KafkaTaskInfo(taskAfterCommit, taskProgress, false);
+            taskAfterAbort.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask thriftTaskAfterAbort = new TRoutineLoadTask();
+            Deencapsulation.invoke(taskAfterAbort, "adaptiveBatchParam", thriftTaskAfterAbort, routineLoadJob);
+            Assert.assertEquals(20L, thriftTaskAfterAbort.getMaxIntervalS());
+            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, taskAfterAbort.getTimeoutMs());
+        } finally {
+            Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
+        }
+    }
+
+    @Test
     public void testProcessTimeOutTasks() throws Exception {
         RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
         Env env = Mockito.mock(Env.class);
         RoutineLoadTaskScheduler routineLoadTaskScheduler = Mockito.mock(RoutineLoadTaskScheduler.class);
+        int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
 
         try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            Config.routine_load_adaptive_min_batch_interval_sec = 360;
             envStatic.when(Env::getCurrentEnv).thenReturn(env);
             Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
             Mockito.when(env.getRoutineLoadTaskScheduler()).thenReturn(routineLoadTaskScheduler);
@@ -406,12 +623,17 @@ public class KafkaRoutineLoadJobTest {
                             1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
             long maxBatchIntervalS = 10;
             Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", maxBatchIntervalS);
+            Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
 
             List<RoutineLoadTaskInfo> routineLoadTaskInfoList = new ArrayList<>();
             Map<Integer, Long> partitionIdsToOffset = Maps.newHashMap();
             partitionIdsToOffset.put(100, 0L);
             KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L,
                     maxBatchIntervalS * 2 * 1000, partitionIdsToOffset, false, -1, false);
+            RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
+            Deencapsulation.setField(attachment, "receivedBytes", 100L * 1024 * 1024);
+            Deencapsulation.setField(attachment, "taskExecutionTimeMs", 20000L);
+            kafkaTaskInfo.handleTaskByTxnCommitAttachment(attachment);
             kafkaTaskInfo.setExecuteStartTimeMs(System.currentTimeMillis() - maxBatchIntervalS * 2 * 1000 - 1);
             routineLoadTaskInfoList.add(kafkaTaskInfo);
 
@@ -423,6 +645,13 @@ public class KafkaRoutineLoadJobTest {
                     Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
             Assert.assertNotEquals("1", idToRoutineLoadTask.get(0).getId());
             Assert.assertEquals(1, idToRoutineLoadTask.size());
+            KafkaTaskInfo taskAfterTimeout = (KafkaTaskInfo) idToRoutineLoadTask.get(0);
+            taskAfterTimeout.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask thriftTaskAfterTimeout = new TRoutineLoadTask();
+            Deencapsulation.invoke(taskAfterTimeout, "adaptiveBatchParam", thriftTaskAfterTimeout, routineLoadJob);
+            Assert.assertEquals(maxBatchIntervalS, thriftTaskAfterTimeout.getMaxIntervalS());
+        } finally {
+            Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -47,7 +47,6 @@ import org.apache.doris.nereids.trees.plans.commands.load.LoadSeparator;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TResourceInfo;
 import org.apache.doris.thrift.TRoutineLoadTask;
-import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -393,7 +392,7 @@ public class KafkaRoutineLoadJobTest {
     }
 
     @Test
-    public void testAdaptiveBatchUsesInternalThroughputThreshold() {
+    public void testAdaptiveBatchUsesTaskLagThreshold() {
         RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
         Env env = Mockito.mock(Env.class);
         int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
@@ -412,88 +411,78 @@ public class KafkaRoutineLoadJobTest {
 
             Map<Integer, Long> taskProgress = Maps.newHashMap();
             taskProgress.put(1, 10L);
+            taskProgress.put(2, 20L);
 
-            KafkaTaskInfo initialTask = new KafkaTaskInfo(new UUID(1, 1), 1L, 20000,
+            KafkaTaskInfo taskWithUnknownLag = new KafkaTaskInfo(new UUID(1, 1), 1L, 20000,
                     taskProgress, false, 1000, false);
-            initialTask.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask initialThriftTask = new TRoutineLoadTask();
-            Deencapsulation.invoke(initialTask, "adaptiveBatchParam", initialThriftTask, routineLoadJob);
-            Assert.assertEquals(20L, initialThriftTask.getMaxIntervalS());
-            Assert.assertEquals(200000L, initialThriftTask.getMaxBatchRows());
-            Assert.assertEquals(100L * 1024 * 1024, initialThriftTask.getMaxBatchSize());
+            taskWithUnknownLag.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask unknownLagThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(
+                    taskWithUnknownLag, "adaptiveBatchParam", unknownLagThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, unknownLagThriftTask.getMaxIntervalS());
 
-            KafkaTaskInfo lowThroughputTask = new KafkaTaskInfo(new UUID(1, 2), 1L, 20000,
-                    taskProgress, false, 1000, false);
-            RLTaskTxnCommitAttachment lowThroughputAttachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(lowThroughputAttachment, "loadedRows", 100000L);
-            Deencapsulation.setField(lowThroughputAttachment, "receivedBytes", 4L * 1024 * 1024);
-            Deencapsulation.setField(lowThroughputAttachment, "taskExecutionTimeMs", 20000L);
-            lowThroughputTask.handleTaskByTxnCommitAttachment(lowThroughputAttachment);
-            KafkaTaskInfo nextLowThroughputTask = new KafkaTaskInfo(lowThroughputTask, taskProgress, false);
-            nextLowThroughputTask.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask lowThroughputThriftTask = new TRoutineLoadTask();
-            Deencapsulation.invoke(nextLowThroughputTask, "adaptiveBatchParam",
-                    lowThroughputThriftTask, routineLoadJob);
-            Assert.assertEquals(20L, lowThroughputThriftTask.getMaxIntervalS());
-            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, nextLowThroughputTask.getTimeoutMs());
+            Map<Integer, Long> latestOffsets = Maps.newHashMap();
+            latestOffsets.put(1, 10_000_010L);
+            latestOffsets.put(2, 10_000_020L);
+            latestOffsets.put(3, 100_000_000L);
+            Deencapsulation.setField(routineLoadJob, "cachedPartitionWithLatestOffsets", latestOffsets);
 
-            KafkaTaskInfo adaptiveLowThroughputTask = new KafkaTaskInfo(new UUID(1, 5), 1L, 20000,
+            KafkaTaskInfo taskAtLagThreshold = new KafkaTaskInfo(new UUID(1, 2), 1L, 20000,
                     taskProgress, false, 1000, false);
-            RLTaskTxnCommitAttachment adaptiveLowThroughputAttachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(adaptiveLowThroughputAttachment, "loadedRows", 162458L);
-            Deencapsulation.setField(adaptiveLowThroughputAttachment, "receivedBytes", 70045427L);
-            Deencapsulation.setField(adaptiveLowThroughputAttachment, "taskExecutionTimeMs", 360000L);
-            adaptiveLowThroughputTask.handleTaskByTxnCommitAttachment(adaptiveLowThroughputAttachment);
-            KafkaTaskInfo nextAdaptiveLowThroughputTask =
-                    new KafkaTaskInfo(adaptiveLowThroughputTask, taskProgress, false);
-            nextAdaptiveLowThroughputTask.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask adaptiveLowThroughputThriftTask = new TRoutineLoadTask();
-            Deencapsulation.invoke(nextAdaptiveLowThroughputTask, "adaptiveBatchParam",
-                    adaptiveLowThroughputThriftTask, routineLoadJob);
-            Assert.assertEquals(20L, adaptiveLowThroughputThriftTask.getMaxIntervalS());
+            taskAtLagThreshold.updateAdaptiveTimeout(routineLoadJob);
+            latestOffsets.put(2, 10_000_021L);
+            TRoutineLoadTask thresholdThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(
+                    taskAtLagThreshold, "adaptiveBatchParam", thresholdThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, thresholdThriftTask.getMaxIntervalS());
+            Assert.assertEquals(200000L, thresholdThriftTask.getMaxBatchRows());
+            Assert.assertEquals(100L * 1024 * 1024, thresholdThriftTask.getMaxBatchSize());
+            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, taskAtLagThreshold.getTimeoutMs());
 
-            KafkaTaskInfo highRowsOnlyTask = new KafkaTaskInfo(new UUID(1, 3), 1L, 20000,
-                    taskProgress, false, 1000, false);
-            RLTaskTxnCommitAttachment highRowsOnlyAttachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(highRowsOnlyAttachment, "loadedRows", 2000000L);
-            Deencapsulation.setField(highRowsOnlyAttachment, "receivedBytes", 1L);
-            Deencapsulation.setField(highRowsOnlyAttachment, "taskExecutionTimeMs", 20000L);
-            highRowsOnlyTask.handleTaskByTxnCommitAttachment(highRowsOnlyAttachment);
-            KafkaTaskInfo nextHighRowsOnlyTask = new KafkaTaskInfo(highRowsOnlyTask, taskProgress, false);
-            nextHighRowsOnlyTask.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask highRowsOnlyThriftTask = new TRoutineLoadTask();
-            Deencapsulation.invoke(nextHighRowsOnlyTask, "adaptiveBatchParam",
-                    highRowsOnlyThriftTask, routineLoadJob);
-            Assert.assertEquals(20L, highRowsOnlyThriftTask.getMaxIntervalS());
-            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, nextHighRowsOnlyTask.getTimeoutMs());
-
-            KafkaTaskInfo highBytesThroughputTask = new KafkaTaskInfo(new UUID(1, 4), 1L, 20000,
-                    taskProgress, false, 1000, false);
-            RLTaskTxnCommitAttachment highBytesThroughputAttachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(highBytesThroughputAttachment, "loadedRows", 1L);
-            Deencapsulation.setField(highBytesThroughputAttachment, "receivedBytes", 100L * 1024 * 1024);
-            Deencapsulation.setField(highBytesThroughputAttachment, "taskExecutionTimeMs", 20000L);
-            highBytesThroughputTask.handleTaskByTxnCommitAttachment(highBytesThroughputAttachment);
-            KafkaTaskInfo nextHighBytesThroughputTask =
-                    new KafkaTaskInfo(highBytesThroughputTask, taskProgress, false);
-            nextHighBytesThroughputTask.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask highBytesThroughputThriftTask = new TRoutineLoadTask();
-            Deencapsulation.invoke(nextHighBytesThroughputTask, "adaptiveBatchParam",
-                    highBytesThroughputThriftTask, routineLoadJob);
-            Assert.assertEquals(360L, highBytesThroughputThriftTask.getMaxIntervalS());
+            KafkaTaskInfo taskAboveLagThreshold = new KafkaTaskInfo(new UUID(1, 3), 1L, 20000,
+                    taskProgress, false, 1000, true);
+            taskAboveLagThreshold.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask adaptiveThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(
+                    taskAboveLagThreshold, "adaptiveBatchParam", adaptiveThriftTask, routineLoadJob);
+            Assert.assertEquals(360L, adaptiveThriftTask.getMaxIntervalS());
             Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS,
-                    highBytesThroughputThriftTask.getMaxBatchRows());
+                    adaptiveThriftTask.getMaxBatchRows());
             Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE,
-                    highBytesThroughputThriftTask.getMaxBatchSize());
+                    adaptiveThriftTask.getMaxBatchSize());
             Assert.assertEquals(360L * Config.routine_load_task_timeout_multiplier * 1000,
-                    nextHighBytesThroughputTask.getTimeoutMs());
+                    taskAboveLagThreshold.getTimeoutMs());
+
+            Deencapsulation.setField(routineLoadJob, "maxBatchRows", 50_000_000L);
+            latestOffsets.put(1, 25_000_010L);
+            latestOffsets.put(2, 25_000_020L);
+            KafkaTaskInfo taskAtConfiguredLagThreshold = new KafkaTaskInfo(new UUID(1, 4), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            taskAtConfiguredLagThreshold.updateAdaptiveTimeout(routineLoadJob);
+            latestOffsets.put(2, 25_000_021L);
+            TRoutineLoadTask configuredThresholdThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(taskAtConfiguredLagThreshold, "adaptiveBatchParam",
+                    configuredThresholdThriftTask, routineLoadJob);
+            Assert.assertEquals(20L, configuredThresholdThriftTask.getMaxIntervalS());
+            Assert.assertEquals(50_000_000L, configuredThresholdThriftTask.getMaxBatchRows());
+            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L,
+                    taskAtConfiguredLagThreshold.getTimeoutMs());
+
+            KafkaTaskInfo taskAboveConfiguredLagThreshold = new KafkaTaskInfo(new UUID(1, 5), 1L, 20000,
+                    taskProgress, false, 1000, false);
+            taskAboveConfiguredLagThreshold.updateAdaptiveTimeout(routineLoadJob);
+            TRoutineLoadTask configuredAdaptiveThriftTask = new TRoutineLoadTask();
+            Deencapsulation.invoke(taskAboveConfiguredLagThreshold, "adaptiveBatchParam",
+                    configuredAdaptiveThriftTask, routineLoadJob);
+            Assert.assertEquals(360L, configuredAdaptiveThriftTask.getMaxIntervalS());
+            Assert.assertEquals(50_000_000L, configuredAdaptiveThriftTask.getMaxBatchRows());
         } finally {
             Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
         }
     }
 
     @Test
-    public void testAdaptiveBatchSnapshotAcrossConfigChange() {
+    public void testAdaptiveBatchUsesCapturedIntervalAcrossConfigChange() {
         RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
         Env env = Mockito.mock(Env.class);
         int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
@@ -506,36 +495,32 @@ public class KafkaRoutineLoadJobTest {
             KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
                     1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
             Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", 30L);
-            Deencapsulation.setField(routineLoadJob, "maxBatchRows", 50000000L);
-            Deencapsulation.setField(routineLoadJob, "maxBatchSizeBytes", 10L * 1024 * 1024 * 1024);
+            Deencapsulation.setField(routineLoadJob, "maxBatchRows", 200000L);
+            Deencapsulation.setField(routineLoadJob, "maxBatchSizeBytes", 100L * 1024 * 1024);
             Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
 
             Map<Integer, Long> taskProgress = Maps.newHashMap();
             taskProgress.put(1, 10L);
+            Map<Integer, Long> latestOffsets = Maps.newHashMap();
+            latestOffsets.put(1, 20_000_011L);
+            Deencapsulation.setField(routineLoadJob, "cachedPartitionWithLatestOffsets", latestOffsets);
 
-            KafkaTaskInfo completedTask = new KafkaTaskInfo(new UUID(1, 6), 1L, 20000,
+            KafkaTaskInfo scheduledTask = new KafkaTaskInfo(new UUID(1, 6), 1L, 20000,
                     taskProgress, false, 1000, false);
-            RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(attachment, "loadedRows", 1000000L);
-            Deencapsulation.setField(attachment, "receivedBytes", 64L * 1024 * 1024);
-            Deencapsulation.setField(attachment, "taskExecutionTimeMs", 30000L);
-            completedTask.handleTaskByTxnCommitAttachment(attachment);
-
-            KafkaTaskInfo scheduledTask = new KafkaTaskInfo(completedTask, taskProgress, false);
             scheduledTask.updateAdaptiveTimeout(routineLoadJob);
-            long normalTimeoutMs = Math.max(30L * Config.routine_load_task_timeout_multiplier,
-                    Config.routine_load_task_min_timeout_sec) * 1000L;
-            Assert.assertEquals(normalTimeoutMs, scheduledTask.getTimeoutMs());
+            long adaptiveTimeoutMs = 360L * Config.routine_load_task_timeout_multiplier * 1000L;
+            Assert.assertEquals(adaptiveTimeoutMs, scheduledTask.getTimeoutMs());
 
             Config.routine_load_adaptive_min_batch_interval_sec = 720;
             TRoutineLoadTask scheduledThriftTask = new TRoutineLoadTask();
             Deencapsulation.invoke(scheduledTask, "adaptiveBatchParam", scheduledThriftTask, routineLoadJob);
-            Assert.assertEquals(30L, scheduledThriftTask.getMaxIntervalS());
-            Assert.assertEquals(50000000L, scheduledThriftTask.getMaxBatchRows());
-            Assert.assertEquals(10L * 1024 * 1024 * 1024, scheduledThriftTask.getMaxBatchSize());
-            Assert.assertEquals(normalTimeoutMs, scheduledTask.getTimeoutMs());
+            Assert.assertEquals(360L, scheduledThriftTask.getMaxIntervalS());
+            Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS, scheduledThriftTask.getMaxBatchRows());
+            Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE, scheduledThriftTask.getMaxBatchSize());
+            Assert.assertEquals(adaptiveTimeoutMs, scheduledTask.getTimeoutMs());
 
-            KafkaTaskInfo nextSchedulingAttempt = new KafkaTaskInfo(completedTask, taskProgress, false);
+            KafkaTaskInfo nextSchedulingAttempt = new KafkaTaskInfo(new UUID(1, 7), 1L, 20000,
+                    taskProgress, false, 1000, false);
             nextSchedulingAttempt.updateAdaptiveTimeout(routineLoadJob);
             TRoutineLoadTask nextThriftTask = new TRoutineLoadTask();
             Deencapsulation.invoke(nextSchedulingAttempt, "adaptiveBatchParam", nextThriftTask, routineLoadJob);
@@ -545,61 +530,21 @@ public class KafkaRoutineLoadJobTest {
 
             for (int nonPositiveInterval : new int[] {0, -1}) {
                 Config.routine_load_adaptive_min_batch_interval_sec = nonPositiveInterval;
-                KafkaTaskInfo nonPositiveConfigTask = new KafkaTaskInfo(completedTask, taskProgress, false);
+                KafkaTaskInfo nonPositiveConfigTask = new KafkaTaskInfo(new UUID(1, 8), 1L, 20000,
+                        taskProgress, false, 1000, false);
                 nonPositiveConfigTask.updateAdaptiveTimeout(routineLoadJob);
                 TRoutineLoadTask nonPositiveConfigThriftTask = new TRoutineLoadTask();
                 Deencapsulation.invoke(nonPositiveConfigTask, "adaptiveBatchParam",
                         nonPositiveConfigThriftTask, routineLoadJob);
                 Assert.assertEquals(30L, nonPositiveConfigThriftTask.getMaxIntervalS());
+                Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS,
+                        nonPositiveConfigThriftTask.getMaxBatchRows());
+                Assert.assertEquals(RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE,
+                        nonPositiveConfigThriftTask.getMaxBatchSize());
+                long normalTimeoutMs = Math.max(30L * Config.routine_load_task_timeout_multiplier,
+                        Config.routine_load_task_min_timeout_sec) * 1000L;
                 Assert.assertEquals(normalTimeoutMs, nonPositiveConfigTask.getTimeoutMs());
             }
-        } finally {
-            Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
-        }
-    }
-
-    @Test
-    public void testAdaptiveBatchSampleInheritanceOnRenew() {
-        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
-        Env env = Mockito.mock(Env.class);
-        int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
-
-        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
-            Config.routine_load_adaptive_min_batch_interval_sec = 360;
-            envStatic.when(Env::getCurrentEnv).thenReturn(env);
-            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
-
-            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
-                    1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
-            Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", 20L);
-            Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
-
-            Map<Integer, Long> taskProgress = Maps.newHashMap();
-            taskProgress.put(1, 10L);
-
-            KafkaTaskInfo committedTask = new KafkaTaskInfo(new UUID(1, 7), 1L, 20000,
-                    taskProgress, false, 1000, false);
-            RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(attachment, "receivedBytes", 100L * 1024 * 1024);
-            Deencapsulation.setField(attachment, "taskExecutionTimeMs", 20000L);
-            committedTask.handleTaskByTxnCommitAttachment(attachment);
-            committedTask.setExecuteStartTimeMs(System.currentTimeMillis());
-            committedTask.setTxnStatus(TransactionStatus.COMMITTED);
-
-            KafkaTaskInfo taskAfterCommit = new KafkaTaskInfo(committedTask, taskProgress, false);
-            taskAfterCommit.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask thriftTaskAfterCommit = new TRoutineLoadTask();
-            Deencapsulation.invoke(taskAfterCommit, "adaptiveBatchParam", thriftTaskAfterCommit, routineLoadJob);
-            Assert.assertEquals(360L, thriftTaskAfterCommit.getMaxIntervalS());
-
-            taskAfterCommit.setExecuteStartTimeMs(System.currentTimeMillis());
-            taskAfterCommit.setTxnStatus(TransactionStatus.ABORTED);
-            KafkaTaskInfo taskAfterAbort = new KafkaTaskInfo(taskAfterCommit, taskProgress, false);
-            taskAfterAbort.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask thriftTaskAfterAbort = new TRoutineLoadTask();
-            Deencapsulation.invoke(taskAfterAbort, "adaptiveBatchParam", thriftTaskAfterAbort, routineLoadJob);
-            Assert.assertEquals(20L, thriftTaskAfterAbort.getMaxIntervalS());
-            Assert.assertEquals(routineLoadJob.getTimeout() * 1000L, taskAfterAbort.getTimeoutMs());
         } finally {
             Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
         }
@@ -610,10 +555,8 @@ public class KafkaRoutineLoadJobTest {
         RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
         Env env = Mockito.mock(Env.class);
         RoutineLoadTaskScheduler routineLoadTaskScheduler = Mockito.mock(RoutineLoadTaskScheduler.class);
-        int previousAdaptiveIntervalSec = Config.routine_load_adaptive_min_batch_interval_sec;
 
         try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
-            Config.routine_load_adaptive_min_batch_interval_sec = 360;
             envStatic.when(Env::getCurrentEnv).thenReturn(env);
             Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
             Mockito.when(env.getRoutineLoadTaskScheduler()).thenReturn(routineLoadTaskScheduler);
@@ -623,17 +566,12 @@ public class KafkaRoutineLoadJobTest {
                             1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
             long maxBatchIntervalS = 10;
             Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", maxBatchIntervalS);
-            Mockito.when(routineLoadManager.getJob(1L)).thenReturn(routineLoadJob);
 
             List<RoutineLoadTaskInfo> routineLoadTaskInfoList = new ArrayList<>();
             Map<Integer, Long> partitionIdsToOffset = Maps.newHashMap();
             partitionIdsToOffset.put(100, 0L);
             KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L,
                     maxBatchIntervalS * 2 * 1000, partitionIdsToOffset, false, -1, false);
-            RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
-            Deencapsulation.setField(attachment, "receivedBytes", 100L * 1024 * 1024);
-            Deencapsulation.setField(attachment, "taskExecutionTimeMs", 20000L);
-            kafkaTaskInfo.handleTaskByTxnCommitAttachment(attachment);
             kafkaTaskInfo.setExecuteStartTimeMs(System.currentTimeMillis() - maxBatchIntervalS * 2 * 1000 - 1);
             routineLoadTaskInfoList.add(kafkaTaskInfo);
 
@@ -645,13 +583,6 @@ public class KafkaRoutineLoadJobTest {
                     Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
             Assert.assertNotEquals("1", idToRoutineLoadTask.get(0).getId());
             Assert.assertEquals(1, idToRoutineLoadTask.size());
-            KafkaTaskInfo taskAfterTimeout = (KafkaTaskInfo) idToRoutineLoadTask.get(0);
-            taskAfterTimeout.updateAdaptiveTimeout(routineLoadJob);
-            TRoutineLoadTask thriftTaskAfterTimeout = new TRoutineLoadTask();
-            Deencapsulation.invoke(taskAfterTimeout, "adaptiveBatchParam", thriftTaskAfterTimeout, routineLoadJob);
-            Assert.assertEquals(maxBatchIntervalS, thriftTaskAfterTimeout.getMaxIntervalS());
-        } finally {
-            Config.routine_load_adaptive_min_batch_interval_sec = previousAdaptiveIntervalSec;
         }
     }
 

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
@@ -65,9 +65,11 @@ suite("test_routine_load_adaptive_param","nonConcurrent") {
                 );
             """
 
-            def injection = "RoutineLoadTaskInfo.judgeEof"
+            def eofInjection = "RoutineLoadTaskInfo.judgeEof"
+            def adaptiveBatchInjection = "KafkaTaskInfo.shouldUseAdaptiveBatch"
             try {
-                GetDebugPoint().enableDebugPointForAllFEs(injection)
+                GetDebugPoint().enableDebugPointForAllFEs(eofInjection)
+                GetDebugPoint().enableDebugPointForAllFEs(adaptiveBatchInjection)
 
                 RoutineLoadTestUtils.sendTestDataToKafka(producer, kafkaCsvTpoics)
                 RoutineLoadTestUtils.waitForTaskFinish(runSql, job, tableName, 0)
@@ -82,7 +84,8 @@ suite("test_routine_load_adaptive_param","nonConcurrent") {
                 RoutineLoadTestUtils.checkTxnTimeoutMatchesTaskTimeout(runSql, producer, kafkaCsvTpoics, job, "3600000")
                 RoutineLoadTestUtils.waitForTaskFinish(runSql, job, tableName, 2)
             } finally {
-                GetDebugPoint().disableDebugPointForAllFEs(injection)
+                GetDebugPoint().disableDebugPointForAllFEs(adaptiveBatchInjection)
+                GetDebugPoint().disableDebugPointForAllFEs(eofInjection)
             }
 
             logger.info("---test restore adaptively---")

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
@@ -76,8 +76,8 @@ suite("test_routine_load_adaptive_param","nonConcurrent") {
                 
                 logger.info("---test adaptively increase---")
                 RoutineLoadTestUtils.sendTestDataToKafka(producer, kafkaCsvTpoics)
-                // Drive data each round so an isEof=false task keeps being scheduled. The converged
-                // adaptive timeout (3600) lives on the renewed idle task (txnId == -1), so both checks
+                // Drive data each round so a task keeps being scheduled. The converged adaptive timeout
+                // (3600) lives on the renewed idle task (txnId == -1), so both checks
                 // poll by value (task timeout col, and the committed txn's persisted timeout looked up
                 // by task-UUID label) instead of racing a sub-second running task.
                 RoutineLoadTestUtils.checkTaskTimeoutWithData(runSql, producer, kafkaCsvTpoics, job, "3600")
@@ -91,8 +91,7 @@ suite("test_routine_load_adaptive_param","nonConcurrent") {
             logger.info("---test restore adaptively---")
             RoutineLoadTestUtils.sendTestDataToKafka(producer, kafkaCsvTpoics)
             RoutineLoadTestUtils.waitForTaskFinish(runSql, job, tableName, 4)
-            // After EOF the adaptive timeout only converges when an isEof task is scheduled with
-            // data, so keep feeding small batches until the task timeout restores to the job timeout.
+            // Keep feeding small batches until the low task lag restores the timeout to the job timeout.
             RoutineLoadTestUtils.checkTaskTimeoutWithData(runSql, producer, kafkaCsvTpoics, job, "100")
         } finally {
             sql "stop routine load for ${job}"


### PR DESCRIPTION
### What problem does this PR solve?

Kafka Routine Load previously enabled adaptive batching whenever a task was not at EOF. For a continuously written but lightly backlogged topic, this could repeatedly increase a short user-configured batch interval to the adaptive interval, delaying offset commits and increasing ingestion latency.

Using bytes or observed processing speed is not a reliable admission criterion. Records may be small while the topic contains many pending records, and processing may also slow down because the cluster is under pressure.

This PR changes Kafka adaptive batching to use task-level Kafka lag:

- Calculate the pending offset lag only for the partitions assigned to the current task.
- Enable adaptive batching only when the aggregate task lag is greater than the effective adaptive row limit: `max(max_batch_rows, RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS)`.
- Keep the configured batch parameters when lag is unknown, non-positive, or no greater than that threshold.
- Ignore lag from partitions that are not assigned to the task.
- Capture the adaptive decision and `routine_load_adaptive_min_batch_interval_sec` once in `updateAdaptiveTimeout()`, before `beginTxn()`.
- Reuse the captured values when constructing the Thrift task so that the transaction timeout and BE batch parameters remain consistent during the same scheduling attempt.
- When adaptive batching is enabled, retain the existing behavior of raising the limits to at least `RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS` and `RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE`.

This change only affects Kafka Routine Load. Kinesis behavior is unchanged.

### Check List

- Test: Unit Test
  - `testAdaptiveBatchUsesTaskLagThreshold`
  - `testAdaptiveBatchUsesCapturedIntervalAcrossConfigChange`
- Test: Regression Test
  - `test_routine_load_adaptive_param`
- Behavior changed: Yes
- Does this need documentation: No
