### PR TITLE
branch-4.0:[fix](filecache) fix flaky be UT for LRU dump(pick#65427)

### DIFF
--- a/be/test/io/cache/block_file_cache_test_lru_dump.cpp
+++ b/be/test/io/cache/block_file_cache_test_lru_dump.cpp
@@ -203,8 +203,7 @@ TEST_F(BlockFileCacheTest, test_lru_log_record_replay_dump_restore) {
     ASSERT_EQ(offsets[3], 400000);
     ASSERT_EQ(offsets[4], 200000);
 
-    std::this_thread::sleep_for(
-            std::chrono::milliseconds(2 * config::file_cache_background_lru_dump_interval_ms));
+    cache.dump_lru_queues(true);
 
 #if 0
     // Verify all 4 dump files


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65427

Problem Summary: Pick apache/doris#65427 into branch-4.0. 

### Release note

None

### Check List (For Author)

- Test:
    - Format: build-support/clang-format.sh and build-support/check-format.sh passed.
    - BE: JAVA_HOME=/mnt/disk1/zhangzhengyu/build-dep/jdk-17.0.2/ DORIS_TOOLCHAIN=clang DISABLE_BE_JAVA_EXTENSIONS=ON ENABLE_INJECTION_POINT=ON ENABLE_CACHE_LOCK_DEBUG=0 ENABLE_PCH=0 ./build.sh --be
    - BE UT: same environment, sh run-be-ut.sh --run --filter=CacheLRUDumperTest.*
- Behavior changed: No
- Does this need documentation: No