### PR TITLE
branch-4.1: [opt](cloud) Add warm up job count metric on BE

### DIFF
--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -639,7 +639,13 @@ std::vector<JobReplicaInfo> CloudWarmUpManager::get_replica_info(int64_t tablet_
     }
     for (auto job_id : cancelled_jobs) {
         LOG(INFO) << "get_replica_info: erasing cancelled job, job_id=" << job_id;
-        _tablet_replica_cache.erase(job_id);
+        // Lazy cleanup path: FE reported the warm up job as CANCELLED, so the job is
+        // no longer held in memory. Keep the job-count metric and the event filter
+        // consistent with the explicit CLEAR_JOB path in set_event().
+        if (_tablet_replica_cache.erase(job_id) > 0) {
+            g_file_cache_warm_up_job_num << -1;
+        }
+        _event_driven_filters.erase(job_id);
     }
     VLOG_DEBUG << "get_replica_info: return " << replicas.size()
                << " replicas, tablet id=" << tablet_id;

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -93,6 +93,10 @@ bvar::Status<int64_t> g_file_cache_warm_up_rowset_last_call_unix_ts(
         "file_cache_warm_up_rowset_last_call_unix_ts", 0);
 bvar::Adder<uint64_t> file_cache_warm_up_failed_task_num("file_cache_warm_up", "failed_task_num");
 bvar::Adder<uint64_t> g_balance_tablet_be_mapping_size("balance_tablet_be_mapping_size");
+// Number of warm up jobs currently held in this BE's memory.
+// Incremented when FE dispatches a new job to this BE (SET_JOB / SET_BATCH / event SET_JOB),
+// decremented when the job is cleared (CLEAR_JOB / event CLEAR_JOB).
+bvar::Adder<int64_t> g_file_cache_warm_up_job_num("file_cache_warm_up_job_num");
 
 bvar::LatencyRecorder g_file_cache_warm_up_rowset_wait_for_compaction_latency(
         "file_cache_warm_up_rowset_wait_for_compaction_latency");
@@ -404,6 +408,7 @@ Status CloudWarmUpManager::check_and_set_job_id(int64_t job_id) {
     std::lock_guard lock(_mtx);
     if (_cur_job_id == 0) {
         _cur_job_id = job_id;
+        g_file_cache_warm_up_job_num << 1;
     }
     Status st = Status::OK();
     if (_cur_job_id != job_id) {
@@ -422,6 +427,7 @@ Status CloudWarmUpManager::check_and_set_batch_id(int64_t job_id, int64_t batch_
     }
     if (_cur_job_id == 0) {
         _cur_job_id = job_id;
+        g_file_cache_warm_up_job_num << 1;
     }
     if (_cur_batch_id == batch_id) {
         *retry = true;
@@ -467,6 +473,9 @@ Status CloudWarmUpManager::clear_job(int64_t job_id) {
     std::lock_guard lock(_mtx);
     Status st = Status::OK();
     if (job_id == _cur_job_id) {
+        if (_cur_job_id != 0) {
+            g_file_cache_warm_up_job_num << -1;
+        }
         _cur_job_id = 0;
         _cur_batch_id = -1;
         _pending_job_metas.clear();
@@ -489,11 +498,14 @@ Status CloudWarmUpManager::set_event(int64_t job_id, TWarmUpEventType::type even
     Status st = Status::OK();
     if (event == TWarmUpEventType::type::LOAD) {
         if (clear) {
-            _tablet_replica_cache.erase(job_id);
+            if (_tablet_replica_cache.erase(job_id) > 0) {
+                g_file_cache_warm_up_job_num << -1;
+            }
             _event_driven_filters.erase(job_id);
             LOG(INFO) << "Clear event driven sync, job_id=" << job_id << ", event=" << event;
         } else if (!_tablet_replica_cache.contains(job_id)) {
             static_cast<void>(_tablet_replica_cache[job_id]);
+            g_file_cache_warm_up_job_num << 1;
             if (table_ids != nullptr) {
                 // table-level filter: set to the given table_id set (may be empty,
                 // meaning all matched tables were deleted — warm up nothing)


### PR DESCRIPTION
Backport apache/doris#64734 to branch-4.1.

### What problem does this PR solve?

Issue Number: None

Related PR: apache/doris#64734

Problem Summary: Add the per-BE `file_cache_warm_up_job_num` bvar so operators can see how many warm-up jobs are currently held in BE memory. The count changes only on real job state transitions, so retry/replay and duplicate clear requests do not skew it. The lazy cancellation cleanup path also decrements the metric and removes the matching event filter.

### Release note

Add the `file_cache_warm_up_job_num` BE metric.

### Check List (For Author)

- Test: Manual test
  - clang-format 16 dry-run check passed for `be/src/cloud/cloud_warm_up_manager.cpp`
  - `git diff --check` passed
  - Local build was not run because this target-branch worktree does not provide `hooks/setup_worktree.sh` or `thirdparty/installed`; CI is pending
- Behavior changed: Yes. A new per-BE warm-up job count metric is exposed.
- Does this need documentation: No
