### PR TITLE
[opt](hive) prune trailing fields in hive text split for column-pruned queries

### DIFF
--- a/be/src/format/csv/csv_reader.cpp
+++ b/be/src/format/csv/csv_reader.cpp
@@ -313,6 +313,10 @@ Status CsvReader::init_reader(bool is_load) {
             }
             idx++;
         }
+        if (_fields_splitter != nullptr && !_col_idxs.empty()) {
+            int max_col_idx = *std::max_element(_col_idxs.begin(), _col_idxs.end());
+            _fields_splitter->set_split_limit(static_cast<size_t>(max_col_idx) + 1);
+        }
     } else {
         // For load task, the column order is same as file column order
         int i = 0;
@@ -384,6 +388,10 @@ Status CsvReader::_do_init_reader(ReaderInitContext* base_ctx) {
                 _file_slot_idx_map.push_back(idx);
             }
             idx++;
+        }
+        if (_fields_splitter != nullptr && !_col_idxs.empty()) {
+            int max_col_idx = *std::max_element(_col_idxs.begin(), _col_idxs.end());
+            _fields_splitter->set_split_limit(static_cast<size_t>(max_col_idx) + 1);
         }
     } else {
         int i = 0;

--- a/be/src/format/csv/csv_reader.h
+++ b/be/src/format/csv/csv_reader.h
@@ -61,6 +61,11 @@ public:
     virtual ~LineFieldSplitterIf() = default;
 
     virtual void split_line(const Slice& line, std::vector<Slice>* splitted_values) = 0;
+
+    void set_split_limit(size_t limit) { _split_limit = limit; }
+
+protected:
+    size_t _split_limit = 0;
 };
 
 template <typename Splitter>

--- a/be/src/format/text/text_reader.cpp
+++ b/be/src/format/text/text_reader.cpp
@@ -66,6 +66,9 @@ void HiveTextFieldSplitter::_split_field_single_char(const Slice& line,
             }
             process_value_func(data, value_start, i - value_start, _trimming_char, splitted_values);
             value_start = i + _value_sep_len;
+            if (_escape_char == 0 && _split_limit != 0 && splitted_values->size() >= _split_limit) {
+                return;
+            }
         }
     }
     process_value_func(data, value_start, size - value_start, _trimming_char, splitted_values);

--- a/be/test/format/text/hive_text_field_splitter_test.cpp
+++ b/be/test/format/text/hive_text_field_splitter_test.cpp
@@ -96,4 +96,46 @@ TEST_F(HiveTextFieldSplitterTest, RealWorldScenarios) {
     verify_field_split("a|+||+|c", "|+|", {"a", "", "c"});
 }
 
+class SplitLimitHelper {
+public:
+    static std::vector<std::string> split(const std::string& input, char sep, size_t limit,
+                                          char escape_char = 0) {
+        HiveTextFieldSplitter splitter(false, false, std::string(1, sep), 1, 0, escape_char);
+        splitter.set_split_limit(limit);
+        Slice line(input.data(), input.size());
+        std::vector<Slice> out;
+        splitter.do_split(line, &out);
+        std::vector<std::string> res;
+        for (const auto& s : out) {
+            res.emplace_back(s.data, s.size);
+        }
+        return res;
+    }
+};
+
+TEST_F(HiveTextFieldSplitterTest, SplitLimitStopsEarly) {
+    EXPECT_EQ((std::vector<std::string> {"a", "b"}), SplitLimitHelper::split("a,b,c,d,e", ',', 2));
+    EXPECT_EQ((std::vector<std::string> {"a", "b", "c"}),
+              SplitLimitHelper::split("a,b,c,d,e", ',', 3));
+    EXPECT_EQ((std::vector<std::string> {"a"}), SplitLimitHelper::split("a,b,c", ',', 1));
+}
+
+TEST_F(HiveTextFieldSplitterTest, SplitLimitAtOrAboveFieldCount) {
+    EXPECT_EQ((std::vector<std::string> {"a", "b", "c"}), SplitLimitHelper::split("a,b,c", ',', 3));
+    EXPECT_EQ((std::vector<std::string> {"a", "b", "c"}),
+              SplitLimitHelper::split("a,b,c", ',', 10));
+    EXPECT_EQ((std::vector<std::string> {"a", "b", "c"}), SplitLimitHelper::split("a,b,c", ',', 0));
+}
+
+TEST_F(HiveTextFieldSplitterTest, SplitLimitEdgeCases) {
+    EXPECT_EQ((std::vector<std::string> {""}), SplitLimitHelper::split("", ',', 3));
+    EXPECT_EQ((std::vector<std::string> {"a", ""}), SplitLimitHelper::split("a,,,b", ',', 2));
+    EXPECT_EQ((std::vector<std::string> {"x", "y"}), SplitLimitHelper::split("x,y,", ',', 2));
+}
+
+TEST_F(HiveTextFieldSplitterTest, SplitLimitIgnoredWhenEscapeConfigured) {
+    EXPECT_EQ((std::vector<std::string> {"a\\,b", "c", "d"}),
+              SplitLimitHelper::split("a\\,b,c,d", ',', 2, '\\'));
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66121

Problem Summary: A column-pruned Hive TEXTFILE query reads only the
columns listed in _col_idxs, but the field splitter still scanned every
separator of each line, including trailing fields that are never used.
For wide tables with many unused trailing columns this is wasted work
proportional to the unused tail length of every row.

This adds a split limit on the query path: after the reader resolves
_col_idxs it computes max_col_idx+1 and passes it to the splitter via
set_split_limit. The single-char, non-escape path of
HiveTextFieldSplitter stops as soon as it has emitted that many fields
(each field is still bounded by its own separator, so the prefix is
identical to a full split). The escape-configured path, the multi-char
(KMP) path, and EncloseCsvTextFieldSplitter ignore the limit and split
fully, so escaped separators and enclose quoting are unaffected.

### Release note

None

### Check List (For Author)

- Test: BE unit test (run-be-ut --filter="*HiveTextFieldSplitter*")
    - Added 4 TEST_F cases covering early stop, limit at/above field
      count, edge cases (empty input, consecutive separators, trailing
      separator), and limit-ignored-when-escape-configured.
    - All 9 tests in HiveTextFieldSplitterTest PASSED.
- Behavior changed: No (query results unchanged; only the number of
  separator scans for the non-escape single-char path on
  column-pruned queries).
- Does this need documentation: No

