### PR TITLE
[fix](loadstream) Fix Status::Error usage and improve error logging in load stream

### DIFF
--- a/be/src/load/channel/load_stream.cpp
+++ b/be/src/load/channel/load_stream.cpp
@@ -189,9 +189,9 @@ Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data
     while (_flush_token->num_tasks() >= load_stream_flush_token_max_tasks) {
         if (timer.elapsed_time() / 1000 / 1000 >= load_stream_max_wait_flush_token_time_ms) {
             _status.update(
-                    Status::Error<true>("wait flush token back pressure time is more than "
-                                        "load_stream_max_wait_flush_token_time {}",
-                                        load_stream_max_wait_flush_token_time_ms));
+                    Status::InternalError("wait flush token back pressure time is more than "
+                                          "load_stream_max_wait_flush_token_time {}",
+                                          load_stream_max_wait_flush_token_time_ms));
             return _status.status();
         }
         bthread_usleep(2 * 1000); // 2ms
@@ -528,8 +528,8 @@ bool LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_to_
 void LoadStream::_report_result(StreamId stream, const Status& status,
                                 const std::vector<int64_t>& success_tablet_ids,
                                 const FailedTablets& failed_tablets, bool eos) {
-    LOG(INFO) << "report result " << *this << ", success tablet num " << success_tablet_ids.size()
-              << ", failed tablet num " << failed_tablets.size();
+    LOG(INFO) << "report result " << *this << ", status=" << status << ", success tablet num "
+              << success_tablet_ids.size() << ", failed tablet num " << failed_tablets.size();
     butil::IOBuf buf;
     PLoadStreamResponse response;
     response.set_eos(eos);

--- a/be/src/load/channel/load_stream.cpp
+++ b/be/src/load/channel/load_stream.cpp
@@ -528,8 +528,11 @@ bool LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_to_
 void LoadStream::_report_result(StreamId stream, const Status& status,
                                 const std::vector<int64_t>& success_tablet_ids,
                                 const FailedTablets& failed_tablets, bool eos) {
-    LOG(INFO) << "report result " << *this << ", status=" << status << ", success tablet num "
-              << success_tablet_ids.size() << ", failed tablet num " << failed_tablets.size();
+    if (!status.ok()) {
+        LOG(WARNING) << "report result " << *this << ", status=" << status
+                     << ", success tablet num " << success_tablet_ids.size()
+                     << ", failed tablet num " << failed_tablets.size();
+    }
     butil::IOBuf buf;
     PLoadStreamResponse response;
     response.set_eos(eos);


### PR DESCRIPTION
### What problem does this PR solve?

1. `Status::Error<true>(...)` in `TabletStream::append_data` incorrectly uses `true` as the error code template parameter, which resolves to `code=1` instead of enabling stacktrace. Use `Status::InternalError(...)` instead.

2. Added the status message to prevent loss of error details when called from `_report_failure`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

