### PR TITLE
[fix](regression) Initialize OceanBase test data explicitly

### DIFF
--- a/docker/thirdparties/docker-compose/oceanbase/oceanbase.yaml.tpl
+++ b/docker/thirdparties/docker-compose/oceanbase/oceanbase.yaml.tpl
@@ -30,12 +30,37 @@ services:
       - ${DOCKER_OCEANBASE_EXTERNAL_PORT}:2881
       - ${DOCKER_OCEANBASE_PROXY_EXTERNAL_PORT}:2883
     healthcheck:
-      test: ["CMD-SHELL", "obclient -h127.0.0.1 -P2881 -uroot@test -p123456 -e 'SELECT * FROM doris_test.all_types LIMIT 1' >/dev/null && obclient -h127.0.0.1 -P2883 -uroot@test -p123456 -Nse 'SHOW MASTER STATUS' | grep -q ."]
+      test: ["CMD-SHELL", "obclient -h127.0.0.1 -P2881 -uroot@test -p123456 -e 'SELECT 1' >/dev/null && obclient -h127.0.0.1 -P2883 -uroot@test -p123456 -Nse 'SHOW MASTER STATUS' | grep -q ."]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    networks:
+      - doris--oceanbase
+
+  doris--oceanbase-init:
+    image: quay.io/oceanbase/obbinlog-ce:4.2.5-test
+    depends_on:
+      doris--oceanbase:
+        condition: service_healthy
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -euo pipefail
+        rm -f /tmp/oceanbase_initialized
+        for sql in /root/boot/init.d/*.sql; do
+          echo "Running $${sql}"
+          obclient -hdoris--oceanbase -P2881 -uroot@test -p123456 < "$${sql}"
+        done
+        touch /tmp/oceanbase_initialized
+        exec tail -f /dev/null
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/oceanbase_initialized && obclient -hdoris--oceanbase -P2881 -uroot@test -p123456 -Nse 'SELECT 1 FROM doris_test.all_types LIMIT 1' | grep -q '^1$$'"]
       interval: 5s
       timeout: 60s
       retries: 120
     volumes:
-      - ./init:/root/boot/init.d
+      - ./init:/root/boot/init.d:ro
     networks:
       - doris--oceanbase
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

The OceanBase all-in-one image starts Observer, OBProxy, and OBBinlog, but it does not execute SQL files mounted at `/root/boot/init.d`. The existing healthcheck queries a table created by those SQL files, so the service cannot become healthy and initialization cannot progress.

This change separates service readiness from test-data readiness. The main service healthcheck verifies the Observer and OBBinlog endpoints, while a dedicated init service waits for the main service to become healthy and then executes all initialization SQL files in order. The init service reports healthy only after the current initialization run completes and the seeded table is readable.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Verified the rendered Compose configuration with `docker compose config --quiet`.
        - Started the real all-in-one image with `docker compose up -d --wait`.
        - Verified all four initialization SQL files ran in order.
        - Verified the seeded table contains four rows and `SHOW MASTER STATUS` returns a binlog position.
        - Restarted the init service with an existing completion marker and verified it reran all SQL files before becoming healthy.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. OceanBase initialization SQL is now executed explicitly after the all-in-one service becomes ready.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
