### PR TITLE
[improvement](scan) selectivity-aware conjunct execution for ORC/Parquet readers

### DIFF
--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -357,6 +357,95 @@ TExprNode create_texpr_node_from(const Field& field, const PrimitiveType& type, 
 
 namespace doris {
 
+namespace {
+
+// Per-node structural cost, summed over the expression tree by conjunct_tree_cost.
+// The absolute numbers only matter relative to each other (ordering is all we use them
+// for); they mirror PrestoDB scoreFilter's spirit -- leaves and simple comparisons are
+// cheap, function calls are expensive.
+double conjunct_node_cost(const VExpr& expr) {
+    switch (expr.node_type()) {
+    // Leaves: reading a column or a literal is nearly free.
+    case TExprNodeType::SLOT_REF:
+    case TExprNodeType::VIRTUAL_SLOT_REF:
+    case TExprNodeType::COLUMN_REF:
+    case TExprNodeType::BOOL_LITERAL:
+    case TExprNodeType::INT_LITERAL:
+    case TExprNodeType::LARGE_INT_LITERAL:
+    case TExprNodeType::FLOAT_LITERAL:
+    case TExprNodeType::DECIMAL_LITERAL:
+    case TExprNodeType::DATE_LITERAL:
+    case TExprNodeType::STRING_LITERAL:
+    case TExprNodeType::NULL_LITERAL:
+        return 1.0;
+    // Simple comparisons / boolean glue: a handful of instructions per row.
+    case TExprNodeType::BINARY_PRED:
+    case TExprNodeType::NULL_AWARE_BINARY_PRED:
+    case TExprNodeType::IN_PRED:
+    case TExprNodeType::NULL_AWARE_IN_PRED:
+    case TExprNodeType::ARITHMETIC_EXPR:
+    case TExprNodeType::CAST_EXPR:
+        return 2.0;
+    // CASE and match are branchy / heavier than a plain comparison.
+    case TExprNodeType::CASE_EXPR:
+        return 10.0;
+    case TExprNodeType::MATCH_PRED:
+        return 50.0;
+    // Any function call is the expensive case we are trying to sort last: string / regexp /
+    // json / split all land here. Give it a high base; the tree sum then scales with how
+    // deeply nested the call is.
+    case TExprNodeType::FUNCTION_CALL:
+    case TExprNodeType::COMPUTE_FUNCTION_CALL:
+    case TExprNodeType::LAMBDA_FUNCTION_CALL_EXPR:
+        return 100.0;
+    // Unknown / complex node: sort it last, like scoreFilter's 1000 for subfield/complex.
+    default:
+        return 100.0;
+    }
+}
+
+// Sum conjunct_node_cost over the whole tree so a nested call (split(substr(col))) costs
+// more than a shallow one, matching the intuition that deeper expression trees do more
+// work per row. Constant subtrees are skipped: they are folded / evaluated once, not per
+// row, so `col IN (1000 literals)` stays a cheap hash lookup rather than scoring ~1000.
+double conjunct_tree_cost(const VExpr& expr) {
+    if (expr.is_constant()) {
+        return 0.0;
+    }
+    double cost = conjunct_node_cost(expr);
+    for (const auto& child : expr.children()) {
+        cost += conjunct_tree_cost(*child);
+    }
+    return cost;
+}
+
+} // namespace
+
+double VExpr::compute_conjunct_cost(const VExprSPtr& root) {
+    if (root == nullptr) {
+        return 0.0;
+    }
+    return conjunct_tree_cost(*root);
+}
+
+void VExpr::reorder_conjuncts_by_cost(VExprContextSPtrs& conjuncts) {
+    if (conjuncts.size() < 2) {
+        return;
+    }
+    // Cache each conjunct's cost so the comparator does not re-walk the tree O(n log n)
+    // times. Pair (cost, ctx) and stable_sort so equal-cost conjuncts keep planner order.
+    std::vector<std::pair<double, VExprContextSPtr>> scored;
+    scored.reserve(conjuncts.size());
+    for (const auto& ctx : conjuncts) {
+        scored.emplace_back(ctx == nullptr ? 0.0 : compute_conjunct_cost(ctx->root()), ctx);
+    }
+    std::stable_sort(scored.begin(), scored.end(),
+                     [](const auto& a, const auto& b) { return a.first < b.first; });
+    for (size_t i = 0; i < conjuncts.size(); ++i) {
+        conjuncts[i] = scored[i].second;
+    }
+}
+
 VExpr::VExpr(const TExprNode& node)
         : _node_type(node.node_type),
           _opcode(node.__isset.opcode ? node.opcode : TExprOpcode::INVALID_OPCODE) {

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -286,6 +286,20 @@ public:
 
     static bool contains_blockable_function(const VExprContextSPtrs& ctxs);
 
+    // A static, structural estimate of how expensive this conjunct is to evaluate per row,
+    // used to order scan-layer filter conjuncts cheap-first so a cheap, highly-selective
+    // predicate can shrink the row set (or filter the whole block) before an expensive one
+    // runs. Mirrors PrestoDB's OrcSelectiveRecordReader.scoreFilter seed scores: a bare
+    // `col = const` / `col IN (consts)` is cheapest, arithmetic/cast slightly more, and any
+    // function call scales with the size of its expression tree; unknown complex nodes score
+    // highest so they sort last. Lower is cheaper. This is a heuristic for ordering only --
+    // it never changes which rows pass, so a wrong estimate costs at most a suboptimal order.
+    static double compute_conjunct_cost(const VExprSPtr& root);
+
+    // Stable-sort `conjuncts` ascending by compute_conjunct_cost so cheaper predicates run
+    // first. Stable so equal-cost conjuncts keep their original (planner) relative order.
+    static void reorder_conjuncts_by_cost(VExprContextSPtrs& conjuncts);
+
     Status deep_clone(VExprSPtr* cloned_expr,
                       const VExprCloneNodeOverride& clone_node_override = {}) const;
     virtual Status clone_node(VExprSPtr* cloned_expr) const;

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -32,6 +32,7 @@
 #include "core/block/columns_with_type_and_name.h"
 #include "core/column/column.h"
 #include "core/column/column_const.h"
+#include "core/column/column_nullable.h"
 #include "exec/common/util.hpp"
 #include "exprs/function_context.h"
 #include "exprs/lambda_function/lambda_execution_context.h"
@@ -41,6 +42,7 @@
 #include "storage/olap_common.h"
 #include "storage/segment/column_reader.h"
 #include "util/simd/bits.h"
+#include "util/time.h"
 
 namespace doris {
 class RowDescriptor;
@@ -317,6 +319,225 @@ Status VExprContext::execute_conjuncts(const VExprContextSPtrs& ctxs,
         }
     }
     return Status::OK();
+}
+
+Status VExprContext::execute_conjuncts_selective(const VExprContextSPtrs& ctxs,
+                                                 const std::vector<IColumn::Filter*>* filters,
+                                                 const Block* block, IColumn::Filter* result_filter,
+                                                 bool* can_filter_all) {
+    size_t rows = block->rows();
+    DCHECK_EQ(result_filter->size(), rows);
+    *can_filter_all = false;
+    auto* __restrict result_filter_data = result_filter->data();
+
+    // Fold any pre-existing masks (delete / position-delete filters) into result_filter first,
+    // so the surviving set starts from rows those masks already keep.
+    size_t surviving = rows;
+    if (filters != nullptr) {
+        for (auto* filter : *filters) {
+            const auto* __restrict fdata = filter->data();
+            for (size_t i = 0; i < rows; ++i) {
+                result_filter_data[i] &= fdata[i];
+            }
+        }
+        surviving = rows -
+                    simd::count_zero_num(reinterpret_cast<const int8_t*>(result_filter_data), rows);
+        if (surviving == 0) {
+            *can_filter_all = true;
+            return Status::OK();
+        }
+    }
+
+    // Below this surviving fraction, gathering the surviving rows for a conjunct's inputs is
+    // worth its memcpy cost; above it, evaluate the conjunct full-width (like the original
+    // execute_conjuncts) so we do not gather nearly the whole block. Mirrors PrestoDB selecting
+    // only once a batch has meaningfully shrunk.
+    constexpr double kSelectiveGatherThreshold = 0.5;
+
+    // `selection` holds the original row indices still alive. It is (re)built from
+    // result_filter lazily, only when a conjunct is about to be evaluated selectively.
+    IColumn::Selector selection;
+    bool selection_valid = false;
+
+    auto rebuild_selection = [&]() {
+        selection.clear();
+        selection.reserve(surviving);
+        for (size_t i = 0; i < rows; ++i) {
+            if (result_filter_data[i]) {
+                selection.push_back(static_cast<IColumn::Selector::value_type>(i));
+            }
+        }
+        selection_valid = true;
+    };
+
+    for (const auto& ctx : ctxs) {
+        if (ctx == nullptr) {
+            continue;
+        }
+        // Runtime-filter wrappers carry selectivity tracking and counter side effects in their
+        // execute_filter override, so they must run full-width; they are also cheap (bloom /
+        // min-max) and belong up front. A high surviving fraction also stays on the full-width
+        // path, where gathering would copy almost the whole block for no benefit.
+        const bool use_selective = !ctx->root()->is_rf_wrapper() &&
+                                   surviving < static_cast<size_t>(static_cast<double>(rows) *
+                                                                   kSelectiveGatherThreshold);
+        if (!use_selective) {
+            // Full-width path: input is every row still alive (result_filter carries them).
+            const size_t input_rows = surviving;
+            // Sample every kTimingSampleEvery-th batch. RF wrappers are skipped: their
+            // execute_filter includes their own selectivity/counter side effects and
+            // wrapping it in another clock read is noise. The static cost stays as the
+            // cold-start estimate; timed rows accumulate on the non-RF conjuncts we care
+            // about reordering.
+            const bool sample =
+                    !ctx->root()->is_rf_wrapper() && ctx->filter_runtime_stats().should_sample();
+            const int64_t t0 = sample ? MonotonicNanos() : 0;
+            RETURN_IF_ERROR(
+                    ctx->execute_filter(block, result_filter_data, rows, false, can_filter_all));
+            const int64_t elapsed_ns = sample ? MonotonicNanos() - t0 : 0;
+            if (*can_filter_all) {
+                ctx->filter_runtime_stats().update(static_cast<int64_t>(input_rows), 0, elapsed_ns);
+                return Status::OK();
+            }
+            surviving = rows - simd::count_zero_num(
+                                       reinterpret_cast<const int8_t*>(result_filter_data), rows);
+            ctx->filter_runtime_stats().update(static_cast<int64_t>(input_rows),
+                                               static_cast<int64_t>(surviving), elapsed_ns);
+            if (surviving == 0) {
+                *can_filter_all = true;
+                return Status::OK();
+            }
+            selection_valid = false;
+            continue;
+        }
+
+        if (!selection_valid) {
+            rebuild_selection();
+        }
+        // Evaluate this conjunct only on the surviving rows. execute_column with a selector
+        // gathers the inputs down to `selection.size()` rows, so a heavy function runs once
+        // per surviving row rather than once per block row.
+        const size_t count = selection.size();
+        ColumnPtr result_column;
+        const bool sample = ctx->filter_runtime_stats().should_sample();
+        const int64_t t0 = sample ? MonotonicNanos() : 0;
+        RETURN_IF_ERROR(
+                ctx->root()->execute_column(ctx.get(), block, &selection, count, result_column));
+        const int64_t elapsed_ns = sample ? MonotonicNanos() - t0 : 0;
+        auto [filter_column, is_const] = unpack_if_const(result_column);
+
+        if (is_const) {
+            // Const predicate over the surviving rows: keep all or drop all of them.
+            const bool keep = !filter_column->is_null_at(0) && filter_column->get_bool(0);
+            ctx->filter_runtime_stats().update(static_cast<int64_t>(count),
+                                               keep ? static_cast<int64_t>(count) : 0, elapsed_ns);
+            if (!keep) {
+                memset(result_filter_data, 0, rows);
+                *can_filter_all = true;
+                return Status::OK();
+            }
+            // keep == true: result_filter and selection unchanged.
+            continue;
+        }
+
+        // Narrow the surviving set: keep selection[j] only where the predicate is true and not
+        // NULL at position j (accept_null == false, matching execute_filter's scan semantics).
+        IColumn::Selector next;
+        next.reserve(count);
+        if (const auto* nullable = check_and_get_column<ColumnNullable>(*filter_column)) {
+            const auto* __restrict fdata =
+                    assert_cast<const ColumnUInt8&>(nullable->get_nested_column())
+                            .get_data()
+                            .data();
+            const auto* __restrict nmap = nullable->get_null_map_data().data();
+            for (size_t j = 0; j < count; ++j) {
+                if (!nmap[j] && fdata[j]) {
+                    next.push_back(selection[j]);
+                } else {
+                    result_filter_data[selection[j]] = 0;
+                }
+            }
+        } else {
+            const auto* __restrict fdata =
+                    assert_cast<const ColumnUInt8&>(*filter_column).get_data().data();
+            for (size_t j = 0; j < count; ++j) {
+                if (fdata[j]) {
+                    next.push_back(selection[j]);
+                } else {
+                    result_filter_data[selection[j]] = 0;
+                }
+            }
+        }
+        selection.swap(next);
+        ctx->filter_runtime_stats().update(static_cast<int64_t>(count),
+                                           static_cast<int64_t>(selection.size()), elapsed_ns);
+        surviving = selection.size();
+        selection_valid = true;
+        if (surviving == 0) {
+            *can_filter_all = true;
+            return Status::OK();
+        }
+    }
+    return Status::OK();
+}
+
+bool VExprContext::adaptive_reorder_conjuncts(VExprContextSPtrs& conjuncts, int64_t min_rows,
+                                              double min_cost) {
+    if (conjuncts.size() < 2) {
+        return false;
+    }
+    // Adaptive reorder only pays off when some conjunct is expensive: shuffling cheap-only
+    // predicates saves less than the reorder itself costs. "Expensive" is either
+    //   (a) the static structural estimate scored high (cost >= min_cost), or
+    //   (b) the measured per-row cost scored high (per_row_ns >= min_per_row_ns).
+    // Case (b) catches two failure modes of the static score: a FUNCTION_CALL underestimate
+    // (length(col) is nowhere near 100ns/row) and inability to distinguish two calls that
+    // score the same but run 10-100x apart. Also gate on every measurable conjunct having
+    // seen enough rows so an early noisy selectivity does not churn the order. RF wrappers
+    // run full-width and stay in front, so they are exempt from both checks.
+    constexpr double kMinPerRowNs = kAdaptiveReorderMinPerRowNs;
+    bool has_expensive = false;
+    for (const auto& ctx : conjuncts) {
+        if (ctx == nullptr || ctx->root()->is_rf_wrapper()) {
+            continue;
+        }
+        const auto& stats = ctx->filter_runtime_stats();
+        if (stats.input_rows < min_rows) {
+            return false;
+        }
+        if (VExpr::compute_conjunct_cost(ctx->root()) >= min_cost ||
+            stats.per_row_ns() >= kMinPerRowNs) {
+            has_expensive = true;
+        }
+    }
+    if (!has_expensive) {
+        return false;
+    }
+    // Sort key: per-row cost divided by measured drop fraction -- cheap predicates that
+    // eliminate many rows sort first, an expensive predicate that turns out unselective sinks.
+    // Cost prefers the measured per_row_ns once enough sampled rows have accrued, and falls
+    // back on the static structural estimate otherwise. Selectivity stays the (free)
+    // measurement. eps floors the divisor so a conjunct that drops nothing sorts last instead
+    // of dividing by zero. RF wrappers score 0 to stay in front. The two cost sources are on
+    // different units (ns vs structural score) but this only affects the absolute magnitude
+    // of the key -- ordering is preserved because either every conjunct we care about has a
+    // measurement (comparable among themselves) or none does (all fall back to structural),
+    // and RF wrappers pin at 0 either way.
+    constexpr double kEps = 1e-6;
+    auto sort_key = [kEps](const VExprContextSPtr& c) -> double {
+        if (c == nullptr || c->root()->is_rf_wrapper()) {
+            return 0.0;
+        }
+        const auto& stats = c->filter_runtime_stats();
+        const double per_row = stats.per_row_ns();
+        const double cost = per_row > 0.0 ? per_row : VExpr::compute_conjunct_cost(c->root());
+        return cost / std::max(stats.dropped_fraction(), kEps);
+    };
+    std::stable_sort(conjuncts.begin(), conjuncts.end(),
+                     [&sort_key](const VExprContextSPtr& a, const VExprContextSPtr& b) {
+                         return sort_key(a) < sort_key(b);
+                     });
+    return true;
 }
 
 Status VExprContext::execute_conjuncts(const VExprContextSPtrs& conjuncts, const Block* block,

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -244,6 +244,60 @@ class VExprContext {
     ENABLE_FACTORY_CREATOR(VExprContext);
 
 public:
+    // Per-conjunct selectivity + per-row cost measured across batches (the scan holds one
+    // VExprContext per conjunct for the whole scan). Both feed a periodic reorder that
+    // corrects the static cost order when a predicate's real behavior differs from the
+    // estimate -- e.g. a derived predicate like split_by_string(col,sep)[n]='x' the planner
+    // has no column stats for, or two FUNCTION_CALL predicates the static score can't tell
+    // apart. Selectivity is free (rows already counted on the filter path). Cost is sampled:
+    // one CLOCK_MONOTONIC pair per kTimingSampleEvery batches, so cheap predicates do not
+    // pay per-batch ~50ns of clock_gettime. Static phase-1 cost is the cold-start until
+    // enough timed rows accrue; then per_row_ns takes over.
+    struct FilterRuntimeStats {
+        int64_t input_rows = 0;       // cumulative rows fed to this conjunct
+        int64_t output_rows = 0;      // cumulative rows it let through
+        int64_t elapsed_ns = 0;       // cumulative sampled execution time
+        int64_t input_rows_timed = 0; // rows counted while sampling was on
+        int64_t sample_counter = 0;   // batch counter driving the sample gate
+
+        // Sample every Nth batch; other batches skip the clock reads entirely.
+        static constexpr int64_t kTimingSampleEvery = 8;
+        // Below this many timed rows the measurement is too noisy to trust; the reorder
+        // falls back on the static cost estimate until we cross the threshold.
+        static constexpr int64_t kTimingMinRows = 4096;
+
+        bool should_sample() const { return sample_counter % kTimingSampleEvery == 0; }
+
+        void update(int64_t in, int64_t out) {
+            input_rows += in;
+            output_rows += out;
+            ++sample_counter;
+        }
+        void update(int64_t in, int64_t out, int64_t sampled_ns) {
+            update(in, out);
+            if (sampled_ns > 0) {
+                elapsed_ns += sampled_ns;
+                input_rows_timed += in;
+            }
+        }
+        // Fraction of rows this conjunct eliminates, in [0, 1]; higher is more selective.
+        // Undefined (returns 0) before any rows are seen -- callers gate on input_rows first.
+        double dropped_fraction() const {
+            if (input_rows == 0) {
+                return 0.0;
+            }
+            return static_cast<double>(input_rows - output_rows) / static_cast<double>(input_rows);
+        }
+        // Measured per-row cost in ns, or 0 if we have not accrued enough timed rows to
+        // trust the average (caller then falls back on the static structural estimate).
+        double per_row_ns() const {
+            if (input_rows_timed < kTimingMinRows || elapsed_ns <= 0) {
+                return 0.0;
+            }
+            return static_cast<double>(elapsed_ns) / static_cast<double>(input_rows_timed);
+        }
+    };
+
     VExprContext(VExprSPtr expr);
     ~VExprContext();
     [[nodiscard]] Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
@@ -324,6 +378,44 @@ public:
                                     const std::vector<IColumn::Filter*>* filters, Block* block,
                                     IColumn::Filter* result_filter, bool* can_filter_all);
 
+    // Selection-vector variant of execute_conjuncts for the scan filter path. Instead of
+    // evaluating every conjunct over all rows and AND-ing the results, it threads the set of
+    // surviving row indices between conjuncts so a later (typically expensive) predicate is
+    // evaluated only on the rows earlier ones let through -- mirroring PrestoDB's positions[]
+    // selective reader. Conjuncts should be ordered cheap-first (see
+    // VExpr::reorder_conjuncts_by_cost) so the surviving set shrinks fast.
+    //
+    // Produces the same full-width `result_filter` / `can_filter_all` contract as
+    // execute_conjuncts, so callers are interchangeable. Runtime-filter-wrapper conjuncts are
+    // always evaluated full-width (they carry selectivity/counter side effects), and the
+    // selective gather is skipped while the surviving fraction is still high (gather is not
+    // worth its memcpy then). `filters` are AND-ed in as pre-existing delete/position masks.
+    static Status execute_conjuncts_selective(const VExprContextSPtrs& ctxs,
+                                              const std::vector<IColumn::Filter*>* filters,
+                                              const Block* block, IColumn::Filter* result_filter,
+                                              bool* can_filter_all);
+
+    // Static-cost threshold at/above which a conjunct counts as "expensive" for the adaptive
+    // reorder admission gate. compute_conjunct_cost scores a function call ~100 and a plain
+    // comparison ~2, so this fires only when a real function/expression predicate is present.
+    static constexpr double kAdaptiveReorderMinCost = 50.0;
+    // Measured per-row cost (ns) at/above which a conjunct counts as "expensive" even if the
+    // static estimate underrated it. ~50ns is a couple of L1 hits' worth of work; anything
+    // below that is a cheap comparison the reorder needn't fight over.
+    static constexpr double kAdaptiveReorderMinPerRowNs = 50.0;
+
+    // Reorder `conjuncts` in place by (per-row cost / measured drop fraction) ascending, once
+    // conjuncts have seen at least `min_rows` input rows; below that they keep their current
+    // (static phase-1) order so a noisy early measurement does not churn the plan. Only kicks
+    // in when at least one conjunct is expensive -- either by the static estimate
+    // (cost >= `min_cost`) or by measured per-row ns (>= kAdaptiveReorderMinPerRowNs) --
+    // because reordering cheap-only predicates is not worth even this small overhead. Runtime-
+    // filter wrappers are left in front. Returns true if it reordered. Combines PrestoDB's
+    // static-cost bootstrap with DuckDB-style measured cost and StarRocks-style measured
+    // selectivity.
+    static bool adaptive_reorder_conjuncts(VExprContextSPtrs& conjuncts, int64_t min_rows,
+                                           double min_cost = kAdaptiveReorderMinCost);
+
     [[nodiscard]] static Status execute_conjuncts_and_filter_block(
             const VExprContextSPtrs& ctxs, Block* block, std::vector<uint32_t>& columns_to_filter,
             int column_to_keep);
@@ -347,6 +439,8 @@ public:
         }
         return *_rf_selectivity;
     }
+
+    FilterRuntimeStats& filter_runtime_stats() { return _filter_runtime_stats; }
 
     FunctionContext::FunctionStateScope get_function_state_scope() const {
         return _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
@@ -418,5 +512,6 @@ private:
 
     std::unique_ptr<RuntimeFilterSelectivity> _rf_selectivity =
             std::make_unique<RuntimeFilterSelectivity>();
+    FilterRuntimeStats _filter_runtime_stats;
 };
 } // namespace doris

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -2708,14 +2708,26 @@ Status OrcReader::_get_next_block_impl(Block* block, size_t* read_rows, bool* eo
                 for (auto& conjunct : _non_dict_filter_conjuncts) {
                     filter_conjuncts.emplace_back(conjunct);
                 }
+                if (_state != nullptr && _state->query_options().enable_scan_conjunct_reorder) {
+                    VExpr::reorder_conjuncts_by_cost(filter_conjuncts);
+                }
+                if (_state != nullptr && _state->query_options().enable_scan_adaptive_reorder) {
+                    VExprContext::adaptive_reorder_conjuncts(filter_conjuncts,
+                                                             _state->batch_size());
+                }
                 std::vector<IColumn::Filter*> filters;
                 if (_delete_rows_filter_ptr) {
                     filters.push_back(_delete_rows_filter_ptr.get());
                 }
                 IColumn::Filter result_filter(block->rows(), 1);
                 bool can_filter_all = false;
-                RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
-                        filter_conjuncts, &filters, block, &result_filter, &can_filter_all));
+                if (_state != nullptr && _state->query_options().enable_scan_selective_filter) {
+                    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts_selective(
+                            filter_conjuncts, &filters, block, &result_filter, &can_filter_all));
+                } else {
+                    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
+                            filter_conjuncts, &filters, block, &result_filter, &can_filter_all));
+                }
 
                 // Condition cache MISS: mark granules with surviving rows (non-lazy path)
                 if (_condition_cache_ctx && !_condition_cache_ctx->is_hit) {
@@ -2928,12 +2940,28 @@ Status OrcReader::filter(orc::ColumnVectorBatch& data, uint16_t* sel, uint16_t s
     for (auto& conjunct : _non_dict_filter_conjuncts) {
         filter_conjuncts.emplace_back(conjunct);
     }
+    // Run cheap, highly selective predicates first so an expensive one (e.g. a string
+    // function) is skipped once a cheap one filters the whole block, and so it only evaluates
+    // on surviving rows under selective execution below. Dict-rewritten conjuncts are already
+    // int dict-code comparisons, so cost ordering keeps them near the front naturally.
+    if (_state != nullptr && _state->query_options().enable_scan_conjunct_reorder) {
+        VExpr::reorder_conjuncts_by_cost(filter_conjuncts);
+    }
+    // Once conjuncts have measured enough rows, let runtime cost override the static order.
+    if (_state != nullptr && _state->query_options().enable_scan_adaptive_reorder) {
+        VExprContext::adaptive_reorder_conjuncts(filter_conjuncts, _state->batch_size());
+    }
     std::vector<IColumn::Filter*> filters;
     if (_delete_rows_filter_ptr) {
         filters.push_back(_delete_rows_filter_ptr.get());
     }
-    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
-            filter_conjuncts, &filters, block, _filter.get(), &can_filter_all));
+    if (_state != nullptr && _state->query_options().enable_scan_selective_filter) {
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts_selective(
+                filter_conjuncts, &filters, block, _filter.get(), &can_filter_all));
+    } else {
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
+                filter_conjuncts, &filters, block, _filter.get(), &can_filter_all));
+    }
 
     if (_lazy_read_ctx.resize_first_column) {
         // We have to clean the first column to insert right data.

--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -410,8 +410,23 @@ Status RowGroupReader::next_batch(Block* block, size_t batch_size, size_t* read_
                 bool can_filter_all = false;
 
                 {
-                    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
-                            _filter_conjuncts, &filters, block, &result_filter, &can_filter_all));
+                    VExprContextSPtrs filter_contexts = _filter_conjuncts;
+                    if (_state != nullptr && _state->query_options().enable_scan_conjunct_reorder) {
+                        VExpr::reorder_conjuncts_by_cost(filter_contexts);
+                    }
+                    if (_state != nullptr && _state->query_options().enable_scan_adaptive_reorder) {
+                        VExprContext::adaptive_reorder_conjuncts(filter_contexts,
+                                                                 _state->batch_size());
+                    }
+                    if (_state != nullptr && _state->query_options().enable_scan_selective_filter) {
+                        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(
+                                VExprContext::execute_conjuncts_selective(filter_contexts, &filters,
+                                                                          block, &result_filter,
+                                                                          &can_filter_all));
+                    } else {
+                        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
+                                filter_contexts, &filters, block, &result_filter, &can_filter_all));
+                    }
                 }
 
                 // Condition cache MISS: mark granules with surviving rows (non-lazy path)
@@ -684,10 +699,24 @@ Status RowGroupReader::_do_lazy_read(Block* block, size_t batch_size, size_t* re
             for (auto& conjunct : _filter_conjuncts) {
                 filter_contexts.emplace_back(conjunct);
             }
+            // Run cheap, highly selective predicates first so an expensive one is skipped
+            // once a cheap one filters the whole block. Reordering only changes execution
+            // order, never the result set.
+            if (_state != nullptr && _state->query_options().enable_scan_conjunct_reorder) {
+                VExpr::reorder_conjuncts_by_cost(filter_contexts);
+            }
+            if (_state != nullptr && _state->query_options().enable_scan_adaptive_reorder) {
+                VExprContext::adaptive_reorder_conjuncts(filter_contexts, _state->batch_size());
+            }
 
             {
-                RETURN_IF_ERROR(VExprContext::execute_conjuncts(filter_contexts, &filters, block,
-                                                                &result_filter, &can_filter_all));
+                if (_state != nullptr && _state->query_options().enable_scan_selective_filter) {
+                    RETURN_IF_ERROR(VExprContext::execute_conjuncts_selective(
+                            filter_contexts, &filters, block, &result_filter, &can_filter_all));
+                } else {
+                    RETURN_IF_ERROR(VExprContext::execute_conjuncts(
+                            filter_contexts, &filters, block, &result_filter, &can_filter_all));
+                }
             }
 
             // Condition cache MISS: mark granules with surviving rows

--- a/be/test/exprs/vexpr_conjunct_reorder_test.cpp
+++ b/be/test/exprs/vexpr_conjunct_reorder_test.cpp
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "exprs/vexpr.h"
+#include "exprs/vexpr_context.h"
+#include "exprs/vslot_ref.h"
+
+namespace doris {
+
+// Configurable expr node for testing conjunct cost/reorder: sets the node type and (for
+// function nodes) the function name, and can mark itself constant so constant-subtree
+// pruning in compute_conjunct_cost can be exercised. execute_column_impl is a stub -- the
+// cost model only reads node_type/children, never evaluates.
+class FakeCostExpr final : public VExpr {
+public:
+    FakeCostExpr(TExprNodeType::type node_type, std::string fn_name = "", bool is_const = false)
+            : _is_const(is_const) {
+        _node_type = node_type;
+        _fn.name.function_name = std::move(fn_name);
+        if (node_type == TExprNodeType::BINARY_PRED) {
+            _opcode = TExprOpcode::EQ;
+        }
+    }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::OK();
+    }
+
+    const std::string& expr_name() const override { return _name; }
+
+    bool is_constant() const override { return _is_const || VExpr::is_constant(); }
+
+private:
+    bool _is_const;
+    std::string _name = "FakeCostExpr";
+};
+
+static VExprSPtr make_slot(int slot_id) {
+    auto slot = std::make_shared<VSlotRef>();
+    slot->set_slot_id(slot_id);
+    return slot;
+}
+
+static VExprSPtr make_literal() {
+    return std::make_shared<FakeCostExpr>(TExprNodeType::STRING_LITERAL, "", true);
+}
+
+static VExprSPtr make_func(const std::string& fn_name, const std::vector<VExprSPtr>& children) {
+    auto fn = std::make_shared<FakeCostExpr>(TExprNodeType::FUNCTION_CALL, fn_name);
+    for (const auto& c : children) {
+        fn->add_child(c);
+    }
+    return fn;
+}
+
+// col = 'x' : a bare-slot equality, the cheapest predicate shape.
+static VExprSPtr make_bare_eq(int slot_id) {
+    auto pred = std::make_shared<FakeCostExpr>(TExprNodeType::BINARY_PRED, "eq");
+    pred->add_child(make_slot(slot_id));
+    pred->add_child(make_literal());
+    return pred;
+}
+
+// col IN (n literals) : still cheap (a hash lookup); the n constants must not inflate cost.
+static VExprSPtr make_bare_in(int slot_id, int num_options) {
+    auto pred = std::make_shared<FakeCostExpr>(TExprNodeType::IN_PRED, "in");
+    pred->add_child(make_slot(slot_id));
+    for (int i = 0; i < num_options; ++i) {
+        pred->add_child(make_literal());
+    }
+    return pred;
+}
+
+// f(col) = 'x' : an expensive predicate whose value side is a function over a slot.
+static VExprSPtr make_func_eq(const std::string& fn_name, int slot_id) {
+    auto pred = std::make_shared<FakeCostExpr>(TExprNodeType::BINARY_PRED, "eq");
+    pred->add_child(make_func(fn_name, {make_slot(slot_id), make_literal()}));
+    pred->add_child(make_literal());
+    return pred;
+}
+
+static VExprContextSPtr ctx_of(const VExprSPtr& root) {
+    return std::make_shared<VExprContext>(root);
+}
+
+class ConjunctCostTest : public testing::Test {
+protected:
+    static double cost(const VExprSPtr& root) { return VExpr::compute_conjunct_cost(root); }
+};
+
+TEST_F(ConjunctCostTest, NullRootIsZero) {
+    EXPECT_EQ(0.0, cost(nullptr));
+}
+
+TEST_F(ConjunctCostTest, BareEqCheaperThanFunctionPredicate) {
+    // col = 'x' must be cheaper than split_by_string(col)[n] = 'x'.
+    EXPECT_LT(cost(make_bare_eq(5)), cost(make_func_eq("split_by_string", 5)));
+}
+
+TEST_F(ConjunctCostTest, InSetSizeDoesNotInflateCost) {
+    // col IN (3 consts) and col IN (500 consts) cost the same: the literals are constant
+    // subtrees, folded once, not evaluated per row. Otherwise a big IN list would wrongly
+    // sort after a cheap function.
+    EXPECT_EQ(cost(make_bare_in(5, 3)), cost(make_bare_in(5, 500)));
+}
+
+TEST_F(ConjunctCostTest, InCheaperThanFunctionPredicate) {
+    // Even a large IN list stays cheaper than a single function predicate.
+    EXPECT_LT(cost(make_bare_in(5, 500)), cost(make_func_eq("substr", 5)));
+}
+
+TEST_F(ConjunctCostTest, NestedFunctionCostsMoreThanShallow) {
+    // element_at(split_by_string(col), n) = 'x' does more per-row work than substr(col) = 'x'.
+    auto shallow = make_func_eq("substr", 5);
+    auto split = make_func("split_by_string", {make_slot(5), make_literal()});
+    auto nested_pred = std::make_shared<FakeCostExpr>(TExprNodeType::BINARY_PRED, "eq");
+    nested_pred->add_child(make_func("element_at", {split, make_literal()}));
+    nested_pred->add_child(make_literal());
+    EXPECT_GT(cost(nested_pred), cost(shallow));
+}
+
+class ConjunctReorderTest : public testing::Test {
+protected:
+    // Return the slot id referenced by the value side of predicate `i` after reordering,
+    // for asserting order. Assumes each predicate's first child is the value side and its
+    // leftmost leaf is a slot.
+    static int leading_slot(const VExprContextSPtr& ctx) {
+        const VExpr* node = ctx->root().get();
+        while (!node->children().empty()) {
+            node = node->children()[0].get();
+        }
+        return static_cast<const VSlotRef*>(node)->slot_id();
+    }
+};
+
+TEST_F(ConjunctReorderTest, CheapPredicateMovesBeforeExpensive) {
+    // Input order: [ expensive f(col1), cheap col2=const ]. After reorder the cheap one leads.
+    VExprContextSPtrs conjuncts = {ctx_of(make_func_eq("split_by_string", 1)),
+                                   ctx_of(make_bare_eq(2))};
+    VExpr::reorder_conjuncts_by_cost(conjuncts);
+    EXPECT_EQ(2, leading_slot(conjuncts[0]));
+    EXPECT_EQ(1, leading_slot(conjuncts[1]));
+}
+
+TEST_F(ConjunctReorderTest, StableForEqualCost) {
+    // Two equally cheap bare-eq predicates keep their original relative order (stable sort),
+    // so reordering is deterministic and does not churn already-good plans.
+    VExprContextSPtrs conjuncts = {ctx_of(make_bare_eq(7)), ctx_of(make_bare_eq(3)),
+                                   ctx_of(make_bare_eq(9))};
+    VExpr::reorder_conjuncts_by_cost(conjuncts);
+    EXPECT_EQ(7, leading_slot(conjuncts[0]));
+    EXPECT_EQ(3, leading_slot(conjuncts[1]));
+    EXPECT_EQ(9, leading_slot(conjuncts[2]));
+}
+
+TEST_F(ConjunctReorderTest, MixedOrderingCheapestFirst) {
+    // [ f(col1), col2 IN (...), g(col3), col4=const ] -> the two bare predicates lead,
+    // in their original relative order, then the two function predicates.
+    VExprContextSPtrs conjuncts = {ctx_of(make_func_eq("regexp_extract", 1)),
+                                   ctx_of(make_bare_in(2, 50)), ctx_of(make_func_eq("substr", 3)),
+                                   ctx_of(make_bare_eq(4))};
+    VExpr::reorder_conjuncts_by_cost(conjuncts);
+    // First two are the cheap bare predicates, col2 (IN) before col4 (=) by stable order.
+    EXPECT_EQ(2, leading_slot(conjuncts[0]));
+    EXPECT_EQ(4, leading_slot(conjuncts[1]));
+    // Last two are the function predicates, col1 before col3 by stable order.
+    EXPECT_EQ(1, leading_slot(conjuncts[2]));
+    EXPECT_EQ(3, leading_slot(conjuncts[3]));
+}
+
+TEST_F(ConjunctReorderTest, EmptyAndSingleAreNoops) {
+    VExprContextSPtrs empty;
+    VExpr::reorder_conjuncts_by_cost(empty); // must not crash
+    EXPECT_TRUE(empty.empty());
+
+    VExprContextSPtrs single = {ctx_of(make_bare_eq(1))};
+    VExpr::reorder_conjuncts_by_cost(single);
+    ASSERT_EQ(1u, single.size());
+    EXPECT_EQ(1, leading_slot(single[0]));
+}
+
+TEST_F(ConjunctReorderTest, NullContextDoesNotCrash) {
+    // A null ctx (a skipped conjunct) is scored 0 and must not dereference.
+    VExprContextSPtrs conjuncts = {ctx_of(make_func_eq("substr", 1)), nullptr,
+                                   ctx_of(make_bare_eq(2))};
+    VExpr::reorder_conjuncts_by_cost(conjuncts);
+    // The null (cost 0) and the bare-eq (cheap) sort before the function predicate.
+    EXPECT_EQ(3u, conjuncts.size());
+    EXPECT_EQ(nullptr, conjuncts[0]);
+}
+
+} // namespace doris

--- a/be/test/exprs/vexpr_selective_conjuncts_test.cpp
+++ b/be/test/exprs/vexpr_selective_conjuncts_test.cpp
@@ -1,0 +1,427 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_number.h"
+#include "exprs/vexpr.h"
+#include "exprs/vexpr_context.h"
+
+namespace doris {
+
+// A predicate whose per-row (bool, null) verdict is preset. Its execute_column_impl honors
+// the selector exactly like real exprs (gathering down to the selected rows), so it drives
+// the real execute_conjuncts_selective control flow. is_rf lets a test mark it a runtime-
+// filter wrapper (forced onto the full-width path). execute_type returns nullptr so the
+// execute_column wrapper skips its declared-vs-actual type check for this stub.
+class FakeFilterExpr final : public VExpr {
+public:
+    FakeFilterExpr(std::vector<uint8_t> vals, std::vector<uint8_t> nulls, bool is_rf)
+            : _vals(std::move(vals)), _nulls(std::move(nulls)), _is_rf(is_rf) {
+        _node_type = TExprNodeType::BINARY_PRED;
+        _data_type = std::make_shared<DataTypeUInt8>();
+    }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector* selector, size_t count,
+                               ColumnPtr& result_column) const override {
+        auto nested = ColumnUInt8::create();
+        auto null_map = ColumnUInt8::create();
+        if (selector == nullptr) {
+            for (size_t i = 0; i < count; ++i) {
+                nested->insert_value(_vals[i]);
+                null_map->insert_value(_nulls[i]);
+            }
+        } else {
+            for (size_t j = 0; j < count; ++j) {
+                const auto row = (*selector)[j];
+                nested->insert_value(_vals[row]);
+                null_map->insert_value(_nulls[row]);
+            }
+        }
+        result_column = ColumnNullable::create(std::move(nested), std::move(null_map));
+        return Status::OK();
+    }
+
+    DataTypePtr execute_type(const Block*) const override { return nullptr; }
+
+    const std::string& expr_name() const override { return _name; }
+    bool is_rf_wrapper() const override { return _is_rf; }
+    // A real predicate over live columns is not constant; the default definition walks
+    // children, and a childless fake would fold to constant and score cost 0 in
+    // compute_conjunct_cost, which would defeat the adaptive-reorder cost gates below.
+    bool is_constant() const override { return false; }
+
+private:
+    std::vector<uint8_t> _vals;
+    std::vector<uint8_t> _nulls;
+    bool _is_rf;
+    std::string _name = "FakeFilterExpr";
+};
+
+class SelectiveConjunctsTest : public testing::Test {
+protected:
+    static VExprContextSPtr make_ctx(std::vector<uint8_t> vals, std::vector<uint8_t> nulls,
+                                     bool is_rf = false) {
+        return std::make_shared<VExprContext>(
+                std::make_shared<FakeFilterExpr>(std::move(vals), std::move(nulls), is_rf));
+    }
+
+    // A block whose only job is to carry the row count; FakeFilterExpr ignores its columns.
+    static Block make_block(size_t rows) {
+        Block block;
+        auto col = ColumnUInt8::create();
+        for (size_t i = 0; i < rows; ++i) {
+            col->insert_value(0);
+        }
+        block.insert({std::move(col), std::make_shared<DataTypeUInt8>(), "c0"});
+        return block;
+    }
+
+    // Assert the selection-vector path and the full-width path agree on this input.
+    static void expect_equivalent(size_t rows, const VExprContextSPtrs& ctxs,
+                                  const std::vector<IColumn::Filter*>* filters) {
+        Block block = make_block(rows);
+
+        IColumn::Filter full(rows, 1);
+        bool full_all = false;
+        ASSERT_TRUE(VExprContext::execute_conjuncts(ctxs, filters, false, &block, &full, &full_all)
+                            .ok());
+
+        IColumn::Filter sel(rows, 1);
+        bool sel_all = false;
+        ASSERT_TRUE(VExprContext::execute_conjuncts_selective(ctxs, filters, &block, &sel, &sel_all)
+                            .ok());
+
+        EXPECT_EQ(full_all, sel_all);
+        if (!full_all) {
+            for (size_t i = 0; i < rows; ++i) {
+                EXPECT_EQ(full[i], sel[i]) << "row " << i;
+            }
+        }
+    }
+};
+
+TEST_F(SelectiveConjunctsTest, SingleConjunctMatchesFullWidth) {
+    // vals: keep even rows. No nulls.
+    std::vector<uint8_t> vals(100), nulls(100, 0);
+    for (int i = 0; i < 100; ++i) {
+        vals[i] = (i % 2 == 0);
+    }
+    expect_equivalent(100, {make_ctx(vals, nulls)}, nullptr);
+}
+
+TEST_F(SelectiveConjunctsTest, CheapThenExpensiveNarrows) {
+    // First conjunct keeps 10% (drops below the 0.5 gather threshold), second keeps a subset;
+    // the selective path must reach the same result as full-width.
+    std::vector<uint8_t> v1(200), v2(200), n(200, 0);
+    for (int i = 0; i < 200; ++i) {
+        v1[i] = (i % 10 == 0); // keep 20 rows
+        v2[i] = (i % 4 == 0);  // overlaps partially
+    }
+    expect_equivalent(200, {make_ctx(v1, n), make_ctx(v2, n)}, nullptr);
+}
+
+TEST_F(SelectiveConjunctsTest, NullRowsAreDropped) {
+    // A row that is NULL for the predicate must be dropped (accept_null == false), the same
+    // way full-width execute_filter drops it.
+    std::vector<uint8_t> vals(150, 1), nulls(150, 0);
+    for (int i = 0; i < 150; ++i) {
+        vals[i] = (i % 3 != 0);  // structural selectivity
+        nulls[i] = (i % 7 == 0); // some rows null
+    }
+    // Two conjuncts so the second runs selectively over survivors including the NULL logic.
+    expect_equivalent(150, {make_ctx(vals, nulls), make_ctx(vals, nulls)}, nullptr);
+}
+
+TEST_F(SelectiveConjunctsTest, RuntimeFilterWrapperStaysFullWidth) {
+    // An RF-wrapper conjunct must be handled full-width but still yield the same result.
+    std::vector<uint8_t> v1(120), v2(120), n(120, 0);
+    for (int i = 0; i < 120; ++i) {
+        v1[i] = (i < 12); // cheap, keeps 10%
+        v2[i] = (i % 2 == 0);
+    }
+    expect_equivalent(120, {make_ctx(v1, n, /*is_rf=*/true), make_ctx(v2, n)}, nullptr);
+}
+
+TEST_F(SelectiveConjunctsTest, CanFilterAllWhenEmpty) {
+    // A conjunct that rejects everything -> can_filter_all on both paths.
+    std::vector<uint8_t> vals(80, 0), nulls(80, 0);
+    expect_equivalent(80, {make_ctx(vals, nulls)}, nullptr);
+}
+
+TEST_F(SelectiveConjunctsTest, PreexistingMaskFolded) {
+    // A delete-style mask AND-ed in must be respected identically.
+    std::vector<uint8_t> vals(100), nulls(100, 0);
+    for (int i = 0; i < 100; ++i) {
+        vals[i] = (i % 5 != 0);
+    }
+    IColumn::Filter mask(100, 1);
+    for (int i = 0; i < 100; ++i) {
+        mask[i] = (i < 30); // keep first 30
+    }
+    std::vector<IColumn::Filter*> filters = {&mask};
+    expect_equivalent(100, {make_ctx(vals, nulls)}, &filters);
+}
+
+TEST_F(SelectiveConjunctsTest, RandomizedEquivalence) {
+    // Fuzz: random rows, predicate count, selectivity, null rate, and RF flags. The selective
+    // path must always agree with the full-width path (the core correctness contract).
+    std::mt19937 rng(20260716);
+    for (int iter = 0; iter < 500; ++iter) {
+        const size_t rows = 1 + rng() % 400;
+        const int npred = 1 + rng() % 5;
+        VExprContextSPtrs ctxs;
+        for (int p = 0; p < npred; ++p) {
+            const double sel_rate = (rng() % 100) / 100.0;
+            const double null_rate = (rng() % 25) / 100.0;
+            std::vector<uint8_t> vals(rows), nulls(rows);
+            for (size_t i = 0; i < rows; ++i) {
+                vals[i] = ((rng() % 100) / 100.0) < sel_rate;
+                nulls[i] = ((rng() % 100) / 100.0) < null_rate;
+            }
+            ctxs.push_back(make_ctx(std::move(vals), std::move(nulls), rng() % 4 == 0));
+        }
+        expect_equivalent(rows, ctxs, nullptr);
+    }
+}
+
+class AdaptiveReorderTest : public testing::Test {
+protected:
+    // Build a conjunct with preset selectivity stats. `expensive` gives it a FUNCTION_CALL
+    // child so compute_conjunct_cost scores it above the adaptive-reorder admission threshold
+    // (a bare predicate scores ~2, below it); otherwise it stays a cheap comparison.
+    static VExprContextSPtr with_stats(int64_t in, int64_t out, bool expensive,
+                                       bool is_rf = false) {
+        auto expr = std::make_shared<FakeFilterExpr>(std::vector<uint8_t> {},
+                                                     std::vector<uint8_t> {}, is_rf);
+        if (expensive) {
+            auto fn = std::make_shared<FakeFilterExpr>(std::vector<uint8_t> {},
+                                                       std::vector<uint8_t> {}, false);
+            fn->set_node_type(TExprNodeType::FUNCTION_CALL);
+            expr->add_child(fn);
+        }
+        auto ctx = std::make_shared<VExprContext>(expr);
+        ctx->filter_runtime_stats().update(in, out);
+        return ctx;
+    }
+
+    // Same, plus preset timing measurements. `elapsed_ns` accrues over `timed_rows`, which
+    // must be >= kTimingMinRows for per_row_ns() to return the measurement (else the reorder
+    // falls back on the static cost).
+    static VExprContextSPtr with_timed_stats(int64_t in, int64_t out, bool expensive,
+                                             int64_t elapsed_ns, int64_t timed_rows) {
+        auto ctx = with_stats(in, out, expensive);
+        auto& stats = ctx->filter_runtime_stats();
+        stats.elapsed_ns = elapsed_ns;
+        stats.input_rows_timed = timed_rows;
+        return ctx;
+    }
+};
+
+TEST_F(AdaptiveReorderTest, DroppedFractionFormula) {
+    VExprContext::FilterRuntimeStats s;
+    s.update(1000, 100); // dropped 900 of 1000
+    EXPECT_DOUBLE_EQ(0.9, s.dropped_fraction());
+    VExprContext::FilterRuntimeStats none;
+    EXPECT_DOUBLE_EQ(0.0, none.dropped_fraction()); // no rows seen
+    VExprContext::FilterRuntimeStats keep;
+    keep.update(1000, 1000); // dropped nothing
+    EXPECT_DOUBLE_EQ(0.0, keep.dropped_fraction());
+}
+
+TEST_F(AdaptiveReorderTest, NotReorderedWhenAllCheap) {
+    // No conjunct is expensive by the static estimate -> the reorder is not worth its cost,
+    // even though their selectivities differ.
+    auto c1 = with_stats(1000, 900, /*expensive=*/false);
+    auto c2 = with_stats(1000, 100, /*expensive=*/false);
+    VExprContextSPtrs conjuncts = {c1, c2};
+    EXPECT_FALSE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    EXPECT_EQ(c1.get(), conjuncts[0].get());
+    EXPECT_EQ(c2.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, NotReorderedBelowMinRows) {
+    // An expensive conjunct is present, but conjuncts have only seen 50 rows (< min_rows):
+    // keep the static order until measurements are meaningful.
+    auto c1 = with_stats(50, 45, /*expensive=*/true);
+    auto c2 = with_stats(50, 5, /*expensive=*/false);
+    VExprContextSPtrs conjuncts = {c1, c2};
+    EXPECT_FALSE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 100));
+    EXPECT_EQ(c1.get(), conjuncts[0].get());
+    EXPECT_EQ(c2.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, UnselectiveExpensiveSinksBelowCheap) {
+    // An expensive predicate that turns out unselective (drops 10%) sorts after a cheap one
+    // that drops half -- the whole point of the adaptive correction.
+    auto expensive = with_stats(1000, 900, /*expensive=*/true); // cost~100, drop 0.1 -> ~1000
+    auto cheap = with_stats(1000, 500, /*expensive=*/false);    // cost~2, drop 0.5 -> ~4
+    VExprContextSPtrs conjuncts = {expensive, cheap};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    EXPECT_EQ(cheap.get(), conjuncts[0].get());
+    EXPECT_EQ(expensive.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, SelectiveExpensiveBeatsUnselectiveExpensive) {
+    // Two expensive predicates, same static cost; the one measured more selective runs first.
+    auto sel = with_stats(1000, 50, /*expensive=*/true);    // drop 0.95
+    auto unsel = with_stats(1000, 950, /*expensive=*/true); // drop 0.05
+    VExprContextSPtrs conjuncts = {unsel, sel};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    EXPECT_EQ(sel.get(), conjuncts[0].get());
+    EXPECT_EQ(unsel.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, DropNothingExpensiveSortsLast) {
+    // A conjunct that drops nothing must not divide by zero; the eps floor sends it last.
+    auto drops_nothing = with_stats(1000, 1000, /*expensive=*/true);
+    auto drops_some = with_stats(1000, 100, /*expensive=*/true);
+    VExprContextSPtrs conjuncts = {drops_nothing, drops_some};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    EXPECT_EQ(drops_some.get(), conjuncts[0].get());
+    EXPECT_EQ(drops_nothing.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, RuntimeFilterWrapperExemptAndFirst) {
+    // The RF wrapper is exempt from both gates and sorts first (key 0).
+    auto cheap = with_stats(1000, 100, /*expensive=*/true);
+    auto rf = with_stats(0, 0, /*expensive=*/false, /*is_rf=*/true);
+    VExprContextSPtrs conjuncts = {cheap, rf};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    EXPECT_EQ(rf.get(), conjuncts[0].get());
+    EXPECT_EQ(cheap.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, StatsAccumulateAcrossExecution) {
+    // Running execute_conjuncts_selective must populate FilterRuntimeStats so a later
+    // adaptive reorder has data. Use a low-selectivity first conjunct to trigger the
+    // selective path on the second.
+    std::vector<uint8_t> keep_few(200), n(200, 0);
+    for (int i = 0; i < 200; ++i) {
+        keep_few[i] = (i % 20 == 0); // keep 10
+    }
+    auto c1 = std::make_shared<VExprContext>(std::make_shared<FakeFilterExpr>(keep_few, n, false));
+    std::vector<uint8_t> keep_half(200);
+    for (int i = 0; i < 200; ++i) {
+        keep_half[i] = (i % 2 == 0);
+    }
+    auto c2 = std::make_shared<VExprContext>(std::make_shared<FakeFilterExpr>(keep_half, n, false));
+    VExprContextSPtrs conjuncts = {c1, c2};
+
+    Block block;
+    auto col = ColumnUInt8::create();
+    for (int i = 0; i < 200; ++i) {
+        col->insert_value(0);
+    }
+    block.insert({std::move(col), std::make_shared<DataTypeUInt8>(), "c0"});
+
+    IColumn::Filter f(200, 1);
+    bool can_all = false;
+    ASSERT_TRUE(VExprContext::execute_conjuncts_selective(conjuncts, nullptr, &block, &f, &can_all)
+                        .ok());
+    // Both conjuncts saw rows; c1 over the full block, c2 over the survivors of c1.
+    EXPECT_GT(c1->filter_runtime_stats().input_rows, 0);
+    EXPECT_GT(c2->filter_runtime_stats().input_rows, 0);
+    EXPECT_LT(c2->filter_runtime_stats().input_rows, c1->filter_runtime_stats().input_rows);
+}
+
+TEST_F(AdaptiveReorderTest, PerRowNsFormulaAndThreshold) {
+    // Below kTimingMinRows the measurement is untrusted and per_row_ns returns 0.
+    VExprContext::FilterRuntimeStats too_few;
+    too_few.elapsed_ns = 100000;
+    too_few.input_rows_timed = 100;
+    EXPECT_DOUBLE_EQ(0.0, too_few.per_row_ns());
+
+    // Above the threshold the mean nanoseconds per row is returned.
+    VExprContext::FilterRuntimeStats enough;
+    enough.elapsed_ns = 100000; // 100 us
+    enough.input_rows_timed = 10000;
+    EXPECT_DOUBLE_EQ(10.0, enough.per_row_ns()); // 100000 / 10000
+}
+
+TEST_F(AdaptiveReorderTest, MeasuredCostAdmitsWhenStaticUnderrates) {
+    // A predicate that scores cheap statically (BINARY_PRED ~2) but is measured at 200ns/row
+    // must still admit the reorder -- this is the whole point of adding measured cost. The
+    // pair here is both statically cheap, so before this change adaptive_reorder_conjuncts
+    // would refuse to reorder.
+    auto slow = with_timed_stats(1000, 900, /*expensive=*/false,
+                                 /*elapsed_ns=*/200 * 10000, /*timed_rows=*/10000);
+    auto fast = with_timed_stats(1000, 100, /*expensive=*/false,
+                                 /*elapsed_ns=*/2 * 10000, /*timed_rows=*/10000);
+    VExprContextSPtrs conjuncts = {slow, fast};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    // Slow drops 10%, fast drops 90%. Keys: 200/0.1=2000 vs 2/0.9=2.2 -> fast first.
+    EXPECT_EQ(fast.get(), conjuncts[0].get());
+    EXPECT_EQ(slow.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, MeasuredCostSeparatesEqualStaticScores) {
+    // Two FUNCTION_CALL predicates score the same statically (~102) but run 100x apart. The
+    // measured per_row_ns lets the reorder distinguish them: whichever runs slower with worse
+    // selectivity should sink.
+    auto slow_call = with_timed_stats(1000, 500, /*expensive=*/true,
+                                      /*elapsed_ns=*/500 * 10000, /*timed_rows=*/10000);
+    auto fast_call = with_timed_stats(1000, 500, /*expensive=*/true,
+                                      /*elapsed_ns=*/5 * 10000, /*timed_rows=*/10000);
+    VExprContextSPtrs conjuncts = {slow_call, fast_call};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    // Same selectivity 0.5; key is per_row_ns/0.5 -> 1000 vs 10 -> fast first.
+    EXPECT_EQ(fast_call.get(), conjuncts[0].get());
+    EXPECT_EQ(slow_call.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, StaticCostFallbackWhenUntimed) {
+    // When per_row_ns is 0 (samples below kTimingMinRows), sort_key falls back on the static
+    // structural cost -- the pre-timing behavior, still driven by selectivity.
+    auto slow_static = with_timed_stats(1000, 900, /*expensive=*/true,
+                                        /*elapsed_ns=*/100000, /*timed_rows=*/100); // < 4096
+    auto cheap_static = with_stats(1000, 500, /*expensive=*/false);
+    VExprContextSPtrs conjuncts = {slow_static, cheap_static};
+    EXPECT_TRUE(VExprContext::adaptive_reorder_conjuncts(conjuncts, 1000));
+    // Static: expensive 102/0.1=1020, cheap 2/0.5=4 -> cheap first.
+    EXPECT_EQ(cheap_static.get(), conjuncts[0].get());
+    EXPECT_EQ(slow_static.get(), conjuncts[1].get());
+}
+
+TEST_F(AdaptiveReorderTest, SamplingCounterOnlyTimesEveryNthBatch) {
+    // Sampling gate should_sample() must fire on batch 0 and every kTimingSampleEvery-th
+    // batch after that, and stay quiet in between. Locks in the sample cadence so a naive
+    // "always time" or "never time" regression is caught by the unit test.
+    VExprContext::FilterRuntimeStats stats;
+    std::vector<int64_t> sample_at;
+    for (int64_t i = 0; i < 32; ++i) {
+        if (stats.should_sample()) {
+            sample_at.push_back(i);
+        }
+        stats.update(1, 1); // bumps sample_counter
+    }
+    const auto every = VExprContext::FilterRuntimeStats::kTimingSampleEvery;
+    ASSERT_FALSE(sample_at.empty());
+    EXPECT_EQ(0, sample_at.front());
+    for (size_t i = 1; i < sample_at.size(); ++i) {
+        EXPECT_EQ(every, sample_at[i] - sample_at[i - 1]);
+    }
+}
+
+} // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -600,6 +600,12 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_EXPR_ZONEMAP_FILTER = "enable_expr_zonemap_filter";
 
+    public static final String ENABLE_SCAN_CONJUNCT_REORDER = "enable_scan_conjunct_reorder";
+
+    public static final String ENABLE_SCAN_SELECTIVE_FILTER = "enable_scan_selective_filter";
+
+    public static final String ENABLE_SCAN_ADAPTIVE_REORDER = "enable_scan_adaptive_reorder";
+
     public static final String CHECK_ORC_INIT_SARGS_SUCCESS = "check_orc_init_sargs_success";
 
     public static final String INLINE_CTE_REFERENCED_THRESHOLD = "inline_cte_referenced_threshold";
@@ -2718,6 +2724,46 @@ public class SessionVariable implements Serializable, Writable {
                             + "The default value is true."},
             needForward = true)
     public boolean enableExprZonemapFilter = true;
+
+    @VarAttrDef.VarAttr(
+            name = ENABLE_SCAN_CONJUNCT_REORDER,
+            description = {"控制 orc/parquet reader 是否按结构化代价对 filter 谓词重排序,"
+                    + "让便宜且高过滤率的谓词先执行(便宜谓词刷空整块后昂贵谓词天然跳过)。"
+                    + "重排只改执行顺序,不改变结果集。默认为 false。",
+                    "Controls whether orc/parquet readers reorder filter conjuncts by a "
+                            + "structural cost estimate so cheap, highly selective predicates "
+                            + "run first (an expensive predicate is skipped when a cheap one "
+                            + "already filters the whole block). Reordering only changes "
+                            + "execution order, never the result set. The default value is false."},
+            needForward = true)
+    public boolean enableScanConjunctReorder = false;
+
+    @VarAttrDef.VarAttr(
+            name = ENABLE_SCAN_SELECTIVE_FILTER,
+            description = {"控制 orc/parquet reader 是否用选择向量执行 filter:后续谓词只在前面谓词"
+                    + "保留下来的幸存行上求值(而非每个谓词都在全部行上算再 AND),让昂贵谓词只在"
+                    + "少量幸存行上执行。只改执行方式,不改变结果集。默认为 false。",
+                    "Controls whether orc/parquet readers evaluate filters with a selection "
+                            + "vector: a later predicate is evaluated only on rows surviving the "
+                            + "earlier ones (instead of every predicate over all rows then AND), "
+                            + "so an expensive predicate runs only on the few surviving rows. It "
+                            + "changes execution only, never the result set. Default is false."},
+            needForward = true)
+    public boolean enableScanSelectiveFilter = false;
+
+    @VarAttrDef.VarAttr(
+            name = ENABLE_SCAN_ADAPTIVE_REORDER,
+            description = {"控制 orc/parquet reader 是否在运行时按实测代价(每消除一行的耗时)重排 filter"
+                    + "谓词:攒够一定行数后用实测顺序覆盖静态估计,纠正倾斜数据或 UDF 未知代价导致的"
+                    + "误判。依赖 enable_scan_selective_filter 采集统计。只改执行顺序,不改结果集。默认为 false。",
+                    "Controls whether orc/parquet readers reorder filter conjuncts at runtime by "
+                            + "measured cost (time per row eliminated): once enough rows are seen, "
+                            + "the measured order overrides the static estimate, correcting for "
+                            + "skewed data or unknown UDF cost. Relies on enable_scan_selective_filter "
+                            + "to collect stats. Changes execution order only, never the result "
+                            + "set. Default is false."},
+            needForward = true)
+    public boolean enableScanAdaptiveReorder = false;
 
     @VarAttrDef.VarAttr(
             name = CHECK_ORC_INIT_SARGS_SUCCESS,
@@ -5053,6 +5099,30 @@ public class SessionVariable implements Serializable, Writable {
         this.enableExprZonemapFilter = enableExprZonemapFilter;
     }
 
+    public boolean isEnableScanConjunctReorder() {
+        return enableScanConjunctReorder;
+    }
+
+    public void setEnableScanConjunctReorder(boolean enableScanConjunctReorder) {
+        this.enableScanConjunctReorder = enableScanConjunctReorder;
+    }
+
+    public boolean isEnableScanSelectiveFilter() {
+        return enableScanSelectiveFilter;
+    }
+
+    public void setEnableScanSelectiveFilter(boolean enableScanSelectiveFilter) {
+        this.enableScanSelectiveFilter = enableScanSelectiveFilter;
+    }
+
+    public boolean isEnableScanAdaptiveReorder() {
+        return enableScanAdaptiveReorder;
+    }
+
+    public void setEnableScanAdaptiveReorder(boolean enableScanAdaptiveReorder) {
+        this.enableScanAdaptiveReorder = enableScanAdaptiveReorder;
+    }
+
     public boolean isCheckOrcInitSargsSuccess() {
         return checkOrcInitSargsSuccess;
     }
@@ -5771,6 +5841,9 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableParquetFilePageCache(enableParquetFilePageCache);
         tResult.setEnableOrcFilterByMinMax(enableOrcFilterByMinMax);
         tResult.setEnableExprZonemapFilter(enableExprZonemapFilter);
+        tResult.setEnableScanConjunctReorder(enableScanConjunctReorder);
+        tResult.setEnableScanSelectiveFilter(enableScanSelectiveFilter);
+        tResult.setEnableScanAdaptiveReorder(enableScanAdaptiveReorder);
         tResult.setEnablePaimonCppReader(enablePaimonCppReader);
         tResult.setFilePresignedUrlTtlSeconds(filePresignedUrlTtlSeconds);
         tResult.setEmbedMaxBatchSize(embedMaxBatchSize);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -401,4 +401,49 @@ public class SessionVariablesTest extends TestWithFeService {
         Assertions.assertTrue(queryOptions.isSetFileCacheQueryLimitBytes());
         Assertions.assertEquals(262144L, queryOptions.getFileCacheQueryLimitBytes());
     }
+
+    @Test
+    public void testScanFilterSelectivityVariables() {
+        SessionVariable sv = new SessionVariable();
+
+        // All three scan-filter optimizations default off (opt-in).
+        Assertions.assertFalse(sv.isEnableScanConjunctReorder());
+        Assertions.assertFalse(sv.isEnableScanSelectiveFilter());
+        Assertions.assertFalse(sv.isEnableScanAdaptiveReorder());
+
+        // Setters flip the values.
+        sv.setEnableScanConjunctReorder(true);
+        sv.setEnableScanSelectiveFilter(true);
+        sv.setEnableScanAdaptiveReorder(true);
+        Assertions.assertTrue(sv.isEnableScanConjunctReorder());
+        Assertions.assertTrue(sv.isEnableScanSelectiveFilter());
+        Assertions.assertTrue(sv.isEnableScanAdaptiveReorder());
+
+        // toThrift carries the current values to the BE.
+        TQueryOptions on = sv.toThrift();
+        Assertions.assertTrue(on.isEnableScanConjunctReorder());
+        Assertions.assertTrue(on.isEnableScanSelectiveFilter());
+        Assertions.assertTrue(on.isEnableScanAdaptiveReorder());
+
+        sv.setEnableScanConjunctReorder(false);
+        sv.setEnableScanSelectiveFilter(false);
+        sv.setEnableScanAdaptiveReorder(false);
+        TQueryOptions off = sv.toThrift();
+        Assertions.assertFalse(off.isEnableScanConjunctReorder());
+        Assertions.assertFalse(off.isEnableScanSelectiveFilter());
+        Assertions.assertFalse(off.isEnableScanAdaptiveReorder());
+    }
+
+    @Test
+    public void testScanFilterSelectivityVariablesForward() {
+        SessionVariable sv = new SessionVariable();
+        Map<String, String> forwardVars = sv.getForwardVariables();
+        Assertions.assertTrue(forwardVars.containsKey(SessionVariable.ENABLE_SCAN_CONJUNCT_REORDER));
+        Assertions.assertTrue(forwardVars.containsKey(SessionVariable.ENABLE_SCAN_SELECTIVE_FILTER));
+        Assertions.assertTrue(forwardVars.containsKey(SessionVariable.ENABLE_SCAN_ADAPTIVE_REORDER));
+
+        forwardVars.put(SessionVariable.ENABLE_SCAN_CONJUNCT_REORDER, "false");
+        sv.setForwardedSessionVariables(forwardVars);
+        Assertions.assertFalse(sv.isEnableScanConjunctReorder());
+    }
 }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -508,6 +508,22 @@ struct TQueryOptions {
 
   226: optional bool enable_prune_nested_column = false;
   227: optional bool new_version_bitmap_op_count = false;
+
+  // Whether orc/parquet readers reorder filter conjuncts by a structural cost estimate so
+  // cheap, highly selective predicates run first. Reordering only changes execution order,
+  // never the result set. Default off; opt-in.
+  228: optional bool enable_scan_conjunct_reorder = false;
+
+  // Whether orc/parquet readers evaluate filters with a selection vector, so a later
+  // predicate is evaluated only on rows surviving the earlier ones instead of every
+  // predicate over all rows. Changes execution only, never the result set. Default off; opt-in.
+  229: optional bool enable_scan_selective_filter = false;
+
+  // Whether orc/parquet readers reorder filter conjuncts at runtime by measured cost (time
+  // per row eliminated), overriding the static estimate once enough rows are measured.
+  // Relies on enable_scan_selective_filter to collect stats. Default off; opt-in.
+  230: optional bool enable_scan_adaptive_reorder = false;
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66108

Problem Summary:

The ORC and Parquet readers evaluate every filter conjunct over all rows of a
block and AND the results together, regardless of how cheap/selective each
predicate is or the order the planner emitted them. An expensive predicate
(e.g. a string function like split_by_string(col)[n]='x') is therefore run over
the full block even when a cheap, highly-selective predicate on the same block
would have filtered almost everything first.

This adds three session-gated, correctness-neutral optimizations that only
change the order/method of filter execution, never which rows pass:

1. Static cost-based conjunct reorder (enable_scan_conjunct_reorder):
   VExpr::compute_conjunct_cost scores each conjunct by a structural per-node
   cost (leaves/comparisons cheap, function calls expensive, summed over the
   tree with constant subtrees skipped), and VExpr::reorder_conjuncts_by_cost
   stable-sorts conjuncts cheap-first.

2. Selection-vector selective execution (enable_scan_selective_filter):
   VExprContext::execute_conjuncts_selective threads the set of surviving row
   indices between conjuncts, so a later (typically expensive) predicate is
   evaluated only on rows earlier ones let through. It produces the identical
   full-width result_filter / can_filter_all contract as execute_conjuncts, so
   it is a drop-in. Runtime-filter-wrapper conjuncts stay full-width (they carry
   selectivity/counter side effects) and the selective gather is skipped while
   the surviving fraction is still high (> 0.5), where gather is not worth its
   memcpy.

3. Adaptive runtime reorder (enable_scan_adaptive_reorder):
   A per-VExprContext FilterRuntimeStats samples ~1/8 of batches (min 4096 timed
   rows) and re-sorts conjuncts by measured (per-row cost / drop fraction),
   correcting the static estimate for skewed data or unknown UDF cost.

All three default OFF (opt-in): with the flags unset the ORC/Parquet filter
path is byte-identical to before, so this carries zero risk for existing
queries and lets operators enable/benchmark it per session. A wrong
cost/selectivity estimate can only cost a suboptimal execution order, never a
wrong result.

### Release note

Add three session variables (all default false / opt-in, execution-order only,
never change query results): enable_scan_conjunct_reorder,
enable_scan_selective_filter, enable_scan_adaptive_reorder — controlling
selectivity-aware filter execution in the ORC/Parquet readers.

### Check List (For Author)

- Test:
    - Unit Test: Added be/test/exprs/vexpr_conjunct_reorder_test.cpp (10 cases:
      cost model + static reorder) and be/test/exprs/vexpr_selective_conjuncts_test.cpp
      (20 cases: selective-vs-full-width equivalence incl. a 500-iter randomized
      fuzz, plus adaptive-reorder gating) — 30 BE tests pass. Extended
      SessionVariablesTest for the three new vars (FE) — asserts default false,
      setter/toThrift round-trip, and forward-variable propagation.
    - The four reader call sites (ORC _get_next_block_impl + OrcReader::filter,
      Parquet next_batch + _do_lazy_read) wrap the existing execute_conjuncts
      with the session-gated reorder/selective path; with the flags off the path
      is byte-identical to before. No dedicated reader regression suite was added
      (requires a live cluster) — noted as follow-up.
- Behavior changed: No (opt-in, default off; execution order/method only when
  enabled; results are identical either way).
- Does this need documentation: No.

