### PR TITLE
[feature](ci) Rotate review credentials after quota errors

### DIFF
--- a/.github/scripts/codex_auth_state.py
+++ b/.github/scripts/codex_auth_state.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Persist and select the rotating credentials used by code review jobs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+STATE_VERSION = 1
+AVAILABLE = "available"
+QUOTA_EXHAUSTED = "quota_exhausted"
+RATE_LIMITED = "rate_limited"
+AUTHENTICATION_FAILED = "authentication_failed"
+TRANSIENT_FAILURE = "transient_failure"
+STATUS_VALUES = {AVAILABLE, QUOTA_EXHAUSTED, RATE_LIMITED, AUTHENTICATION_FAILED}
+QUOTA_RETRY_DELAY = timedelta(days=1)
+RATE_LIMIT_RETRY_DELAY = timedelta(hours=1)
+AUTHENTICATION_RETRY_DELAY = timedelta(days=1)
+
+
+@dataclass(frozen=True)
+class Selection:
+    auth_object: str | None
+    all_quota_exhausted: bool
+    next_retry_at: str | None
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError(f"Timestamp must include a timezone: {value!r}")
+    return parsed.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_account_state() -> dict[str, Any]:
+    return {
+        "status": AVAILABLE,
+        "last_failure_at": None,
+        "last_http_status": None,
+        "last_success_at": None,
+        "last_recovered_at": None,
+        "retry_after": None,
+    }
+
+
+def default_state() -> dict[str, Any]:
+    return {"version": STATE_VERSION, "next_account": 0, "accounts": {}}
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return default_state()
+
+    state = json.loads(path.read_text())
+    if not isinstance(state, dict):
+        raise ValueError("Authentication state must be a JSON object")
+    if state.get("version") != STATE_VERSION:
+        raise ValueError(f"Unsupported authentication state version: {state.get('version')!r}")
+    if not isinstance(state.get("next_account"), int):
+        raise ValueError("Authentication state next_account must be an integer")
+    if not isinstance(state.get("accounts"), dict):
+        raise ValueError("Authentication state accounts must be an object")
+    return state
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as temporary:
+        json.dump(state, temporary, indent=2, sort_keys=True)
+        temporary.write("\n")
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+def account_state(state: dict[str, Any], auth_object: str) -> dict[str, Any]:
+    accounts = state["accounts"]
+    entry = accounts.setdefault(auth_object, default_account_state())
+    if not isinstance(entry, dict):
+        raise ValueError(f"Authentication state for {auth_object!r} must be an object")
+    status = entry.get("status", AVAILABLE)
+    if status not in STATUS_VALUES:
+        raise ValueError(f"Unknown authentication status for {auth_object!r}: {status!r}")
+    entry.setdefault("status", AVAILABLE)
+    entry.setdefault("last_failure_at", None)
+    entry.setdefault("last_http_status", None)
+    entry.setdefault("last_success_at", None)
+    entry.setdefault("last_recovered_at", None)
+    entry.setdefault("retry_after", None)
+    return entry
+
+
+def recover_expired_accounts(state: dict[str, Any], auth_objects: list[str], now: datetime) -> None:
+    for auth_object in auth_objects:
+        entry = account_state(state, auth_object)
+        retry_after = entry["retry_after"]
+        if retry_after is None:
+            continue
+        if parse_timestamp(retry_after) <= now:
+            entry["status"] = AVAILABLE
+            entry["retry_after"] = None
+            entry["last_recovered_at"] = format_timestamp(now)
+
+
+def next_retry_at(state: dict[str, Any], auth_objects: list[str]) -> str | None:
+    retry_at = [
+        entry["retry_after"]
+        for auth_object in auth_objects
+        for entry in [account_state(state, auth_object)]
+        if entry["retry_after"] is not None
+    ]
+    return min(retry_at, key=parse_timestamp, default=None)
+
+
+def all_quota_exhausted(state: dict[str, Any], auth_objects: list[str]) -> bool:
+    return bool(auth_objects) and all(
+        account_state(state, auth_object)["status"] == QUOTA_EXHAUSTED for auth_object in auth_objects
+    )
+
+
+def select_auth_object(state: dict[str, Any], auth_objects: list[str], now: datetime) -> Selection:
+    if not auth_objects:
+        raise ValueError("At least one auth object is required")
+
+    recover_expired_accounts(state, auth_objects, now)
+    starting_index = state["next_account"] % len(auth_objects)
+    for offset in range(len(auth_objects)):
+        index = (starting_index + offset) % len(auth_objects)
+        auth_object = auth_objects[index]
+        if account_state(state, auth_object)["status"] == AVAILABLE:
+            state["next_account"] = (index + 1) % len(auth_objects)
+            return Selection(auth_object, False, None)
+
+    return Selection(None, all_quota_exhausted(state, auth_objects), next_retry_at(state, auth_objects))
+
+
+def record_result(
+    state: dict[str, Any], auth_object: str, result: str, now: datetime, http_status: int | None = None
+) -> None:
+    entry = account_state(state, auth_object)
+    timestamp = format_timestamp(now)
+    if result == AVAILABLE:
+        entry["status"] = AVAILABLE
+        entry["last_success_at"] = timestamp
+        entry["retry_after"] = None
+        return
+
+    if result == QUOTA_EXHAUSTED:
+        retry_delay = QUOTA_RETRY_DELAY
+        http_status = http_status or 403
+    elif result == RATE_LIMITED:
+        retry_delay = RATE_LIMIT_RETRY_DELAY
+        http_status = http_status or 429
+    elif result == AUTHENTICATION_FAILED:
+        retry_delay = AUTHENTICATION_RETRY_DELAY
+        http_status = http_status or 401
+    elif result == TRANSIENT_FAILURE:
+        entry["status"] = AVAILABLE
+        entry["last_failure_at"] = timestamp
+        entry["last_http_status"] = http_status
+        entry["retry_after"] = None
+        return
+    else:
+        raise ValueError(f"Unsupported result: {result!r}")
+
+    entry["status"] = result
+    entry["last_failure_at"] = timestamp
+    entry["last_http_status"] = http_status
+    entry["retry_after"] = format_timestamp(now + retry_delay)
+
+
+def extract_http_status(text: str) -> int | None:
+    labelled_statuses = re.findall(
+        r"(?:http(?:\s+status)?|status(?:\s+code)?|error\s+code)\s*[:=]?\s*([1-5]\d{2})",
+        text,
+        re.IGNORECASE,
+    )
+    if labelled_statuses:
+        return int(labelled_statuses[-1])
+    matches = re.findall(r"(?<!\d)([1-5]\d{2})(?!\d)", text)
+    return int(matches[0]) if matches else None
+
+
+def classify_failure(text: str) -> str:
+    http_status = extract_http_status(text)
+    if http_status == 429:
+        return RATE_LIMITED
+    if http_status in {402, 403}:
+        return QUOTA_EXHAUSTED
+    if http_status == 401:
+        return AUTHENTICATION_FAILED
+    if http_status in {408, 409, 425, 500, 502, 503, 504}:
+        return TRANSIENT_FAILURE
+    if re.search(
+        r"connection reset|econnreset|eai_again|network is unreachable|etimedout|timeout|timed? out",
+        text,
+        re.IGNORECASE,
+    ):
+        return TRANSIENT_FAILURE
+    return "fatal"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    commands_with_state = (
+        subcommands.add_parser("initialize"),
+        subcommands.add_parser("select"),
+        subcommands.add_parser("record"),
+    )
+    for command in commands_with_state:
+        command.add_argument("--state", type=Path, required=True)
+        command.add_argument("--now", type=parse_timestamp)
+
+    initialize = subcommands.choices["initialize"]
+    initialize.add_argument("--auth-object", action="append", required=True)
+
+    select = subcommands.choices["select"]
+    select.add_argument("--auth-object", action="append", required=True)
+
+    record = subcommands.choices["record"]
+    record.add_argument("--auth-object", required=True)
+    record.add_argument(
+        "--result",
+        choices=[AVAILABLE, QUOTA_EXHAUSTED, RATE_LIMITED, AUTHENTICATION_FAILED, TRANSIENT_FAILURE],
+        required=True,
+    )
+    record.add_argument("--http-status", type=int)
+    record.add_argument("--known-auth-object", action="append", required=True)
+
+    classify = subcommands.add_parser("classify")
+    classify.add_argument("--input", action="append", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "classify":
+        text = "\n".join(path.read_text(errors="replace") for path in args.input)
+        print(json.dumps({"kind": classify_failure(text), "http_status": extract_http_status(text)}))
+        return
+
+    now = args.now or utc_now()
+    state = load_state(args.state)
+    if args.command == "initialize":
+        for auth_object in args.auth_object:
+            account_state(state, auth_object)
+        save_state(args.state, state)
+        return
+
+    if args.command == "select":
+        selection = select_auth_object(state, args.auth_object, now)
+        save_state(args.state, state)
+        print(
+            json.dumps(
+                {
+                    "auth_object": selection.auth_object,
+                    "all_quota_exhausted": selection.all_quota_exhausted,
+                    "next_retry_at": selection.next_retry_at,
+                }
+            )
+        )
+        return
+
+    record_result(state, args.auth_object, args.result, now, args.http_status)
+    recover_expired_accounts(state, args.known_auth_object, now)
+    save_state(args.state, state)
+    print(
+        json.dumps(
+            {
+                "all_quota_exhausted": all_quota_exhausted(state, args.known_auth_object),
+                "next_retry_at": next_retry_at(state, args.known_auth_object),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_codex_auth_state.py
+++ b/.github/scripts/test_codex_auth_state.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+import codex_auth_state as auth_state  # noqa: E402
+
+
+AUTH_1 = "oss://doris-community-ci/codex/auth.json.1"
+AUTH_2 = "oss://doris-community-ci/codex/auth.json.2"
+AUTH_OBJECTS = [AUTH_1, AUTH_2]
+NOW = datetime(2026, 7, 27, 10, 0, tzinfo=timezone.utc)
+
+
+class CodexAuthStateTest(unittest.TestCase):
+    def test_selection_rotates_accounts(self) -> None:
+        state = auth_state.default_state()
+
+        first = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW)
+        second = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW)
+
+        self.assertEqual(AUTH_1, first.auth_object)
+        self.assertEqual(AUTH_2, second.auth_object)
+
+    def test_rate_limit_skips_account_for_one_hour_then_recovers(self) -> None:
+        state = auth_state.default_state()
+        auth_state.record_result(state, AUTH_1, auth_state.RATE_LIMITED, NOW)
+
+        during_cooldown = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW + timedelta(minutes=30))
+        after_cooldown = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW + timedelta(hours=1))
+
+        self.assertEqual(AUTH_2, during_cooldown.auth_object)
+        self.assertEqual(AUTH_1, after_cooldown.auth_object)
+        self.assertEqual(auth_state.AVAILABLE, auth_state.account_state(state, AUTH_1)["status"])
+
+    def test_quota_exhaustion_retries_after_one_day_and_alerts_for_both_accounts(self) -> None:
+        state = auth_state.default_state()
+        auth_state.record_result(state, AUTH_1, auth_state.QUOTA_EXHAUSTED, NOW)
+        auth_state.record_result(state, AUTH_2, auth_state.QUOTA_EXHAUSTED, NOW)
+
+        unavailable = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW + timedelta(hours=23))
+        available_again = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW + timedelta(days=1))
+
+        self.assertIsNone(unavailable.auth_object)
+        self.assertTrue(unavailable.all_quota_exhausted)
+        self.assertEqual(AUTH_1, available_again.auth_object)
+
+    def test_success_clears_the_retry_marker(self) -> None:
+        state = auth_state.default_state()
+        auth_state.record_result(state, AUTH_1, auth_state.QUOTA_EXHAUSTED, NOW)
+        auth_state.record_result(state, AUTH_1, auth_state.AVAILABLE, NOW + timedelta(minutes=1))
+
+        entry = auth_state.account_state(state, AUTH_1)
+        self.assertEqual(auth_state.AVAILABLE, entry["status"])
+        self.assertIsNone(entry["retry_after"])
+        self.assertEqual("2026-07-27T10:01:00Z", entry["last_success_at"])
+
+    def test_authentication_failure_switches_accounts_for_one_day(self) -> None:
+        state = auth_state.default_state()
+        auth_state.record_result(state, AUTH_1, auth_state.AUTHENTICATION_FAILED, NOW, 401)
+
+        during_cooldown = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW + timedelta(hours=23))
+        after_cooldown = auth_state.select_auth_object(state, AUTH_OBJECTS, NOW + timedelta(days=1))
+
+        self.assertEqual(AUTH_2, during_cooldown.auth_object)
+        self.assertEqual(AUTH_1, after_cooldown.auth_object)
+
+    def test_initialize_creates_state_file_for_all_accounts(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            state_file = Path(temporary_directory) / "auth-status.json"
+            state = auth_state.load_state(state_file)
+            for auth_object in AUTH_OBJECTS:
+                auth_state.account_state(state, auth_object)
+            auth_state.save_state(state_file, state)
+
+            created = auth_state.load_state(state_file)
+            self.assertEqual(set(AUTH_OBJECTS), set(created["accounts"]))
+
+    def test_classify_failure_uses_status_and_network_rules(self) -> None:
+        self.assertEqual(auth_state.RATE_LIMITED, auth_state.classify_failure("request failed: HTTP 429"))
+        self.assertEqual(auth_state.QUOTA_EXHAUSTED, auth_state.classify_failure("request failed: HTTP 403"))
+        self.assertEqual(
+            auth_state.QUOTA_EXHAUSTED,
+            auth_state.classify_failure("HTTP status 403 for request 123"),
+        )
+        self.assertEqual(auth_state.AUTHENTICATION_FAILED, auth_state.classify_failure("request failed: HTTP 401"))
+        self.assertEqual(auth_state.TRANSIENT_FAILURE, auth_state.classify_failure("request failed: HTTP 503"))
+        self.assertEqual(auth_state.TRANSIENT_FAILURE, auth_state.classify_failure("connection reset by peer"))
+        self.assertEqual("fatal", auth_state.classify_failure("request failed: HTTP 422"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -74,6 +74,20 @@ jobs:
           unzip -q "$tmp_dir/ossutil.zip" -d "$tmp_dir"
           sudo install -m 0755 "$tmp_dir/ossutil-v1.7.19-linux-amd64/ossutil" /usr/local/bin/ossutil
 
+      - name: Prepare Codex auth state helper
+        run: |
+          helper="$RUNNER_TEMP/codex_auth_state.py"
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            "repos/${REPO}/contents/.github/scripts/codex_auth_state.py?ref=${HELPER_REF}" \
+            > "$helper"
+          chmod 700 "$helper"
+          printf 'CODEX_AUTH_STATE_HELPER=%s\n' "$helper" >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HELPER_REF: ${{ github.workflow_sha || github.sha }}
+
       - name: Install Codex goal binary
         run: |
           codex_cmd="$(command -v codex)"
@@ -101,14 +115,48 @@ jobs:
           OSS_CODEX_GOAL_FALLBACK_OBJECT: oss://doris-community-ci/codex/codex-goal
 
       - name: Configure Codex auth
+        id: configure_auth
         run: |
           install -m 700 -d "$RUNNER_TEMP/codex-home"
           printf 'CODEX_HOME=%s\n' "$RUNNER_TEMP/codex-home" >> "$GITHUB_ENV"
 
-          auth_object="$(printf '%s\n' \
-            'oss://doris-community-ci/codex/auth.json.1' \
-            'oss://doris-community-ci/codex/auth.json.2' \
-            | shuf -n 1)"
+          state_file="$RUNNER_TEMP/codex-home/auth-status.json"
+          set +e
+          state_stat_output="$(ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" stat "$OSS_CODEX_AUTH_STATUS_OBJECT" 2>&1)"
+          state_stat_status=$?
+          set -e
+          if [ "$state_stat_status" -eq 0 ]; then
+            ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$OSS_CODEX_AUTH_STATUS_OBJECT" "$state_file"
+          elif grep -Eqi 'NoSuchKey|NoSuchObject|404' <<<"$state_stat_output"; then
+            "$CODEX_AUTH_STATE_HELPER" initialize \
+              --state "$state_file" \
+              --auth-object "$OSS_CODEX_AUTH_OBJECT_1" \
+              --auth-object "$OSS_CODEX_AUTH_OBJECT_2"
+            ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$state_file" "$OSS_CODEX_AUTH_STATUS_OBJECT"
+            echo "Created Codex auth status file in OSS."
+          else
+            echo "Unable to determine whether the Codex auth status file exists." >&2
+            exit 1
+          fi
+
+          selection_json="$("$CODEX_AUTH_STATE_HELPER" select \
+            --state "$state_file" \
+            --auth-object "$OSS_CODEX_AUTH_OBJECT_1" \
+            --auth-object "$OSS_CODEX_AUTH_OBJECT_2")"
+          ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$state_file" "$OSS_CODEX_AUTH_STATUS_OBJECT"
+          chmod 600 "$state_file"
+          printf 'CODEX_AUTH_STATE_FILE=%s\n' "$state_file" >> "$GITHUB_ENV"
+
+          auth_object="$(jq -r '.auth_object // empty' <<<"$selection_json")"
+          all_quota_exhausted="$(jq -r '.all_quota_exhausted' <<<"$selection_json")"
+          printf 'all_quota_exhausted=%s\n' "$all_quota_exhausted" >> "$GITHUB_OUTPUT"
+          if [ -z "$auth_object" ]; then
+            next_retry_at="$(jq -r '.next_retry_at // "unknown"' <<<"$selection_json")"
+            echo "No Codex auth account is currently eligible; next retry: $next_retry_at"
+            printf 'auth_unavailable=true\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$auth_object" >> "$GITHUB_ENV"
           echo "Selected Codex auth object: ${auth_object##*/}"
           ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$auth_object" "$RUNNER_TEMP/codex-home/auth.json"
@@ -145,6 +193,9 @@ jobs:
           OSS_AK: ${{ secrets.OSS_AK }}
           OSS_SK: ${{ secrets.OSS_SK }}
           OSS_ENDPOINT: oss-cn-hongkong.aliyuncs.com
+          OSS_CODEX_AUTH_OBJECT_1: oss://doris-community-ci/codex/auth.json.1
+          OSS_CODEX_AUTH_OBJECT_2: oss://doris-community-ci/codex/auth.json.2
+          OSS_CODEX_AUTH_STATUS_OBJECT: oss://doris-community-ci/codex/auth-status.json
 
       - name: Sync Codex memories from OSS
         run: |
@@ -493,44 +544,183 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OSS_AK: ${{ secrets.OSS_AK }}
+          OSS_SK: ${{ secrets.OSS_SK }}
+          OSS_ENDPOINT: oss-cn-hongkong.aliyuncs.com
+          OSS_CODEX_AUTH_OBJECT_1: oss://doris-community-ci/codex/auth.json.1
+          OSS_CODEX_AUTH_OBJECT_2: oss://doris-community-ci/codex/auth.json.2
+          OSS_CODEX_AUTH_STATUS_OBJECT: oss://doris-community-ci/codex/auth-status.json
+          AUTH_UNAVAILABLE: ${{ steps.configure_auth.outputs.auth_unavailable }}
+          CONFIGURED_ALL_QUOTA_EXHAUSTED: ${{ steps.configure_auth.outputs.all_quota_exhausted }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}
           HEAD_SHA: ${{ inputs.head_sha }}
         run: |
+          write_review_output() {
+            local key="$1"
+            local value="$2"
+            {
+              echo "${key}<<EOF"
+              printf '%s\n' "$value"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          sync_auth_state() {
+            ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f \
+              "$CODEX_AUTH_STATE_FILE" "$OSS_CODEX_AUTH_STATUS_OBJECT"
+          }
+
+          sync_current_auth() {
+            if [ -s "$CODEX_HOME/auth.json" ] && jq -e '
+              .auth_mode == "chatgpt"
+              and (.tokens.access_token | type == "string" and length > 0)
+              and (.tokens.refresh_token | type == "string" and length > 0)
+            ' "$CODEX_HOME/auth.json" >/dev/null; then
+              ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f \
+                "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT"
+            else
+              echo "The current Codex auth file is invalid; it will not be synced to OSS."
+            fi
+          }
+
+          record_auth_result() {
+            local result="$1"
+            local http_status="$2"
+            local record_args=(
+              record
+              --state "$CODEX_AUTH_STATE_FILE"
+              --auth-object "$CODEX_AUTH_OSS_OBJECT"
+              --known-auth-object "$OSS_CODEX_AUTH_OBJECT_1"
+              --known-auth-object "$OSS_CODEX_AUTH_OBJECT_2"
+              --result "$result"
+            )
+            if [ -n "$http_status" ]; then
+              record_args+=(--http-status "$http_status")
+            fi
+            "$CODEX_AUTH_STATE_HELPER" "${record_args[@]}"
+          }
+
+          select_next_auth() {
+            local selection_json
+            selection_json="$("$CODEX_AUTH_STATE_HELPER" select \
+              --state "$CODEX_AUTH_STATE_FILE" \
+              --auth-object "$OSS_CODEX_AUTH_OBJECT_1" \
+              --auth-object "$OSS_CODEX_AUTH_OBJECT_2")"
+            sync_auth_state
+            selected_auth_object="$(jq -r '.auth_object // empty' <<<"$selection_json")"
+            all_quota_exhausted="$(jq -r '.all_quota_exhausted' <<<"$selection_json")"
+            next_retry_at="$(jq -r '.next_retry_at // empty' <<<"$selection_json")"
+          }
+
+          if [ "$AUTH_UNAVAILABLE" = "true" ]; then
+            write_review_output "all_quota_exhausted" "$CONFIGURED_ALL_QUOTA_EXHAUSTED"
+            write_review_output "failure_reason" "No Codex auth account is currently eligible for review."
+            exit 1
+          fi
+
           GOAL_PROMPT="$(cat "$REVIEW_CONTEXT_DIR/codex_goal_prompt.txt")"
-          review_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-          set +e
-          # GitHub-hosted runners are ephemeral. Avoid workspace-write here because
-          # Codex uses bubblewrap for that mode and uid maps can be unavailable.
-          codex exec --goal "$GOAL_PROMPT" \
-            --cd "$GITHUB_WORKSPACE" \
-            --model "gpt-5.6-sol" \
-            --config "model_reasoning_effort=xhigh" \
-            --sandbox danger-full-access \
-            --color never \
-            --json \
-            --output-last-message "$REVIEW_CONTEXT_DIR/codex-final-message.txt" \
-            > "$REVIEW_CONTEXT_DIR/codex-events.jsonl" \
-            2> >(tee "$REVIEW_CONTEXT_DIR/codex-stderr.log" >&2)
-          status=$?
-          set -e
-
           failure_reason=""
-          if [ "$status" -ne 0 ]; then
-            if [ -s "$REVIEW_CONTEXT_DIR/codex-events.jsonl" ]; then
-              failure_reason="$(jq -r 'select(.type == "turn.failed") | .error.message // empty' "$REVIEW_CONTEXT_DIR/codex-events.jsonl" | tail -n 1)"
+          all_quota_exhausted="${CONFIGURED_ALL_QUOTA_EXHAUSTED:-false}"
+          transient_attempt=0
+          while :; do
+            review_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            events_file="$REVIEW_CONTEXT_DIR/codex-events.jsonl"
+            stderr_file="$REVIEW_CONTEXT_DIR/codex-stderr.log"
+
+            set +e
+            # GitHub-hosted runners are ephemeral. Avoid workspace-write here because
+            # Codex uses bubblewrap for that mode and uid maps can be unavailable.
+            codex exec --goal "$GOAL_PROMPT" \
+              --cd "$GITHUB_WORKSPACE" \
+              --model "gpt-5.6-sol" \
+              --config "model_reasoning_effort=xhigh" \
+              --sandbox danger-full-access \
+              --color never \
+              --json \
+              --output-last-message "$REVIEW_CONTEXT_DIR/codex-final-message.txt" \
+              > "$events_file" \
+              2> >(tee "$stderr_file" >&2)
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              state_result="$("$CODEX_AUTH_STATE_HELPER" record \
+                --state "$CODEX_AUTH_STATE_FILE" \
+                --auth-object "$CODEX_AUTH_OSS_OBJECT" \
+                --known-auth-object "$OSS_CODEX_AUTH_OBJECT_1" \
+                --known-auth-object "$OSS_CODEX_AUTH_OBJECT_2" \
+                --result available)"
+              sync_auth_state
+              all_quota_exhausted="$(jq -r '.all_quota_exhausted' <<<"$state_result")"
+              break
+            fi
+
+            if [ -s "$events_file" ]; then
+              failure_reason="$(jq -r 'select(.type == "turn.failed") | .error.message // empty' "$events_file" | tail -n 1)"
               if [ -z "$failure_reason" ]; then
-                failure_reason="$(jq -r 'select(.type == "error") | .message // .error.message // empty' "$REVIEW_CONTEXT_DIR/codex-events.jsonl" | tail -n 1)"
+                failure_reason="$(jq -r 'select(.type == "error") | .message // .error.message // empty' "$events_file" | tail -n 1)"
               fi
             fi
-            if [ -z "$failure_reason" ] && [ -s "$REVIEW_CONTEXT_DIR/codex-stderr.log" ]; then
-              failure_reason="$(awk 'NF { line = $0 } END { print line }' "$REVIEW_CONTEXT_DIR/codex-stderr.log")"
+            if [ -z "$failure_reason" ] && [ -s "$stderr_file" ]; then
+              failure_reason="$(awk 'NF { line = $0 } END { print line }' "$stderr_file")"
             fi
             if [ -z "$failure_reason" ]; then
               failure_reason="Codex exited with status $status"
             fi
-          fi
+
+            classification="$("$CODEX_AUTH_STATE_HELPER" classify --input "$events_file" --input "$stderr_file")"
+            failure_kind="$(jq -r '.kind' <<<"$classification")"
+            http_status="$(jq -r '.http_status // empty' <<<"$classification")"
+            if [ "$failure_kind" = "transient_failure" ]; then
+              state_result="$(record_auth_result "$failure_kind" "$http_status")"
+              sync_auth_state
+              transient_attempt=$((transient_attempt + 1))
+              if [ "$transient_attempt" -ge 4 ]; then
+                break
+              fi
+              retry_delay=$((5 * (2 ** (transient_attempt - 1))))
+              echo "Codex transient failure; retrying the same account in ${retry_delay}s (attempt ${transient_attempt}/4)."
+              sleep "$retry_delay"
+              failure_reason=""
+              continue
+            fi
+
+            if [ "$failure_kind" != "quota_exhausted" ] && [ "$failure_kind" != "rate_limited" ] && [ "$failure_kind" != "authentication_failed" ]; then
+              break
+            fi
+
+            state_result="$(record_auth_result "$failure_kind" "$http_status")"
+            sync_auth_state
+            all_quota_exhausted="$(jq -r '.all_quota_exhausted' <<<"$state_result")"
+            sync_current_auth
+
+            select_next_auth
+            if [ -z "$selected_auth_object" ]; then
+              if [ -n "$next_retry_at" ]; then
+                failure_reason="Codex ${failure_kind}; no auth account is eligible before ${next_retry_at}."
+              else
+                failure_reason="Codex ${failure_kind}; no auth account is eligible."
+              fi
+              break
+            fi
+
+            printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$selected_auth_object" >> "$GITHUB_ENV"
+            CODEX_AUTH_OSS_OBJECT="$selected_auth_object"
+            echo "Retrying code review with ${CODEX_AUTH_OSS_OBJECT##*/} after ${failure_kind}."
+            ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f \
+              "$CODEX_AUTH_OSS_OBJECT" "$CODEX_HOME/auth.json"
+            chmod 600 "$CODEX_HOME/auth.json"
+            jq -e '
+              .auth_mode == "chatgpt"
+              and (.tokens.access_token | type == "string" and length > 0)
+              and (.tokens.refresh_token | type == "string" and length > 0)
+            ' "$CODEX_HOME/auth.json" >/dev/null
+            transient_attempt=0
+            failure_reason=""
+          done
+
+          write_review_output "all_quota_exhausted" "$all_quota_exhausted"
 
           if [ -z "$failure_reason" ]; then
             reviews_file="$REVIEW_CONTEXT_DIR/pr_reviews_after_codex.json"
@@ -566,6 +756,36 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             exit 1
           fi
+
+      - name: Alert when all Codex accounts lack quota
+        if: ${{ always() && (steps.configure_auth.outputs.all_quota_exhausted == 'true' || steps.review.outputs.all_quota_exhausted == 'true') }}
+        continue-on-error: true
+        env:
+          FEISHU_CODEX_QUOTA_ALERT_WEBHOOK_1: ${{ secrets.FEISHU_CODEX_QUOTA_ALERT_WEBHOOK_1 }}
+          FEISHU_CODEX_QUOTA_ALERT_WEBHOOK_2: ${{ secrets.FEISHU_CODEX_QUOTA_ALERT_WEBHOOK_2 }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload="$(jq -nc \
+            --arg text "Code review cannot start because both Codex accounts are marked quota exhausted. Repository: ${REPO}; PR: #${PR_NUMBER}; run: ${RUN_URL}" \
+            '{msg_type: "text", content: {text: $text}}')"
+          failed=0
+          for webhook in "$FEISHU_CODEX_QUOTA_ALERT_WEBHOOK_1" "$FEISHU_CODEX_QUOTA_ALERT_WEBHOOK_2"; do
+            if [ -z "$webhook" ]; then
+              echo "A Codex quota alert webhook secret is not configured."
+              failed=1
+              continue
+            fi
+            if ! curl --fail --silent --show-error --retry 2 --retry-all-errors \
+              --header 'Content-Type: application/json' \
+              --data "$payload" \
+              "$webhook"; then
+              echo "Failed to send a Codex quota alert."
+              failed=1
+            fi
+          done
+          exit "$failed"
 
       - name: Record review I/O to Litefuse
         if: ${{ always() }}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Code review jobs selected credentials randomly and could not retain quota, rate-limit, or authentication-failure state across runs. This change persists account state in object storage, initializes the state object when it is absent, rotates after account-specific failures, and retries transient service failures with exponential backoff.

### Release note

Code review jobs now rotate credentials based on persisted availability and send an alert when both accounts exhaust quota.

### Check List (For Author)

- Test: Unit Test
    - Python unit tests for state initialization, rotation, cooldown recovery, failure classification, and alert eligibility
    - Workflow YAML and Bash syntax validation
    - State helper command-line flow validation
- Behavior changed: Yes (credential selection and retry behavior are persisted across code review jobs)
- Does this need documentation: No