### PR TITLE
[improvement](hive) bump external table updateTime from file mtime to keep SQL cache fresh

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -365,6 +365,9 @@ public class HiveScanNode extends FileQueryScanNode {
             boolean isSplittable = fileCacheValue.isSplittable();
 
             for (HiveExternalMetaCache.HiveFileStatus status : fileCacheValue.getFiles()) {
+                if (status.getModificationTime() > hmsTable.getUpdateTime()) {
+                    hmsTable.setUpdateTime(status.getModificationTime());
+                }
                 allFiles.addAll(fileSplitter.splitFile(
                         status.getPath(),
                         targetFileSplitSize,

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/source/HiveScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/source/HiveScanNodeTest.java
@@ -19,6 +19,8 @@ package org.apache.doris.datasource.hive.source;
 
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.common.util.LocationPath;
+import org.apache.doris.datasource.FileSplitter;
 import org.apache.doris.datasource.TableFormatType;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalTable;
@@ -27,14 +29,17 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan.SelectedPart
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.spi.Split;
 import org.apache.doris.thrift.TFileScanRangeParams;
 import org.apache.doris.thrift.TFileTextScanRangeParams;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
@@ -136,6 +141,88 @@ public class HiveScanNodeTest {
 
         textParams.setEnclose((byte) '\'');
         Assert.assertFalse(HiveScanNode.shouldTrimDoubleQuotes(textParams));
+    }
+
+    @Test
+    public void testGetFileSplitBumpsUpdateTimeWhenFileMtimeNewer() throws Exception {
+        long oldUpdateTime = 1_000L;
+        long newMtime = 5_000L;
+        HMSExternalTable table = Mockito.mock(HMSExternalTable.class);
+        HiveScanNode node = newHiveScanNodeWithFileSplitter(table);
+        Mockito.when(table.getUpdateTime()).thenReturn(oldUpdateTime);
+
+        HiveExternalMetaCache cache = Mockito.mock(HiveExternalMetaCache.class);
+        Mockito.when(cache.getFilesByPartitions(
+                Mockito.anyList(), Mockito.anyBoolean(), Mockito.anyBoolean(),
+                Mockito.any(), Mockito.any()))
+                .thenReturn(Collections.singletonList(buildFileCacheValue(newMtime)));
+
+        List<Split> allFiles = Lists.newArrayList();
+        invokeGetFileSplitByPartitions(node, cache, allFiles);
+
+        Mockito.verify(table).setUpdateTime(newMtime);
+        Assert.assertFalse("splitter should have produced splits for a non-empty file", allFiles.isEmpty());
+    }
+
+    @Test
+    public void testGetFileSplitDoesNotBumpUpdateTimeWhenFileMtimeNotNewer() throws Exception {
+        long oldUpdateTime = 5_000L;
+        long olderMtime = 1_000L;
+        HMSExternalTable table = Mockito.mock(HMSExternalTable.class);
+        HiveScanNode node = newHiveScanNodeWithFileSplitter(table);
+        Mockito.when(table.getUpdateTime()).thenReturn(oldUpdateTime);
+
+        HiveExternalMetaCache cache = Mockito.mock(HiveExternalMetaCache.class);
+        Mockito.when(cache.getFilesByPartitions(
+                Mockito.anyList(), Mockito.anyBoolean(), Mockito.anyBoolean(),
+                Mockito.any(), Mockito.any()))
+                .thenReturn(Collections.singletonList(buildFileCacheValue(olderMtime)));
+
+        List<Split> allFiles = Lists.newArrayList();
+        invokeGetFileSplitByPartitions(node, cache, allFiles);
+
+        Mockito.verify(table, Mockito.never()).setUpdateTime(Mockito.anyLong());
+    }
+
+    private static HiveExternalMetaCache.FileCacheValue buildFileCacheValue(long modificationTime) {
+        HiveExternalMetaCache.FileCacheValue fileCacheValue = new HiveExternalMetaCache.FileCacheValue();
+        HiveExternalMetaCache.HiveFileStatus status = new HiveExternalMetaCache.HiveFileStatus();
+        status.setPath(LocationPath.of("hdfs://test-host:9000/warehouse/tbl/f1"));
+        status.setLength(10_000L * MB);
+        status.setModificationTime(modificationTime);
+        fileCacheValue.setSplittable(false);
+        fileCacheValue.getFiles().add(status);
+        return fileCacheValue;
+    }
+
+    private static HiveScanNode newHiveScanNodeWithFileSplitter(HMSExternalTable table) throws Exception {
+        SessionVariable sv = new SessionVariable();
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        HMSExternalCatalog catalog = Mockito.mock(HMSExternalCatalog.class);
+        Mockito.when(table.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.bindBrokerName()).thenReturn("");
+        desc.setTable(table);
+        HiveScanNode node = new HiveScanNode(
+                new PlanNodeId(0), desc, false, sv, null, ScanContext.EMPTY);
+        // The fileSplitter field is normally initialized in FileQueryScanNode.doInitialize(),
+        // which requires a fully wired external table / schema; for this test we only need a
+        // non-null splitter so the loop body can call splitFile(...). A real FileSplitter works
+        // because the crafted file is non-splittable, so splitFile takes its early single-split
+        // branch and never reaches filesystem APIs.
+        Field fileSplitterField = node.getClass().getSuperclass().getDeclaredField("fileSplitter");
+        fileSplitterField.setAccessible(true);
+        fileSplitterField.set(node, new FileSplitter(32 * MB, 32 * MB, 100));
+        return node;
+    }
+
+    private static void invokeGetFileSplitByPartitions(
+            HiveScanNode node, HiveExternalMetaCache cache, List<Split> allFiles) throws Exception {
+        Method method = HiveScanNode.class.getDeclaredMethod(
+                "getFileSplitByPartitions",
+                HiveExternalMetaCache.class, List.class, List.class,
+                String.class, int.class, boolean.class);
+        method.setAccessible(true);
+        method.invoke(node, cache, Collections.emptyList(), allFiles, "", 1, false);
     }
 
     private HiveScanNode createHiveScanNode() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66133

Problem Summary: When Hive table files are written out-of-band (e.g. by an
external job that only replaces data files without issuing an HMS DDL/event
notification), the HMS table's in-memory `updateTime` on the FE never advances.
The FE SQL cache (`NereidsSqlCacheManager` / `SqlCacheContext`) keys cache
validity on `HMSExternalTable.getUpdateTime()`, so a stale `updateTime` lets the
cache keep serving result sets computed from the old files, returning incorrect
data to queries until the table's metadata is next refreshed.

Fix: in `HiveScanNode.getFileSplitByPartitions(...)`, while iterating the file
status list of each partition, bump `hmsTable.updateTime` to the maximum file
`modificationTime` seen when that mtime is greater than the current
`updateTime`. This mirrors the semantics already used for the count-pushdown
path (which also reads file mtimes) and ensures the SQL cache key advances the
first time a query observes a fresher file, so subsequent queries recompute.

This is strictly an improvement over the pre-patch state (where `updateTime`
never advanced from file scans at all). Concurrent `getFileSplitByPartitions`
calls are a racy read-modify-write on `updateTime`, but the worst case is that
two racing scans both observe the same (or a slightly older) mtime and only one
wins the `setUpdateTime` — the value still only moves forward, so this can never
make the cache *more* stale than before; at most it delays invalidation by one
scan.

### Release note

When Hive data files are replaced out-of-band (without an HMS DDL event), the
FE SQL cache now invalidates correctly because the table's `updateTime` is
bumped from the freshest file modification time observed during the scan.

### Check List (For Author)

- Test: Unit Test
    - Added `HiveScanNodeTest.testGetFileSplitBumpsUpdateTimeWhenFileMtimeNewer`
      and `testGetFileSplitDoesNotBumpUpdateTimeWhenFileMtimeNotNewer`. Both
      drive the real `getFileSplitByPartitions` (via reflection) against a
      mocked `HMSExternalTable` and `HiveExternalMetaCache` returning a crafted
      `FileCacheValue`, and assert via Mockito verification that
      `setUpdateTime` is called / not called. Full class: 10 tests, 0 failures,
      0 errors.
    - FE build (`./build.sh --fe`) green; checkstyle 0 violations.
- Behavior changed: Yes — `HMSExternalTable.updateTime` may now advance during
  a scan to the max file mtime; this only affects SQL cache invalidation timing
  for Hive external tables and cannot make the cache more stale.
- Does this need documentation: No

