### PR TITLE
branch-4.1: [opt](scan) Schedule scanners up to max concurrency

### DIFF
--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -451,20 +451,11 @@ void ScannerContext::update_peak_running_scanner(int num) {
 
 int32_t ScannerContext::_get_margin(std::unique_lock<std::mutex>& transfer_lock,
                                     std::unique_lock<std::shared_mutex>& scheduler_lock) {
-    // margin_1 is used to ensure each scan operator could have at least _min_scan_concurrency scan tasks.
-    int32_t margin_1 = _min_scan_concurrency -
-                       (cast_set<int32_t>(_tasks_queue.size()) + _num_scheduled_scanners);
+    int32_t margin = _max_scan_concurrency - _num_scheduled_scanners;
 
-    // margin_2 is used to ensure the scan scheduler could have at least _min_scan_concurrency_of_scan_scheduler scan tasks.
-    int32_t margin_2 =
-            _min_scan_concurrency_of_scan_scheduler -
-            (_scanner_scheduler->get_active_threads() + _scanner_scheduler->get_queue_size());
-
-    if (margin_1 <= 0 && margin_2 <= 0) {
+    if (margin <= 0) {
         return 0;
     }
-
-    int32_t margin = std::max(margin_1, margin_2);
 
     if (low_memory_mode()) {
         // In low memory mode, we will limit the number of running scanners to `low_memory_mode_scanners()`.
@@ -472,12 +463,9 @@ int32_t ScannerContext::_get_margin(std::unique_lock<std::mutex>& transfer_lock,
         margin = std::min(low_memory_mode_scanners() - _num_scheduled_scanners, margin);
     }
 
-    VLOG_DEBUG << fmt::format(
-            "[{}|{}] schedule scan task, margin_1: {} = {} - ({} + {}), margin_2: {} = {} - "
-            "({} + {}), margin: {}",
-            print_id(_query_id), ctx_id, margin_1, _min_scan_concurrency, _tasks_queue.size(),
-            _num_scheduled_scanners, margin_2, _min_scan_concurrency_of_scan_scheduler,
-            _scanner_scheduler->get_active_threads(), _scanner_scheduler->get_queue_size(), margin);
+    VLOG_DEBUG << fmt::format("[{}|{}] schedule scan task, margin: {} = {} - {}",
+                              print_id(_query_id), ctx_id, margin, _max_scan_concurrency,
+                              _num_scheduled_scanners);
 
     return margin;
 }
@@ -526,8 +514,8 @@ Status ScannerContext::schedule_scan_task(std::shared_ptr<ScanTask> current_scan
 
     while (margin-- > 0) {
         std::shared_ptr<ScanTask> task_to_run;
-        const int32_t current_concurrency = cast_set<int32_t>(
-                _tasks_queue.size() + _num_scheduled_scanners + tasks_to_submit.size());
+        const auto current_concurrency =
+                cast_set<int32_t>(_num_scheduled_scanners + tasks_to_submit.size());
         VLOG_DEBUG << fmt::format("{} currenct concurrency: {} = {} + {} + {}", ctx_id,
                                   current_concurrency, _tasks_queue.size(), _num_scheduled_scanners,
                                   tasks_to_submit.size());


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Cherry-pick "Schedule scanners up to max concurrency" from opt_perf_4.1 (commit 29034570a69) to branch-4.1.

Previously `ScannerContext::_get_margin` computed two margins (per-scan-operator `_min_scan_concurrency` guarantee and scheduler-level `_min_scan_concurrency_of_scan_scheduler` guarantee) and took the max, which under-utilizes scan concurrency. This change schedules scanners directly up to `_max_scan_concurrency` (`_max_scan_concurrency - _num_scheduled_scanners`), keeping the low-memory-mode cap, so scanners are scheduled at full concurrency and scan performance improves.

### Release note

None

### Check List (For Author)

- Test: No need to test (clean cherry-pick, verified on opt_perf_4.1)
- Behavior changed: No
- Does this need documentation: No