### PR TITLE
[fix](parquet) Directly evaluate runtime filters in V2 reader

### DIFF
--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
@@ -200,8 +200,14 @@ public:
 class DateTimeV2PredicateParquetConsumer final : public ParquetFixedValueConsumer {
 public:
     DateTimeV2PredicateParquetConsumer(const ParquetDecodeContext& context, bool enable_strict_mode,
-                                       ParquetLogicalValueConsumer& consumer)
-            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+                                       ParquetLogicalValueConsumer& consumer,
+                                       ColumnDateTimeV2::Container& logical_values,
+                                       IColumn::Filter& conversion_nulls)
+            : _context(context),
+              _enable_strict_mode(enable_strict_mode),
+              _consumer(consumer),
+              _logical_values(logical_values),
+              _conversion_nulls(conversion_nulls) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         _logical_values.clear();
@@ -212,17 +218,18 @@ public:
         state.conversion_failure_null_map = &_conversion_nulls;
         DateTimeV2ParquetConsumer converter(_logical_values, _context, &state);
         RETURN_IF_ERROR(converter.consume(values, num_values, value_width));
-        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
-                                 num_values, sizeof(DateV2Value<DateTimeV2ValueType>),
-                                 _conversion_nulls.data());
+        return _consumer.consume(
+                reinterpret_cast<const uint8_t*>(_logical_values.data()), num_values,
+                sizeof(DateV2Value<DateTimeV2ValueType>),
+                _context.conversion_failure_is_null ? _conversion_nulls.data() : nullptr);
     }
 
 private:
     const ParquetDecodeContext& _context;
     bool _enable_strict_mode;
     ParquetLogicalValueConsumer& _consumer;
-    ColumnDateTimeV2::Container _logical_values;
-    IColumn::Filter _conversion_nulls;
+    ColumnDateTimeV2::Container& _logical_values;
+    IColumn::Filter& _conversion_nulls;
 };
 
 } // namespace
@@ -756,7 +763,9 @@ Status DataTypeDateTimeV2SerDe::read_parquet_raw_predicate(
     if (!supports_parquet_raw_predicate(context)) {
         return Status::NotSupported("Unsupported Parquet raw predicate conversion for DATETIMEV2");
     }
-    DateTimeV2PredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer);
+    DateTimeV2PredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer,
+                                                          _parquet_predicate_values,
+                                                          _parquet_predicate_nulls);
     return source.decode_fixed_values(num_values, predicate_consumer);
 }
 

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
@@ -131,9 +131,13 @@ class DateTimeV2ParquetConsumer final : public ParquetFixedValueConsumer {
 public:
     DateTimeV2ParquetConsumer(IColumn& column, const ParquetDecodeContext& context,
                               ParquetMaterializationState* state = nullptr)
-            : _data(assert_cast<ColumnDateTimeV2&>(column).get_data()),
-              _context(context),
-              _state(state) {}
+            : DateTimeV2ParquetConsumer(assert_cast<ColumnDateTimeV2&>(column).get_data(), context,
+                                        state) {}
+
+    DateTimeV2ParquetConsumer(ColumnDateTimeV2::Container& data,
+                              const ParquetDecodeContext& context,
+                              ParquetMaterializationState* state = nullptr)
+            : _data(data), _context(context), _state(state) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         const size_t old_size = _data.size();
@@ -191,6 +195,34 @@ public:
     Status consume(const StringRef* values, size_t num_values) override {
         return Status::NotSupported("Binary Parquet values cannot be materialized as DATETIMEV2");
     }
+};
+
+class DateTimeV2PredicateParquetConsumer final : public ParquetFixedValueConsumer {
+public:
+    DateTimeV2PredicateParquetConsumer(const ParquetDecodeContext& context, bool enable_strict_mode,
+                                       ParquetLogicalValueConsumer& consumer)
+            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        _logical_values.clear();
+        _conversion_nulls.clear();
+        _conversion_nulls.resize_fill(num_values, 0);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = _enable_strict_mode;
+        state.conversion_failure_null_map = &_conversion_nulls;
+        DateTimeV2ParquetConsumer converter(_logical_values, _context, &state);
+        RETURN_IF_ERROR(converter.consume(values, num_values, value_width));
+        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
+                                 num_values, sizeof(DateV2Value<DateTimeV2ValueType>),
+                                 _conversion_nulls.data());
+    }
+
+private:
+    const ParquetDecodeContext& _context;
+    bool _enable_strict_mode;
+    ParquetLogicalValueConsumer& _consumer;
+    ColumnDateTimeV2::Container _logical_values;
+    IColumn::Filter _conversion_nulls;
 };
 
 } // namespace
@@ -708,6 +740,24 @@ Status DataTypeDateTimeV2SerDe::read_column_from_parquet(IColumn& column,
         state.dictionary_generation = source.dictionary_generation();
     }
     return state.materialize_dictionary(column, source, num_values);
+}
+
+bool DataTypeDateTimeV2SerDe::supports_parquet_raw_predicate(
+        const ParquetDecodeContext& context) const {
+    return context.encoding != ParquetValueEncoding::DICTIONARY &&
+           (context.physical_type == ParquetPhysicalType::INT64 ||
+            context.physical_type == ParquetPhysicalType::INT96) &&
+           context.logical_type == ParquetLogicalType::TIMESTAMP;
+}
+
+Status DataTypeDateTimeV2SerDe::read_parquet_raw_predicate(
+        ParquetDecodeSource& source, const ParquetDecodeContext& context, size_t num_values,
+        bool enable_strict_mode, ParquetLogicalValueConsumer& consumer) const {
+    if (!supports_parquet_raw_predicate(context)) {
+        return Status::NotSupported("Unsupported Parquet raw predicate conversion for DATETIMEV2");
+    }
+    DateTimeV2PredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer);
+    return source.decode_fixed_values(num_values, predicate_consumer);
 }
 
 Status DataTypeDateTimeV2SerDe::write_column_to_mysql_binary(const IColumn& column,

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.h
@@ -93,6 +93,11 @@ public:
     Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                     const ParquetDecodeContext& context, size_t num_values,
                                     ParquetMaterializationState& state) const override;
+    bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const override;
+    Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                      const ParquetDecodeContext& context, size_t num_values,
+                                      bool enable_strict_mode,
+                                      ParquetLogicalValueConsumer& consumer) const override;
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;

--- a/be/src/core/data_type_serde/data_type_datev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.cpp
@@ -56,7 +56,11 @@ Status decode_parquet_date(int32_t encoded_date, DateV2Value<DateV2ValueType>* v
 class DateV2ParquetConsumer final : public ParquetFixedValueConsumer {
 public:
     explicit DateV2ParquetConsumer(IColumn& column, ParquetMaterializationState* state = nullptr)
-            : _data(assert_cast<ColumnDateV2&>(column).get_data()), _state(state) {}
+            : DateV2ParquetConsumer(assert_cast<ColumnDateV2&>(column).get_data(), state) {}
+
+    explicit DateV2ParquetConsumer(ColumnDateV2::Container& data,
+                                   ParquetMaterializationState* state = nullptr)
+            : _data(data), _state(state) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         DORIS_CHECK_EQ(value_width, sizeof(int32_t));
@@ -89,6 +93,32 @@ public:
     Status consume(const StringRef* values, size_t num_values) override {
         return Status::NotSupported("Binary Parquet values cannot be materialized as DATEV2");
     }
+};
+
+class DateV2PredicateParquetConsumer final : public ParquetFixedValueConsumer {
+public:
+    DateV2PredicateParquetConsumer(bool enable_strict_mode, ParquetLogicalValueConsumer& consumer)
+            : _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        _logical_values.clear();
+        _conversion_nulls.clear();
+        _conversion_nulls.resize_fill(num_values, 0);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = _enable_strict_mode;
+        state.conversion_failure_null_map = &_conversion_nulls;
+        DateV2ParquetConsumer converter(_logical_values, &state);
+        RETURN_IF_ERROR(converter.consume(values, num_values, value_width));
+        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
+                                 num_values, sizeof(DateV2Value<DateV2ValueType>),
+                                 _conversion_nulls.data());
+    }
+
+private:
+    bool _enable_strict_mode;
+    ParquetLogicalValueConsumer& _consumer;
+    ColumnDateV2::Container _logical_values;
+    IColumn::Filter _conversion_nulls;
 };
 
 } // namespace
@@ -250,6 +280,23 @@ Status DataTypeDateV2SerDe::read_column_from_parquet(IColumn& column, ParquetDec
         state.dictionary_generation = source.dictionary_generation();
     }
     return state.materialize_dictionary(column, source, num_values);
+}
+
+bool DataTypeDateV2SerDe::supports_parquet_raw_predicate(
+        const ParquetDecodeContext& context) const {
+    return context.encoding != ParquetValueEncoding::DICTIONARY &&
+           context.physical_type == ParquetPhysicalType::INT32 &&
+           context.logical_type == ParquetLogicalType::DATE;
+}
+
+Status DataTypeDateV2SerDe::read_parquet_raw_predicate(
+        ParquetDecodeSource& source, const ParquetDecodeContext& context, size_t num_values,
+        bool enable_strict_mode, ParquetLogicalValueConsumer& consumer) const {
+    if (!supports_parquet_raw_predicate(context)) {
+        return Status::NotSupported("Unsupported Parquet raw predicate conversion for DATEV2");
+    }
+    DateV2PredicateParquetConsumer predicate_consumer(enable_strict_mode, consumer);
+    return source.decode_fixed_values(num_values, predicate_consumer);
 }
 
 Status DataTypeDateV2SerDe::write_column_to_mysql_binary(const IColumn& column,

--- a/be/src/core/data_type_serde/data_type_datev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.cpp
@@ -97,8 +97,13 @@ public:
 
 class DateV2PredicateParquetConsumer final : public ParquetFixedValueConsumer {
 public:
-    DateV2PredicateParquetConsumer(bool enable_strict_mode, ParquetLogicalValueConsumer& consumer)
-            : _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+    DateV2PredicateParquetConsumer(bool enable_strict_mode, ParquetLogicalValueConsumer& consumer,
+                                   ColumnDateV2::Container& logical_values,
+                                   IColumn::Filter& conversion_nulls)
+            : _enable_strict_mode(enable_strict_mode),
+              _consumer(consumer),
+              _logical_values(logical_values),
+              _conversion_nulls(conversion_nulls) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         _logical_values.clear();
@@ -117,8 +122,8 @@ public:
 private:
     bool _enable_strict_mode;
     ParquetLogicalValueConsumer& _consumer;
-    ColumnDateV2::Container _logical_values;
-    IColumn::Filter _conversion_nulls;
+    ColumnDateV2::Container& _logical_values;
+    IColumn::Filter& _conversion_nulls;
 };
 
 } // namespace
@@ -295,7 +300,8 @@ Status DataTypeDateV2SerDe::read_parquet_raw_predicate(
     if (!supports_parquet_raw_predicate(context)) {
         return Status::NotSupported("Unsupported Parquet raw predicate conversion for DATEV2");
     }
-    DateV2PredicateParquetConsumer predicate_consumer(enable_strict_mode, consumer);
+    DateV2PredicateParquetConsumer predicate_consumer(
+            enable_strict_mode, consumer, _parquet_predicate_values, _parquet_predicate_nulls);
     return source.decode_fixed_values(num_values, predicate_consumer);
 }
 

--- a/be/src/core/data_type_serde/data_type_datev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.h
@@ -91,6 +91,11 @@ public:
     Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                     const ParquetDecodeContext& context, size_t num_values,
                                     ParquetMaterializationState& state) const override;
+    bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const override;
+    Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                      const ParquetDecodeContext& context, size_t num_values,
+                                      bool enable_strict_mode,
+                                      ParquetLogicalValueConsumer& consumer) const override;
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -262,7 +262,13 @@ public:
     DecimalParquetConsumer(IColumn& column, const ParquetDecodeContext& context,
                            UInt32 target_precision, int32_t target_scale,
                            ParquetMaterializationState* state = nullptr)
-            : _data(assert_cast<ColumnDecimal<T>&>(column).get_data()),
+            : DecimalParquetConsumer(assert_cast<ColumnDecimal<T>&>(column).get_data(), context,
+                                     target_precision, target_scale, state) {}
+
+    DecimalParquetConsumer(typename ColumnDecimal<T>::Container& data,
+                           const ParquetDecodeContext& context, UInt32 target_precision,
+                           int32_t target_scale, ParquetMaterializationState* state = nullptr)
+            : _data(data),
               _context(context),
               _target_precision(target_precision),
               _target_scale(target_scale),
@@ -395,6 +401,59 @@ private:
     UInt32 _target_precision;
     int32_t _target_scale;
     ParquetMaterializationState* _state;
+};
+
+template <PrimitiveType T>
+class DecimalPredicateParquetConsumer final : public ParquetFixedValueConsumer,
+                                              public ParquetBinaryValueConsumer {
+public:
+    using FieldType = typename PrimitiveTypeTraits<T>::CppType;
+
+    DecimalPredicateParquetConsumer(const ParquetDecodeContext& context, UInt32 target_precision,
+                                    int32_t target_scale, bool enable_strict_mode,
+                                    ParquetLogicalValueConsumer& consumer)
+            : _context(context),
+              _target_precision(target_precision),
+              _target_scale(target_scale),
+              _enable_strict_mode(enable_strict_mode),
+              _consumer(consumer),
+              _logical_values(0, static_cast<UInt32>(target_scale)) {}
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        return convert_and_publish(num_values, [&](DecimalParquetConsumer<T>& converter) {
+            return converter.consume(values, num_values, value_width);
+        });
+    }
+
+    Status consume(const StringRef* values, size_t num_values) override {
+        return convert_and_publish(num_values, [&](DecimalParquetConsumer<T>& converter) {
+            return converter.consume(values, num_values);
+        });
+    }
+
+private:
+    template <typename Convert>
+    Status convert_and_publish(size_t num_values, Convert&& convert) {
+        _logical_values.clear();
+        _conversion_nulls.clear();
+        _conversion_nulls.resize_fill(num_values, 0);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = _enable_strict_mode;
+        state.conversion_failure_null_map = &_conversion_nulls;
+        DecimalParquetConsumer<T> converter(_logical_values, _context, _target_precision,
+                                            _target_scale, &state);
+        RETURN_IF_ERROR(convert(converter));
+        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
+                                 num_values, sizeof(FieldType), _conversion_nulls.data());
+    }
+
+    const ParquetDecodeContext& _context;
+    UInt32 _target_precision;
+    int32_t _target_scale;
+    bool _enable_strict_mode;
+    ParquetLogicalValueConsumer& _consumer;
+    typename ColumnDecimal<T>::Container _logical_values;
+    IColumn::Filter _conversion_nulls;
 };
 
 } // namespace
@@ -789,6 +848,35 @@ Status DataTypeDecimalSerDe<T>::read_column_from_parquet(IColumn& column,
         state.dictionary_generation = source.dictionary_generation();
     }
     return state.materialize_dictionary(column, source, num_values);
+}
+
+template <PrimitiveType T>
+bool DataTypeDecimalSerDe<T>::supports_parquet_raw_predicate(
+        const ParquetDecodeContext& context) const {
+    if (context.encoding == ParquetValueEncoding::DICTIONARY ||
+        context.logical_type != ParquetLogicalType::DECIMAL) {
+        return false;
+    }
+    return context.physical_type == ParquetPhysicalType::INT32 ||
+           context.physical_type == ParquetPhysicalType::INT64 ||
+           context.physical_type == ParquetPhysicalType::BYTE_ARRAY ||
+           context.physical_type == ParquetPhysicalType::FIXED_LEN_BYTE_ARRAY;
+}
+
+template <PrimitiveType T>
+Status DataTypeDecimalSerDe<T>::read_parquet_raw_predicate(
+        ParquetDecodeSource& source, const ParquetDecodeContext& context, size_t num_values,
+        bool enable_strict_mode, ParquetLogicalValueConsumer& consumer) const {
+    if (!supports_parquet_raw_predicate(context)) {
+        return Status::NotSupported("Unsupported Parquet raw predicate conversion for {}",
+                                    get_name());
+    }
+    DecimalPredicateParquetConsumer<T> predicate_consumer(context, static_cast<UInt32>(precision),
+                                                          scale, enable_strict_mode, consumer);
+    if (context.physical_type == ParquetPhysicalType::BYTE_ARRAY) {
+        return source.decode_binary_values(num_values, predicate_consumer);
+    }
+    return source.decode_fixed_values(num_values, predicate_consumer);
 }
 
 template <PrimitiveType T>

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -411,13 +411,16 @@ public:
 
     DecimalPredicateParquetConsumer(const ParquetDecodeContext& context, UInt32 target_precision,
                                     int32_t target_scale, bool enable_strict_mode,
-                                    ParquetLogicalValueConsumer& consumer)
+                                    ParquetLogicalValueConsumer& consumer,
+                                    typename ColumnDecimal<T>::Container& logical_values,
+                                    IColumn::Filter& conversion_nulls)
             : _context(context),
               _target_precision(target_precision),
               _target_scale(target_scale),
               _enable_strict_mode(enable_strict_mode),
               _consumer(consumer),
-              _logical_values(0, static_cast<UInt32>(target_scale)) {}
+              _logical_values(logical_values),
+              _conversion_nulls(conversion_nulls) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         return convert_and_publish(num_values, [&](DecimalParquetConsumer<T>& converter) {
@@ -452,8 +455,8 @@ private:
     int32_t _target_scale;
     bool _enable_strict_mode;
     ParquetLogicalValueConsumer& _consumer;
-    typename ColumnDecimal<T>::Container _logical_values;
-    IColumn::Filter _conversion_nulls;
+    typename ColumnDecimal<T>::Container& _logical_values;
+    IColumn::Filter& _conversion_nulls;
 };
 
 } // namespace
@@ -871,8 +874,9 @@ Status DataTypeDecimalSerDe<T>::read_parquet_raw_predicate(
         return Status::NotSupported("Unsupported Parquet raw predicate conversion for {}",
                                     get_name());
     }
-    DecimalPredicateParquetConsumer<T> predicate_consumer(context, static_cast<UInt32>(precision),
-                                                          scale, enable_strict_mode, consumer);
+    DecimalPredicateParquetConsumer<T> predicate_consumer(
+            context, static_cast<UInt32>(precision), scale, enable_strict_mode, consumer,
+            _parquet_predicate_values, _parquet_predicate_nulls);
     if (context.physical_type == ParquetPhysicalType::BYTE_ARRAY) {
         return source.decode_binary_values(num_values, predicate_consumer);
     }

--- a/be/src/core/data_type_serde/data_type_decimal_serde.h
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.h
@@ -113,6 +113,11 @@ public:
     Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                     const ParquetDecodeContext& context, size_t num_values,
                                     ParquetMaterializationState& state) const override;
+    bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const override;
+    Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                      const ParquetDecodeContext& context, size_t num_values,
+                                      bool enable_strict_mode,
+                                      ParquetLogicalValueConsumer& consumer) const override;
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;

--- a/be/src/core/data_type_serde/data_type_decimal_serde.h
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.h
@@ -50,7 +50,8 @@ public:
             : DataTypeSerDe(nesting_level),
               precision(precision_),
               scale(scale_),
-              scale_multiplier(decimal_scale_multiplier<typename FieldType::NativeType>(scale)) {}
+              scale_multiplier(decimal_scale_multiplier<typename FieldType::NativeType>(scale)),
+              _parquet_predicate_values(0, static_cast<UInt32>(scale)) {}
 
     std::string get_name() const override { return type_to_string(T); }
 
@@ -118,6 +119,23 @@ public:
                                       const ParquetDecodeContext& context, size_t num_values,
                                       bool enable_strict_mode,
                                       ParquetLogicalValueConsumer& consumer) const override;
+    size_t retained_parquet_raw_predicate_scratch_bytes() const override {
+        return _parquet_predicate_values.capacity() * sizeof(FieldType) +
+               _parquet_predicate_nulls.capacity();
+    }
+    size_t active_parquet_raw_predicate_scratch_bytes() const override {
+        return _parquet_predicate_values.size() * sizeof(FieldType) +
+               _parquet_predicate_nulls.size();
+    }
+    void release_parquet_raw_predicate_scratch(size_t max_retained_bytes) const override {
+        if (_parquet_predicate_values.capacity() * sizeof(FieldType) > max_retained_bytes) {
+            typename ColumnDecimal<T>::Container(0, static_cast<UInt32>(scale))
+                    .swap(_parquet_predicate_values);
+        }
+        if (_parquet_predicate_nulls.capacity() > max_retained_bytes) {
+            IColumn::Filter().swap(_parquet_predicate_nulls);
+        }
+    }
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;
@@ -160,6 +178,8 @@ private:
     int precision;
     int scale;
     const typename FieldType::NativeType scale_multiplier;
+    mutable typename ColumnDecimal<T>::Container _parquet_predicate_values;
+    mutable IColumn::Filter _parquet_predicate_nulls;
 };
 
 template <PrimitiveType T>

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -477,8 +477,14 @@ public:
     using DorisCppType = typename PrimitiveTypeTraits<DorisType>::CppType;
 
     NumberPredicateParquetConsumer(const ParquetDecodeContext& context, bool enable_strict_mode,
-                                   ParquetLogicalValueConsumer& consumer)
-            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+                                   ParquetLogicalValueConsumer& consumer,
+                                   PaddedPODArray<DorisCppType>& logical_values,
+                                   IColumn::Filter& conversion_nulls)
+            : _context(context),
+              _enable_strict_mode(enable_strict_mode),
+              _consumer(consumer),
+              _logical_values(logical_values),
+              _conversion_nulls(conversion_nulls) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         _logical_values.clear();
@@ -498,8 +504,8 @@ private:
     const ParquetDecodeContext& _context;
     bool _enable_strict_mode;
     ParquetLogicalValueConsumer& _consumer;
-    PaddedPODArray<DorisCppType> _logical_values;
-    IColumn::Filter _conversion_nulls;
+    PaddedPODArray<DorisCppType>& _logical_values;
+    IColumn::Filter& _conversion_nulls;
 };
 
 } // namespace
@@ -732,7 +738,9 @@ Status DataTypeNumberSerDe<T>::read_parquet_raw_predicate(
             return Status::NotSupported("Unsupported Parquet raw predicate conversion for {}",
                                         get_name());
         }
-        NumberPredicateParquetConsumer<T> predicate_consumer(context, enable_strict_mode, consumer);
+        NumberPredicateParquetConsumer<T> predicate_consumer(context, enable_strict_mode, consumer,
+                                                             _parquet_predicate_values,
+                                                             _parquet_predicate_nulls);
         return source.decode_fixed_values(num_values, predicate_consumer);
     }
 }

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -387,9 +387,11 @@ public:
 
     NumberParquetConsumer(IColumn& column, const ParquetDecodeContext& context,
                           ParquetMaterializationState* state = nullptr)
-            : _data(assert_cast<ColumnType&>(column).get_data()),
-              _context(context),
-              _state(state) {}
+            : NumberParquetConsumer(assert_cast<ColumnType&>(column).get_data(), context, state) {}
+
+    NumberParquetConsumer(PaddedPODArray<DorisCppType>& data, const ParquetDecodeContext& context,
+                          ParquetMaterializationState* state = nullptr)
+            : _data(data), _context(context), _state(state) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         return consume_impl(values, num_values, value_width);
@@ -467,6 +469,37 @@ public:
     Status consume(const StringRef* values, size_t num_values) override {
         return Status::NotSupported("Binary Parquet values cannot be materialized as a number");
     }
+};
+
+template <PrimitiveType DorisType>
+class NumberPredicateParquetConsumer final : public ParquetFixedValueConsumer {
+public:
+    using DorisCppType = typename PrimitiveTypeTraits<DorisType>::CppType;
+
+    NumberPredicateParquetConsumer(const ParquetDecodeContext& context, bool enable_strict_mode,
+                                   ParquetLogicalValueConsumer& consumer)
+            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        _logical_values.clear();
+        _conversion_nulls.clear();
+        _conversion_nulls.resize_fill(num_values, 0);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = _enable_strict_mode;
+        state.conversion_failure_null_map = &_conversion_nulls;
+        NumberParquetConsumer<DorisType> converter(_logical_values, _context, &state);
+        RETURN_IF_ERROR(converter.consume(values, num_values, value_width));
+        DORIS_CHECK_EQ(_logical_values.size(), num_values);
+        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
+                                 num_values, sizeof(DorisCppType), _conversion_nulls.data());
+    }
+
+private:
+    const ParquetDecodeContext& _context;
+    bool _enable_strict_mode;
+    ParquetLogicalValueConsumer& _consumer;
+    PaddedPODArray<DorisCppType> _logical_values;
+    IColumn::Filter _conversion_nulls;
 };
 
 } // namespace
@@ -663,6 +696,44 @@ Status DataTypeNumberSerDe<T>::read_column_from_parquet(IColumn& column,
             state.dictionary_generation = source.dictionary_generation();
         }
         return state.materialize_dictionary(column, source, num_values);
+    }
+}
+
+template <PrimitiveType T>
+bool DataTypeNumberSerDe<T>::supports_parquet_raw_predicate(
+        const ParquetDecodeContext& context) const {
+    if (context.encoding == ParquetValueEncoding::DICTIONARY) {
+        return false;
+    }
+    if constexpr (T == TYPE_BOOLEAN) {
+        return context.physical_type == ParquetPhysicalType::BOOLEAN;
+    } else if constexpr (T == TYPE_TINYINT || T == TYPE_SMALLINT || T == TYPE_INT ||
+                         T == TYPE_BIGINT || T == TYPE_LARGEINT) {
+        return context.physical_type == ParquetPhysicalType::INT32 ||
+               context.physical_type == ParquetPhysicalType::INT64;
+    } else if constexpr (T == TYPE_FLOAT || T == TYPE_DOUBLE) {
+        return context.physical_type == ParquetPhysicalType::FLOAT ||
+               context.physical_type == ParquetPhysicalType::DOUBLE || context.logical_float16;
+    }
+    return false;
+}
+
+template <PrimitiveType T>
+Status DataTypeNumberSerDe<T>::read_parquet_raw_predicate(
+        ParquetDecodeSource& source, const ParquetDecodeContext& context, size_t num_values,
+        bool enable_strict_mode, ParquetLogicalValueConsumer& consumer) const {
+    if constexpr (!(T == TYPE_BOOLEAN || T == TYPE_TINYINT || T == TYPE_SMALLINT || T == TYPE_INT ||
+                    T == TYPE_BIGINT || T == TYPE_LARGEINT || T == TYPE_FLOAT ||
+                    T == TYPE_DOUBLE)) {
+        return Status::NotSupported("Unsupported Parquet raw predicate conversion for {}",
+                                    get_name());
+    } else {
+        if (!supports_parquet_raw_predicate(context)) {
+            return Status::NotSupported("Unsupported Parquet raw predicate conversion for {}",
+                                        get_name());
+        }
+        NumberPredicateParquetConsumer<T> predicate_consumer(context, enable_strict_mode, consumer);
+        return source.decode_fixed_values(num_values, predicate_consumer);
     }
 }
 

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -128,6 +128,23 @@ public:
                                       const ParquetDecodeContext& context, size_t num_values,
                                       bool enable_strict_mode,
                                       ParquetLogicalValueConsumer& consumer) const override;
+    size_t retained_parquet_raw_predicate_scratch_bytes() const override {
+        return _parquet_predicate_values.capacity() * sizeof(typename ColumnType::value_type) +
+               _parquet_predicate_nulls.capacity();
+    }
+    size_t active_parquet_raw_predicate_scratch_bytes() const override {
+        return _parquet_predicate_values.size() * sizeof(typename ColumnType::value_type) +
+               _parquet_predicate_nulls.size();
+    }
+    void release_parquet_raw_predicate_scratch(size_t max_retained_bytes) const override {
+        if (_parquet_predicate_values.capacity() * sizeof(typename ColumnType::value_type) >
+            max_retained_bytes) {
+            typename ColumnType::Container().swap(_parquet_predicate_values);
+        }
+        if (_parquet_predicate_nulls.capacity() > max_retained_bytes) {
+            IColumn::Filter().swap(_parquet_predicate_nulls);
+        }
+    }
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;
@@ -167,6 +184,12 @@ public:
 protected:
     Status from_olap_string(const std::string& str, Field& field,
                             const FormatOptions& options) const override;
+
+    // One SerDe instance belongs to one persistent Parquet leaf reader. Keep converted POD and
+    // null scratch here so decoder fragments reuse high-water capacity instead of allocating a
+    // temporary column-sized pair of buffers on every callback.
+    mutable typename ColumnType::Container _parquet_predicate_values;
+    mutable IColumn::Filter _parquet_predicate_nulls;
 };
 
 template <PrimitiveType T>

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -123,6 +123,11 @@ public:
     Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                     const ParquetDecodeContext& context, size_t num_values,
                                     ParquetMaterializationState& state) const override;
+    bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const override;
+    Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                      const ParquetDecodeContext& context, size_t num_values,
+                                      bool enable_strict_mode,
+                                      ParquetLogicalValueConsumer& consumer) const override;
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;

--- a/be/src/core/data_type_serde/data_type_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_serde.cpp
@@ -718,6 +718,17 @@ Status DataTypeSerDe::read_column_from_parquet(IColumn& column, ParquetDecodeSou
     return Status::NotSupported("read_column_from_parquet is not supported for {}", get_name());
 }
 
+bool DataTypeSerDe::supports_parquet_raw_predicate(const ParquetDecodeContext& context) const {
+    return false;
+}
+
+Status DataTypeSerDe::read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                                 const ParquetDecodeContext& context,
+                                                 size_t num_values, bool enable_strict_mode,
+                                                 ParquetLogicalValueConsumer& consumer) const {
+    return Status::NotSupported("read_parquet_raw_predicate is not supported for {}", get_name());
+}
+
 Status DataTypeSerDe::read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                               const ParquetDecodeContext& context) const {
     return Status::NotSupported("read_parquet_dictionary is not supported for {}", get_name());

--- a/be/src/core/data_type_serde/data_type_serde.h
+++ b/be/src/core/data_type_serde/data_type_serde.h
@@ -521,6 +521,12 @@ public:
                                               const ParquetDecodeContext& context,
                                               size_t num_values, bool enable_strict_mode,
                                               ParquetLogicalValueConsumer& consumer) const;
+    // Raw conversion scratch is owned by the persistent leaf SerDe. The reader accounts active
+    // and retained bytes separately, then asks the SerDe to discard idle oversized capacity using
+    // the same bounded high-water policy as decoder scratch.
+    virtual size_t retained_parquet_raw_predicate_scratch_bytes() const { return 0; }
+    virtual size_t active_parquet_raw_predicate_scratch_bytes() const { return 0; }
+    virtual void release_parquet_raw_predicate_scratch(size_t max_retained_bytes) const {}
     // Decode one dictionary page into the selected Doris type without consuming data-page
     // indices. Dictionary filters use this to keep type interpretation in SerDe instead of
     // exposing dictionary bytes or decoder-owned strings to ColumnReader.

--- a/be/src/core/data_type_serde/data_type_serde.h
+++ b/be/src/core/data_type_serde/data_type_serde.h
@@ -95,6 +95,7 @@ class DataTypeSerDe;
 using DataTypeSerDeSPtr = std::shared_ptr<DataTypeSerDe>;
 using DataTypeSerDeSPtrs = std::vector<DataTypeSerDeSPtr>;
 class ParquetDecodeSource;
+class ParquetLogicalValueConsumer;
 struct ParquetDecodeContext;
 struct ParquetMaterializationState;
 
@@ -513,6 +514,13 @@ public:
     virtual Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                             const ParquetDecodeContext& context, size_t num_values,
                                             ParquetMaterializationState& state) const;
+    // Convert decoder-owned physical values into contiguous Doris logical POD values and publish
+    // them directly to a predicate sink. Implementations must not construct an IColumn.
+    virtual bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const;
+    virtual Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                              const ParquetDecodeContext& context,
+                                              size_t num_values, bool enable_strict_mode,
+                                              ParquetLogicalValueConsumer& consumer) const;
     // Decode one dictionary page into the selected Doris type without consuming data-page
     // indices. Dictionary filters use this to keep type interpretation in SerDe instead of
     // exposing dictionary bytes or decoder-owned strings to ColumnReader.

--- a/be/src/core/data_type_serde/data_type_time_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_time_serde.cpp
@@ -63,6 +63,10 @@ public:
               _context(context),
               _state(state) {}
 
+    TimeV2ParquetConsumer(ColumnTimeV2::Container& data, const ParquetDecodeContext& context,
+                          ParquetMaterializationState* state = nullptr)
+            : _data(data), _context(context), _state(state) {}
+
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         const size_t old_size = _data.size();
         _data.resize(old_size + num_values);
@@ -121,6 +125,33 @@ public:
     Status consume(const StringRef* values, size_t num_values) override {
         return Status::NotSupported("Binary Parquet values cannot be materialized as TIMEV2");
     }
+};
+
+class TimeV2PredicateParquetConsumer final : public ParquetFixedValueConsumer {
+public:
+    TimeV2PredicateParquetConsumer(const ParquetDecodeContext& context, bool enable_strict_mode,
+                                   ParquetLogicalValueConsumer& consumer)
+            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        _logical_values.clear();
+        _conversion_nulls.clear();
+        _conversion_nulls.resize_fill(num_values, 0);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = _enable_strict_mode;
+        state.conversion_failure_null_map = &_conversion_nulls;
+        TimeV2ParquetConsumer converter(_logical_values, _context, &state);
+        RETURN_IF_ERROR(converter.consume(values, num_values, value_width));
+        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
+                                 num_values, sizeof(TimeValue::TimeType), _conversion_nulls.data());
+    }
+
+private:
+    const ParquetDecodeContext& _context;
+    bool _enable_strict_mode;
+    ParquetLogicalValueConsumer& _consumer;
+    ColumnTimeV2::Container _logical_values;
+    IColumn::Filter _conversion_nulls;
 };
 
 } // namespace
@@ -298,6 +329,24 @@ Status DataTypeTimeV2SerDe::read_column_from_parquet(IColumn& column, ParquetDec
         state.dictionary_generation = source.dictionary_generation();
     }
     return state.materialize_dictionary(column, source, num_values);
+}
+
+bool DataTypeTimeV2SerDe::supports_parquet_raw_predicate(
+        const ParquetDecodeContext& context) const {
+    return context.encoding != ParquetValueEncoding::DICTIONARY &&
+           (context.physical_type == ParquetPhysicalType::INT32 ||
+            context.physical_type == ParquetPhysicalType::INT64) &&
+           context.logical_type == ParquetLogicalType::TIME;
+}
+
+Status DataTypeTimeV2SerDe::read_parquet_raw_predicate(
+        ParquetDecodeSource& source, const ParquetDecodeContext& context, size_t num_values,
+        bool enable_strict_mode, ParquetLogicalValueConsumer& consumer) const {
+    if (!supports_parquet_raw_predicate(context)) {
+        return Status::NotSupported("Unsupported Parquet raw predicate conversion for TIMEV2");
+    }
+    TimeV2PredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer);
+    return source.decode_fixed_values(num_values, predicate_consumer);
 }
 
 template <typename IntDataType>

--- a/be/src/core/data_type_serde/data_type_time_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_time_serde.cpp
@@ -130,8 +130,14 @@ public:
 class TimeV2PredicateParquetConsumer final : public ParquetFixedValueConsumer {
 public:
     TimeV2PredicateParquetConsumer(const ParquetDecodeContext& context, bool enable_strict_mode,
-                                   ParquetLogicalValueConsumer& consumer)
-            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+                                   ParquetLogicalValueConsumer& consumer,
+                                   ColumnTimeV2::Container& logical_values,
+                                   IColumn::Filter& conversion_nulls)
+            : _context(context),
+              _enable_strict_mode(enable_strict_mode),
+              _consumer(consumer),
+              _logical_values(logical_values),
+              _conversion_nulls(conversion_nulls) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         _logical_values.clear();
@@ -150,8 +156,8 @@ private:
     const ParquetDecodeContext& _context;
     bool _enable_strict_mode;
     ParquetLogicalValueConsumer& _consumer;
-    ColumnTimeV2::Container _logical_values;
-    IColumn::Filter _conversion_nulls;
+    ColumnTimeV2::Container& _logical_values;
+    IColumn::Filter& _conversion_nulls;
 };
 
 } // namespace
@@ -345,7 +351,9 @@ Status DataTypeTimeV2SerDe::read_parquet_raw_predicate(
     if (!supports_parquet_raw_predicate(context)) {
         return Status::NotSupported("Unsupported Parquet raw predicate conversion for TIMEV2");
     }
-    TimeV2PredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer);
+    TimeV2PredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer,
+                                                      _parquet_predicate_values,
+                                                      _parquet_predicate_nulls);
     return source.decode_fixed_values(num_values, predicate_consumer);
 }
 

--- a/be/src/core/data_type_serde/data_type_time_serde.h
+++ b/be/src/core/data_type_serde/data_type_time_serde.h
@@ -75,6 +75,11 @@ public:
                                     ParquetMaterializationState& state) const override;
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
+    bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const override;
+    Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                      const ParquetDecodeContext& context, size_t num_values,
+                                      bool enable_strict_mode,
+                                      ParquetLogicalValueConsumer& consumer) const override;
     int get_scale() const override { return _scale; }
 
 protected:

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
@@ -129,8 +129,14 @@ class TimestampTzPredicateParquetConsumer final : public ParquetFixedValueConsum
 public:
     TimestampTzPredicateParquetConsumer(const ParquetDecodeContext& context,
                                         bool enable_strict_mode,
-                                        ParquetLogicalValueConsumer& consumer)
-            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+                                        ParquetLogicalValueConsumer& consumer,
+                                        ColumnTimeStampTz::Container& logical_values,
+                                        IColumn::Filter& conversion_nulls)
+            : _context(context),
+              _enable_strict_mode(enable_strict_mode),
+              _consumer(consumer),
+              _logical_values(logical_values),
+              _conversion_nulls(conversion_nulls) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         _logical_values.clear();
@@ -149,8 +155,8 @@ private:
     const ParquetDecodeContext& _context;
     bool _enable_strict_mode;
     ParquetLogicalValueConsumer& _consumer;
-    ColumnTimeStampTz::Container _logical_values;
-    IColumn::Filter _conversion_nulls;
+    ColumnTimeStampTz::Container& _logical_values;
+    IColumn::Filter& _conversion_nulls;
 };
 
 } // namespace
@@ -483,7 +489,9 @@ Status DataTypeTimeStampTzSerDe::read_parquet_raw_predicate(
     if (!supports_parquet_raw_predicate(context)) {
         return Status::NotSupported("Unsupported Parquet raw predicate conversion for TIMESTAMPTZ");
     }
-    TimestampTzPredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer);
+    TimestampTzPredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer,
+                                                           _parquet_predicate_values,
+                                                           _parquet_predicate_nulls);
     return source.decode_fixed_values(num_values, predicate_consumer);
 }
 

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
@@ -71,9 +71,13 @@ class TimestampTzParquetConsumer final : public ParquetFixedValueConsumer {
 public:
     TimestampTzParquetConsumer(IColumn& column, const ParquetDecodeContext& context,
                                ParquetMaterializationState* state = nullptr)
-            : _data(assert_cast<ColumnTimeStampTz&>(column).get_data()),
-              _context(context),
-              _state(state) {}
+            : TimestampTzParquetConsumer(assert_cast<ColumnTimeStampTz&>(column).get_data(),
+                                         context, state) {}
+
+    TimestampTzParquetConsumer(ColumnTimeStampTz::Container& data,
+                               const ParquetDecodeContext& context,
+                               ParquetMaterializationState* state = nullptr)
+            : _data(data), _context(context), _state(state) {}
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
         const size_t old_size = _data.size();
@@ -119,6 +123,34 @@ public:
     Status consume(const StringRef* values, size_t num_values) override {
         return Status::NotSupported("Binary Parquet values cannot be materialized as TIMESTAMPTZ");
     }
+};
+
+class TimestampTzPredicateParquetConsumer final : public ParquetFixedValueConsumer {
+public:
+    TimestampTzPredicateParquetConsumer(const ParquetDecodeContext& context,
+                                        bool enable_strict_mode,
+                                        ParquetLogicalValueConsumer& consumer)
+            : _context(context), _enable_strict_mode(enable_strict_mode), _consumer(consumer) {}
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        _logical_values.clear();
+        _conversion_nulls.clear();
+        _conversion_nulls.resize_fill(num_values, 0);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = _enable_strict_mode;
+        state.conversion_failure_null_map = &_conversion_nulls;
+        TimestampTzParquetConsumer converter(_logical_values, _context, &state);
+        RETURN_IF_ERROR(converter.consume(values, num_values, value_width));
+        return _consumer.consume(reinterpret_cast<const uint8_t*>(_logical_values.data()),
+                                 num_values, sizeof(TimestampTzValue), _conversion_nulls.data());
+    }
+
+private:
+    const ParquetDecodeContext& _context;
+    bool _enable_strict_mode;
+    ParquetLogicalValueConsumer& _consumer;
+    ColumnTimeStampTz::Container _logical_values;
+    IColumn::Filter _conversion_nulls;
 };
 
 } // namespace
@@ -435,6 +467,24 @@ Status DataTypeTimeStampTzSerDe::read_column_from_parquet(
         state.dictionary_generation = source.dictionary_generation();
     }
     return state.materialize_dictionary(column, source, num_values);
+}
+
+bool DataTypeTimeStampTzSerDe::supports_parquet_raw_predicate(
+        const ParquetDecodeContext& context) const {
+    return context.encoding != ParquetValueEncoding::DICTIONARY &&
+           (context.physical_type == ParquetPhysicalType::INT64 ||
+            context.physical_type == ParquetPhysicalType::INT96) &&
+           context.logical_type == ParquetLogicalType::TIMESTAMP;
+}
+
+Status DataTypeTimeStampTzSerDe::read_parquet_raw_predicate(
+        ParquetDecodeSource& source, const ParquetDecodeContext& context, size_t num_values,
+        bool enable_strict_mode, ParquetLogicalValueConsumer& consumer) const {
+    if (!supports_parquet_raw_predicate(context)) {
+        return Status::NotSupported("Unsupported Parquet raw predicate conversion for TIMESTAMPTZ");
+    }
+    TimestampTzPredicateParquetConsumer predicate_consumer(context, enable_strict_mode, consumer);
+    return source.decode_fixed_values(num_values, predicate_consumer);
 }
 
 std::string DataTypeTimeStampTzSerDe::to_olap_string(const Field& field) const {

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.h
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.h
@@ -78,6 +78,11 @@ public:
     Status read_column_from_parquet(IColumn& column, ParquetDecodeSource& source,
                                     const ParquetDecodeContext& context, size_t num_values,
                                     ParquetMaterializationState& state) const override;
+    bool supports_parquet_raw_predicate(const ParquetDecodeContext& context) const override;
+    Status read_parquet_raw_predicate(ParquetDecodeSource& source,
+                                      const ParquetDecodeContext& context, size_t num_values,
+                                      bool enable_strict_mode,
+                                      ParquetLogicalValueConsumer& consumer) const override;
     Status read_parquet_dictionary(IColumn& column, ParquetDecodeSource& source,
                                    const ParquetDecodeContext& context) const override;
     Status read_column_from_orc(IColumn& column, const OrcDecodedColumnView& view) const override;

--- a/be/src/core/data_type_serde/parquet_decode_source.h
+++ b/be/src/core/data_type_serde/parquet_decode_source.h
@@ -140,6 +140,15 @@ public:
     }
 };
 
+// SerDes use this sink to publish converted logical POD batches straight to predicate kernels.
+// `conversion_nulls` is optional and marks permissive conversion failures without an IColumn.
+class ParquetLogicalValueConsumer {
+public:
+    virtual ~ParquetLogicalValueConsumer() = default;
+    virtual Status consume(const uint8_t* values, size_t num_values, size_t value_width,
+                           const uint8_t* conversion_nulls) = 0;
+};
+
 // Dictionary decoders publish validated IDs without knowing the destination Doris type. A
 // cache-resident dictionary can therefore fuse RLE decode with target-column gathering, while a
 // large sparse dictionary can still choose a compact ID buffer before random dictionary access.

--- a/be/src/core/data_type_serde/parquet_decode_source.h
+++ b/be/src/core/data_type_serde/parquet_decode_source.h
@@ -93,6 +93,10 @@ struct ParquetDecodeContext {
     bool logical_float16 = false;
     bool logical_uuid = false;
     bool dictionary_index_only = false;
+    // Legacy UTC/INT96 DATETIMEV2 materialization keeps permissive conversion failures as the
+    // zero default instead of exposing them as SQL NULL. Raw predicates must follow the same
+    // policy so pushdown cannot change comparison or IS NULL results.
+    bool conversion_failure_is_null = true;
 
     const cctz::time_zone* timezone = nullptr;
 };

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -145,6 +145,9 @@ public:
     virtual size_t raw_fixed_value_size() const = 0;
     virtual Status find_batch_raw_fixed(const uint8_t* values, size_t rows, size_t value_width,
                                         uint8_t* matches) const = 0;
+    virtual bool supports_raw_binary_values() const = 0;
+    virtual Status find_batch_raw_binary(const StringRef* values, size_t rows,
+                                         uint8_t* matches) const = 0;
     virtual bool test_field(const Field& field) const = 0;
 
     virtual uint16_t find_fixed_len_olap_engine(const IColumn& column, const uint8_t* nullmap,
@@ -223,6 +226,26 @@ public:
                 ValueType value;
                 std::memcpy(&value, values + row * sizeof(ValueType), sizeof(ValueType));
                 matches[row] &= _bloom_filter->test_element<fixed_len_to_uint32_v2>(value) ? 1 : 0;
+            }
+            return Status::OK();
+        }
+    }
+
+    bool supports_raw_binary_values() const override { return is_string_type(type); }
+
+    Status find_batch_raw_binary(const StringRef* values, size_t rows,
+                                 uint8_t* matches) const override {
+        if constexpr (!is_string_type(type)) {
+            return Status::NotSupported("Non-string Bloom filter cannot probe binary values");
+        } else {
+            if (_bloom_filter == nullptr) {
+                return Status::InternalError("Bloom filter is not initialized");
+            }
+            DORIS_CHECK(values != nullptr || rows == 0);
+            DORIS_CHECK(matches != nullptr || rows == 0);
+            for (size_t row = 0; row < rows; ++row) {
+                matches[row] &=
+                        _bloom_filter->test_element<fixed_len_to_uint32_v2>(values[row]) ? 1 : 0;
             }
             return Status::OK();
         }

--- a/be/src/exprs/create_predicate_function.h
+++ b/be/src/exprs/create_predicate_function.h
@@ -90,6 +90,7 @@ public:
     M(TYPE_DATEV2)            \
     M(TYPE_DATETIMEV2)        \
     M(TYPE_TIMESTAMPTZ)       \
+    M(TYPE_TIMEV2)            \
     M(TYPE_CHAR)              \
     M(TYPE_VARCHAR)           \
     M(TYPE_STRING)            \

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -207,6 +207,27 @@ public:
         }
     }
 
+    virtual void find_batch_raw_fixed_negative(const uint8_t* values, size_t rows,
+                                               size_t value_width, uint8_t* matches) const {
+        for (size_t row = 0; row < rows; ++row) {
+            matches[row] &= find(values + row * value_width) ? 0 : 1;
+        }
+    }
+
+    virtual void find_batch_raw_binary(const StringRef* values, size_t rows,
+                                       uint8_t* matches) const {
+        for (size_t row = 0; row < rows; ++row) {
+            matches[row] &= find(values[row].data, values[row].size) ? 1 : 0;
+        }
+    }
+
+    virtual void find_batch_raw_binary_negative(const StringRef* values, size_t rows,
+                                                uint8_t* matches) const {
+        for (size_t row = 0; row < rows; ++row) {
+            matches[row] &= find(values[row].data, values[row].size) ? 0 : 1;
+        }
+    }
+
     virtual void find_batch(const doris::IColumn& column, size_t rows,
                             doris::ColumnUInt8::Container& results,
                             const uint8_t* __restrict filter = nullptr) = 0;
@@ -307,6 +328,16 @@ public:
             ElementType value;
             std::memcpy(&value, values + row * sizeof(ElementType), sizeof(ElementType));
             matches[row] &= _set.find(value) ? 1 : 0;
+        }
+    }
+
+    void find_batch_raw_fixed_negative(const uint8_t* values, size_t rows, size_t value_width,
+                                       uint8_t* matches) const override {
+        DORIS_CHECK_EQ(value_width, sizeof(ElementType));
+        for (size_t row = 0; row < rows; ++row) {
+            ElementType value;
+            std::memcpy(&value, values + row * sizeof(ElementType), sizeof(ElementType));
+            matches[row] &= _set.find(value) ? 0 : 1;
         }
     }
 

--- a/be/src/exprs/runtime_filter_expr.cpp
+++ b/be/src/exprs/runtime_filter_expr.cpp
@@ -247,6 +247,24 @@ Status RuntimeFilterExpr::execute_on_raw_fixed_values(const uint8_t* values, siz
                                               matches);
 }
 
+bool RuntimeFilterExpr::can_execute_on_reader_values(const DataTypePtr& data_type,
+                                                     int column_id) const {
+    if (_null_aware || _impl == nullptr || data_type == nullptr || _impl->get_num_children() == 0) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(_impl->get_child(0));
+    if (slot == nullptr || slot->column_id() != column_id || slot->data_type() == nullptr) {
+        return false;
+    }
+    const auto reader_type = remove_nullable(data_type);
+    const auto probe_type = remove_nullable(slot->data_type());
+    // CHAR/VARCHAR/STRING share the same runtime-filter representation; every other logical type
+    // must match exactly so Parquet conversions cannot be interpreted with the wrong RF template.
+    return reader_type->equals(*probe_type) ||
+           (is_string_type(reader_type->get_primitive_type()) &&
+            is_string_type(probe_type->get_primitive_type()));
+}
+
 ZoneMapFilterResult RuntimeFilterExpr::evaluate_dictionary_filter(
         const DictionaryEvalContext& ctx) const {
     if (!can_evaluate_dictionary_filter()) {

--- a/be/src/exprs/runtime_filter_expr.cpp
+++ b/be/src/exprs/runtime_filter_expr.cpp
@@ -247,6 +247,23 @@ Status RuntimeFilterExpr::execute_on_raw_fixed_values(const uint8_t* values, siz
                                               matches);
 }
 
+bool RuntimeFilterExpr::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                                         int column_id) const {
+    // Definition levels do not carry a payload for NULL. Preserve null-aware semantics on the
+    // ordinary wrapper path instead of treating an absent byte slice as a non-match.
+    return !_null_aware && _impl->can_execute_on_raw_binary_values(data_type, column_id);
+}
+
+Status RuntimeFilterExpr::execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                                       const DataTypePtr& data_type, int column_id,
+                                                       uint8_t* matches) const {
+    if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+        return Status::NotSupported("Runtime filter {} cannot evaluate raw binary values",
+                                    _filter_id);
+    }
+    return _impl->execute_on_raw_binary_values(values, num_values, data_type, column_id, matches);
+}
+
 bool RuntimeFilterExpr::can_execute_on_reader_values(const DataTypePtr& data_type,
                                                      int column_id) const {
     if (_null_aware || _impl == nullptr || data_type == nullptr || _impl->get_num_children() == 0) {
@@ -260,9 +277,8 @@ bool RuntimeFilterExpr::can_execute_on_reader_values(const DataTypePtr& data_typ
     const auto probe_type = remove_nullable(slot->data_type());
     // CHAR/VARCHAR/STRING share the same runtime-filter representation; every other logical type
     // must match exactly so Parquet conversions cannot be interpreted with the wrong RF template.
-    return reader_type->equals(*probe_type) ||
-           (is_string_type(reader_type->get_primitive_type()) &&
-            is_string_type(probe_type->get_primitive_type()));
+    return reader_type->equals(*probe_type) || (is_string_type(reader_type->get_primitive_type()) &&
+                                                is_string_type(probe_type->get_primitive_type()));
 }
 
 ZoneMapFilterResult RuntimeFilterExpr::evaluate_dictionary_filter(

--- a/be/src/exprs/runtime_filter_expr.h
+++ b/be/src/exprs/runtime_filter_expr.h
@@ -112,6 +112,7 @@ public:
     Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
                                        const DataTypePtr& data_type, int column_id,
                                        uint8_t* matches) const override;
+    bool can_execute_on_reader_values(const DataTypePtr& data_type, int column_id) const override;
     ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const override;
     bool can_evaluate_dictionary_filter() const override;
     void collect_slot_column_ids(std::set<int>& column_ids) const override;

--- a/be/src/exprs/runtime_filter_expr.h
+++ b/be/src/exprs/runtime_filter_expr.h
@@ -112,6 +112,11 @@ public:
     Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
                                        const DataTypePtr& data_type, int column_id,
                                        uint8_t* matches) const override;
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override;
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override;
     bool can_execute_on_reader_values(const DataTypePtr& data_type, int column_id) const override;
     ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const override;
     bool can_evaluate_dictionary_filter() const override;

--- a/be/src/exprs/vbloom_predicate.cpp
+++ b/be/src/exprs/vbloom_predicate.cpp
@@ -145,6 +145,26 @@ Status VBloomPredicate::execute_on_raw_fixed_values(const uint8_t* values, size_
     return _filter->find_batch_raw_fixed(values, num_values, value_width, matches);
 }
 
+bool VBloomPredicate::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                                       int column_id) const {
+    if (_filter == nullptr || !_filter->supports_raw_binary_values() || _children.size() != 1) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
+    return slot != nullptr && slot->column_id() == column_id &&
+           bloom_filter_type_matches(_filter->primitive_type(), slot->data_type()) &&
+           bloom_filter_type_matches(_filter->primitive_type(), data_type);
+}
+
+Status VBloomPredicate::execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                                     const DataTypePtr& data_type, int column_id,
+                                                     uint8_t* matches) const {
+    if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+        return Status::NotSupported("Bloom predicate cannot evaluate raw binary values");
+    }
+    return _filter->find_batch_raw_binary(values, num_values, matches);
+}
+
 ZoneMapFilterResult VBloomPredicate::evaluate_dictionary_filter(
         const DictionaryEvalContext& ctx) const {
     if (!can_evaluate_dictionary_filter()) {

--- a/be/src/exprs/vbloom_predicate.h
+++ b/be/src/exprs/vbloom_predicate.h
@@ -54,6 +54,11 @@ public:
     Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
                                        const DataTypePtr& data_type, int column_id,
                                        uint8_t* matches) const override;
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override;
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override;
     ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const override;
     bool can_evaluate_dictionary_filter() const override;
 

--- a/be/src/exprs/vcompound_pred.h
+++ b/be/src/exprs/vcompound_pred.h
@@ -70,8 +70,7 @@ public:
     bool can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
                                          int column_id) const override {
         return !_children.empty() &&
-               (_op == TExprOpcode::COMPOUND_AND || _op == TExprOpcode::COMPOUND_OR ||
-                (_op == TExprOpcode::COMPOUND_NOT && _children.size() == 1)) &&
+               (_op == TExprOpcode::COMPOUND_AND || _op == TExprOpcode::COMPOUND_OR) &&
                std::ranges::all_of(_children, [&](const VExprSPtr& child) {
                    return child->can_execute_on_raw_fixed_values(data_type, column_id);
                });
@@ -93,8 +92,7 @@ public:
     bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
                                           int column_id) const override {
         return !_children.empty() &&
-               (_op == TExprOpcode::COMPOUND_AND || _op == TExprOpcode::COMPOUND_OR ||
-                (_op == TExprOpcode::COMPOUND_NOT && _children.size() == 1)) &&
+               (_op == TExprOpcode::COMPOUND_AND || _op == TExprOpcode::COMPOUND_OR) &&
                std::ranges::all_of(_children, [&](const VExprSPtr& child) {
                    return child->can_execute_on_raw_binary_values(data_type, column_id);
                });
@@ -111,6 +109,22 @@ public:
                     return child->execute_on_raw_binary_values(values, num_values, data_type,
                                                                column_id, child_matches);
                 });
+    }
+
+    bool raw_predicate_result_for_null() const override {
+        if (_op != TExprOpcode::COMPOUND_AND && _op != TExprOpcode::COMPOUND_OR) {
+            // A Boolean keep bit cannot distinguish FALSE from UNKNOWN, so negating a child's
+            // collapsed result is not SQL-correct. NOT remains residual and rejects NULL here.
+            return false;
+        }
+        if (_op == TExprOpcode::COMPOUND_AND) {
+            return std::ranges::all_of(_children, [](const VExprSPtr& child) {
+                return child->raw_predicate_result_for_null();
+            });
+        }
+        return std::ranges::any_of(_children, [](const VExprSPtr& child) {
+            return child->raw_predicate_result_for_null();
+        });
     }
 
     bool can_evaluate_zonemap_filter() const override {
@@ -540,25 +554,38 @@ private:
             return Status::OK();
         }
 
-        IColumn::Filter combined(num_values, _op == TExprOpcode::COMPOUND_NOT ? 1 : 0);
+        // Each execution context owns its expression tree. Retaining masks on the OR node avoids
+        // N+1 row-sized allocations for every decoder fragment, while nested OR nodes keep
+        // independent buffers and therefore cannot overwrite their parent's in-flight state.
+        _raw_combined_scratch.resize(num_values);
+        std::ranges::fill(_raw_combined_scratch, 0);
         for (const auto& child : _children) {
-            IColumn::Filter child_matches(num_values, 1);
-            RETURN_IF_ERROR(execute_child(child, child_matches.data()));
+            // resize_fill() initializes only newly appended bytes; explicitly reset a reused mask
+            // so matches from an earlier page fragment cannot leak into this OR evaluation.
+            _raw_child_scratch.resize(num_values);
+            std::ranges::fill(_raw_child_scratch, 1);
+            RETURN_IF_ERROR(execute_child(child, _raw_child_scratch.data()));
             for (size_t row = 0; row < num_values; ++row) {
-                if (_op == TExprOpcode::COMPOUND_OR) {
-                    combined[row] |= child_matches[row];
-                } else {
-                    combined[row] = child_matches[row] == 0 ? 1 : 0;
-                }
+                _raw_combined_scratch[row] |= _raw_child_scratch[row];
             }
         }
         // Raw kernels receive an existing selection mask, so composition must preserve rows that
         // an earlier conjunct already rejected instead of replacing the caller's mask.
         for (size_t row = 0; row < num_values; ++row) {
-            matches[row] &= combined[row];
+            matches[row] &= _raw_combined_scratch[row];
+        }
+        constexpr size_t MAX_RETAINED_RAW_MASK_BYTES = 1UL << 20;
+        if (_raw_combined_scratch.capacity() > MAX_RETAINED_RAW_MASK_BYTES) {
+            IColumn::Filter().swap(_raw_combined_scratch);
+        }
+        if (_raw_child_scratch.capacity() > MAX_RETAINED_RAW_MASK_BYTES) {
+            IColumn::Filter().swap(_raw_child_scratch);
         }
         return Status::OK();
     }
+
+    mutable IColumn::Filter _raw_combined_scratch;
+    mutable IColumn::Filter _raw_child_scratch;
 
     static inline constexpr uint8_t apply_and_null(UInt8 a, UInt8 l_null, UInt8 b, UInt8 r_null) {
         // (<> && false) is false, (true && NULL) is NULL

--- a/be/src/exprs/vcompound_pred.h
+++ b/be/src/exprs/vcompound_pred.h
@@ -67,6 +67,52 @@ public:
         return Status::OK();
     }
 
+    bool can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
+                                         int column_id) const override {
+        return !_children.empty() &&
+               (_op == TExprOpcode::COMPOUND_AND || _op == TExprOpcode::COMPOUND_OR ||
+                (_op == TExprOpcode::COMPOUND_NOT && _children.size() == 1)) &&
+               std::ranges::all_of(_children, [&](const VExprSPtr& child) {
+                   return child->can_execute_on_raw_fixed_values(data_type, column_id);
+               });
+    }
+
+    Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
+                                       const DataTypePtr& data_type, int column_id,
+                                       uint8_t* matches) const override {
+        if (!can_execute_on_raw_fixed_values(data_type, column_id)) {
+            return Status::NotSupported("Compound predicate cannot evaluate raw fixed values");
+        }
+        return _execute_raw_compound(
+                num_values, matches, [&](const VExprSPtr& child, uint8_t* child_matches) {
+                    return child->execute_on_raw_fixed_values(values, num_values, value_width,
+                                                              data_type, column_id, child_matches);
+                });
+    }
+
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override {
+        return !_children.empty() &&
+               (_op == TExprOpcode::COMPOUND_AND || _op == TExprOpcode::COMPOUND_OR ||
+                (_op == TExprOpcode::COMPOUND_NOT && _children.size() == 1)) &&
+               std::ranges::all_of(_children, [&](const VExprSPtr& child) {
+                   return child->can_execute_on_raw_binary_values(data_type, column_id);
+               });
+    }
+
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override {
+        if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+            return Status::NotSupported("Compound predicate cannot evaluate raw binary values");
+        }
+        return _execute_raw_compound(
+                num_values, matches, [&](const VExprSPtr& child, uint8_t* child_matches) {
+                    return child->execute_on_raw_binary_values(values, num_values, data_type,
+                                                               column_id, child_matches);
+                });
+    }
+
     bool can_evaluate_zonemap_filter() const override {
         switch (_op) {
         case TExprOpcode::COMPOUND_AND:
@@ -484,6 +530,36 @@ public:
     }
 
 private:
+    template <typename ExecuteChild>
+    Status _execute_raw_compound(size_t num_values, uint8_t* matches,
+                                 ExecuteChild&& execute_child) const {
+        if (_op == TExprOpcode::COMPOUND_AND) {
+            for (const auto& child : _children) {
+                RETURN_IF_ERROR(execute_child(child, matches));
+            }
+            return Status::OK();
+        }
+
+        IColumn::Filter combined(num_values, _op == TExprOpcode::COMPOUND_NOT ? 1 : 0);
+        for (const auto& child : _children) {
+            IColumn::Filter child_matches(num_values, 1);
+            RETURN_IF_ERROR(execute_child(child, child_matches.data()));
+            for (size_t row = 0; row < num_values; ++row) {
+                if (_op == TExprOpcode::COMPOUND_OR) {
+                    combined[row] |= child_matches[row];
+                } else {
+                    combined[row] = child_matches[row] == 0 ? 1 : 0;
+                }
+            }
+        }
+        // Raw kernels receive an existing selection mask, so composition must preserve rows that
+        // an earlier conjunct already rejected instead of replacing the caller's mask.
+        for (size_t row = 0; row < num_values; ++row) {
+            matches[row] &= combined[row];
+        }
+        return Status::OK();
+    }
+
     static inline constexpr uint8_t apply_and_null(UInt8 a, UInt8 l_null, UInt8 b, UInt8 r_null) {
         // (<> && false) is false, (true && NULL) is NULL
         return (l_null & r_null) | (r_null & (l_null ^ a)) | (l_null & (r_null ^ b));

--- a/be/src/exprs/vdirect_in_predicate.h
+++ b/be/src/exprs/vdirect_in_predicate.h
@@ -147,6 +147,34 @@ public:
         return Status::OK();
     }
 
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override {
+        if (!_hybrid_set_values_match_child_type || data_type == nullptr || _filter == nullptr ||
+            get_num_children() != 1) {
+            return false;
+        }
+        const auto slot = std::dynamic_pointer_cast<VSlotRef>(get_child(0));
+        if (slot == nullptr || slot->column_id() != column_id || slot->data_type() == nullptr) {
+            return false;
+        }
+        return is_string_type(remove_nullable(data_type)->get_primitive_type()) &&
+               is_string_type(remove_nullable(slot->data_type())->get_primitive_type());
+    }
+
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override {
+        if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+            return Status::NotSupported("Direct IN predicate cannot evaluate raw binary values");
+        }
+        DORIS_CHECK(values != nullptr || num_values == 0);
+        DORIS_CHECK(matches != nullptr || num_values == 0);
+        // Probe immutable decoder slices directly; constructing ColumnString first would copy
+        // every rejected payload and defeat predicate-only late materialization.
+        _filter->find_batch_raw_binary(values, num_values, matches);
+        return Status::OK();
+    }
+
     Status clone_node(VExprSPtr* cloned_expr) const override {
         DORIS_CHECK(cloned_expr != nullptr);
         *cloned_expr = VDirectInPredicate::create_shared(clone_texpr_node(), _filter,
@@ -222,6 +250,7 @@ private:
             RETURN_RAW_FIXED_SIZE(TYPE_DATEV2);
             RETURN_RAW_FIXED_SIZE(TYPE_DATETIMEV2);
             RETURN_RAW_FIXED_SIZE(TYPE_TIMESTAMPTZ);
+            RETURN_RAW_FIXED_SIZE(TYPE_TIMEV2);
             RETURN_RAW_FIXED_SIZE(TYPE_DECIMAL32);
             RETURN_RAW_FIXED_SIZE(TYPE_DECIMAL64);
             RETURN_RAW_FIXED_SIZE(TYPE_DECIMALV2);

--- a/be/src/exprs/vectorized_fn_call.cpp
+++ b/be/src/exprs/vectorized_fn_call.cpp
@@ -91,7 +91,7 @@ using simd::RawComparisonOp;
 
 std::optional<RawComparisonOp> raw_comparison_op(std::string_view function_name, bool reverse) {
     RawComparisonOp op;
-    if (function_name == "eq") {
+    if (function_name == "eq" || function_name == "eq_for_null") {
         op = RawComparisonOp::EQ;
     } else if (function_name == "ne") {
         op = RawComparisonOp::NE;
@@ -125,11 +125,92 @@ std::optional<RawComparisonOp> raw_comparison_op(std::string_view function_name,
     __builtin_unreachable();
 }
 
+bool raw_string_comparison_matches(int comparison, RawComparisonOp op) {
+    switch (op) {
+    case RawComparisonOp::EQ:
+        return comparison == 0;
+    case RawComparisonOp::NE:
+        return comparison != 0;
+    case RawComparisonOp::LT:
+        return comparison < 0;
+    case RawComparisonOp::LE:
+        return comparison <= 0;
+    case RawComparisonOp::GT:
+        return comparison > 0;
+    case RawComparisonOp::GE:
+        return comparison >= 0;
+    }
+    __builtin_unreachable();
+}
+
 template <typename T, PrimitiveType PT>
 void execute_raw_comparison(const uint8_t* values, size_t num_values, const Field& literal,
                             RawComparisonOp op, uint8_t* matches) {
     const T rhs = literal.get<PT>();
     simd::raw_compare(values, num_values, rhs, op, matches);
+}
+
+template <typename T>
+bool raw_scalar_comparison_matches(const T& lhs, const T& rhs, RawComparisonOp op) {
+    switch (op) {
+    case RawComparisonOp::EQ:
+        return lhs == rhs;
+    case RawComparisonOp::NE:
+        return lhs != rhs;
+    case RawComparisonOp::LT:
+        return lhs < rhs;
+    case RawComparisonOp::LE:
+        return lhs <= rhs;
+    case RawComparisonOp::GT:
+        return lhs > rhs;
+    case RawComparisonOp::GE:
+        return lhs >= rhs;
+    }
+    __builtin_unreachable();
+}
+
+template <PrimitiveType PT>
+void execute_raw_scalar_comparison(const uint8_t* values, size_t num_values, const Field& literal,
+                                   RawComparisonOp op, uint8_t* matches) {
+    using T = typename PrimitiveTypeTraits<PT>::CppType;
+    const T& rhs = literal.get<PT>();
+    for (size_t row = 0; row < num_values; ++row) {
+        T lhs;
+        std::memcpy(&lhs, values + row * sizeof(T), sizeof(T));
+        matches[row] &= raw_scalar_comparison_matches(lhs, rhs, op) ? 1 : 0;
+    }
+}
+
+size_t raw_comparison_value_size(PrimitiveType primitive_type) {
+    switch (primitive_type) {
+#define RETURN_RAW_COMPARISON_SIZE(TYPE) \
+    case TYPE:                           \
+        return sizeof(typename PrimitiveTypeTraits<TYPE>::CppType)
+        RETURN_RAW_COMPARISON_SIZE(TYPE_BOOLEAN);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_TINYINT);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_SMALLINT);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_INT);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_BIGINT);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_LARGEINT);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_FLOAT);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DOUBLE);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DATE);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DATETIME);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DATEV2);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DATETIMEV2);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_TIMESTAMPTZ);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_TIMEV2);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DECIMAL32);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DECIMAL64);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DECIMALV2);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DECIMAL128I);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_DECIMAL256);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_IPV4);
+        RETURN_RAW_COMPARISON_SIZE(TYPE_IPV6);
+#undef RETURN_RAW_COMPARISON_SIZE
+    default:
+        return 0;
+    }
 }
 
 } // namespace
@@ -405,9 +486,7 @@ bool VectorizedFnCall::can_execute_on_raw_fixed_values(const DataTypePtr& data_t
         !remove_nullable(slot_literal->literal_type)->equals(*raw_type)) {
         return false;
     }
-    const auto primitive_type = raw_type->get_primitive_type();
-    return primitive_type == TYPE_INT || primitive_type == TYPE_BIGINT ||
-           primitive_type == TYPE_FLOAT || primitive_type == TYPE_DOUBLE;
+    return raw_comparison_value_size(raw_type->get_primitive_type()) != 0;
 }
 
 Status VectorizedFnCall::execute_on_raw_fixed_values(const uint8_t* values, size_t num_values,
@@ -425,9 +504,7 @@ Status VectorizedFnCall::execute_on_raw_fixed_values(const uint8_t* values, size
     const auto op = raw_comparison_op(_function_name, slot_literal->literal_on_left);
     DORIS_CHECK(op.has_value());
     const auto primitive_type = remove_nullable(data_type)->get_primitive_type();
-    const size_t expected_width = primitive_type == TYPE_INT || primitive_type == TYPE_FLOAT
-                                          ? sizeof(uint32_t)
-                                          : sizeof(uint64_t);
+    const size_t expected_width = raw_comparison_value_size(primitive_type);
     if (value_width != expected_width) {
         return Status::Corruption("Raw expression width {} does not match expected {}", value_width,
                                   expected_width);
@@ -449,8 +526,97 @@ Status VectorizedFnCall::execute_on_raw_fixed_values(const uint8_t* values, size
         execute_raw_comparison<double, TYPE_DOUBLE>(values, num_values, slot_literal->literal, *op,
                                                     matches);
         break;
+#define EXECUTE_RAW_SCALAR_COMPARISON(TYPE)                                                 \
+    case TYPE:                                                                              \
+        execute_raw_scalar_comparison<TYPE>(values, num_values, slot_literal->literal, *op, \
+                                            matches);                                       \
+        break
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_BOOLEAN);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_TINYINT);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_SMALLINT);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_LARGEINT);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DATE);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DATETIME);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DATEV2);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DATETIMEV2);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_TIMESTAMPTZ);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_TIMEV2);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DECIMAL32);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DECIMAL64);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DECIMALV2);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DECIMAL128I);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_DECIMAL256);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_IPV4);
+        EXECUTE_RAW_SCALAR_COMPARISON(TYPE_IPV6);
+#undef EXECUTE_RAW_SCALAR_COMPARISON
     default:
         __builtin_unreachable();
+    }
+    return Status::OK();
+}
+
+bool VectorizedFnCall::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                                        int column_id) const {
+    if (data_type == nullptr || !is_string_type(remove_nullable(data_type)->get_primitive_type()) ||
+        !raw_comparison_op(_function_name, false).has_value()) {
+        return false;
+    }
+    const auto slot_literal = expr_zonemap::extract_slot_and_literal(_children);
+    return slot_literal.has_value() && slot_literal->slot_index == column_id &&
+           !slot_literal->literal.is_null() &&
+           is_string_type(remove_nullable(slot_literal->slot_type)->get_primitive_type()) &&
+           is_string_type(remove_nullable(slot_literal->literal_type)->get_primitive_type());
+}
+
+Status VectorizedFnCall::execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                                      const DataTypePtr& data_type, int column_id,
+                                                      uint8_t* matches) const {
+    if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+        return Status::NotSupported("Expression {} cannot evaluate raw binary values", expr_name());
+    }
+    DORIS_CHECK(values != nullptr || num_values == 0);
+    DORIS_CHECK(matches != nullptr || num_values == 0);
+    const auto slot_literal = expr_zonemap::extract_slot_and_literal(_children);
+    DORIS_CHECK(slot_literal.has_value());
+    const auto op = raw_comparison_op(_function_name, slot_literal->literal_on_left);
+    DORIS_CHECK(op.has_value());
+    const auto& literal = slot_literal->literal.get<TYPE_STRING>();
+    const StringRef literal_ref(literal.data(), literal.size());
+    for (size_t row = 0; row < num_values; ++row) {
+        matches[row] &=
+                raw_string_comparison_matches(values[row].compare(literal_ref), *op) ? 1 : 0;
+    }
+    return Status::OK();
+}
+
+bool VectorizedFnCall::can_execute_on_null_map(const DataTypePtr& data_type, int column_id) const {
+    if (data_type == nullptr) {
+        return false;
+    }
+    if (_children.size() == 1 &&
+        (_function_name == "is_null_pred" || _function_name == "is_not_null_pred")) {
+        const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
+        return slot != nullptr && slot->column_id() == column_id;
+    }
+    if (_function_name == "eq_for_null") {
+        const auto slot_literal = expr_zonemap::extract_slot_and_literal(_children);
+        return slot_literal.has_value() && slot_literal->slot_index == column_id &&
+               slot_literal->literal.is_null();
+    }
+    return false;
+}
+
+Status VectorizedFnCall::execute_on_null_map(const uint8_t* null_map, size_t num_values,
+                                             const DataTypePtr& data_type, int column_id,
+                                             uint8_t* matches) const {
+    if (!can_execute_on_null_map(data_type, column_id)) {
+        return Status::NotSupported("Expression {} cannot evaluate a NULL map", expr_name());
+    }
+    DORIS_CHECK(null_map != nullptr || num_values == 0);
+    DORIS_CHECK(matches != nullptr || num_values == 0);
+    const bool keep_nulls = _function_name == "is_null_pred" || _function_name == "eq_for_null";
+    for (size_t row = 0; row < num_values; ++row) {
+        matches[row] &= (null_map[row] != 0) == keep_nulls ? 1 : 0;
     }
     return Status::OK();
 }

--- a/be/src/exprs/vectorized_fn_call.h
+++ b/be/src/exprs/vectorized_fn_call.h
@@ -63,6 +63,15 @@ public:
     Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
                                        const DataTypePtr& data_type, int column_id,
                                        uint8_t* matches) const override;
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override;
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override;
+    bool can_execute_on_null_map(const DataTypePtr& data_type, int column_id) const override;
+    Status execute_on_null_map(const uint8_t* null_map, size_t num_values,
+                               const DataTypePtr& data_type, int column_id,
+                               uint8_t* matches) const override;
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
     ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override;
     bool can_evaluate_zonemap_filter() const override;

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -220,6 +220,11 @@ public:
         return Status::NotSupported("{} cannot evaluate raw binary values", expr_name());
     }
 
+    // Returns the Boolean result for a logical NULL whose payload is absent from decoder value
+    // callbacks. Most raw predicates reject NULL; dynamic predicates override this hook when
+    // their current runtime state can admit it.
+    virtual bool raw_predicate_result_for_null() const { return false; }
+
     // Parquet NULLs have no value payload. Level-aware predicates consume the definition-level
     // null map directly instead of forcing the reader to fabricate a nullable Doris column.
     virtual bool can_execute_on_null_map(const DataTypePtr& data_type, int column_id) const {

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -191,8 +191,11 @@ public:
                                   bool accept_null, bool* can_filter_all) const;
 
     // Raw fixed-width evaluation is an optional expression capability used before a storage reader
-    // materializes a column. `matches` is ANDed in place; callers handle NULL rows separately
-    // because raw value streams contain only non-NULL payloads.
+    // materializes a column. The capability query must validate the bound slot and logical type and
+    // remain stable for the reader lifetime. Execution receives `num_values` tightly packed,
+    // non-NULL logical values of `value_width` bytes; it ANDs decisions into the caller-owned
+    // `matches` array and must leave already rejected rows rejected. Callers handle NULL rows from
+    // definition levels because the physical value stream has no payload for them.
     virtual bool can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
                                                  int column_id) const {
         return false;
@@ -203,8 +206,10 @@ public:
         return Status::NotSupported("{} cannot evaluate raw fixed-width values", expr_name());
     }
 
-    // Variable-width Parquet decoders expose immutable slices rather than an IColumn. Expressions
-    // opt in only when Doris string semantics are identical to comparing those decoded bytes.
+    // Variable-width Parquet decoders expose `num_values` immutable, non-NULL slices rather than an
+    // IColumn. The capability query must validate the bound slot and logical type. Execution may
+    // borrow each slice only for the duration of the call and must AND its decisions into `matches`;
+    // expressions opt in only when Doris semantics are identical to comparing the decoded bytes.
     virtual bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
                                                   int column_id) const {
         return false;
@@ -257,6 +262,11 @@ public:
 
     virtual ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const;
     virtual bool can_evaluate_zonemap_filter() const { return false; }
+    // Dictionary evaluation is an optional conservative pruning capability over non-NULL values.
+    // kNoMatch proves that no dictionary entry can satisfy the expression, kMayMatch means at least
+    // one entry may satisfy it (or pruning cannot currently disprove it), and kUnsupported means the
+    // context lacks a compatible binding. Capability must describe expression shape, not the
+    // current contents of a late-arriving runtime filter, because readers may cache it.
     virtual ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const;
     virtual bool can_evaluate_dictionary_filter() const { return false; }
     virtual ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const;

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -202,6 +202,13 @@ public:
         return Status::NotSupported("{} cannot evaluate raw fixed-width values", expr_name());
     }
 
+    // Typed reader evaluation is an optional capability for runtime-filter wrappers. It lets a
+    // storage reader consume converted logical values without scheduling the same expression on
+    // a materialized file block afterwards.
+    virtual bool can_execute_on_reader_values(const DataTypePtr& data_type, int column_id) const {
+        return false;
+    }
+
     // `is_blockable` means this expr will be blocked in `execute` (e.g. AI Function, Remote Function)
     [[nodiscard]] virtual bool is_blockable() const {
         return std::any_of(_children.begin(), _children.end(),

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -41,6 +41,7 @@
 #include "core/data_type/data_type_ipv6.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/extended_types.h"
+#include "core/string_ref.h"
 #include "core/types.h"
 #include "core/value/large_int_value.h"
 #include "core/value/timestamptz_value.h"
@@ -200,6 +201,29 @@ public:
                                                size_t value_width, const DataTypePtr& data_type,
                                                int column_id, uint8_t* matches) const {
         return Status::NotSupported("{} cannot evaluate raw fixed-width values", expr_name());
+    }
+
+    // Variable-width Parquet decoders expose immutable slices rather than an IColumn. Expressions
+    // opt in only when Doris string semantics are identical to comparing those decoded bytes.
+    virtual bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                                  int column_id) const {
+        return false;
+    }
+    virtual Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                                const DataTypePtr& data_type, int column_id,
+                                                uint8_t* matches) const {
+        return Status::NotSupported("{} cannot evaluate raw binary values", expr_name());
+    }
+
+    // Parquet NULLs have no value payload. Level-aware predicates consume the definition-level
+    // null map directly instead of forcing the reader to fabricate a nullable Doris column.
+    virtual bool can_execute_on_null_map(const DataTypePtr& data_type, int column_id) const {
+        return false;
+    }
+    virtual Status execute_on_null_map(const uint8_t* null_map, size_t num_values,
+                                       const DataTypePtr& data_type, int column_id,
+                                       uint8_t* matches) const {
+        return Status::NotSupported("{} cannot evaluate a NULL map", expr_name());
     }
 
     // Typed reader evaluation is an optional capability for runtime-filter wrappers. It lets a
@@ -674,8 +698,7 @@ Status create_texpr_literal_node(const void* data, TExprNode* node, int precisio
         (*node).__set_ipv6_literal(literal);
         (*node).__set_type(create_type_desc(PrimitiveType::TYPE_IPV6));
     } else if constexpr (T == TYPE_TIMEV2) {
-        // the code use for runtime filter but we dont support timev2 as predicate now
-        // so this part not used
+        // Runtime filters preserve TIMEV2's microsecond carrier and scale in the literal node.
         const auto* origin_value = reinterpret_cast<const double*>(data);
         TTimeV2Literal timev2_literal;
         timev2_literal.__set_value(*origin_value);

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -30,6 +30,7 @@
 #include "core/block/column_numbers.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/block/columns_with_type_and_name.h"
+#include "core/data_type/define_primitive_type.h"
 #include "exprs/expr_zonemap_filter.h"
 #include "exprs/function/in.h"
 #include "exprs/function/simple_function_factory.h"
@@ -44,6 +45,42 @@ class RuntimeState;
 
 namespace doris {
 #include "common/compile_check_begin.h"
+
+namespace {
+
+size_t raw_in_value_size(PrimitiveType primitive_type) {
+    switch (primitive_type) {
+#define RETURN_RAW_IN_SIZE(TYPE) \
+    case TYPE:                   \
+        return sizeof(typename PrimitiveTypeTraits<TYPE>::CppType)
+        RETURN_RAW_IN_SIZE(TYPE_BOOLEAN);
+        RETURN_RAW_IN_SIZE(TYPE_TINYINT);
+        RETURN_RAW_IN_SIZE(TYPE_SMALLINT);
+        RETURN_RAW_IN_SIZE(TYPE_INT);
+        RETURN_RAW_IN_SIZE(TYPE_BIGINT);
+        RETURN_RAW_IN_SIZE(TYPE_LARGEINT);
+        RETURN_RAW_IN_SIZE(TYPE_FLOAT);
+        RETURN_RAW_IN_SIZE(TYPE_DOUBLE);
+        RETURN_RAW_IN_SIZE(TYPE_DATE);
+        RETURN_RAW_IN_SIZE(TYPE_DATETIME);
+        RETURN_RAW_IN_SIZE(TYPE_DATEV2);
+        RETURN_RAW_IN_SIZE(TYPE_DATETIMEV2);
+        RETURN_RAW_IN_SIZE(TYPE_TIMESTAMPTZ);
+        RETURN_RAW_IN_SIZE(TYPE_TIMEV2);
+        RETURN_RAW_IN_SIZE(TYPE_DECIMAL32);
+        RETURN_RAW_IN_SIZE(TYPE_DECIMAL64);
+        RETURN_RAW_IN_SIZE(TYPE_DECIMALV2);
+        RETURN_RAW_IN_SIZE(TYPE_DECIMAL128I);
+        RETURN_RAW_IN_SIZE(TYPE_DECIMAL256);
+        RETURN_RAW_IN_SIZE(TYPE_IPV4);
+        RETURN_RAW_IN_SIZE(TYPE_IPV6);
+#undef RETURN_RAW_IN_SIZE
+    default:
+        return 0;
+    }
+}
+
+} // namespace
 
 VInPredicate::VInPredicate(const TExprNode& node)
         : VExpr(node), _is_not_in(node.in_predicate.is_not_in) {}
@@ -122,6 +159,7 @@ Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
     _seg_filter_values.clear();
     _seg_filter_contains_null = false;
     _zonemap_materialized = false;
+    _direct_filter_set.reset();
     if (_children.size() < 2 || !_children[0]->is_slot_ref()) {
         return Status::OK();
     }
@@ -140,6 +178,7 @@ Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
     DORIS_CHECK(in_state != nullptr);
     DORIS_CHECK(in_state->use_set);
     DORIS_CHECK(in_state->hybrid_set != nullptr);
+    _direct_filter_set = in_state->hybrid_set;
 
     expr_zonemap::InZonemapMaterializedSet materialized;
     RETURN_IF_ERROR(expr_zonemap::materialize_hybrid_set_for_zonemap_filter(
@@ -181,6 +220,79 @@ ZoneMapFilterResult VInPredicate::evaluate_bloom_filter(const BloomFilterEvalCon
 bool VInPredicate::can_evaluate_bloom_filter() const {
     return _zonemap_materialized && !_is_not_in &&
            std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
+}
+
+bool VInPredicate::can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
+                                                   int column_id) const {
+    if (!_zonemap_materialized || _direct_filter_set == nullptr || data_type == nullptr ||
+        !_is_args_all_constant) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(get_child(0));
+    if (slot == nullptr || slot->column_id() != column_id || slot->data_type() == nullptr) {
+        return false;
+    }
+    const auto raw_type = remove_nullable(data_type);
+    return remove_nullable(slot->data_type())->equals(*raw_type) &&
+           raw_in_value_size(raw_type->get_primitive_type()) != 0;
+}
+
+Status VInPredicate::execute_on_raw_fixed_values(const uint8_t* values, size_t num_values,
+                                                 size_t value_width, const DataTypePtr& data_type,
+                                                 int column_id, uint8_t* matches) const {
+    if (!can_execute_on_raw_fixed_values(data_type, column_id)) {
+        return Status::NotSupported("IN predicate cannot evaluate raw fixed-width values");
+    }
+    DORIS_CHECK(values != nullptr || num_values == 0);
+    DORIS_CHECK(matches != nullptr || num_values == 0);
+    const size_t expected_width =
+            raw_in_value_size(remove_nullable(data_type)->get_primitive_type());
+    if (value_width != expected_width) {
+        return Status::Corruption("Raw IN width {} does not match expected {}", value_width,
+                                  expected_width);
+    }
+    // NOT IN with a NULL literal is UNKNOWN for every non-null physical value. Definition levels
+    // handle input NULLs, while this guard preserves the remaining three-valued SQL invariant.
+    if (_is_not_in && _seg_filter_contains_null) {
+        std::fill(matches, matches + num_values, uint8_t {0});
+    } else if (_is_not_in) {
+        _direct_filter_set->find_batch_raw_fixed_negative(values, num_values, value_width, matches);
+    } else {
+        _direct_filter_set->find_batch_raw_fixed(values, num_values, value_width, matches);
+    }
+    return Status::OK();
+}
+
+bool VInPredicate::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                                    int column_id) const {
+    if (!_zonemap_materialized || _direct_filter_set == nullptr || data_type == nullptr ||
+        !_is_args_all_constant ||
+        !is_string_type(remove_nullable(data_type)->get_primitive_type())) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(get_child(0));
+    return slot != nullptr && slot->column_id() == column_id && slot->data_type() != nullptr &&
+           is_string_type(remove_nullable(slot->data_type())->get_primitive_type());
+}
+
+Status VInPredicate::execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                                  const DataTypePtr& data_type, int column_id,
+                                                  uint8_t* matches) const {
+    if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+        return Status::NotSupported("IN predicate cannot evaluate raw binary values");
+    }
+    DORIS_CHECK(values != nullptr || num_values == 0);
+    DORIS_CHECK(matches != nullptr || num_values == 0);
+    if (_is_not_in && _seg_filter_contains_null) {
+        std::fill(matches, matches + num_values, uint8_t {0});
+    } else if (_is_not_in) {
+        _direct_filter_set->find_batch_raw_binary_negative(values, num_values, matches);
+    } else {
+        // Decoder-owned slices remain valid for the whole batch, so regular SQL IN/NOT IN can
+        // probe the prepared hash set without constructing and then compacting a ColumnString.
+        _direct_filter_set->find_batch_raw_binary(values, num_values, matches);
+    }
+    return Status::OK();
 }
 
 Status VInPredicate::execute_column(VExprContext* context, const Block* block, Selector* selector,

--- a/be/src/exprs/vin_predicate.h
+++ b/be/src/exprs/vin_predicate.h
@@ -33,6 +33,7 @@ class RuntimeState;
 class TExprNode;
 class Block;
 class VExprContext;
+class HybridSetBase;
 } // namespace doris
 
 namespace doris {
@@ -67,6 +68,17 @@ public:
     ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override;
     bool can_evaluate_bloom_filter() const override;
 
+    bool can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
+                                         int column_id) const override;
+    Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
+                                       const DataTypePtr& data_type, int column_id,
+                                       uint8_t* matches) const override;
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override;
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override;
+
     uint64_t get_digest(uint64_t seed) const override { return 0; }
     Status clone_node(VExprSPtr* cloned_expr) const override {
         DORIS_CHECK(cloned_expr != nullptr);
@@ -90,6 +102,7 @@ private:
     bool _is_args_all_constant = false;
     bool _zonemap_materialized = false;
     bool _seg_filter_contains_null = false;
+    std::shared_ptr<HybridSetBase> _direct_filter_set;
     std::vector<Field> _seg_filter_values;
     Field _seg_filter_min;
     Field _seg_filter_max;

--- a/be/src/exprs/vtopn_pred.cpp
+++ b/be/src/exprs/vtopn_pred.cpp
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/vtopn_pred.h"
+
+#include <cstring>
+
+#include "exprs/expr_zonemap_filter.h"
+#include "util/simd/parquet_kernels.h"
+
+namespace doris {
+
+namespace {
+
+using simd::RawComparisonOp;
+
+size_t topn_raw_value_size(PrimitiveType type) {
+    switch (type) {
+#define RETURN_TOPN_RAW_SIZE(TYPE) \
+    case TYPE:                     \
+        return sizeof(typename PrimitiveTypeTraits<TYPE>::CppType)
+        RETURN_TOPN_RAW_SIZE(TYPE_BOOLEAN);
+        RETURN_TOPN_RAW_SIZE(TYPE_TINYINT);
+        RETURN_TOPN_RAW_SIZE(TYPE_SMALLINT);
+        RETURN_TOPN_RAW_SIZE(TYPE_INT);
+        RETURN_TOPN_RAW_SIZE(TYPE_BIGINT);
+        RETURN_TOPN_RAW_SIZE(TYPE_LARGEINT);
+        RETURN_TOPN_RAW_SIZE(TYPE_FLOAT);
+        RETURN_TOPN_RAW_SIZE(TYPE_DOUBLE);
+        RETURN_TOPN_RAW_SIZE(TYPE_DATE);
+        RETURN_TOPN_RAW_SIZE(TYPE_DATETIME);
+        RETURN_TOPN_RAW_SIZE(TYPE_DATEV2);
+        RETURN_TOPN_RAW_SIZE(TYPE_DATETIMEV2);
+        RETURN_TOPN_RAW_SIZE(TYPE_TIMESTAMPTZ);
+        RETURN_TOPN_RAW_SIZE(TYPE_TIME);
+        RETURN_TOPN_RAW_SIZE(TYPE_TIMEV2);
+        RETURN_TOPN_RAW_SIZE(TYPE_DECIMAL32);
+        RETURN_TOPN_RAW_SIZE(TYPE_DECIMAL64);
+        RETURN_TOPN_RAW_SIZE(TYPE_DECIMALV2);
+        RETURN_TOPN_RAW_SIZE(TYPE_DECIMAL128I);
+        RETURN_TOPN_RAW_SIZE(TYPE_DECIMAL256);
+        RETURN_TOPN_RAW_SIZE(TYPE_IPV4);
+        RETURN_TOPN_RAW_SIZE(TYPE_IPV6);
+#undef RETURN_TOPN_RAW_SIZE
+    default:
+        return 0;
+    }
+}
+
+bool topn_binary_type(PrimitiveType type) {
+    return is_string_type(type) || type == TYPE_VARBINARY;
+}
+
+template <typename T, PrimitiveType PT>
+void execute_topn_raw_comparison(const uint8_t* values, size_t num_values, const Field& bound,
+                                 RawComparisonOp op, uint8_t* matches) {
+    simd::raw_compare(values, num_values, bound.get<PT>(), op, matches);
+}
+
+template <typename T>
+bool topn_raw_scalar_matches(const T& value, const T& bound, RawComparisonOp op) {
+    return op == RawComparisonOp::LE ? value <= bound : value >= bound;
+}
+
+template <PrimitiveType PT>
+void execute_topn_raw_scalar(const uint8_t* values, size_t num_values, const Field& bound,
+                             RawComparisonOp op, uint8_t* matches) {
+    using T = typename PrimitiveTypeTraits<PT>::CppType;
+    const T& typed_bound = bound.get<PT>();
+    for (size_t row = 0; row < num_values; ++row) {
+        T value;
+        std::memcpy(&value, values + row * sizeof(T), sizeof(T));
+        matches[row] &= topn_raw_scalar_matches(value, typed_bound, op) ? 1 : 0;
+    }
+}
+
+bool topn_string_matches(int comparison, RawComparisonOp op) {
+    return op == RawComparisonOp::LE ? comparison <= 0 : comparison >= 0;
+}
+
+} // namespace
+
+bool VTopNPred::can_execute_on_raw_fixed_values(const DataTypePtr& data_type, int column_id) const {
+    if (_predicate == nullptr || data_type == nullptr || _children.size() != 1 ||
+        (_predicate->nulls_first() && data_type->is_nullable())) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
+    if (slot == nullptr || slot->column_id() != column_id || slot->data_type() == nullptr) {
+        return false;
+    }
+    const auto raw_type = remove_nullable(data_type);
+    return remove_nullable(slot->data_type())->equals(*raw_type) &&
+           topn_raw_value_size(raw_type->get_primitive_type()) != 0;
+}
+
+Status VTopNPred::execute_on_raw_fixed_values(const uint8_t* values, size_t num_values,
+                                              size_t value_width, const DataTypePtr& data_type,
+                                              int column_id, uint8_t* matches) const {
+    if (!can_execute_on_raw_fixed_values(data_type, column_id)) {
+        return Status::NotSupported("TopN predicate cannot evaluate raw fixed-width values");
+    }
+    DORIS_CHECK(values != nullptr || num_values == 0);
+    DORIS_CHECK(matches != nullptr || num_values == 0);
+    const auto primitive_type = remove_nullable(data_type)->get_primitive_type();
+    const size_t expected_width = topn_raw_value_size(primitive_type);
+    if (value_width != expected_width) {
+        return Status::Corruption("Raw TopN width {} does not match expected {}", value_width,
+                                  expected_width);
+    }
+
+    // The bound is mutable and may arrive after reader initialization. Snapshot it once per batch
+    // so every row observes one monotonic TopN frontier without invalidating cached capability.
+    const Field bound = _predicate->get_value();
+    if (bound.is_null()) {
+        return Status::OK();
+    }
+    if (!expr_zonemap::field_types_compatible(bound.get_type(), primitive_type)) {
+        return Status::InternalError("TopN bound type {} does not match raw value type {}",
+                                     type_to_string(bound.get_type()),
+                                     type_to_string(primitive_type));
+    }
+    const auto op = _predicate->is_asc() ? RawComparisonOp::LE : RawComparisonOp::GE;
+    switch (primitive_type) {
+    case TYPE_INT:
+        execute_topn_raw_comparison<int32_t, TYPE_INT>(values, num_values, bound, op, matches);
+        break;
+    case TYPE_BIGINT:
+        execute_topn_raw_comparison<int64_t, TYPE_BIGINT>(values, num_values, bound, op, matches);
+        break;
+    case TYPE_FLOAT:
+        execute_topn_raw_comparison<float, TYPE_FLOAT>(values, num_values, bound, op, matches);
+        break;
+    case TYPE_DOUBLE:
+        execute_topn_raw_comparison<double, TYPE_DOUBLE>(values, num_values, bound, op, matches);
+        break;
+#define EXECUTE_TOPN_RAW_SCALAR(TYPE)                                          \
+    case TYPE:                                                                 \
+        execute_topn_raw_scalar<TYPE>(values, num_values, bound, op, matches); \
+        break
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_BOOLEAN);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_TINYINT);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_SMALLINT);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_LARGEINT);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DATE);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DATETIME);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DATEV2);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DATETIMEV2);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_TIMESTAMPTZ);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_TIME);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_TIMEV2);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DECIMAL32);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DECIMAL64);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DECIMALV2);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DECIMAL128I);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_DECIMAL256);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_IPV4);
+        EXECUTE_TOPN_RAW_SCALAR(TYPE_IPV6);
+#undef EXECUTE_TOPN_RAW_SCALAR
+    default:
+        return Status::NotSupported("TopN raw fixed-width type {} is unsupported",
+                                    type_to_string(primitive_type));
+    }
+    return Status::OK();
+}
+
+bool VTopNPred::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                                 int column_id) const {
+    if (_predicate == nullptr || data_type == nullptr || _children.size() != 1 ||
+        (_predicate->nulls_first() && data_type->is_nullable())) {
+        return false;
+    }
+    const auto raw_type = remove_nullable(data_type);
+    const auto raw_primitive_type = raw_type->get_primitive_type();
+    if (!topn_binary_type(raw_primitive_type)) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
+    if (slot == nullptr || slot->column_id() != column_id || slot->data_type() == nullptr) {
+        return false;
+    }
+    const auto slot_primitive_type = remove_nullable(slot->data_type())->get_primitive_type();
+    return (is_string_type(raw_primitive_type) && is_string_type(slot_primitive_type)) ||
+           (raw_primitive_type == TYPE_VARBINARY && slot_primitive_type == TYPE_VARBINARY);
+}
+
+Status VTopNPred::execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                               const DataTypePtr& data_type, int column_id,
+                                               uint8_t* matches) const {
+    if (!can_execute_on_raw_binary_values(data_type, column_id)) {
+        return Status::NotSupported("TopN predicate cannot evaluate raw binary values");
+    }
+    DORIS_CHECK(values != nullptr || num_values == 0);
+    DORIS_CHECK(matches != nullptr || num_values == 0);
+    const Field bound = _predicate->get_value();
+    if (bound.is_null()) {
+        return Status::OK();
+    }
+    const auto primitive_type = remove_nullable(data_type)->get_primitive_type();
+    StringRef bound_ref;
+    if (is_string_type(primitive_type) && is_string_type(bound.get_type())) {
+        const auto& value = bound.get<TYPE_STRING>();
+        bound_ref = StringRef(value.data(), value.size());
+    } else if (primitive_type == TYPE_VARBINARY && bound.get_type() == TYPE_VARBINARY) {
+        bound_ref = bound.get<TYPE_VARBINARY>().to_string_ref();
+    } else {
+        return Status::InternalError("TopN bound type {} does not match raw binary type {}",
+                                     type_to_string(bound.get_type()),
+                                     type_to_string(primitive_type));
+    }
+    const auto op = _predicate->is_asc() ? RawComparisonOp::LE : RawComparisonOp::GE;
+    for (size_t row = 0; row < num_values; ++row) {
+        matches[row] &= topn_string_matches(values[row].compare(bound_ref), op) ? 1 : 0;
+    }
+    return Status::OK();
+}
+
+bool VTopNPred::can_evaluate_dictionary_filter() const {
+    if (_predicate == nullptr || _predicate->nulls_first() || _children.size() != 1) {
+        return false;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
+    if (slot == nullptr || slot->data_type() == nullptr) {
+        return false;
+    }
+    const auto primitive_type = remove_nullable(slot->data_type())->get_primitive_type();
+    return topn_raw_value_size(primitive_type) != 0 || topn_binary_type(primitive_type);
+}
+
+ZoneMapFilterResult VTopNPred::evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const {
+    if (!can_evaluate_dictionary_filter()) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
+    DORIS_CHECK(slot != nullptr);
+    const auto* dictionary = ctx.slot(slot->column_id());
+    if (dictionary == nullptr ||
+        !expr_zonemap::data_types_compatible(dictionary->data_type, slot->data_type())) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    const Field bound = _predicate->get_value();
+    if (bound.is_null()) {
+        return ZoneMapFilterResult::kMayMatch;
+    }
+    const auto primitive_type = remove_nullable(dictionary->data_type)->get_primitive_type();
+    if (!expr_zonemap::field_types_compatible(bound.get_type(), primitive_type)) {
+        return ZoneMapFilterResult::kUnsupported;
+    }
+    for (const Field& value : dictionary->values) {
+        if (value.is_null()) {
+            continue;
+        }
+        if (!expr_zonemap::field_types_compatible(value.get_type(), primitive_type)) {
+            return ZoneMapFilterResult::kUnsupported;
+        }
+        if ((_predicate->is_asc() && value <= bound) || (!_predicate->is_asc() && value >= bound)) {
+            return ZoneMapFilterResult::kMayMatch;
+        }
+    }
+    return ZoneMapFilterResult::kNoMatch;
+}
+
+} // namespace doris

--- a/be/src/exprs/vtopn_pred.cpp
+++ b/be/src/exprs/vtopn_pred.cpp
@@ -95,8 +95,7 @@ bool topn_string_matches(int comparison, RawComparisonOp op) {
 } // namespace
 
 bool VTopNPred::can_execute_on_raw_fixed_values(const DataTypePtr& data_type, int column_id) const {
-    if (_predicate == nullptr || data_type == nullptr || _children.size() != 1 ||
-        (_predicate->nulls_first() && data_type->is_nullable())) {
+    if (_predicate == nullptr || data_type == nullptr || _children.size() != 1) {
         return false;
     }
     const auto slot = std::dynamic_pointer_cast<VSlotRef>(_children[0]);
@@ -180,8 +179,7 @@ Status VTopNPred::execute_on_raw_fixed_values(const uint8_t* values, size_t num_
 
 bool VTopNPred::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
                                                  int column_id) const {
-    if (_predicate == nullptr || data_type == nullptr || _children.size() != 1 ||
-        (_predicate->nulls_first() && data_type->is_nullable())) {
+    if (_predicate == nullptr || data_type == nullptr || _children.size() != 1) {
         return false;
     }
     const auto raw_type = remove_nullable(data_type);

--- a/be/src/exprs/vtopn_pred.h
+++ b/be/src/exprs/vtopn_pred.h
@@ -154,9 +154,16 @@ public:
                                         const DataTypePtr& data_type, int column_id,
                                         uint8_t* matches) const override;
 
-    // Dictionary capability is restricted to a direct slot and NULLS-LAST semantics because the
-    // row-level dictionary-id reader currently drops NULL rows independently of dictionary ids.
-    // It stays enabled before the first bound so late runtime-predicate publication is supported.
+    bool raw_predicate_result_for_null() const override {
+        // execute_column() is all-pass until publication; afterwards NULLS FIRST keeps NULL while
+        // NULLS LAST rejects it. Sample this state per fragment just like the mutable bound.
+        return _predicate != nullptr && (!_predicate->has_value() || _predicate->nulls_first());
+    }
+
+    // Dictionary capability is restricted to a direct slot and NULLS-LAST semantics. It stays
+    // enabled before the first bound so row-group setup can cache an all-pass bitmap; the scan
+    // scheduler retains a per-batch residual and defers dictionary-id filtering while NULL still
+    // matches, then safely resumes it after bound publication.
     bool can_evaluate_dictionary_filter() const override;
 
     // Evaluates every non-NULL entry in the bound slot dictionary against one current-bound

--- a/be/src/exprs/vtopn_pred.h
+++ b/be/src/exprs/vtopn_pred.h
@@ -130,6 +130,40 @@ public:
         return Status::OK();
     }
 
+    // Returns true only for a direct slot binding whose logical fixed-width type exactly matches
+    // `data_type`. Eligibility does not depend on whether the dynamic TopN bound has arrived: a
+    // reader may cache this answer during initialization and observe the bound in a later batch.
+    bool can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
+                                         int column_id) const override;
+
+    // Compares the contiguous non-NULL physical values with one snapshot of the current TopN bound
+    // and ANDs the result into `matches`. `value_width` must equal the logical Doris value width.
+    // When no bound is available yet, this is deliberately an all-pass operation.
+    Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
+                                       const DataTypePtr& data_type, int column_id,
+                                       uint8_t* matches) const override;
+
+    // Returns true for a directly bound STRING-like or VARBINARY slot. As with the fixed-width
+    // capability, a not-yet-published bound does not force the scanner onto a materializing path.
+    bool can_execute_on_raw_binary_values(const DataTypePtr& data_type,
+                                          int column_id) const override;
+
+    // Compares decoder-owned immutable byte slices with the current TopN bound and ANDs each
+    // decision into `matches`; it never copies the slices into a ColumnString/ColumnVarbinary.
+    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
+                                        const DataTypePtr& data_type, int column_id,
+                                        uint8_t* matches) const override;
+
+    // Dictionary capability is restricted to a direct slot and NULLS-LAST semantics because the
+    // row-level dictionary-id reader currently drops NULL rows independently of dictionary ids.
+    // It stays enabled before the first bound so late runtime-predicate publication is supported.
+    bool can_evaluate_dictionary_filter() const override;
+
+    // Evaluates every non-NULL entry in the bound slot dictionary against one current-bound
+    // snapshot. kNoMatch proves that no entry can pass; kMayMatch includes both a matching entry and
+    // a not-yet-published bound; kUnsupported reports an absent or incompatible dictionary slot.
+    ZoneMapFilterResult evaluate_dictionary_filter(const DictionaryEvalContext& ctx) const override;
+
     const std::string& expr_name() const override { return _expr_name; }
 
     // only used in external table (for min-max filter). get `slot > xxx`, not `function(slot) > xxx`.

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -205,6 +205,8 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             profile, "DictFilterTypedCompareColumns", TUnit::UNIT, parquet_profile, 1);
     dict_filter_string_compare_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "DictFilterStringCompareColumns", TUnit::UNIT, parquet_profile, 1);
+    dict_filter_vectorized_runtime_filter_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "DictFilterVectorizedRuntimeFilterColumns", TUnit::UNIT, parquet_profile, 1);
     dict_filter_unsupported_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "DictFilterUnsupportedColumns", TUnit::UNIT, parquet_profile, 1);
     dict_filter_read_failures = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "DictFilterReadFailures",
@@ -345,6 +347,8 @@ ParquetScanProfile ParquetProfile::scan_profile() const {
             .dict_filter_columns = dict_filter_columns,
             .dict_filter_typed_compare_columns = dict_filter_typed_compare_columns,
             .dict_filter_string_compare_columns = dict_filter_string_compare_columns,
+            .dict_filter_vectorized_runtime_filter_columns =
+                    dict_filter_vectorized_runtime_filter_columns,
             .dict_filter_unsupported_columns = dict_filter_unsupported_columns,
             .dict_filter_read_failures = dict_filter_read_failures,
             .rows_filtered_by_dict_filter = rows_filtered_by_dict_filter,

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -181,6 +181,10 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             profile, "FixedWidthPredicateDirectBatches", TUnit::UNIT, parquet_profile, 1);
     fixed_width_predicate_direct_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "FixedWidthPredicateDirectRows", TUnit::UNIT, parquet_profile, 1);
+    raw_value_predicate_direct_batches = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "RawValuePredicateDirectBatches", TUnit::UNIT, parquet_profile, 1);
+    raw_value_predicate_direct_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "RawValuePredicateDirectRows", TUnit::UNIT, parquet_profile, 1);
     typed_runtime_filter_direct_batches = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "TypedRuntimeFilterDirectBatches", TUnit::UNIT, parquet_profile, 1);
     typed_runtime_filter_direct_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
@@ -340,6 +344,8 @@ ParquetScanProfile ParquetProfile::scan_profile() const {
             .predicate_alignment_columns = predicate_alignment_columns,
             .fixed_width_predicate_direct_batches = fixed_width_predicate_direct_batches,
             .fixed_width_predicate_direct_rows = fixed_width_predicate_direct_rows,
+            .raw_value_predicate_direct_batches = raw_value_predicate_direct_batches,
+            .raw_value_predicate_direct_rows = raw_value_predicate_direct_rows,
             .typed_runtime_filter_direct_batches = typed_runtime_filter_direct_batches,
             .typed_runtime_filter_direct_rows = typed_runtime_filter_direct_rows,
             .dictionary_predicate_direct_batches = dictionary_predicate_direct_batches,

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -181,6 +181,10 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             profile, "FixedWidthPredicateDirectBatches", TUnit::UNIT, parquet_profile, 1);
     fixed_width_predicate_direct_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "FixedWidthPredicateDirectRows", TUnit::UNIT, parquet_profile, 1);
+    typed_runtime_filter_direct_batches = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "TypedRuntimeFilterDirectBatches", TUnit::UNIT, parquet_profile, 1);
+    typed_runtime_filter_direct_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "TypedRuntimeFilterDirectRows", TUnit::UNIT, parquet_profile, 1);
     dictionary_predicate_direct_batches = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "DictionaryPredicateDirectBatches", TUnit::UNIT, parquet_profile, 1);
     dictionary_predicate_direct_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
@@ -336,6 +340,8 @@ ParquetScanProfile ParquetProfile::scan_profile() const {
             .predicate_alignment_columns = predicate_alignment_columns,
             .fixed_width_predicate_direct_batches = fixed_width_predicate_direct_batches,
             .fixed_width_predicate_direct_rows = fixed_width_predicate_direct_rows,
+            .typed_runtime_filter_direct_batches = typed_runtime_filter_direct_batches,
+            .typed_runtime_filter_direct_rows = typed_runtime_filter_direct_rows,
             .dictionary_predicate_direct_batches = dictionary_predicate_direct_batches,
             .dictionary_predicate_direct_rows = dictionary_predicate_direct_rows,
             .dictionary_predicate_projected_rows = dictionary_predicate_projected_rows,

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -92,6 +92,8 @@ struct ParquetScanProfile {
     RuntimeProfile::Counter* predicate_alignment_columns = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_batches = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_rows = nullptr;
+    RuntimeProfile::Counter* typed_runtime_filter_direct_batches = nullptr;
+    RuntimeProfile::Counter* typed_runtime_filter_direct_rows = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_direct_batches = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_direct_rows = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_projected_rows = nullptr;
@@ -218,6 +220,8 @@ struct ParquetProfile {
     RuntimeProfile::Counter* predicate_alignment_columns = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_batches = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_rows = nullptr;
+    RuntimeProfile::Counter* typed_runtime_filter_direct_batches = nullptr;
+    RuntimeProfile::Counter* typed_runtime_filter_direct_rows = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_direct_batches = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_direct_rows = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_projected_rows = nullptr;

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -107,6 +107,8 @@ struct ParquetScanProfile {
             nullptr; // fixed-width typed comparison columns
     RuntimeProfile::Counter* dict_filter_string_compare_columns =
             nullptr; // string typed comparison columns
+    RuntimeProfile::Counter* dict_filter_vectorized_runtime_filter_columns =
+            nullptr; // vectorized runtime-filter columns
     RuntimeProfile::Counter* dict_filter_unsupported_columns = nullptr; // unsupported columns
     RuntimeProfile::Counter* dict_filter_read_failures = nullptr;       // dictionary read failures
     RuntimeProfile::Counter* rows_filtered_by_dict_filter = nullptr;    // rows filtered by dict
@@ -227,6 +229,7 @@ struct ParquetProfile {
     RuntimeProfile::Counter* dict_filter_columns = nullptr;
     RuntimeProfile::Counter* dict_filter_typed_compare_columns = nullptr;
     RuntimeProfile::Counter* dict_filter_string_compare_columns = nullptr;
+    RuntimeProfile::Counter* dict_filter_vectorized_runtime_filter_columns = nullptr;
     RuntimeProfile::Counter* dict_filter_unsupported_columns = nullptr;
     RuntimeProfile::Counter* dict_filter_read_failures = nullptr;
     RuntimeProfile::Counter* rows_filtered_by_dict_filter = nullptr;

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -92,6 +92,8 @@ struct ParquetScanProfile {
     RuntimeProfile::Counter* predicate_alignment_columns = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_batches = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_rows = nullptr;
+    RuntimeProfile::Counter* raw_value_predicate_direct_batches = nullptr;
+    RuntimeProfile::Counter* raw_value_predicate_direct_rows = nullptr;
     RuntimeProfile::Counter* typed_runtime_filter_direct_batches = nullptr;
     RuntimeProfile::Counter* typed_runtime_filter_direct_rows = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_direct_batches = nullptr;
@@ -220,6 +222,8 @@ struct ParquetProfile {
     RuntimeProfile::Counter* predicate_alignment_columns = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_batches = nullptr;
     RuntimeProfile::Counter* fixed_width_predicate_direct_rows = nullptr;
+    RuntimeProfile::Counter* raw_value_predicate_direct_batches = nullptr;
+    RuntimeProfile::Counter* raw_value_predicate_direct_rows = nullptr;
     RuntimeProfile::Counter* typed_runtime_filter_direct_batches = nullptr;
     RuntimeProfile::Counter* typed_runtime_filter_direct_rows = nullptr;
     RuntimeProfile::Counter* dictionary_predicate_direct_batches = nullptr;

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -1988,10 +1988,16 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
                         &used_filter));
                 if (used_filter) {
                     DORIS_CHECK_EQ(compact_filter.size(), selected_rows_before);
-                    update_counter_if_not_null(_scan_profile.fixed_width_predicate_direct_batches,
-                                               1);
-                    update_counter_if_not_null(_scan_profile.fixed_width_predicate_direct_rows,
+                    update_counter_if_not_null(_scan_profile.raw_value_predicate_direct_batches, 1);
+                    update_counter_if_not_null(_scan_profile.raw_value_predicate_direct_rows,
                                                selected_rows_before);
+                    if (!is_string_type(
+                                remove_nullable(column_reader->type())->get_primitive_type())) {
+                        update_counter_if_not_null(
+                                _scan_profile.fixed_width_predicate_direct_batches, 1);
+                        update_counter_if_not_null(_scan_profile.fixed_width_predicate_direct_rows,
+                                                   selected_rows_before);
+                    }
                     const uint16_t new_selected_rows = count_selected_rows(compact_filter);
                     const auto filtered_rows = static_cast<int64_t>(selected_rows_before) -
                                                static_cast<int64_t>(new_selected_rows);

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -31,7 +31,9 @@
 #include "core/assert_cast.h"
 #include "core/block/block.h"
 #include "core/column/column_decimal.h"
+#include "core/column/column_nullable.h"
 #include "core/column/column_vector.h"
+#include "core/data_type/data_type_number.h"
 #include "exprs/expr_zonemap_filter.h"
 #include "exprs/vcompound_pred.h"
 #include "exprs/vectorized_fn_call.h"
@@ -1405,6 +1407,7 @@ enum class DictionaryEntryFilterKernel {
     GENERIC,
     TYPED_FIXED_WIDTH,
     TYPED_STRING,
+    VECTORIZED_RUNTIME_FILTER,
 };
 
 template <typename ColumnType>
@@ -1450,6 +1453,54 @@ bool get_typed_dictionary_raw_values(PrimitiveType primitive_type, const IColumn
     default:
         return false;
     }
+}
+
+Status try_apply_runtime_filters_to_dictionary(size_t block_position,
+                                               const ParquetColumnSchema& column_schema,
+                                               const VExprContextSPtrs& conjuncts,
+                                               const IColumn& dictionary,
+                                               IColumn::Filter* dictionary_filter, bool* applied) {
+    DORIS_CHECK(dictionary_filter != nullptr);
+    DORIS_CHECK(applied != nullptr);
+    *applied = false;
+    if (!std::ranges::all_of(conjuncts, [](const auto& conjunct) {
+            return conjunct != nullptr && conjunct->root() != nullptr &&
+                   conjunct->root()->is_rf_wrapper() &&
+                   conjunct->root()->can_evaluate_dictionary_filter() &&
+                   conjunct->root()->get_impl() != nullptr;
+        })) {
+        return Status::OK();
+    }
+
+    Block dictionary_block;
+    const size_t dictionary_size = dictionary.size();
+    const auto dummy_type = std::make_shared<DataTypeUInt8>();
+    for (size_t position = 0; position < block_position; ++position) {
+        dictionary_block.insert(
+                {ColumnUInt8::create(dictionary_size, 0), dummy_type, "dictionary_dummy"});
+    }
+    ColumnPtr dictionary_column = dictionary.get_ptr();
+    if (column_schema.type->is_nullable()) {
+        dictionary_column =
+                ColumnNullable::create(dictionary_column, ColumnUInt8::create(dictionary_size, 0));
+    }
+    dictionary_block.insert({std::move(dictionary_column), column_schema.type, "dictionary_value"});
+
+    dictionary_filter->clear();
+    dictionary_filter->resize_fill(dictionary_size, 1);
+    for (const auto& conjunct : conjuncts) {
+        bool can_filter_all = false;
+        // Execute the wrapped implementation directly. Sampling the tiny dictionary through the
+        // RF wrapper could mark the filter ineffective for the much larger row batches that follow.
+        RETURN_IF_ERROR(conjunct->root()->get_impl()->execute_filter(
+                conjunct.get(), &dictionary_block, dictionary_filter->data(), dictionary_size,
+                false, &can_filter_all));
+        if (can_filter_all) {
+            break;
+        }
+    }
+    *applied = true;
+    return Status::OK();
 }
 
 enum class StringDictionaryCompareOp {
@@ -1585,6 +1636,15 @@ Status build_dictionary_entry_filter(size_t block_position,
         return Status::OK();
     }
 
+    bool applied_runtime_filters = false;
+    RETURN_IF_ERROR(try_apply_runtime_filters_to_dictionary(
+            block_position, column_schema, conjuncts, dictionary, dictionary_filter,
+            &applied_runtime_filters));
+    if (applied_runtime_filters) {
+        *kernel = DictionaryEntryFilterKernel::VECTORIZED_RUNTIME_FILTER;
+        return Status::OK();
+    }
+
     dictionary_filter->clear();
     dictionary_filter->resize_fill(dictionary.size(), 1);
     DictionaryEvalContext ctx;
@@ -1698,6 +1758,9 @@ Status ParquetScanScheduler::prepare_current_dictionary_filters(
                 update_counter_if_not_null(_scan_profile.dict_filter_typed_compare_columns, 1);
             } else if (filter_kernel == DictionaryEntryFilterKernel::TYPED_STRING) {
                 update_counter_if_not_null(_scan_profile.dict_filter_string_compare_columns, 1);
+            } else if (filter_kernel == DictionaryEntryFilterKernel::VECTORIZED_RUNTIME_FILTER) {
+                update_counter_if_not_null(
+                        _scan_profile.dict_filter_vectorized_runtime_filter_columns, 1);
             }
             residual_conjuncts = build_dictionary_residual_conjuncts(conjunct_it->second);
         }

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -1903,11 +1903,11 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
     auto read_predicate_column =
             [&](ParquetColumnReader* column_reader, size_t block_position,
                 format::LocalColumnId local_id, const VExprContextSPtrs* single_column_conjuncts,
-                bool* used_dictionary_filter, bool* used_fixed_width_filter) -> Status {
+                bool* used_dictionary_filter, bool* used_direct_reader_filter) -> Status {
         DORIS_CHECK(used_dictionary_filter != nullptr);
-        DORIS_CHECK(used_fixed_width_filter != nullptr);
+        DORIS_CHECK(used_direct_reader_filter != nullptr);
         *used_dictionary_filter = false;
-        *used_fixed_width_filter = false;
+        *used_direct_reader_filter = false;
         DCHECK(remove_nullable(column_reader->type())
                        ->equals(*remove_nullable(file_block->get_by_position(block_position).type)))
                 << column_reader->type()->get_name() << " "
@@ -2014,7 +2014,41 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
                     read_column_positions.push_back(cast_set<uint32_t>(block_position));
                     remember_column_selection(cast_set<uint32_t>(block_position));
                     *predicate_columns_filtered = true;
-                    *used_fixed_width_filter = true;
+                    *used_direct_reader_filter = true;
+                    return Status::OK();
+                }
+
+                RETURN_IF_ERROR(column_reader->select_with_runtime_filter(
+                        *selection, *selected_rows, batch_rows, *single_column_conjuncts,
+                        cast_set<int>(block_position), predicate_only ? nullptr : &column,
+                        &compact_filter, &used_filter));
+                if (used_filter) {
+                    DORIS_CHECK_EQ(compact_filter.size(), selected_rows_before);
+                    update_counter_if_not_null(_scan_profile.typed_runtime_filter_direct_batches,
+                                               1);
+                    update_counter_if_not_null(_scan_profile.typed_runtime_filter_direct_rows,
+                                               selected_rows_before);
+                    const uint16_t new_selected_rows = count_selected_rows(compact_filter);
+                    const auto filtered_rows = static_cast<int64_t>(selected_rows_before) -
+                                               static_cast<int64_t>(new_selected_rows);
+                    if (conjunct_filtered_rows != nullptr) {
+                        *conjunct_filtered_rows += filtered_rows;
+                    }
+                    if (new_selected_rows != selected_rows_before) {
+                        *selected_rows = apply_compact_filter_to_selection(
+                                compact_filter, selection, selected_rows_before);
+                    }
+                    if (predicate_only) {
+                        auto placeholder = column->clone_empty();
+                        placeholder->insert_many_defaults(*selected_rows);
+                        file_block->replace_by_position(block_position, std::move(placeholder));
+                    } else {
+                        file_block->replace_by_position(block_position, std::move(column));
+                    }
+                    read_column_positions.push_back(cast_set<uint32_t>(block_position));
+                    remember_column_selection(cast_set<uint32_t>(block_position));
+                    *predicate_columns_filtered = true;
+                    *used_direct_reader_filter = true;
                     return Status::OK();
                 }
             }
@@ -2145,10 +2179,10 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
             auto position_it = request.local_positions.find(fid);
             DORIS_CHECK(position_it != request.local_positions.end());
             bool used_dictionary_filter = false;
-            bool used_fixed_width_filter = false;
+            bool used_direct_reader_filter = false;
             RETURN_IF_ERROR(read_predicate_column(column_reader.get(), position_it->second.value(),
                                                   fid, nullptr, &used_dictionary_filter,
-                                                  &used_fixed_width_filter));
+                                                  &used_direct_reader_filter));
             materialized_positions.insert(position_it->second.value());
         }
         return Status::OK();
@@ -2198,14 +2232,14 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
                                                                          predicate_batch_sequence);
             const int64_t start_ns = sample ? MonotonicNanos() : 0;
             bool used_dictionary_filter = false;
-            bool used_fixed_width_filter = false;
+            bool used_direct_reader_filter = false;
             const auto conjunct_it = schedule.single_column_conjuncts.find(block_position);
             const VExprContextSPtrs* column_conjuncts =
                     conjunct_it == schedule.single_column_conjuncts.end() ? nullptr
                                                                           : &conjunct_it->second;
             RETURN_IF_ERROR(read_predicate_column(reader_it->second.get(), block_position, fid,
                                                   column_conjuncts, &used_dictionary_filter,
-                                                  &used_fixed_width_filter));
+                                                  &used_direct_reader_filter));
             materialized_positions.insert(block_position);
             if (*selected_rows != 0 && conjunct_it != schedule.single_column_conjuncts.end()) {
                 if (used_dictionary_filter) {
@@ -2213,7 +2247,7 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
                     DORIS_CHECK(residual_it != _current_dictionary_residual_conjuncts.end());
                     RETURN_IF_ERROR(
                             execute_scheduled_owned_conjuncts_with_profile(residual_it->second));
-                } else if (!used_fixed_width_filter) {
+                } else if (!used_direct_reader_filter) {
                     RETURN_IF_ERROR(execute_scheduled_conjuncts_with_profile(conjunct_it->second));
                 }
             }
@@ -2257,10 +2291,10 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
             const auto reader_it = _current_predicate_columns.find(fid);
             DORIS_CHECK(reader_it != _current_predicate_columns.end());
             bool used_dictionary_filter = false;
-            bool used_fixed_width_filter = false;
+            bool used_direct_reader_filter = false;
             RETURN_IF_ERROR(read_predicate_column(reader_it->second.get(), position, fid, nullptr,
                                                   &used_dictionary_filter,
-                                                  &used_fixed_width_filter));
+                                                  &used_direct_reader_filter));
             materialized_positions.insert(position);
         }
         return Status::OK();

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/block/block.h"
+#include "core/column/column_const.h"
 #include "core/column/column_decimal.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_vector.h"
@@ -1347,6 +1348,12 @@ bool can_evaluate_all_with_dictionary(const VExprContextSPtrs& conjuncts) {
 
 bool can_evaluate_dictionary_exactly(const VExprSPtr& expr) {
     DORIS_CHECK(expr != nullptr);
+    if (expr->is_topn_filter()) {
+        // A row-group bitmap snapshots one bound, while TopN can publish or tighten it between
+        // batches. Keep the row expression as a residual; the cached bitmap remains a safe
+        // monotonic prefilter and the residual observes the current bound on every batch.
+        return false;
+    }
     const auto* compound_pred = dynamic_cast<const VCompoundPred*>(expr.get());
     if (compound_pred == nullptr) {
         return expr->can_evaluate_dictionary_filter();
@@ -1476,8 +1483,10 @@ Status try_apply_runtime_filters_to_dictionary(size_t block_position,
     const size_t dictionary_size = dictionary.size();
     const auto dummy_type = std::make_shared<DataTypeUInt8>();
     for (size_t position = 0; position < block_position; ++position) {
-        dictionary_block.insert(
-                {ColumnUInt8::create(dictionary_size, 0), dummy_type, "dictionary_dummy"});
+        // Slot position is metadata, not a reason to allocate position*rows bytes. Every unused
+        // slot shares the same one-value constant representation while preserving block indexing.
+        dictionary_block.insert({ColumnConst::create(ColumnUInt8::create(1, 0), dictionary_size),
+                                 dummy_type, "dictionary_dummy"});
     }
     ColumnPtr dictionary_column = dictionary.get_ptr();
     if (column_schema.type->is_nullable()) {
@@ -1916,12 +1925,27 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
         auto column = file_block->get_by_position(block_position).column->assert_mutable();
         SCOPED_TIMER(_scan_profile.column_read_time);
         const auto dictionary_filter_it = _current_dictionary_filters.find(local_id);
-        if (dictionary_filter_it != _current_dictionary_filters.end()) {
+        const bool dictionary_predicate_accepts_null =
+                single_column_conjuncts != nullptr && !single_column_conjuncts->empty() &&
+                std::ranges::all_of(*single_column_conjuncts, [](const auto& conjunct) {
+                    return conjunct != nullptr && conjunct->root() != nullptr &&
+                           conjunct->root()->raw_predicate_result_for_null();
+                });
+        if (dictionary_filter_it != _current_dictionary_filters.end() &&
+            !dictionary_predicate_accepts_null) {
+            // Dictionary ids have no entry for a physical NULL. Until an unbound TopN publishes
+            // its first bound, keep the materializing residual path so the all-pass invariant can
+            // preserve those rows; later batches can resume dictionary-id pruning safely.
             const uint16_t selected_rows_before = *selected_rows;
             IColumn::Filter compact_filter;
             uint16_t new_selected_rows = 0;
             bool used_filter = false;
-            const bool predicate_only = request.is_predicate_only(local_id);
+            const auto residual_it = _current_dictionary_residual_conjuncts.find(local_id);
+            const bool has_dictionary_residual =
+                    residual_it != _current_dictionary_residual_conjuncts.end() &&
+                    !residual_it->second.empty();
+            const bool predicate_only =
+                    request.is_predicate_only(local_id) && !has_dictionary_residual;
             // Dictionary ids are sufficient for predicate-only slots; skipping typed survivor
             // gathers preserves the block row shape without materializing an unobservable payload.
             IColumn* projected_column = predicate_only ? nullptr : column.get();
@@ -1978,6 +2002,7 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
                 const uint16_t selected_rows_before = *selected_rows;
                 IColumn::Filter compact_filter;
                 bool used_filter = false;
+                DirectPredicateExecutionKind execution_kind = DirectPredicateExecutionKind::NONE;
                 const bool predicate_only = request.is_predicate_only(local_id);
                 // The raw decoder cannot rewind after evaluating encoded fixed-width values.
                 // Project survivors in that pass when output still needs the predicate column.
@@ -1985,14 +2010,19 @@ Status ParquetScanScheduler::read_filter_columns(int64_t batch_rows,
                 RETURN_IF_ERROR(column_reader->select_with_fixed_width_filter(
                         *selection, *selected_rows, batch_rows, direct_conjuncts,
                         cast_set<int>(block_position), projected_column, &compact_filter,
-                        &used_filter));
+                        &used_filter, &execution_kind));
                 if (used_filter) {
                     DORIS_CHECK_EQ(compact_filter.size(), selected_rows_before);
-                    update_counter_if_not_null(_scan_profile.raw_value_predicate_direct_batches, 1);
-                    update_counter_if_not_null(_scan_profile.raw_value_predicate_direct_rows,
-                                               selected_rows_before);
-                    if (!is_string_type(
-                                remove_nullable(column_reader->type())->get_primitive_type())) {
+                    if (execution_kind == DirectPredicateExecutionKind::RAW_FIXED ||
+                        execution_kind == DirectPredicateExecutionKind::RAW_BINARY ||
+                        execution_kind == DirectPredicateExecutionKind::CONVERTED_FIXED) {
+                        update_counter_if_not_null(_scan_profile.raw_value_predicate_direct_batches,
+                                                   1);
+                        update_counter_if_not_null(_scan_profile.raw_value_predicate_direct_rows,
+                                                   selected_rows_before);
+                    }
+                    if (execution_kind == DirectPredicateExecutionKind::RAW_FIXED ||
+                        execution_kind == DirectPredicateExecutionKind::CONVERTED_FIXED) {
                         update_counter_if_not_null(
                                 _scan_profile.fixed_width_predicate_direct_batches, 1);
                         update_counter_if_not_null(_scan_profile.fixed_width_predicate_direct_rows,

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -81,14 +81,16 @@ Status ParquetColumnReader::select_with_dictionary_filter(const SelectionVector&
                                 name());
 }
 
-Status ParquetColumnReader::select_with_fixed_width_filter(const SelectionVector&, uint16_t,
-                                                           int64_t, const VExprSPtrs&, int,
-                                                           IColumn*, IColumn::Filter* row_filter,
-                                                           bool* used_filter) {
+Status ParquetColumnReader::select_with_fixed_width_filter(
+        const SelectionVector&, uint16_t, int64_t, const VExprSPtrs&, int, IColumn*,
+        IColumn::Filter* row_filter, bool* used_filter,
+        DirectPredicateExecutionKind* execution_kind) {
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(used_filter != nullptr);
+    DORIS_CHECK(execution_kind != nullptr);
     row_filter->clear();
     *used_filter = false;
+    *execution_kind = DirectPredicateExecutionKind::NONE;
     return Status::OK();
 }
 

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -94,7 +94,8 @@ Status ParquetColumnReader::select_with_fixed_width_filter(const SelectionVector
 
 Status ParquetColumnReader::select_with_runtime_filter(const SelectionVector&, uint16_t, int64_t,
                                                        const VExprContextSPtrs&, int,
-                                                       MutableColumnPtr*, IColumn::Filter* row_filter,
+                                                       MutableColumnPtr*,
+                                                       IColumn::Filter* row_filter,
                                                        bool* used_filter) {
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(used_filter != nullptr);

--- a/be/src/format_v2/parquet/reader/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/column_reader.cpp
@@ -92,4 +92,15 @@ Status ParquetColumnReader::select_with_fixed_width_filter(const SelectionVector
     return Status::OK();
 }
 
+Status ParquetColumnReader::select_with_runtime_filter(const SelectionVector&, uint16_t, int64_t,
+                                                       const VExprContextSPtrs&, int,
+                                                       MutableColumnPtr*, IColumn::Filter* row_filter,
+                                                       bool* used_filter) {
+    DORIS_CHECK(row_filter != nullptr);
+    DORIS_CHECK(used_filter != nullptr);
+    row_filter->clear();
+    *used_filter = false;
+    return Status::OK();
+}
+
 } // namespace doris::format::parquet

--- a/be/src/format_v2/parquet/reader/column_reader.h
+++ b/be/src/format_v2/parquet/reader/column_reader.h
@@ -23,9 +23,11 @@
 #include "core/data_type/data_type.h"
 #include "exprs/vexpr_fwd.h"
 #include "format_v2/parquet/parquet_profile.h"
+#include "format_v2/parquet/reader/direct_predicate.h"
 #include "format_v2/parquet/selection_vector.h"
 
 namespace doris::format::parquet {
+
 struct ParquetColumnSchema;
 
 // Scan-time column contract for FileScannerV2.
@@ -69,7 +71,8 @@ public:
                                                   uint16_t selected_rows, int64_t batch_rows,
                                                   const VExprSPtrs& conjuncts, int column_id,
                                                   IColumn* projected_column,
-                                                  IColumn::Filter* row_filter, bool* used_filter);
+                                                  IColumn::Filter* row_filter, bool* used_filter,
+                                                  DirectPredicateExecutionKind* execution_kind);
 
     // Consume batch_rows and evaluate runtime filters on file-local logical values inside the
     // reader. This covers encodings and logical conversions that cannot use the raw fixed-width

--- a/be/src/format_v2/parquet/reader/column_reader.h
+++ b/be/src/format_v2/parquet/reader/column_reader.h
@@ -71,6 +71,15 @@ public:
                                                   IColumn* projected_column,
                                                   IColumn::Filter* row_filter, bool* used_filter);
 
+    // Consume batch_rows and evaluate runtime filters on file-local logical values inside the
+    // reader. This covers encodings and logical conversions that cannot use the raw fixed-width
+    // path while still preventing a second expression pass in the scan scheduler.
+    virtual Status select_with_runtime_filter(const SelectionVector& selection,
+                                              uint16_t selected_rows, int64_t batch_rows,
+                                              const VExprContextSPtrs& conjuncts, int column_id,
+                                              MutableColumnPtr* projected_column,
+                                              IColumn::Filter* row_filter, bool* used_filter);
+
     // Native statistics are cumulative and can be recursively aggregated for complex columns.
     // Flush once at the scheduler batch boundary instead of snapshotting after each operation.
     virtual void flush_profile() {}

--- a/be/src/format_v2/parquet/reader/direct_predicate.h
+++ b/be/src/format_v2/parquet/reader/direct_predicate.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace doris::format::parquet {
+
+// Identifies the kernel that actually consumed a decoder fragment. Capability alone is not
+// sufficient for profile attribution because definition-only and converted paths share the same
+// reader entry point.
+enum class DirectPredicateExecutionKind : uint8_t {
+    NONE,
+    DEFINITION_LEVEL,
+    RAW_FIXED,
+    RAW_BINARY,
+    CONVERTED_FIXED,
+};
+
+} // namespace doris::format::parquet

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
@@ -758,21 +758,42 @@ Status decode_selected_nullable_values(IColumn& column, const DataTypeSerDe& ser
     return Status::OK();
 }
 
-class FixedWidthPredicateConsumer final : public ParquetFixedValueConsumer {
+class FixedWidthPredicateConsumer final : public ParquetFixedValueConsumer,
+                                          public ParquetLogicalValueConsumer {
 public:
     FixedWidthPredicateConsumer(const VExprSPtrs& conjuncts, DataTypePtr data_type, int column_id,
-                                IColumn::Filter* matches, IColumn* projected_column)
+                                IColumn::Filter* matches, IColumn* projected_column,
+                                IColumn::Filter* conversion_nulls = nullptr)
             : _conjuncts(conjuncts),
               _data_type(std::move(data_type)),
               _column_id(column_id),
               _matches(matches),
-              _projected_column(projected_column) {
+              _projected_column(projected_column),
+              _conversion_nulls(conversion_nulls) {
         DORIS_CHECK(_matches != nullptr);
     }
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        return consume(values, num_values, value_width, nullptr);
+    }
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width,
+                   const uint8_t* conversion_nulls) override {
         const size_t old_size = _matches->size();
         _matches->resize_fill(old_size + num_values, 1);
+        if (_conversion_nulls != nullptr) {
+            const size_t old_null_size = _conversion_nulls->size();
+            _conversion_nulls->resize_fill(old_null_size + num_values, 0);
+            if (conversion_nulls != nullptr) {
+                std::memcpy(_conversion_nulls->data() + old_null_size, conversion_nulls,
+                            num_values);
+            }
+        }
+        if (conversion_nulls != nullptr) {
+            for (size_t row = 0; row < num_values; ++row) {
+                _matches->data()[old_size + row] = conversion_nulls[row] == 0 ? 1 : 0;
+            }
+        }
         for (const auto& conjunct : _conjuncts) {
             RETURN_IF_ERROR(conjunct->execute_on_raw_fixed_values(values, num_values, value_width,
                                                                   _data_type, _column_id,
@@ -804,6 +825,55 @@ private:
     int _column_id;
     IColumn::Filter* _matches;
     IColumn* _projected_column;
+    IColumn::Filter* _conversion_nulls;
+};
+
+class BinaryPredicateConsumer final : public ParquetFixedValueConsumer,
+                                      public ParquetBinaryValueConsumer {
+public:
+    BinaryPredicateConsumer(const VExprSPtrs& conjuncts, DataTypePtr data_type, int column_id,
+                            IColumn::Filter* matches, IColumn* projected_column)
+            : _conjuncts(conjuncts),
+              _data_type(std::move(data_type)),
+              _column_id(column_id),
+              _matches(matches),
+              _projected_column(projected_column) {
+        DORIS_CHECK(_matches != nullptr);
+    }
+
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
+        _refs.resize(num_values);
+        for (size_t row = 0; row < num_values; ++row) {
+            _refs[row] = StringRef(reinterpret_cast<const char*>(values + row * value_width),
+                                   value_width);
+        }
+        return consume(_refs.data(), _refs.size());
+    }
+
+    Status consume(const StringRef* values, size_t num_values) override {
+        const size_t old_size = _matches->size();
+        _matches->resize_fill(old_size + num_values, 1);
+        for (const auto& conjunct : _conjuncts) {
+            RETURN_IF_ERROR(conjunct->execute_on_raw_binary_values(
+                    values, num_values, _data_type, _column_id, _matches->data() + old_size));
+        }
+        if (_projected_column != nullptr) {
+            for (size_t row = 0; row < num_values; ++row) {
+                if ((*_matches)[old_size + row] != 0) {
+                    _projected_column->insert_data(values[row].data, values[row].size);
+                }
+            }
+        }
+        return Status::OK();
+    }
+
+private:
+    const VExprSPtrs& _conjuncts;
+    DataTypePtr _data_type;
+    int _column_id;
+    IColumn::Filter* _matches;
+    IColumn* _projected_column;
+    std::vector<StringRef> _refs;
 };
 
 } // namespace
@@ -1637,42 +1707,87 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::materialize_values(
 
 template <bool IN_COLLECTION, bool OFFSET_INDEX>
 bool ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::can_filter_fixed_width_values(
-        const VExprSPtrs& conjuncts, int column_id) const {
-    if (conjuncts.empty() ||
-        !supports_raw_fixed_filter_encoding(_current_encoding, _metadata.type)) {
+        const VExprSPtrs& conjuncts, int column_id, const DataTypeSerDe* serde,
+        const ParquetDecodeContext* decode_context) const {
+    if (conjuncts.empty()) {
         return false;
+    }
+    const auto is_null_map_predicate = [&](const auto& conjunct) {
+        return conjunct != nullptr &&
+               conjunct->can_execute_on_null_map(_field_schema->data_type, column_id);
+    };
+    if (std::ranges::all_of(conjuncts, is_null_map_predicate)) {
+        return true;
     }
     const auto primitive_type = remove_nullable(_field_schema->data_type)->get_primitive_type();
-    const bool has_identity_width =
+    const bool decimal_scale_matches =
+            decode_context != nullptr &&
+            decode_context->decimal_scale == remove_nullable(_field_schema->data_type)->get_scale();
+    // Equal byte width and scale are insufficient when the file precision exceeds the target:
+    // bypassing SerDe would skip the target-precision overflow/null check.
+    const bool decimal_metadata_fits =
+            decode_context != nullptr &&
+            decode_context->logical_type == ParquetLogicalType::DECIMAL &&
+            decode_context->decimal_precision >= 0 &&
+            decode_context->decimal_precision <=
+                    remove_nullable(_field_schema->data_type)->get_precision();
+    const bool has_identity_value =
+            (_metadata.type == tparquet::Type::BOOLEAN && primitive_type == TYPE_BOOLEAN) ||
             (_metadata.type == tparquet::Type::INT32 &&
-             (primitive_type == TYPE_INT || primitive_type == TYPE_DECIMAL32)) ||
+             (primitive_type == TYPE_INT || (primitive_type == TYPE_DECIMAL32 &&
+                                             decimal_scale_matches && decimal_metadata_fits))) ||
             (_metadata.type == tparquet::Type::INT64 &&
-             (primitive_type == TYPE_BIGINT || primitive_type == TYPE_DECIMAL64)) ||
+             (primitive_type == TYPE_BIGINT || (primitive_type == TYPE_DECIMAL64 &&
+                                                decimal_scale_matches && decimal_metadata_fits))) ||
             (_metadata.type == tparquet::Type::FLOAT && primitive_type == TYPE_FLOAT) ||
             (_metadata.type == tparquet::Type::DOUBLE && primitive_type == TYPE_DOUBLE);
-    if (!has_identity_width) {
-        // Raw predicates consume the physical Parquet width. Logical conversions such as UINT32
-        // to BIGINT must stay on the typed path or a four-byte value is interpreted as eight bytes.
+    if (has_identity_value &&
+        supports_raw_fixed_filter_encoding(_current_encoding, _metadata.type)) {
+        return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
+            return conjunct != nullptr && (conjunct->can_execute_on_raw_fixed_values(
+                                                   _field_schema->data_type, column_id) ||
+                                           is_null_map_predicate(conjunct));
+        });
+    }
+    const bool encoding_supports_raw_values =
+            supports_raw_fixed_filter_encoding(_current_encoding, _metadata.type) ||
+            supports_raw_binary_filter_encoding(_current_encoding, _metadata.type);
+    const bool can_convert_logical_values = serde != nullptr && decode_context != nullptr &&
+                                            encoding_supports_raw_values &&
+                                            serde->supports_parquet_raw_predicate(*decode_context);
+    if (can_convert_logical_values) {
+        return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
+            return conjunct != nullptr && (conjunct->can_execute_on_raw_fixed_values(
+                                                   _field_schema->data_type, column_id) ||
+                                           is_null_map_predicate(conjunct));
+        });
+    }
+    if (supports_raw_binary_filter_encoding(_current_encoding, _metadata.type)) {
+        return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
+            return conjunct != nullptr && (conjunct->can_execute_on_raw_binary_values(
+                                                   _field_schema->data_type, column_id) ||
+                                           is_null_map_predicate(conjunct));
+        });
+    }
+    if (!supports_raw_fixed_filter_encoding(_current_encoding, _metadata.type)) {
         return false;
     }
-    return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
-        return conjunct != nullptr &&
-               conjunct->can_execute_on_raw_fixed_values(_field_schema->data_type, column_id);
-    });
+    return false;
 }
 
 template <bool IN_COLLECTION, bool OFFSET_INDEX>
 Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values(
         const VExprSPtrs& conjuncts, int column_id, ColumnSelectVector& select_vector,
         NullMap* selected_nulls, IColumn::Filter* physical_matches, IColumn* projected_column,
-        IColumn::Filter* row_filter, bool* used_filter) {
+        IColumn::Filter* row_filter, const DataTypeSerDe& serde,
+        const ParquetDecodeContext& decode_context, bool enable_strict_mode, bool* used_filter) {
     DORIS_CHECK(selected_nulls != nullptr);
     DORIS_CHECK(physical_matches != nullptr);
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(used_filter != nullptr);
     *used_filter = false;
     row_filter->clear();
-    if (!can_filter_fixed_width_values(conjuncts, column_id)) {
+    if (!can_filter_fixed_width_values(conjuncts, column_id, &serde, &decode_context)) {
         return Status::OK();
     }
     if (UNLIKELY(_remaining_num_values < select_vector.num_values())) {
@@ -1725,22 +1840,77 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
                 selection.total_values);
     }
 
+    VExprSPtrs raw_conjuncts;
+    VExprSPtrs null_map_conjuncts;
+    for (const auto& conjunct : conjuncts) {
+        if (conjunct->can_execute_on_null_map(_field_schema->data_type, column_id)) {
+            null_map_conjuncts.push_back(conjunct);
+        } else {
+            raw_conjuncts.push_back(conjunct);
+        }
+    }
     physical_matches->clear();
+    IColumn::Filter physical_conversion_nulls;
     if (selection.selected_values == 0) {
         RETURN_IF_ERROR(_page_decoder->skip_values(selection.total_values));
+    } else if (raw_conjuncts.empty()) {
+        RETURN_IF_ERROR(_page_decoder->skip_values(selection.total_values));
+        physical_matches->resize_fill(selection.selected_values, 1);
     } else {
-        FixedWidthPredicateConsumer consumer(conjuncts, _field_schema->data_type, column_id,
+        const bool all_raw_binary = std::ranges::all_of(raw_conjuncts, [&](const auto& conjunct) {
+            return conjunct->can_execute_on_raw_binary_values(_field_schema->data_type, column_id);
+        });
+        const bool all_raw_fixed = std::ranges::all_of(raw_conjuncts, [&](const auto& conjunct) {
+            return conjunct->can_execute_on_raw_fixed_values(_field_schema->data_type, column_id);
+        });
+        if (all_raw_binary &&
+            supports_raw_binary_filter_encoding(_current_encoding, _metadata.type)) {
+            BinaryPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
                                              physical_matches, projected_column);
-        RETURN_IF_ERROR(_page_decoder->decode_selected_fixed_values(selection, consumer));
+            if (_metadata.type == tparquet::Type::BYTE_ARRAY) {
+                RETURN_IF_ERROR(_page_decoder->decode_selected_binary_values(selection, consumer));
+            } else {
+                RETURN_IF_ERROR(_page_decoder->decode_selected_fixed_values(selection, consumer));
+            }
+        } else if (all_raw_fixed && serde.supports_parquet_raw_predicate(decode_context)) {
+            // Type conversion is fused between the decoder and predicate sink. Conversion-null
+            // bits travel beside the POD batch, preserving permissive scan semantics without an
+            // intermediate nullable IColumn.
+            SelectedDecodeSource selected_source(*_page_decoder, selection);
+            FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
+                                                 physical_matches, projected_column,
+                                                 &physical_conversion_nulls);
+            RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, decode_context,
+                                                             selection.selected_values,
+                                                             enable_strict_mode, consumer));
+        } else {
+            FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
+                                                 physical_matches, projected_column);
+            RETURN_IF_ERROR(_page_decoder->decode_selected_fixed_values(selection, consumer));
+        }
         DORIS_CHECK_EQ(physical_matches->size(), selection.selected_values);
     }
 
     row_filter->reserve(selected_nulls->size());
     size_t physical_row = 0;
-    for (const uint8_t is_null : *selected_nulls) {
-        row_filter->push_back(is_null != 0 ? 0 : (*physical_matches)[physical_row++]);
+    for (size_t logical_row = 0; logical_row < selected_nulls->size(); ++logical_row) {
+        uint8_t& is_null = (*selected_nulls)[logical_row];
+        if (is_null != 0) {
+            row_filter->push_back(raw_conjuncts.empty() ? 1 : 0);
+        } else {
+            if (!physical_conversion_nulls.empty() &&
+                physical_conversion_nulls[physical_row] != 0) {
+                is_null = 1;
+            }
+            row_filter->push_back((*physical_matches)[physical_row++]);
+        }
     }
     DORIS_CHECK_EQ(physical_row, physical_matches->size());
+    for (const auto& conjunct : null_map_conjuncts) {
+        RETURN_IF_ERROR(conjunct->execute_on_null_map(
+                selected_nulls->data(), selected_nulls->size(), _field_schema->data_type, column_id,
+                row_filter->data()));
+    }
     // Commit logical progress only after both the raw comparison and NULL remapping succeed.
     _remaining_num_values -= select_vector.num_values();
     *used_filter = true;

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
@@ -832,22 +832,45 @@ class BinaryPredicateConsumer final : public ParquetFixedValueConsumer,
                                       public ParquetBinaryValueConsumer {
 public:
     BinaryPredicateConsumer(const VExprSPtrs& conjuncts, DataTypePtr data_type, int column_id,
-                            IColumn::Filter* matches, IColumn* projected_column)
+                            IColumn::Filter* matches, IColumn* projected_column,
+                            std::vector<StringRef>* refs, std::vector<StringRef>* projected_refs)
             : _conjuncts(conjuncts),
               _data_type(std::move(data_type)),
               _column_id(column_id),
               _matches(matches),
-              _projected_column(projected_column) {
+              _projected_column(projected_column),
+              _refs(refs),
+              _projected_refs(projected_refs) {
         DORIS_CHECK(_matches != nullptr);
+        DORIS_CHECK(_refs != nullptr);
+        DORIS_CHECK(_projected_refs != nullptr);
     }
 
     Status consume(const uint8_t* values, size_t num_values, size_t value_width) override {
-        _refs.resize(num_values);
+        _refs->resize(num_values);
         for (size_t row = 0; row < num_values; ++row) {
-            _refs[row] = StringRef(reinterpret_cast<const char*>(values + row * value_width),
-                                   value_width);
+            (*_refs)[row] = StringRef(reinterpret_cast<const char*>(values + row * value_width),
+                                      value_width);
         }
-        return consume(_refs.data(), _refs.size());
+        return consume(_refs->data(), _refs->size());
+    }
+
+    Status consume_plain_byte_array(
+            const char* encoded_data, const uint32_t* payload_offsets,
+            const uint32_t* value_offsets, size_t num_values,
+            const std::vector<ParquetSelectionRange>& value_spans) override {
+        _refs->resize(num_values);
+        size_t covered = 0;
+        for (const auto& span : value_spans) {
+            DORIS_CHECK_EQ(span.first, covered);
+            for (size_t row = span.first; row < span.first + span.count; ++row) {
+                (*_refs)[row] = StringRef(encoded_data + payload_offsets[row],
+                                          value_offsets[row + 1] - value_offsets[row]);
+            }
+            covered += span.count;
+        }
+        DORIS_CHECK_EQ(covered, num_values);
+        return consume(_refs->data(), _refs->size());
     }
 
     Status consume(const StringRef* values, size_t num_values) override {
@@ -858,10 +881,16 @@ public:
                     values, num_values, _data_type, _column_id, _matches->data() + old_size));
         }
         if (_projected_column != nullptr) {
+            _projected_refs->clear();
+            _projected_refs->reserve(num_values);
             for (size_t row = 0; row < num_values; ++row) {
                 if ((*_matches)[old_size + row] != 0) {
-                    _projected_column->insert_data(values[row].data, values[row].size);
+                    _projected_refs->push_back(values[row]);
                 }
+            }
+            if (!_projected_refs->empty()) {
+                _projected_column->insert_many_strings(_projected_refs->data(),
+                                                       _projected_refs->size());
             }
         }
         return Status::OK();
@@ -873,7 +902,8 @@ private:
     int _column_id;
     IColumn::Filter* _matches;
     IColumn* _projected_column;
-    std::vector<StringRef> _refs;
+    std::vector<StringRef>* _refs;
+    std::vector<StringRef>* _projected_refs;
 };
 
 } // namespace
@@ -1716,9 +1746,7 @@ bool ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::can_filter_fixed_width_valu
         return conjunct != nullptr &&
                conjunct->can_execute_on_null_map(_field_schema->data_type, column_id);
     };
-    if (std::ranges::all_of(conjuncts, is_null_map_predicate)) {
-        return true;
-    }
+    const bool all_null_map_predicates = std::ranges::all_of(conjuncts, is_null_map_predicate);
     const auto primitive_type = remove_nullable(_field_schema->data_type)->get_primitive_type();
     const bool decimal_scale_matches =
             decode_context != nullptr &&
@@ -1755,6 +1783,17 @@ bool ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::can_filter_fixed_width_valu
     const bool can_convert_logical_values = serde != nullptr && decode_context != nullptr &&
                                             encoding_supports_raw_values &&
                                             serde->supports_parquet_raw_predicate(*decode_context);
+    if (all_null_map_predicates) {
+        const bool has_identity_binary =
+                (_metadata.type == tparquet::Type::BYTE_ARRAY ||
+                 _metadata.type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) &&
+                (is_string_type(primitive_type) || primitive_type == TYPE_VARBINARY);
+        // Dictionary definition levels are insufficient for logical types whose dictionary entry
+        // conversion can fail (for example an invalid DATE). Use the level-only path only for
+        // identity payloads, or decode PLAIN values through SerDe so strict/error and synthetic
+        // NULL semantics remain identical to ordinary materialization.
+        return has_identity_value || has_identity_binary || can_convert_logical_values;
+    }
     if (can_convert_logical_values) {
         return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
             return conjunct != nullptr && (conjunct->can_execute_on_raw_fixed_values(
@@ -1779,13 +1818,17 @@ template <bool IN_COLLECTION, bool OFFSET_INDEX>
 Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values(
         const VExprSPtrs& conjuncts, int column_id, ColumnSelectVector& select_vector,
         NullMap* selected_nulls, IColumn::Filter* physical_matches, IColumn* projected_column,
-        IColumn::Filter* row_filter, const DataTypeSerDe& serde,
-        const ParquetDecodeContext& decode_context, bool enable_strict_mode, bool* used_filter) {
+        IColumn::Filter* physical_conversion_nulls, IColumn::Filter* row_filter,
+        const DataTypeSerDe& serde, const ParquetDecodeContext& decode_context,
+        bool enable_strict_mode, bool* used_filter, DirectPredicateExecutionKind* execution_kind) {
     DORIS_CHECK(selected_nulls != nullptr);
     DORIS_CHECK(physical_matches != nullptr);
+    DORIS_CHECK(physical_conversion_nulls != nullptr);
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(used_filter != nullptr);
+    DORIS_CHECK(execution_kind != nullptr);
     *used_filter = false;
+    *execution_kind = DirectPredicateExecutionKind::NONE;
     row_filter->clear();
     if (!can_filter_fixed_width_values(conjuncts, column_id, &serde, &decode_context)) {
         return Status::OK();
@@ -1850,12 +1893,29 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
         }
     }
     physical_matches->clear();
-    IColumn::Filter physical_conversion_nulls;
+    physical_conversion_nulls->clear();
     if (selection.selected_values == 0) {
         RETURN_IF_ERROR(_page_decoder->skip_values(selection.total_values));
+        *execution_kind = DirectPredicateExecutionKind::DEFINITION_LEVEL;
     } else if (raw_conjuncts.empty()) {
-        RETURN_IF_ERROR(_page_decoder->skip_values(selection.total_values));
-        physical_matches->resize_fill(selection.selected_values, 1);
+        if (serde.supports_parquet_raw_predicate(decode_context)) {
+            // Definition levels alone cannot distinguish a present payload that permissive SerDe
+            // conversion turns into NULL (or a strict conversion error). Decode only the selected
+            // payloads through the same conversion kernel before evaluating IS NULL/IS NOT NULL.
+            SelectedDecodeSource selected_source(*_page_decoder, selection);
+            FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
+                                                 physical_matches, projected_column,
+                                                 physical_conversion_nulls);
+            RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, decode_context,
+                                                             selection.selected_values,
+                                                             enable_strict_mode, consumer));
+            // Conversion is needed only to refine the logical null map; no value predicate ran.
+            *execution_kind = DirectPredicateExecutionKind::DEFINITION_LEVEL;
+        } else {
+            RETURN_IF_ERROR(_page_decoder->skip_values(selection.total_values));
+            physical_matches->resize_fill(selection.selected_values, 1);
+            *execution_kind = DirectPredicateExecutionKind::DEFINITION_LEVEL;
+        }
     } else {
         const bool all_raw_binary = std::ranges::all_of(raw_conjuncts, [&](const auto& conjunct) {
             return conjunct->can_execute_on_raw_binary_values(_field_schema->data_type, column_id);
@@ -1866,12 +1926,14 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
         if (all_raw_binary &&
             supports_raw_binary_filter_encoding(_current_encoding, _metadata.type)) {
             BinaryPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
-                                             physical_matches, projected_column);
+                                             physical_matches, projected_column,
+                                             &_binary_predicate_refs, &_binary_projected_refs);
             if (_metadata.type == tparquet::Type::BYTE_ARRAY) {
                 RETURN_IF_ERROR(_page_decoder->decode_selected_binary_values(selection, consumer));
             } else {
                 RETURN_IF_ERROR(_page_decoder->decode_selected_fixed_values(selection, consumer));
             }
+            *execution_kind = DirectPredicateExecutionKind::RAW_BINARY;
         } else if (all_raw_fixed && serde.supports_parquet_raw_predicate(decode_context)) {
             // Type conversion is fused between the decoder and predicate sink. Conversion-null
             // bits travel beside the POD batch, preserving permissive scan semantics without an
@@ -1879,28 +1941,36 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
             SelectedDecodeSource selected_source(*_page_decoder, selection);
             FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
                                                  physical_matches, projected_column,
-                                                 &physical_conversion_nulls);
+                                                 physical_conversion_nulls);
             RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, decode_context,
                                                              selection.selected_values,
                                                              enable_strict_mode, consumer));
+            *execution_kind = DirectPredicateExecutionKind::CONVERTED_FIXED;
         } else {
             FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
                                                  physical_matches, projected_column);
             RETURN_IF_ERROR(_page_decoder->decode_selected_fixed_values(selection, consumer));
+            *execution_kind = DirectPredicateExecutionKind::RAW_FIXED;
         }
         DORIS_CHECK_EQ(physical_matches->size(), selection.selected_values);
     }
 
+    const bool raw_null_match = std::ranges::all_of(raw_conjuncts, [](const auto& conjunct) {
+        return conjunct->raw_predicate_result_for_null();
+    });
     row_filter->reserve(selected_nulls->size());
     size_t physical_row = 0;
     for (size_t logical_row = 0; logical_row < selected_nulls->size(); ++logical_row) {
         uint8_t& is_null = (*selected_nulls)[logical_row];
         if (is_null != 0) {
-            row_filter->push_back(raw_conjuncts.empty() ? 1 : 0);
+            row_filter->push_back(raw_null_match ? 1 : 0);
         } else {
-            if (!physical_conversion_nulls.empty() &&
-                physical_conversion_nulls[physical_row] != 0) {
+            if (!physical_conversion_nulls->empty() &&
+                (*physical_conversion_nulls)[physical_row] != 0) {
                 is_null = 1;
+                row_filter->push_back(raw_null_match ? 1 : 0);
+                ++physical_row;
+                continue;
             }
             row_filter->push_back((*physical_matches)[physical_row++]);
         }

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
@@ -1769,6 +1769,9 @@ bool ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::can_filter_fixed_width_valu
                                                 decimal_scale_matches && decimal_metadata_fits))) ||
             (_metadata.type == tparquet::Type::FLOAT && primitive_type == TYPE_FLOAT) ||
             (_metadata.type == tparquet::Type::DOUBLE && primitive_type == TYPE_DOUBLE);
+    const bool has_infallible_identity_value = has_identity_value &&
+                                               primitive_type != TYPE_DECIMAL32 &&
+                                               primitive_type != TYPE_DECIMAL64;
     if (has_identity_value &&
         supports_raw_fixed_filter_encoding(_current_encoding, _metadata.type)) {
         return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
@@ -1790,9 +1793,9 @@ bool ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::can_filter_fixed_width_valu
                 (is_string_type(primitive_type) || primitive_type == TYPE_VARBINARY);
         // Dictionary definition levels are insufficient for logical types whose dictionary entry
         // conversion can fail (for example an invalid DATE). Use the level-only path only for
-        // identity payloads, or decode PLAIN values through SerDe so strict/error and synthetic
-        // NULL semantics remain identical to ordinary materialization.
-        return has_identity_value || has_identity_binary || can_convert_logical_values;
+        // infallible identity payloads, or decode PLAIN values through SerDe so strict/error and
+        // synthetic NULL semantics remain identical to ordinary materialization.
+        return has_infallible_identity_value || has_identity_binary || can_convert_logical_values;
     }
     if (can_convert_logical_values) {
         return std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
@@ -1830,7 +1833,11 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
     *used_filter = false;
     *execution_kind = DirectPredicateExecutionKind::NONE;
     row_filter->clear();
-    if (!can_filter_fixed_width_values(conjuncts, column_id, &serde, &decode_context)) {
+    ParquetDecodeContext page_decode_context = decode_context;
+    // Direct filtering can be the first value operation on a page, so its SerDe dispatch must not
+    // depend on materialize_values() having synchronized the page encoding first.
+    RETURN_IF_ERROR(translate_value_encoding(_current_encoding, &page_decode_context.encoding));
+    if (!can_filter_fixed_width_values(conjuncts, column_id, &serde, &page_decode_context)) {
         return Status::OK();
     }
     if (UNLIKELY(_remaining_num_values < select_vector.num_values())) {
@@ -1898,7 +1905,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
         RETURN_IF_ERROR(_page_decoder->skip_values(selection.total_values));
         *execution_kind = DirectPredicateExecutionKind::DEFINITION_LEVEL;
     } else if (raw_conjuncts.empty()) {
-        if (serde.supports_parquet_raw_predicate(decode_context)) {
+        if (serde.supports_parquet_raw_predicate(page_decode_context)) {
             // Definition levels alone cannot distinguish a present payload that permissive SerDe
             // conversion turns into NULL (or a strict conversion error). Decode only the selected
             // payloads through the same conversion kernel before evaluating IS NULL/IS NOT NULL.
@@ -1906,7 +1913,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
             FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
                                                  physical_matches, projected_column,
                                                  physical_conversion_nulls);
-            RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, decode_context,
+            RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, page_decode_context,
                                                              selection.selected_values,
                                                              enable_strict_mode, consumer));
             // Conversion is needed only to refine the logical null map; no value predicate ran.
@@ -1934,7 +1941,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
                 RETURN_IF_ERROR(_page_decoder->decode_selected_fixed_values(selection, consumer));
             }
             *execution_kind = DirectPredicateExecutionKind::RAW_BINARY;
-        } else if (all_raw_fixed && serde.supports_parquet_raw_predicate(decode_context)) {
+        } else if (all_raw_fixed && serde.supports_parquet_raw_predicate(page_decode_context)) {
             // Type conversion is fused between the decoder and predicate sink. Conversion-null
             // bits travel beside the POD batch, preserving permissive scan semantics without an
             // intermediate nullable IColumn.
@@ -1942,7 +1949,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
             FixedWidthPredicateConsumer consumer(raw_conjuncts, _field_schema->data_type, column_id,
                                                  physical_matches, projected_column,
                                                  physical_conversion_nulls);
-            RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, decode_context,
+            RETURN_IF_ERROR(serde.read_parquet_raw_predicate(selected_source, page_decode_context,
                                                              selection.selected_values,
                                                              enable_strict_mode, consumer));
             *execution_kind = DirectPredicateExecutionKind::CONVERTED_FIXED;

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.h
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.h
@@ -180,20 +180,38 @@ public:
                                                    tparquet::Type::type physical_type) {
         switch (encoding) {
         case tparquet::Encoding::PLAIN:
-            return physical_type == tparquet::Type::INT32 ||
+            return physical_type == tparquet::Type::BOOLEAN ||
+                   physical_type == tparquet::Type::INT32 ||
                    physical_type == tparquet::Type::INT64 ||
+                   physical_type == tparquet::Type::INT96 ||
                    physical_type == tparquet::Type::FLOAT ||
-                   physical_type == tparquet::Type::DOUBLE;
+                   physical_type == tparquet::Type::DOUBLE ||
+                   physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY;
+        case tparquet::Encoding::RLE:
+            return physical_type == tparquet::Type::BOOLEAN;
         case tparquet::Encoding::BYTE_STREAM_SPLIT:
             return physical_type == tparquet::Type::INT32 ||
                    physical_type == tparquet::Type::INT64 ||
                    physical_type == tparquet::Type::FLOAT ||
-                   physical_type == tparquet::Type::DOUBLE;
+                   physical_type == tparquet::Type::DOUBLE ||
+                   physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY;
         case tparquet::Encoding::DELTA_BINARY_PACKED:
             return physical_type == tparquet::Type::INT32 || physical_type == tparquet::Type::INT64;
         default:
             return false;
         }
+    }
+
+    static bool supports_raw_binary_filter_encoding(tparquet::Encoding::type encoding,
+                                                    tparquet::Type::type physical_type) {
+        if (physical_type == tparquet::Type::BYTE_ARRAY) {
+            return encoding == tparquet::Encoding::PLAIN ||
+                   encoding == tparquet::Encoding::DELTA_LENGTH_BYTE_ARRAY ||
+                   encoding == tparquet::Encoding::DELTA_BYTE_ARRAY;
+        }
+        return physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY &&
+               (encoding == tparquet::Encoding::PLAIN ||
+                encoding == tparquet::Encoding::BYTE_STREAM_SPLIT);
     }
 
     // Evaluate selected fixed-width values and return one keep byte per selected logical row.
@@ -202,8 +220,12 @@ public:
     Status filter_fixed_width_values(const VExprSPtrs& conjuncts, int column_id,
                                      ColumnSelectVector& select_vector, NullMap* selected_nulls,
                                      IColumn::Filter* physical_matches, IColumn* projected_column,
-                                     IColumn::Filter* row_filter, bool* used_filter);
-    bool can_filter_fixed_width_values(const VExprSPtrs& conjuncts, int column_id) const;
+                                     IColumn::Filter* row_filter, const DataTypeSerDe& serde,
+                                     const ParquetDecodeContext& decode_context,
+                                     bool enable_strict_mode, bool* used_filter);
+    bool can_filter_fixed_width_values(const VExprSPtrs& conjuncts, int column_id,
+                                       const DataTypeSerDe* serde,
+                                       const ParquetDecodeContext* decode_context) const;
 
     Status filter_dictionary_indices(const IColumn::Filter& dictionary_filter,
                                      ColumnSelectVector& select_vector,

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.h
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.h
@@ -35,6 +35,7 @@
 #include "core/data_type_serde/parquet_decode_source.h"
 #include "exprs/vexpr_fwd.h"
 #include "format_v2/parquet/native_schema_desc.h"
+#include "format_v2/parquet/reader/direct_predicate.h"
 #include "format_v2/parquet/reader/native/common.h"
 #include "format_v2/parquet/reader/native/decoder.h"
 #include "format_v2/parquet/reader/native/level_decoder.h"
@@ -220,9 +221,11 @@ public:
     Status filter_fixed_width_values(const VExprSPtrs& conjuncts, int column_id,
                                      ColumnSelectVector& select_vector, NullMap* selected_nulls,
                                      IColumn::Filter* physical_matches, IColumn* projected_column,
-                                     IColumn::Filter* row_filter, const DataTypeSerDe& serde,
+                                     IColumn::Filter* conversion_nulls, IColumn::Filter* row_filter,
+                                     const DataTypeSerDe& serde,
                                      const ParquetDecodeContext& decode_context,
-                                     bool enable_strict_mode, bool* used_filter);
+                                     bool enable_strict_mode, bool* used_filter,
+                                     DirectPredicateExecutionKind* execution_kind);
     bool can_filter_fixed_width_values(const VExprSPtrs& conjuncts, int column_id,
                                        const DataTypeSerDe* serde,
                                        const ParquetDecodeContext* decode_context) const;
@@ -257,6 +260,12 @@ public:
         if (_selected_dictionary_indices.capacity() * sizeof(uint32_t) > max_retained_bytes) {
             std::vector<uint32_t>().swap(_selected_dictionary_indices);
         }
+        if (_binary_predicate_refs.capacity() * sizeof(StringRef) > max_retained_bytes) {
+            std::vector<StringRef>().swap(_binary_predicate_refs);
+        }
+        if (_binary_projected_refs.capacity() * sizeof(StringRef) > max_retained_bytes) {
+            std::vector<StringRef>().swap(_binary_projected_refs);
+        }
         if (_decompress_buf_size > max_retained_bytes) {
             if (_page_uses_decompress_buf) {
                 // Keep the request until the page boundary because decoders still point into this
@@ -279,7 +288,9 @@ public:
         for (const auto& [encoding, decoder] : _decoders) {
             bytes += decoder->retained_scratch_bytes();
         }
-        return bytes + _selected_dictionary_indices.capacity() * sizeof(uint32_t);
+        return bytes + _selected_dictionary_indices.capacity() * sizeof(uint32_t) +
+               _binary_predicate_refs.capacity() * sizeof(StringRef) +
+               _binary_projected_refs.capacity() * sizeof(StringRef);
     }
 
     size_t active_decoder_scratch_bytes() const {
@@ -289,7 +300,9 @@ public:
                (_page_decoder == nullptr ? 0 : _page_decoder->active_scratch_bytes()) +
                _rep_level_decoder.active_scratch_bytes() +
                _def_level_decoder.active_scratch_bytes() +
-               _selected_dictionary_indices.size() * sizeof(uint32_t);
+               _selected_dictionary_indices.size() * sizeof(uint32_t) +
+               _binary_predicate_refs.size() * sizeof(StringRef) +
+               _binary_projected_refs.size() * sizeof(StringRef);
     }
 
     tparquet::Encoding::type current_encoding() const { return _current_encoding; }
@@ -444,6 +457,8 @@ private:
     std::unordered_map<int, std::unique_ptr<Decoder>> _decoders;
     NullMap _nullable_selection_nulls;
     std::vector<uint32_t> _selected_dictionary_indices;
+    std::vector<StringRef> _binary_predicate_refs;
+    std::vector<StringRef> _binary_projected_refs;
     ColumnChunkReaderStatistics _chunk_statistics;
 };
 

--- a/be/src/format_v2/parquet/reader/native/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_reader.cpp
@@ -742,6 +742,11 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::init(
     _materialization_state.enable_strict_mode = enable_strict_mode;
     RETURN_IF_ERROR(_chunk_reader->init());
     RETURN_IF_ERROR(init_decode_context(*field, _ctz, &_decode_context));
+    // Decoder-direct predicates may be the first typed read for this column, so bind the
+    // file-local SerDe before either materialization or a dictionary probe can initialize it.
+    const DataTypePtr file_type = remove_nullable(_field_schema->data_type);
+    _serde_type = file_type.get();
+    _serde = file_type->get_serde();
     return Status::OK();
 }
 
@@ -1123,7 +1128,8 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::_read_fixed_width_filter
     bool used_filter = false;
     RETURN_IF_ERROR(_chunk_reader->filter_fixed_width_values(
             conjuncts, column_id, _select_vector, &_fixed_width_predicate_nulls,
-            &_fixed_width_predicate_matches, projected_column, row_filter, &used_filter));
+            &_fixed_width_predicate_matches, projected_column, row_filter, *_serde, _decode_context,
+            _materialization_state.enable_strict_mode, &used_filter));
     // Chunk encodings are prevalidated before any definition level is consumed, so a false result
     // here would make a materializing fallback observe an advanced level cursor.
     DORIS_CHECK(used_filter);
@@ -1145,22 +1151,43 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::read_fixed_width_filter(
     if (_in_nested || conjuncts.empty()) {
         return Status::OK();
     }
+    const bool has_null_map_predicate = std::ranges::any_of(conjuncts, [&](const auto& conjunct) {
+        return conjunct != nullptr &&
+               conjunct->can_execute_on_null_map(_field_schema->data_type, column_id);
+    });
+    if (has_null_map_predicate && projected_column != nullptr) {
+        // Definition levels can decide predicate-only columns without touching payloads. A selected
+        // projected NULL still needs nullable-column assembly, which remains on the typed path.
+        return Status::OK();
+    }
     if (!std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
             return conjunct != nullptr &&
-                   conjunct->can_execute_on_raw_fixed_values(_field_schema->data_type, column_id);
+                   (conjunct->can_execute_on_raw_fixed_values(_field_schema->data_type,
+                                                              column_id) ||
+                    conjunct->can_execute_on_raw_binary_values(_field_schema->data_type,
+                                                               column_id) ||
+                    conjunct->can_execute_on_null_map(_field_schema->data_type, column_id));
         })) {
         return Status::OK();
     }
     // Validate every advertised value encoding before touching either cursor. A late fallback
     // cannot rewind definition levels or a previously decoded fixed-width page.
-    const bool supported_encodings = std::ranges::all_of(
-            _chunk_meta.meta_data.encodings, [&](const tparquet::Encoding::type encoding) {
-                return ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::
-                               supports_raw_fixed_filter_encoding(encoding,
-                                                                  _chunk_meta.meta_data.type) ||
-                       encoding == tparquet::Encoding::RLE ||
-                       encoding == tparquet::Encoding::BIT_PACKED;
-            });
+    const bool has_raw_value_predicate = std::ranges::any_of(conjuncts, [&](const auto& conjunct) {
+        return !conjunct->can_execute_on_null_map(_field_schema->data_type, column_id);
+    });
+    const bool supported_encodings =
+            !has_raw_value_predicate ||
+            std::ranges::all_of(_chunk_meta.meta_data.encodings,
+                                [&](const tparquet::Encoding::type encoding) {
+                                    return ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::
+                                                   supports_raw_fixed_filter_encoding(
+                                                           encoding, _chunk_meta.meta_data.type) ||
+                                           ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::
+                                                   supports_raw_binary_filter_encoding(
+                                                           encoding, _chunk_meta.meta_data.type) ||
+                                           encoding == tparquet::Encoding::RLE ||
+                                           encoding == tparquet::Encoding::BIT_PACKED;
+                                });
     if (!supported_encodings) {
         return Status::OK();
     }
@@ -1179,7 +1206,8 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::read_fixed_width_filter(
     } else {
         RETURN_IF_ERROR(_chunk_reader->parse_page_header());
         RETURN_IF_ERROR(_chunk_reader->load_page_data_idempotent());
-        if (!_chunk_reader->can_filter_fixed_width_values(conjuncts, column_id)) {
+        if (!_chunk_reader->can_filter_fixed_width_values(conjuncts, column_id, _serde.get(),
+                                                          &_decode_context)) {
             return Status::OK();
         }
         size_t has_read = 0;

--- a/be/src/format_v2/parquet/reader/native/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_reader.cpp
@@ -72,6 +72,15 @@ bool release_vector_if_oversized(std::vector<T>* values, size_t max_retained_byt
     return true;
 }
 
+bool release_filter_if_oversized(IColumn::Filter* values, size_t max_retained_bytes) {
+    DORIS_CHECK(values != nullptr);
+    if (values->capacity() <= max_retained_bytes) {
+        return false;
+    }
+    IColumn::Filter().swap(*values);
+    return true;
+}
+
 size_t retained_set_bytes(const std::unordered_set<size_t>& values) {
     return values.bucket_count() * sizeof(void*) + values.size() * sizeof(size_t);
 }
@@ -742,6 +751,13 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::init(
     _materialization_state.enable_strict_mode = enable_strict_mode;
     RETURN_IF_ERROR(_chunk_reader->init());
     RETURN_IF_ERROR(init_decode_context(*field, _ctz, &_decode_context));
+    const auto primitive_type = remove_nullable(field->data_type)->get_primitive_type();
+    if (primitive_type == TYPE_DATETIMEV2 && (field->physical_type == tparquet::Type::INT96 ||
+                                              _decode_context.timestamp_is_adjusted_to_utc)) {
+        // Keep decoder-direct filtering aligned with conversion_failure_map(): non-strict UTC
+        // overflow materializes a DATETIME default, while strict mode still reports the error.
+        _decode_context.conversion_failure_is_null = false;
+    }
     // Decoder-direct predicates may be the first typed read for this column, so bind the
     // file-local SerDe before either materialization or a dictionary probe can initialize it.
     const DataTypePtr file_type = remove_nullable(_field_schema->data_type);
@@ -771,6 +787,9 @@ void ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::release_batch_scratch(
         // Persistent decoders also own batch-sized value/slice buffers, not only the reader.
         _chunk_reader->release_decoder_scratch(max_retained_bytes);
     }
+    if (_serde != nullptr) {
+        _serde->release_parquet_raw_predicate_scratch(max_retained_bytes);
+    }
     bool release_selection = false;
     release_selection |= release_vector_if_oversized(&_rep_levels, max_retained_bytes);
     release_selection |= release_vector_if_oversized(&_def_levels, max_retained_bytes);
@@ -779,6 +798,12 @@ void ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::release_batch_scratch(
     release_selection |= release_vector_if_oversized(&_materialization_state.dictionary_indices,
                                                      max_retained_bytes);
     release_selection |= release_vector_if_oversized(&_materialization_state.selection.ranges,
+                                                     max_retained_bytes);
+    release_selection |=
+            release_filter_if_oversized(&_fixed_width_predicate_nulls, max_retained_bytes);
+    release_selection |=
+            release_filter_if_oversized(&_fixed_width_predicate_matches, max_retained_bytes);
+    release_selection |= release_filter_if_oversized(&_fixed_width_predicate_conversion_nulls,
                                                      max_retained_bytes);
     if (retained_set_bytes(_ancestor_null_indices) > max_retained_bytes) {
         std::unordered_set<size_t>().swap(_ancestor_null_indices);
@@ -793,10 +818,14 @@ template <bool IN_COLLECTION, bool OFFSET_INDEX>
 size_t ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::retained_batch_scratch_bytes() const {
     const size_t decoder_bytes =
             _chunk_reader == nullptr ? 0 : _chunk_reader->retained_decoder_scratch_bytes();
-    return decoder_bytes + _rep_levels.capacity() * sizeof(level_t) +
+    const size_t serde_bytes =
+            _serde == nullptr ? 0 : _serde->retained_parquet_raw_predicate_scratch_bytes();
+    return decoder_bytes + serde_bytes + _rep_levels.capacity() * sizeof(level_t) +
            _def_levels.capacity() * sizeof(level_t) +
            _null_run_lengths.capacity() * sizeof(uint16_t) +
            _nested_filter_map_data.capacity() * sizeof(uint8_t) +
+           _fixed_width_predicate_nulls.capacity() + _fixed_width_predicate_matches.capacity() +
+           _fixed_width_predicate_conversion_nulls.capacity() +
            _materialization_state.dictionary_indices.capacity() * sizeof(uint32_t) +
            _materialization_state.selection.ranges.capacity() * sizeof(ParquetSelectionRange) +
            retained_set_bytes(_ancestor_null_indices);
@@ -806,9 +835,12 @@ template <bool IN_COLLECTION, bool OFFSET_INDEX>
 size_t ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::active_batch_scratch_bytes() const {
     const size_t decoder_bytes =
             _chunk_reader == nullptr ? 0 : _chunk_reader->active_decoder_scratch_bytes();
-    return decoder_bytes + _rep_levels.size() * sizeof(level_t) +
+    const size_t serde_bytes =
+            _serde == nullptr ? 0 : _serde->active_parquet_raw_predicate_scratch_bytes();
+    return decoder_bytes + serde_bytes + _rep_levels.size() * sizeof(level_t) +
            _def_levels.size() * sizeof(level_t) + _null_run_lengths.size() * sizeof(uint16_t) +
-           _nested_filter_map_data.size() * sizeof(uint8_t) +
+           _nested_filter_map_data.size() * sizeof(uint8_t) + _fixed_width_predicate_nulls.size() +
+           _fixed_width_predicate_matches.size() + _fixed_width_predicate_conversion_nulls.size() +
            _materialization_state.dictionary_indices.size() * sizeof(uint32_t) +
            _materialization_state.selection.ranges.size() * sizeof(ParquetSelectionRange) +
            _ancestor_null_indices.size() * sizeof(size_t);
@@ -1085,7 +1117,8 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::_read_nested_column(
 template <bool IN_COLLECTION, bool OFFSET_INDEX>
 Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::_read_fixed_width_filter_values(
         size_t num_values, const VExprSPtrs& conjuncts, int column_id, FilterMap& filter_map,
-        IColumn* projected_column, IColumn::Filter* row_filter) {
+        IColumn* projected_column, IColumn::Filter* row_filter,
+        DirectPredicateExecutionKind* execution_kind) {
     DORIS_CHECK(row_filter != nullptr);
     _null_run_lengths.clear();
     if (_chunk_reader->max_def_level() > 0) {
@@ -1128,8 +1161,9 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::_read_fixed_width_filter
     bool used_filter = false;
     RETURN_IF_ERROR(_chunk_reader->filter_fixed_width_values(
             conjuncts, column_id, _select_vector, &_fixed_width_predicate_nulls,
-            &_fixed_width_predicate_matches, projected_column, row_filter, *_serde, _decode_context,
-            _materialization_state.enable_strict_mode, &used_filter));
+            &_fixed_width_predicate_matches, projected_column,
+            &_fixed_width_predicate_conversion_nulls, row_filter, *_serde, _decode_context,
+            _materialization_state.enable_strict_mode, &used_filter, execution_kind));
     // Chunk encodings are prevalidated before any definition level is consumed, so a false result
     // here would make a materializing fallback observe an advanced level cursor.
     DORIS_CHECK(used_filter);
@@ -1140,14 +1174,16 @@ template <bool IN_COLLECTION, bool OFFSET_INDEX>
 Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::read_fixed_width_filter(
         const VExprSPtrs& conjuncts, int column_id, FilterMap& filter_map, size_t batch_size,
         IColumn* projected_column, IColumn::Filter* row_filter, size_t* read_rows, bool* eof,
-        bool* used_filter) {
+        bool* used_filter, DirectPredicateExecutionKind* execution_kind) {
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(read_rows != nullptr);
     DORIS_CHECK(eof != nullptr);
     DORIS_CHECK(used_filter != nullptr);
+    DORIS_CHECK(execution_kind != nullptr);
     row_filter->clear();
     *read_rows = 0;
     *used_filter = false;
+    *execution_kind = DirectPredicateExecutionKind::NONE;
     if (_in_nested || conjuncts.empty()) {
         return Status::OK();
     }
@@ -1158,6 +1194,13 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::read_fixed_width_filter(
     if (has_null_map_predicate && projected_column != nullptr) {
         // Definition levels can decide predicate-only columns without touching payloads. A selected
         // projected NULL still needs nullable-column assembly, which remains on the typed path.
+        return Status::OK();
+    }
+    if (projected_column != nullptr && std::ranges::any_of(conjuncts, [](const auto& conjunct) {
+            return conjunct != nullptr && conjunct->raw_predicate_result_for_null();
+        })) {
+        // A raw consumer has no payload position for physical NULLs. Keep projected nullable TopN
+        // batches on materialization so a NULL survivor is appended with the correct row shape.
         return Status::OK();
     }
     if (!std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
@@ -1219,8 +1262,19 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::read_fixed_width_filter(
             const size_t values =
                     std::min(static_cast<size_t>(range.to() - range.from()), batch_size - has_read);
             IColumn::Filter fragment_filter;
-            RETURN_IF_ERROR(_read_fixed_width_filter_values(
-                    values, conjuncts, column_id, filter_map, projected_column, &fragment_filter));
+            DirectPredicateExecutionKind fragment_kind = DirectPredicateExecutionKind::NONE;
+            RETURN_IF_ERROR(_read_fixed_width_filter_values(values, conjuncts, column_id,
+                                                            filter_map, projected_column,
+                                                            &fragment_filter, &fragment_kind));
+            if (*execution_kind == DirectPredicateExecutionKind::NONE) {
+                *execution_kind = fragment_kind;
+            } else if (fragment_kind != DirectPredicateExecutionKind::DEFINITION_LEVEL) {
+                // All value pages for a logical type use the same raw/converted domain. An
+                // all-NULL fragment may report only level execution without changing that domain.
+                DORIS_CHECK(*execution_kind == DirectPredicateExecutionKind::DEFINITION_LEVEL ||
+                            *execution_kind == fragment_kind);
+                *execution_kind = fragment_kind;
+            }
             row_filter->insert(row_filter->end(), fragment_filter.begin(), fragment_filter.end());
             has_read += values;
             *read_rows += values;

--- a/be/src/format_v2/parquet/reader/native/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_reader.cpp
@@ -809,6 +809,42 @@ void ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::release_batch_scratch(
         std::unordered_set<size_t>().swap(_ancestor_null_indices);
         release_selection = true;
     }
+    // The limit applies to the reader as a whole: several individually small idle buffers must not
+    // evade reclamation merely because none of them crosses the per-buffer threshold.
+    const auto aggregate_over_budget = [&]() {
+        return retained_batch_scratch_bytes() > max_retained_bytes;
+    };
+    const auto release_vector_for_aggregate = [&](auto* values) {
+        if (!aggregate_over_budget()) {
+            return false;
+        }
+        return release_vector_if_oversized(values, 0);
+    };
+    const auto release_filter_for_aggregate = [&](IColumn::Filter* values) {
+        if (!aggregate_over_budget()) {
+            return false;
+        }
+        return release_filter_if_oversized(values, 0);
+    };
+    release_selection |= release_vector_for_aggregate(&_rep_levels);
+    release_selection |= release_vector_for_aggregate(&_def_levels);
+    release_selection |= release_vector_for_aggregate(&_null_run_lengths);
+    release_selection |= release_vector_for_aggregate(&_nested_filter_map_data);
+    release_selection |= release_vector_for_aggregate(&_materialization_state.dictionary_indices);
+    release_selection |= release_vector_for_aggregate(&_materialization_state.selection.ranges);
+    release_selection |= release_filter_for_aggregate(&_fixed_width_predicate_nulls);
+    release_selection |= release_filter_for_aggregate(&_fixed_width_predicate_matches);
+    release_selection |= release_filter_for_aggregate(&_fixed_width_predicate_conversion_nulls);
+    if (aggregate_over_budget() && !_ancestor_null_indices.empty()) {
+        std::unordered_set<size_t>().swap(_ancestor_null_indices);
+        release_selection = true;
+    }
+    if (aggregate_over_budget() && _serde != nullptr) {
+        _serde->release_parquet_raw_predicate_scratch(0);
+    }
+    if (aggregate_over_budget() && _chunk_reader != nullptr) {
+        _chunk_reader->release_decoder_scratch(0);
+    }
     if (release_selection) {
         _select_vector = ColumnSelectVector();
     }
@@ -857,6 +893,13 @@ void ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::reserve_batch_scratch_for_
     _materialization_state.dictionary_indices.reserve(elements);
     _materialization_state.selection.ranges.reserve(elements);
     _ancestor_null_indices.reserve(elements);
+}
+
+template <bool IN_COLLECTION, bool OFFSET_INDEX>
+void ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::reserve_level_scratch_for_test(
+        size_t elements) {
+    _rep_levels.reserve(elements);
+    _def_levels.reserve(elements);
 }
 
 template <bool IN_COLLECTION, bool OFFSET_INDEX>

--- a/be/src/format_v2/parquet/reader/native/column_reader.h
+++ b/be/src/format_v2/parquet/reader/native/column_reader.h
@@ -337,6 +337,7 @@ public:
 
 #ifdef BE_TEST
     void reserve_batch_scratch_for_test(size_t elements);
+    void reserve_level_scratch_for_test(size_t elements);
     size_t retained_batch_scratch_bytes_for_test() const;
     size_t dictionary_materialization_count_for_test() const {
         return _dictionary_materialization_count;

--- a/be/src/format_v2/parquet/reader/native/column_reader.h
+++ b/be/src/format_v2/parquet/reader/native/column_reader.h
@@ -190,14 +190,17 @@ public:
     // is a non-consuming fallback for nested and synthetic readers.
     virtual Status read_fixed_width_filter(const VExprSPtrs&, int, FilterMap&, size_t, IColumn*,
                                            IColumn::Filter* row_filter, size_t* read_rows,
-                                           bool* eof, bool* used_filter) {
+                                           bool* eof, bool* used_filter,
+                                           DirectPredicateExecutionKind* execution_kind) {
         DORIS_CHECK(row_filter != nullptr);
         DORIS_CHECK(read_rows != nullptr);
         DORIS_CHECK(eof != nullptr);
         DORIS_CHECK(used_filter != nullptr);
+        DORIS_CHECK(execution_kind != nullptr);
         row_filter->clear();
         *read_rows = 0;
         *used_filter = false;
+        *execution_kind = DirectPredicateExecutionKind::NONE;
         return Status::OK();
     }
 
@@ -306,7 +309,8 @@ public:
     Status read_fixed_width_filter(const VExprSPtrs& conjuncts, int column_id,
                                    FilterMap& filter_map, size_t batch_size,
                                    IColumn* projected_column, IColumn::Filter* row_filter,
-                                   size_t* read_rows, bool* eof, bool* used_filter) override;
+                                   size_t* read_rows, bool* eof, bool* used_filter,
+                                   DirectPredicateExecutionKind* execution_kind) override;
     Status read_dictionary_filter(const IColumn::Filter& dictionary_filter, FilterMap& filter_map,
                                   size_t batch_size, const IColumn* typed_dictionary,
                                   IColumn* projected_values, ColumnInt32* matched_dictionary_ids,
@@ -429,6 +433,7 @@ private:
     std::vector<uint8_t> _nested_filter_map_data;
     NullMap _fixed_width_predicate_nulls;
     IColumn::Filter _fixed_width_predicate_matches;
+    IColumn::Filter _fixed_width_predicate_conversion_nulls;
     FilterMap _nested_filter_map;
     ColumnSelectVector _select_vector;
     uint8_t _oversized_scratch_idle_batches = 0;
@@ -441,7 +446,8 @@ private:
                         FilterMap& filter_map, bool is_dict_filter);
     Status _read_fixed_width_filter_values(size_t num_values, const VExprSPtrs& conjuncts,
                                            int column_id, FilterMap& filter_map,
-                                           IColumn* projected_column, IColumn::Filter* row_filter);
+                                           IColumn* projected_column, IColumn::Filter* row_filter,
+                                           DirectPredicateExecutionKind* execution_kind);
     Status _read_dictionary_filter_values(size_t num_values,
                                           const IColumn::Filter& dictionary_filter,
                                           FilterMap& filter_map, const IColumn* typed_dictionary,

--- a/be/src/format_v2/parquet/reader/native_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native_column_reader.cpp
@@ -760,8 +760,7 @@ Status NativeColumnReader::select_with_runtime_filter(
     RETURN_IF_ERROR(selection.verify(selected_rows, batch_rows));
     row_filter->clear();
     *used_filter = false;
-    if (_nested || conjuncts.empty() ||
-        !std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
+    if (_nested || conjuncts.empty() || !std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
             return conjunct != nullptr && conjunct->root() != nullptr &&
                    conjunct->root()->is_rf_wrapper() &&
                    conjunct->root()->can_execute_on_reader_values(_type, column_id);

--- a/be/src/format_v2/parquet/reader/native_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native_column_reader.cpp
@@ -27,6 +27,7 @@
 #include "common/cast_set.h"
 #include "common/config.h"
 #include "core/assert_cast.h"
+#include "core/block/block.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
@@ -35,6 +36,8 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_struct.h"
+#include "exprs/vexpr.h"
+#include "exprs/vexpr_context.h"
 #include "format_v2/column_data.h"
 #include "format_v2/parquet/parquet_column_schema.h"
 #include "format_v2/parquet/parquet_file_context.h"
@@ -744,6 +747,72 @@ Status NativeColumnReader::select_with_fixed_width_filter(
     advance_selected_span(rows_read);
     update_reader_read_rows(selected_rows);
     update_reader_skip_rows(batch_rows - selected_rows);
+    return Status::OK();
+}
+
+Status NativeColumnReader::select_with_runtime_filter(
+        const SelectionVector& selection, uint16_t selected_rows, int64_t batch_rows,
+        const VExprContextSPtrs& conjuncts, int column_id, MutableColumnPtr* projected_column,
+        IColumn::Filter* row_filter, bool* used_filter) {
+    DORIS_CHECK(row_filter != nullptr);
+    DORIS_CHECK(used_filter != nullptr);
+    RETURN_IF_ERROR(validate_selected_span(batch_rows));
+    RETURN_IF_ERROR(selection.verify(selected_rows, batch_rows));
+    row_filter->clear();
+    *used_filter = false;
+    if (_nested || conjuncts.empty() ||
+        !std::ranges::all_of(conjuncts, [&](const auto& conjunct) {
+            return conjunct != nullptr && conjunct->root() != nullptr &&
+                   conjunct->root()->is_rf_wrapper() &&
+                   conjunct->root()->can_execute_on_reader_values(_type, column_id);
+        })) {
+        return Status::OK();
+    }
+
+    const uint8_t* selection_filter = nullptr;
+    RETURN_IF_ERROR(selection.materialize_filter(selected_rows, batch_rows, &selection_filter));
+    auto values = _type->create_column();
+    int64_t rows_read = 0;
+    RETURN_IF_ERROR(read_with_filter(batch_rows, selection_filter, selected_rows == 0, values,
+                                     _type, false, &rows_read));
+    DORIS_CHECK_EQ(rows_read, batch_rows);
+    DORIS_CHECK_EQ(values->size(), selected_rows);
+
+    row_filter->resize_fill(selected_rows, 1);
+    {
+        Block value_block;
+        const auto dummy_type = std::make_shared<DataTypeUInt8>();
+        for (int position = 0; position < column_id; ++position) {
+            value_block.insert(
+                    {ColumnUInt8::create(selected_rows, 0), dummy_type, "runtime_filter_dummy"});
+        }
+        value_block.insert({values->get_ptr(), _type, "runtime_filter_value"});
+        for (const auto& conjunct : conjuncts) {
+            bool can_filter_all = false;
+            // Once eligibility is established, adaptive RF sampling may make a later batch a
+            // no-op but must not send this forward-only reader back to scheduler materialization.
+            RETURN_IF_ERROR(conjunct->root()->execute_filter(conjunct.get(), &value_block,
+                                                             row_filter->data(), selected_rows,
+                                                             false, &can_filter_all));
+            if (can_filter_all) {
+                row_filter->clear();
+                row_filter->resize_fill(selected_rows, 0);
+                break;
+            }
+        }
+    }
+
+    if (projected_column != nullptr) {
+        values->filter(*row_filter);
+        *projected_column = std::move(values);
+    }
+    advance_selected_span(rows_read);
+    if (_profile.reader_select_rows != nullptr) {
+        COUNTER_UPDATE(_profile.reader_select_rows, selected_rows);
+    }
+    update_reader_read_rows(selected_rows);
+    update_reader_skip_rows(batch_rows - selected_rows);
+    *used_filter = true;
     return Status::OK();
 }
 

--- a/be/src/format_v2/parquet/reader/native_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native_column_reader.cpp
@@ -802,8 +802,16 @@ Status NativeColumnReader::select_with_runtime_filter(
     }
 
     if (projected_column != nullptr) {
-        values->filter(*row_filter);
-        *projected_column = std::move(values);
+        const bool target_is_nullable = is_column_nullable(**projected_column);
+        auto filtered_values = IColumn::mutate(values->filter(*row_filter, -1));
+        // A required file field may back a nullable table slot after schema evolution. Preserve
+        // the target wrapper even though reader-local RF evaluation uses the physical file type.
+        if (target_is_nullable && !is_column_nullable(*filtered_values)) {
+            auto null_map = ColumnUInt8::create(filtered_values->size(), 0);
+            filtered_values =
+                    ColumnNullable::create(std::move(filtered_values), std::move(null_map));
+        }
+        *projected_column = std::move(filtered_values);
     }
     advance_selected_span(rows_read);
     if (_profile.reader_select_rows != nullptr) {

--- a/be/src/format_v2/parquet/reader/native_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native_column_reader.cpp
@@ -28,6 +28,7 @@
 #include "common/config.h"
 #include "core/assert_cast.h"
 #include "core/block/block.h"
+#include "core/column/column_const.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
@@ -320,19 +321,19 @@ Status NativeColumnReader::read_with_filter(int64_t rows, const uint8_t* filter_
     return Status::OK();
 }
 
-Status NativeColumnReader::read_with_fixed_width_filter(int64_t rows, const uint8_t* filter_data,
-                                                        bool filter_all,
-                                                        const VExprSPtrs& conjuncts, int column_id,
-                                                        IColumn* projected_column,
-                                                        IColumn::Filter* row_filter,
-                                                        int64_t* rows_read, bool* used_filter) {
+Status NativeColumnReader::read_with_fixed_width_filter(
+        int64_t rows, const uint8_t* filter_data, bool filter_all, const VExprSPtrs& conjuncts,
+        int column_id, IColumn* projected_column, IColumn::Filter* row_filter, int64_t* rows_read,
+        bool* used_filter, DirectPredicateExecutionKind* execution_kind) {
     DORIS_CHECK(rows >= 0);
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(rows_read != nullptr);
     DORIS_CHECK(used_filter != nullptr);
+    DORIS_CHECK(execution_kind != nullptr);
     row_filter->clear();
     *rows_read = 0;
     *used_filter = false;
+    *execution_kind = DirectPredicateExecutionKind::NONE;
     if (rows == 0) {
         return Status::OK();
     }
@@ -346,9 +347,10 @@ Status NativeColumnReader::read_with_fixed_width_filter(int64_t rows, const uint
         size_t loop_rows = 0;
         IColumn::Filter loop_filter;
         bool loop_used = false;
+        DirectPredicateExecutionKind loop_kind = DirectPredicateExecutionKind::NONE;
         RETURN_IF_ERROR(_native_reader->read_fixed_width_filter(
                 conjuncts, column_id, filter, static_cast<size_t>(rows - *rows_read),
-                projected_column, &loop_filter, &loop_rows, &eof, &loop_used));
+                projected_column, &loop_filter, &loop_rows, &eof, &loop_used, &loop_kind));
         if (!loop_used) {
             if (UNLIKELY(*rows_read != 0)) {
                 // Footer encoding lists are untrusted. Once a prior page advanced the cursor, a
@@ -361,6 +363,13 @@ Status NativeColumnReader::read_with_fixed_width_filter(int64_t rows, const uint
             }
             row_filter->clear();
             return Status::OK();
+        }
+        if (*execution_kind == DirectPredicateExecutionKind::NONE) {
+            *execution_kind = loop_kind;
+        } else if (loop_kind != DirectPredicateExecutionKind::DEFINITION_LEVEL) {
+            DORIS_CHECK(*execution_kind == DirectPredicateExecutionKind::DEFINITION_LEVEL ||
+                        *execution_kind == loop_kind);
+            *execution_kind = loop_kind;
         }
         row_filter->insert(row_filter->end(), loop_filter.begin(), loop_filter.end());
         if (loop_rows == 0 && !eof) {
@@ -723,9 +732,11 @@ Status NativeColumnReader::select_with_dictionary_filter(
 Status NativeColumnReader::select_with_fixed_width_filter(
         const SelectionVector& selection, uint16_t selected_rows, int64_t batch_rows,
         const VExprSPtrs& conjuncts, int column_id, IColumn* projected_column,
-        IColumn::Filter* row_filter, bool* used_filter) {
+        IColumn::Filter* row_filter, bool* used_filter,
+        DirectPredicateExecutionKind* execution_kind) {
     DORIS_CHECK(row_filter != nullptr);
     DORIS_CHECK(used_filter != nullptr);
+    DORIS_CHECK(execution_kind != nullptr);
     RETURN_IF_ERROR(validate_selected_span(batch_rows));
     RETURN_IF_ERROR(selection.verify(selected_rows, batch_rows));
     const uint8_t* filter_data = nullptr;
@@ -733,7 +744,7 @@ Status NativeColumnReader::select_with_fixed_width_filter(
     int64_t rows_read = 0;
     RETURN_IF_ERROR(read_with_fixed_width_filter(batch_rows, filter_data, selected_rows == 0,
                                                  conjuncts, column_id, projected_column, row_filter,
-                                                 &rows_read, used_filter));
+                                                 &rows_read, used_filter, execution_kind));
     if (!*used_filter) {
         return Status::OK();
     }
@@ -770,10 +781,14 @@ Status NativeColumnReader::select_with_runtime_filter(
 
     const uint8_t* selection_filter = nullptr;
     RETURN_IF_ERROR(selection.materialize_filter(selected_rows, batch_rows, &selection_filter));
-    auto values = _type->create_column();
+    // The scan contract can synthesize NULL on conversion even for a required Parquet field.
+    // Always retain that effective nullability in the RF temporary instead of turning a
+    // permissive conversion failure into a DataQualityError.
+    const auto value_type = make_nullable(_type);
+    auto values = value_type->create_column();
     int64_t rows_read = 0;
     RETURN_IF_ERROR(read_with_filter(batch_rows, selection_filter, selected_rows == 0, values,
-                                     _type, false, &rows_read));
+                                     value_type, false, &rows_read));
     DORIS_CHECK_EQ(rows_read, batch_rows);
     DORIS_CHECK_EQ(values->size(), selected_rows);
 
@@ -782,10 +797,10 @@ Status NativeColumnReader::select_with_runtime_filter(
         Block value_block;
         const auto dummy_type = std::make_shared<DataTypeUInt8>();
         for (int position = 0; position < column_id; ++position) {
-            value_block.insert(
-                    {ColumnUInt8::create(selected_rows, 0), dummy_type, "runtime_filter_dummy"});
+            value_block.insert({ColumnConst::create(ColumnUInt8::create(1, 0), selected_rows),
+                                dummy_type, "runtime_filter_dummy"});
         }
-        value_block.insert({values->get_ptr(), _type, "runtime_filter_value"});
+        value_block.insert({values->get_ptr(), value_type, "runtime_filter_value"});
         for (const auto& conjunct : conjuncts) {
             bool can_filter_all = false;
             // Once eligibility is established, adaptive RF sampling may make a later batch a
@@ -810,6 +825,10 @@ Status NativeColumnReader::select_with_runtime_filter(
             auto null_map = ColumnUInt8::create(filtered_values->size(), 0);
             filtered_values =
                     ColumnNullable::create(std::move(filtered_values), std::move(null_map));
+        } else if (!target_is_nullable && is_column_nullable(*filtered_values)) {
+            const auto& nullable = assert_cast<const ColumnNullable&>(*filtered_values);
+            DORIS_CHECK(!nullable.has_null());
+            filtered_values = IColumn::mutate(nullable.get_nested_column_ptr());
         }
         *projected_column = std::move(filtered_values);
     }

--- a/be/src/format_v2/parquet/reader/native_column_reader.h
+++ b/be/src/format_v2/parquet/reader/native_column_reader.h
@@ -92,6 +92,10 @@ public:
                                           int64_t batch_rows, const VExprSPtrs& conjuncts,
                                           int column_id, IColumn* projected_column,
                                           IColumn::Filter* row_filter, bool* used_filter) override;
+    Status select_with_runtime_filter(const SelectionVector& selection, uint16_t selected_rows,
+                                      int64_t batch_rows, const VExprContextSPtrs& conjuncts,
+                                      int column_id, MutableColumnPtr* projected_column,
+                                      IColumn::Filter* row_filter, bool* used_filter) override;
     void flush_profile() override;
     bool crossed_page_since_last_batch() override;
     Result<MutableColumnPtr> dictionary_values() override;

--- a/be/src/format_v2/parquet/reader/native_column_reader.h
+++ b/be/src/format_v2/parquet/reader/native_column_reader.h
@@ -91,7 +91,8 @@ public:
     Status select_with_fixed_width_filter(const SelectionVector& selection, uint16_t selected_rows,
                                           int64_t batch_rows, const VExprSPtrs& conjuncts,
                                           int column_id, IColumn* projected_column,
-                                          IColumn::Filter* row_filter, bool* used_filter) override;
+                                          IColumn::Filter* row_filter, bool* used_filter,
+                                          DirectPredicateExecutionKind* execution_kind) override;
     Status select_with_runtime_filter(const SelectionVector& selection, uint16_t selected_rows,
                                       int64_t batch_rows, const VExprContextSPtrs& conjuncts,
                                       int column_id, MutableColumnPtr* projected_column,
@@ -119,7 +120,8 @@ private:
     Status read_with_fixed_width_filter(int64_t rows, const uint8_t* filter_data, bool filter_all,
                                         const VExprSPtrs& conjuncts, int column_id,
                                         IColumn* projected_column, IColumn::Filter* row_filter,
-                                        int64_t* rows_read, bool* used_filter);
+                                        int64_t* rows_read, bool* used_filter,
+                                        DirectPredicateExecutionKind* execution_kind);
     Status read_with_dictionary_filter(int64_t rows, const uint8_t* filter_data, bool filter_all,
                                        const IColumn::Filter& dictionary_filter,
                                        const IColumn* typed_dictionary, IColumn* projected_values,

--- a/be/test/core/data_type_serde/data_type_serde_parquet_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_parquet_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -200,6 +201,59 @@ TEST(DataTypeSerDeParquetTest, PublishesNarrowIntegerPredicateValuesWithoutColum
             type.get_serde()->read_parquet_raw_predicate(source, context, 4, false, consumer).ok());
     EXPECT_EQ(consumer.typed_values<int8_t>(), (std::vector<int8_t> {1, 127, -128, -1}));
     EXPECT_EQ(consumer.nulls, IColumn::Filter(4, 0));
+}
+
+TEST(DataTypeSerDeParquetTest, RawPredicateConversionScratchIsPersistentAndReleasable) {
+    auto verify = [](const DataTypePtr& type, const ParquetDecodeContext& context) {
+        const auto serde = type->get_serde();
+        CapturingLogicalValueConsumer consumer;
+        TestParquetDecodeSource large_source;
+        large_source.set_fixed_values<int32_t>(std::vector<int32_t>(1UL << 16, 1));
+        ASSERT_TRUE(
+                serde->read_parquet_raw_predicate(large_source, context, 1UL << 16, false, consumer)
+                        .ok());
+        const size_t large_capacity = serde->retained_parquet_raw_predicate_scratch_bytes();
+        ASSERT_GT(large_capacity, 0);
+
+        TestParquetDecodeSource small_source;
+        small_source.set_fixed_values<int32_t>({1, 2});
+        ASSERT_TRUE(
+                serde->read_parquet_raw_predicate(small_source, context, 2, false, consumer).ok());
+        EXPECT_EQ(serde->retained_parquet_raw_predicate_scratch_bytes(), large_capacity);
+
+        serde->release_parquet_raw_predicate_scratch(0);
+        EXPECT_EQ(serde->retained_parquet_raw_predicate_scratch_bytes(), 0);
+    };
+
+    verify(std::make_shared<DataTypeDateV2>(),
+           {.physical_type = ParquetPhysicalType::INT32, .logical_type = ParquetLogicalType::DATE});
+    verify(std::make_shared<DataTypeDecimal32>(9, 0), {.physical_type = ParquetPhysicalType::INT32,
+                                                       .logical_type = ParquetLogicalType::DECIMAL,
+                                                       .decimal_precision = 9,
+                                                       .decimal_scale = 0});
+}
+
+TEST(DataTypeSerDeParquetTest, RawUtcTimestampFailureUsesLegacyDefaultPolicy) {
+    DataTypeDateTimeV2 type(6);
+    const auto serde = type.get_serde();
+    const ParquetDecodeContext context {.physical_type = ParquetPhysicalType::INT64,
+                                        .logical_type = ParquetLogicalType::TIMESTAMP,
+                                        .time_unit = ParquetTimeUnit::MILLIS,
+                                        .timestamp_is_adjusted_to_utc = true,
+                                        .conversion_failure_is_null = false};
+    CapturingLogicalValueConsumer consumer;
+    TestParquetDecodeSource permissive_source;
+    permissive_source.set_fixed_values<int64_t>({std::numeric_limits<int64_t>::max()});
+    ASSERT_TRUE(
+            serde->read_parquet_raw_predicate(permissive_source, context, 1, false, consumer).ok());
+    EXPECT_EQ(consumer.nulls, IColumn::Filter(1, 0));
+    EXPECT_TRUE(std::ranges::all_of(consumer.bytes, [](uint8_t byte) { return byte == 0; }));
+
+    TestParquetDecodeSource strict_source;
+    strict_source.set_fixed_values<int64_t>({std::numeric_limits<int64_t>::max()});
+    const auto status =
+            serde->read_parquet_raw_predicate(strict_source, context, 1, true, consumer);
+    EXPECT_TRUE(status.is<ErrorCode::DATA_QUALITY_ERROR>()) << status;
 }
 
 TEST(DataTypeSerDeParquetTest, RawPredicateConversionSupportsEveryFixedLogicalFamily) {

--- a/be/test/core/data_type_serde/data_type_serde_parquet_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_parquet_test.cpp
@@ -138,6 +138,33 @@ private:
     size_t _dictionary_decode_calls = 0;
 };
 
+class CapturingLogicalValueConsumer final : public ParquetLogicalValueConsumer {
+public:
+    Status consume(const uint8_t* values, size_t num_values, size_t value_width,
+                   const uint8_t* conversion_nulls) override {
+        width = value_width;
+        bytes.assign(values, values + num_values * value_width);
+        nulls.clear();
+        nulls.resize_fill(num_values, 0);
+        if (conversion_nulls != nullptr) {
+            memcpy(nulls.data(), conversion_nulls, num_values);
+        }
+        return Status::OK();
+    }
+
+    template <typename T>
+    std::vector<T> typed_values() const {
+        DORIS_CHECK_EQ(width, sizeof(T));
+        std::vector<T> values(bytes.size() / sizeof(T));
+        memcpy(values.data(), bytes.data(), bytes.size());
+        return values;
+    }
+
+    std::vector<uint8_t> bytes;
+    IColumn::Filter nulls;
+    size_t width = 0;
+};
+
 TEST(DataTypeSerDeParquetTest, MaterializesLogicalUnsignedIntegersDirectly) {
     TestParquetDecodeSource source;
     source.set_fixed_values<int32_t>({-1, 0, 7});
@@ -156,6 +183,62 @@ TEST(DataTypeSerDeParquetTest, MaterializesLogicalUnsignedIntegersDirectly) {
     EXPECT_EQ(data[0], 4294967295LL);
     EXPECT_EQ(data[1], 0);
     EXPECT_EQ(data[2], 7);
+}
+
+TEST(DataTypeSerDeParquetTest, PublishesNarrowIntegerPredicateValuesWithoutColumnMaterialization) {
+    TestParquetDecodeSource source;
+    source.set_fixed_values<int32_t>({1, 127, 128, 255});
+    ParquetDecodeContext context {.physical_type = ParquetPhysicalType::INT32,
+                                  .logical_type = ParquetLogicalType::INTEGER,
+                                  .logical_integer_bit_width = 8,
+                                  .logical_integer_is_signed = true};
+    DataTypeInt8 type;
+    CapturingLogicalValueConsumer consumer;
+
+    ASSERT_TRUE(type.get_serde()->supports_parquet_raw_predicate(context));
+    ASSERT_TRUE(
+            type.get_serde()->read_parquet_raw_predicate(source, context, 4, false, consumer).ok());
+    EXPECT_EQ(consumer.typed_values<int8_t>(), (std::vector<int8_t> {1, 127, -128, -1}));
+    EXPECT_EQ(consumer.nulls, IColumn::Filter(4, 0));
+}
+
+TEST(DataTypeSerDeParquetTest, RawPredicateConversionSupportsEveryFixedLogicalFamily) {
+    ParquetDecodeContext integer_context {.physical_type = ParquetPhysicalType::INT32,
+                                          .logical_type = ParquetLogicalType::INTEGER,
+                                          .logical_integer_bit_width = 16};
+    EXPECT_TRUE(DataTypeInt16().get_serde()->supports_parquet_raw_predicate(integer_context));
+
+    ParquetDecodeContext date_context {.physical_type = ParquetPhysicalType::INT32,
+                                       .logical_type = ParquetLogicalType::DATE};
+    EXPECT_TRUE(DataTypeDateV2().get_serde()->supports_parquet_raw_predicate(date_context));
+
+    ParquetDecodeContext timestamp_context {.physical_type = ParquetPhysicalType::INT64,
+                                            .logical_type = ParquetLogicalType::TIMESTAMP,
+                                            .time_unit = ParquetTimeUnit::MICROS};
+    EXPECT_TRUE(
+            DataTypeDateTimeV2(6).get_serde()->supports_parquet_raw_predicate(timestamp_context));
+    EXPECT_TRUE(
+            DataTypeTimeStampTz(6).get_serde()->supports_parquet_raw_predicate(timestamp_context));
+
+    ParquetDecodeContext time_context {.physical_type = ParquetPhysicalType::INT64,
+                                       .logical_type = ParquetLogicalType::TIME,
+                                       .time_unit = ParquetTimeUnit::MICROS};
+    EXPECT_TRUE(DataTypeTimeV2(6).get_serde()->supports_parquet_raw_predicate(time_context));
+
+    ParquetDecodeContext decimal_context {
+            .physical_type = ParquetPhysicalType::FIXED_LEN_BYTE_ARRAY,
+            .logical_type = ParquetLogicalType::DECIMAL,
+            .type_length = 16,
+            .decimal_precision = 38,
+            .decimal_scale = 8};
+    EXPECT_TRUE(
+            DataTypeDecimal32(9, 2).get_serde()->supports_parquet_raw_predicate(decimal_context));
+    EXPECT_TRUE(
+            DataTypeDecimal64(18, 4).get_serde()->supports_parquet_raw_predicate(decimal_context));
+    EXPECT_TRUE(
+            DataTypeDecimal128(38, 8).get_serde()->supports_parquet_raw_predicate(decimal_context));
+    EXPECT_TRUE(
+            DataTypeDecimal256(76, 8).get_serde()->supports_parquet_raw_predicate(decimal_context));
 }
 
 TEST(DataTypeSerDeParquetTest, NonStrictNarrowUnsignedIntegersPreserveBitWidthCompatibility) {

--- a/be/test/format_v2/parquet/native_decoder_test.cpp
+++ b/be/test/format_v2/parquet/native_decoder_test.cpp
@@ -4866,5 +4866,23 @@ TEST(ParquetV2NativeDecoderTest, OversizedNestedBatchScratchUsesIdleBatchHystere
     EXPECT_LE(released_bytes, max_retained_bytes + sizeof(void*));
 }
 
+TEST(ParquetV2NativeDecoderTest, NestedBatchScratchEnforcesAggregateRetentionLimit) {
+    ::doris::RowRanges row_ranges;
+    tparquet::ColumnChunk chunk;
+    ScalarColumnReader<true, false> reader(row_ranges, 1, chunk, nullptr, nullptr, nullptr);
+
+    constexpr size_t max_retained_bytes = 64UL << 10;
+    constexpr size_t elements_per_level_buffer = 24UL << 10;
+    reader.reserve_level_scratch_for_test(elements_per_level_buffer);
+    const size_t aggregate_bytes = reader.retained_batch_scratch_bytes_for_test();
+    ASSERT_GT(aggregate_bytes, max_retained_bytes);
+    ASSERT_LT(elements_per_level_buffer * sizeof(level_t), max_retained_bytes);
+
+    reader.release_batch_scratch(max_retained_bytes);
+    reader.release_batch_scratch(max_retained_bytes);
+    reader.release_batch_scratch(max_retained_bytes);
+    EXPECT_LE(reader.retained_batch_scratch_bytes_for_test(), max_retained_bytes);
+}
+
 } // namespace
 } // namespace doris::format::parquet::native

--- a/be/test/format_v2/parquet/native_decoder_test.cpp
+++ b/be/test/format_v2/parquet/native_decoder_test.cpp
@@ -1188,11 +1188,13 @@ TEST(ParquetV2NativeDecoderTest, RawExprMapsNullableSparseRowsDirectly) {
     decode_context.physical_type = ParquetPhysicalType::INT32;
     decode_context.encoding = ParquetValueEncoding::PLAIN;
     bool used_filter = false;
+    IColumn::Filter conversion_nulls;
+    DirectPredicateExecutionKind execution_kind = DirectPredicateExecutionKind::NONE;
     ASSERT_TRUE(chunk_reader
-                        .filter_fixed_width_values(predicates, 0, select_vector, &selected_nulls,
-                                                   &physical_matches, projected_column.get(),
-                                                   &row_filter, serde, decode_context, false,
-                                                   &used_filter)
+                        .filter_fixed_width_values(
+                                predicates, 0, select_vector, &selected_nulls, &physical_matches,
+                                projected_column.get(), &conversion_nulls, &row_filter, serde,
+                                decode_context, false, &used_filter, &execution_kind)
                         .ok());
 
     EXPECT_TRUE(used_filter);
@@ -3442,9 +3444,10 @@ TEST(ParquetV2NativeDecoderTest, LazyFixedWidthFilterUsesReconciledFirstPageRang
     size_t rows = 0;
     bool eof = false;
     bool used_filter = false;
+    DirectPredicateExecutionKind execution_kind = DirectPredicateExecutionKind::NONE;
     const auto status = reader.read_fixed_width_filter(
             {create_int32_raw_comparison(0, "ge", TExprOpcode::GE, 0)}, 0, filter, 2, nullptr,
-            &row_filter, &rows, &eof, &used_filter);
+            &row_filter, &rows, &eof, &used_filter, &execution_kind);
     ASSERT_TRUE(status.ok()) << status;
     EXPECT_TRUE(used_filter);
     EXPECT_EQ(rows, 2);

--- a/be/test/format_v2/parquet/native_decoder_test.cpp
+++ b/be/test/format_v2/parquet/native_decoder_test.cpp
@@ -176,8 +176,16 @@ TEST(ParquetV2NativeDecoderTest, RawExprPreservesFloatNanOrdering) {
     EXPECT_EQ(matches, (std::array<uint8_t, values.size()> {0, 0, 0, 1}));
 }
 
-TEST(ParquetV2NativeDecoderTest, RawFixedFilterSupportsIdentityWidthEncodingTypes) {
+TEST(ParquetV2NativeDecoderTest, RawFilterSupportsDecoderEncodingTypes) {
     using Reader = ColumnChunkReader<false, false>;
+    EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::PLAIN,
+                                                           tparquet::Type::BOOLEAN));
+    EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::RLE,
+                                                           tparquet::Type::BOOLEAN));
+    EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::PLAIN,
+                                                           tparquet::Type::INT96));
+    EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::PLAIN,
+                                                           tparquet::Type::FIXED_LEN_BYTE_ARRAY));
     EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::BYTE_STREAM_SPLIT,
                                                            tparquet::Type::INT32));
     EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::BYTE_STREAM_SPLIT,
@@ -186,6 +194,10 @@ TEST(ParquetV2NativeDecoderTest, RawFixedFilterSupportsIdentityWidthEncodingType
                                                            tparquet::Type::FLOAT));
     EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::BYTE_STREAM_SPLIT,
                                                            tparquet::Type::DOUBLE));
+    EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::BYTE_STREAM_SPLIT,
+                                                           tparquet::Type::FIXED_LEN_BYTE_ARRAY));
+    EXPECT_TRUE(Reader::supports_raw_binary_filter_encoding(tparquet::Encoding::BYTE_STREAM_SPLIT,
+                                                            tparquet::Type::FIXED_LEN_BYTE_ARRAY));
     EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::DELTA_BINARY_PACKED,
                                                            tparquet::Type::INT32));
     EXPECT_TRUE(Reader::supports_raw_fixed_filter_encoding(tparquet::Encoding::DELTA_BINARY_PACKED,
@@ -1171,11 +1183,16 @@ TEST(ParquetV2NativeDecoderTest, RawExprMapsNullableSparseRowsDirectly) {
     IColumn::Filter physical_matches;
     auto projected_column = make_nullable(field.data_type)->create_column();
     IColumn::Filter row_filter;
+    DataTypeNumberSerDe<TYPE_INT> serde;
+    ParquetDecodeContext decode_context;
+    decode_context.physical_type = ParquetPhysicalType::INT32;
+    decode_context.encoding = ParquetValueEncoding::PLAIN;
     bool used_filter = false;
     ASSERT_TRUE(chunk_reader
                         .filter_fixed_width_values(predicates, 0, select_vector, &selected_nulls,
                                                    &physical_matches, projected_column.get(),
-                                                   &row_filter, &used_filter)
+                                                   &row_filter, serde, decode_context, false,
+                                                   &used_filter)
                         .ok());
 
     EXPECT_TRUE(used_filter);

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -59,6 +59,7 @@
 #include "exprs/vin_predicate.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
+#include "exprs/vtopn_pred.h"
 #include "format_v2/expr/cast.h"
 #include "format_v2/expr/delete_predicate.h"
 #include "format_v2/file_reader.h"
@@ -72,6 +73,7 @@
 #include "storage/index/zone_map/zonemap_eval_context.h"
 #include "storage/index/zone_map/zonemap_filter_result.h"
 #include "storage/utils.h"
+#include "testutil/mock/mock_query_context.h"
 #include "util/coding.h"
 #include "util/thrift_util.h"
 
@@ -885,6 +887,50 @@ VExprContextSPtr create_reader_values_string_runtime_conjunct(int column_id,
                                             make_nullable(std::make_shared<DataTypeString>()),
                                             "runtime_reader_value_key"));
     return wrap_runtime_filter(std::move(impl), make_runtime_in_node(), filter_id);
+}
+
+struct PreparedTopNConjunct {
+    std::shared_ptr<MockQueryContext> query_context;
+    VExprContextSPtr conjunct;
+};
+
+PreparedTopNConjunct create_topn_conjunct(RuntimeState* state, int column_id,
+                                          const DataTypePtr& data_type, const Field& bound) {
+    DORIS_CHECK(state != nullptr);
+    DORIS_CHECK(data_type != nullptr);
+    TExpr target_expr;
+    TExprNode slot_node;
+    slot_node.__set_node_type(TExprNodeType::SLOT_REF);
+    slot_node.__set_type(data_type->to_thrift());
+    slot_node.__set_num_children(0);
+    TSlotRef slot_ref;
+    slot_ref.__set_slot_id(column_id);
+    slot_ref.__set_tuple_id(0);
+    slot_node.__set_slot_ref(slot_ref);
+    target_expr.nodes.push_back(std::move(slot_node));
+
+    TTopnFilterDesc desc;
+    desc.__set_source_node_id(10);
+    desc.__set_is_asc(true);
+    desc.__set_null_first(false);
+    desc.__set_target_node_id_to_target_expr({{20, std::move(target_expr)}});
+    auto query_context = MockQueryContext::create();
+    state->_query_ctx = query_context.get();
+    query_context->init_runtime_predicates({desc});
+    auto& predicate = query_context->get_runtime_predicate(10);
+    predicate.set_detected_source();
+    DORIS_CHECK(predicate.init_target(20, {}, -1).ok());
+    DORIS_CHECK(predicate.update(bound).ok());
+
+    TExprNode topn_node;
+    topn_node.__set_type(std::make_shared<DataTypeUInt8>()->to_thrift());
+    topn_node.__set_is_nullable(false);
+    auto topn = VTopNPred::create_shared(topn_node, 10, nullptr);
+    topn->add_child(VSlotRef::create_shared(column_id, column_id, -1, data_type, "topn_column"));
+    auto conjunct = VExprContext::create_shared(std::move(topn));
+    DORIS_CHECK(conjunct->prepare(state, RowDescriptor()).ok());
+    DORIS_CHECK(conjunct->open(state).ok());
+    return {.query_context = std::move(query_context), .conjunct = std::move(conjunct)};
 }
 
 template <PrimitiveType T>
@@ -2453,6 +2499,38 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainRuntimeFiltersUsePhysicalDirectPath) {
     EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectRows"), 6);
 }
 
+TEST_F(ParquetScanTest, PredicateOnlyPlainTopNUsesPhysicalDirectPath) {
+    write_int_pair_parquet_file(_file_path, 6, false);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto prepared =
+            create_topn_conjunct(&state, 0, schema[0].type, Field::create_field<TYPE_INT>(3));
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    request->conjuncts.push_back(prepared.conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 3);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {10, 20, 30}));
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
+    prepared.conjunct->close();
+}
+
 TEST_F(ParquetScanTest, PredicateOnlyTinyIntConversionUsesDecoderDirectPath) {
     write_tinyint_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
@@ -2842,6 +2920,39 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryRangeSkipsTypedValueMaterializati
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateProjectedRows"), 0);
     EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
     conjunct->close();
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyDictionaryTopNUsesDictionaryIds) {
+    write_dictionary_int_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto prepared =
+            create_topn_conjunct(&state, 0, schema[0].type, Field::create_field<TYPE_INT>(3));
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    request->conjuncts.push_back(prepared.conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 3);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {10, 20, 30}));
+    EXPECT_EQ(counter_value(profile, "DictFilterCandidateColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "RowsFilteredByDictFilter"), 3);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
+    prepared.conjunct->close();
 }
 
 TEST_F(ParquetScanTest, PredicateOnlyDictionaryBloomRuntimeFilterUsesTypedValues) {

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -43,6 +43,7 @@
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
+#include "core/data_type/data_type_factory.hpp"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/field.h"
@@ -728,6 +729,48 @@ VExprContextSPtr create_string_runtime_comparison_conjunct(int column_id,
     return wrap_runtime_filter(impl_context->root(), node, filter_id);
 }
 
+TEST(ParquetRuntimeFilterDirectReaderTest, EveryRuntimeFilterScalarTypeIsEligible) {
+    struct TypeSpec {
+        PrimitiveType primitive_type;
+        int precision = 0;
+        int scale = 0;
+        int length = -1;
+    };
+    const std::vector<TypeSpec> supported_types {
+            {TYPE_BOOLEAN},       {TYPE_TINYINT},        {TYPE_SMALLINT},
+            {TYPE_INT},           {TYPE_BIGINT},         {TYPE_LARGEINT},
+            {TYPE_FLOAT},         {TYPE_DOUBLE},         {TYPE_DATE},
+            {TYPE_DATETIME},      {TYPE_DATEV2},         {TYPE_DATETIMEV2, 0, 6},
+            {TYPE_TIMESTAMPTZ, 0, 6},
+            {TYPE_CHAR, 0, 0, 16},
+            {TYPE_VARCHAR, 0, 0, 16},
+            {TYPE_STRING},
+            {TYPE_DECIMALV2, 27, 9},
+            {TYPE_DECIMAL32, 9, 2},
+            {TYPE_DECIMAL64, 18, 4},
+            {TYPE_DECIMAL128I, 38, 8},
+            {TYPE_DECIMAL256, 76, 8},
+            {TYPE_IPV4},
+            {TYPE_IPV6},
+    };
+
+    int filter_id = 1000;
+    for (const auto& spec : supported_types) {
+        const auto type = DataTypeFactory::instance().create_data_type(
+                spec.primitive_type, false, spec.precision, spec.scale, spec.length);
+        std::shared_ptr<HybridSetBase> filter(create_set(spec.primitive_type, false));
+        auto node = make_runtime_in_node();
+        auto impl = VDirectInPredicate::create_shared(node, std::move(filter), true);
+        impl->add_child(
+                VSlotRef::create_shared(0, 0, -1, make_nullable(type), "runtime_filter_key"));
+        const auto conjunct = wrap_runtime_filter(std::move(impl), node, filter_id++);
+        EXPECT_TRUE(conjunct->root()->can_execute_on_reader_values(type, 0))
+                << type->get_name();
+        EXPECT_FALSE(conjunct->root()->can_execute_on_reader_values(type, 1))
+                << type->get_name();
+    }
+}
+
 VExprContextSPtr create_int64_direct_greater_conjunct(int column_id, int64_t lower_bound) {
     return VExprContext::create_shared(
             std::make_shared<Int64DirectGreaterExpr>(column_id, lower_bound));
@@ -925,6 +968,17 @@ void write_dictionary_string_pair_parquet_file(const std::string& file_path) {
             arrow::Table::Make(schema, {build_string_array({"alpha", "bravo", "charlie", "delta"}),
                                         build_int32_array({10, 20, 30, 40})});
     write_table(file_path, table, 4, true, false, false);
+}
+
+void write_string_pair_parquet_file(const std::string& file_path) {
+    auto schema = arrow::schema({
+            arrow::field("text", arrow::utf8(), false),
+            arrow::field("score", arrow::int32(), false),
+    });
+    auto table =
+            arrow::Table::Make(schema, {build_string_array({"alpha", "bravo", "charlie", "delta"}),
+                                        build_int32_array({10, 20, 30, 40})});
+    write_table(file_path, table, 4, false, false, false);
 }
 
 void write_int_triple_parquet_file(const std::string& file_path) {
@@ -2071,6 +2125,125 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainBloomRuntimeFilterUsesPhysicalDirectPa
               (ColumnInt32::Container {30, 50, 60}));
     EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
     EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectRows"), 6);
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyPlainStringBloomRuntimeFilterUsesDirectReader) {
+    write_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    auto conjunct = create_string_runtime_bloom_conjunct(0, {"bravo", "delta"}, 15);
+    conjunct->_prepared = false;
+    conjunct->_opened = false;
+    ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(conjunct->open(&state).ok());
+    request->conjuncts.push_back(conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 2);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {20, 40}));
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectRows"), 4);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+    conjunct->close();
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyPlainStringAllRuntimeFilterKindsUseDirectReader) {
+    write_string_pair_parquet_file(_file_path);
+    enum class FilterKind { IN, BLOOM, MIN, MAX, MINMAX };
+    struct TestCase {
+        FilterKind kind;
+        std::vector<int32_t> expected_scores;
+    };
+    const std::vector<TestCase> cases {
+            {FilterKind::IN, {20, 40}},
+            {FilterKind::BLOOM, {20, 40}},
+            {FilterKind::MIN, {20, 30, 40}},
+            {FilterKind::MAX, {10, 20, 30}},
+            {FilterKind::MINMAX, {20, 30}},
+    };
+
+    int filter_id = 100;
+    for (const auto& test_case : cases) {
+        RuntimeProfile profile("profile");
+        auto reader = create_reader(0, -1, &profile);
+        RuntimeState state {TQueryOptions(), TQueryGlobals()};
+        ASSERT_TRUE(reader->init(&state).ok());
+
+        std::vector<format::ColumnDefinition> schema;
+        ASSERT_TRUE(reader->get_schema(&schema).ok());
+        auto request = std::make_shared<format::FileScanRequest>();
+        format::FileScanRequestBuilder request_builder(request.get());
+        ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+        ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+        request->predicate_only_columns.push_back(format::LocalColumnId(0));
+
+        VExprContextSPtrs conjuncts;
+        switch (test_case.kind) {
+        case FilterKind::IN:
+            conjuncts.push_back(
+                    create_string_runtime_in_conjunct(0, {"bravo", "delta"}, filter_id++));
+            break;
+        case FilterKind::BLOOM:
+            conjuncts.push_back(
+                    create_string_runtime_bloom_conjunct(0, {"bravo", "delta"}, filter_id++));
+            break;
+        case FilterKind::MIN:
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(
+                    0, "gt", TExprOpcode::GT, "alpha", filter_id++));
+            break;
+        case FilterKind::MAX:
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(
+                    0, "lt", TExprOpcode::LT, "delta", filter_id++));
+            break;
+        case FilterKind::MINMAX:
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(
+                    0, "gt", TExprOpcode::GT, "alpha", filter_id++));
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(
+                    0, "lt", TExprOpcode::LT, "delta", filter_id++));
+            break;
+        }
+        for (const auto& conjunct : conjuncts) {
+            conjunct->_prepared = false;
+            conjunct->_opened = false;
+            ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+            ASSERT_TRUE(conjunct->open(&state).ok());
+            request->conjuncts.push_back(conjunct);
+        }
+        ASSERT_TRUE(reader->open(request).ok());
+
+        Block block = build_file_block(schema);
+        size_t rows = 0;
+        bool eof = false;
+        ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+        ASSERT_EQ(rows, test_case.expected_scores.size());
+        const auto& actual_scores =
+                int32_data_column(*block.get_by_position(1).column).get_data();
+        ASSERT_EQ(actual_scores.size(), test_case.expected_scores.size());
+        for (size_t row = 0; row < actual_scores.size(); ++row) {
+            EXPECT_EQ(actual_scores[row], test_case.expected_scores[row]);
+        }
+        EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
+        EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectRows"), 4);
+        EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+        for (const auto& conjunct : conjuncts) {
+            conjunct->close();
+        }
+    }
 }
 
 TEST_F(ParquetScanTest, PredicateOnlyDictionaryRangeSkipsTypedValueMaterialization) {

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -688,12 +688,40 @@ VExprContextSPtr create_string_runtime_bloom_conjunct(int column_id,
     return wrap_runtime_filter(std::move(impl), node, filter_id);
 }
 
+VExprContextSPtr create_string_runtime_in_conjunct(int column_id,
+                                                   const std::vector<std::string>& values,
+                                                   int filter_id) {
+    std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_STRING, false));
+    for (const auto& value : values) {
+        StringRef value_ref(value.data(), value.size());
+        filter->insert(&value_ref);
+    }
+    auto node = make_runtime_in_node();
+    auto impl = VDirectInPredicate::create_shared(node, std::move(filter), true);
+    impl->add_child(VSlotRef::create_shared(column_id, column_id, -1,
+                                            make_nullable(std::make_shared<DataTypeString>()),
+                                            "runtime_in_key"));
+    return wrap_runtime_filter(std::move(impl), node, filter_id);
+}
+
 VExprContextSPtr create_int32_runtime_comparison_conjunct(int column_id,
                                                           const std::string& function_name,
                                                           TExprOpcode::type opcode, int32_t value,
                                                           int filter_id) {
     auto impl_context =
             create_int32_function_conjunct(column_id, function_name, opcode, value, true);
+    TExprNode node;
+    node.__set_type(std::make_shared<DataTypeUInt8>()->to_thrift());
+    node.__set_is_nullable(false);
+    return wrap_runtime_filter(impl_context->root(), node, filter_id);
+}
+
+VExprContextSPtr create_string_runtime_comparison_conjunct(int column_id,
+                                                           const std::string& function_name,
+                                                           TExprOpcode::type opcode,
+                                                           const std::string& value,
+                                                           int filter_id) {
+    auto impl_context = create_string_function_conjunct(column_id, function_name, opcode, value);
     TExprNode node;
     node.__set_type(std::make_shared<DataTypeUInt8>()->to_thrift());
     node.__set_is_nullable(false);
@@ -2112,7 +2140,7 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryBloomRuntimeFilterUsesTypedValues
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 6);
 }
 
-TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryBloomRuntimeFilterUsesDictionaryValues) {
+TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryBloomRuntimeFilterUsesVectorizedValues) {
     write_dictionary_string_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -2126,7 +2154,12 @@ TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryBloomRuntimeFilterUsesDicti
     ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
     ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
     request->predicate_only_columns.push_back(format::LocalColumnId(0));
-    request->conjuncts.push_back(create_string_runtime_bloom_conjunct(0, {"bravo", "delta"}, 11));
+    auto conjunct = create_string_runtime_bloom_conjunct(0, {"bravo", "delta"}, 11);
+    conjunct->_prepared = false;
+    conjunct->_opened = false;
+    ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(conjunct->open(&state).ok());
+    request->conjuncts.push_back(conjunct);
     ASSERT_TRUE(reader->open(request).ok());
 
     Block block = build_file_block(schema);
@@ -2136,8 +2169,88 @@ TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryBloomRuntimeFilterUsesDicti
     ASSERT_EQ(rows, 2);
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {20, 40}));
+    EXPECT_EQ(counter_value(profile, "DictFilterCandidateColumns"), 1);
     EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
+    auto* vectorized_filter_columns =
+            profile.get_counter("DictFilterVectorizedRuntimeFilterColumns");
+    ASSERT_NE(vectorized_filter_columns, nullptr);
+    EXPECT_EQ(vectorized_filter_columns->value(), 1);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 4);
+    conjunct->close();
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryInRuntimeFilterUsesVectorizedValues) {
+    write_dictionary_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    auto conjunct = create_string_runtime_in_conjunct(0, {"bravo", "delta"}, 12);
+    conjunct->_prepared = false;
+    conjunct->_opened = false;
+    ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(conjunct->open(&state).ok());
+    request->conjuncts.push_back(conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 2);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {20, 40}));
+    EXPECT_EQ(counter_value(profile, "DictFilterVectorizedRuntimeFilterColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 4);
+    conjunct->close();
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryMinMaxRuntimeFilterUsesVectorizedValues) {
+    write_dictionary_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    auto min_conjunct =
+            create_string_runtime_comparison_conjunct(0, "gt", TExprOpcode::GT, "alpha", 13);
+    auto max_conjunct =
+            create_string_runtime_comparison_conjunct(0, "lt", TExprOpcode::LT, "delta", 14);
+    for (const auto& conjunct : {min_conjunct, max_conjunct}) {
+        conjunct->_prepared = false;
+        conjunct->_opened = false;
+        ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+        ASSERT_TRUE(conjunct->open(&state).ok());
+        request->conjuncts.push_back(conjunct);
+    }
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 2);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {20, 30}));
+    EXPECT_EQ(counter_value(profile, "DictFilterVectorizedRuntimeFilterColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 4);
+    min_conjunct->close();
+    max_conjunct->close();
 }
 
 TEST_F(ParquetScanTest, ProjectedDictionaryRangeGathersOnlySurvivors) {

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -56,6 +56,7 @@
 #include "exprs/vectorized_fn_call.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
+#include "exprs/vin_predicate.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
 #include "format_v2/expr/cast.h"
@@ -398,6 +399,9 @@ VExprContextSPtr create_int32_zonemap_conjunct(int column_id, Int32ZoneMapExpr::
     return VExprContext::create_shared(std::make_shared<Int32ZoneMapExpr>(column_id, op, value));
 }
 
+VExprSPtr create_binary_predicate(const std::string& function_name, TExprOpcode::type opcode,
+                                  VExprSPtr left, VExprSPtr right);
+
 VExprContextSPtr create_int32_function_conjunct(int column_id, const std::string& function_name,
                                                 TExprOpcode::type opcode, int32_t value,
                                                 bool mark_prepared = true) {
@@ -460,6 +464,20 @@ VExprContextSPtr create_int64_function_conjunct(int column_id, const std::string
     return VExprContext::create_shared(std::move(root));
 }
 
+VExprContextSPtr create_tinyint_function_conjunct(int column_id, const std::string& function_name,
+                                                  TExprOpcode::type opcode, int8_t value) {
+    const auto value_type = std::make_shared<DataTypeInt8>();
+    const auto nullable_value_type = make_nullable(value_type);
+    auto root = create_binary_predicate(
+            function_name, opcode,
+            VSlotRef::create_shared(column_id, column_id, -1, nullable_value_type, "tiny_key"),
+            VLiteral::create_shared(value_type, Field::create_field<TYPE_TINYINT>(value)));
+    auto context = VExprContext::create_shared(std::move(root));
+    context->_prepared = true;
+    context->_opened = true;
+    return context;
+}
+
 VExprContextSPtr create_string_function_conjunct(int column_id, const std::string& function_name,
                                                  TExprOpcode::type opcode, const std::string& value,
                                                  bool literal_on_left = false) {
@@ -492,6 +510,53 @@ VExprContextSPtr create_string_function_conjunct(int column_id, const std::strin
         root->add_child(std::move(slot));
         root->add_child(std::move(literal));
     }
+    return VExprContext::create_shared(std::move(root));
+}
+
+VExprContextSPtr create_string_in_conjunct(int column_id, const std::vector<std::string>& values,
+                                           bool is_not_in) {
+    const DataTypePtr string_type = std::make_shared<DataTypeString>();
+    const auto nullable_string_type = make_nullable(string_type);
+    const auto result_type = make_nullable(std::make_shared<DataTypeUInt8>());
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::IN_PRED);
+    node.__set_type(result_type->to_thrift());
+    node.__set_num_children(static_cast<int16_t>(values.size() + 1));
+    node.__set_is_nullable(true);
+    TInPredicate in_predicate;
+    in_predicate.__set_is_not_in(is_not_in);
+    node.__set_in_predicate(in_predicate);
+    auto root = VInPredicate::create_shared(node);
+    root->add_child(
+            VSlotRef::create_shared(column_id, column_id, -1, nullable_string_type, "plain_text"));
+    for (const auto& value : values) {
+        root->add_child(
+                VLiteral::create_shared(string_type, Field::create_field<TYPE_STRING>(value)));
+    }
+    return VExprContext::create_shared(std::move(root));
+}
+
+VExprContextSPtr create_string_null_conjunct(int column_id, bool is_null) {
+    const auto nullable_string_type = make_nullable(std::make_shared<DataTypeString>());
+    const auto result_type = std::make_shared<DataTypeUInt8>();
+    const std::string function_name = is_null ? "is_null_pred" : "is_not_null_pred";
+    TFunctionName fn_name;
+    fn_name.__set_function_name(function_name);
+    TFunction fn;
+    fn.__set_name(fn_name);
+    fn.__set_binary_type(TFunctionBinaryType::BUILTIN);
+    fn.__set_arg_types({nullable_string_type->to_thrift()});
+    fn.__set_ret_type(result_type->to_thrift());
+    fn.__set_has_var_args(false);
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::FUNCTION_CALL);
+    node.__set_type(result_type->to_thrift());
+    node.__set_fn(fn);
+    node.__set_num_children(1);
+    node.__set_is_nullable(false);
+    auto root = VectorizedFnCall::create_shared(node);
+    root->add_child(
+            VSlotRef::create_shared(column_id, column_id, -1, nullable_string_type, "plain_text"));
     return VExprContext::create_shared(std::move(root));
 }
 
@@ -545,13 +610,14 @@ VExprContextSPtr create_int32_pair_sum_conjunct(int left_column_id, int right_co
             std::make_shared<Int32PairSumExpr>(left_column_id, right_column_id, upper_bound));
 }
 
-VExprContextSPtr create_and_conjunct(VExprSPtr left, VExprSPtr right) {
+VExprContextSPtr create_compound_conjunct(TExprOpcode::type opcode, VExprSPtr left,
+                                          VExprSPtr right) {
     const auto result_type = left->data_type()->is_nullable() || right->data_type()->is_nullable()
                                      ? make_nullable(std::make_shared<DataTypeUInt8>())
                                      : std::make_shared<DataTypeUInt8>();
     TExprNode node;
     node.__set_node_type(TExprNodeType::COMPOUND_PRED);
-    node.__set_opcode(TExprOpcode::COMPOUND_AND);
+    node.__set_opcode(opcode);
     node.__set_type(result_type->to_thrift());
     node.__set_num_children(2);
     node.__set_is_nullable(result_type->is_nullable());
@@ -559,6 +625,10 @@ VExprContextSPtr create_and_conjunct(VExprSPtr left, VExprSPtr right) {
     compound->add_child(std::move(left));
     compound->add_child(std::move(right));
     return VExprContext::create_shared(std::move(compound));
+}
+
+VExprContextSPtr create_and_conjunct(VExprSPtr left, VExprSPtr right) {
+    return create_compound_conjunct(TExprOpcode::COMPOUND_AND, std::move(left), std::move(right));
 }
 
 VExprSPtr create_binary_predicate(const std::string& function_name, TExprOpcode::type opcode,
@@ -633,6 +703,53 @@ VExprContextSPtr create_int32_runtime_in_conjunct(int column_id, const std::vect
                                             make_nullable(std::make_shared<DataTypeInt32>()),
                                             "runtime_in_key"));
     return wrap_runtime_filter(std::move(impl), node, filter_id);
+}
+
+VExprContextSPtr create_tinyint_runtime_in_conjunct(int column_id,
+                                                    const std::vector<int8_t>& values,
+                                                    int filter_id) {
+    std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_TINYINT, false));
+    for (const auto value : values) {
+        filter->insert(&value);
+    }
+    auto node = make_runtime_in_node();
+    auto impl = VDirectInPredicate::create_shared(node, std::move(filter), true);
+    impl->add_child(VSlotRef::create_shared(column_id, column_id, -1,
+                                            make_nullable(std::make_shared<DataTypeInt8>()),
+                                            "runtime_tinyint_key"));
+    return wrap_runtime_filter(std::move(impl), node, filter_id);
+}
+
+VExprContextSPtr create_decimal64_runtime_in_conjunct(int column_id,
+                                                      const std::vector<int64_t>& scaled_values,
+                                                      int filter_id) {
+    std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_DECIMAL64, false));
+    for (const auto scaled_value : scaled_values) {
+        const Decimal64 value {scaled_value};
+        filter->insert(&value);
+    }
+    auto node = make_runtime_in_node();
+    auto impl = VDirectInPredicate::create_shared(node, std::move(filter), true);
+    impl->add_child(VSlotRef::create_shared(
+            column_id, column_id, -1, make_nullable(std::make_shared<DataTypeDecimal64>(10, 2)),
+            "runtime_decimal_key"));
+    return wrap_runtime_filter(std::move(impl), node, filter_id);
+}
+
+VExprContextSPtr create_decimal64_function_conjunct(int column_id, const std::string& function_name,
+                                                    TExprOpcode::type opcode,
+                                                    int64_t scaled_value) {
+    const auto value_type = std::make_shared<DataTypeDecimal64>(10, 2);
+    auto root = create_binary_predicate(
+            function_name, opcode,
+            VSlotRef::create_shared(column_id, column_id, -1, make_nullable(value_type),
+                                    "decimal_key"),
+            VLiteral::create_shared(value_type,
+                                    Field::create_field<TYPE_DECIMAL64>(Decimal64 {scaled_value})));
+    auto context = VExprContext::create_shared(std::move(root));
+    context->_prepared = true;
+    context->_opened = true;
+    return context;
 }
 
 VExprContextSPtr create_int32_runtime_bloom_conjunct(int column_id,
@@ -729,6 +846,83 @@ VExprContextSPtr create_string_runtime_comparison_conjunct(int column_id,
     return wrap_runtime_filter(impl_context->root(), node, filter_id);
 }
 
+template <PrimitiveType T>
+void expect_fixed_comparison_raw_eligible(const DataTypePtr& type) {
+    const auto predicate = create_binary_predicate(
+            "gt", TExprOpcode::GT,
+            VSlotRef::create_shared(0, 0, -1, make_nullable(type), "raw_comparison_key"),
+            VLiteral::create_shared(
+                    type, Field::create_field<T>(typename PrimitiveTypeTraits<T>::CppType {})));
+    EXPECT_TRUE(predicate->can_execute_on_raw_fixed_values(type, 0)) << type->get_name();
+}
+
+TEST(ParquetRuntimeFilterDirectReaderTest, EveryFixedScalarComparisonIsRawEligible) {
+    expect_fixed_comparison_raw_eligible<TYPE_BOOLEAN>(std::make_shared<DataTypeUInt8>());
+    expect_fixed_comparison_raw_eligible<TYPE_TINYINT>(std::make_shared<DataTypeInt8>());
+    expect_fixed_comparison_raw_eligible<TYPE_SMALLINT>(std::make_shared<DataTypeInt16>());
+    expect_fixed_comparison_raw_eligible<TYPE_INT>(std::make_shared<DataTypeInt32>());
+    expect_fixed_comparison_raw_eligible<TYPE_BIGINT>(std::make_shared<DataTypeInt64>());
+    expect_fixed_comparison_raw_eligible<TYPE_LARGEINT>(std::make_shared<DataTypeInt128>());
+    expect_fixed_comparison_raw_eligible<TYPE_FLOAT>(std::make_shared<DataTypeFloat32>());
+    expect_fixed_comparison_raw_eligible<TYPE_DOUBLE>(std::make_shared<DataTypeFloat64>());
+    expect_fixed_comparison_raw_eligible<TYPE_DATE>(
+            DataTypeFactory::instance().create_data_type(TYPE_DATE, false));
+    expect_fixed_comparison_raw_eligible<TYPE_DATETIME>(
+            DataTypeFactory::instance().create_data_type(TYPE_DATETIME, false));
+    expect_fixed_comparison_raw_eligible<TYPE_DATEV2>(
+            DataTypeFactory::instance().create_data_type(TYPE_DATEV2, false));
+    expect_fixed_comparison_raw_eligible<TYPE_DATETIMEV2>(
+            DataTypeFactory::instance().create_data_type(TYPE_DATETIMEV2, false, 0, 6));
+    expect_fixed_comparison_raw_eligible<TYPE_TIMESTAMPTZ>(
+            DataTypeFactory::instance().create_data_type(TYPE_TIMESTAMPTZ, false, 0, 6));
+    expect_fixed_comparison_raw_eligible<TYPE_TIMEV2>(
+            DataTypeFactory::instance().create_data_type(TYPE_TIMEV2, false, 0, 6));
+    expect_fixed_comparison_raw_eligible<TYPE_DECIMALV2>(
+            DataTypeFactory::instance().create_data_type(TYPE_DECIMALV2, false, 27, 9));
+    expect_fixed_comparison_raw_eligible<TYPE_DECIMAL32>(
+            DataTypeFactory::instance().create_data_type(TYPE_DECIMAL32, false, 9, 2));
+    expect_fixed_comparison_raw_eligible<TYPE_DECIMAL64>(
+            DataTypeFactory::instance().create_data_type(TYPE_DECIMAL64, false, 18, 4));
+    expect_fixed_comparison_raw_eligible<TYPE_DECIMAL128I>(
+            DataTypeFactory::instance().create_data_type(TYPE_DECIMAL128I, false, 38, 8));
+    expect_fixed_comparison_raw_eligible<TYPE_DECIMAL256>(
+            DataTypeFactory::instance().create_data_type(TYPE_DECIMAL256, false, 76, 8));
+    expect_fixed_comparison_raw_eligible<TYPE_IPV4>(
+            DataTypeFactory::instance().create_data_type(TYPE_IPV4, false));
+    expect_fixed_comparison_raw_eligible<TYPE_IPV6>(
+            DataTypeFactory::instance().create_data_type(TYPE_IPV6, false));
+}
+
+TEST(ParquetRuntimeFilterDirectReaderTest, CompoundPredicatesPreserveRawSelectionMask) {
+    const auto lower = create_int32_function_conjunct(0, "gt", TExprOpcode::GT, 1);
+    const auto upper = create_int32_function_conjunct(0, "lt", TExprOpcode::LT, 5);
+    const auto compound = create_and_conjunct(lower->root(), upper->root());
+    const auto type = std::make_shared<DataTypeInt32>();
+    ASSERT_TRUE(compound->root()->can_execute_on_raw_fixed_values(type, 0));
+
+    const std::array<int32_t, 4> values {0, 2, 4, 6};
+    IColumn::Filter matches {0, 1, 1, 1};
+    ASSERT_TRUE(compound->root()
+                        ->execute_on_raw_fixed_values(
+                                reinterpret_cast<const uint8_t*>(values.data()), values.size(),
+                                sizeof(int32_t), type, 0, matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {0, 1, 1, 0}));
+
+    const auto below_one = create_int32_function_conjunct(0, "lt", TExprOpcode::LT, 1);
+    const auto above_five = create_int32_function_conjunct(0, "gt", TExprOpcode::GT, 5);
+    const auto disjunction = create_compound_conjunct(TExprOpcode::COMPOUND_OR, below_one->root(),
+                                                      above_five->root());
+    ASSERT_TRUE(disjunction->root()->can_execute_on_raw_fixed_values(type, 0));
+    matches = {0, 1, 1, 1};
+    ASSERT_TRUE(disjunction->root()
+                        ->execute_on_raw_fixed_values(
+                                reinterpret_cast<const uint8_t*>(values.data()), values.size(),
+                                sizeof(int32_t), type, 0, matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {0, 0, 0, 1}));
+}
+
 TEST(ParquetRuntimeFilterDirectReaderTest, EveryRuntimeFilterScalarTypeIsEligible) {
     struct TypeSpec {
         PrimitiveType primitive_type;
@@ -737,11 +931,20 @@ TEST(ParquetRuntimeFilterDirectReaderTest, EveryRuntimeFilterScalarTypeIsEligibl
         int length = -1;
     };
     const std::vector<TypeSpec> supported_types {
-            {TYPE_BOOLEAN},       {TYPE_TINYINT},        {TYPE_SMALLINT},
-            {TYPE_INT},           {TYPE_BIGINT},         {TYPE_LARGEINT},
-            {TYPE_FLOAT},         {TYPE_DOUBLE},         {TYPE_DATE},
-            {TYPE_DATETIME},      {TYPE_DATEV2},         {TYPE_DATETIMEV2, 0, 6},
+            {TYPE_BOOLEAN},
+            {TYPE_TINYINT},
+            {TYPE_SMALLINT},
+            {TYPE_INT},
+            {TYPE_BIGINT},
+            {TYPE_LARGEINT},
+            {TYPE_FLOAT},
+            {TYPE_DOUBLE},
+            {TYPE_DATE},
+            {TYPE_DATETIME},
+            {TYPE_DATEV2},
+            {TYPE_DATETIMEV2, 0, 6},
             {TYPE_TIMESTAMPTZ, 0, 6},
+            {TYPE_TIMEV2, 0, 6},
             {TYPE_CHAR, 0, 0, 16},
             {TYPE_VARCHAR, 0, 0, 16},
             {TYPE_STRING},
@@ -764,10 +967,61 @@ TEST(ParquetRuntimeFilterDirectReaderTest, EveryRuntimeFilterScalarTypeIsEligibl
         impl->add_child(
                 VSlotRef::create_shared(0, 0, -1, make_nullable(type), "runtime_filter_key"));
         const auto conjunct = wrap_runtime_filter(std::move(impl), node, filter_id++);
-        EXPECT_TRUE(conjunct->root()->can_execute_on_reader_values(type, 0))
-                << type->get_name();
-        EXPECT_FALSE(conjunct->root()->can_execute_on_reader_values(type, 1))
-                << type->get_name();
+        EXPECT_TRUE(conjunct->root()->can_execute_on_reader_values(type, 0)) << type->get_name();
+        EXPECT_FALSE(conjunct->root()->can_execute_on_reader_values(type, 1)) << type->get_name();
+        if (is_string_type(spec.primitive_type)) {
+            EXPECT_TRUE(conjunct->root()->can_execute_on_raw_binary_values(type, 0))
+                    << type->get_name();
+        } else {
+            EXPECT_TRUE(conjunct->root()->can_execute_on_raw_fixed_values(type, 0))
+                    << type->get_name();
+        }
+
+        const auto default_column = type->create_column_const_with_default_value(1);
+        for (const auto& [function_name, opcode] :
+             {std::pair {"ge", TExprOpcode::GE}, std::pair {"le", TExprOpcode::LE}}) {
+            auto comparison = create_binary_predicate(
+                    function_name, opcode,
+                    VSlotRef::create_shared(0, 0, -1, make_nullable(type), "runtime_minmax_key"),
+                    VLiteral::create_shared(type, (*default_column)[0]));
+            TExprNode comparison_node;
+            comparison_node.__set_type(std::make_shared<DataTypeUInt8>()->to_thrift());
+            comparison_node.__set_is_nullable(false);
+            const auto comparison_conjunct =
+                    wrap_runtime_filter(std::move(comparison), comparison_node, filter_id++);
+            if (is_string_type(spec.primitive_type)) {
+                EXPECT_TRUE(comparison_conjunct->root()->can_execute_on_raw_binary_values(type, 0))
+                        << type->get_name() << " " << function_name;
+            } else {
+                EXPECT_TRUE(comparison_conjunct->root()->can_execute_on_raw_fixed_values(type, 0))
+                        << type->get_name() << " " << function_name;
+            }
+        }
+
+        std::shared_ptr<BloomFilterFuncBase> bloom_filter(
+                create_bloom_filter(spec.primitive_type, false));
+        RuntimeFilterParams params;
+        params.filter_type = RuntimeFilterType::BLOOM_FILTER;
+        params.column_return_type = spec.primitive_type;
+        params.bloom_filter_size = 1024;
+        bloom_filter->init_params(&params);
+        ASSERT_TRUE(bloom_filter->init_with_fixed_length(1024).ok()) << type->get_name();
+        auto bloom_node = make_runtime_in_node();
+        bloom_node.__set_node_type(TExprNodeType::BLOOM_PRED);
+        bloom_node.__set_opcode(TExprOpcode::RT_FILTER);
+        auto bloom_impl = VBloomPredicate::create_shared(bloom_node);
+        bloom_impl->set_filter(std::move(bloom_filter));
+        bloom_impl->add_child(
+                VSlotRef::create_shared(0, 0, -1, make_nullable(type), "runtime_bloom_key"));
+        const auto bloom_conjunct =
+                wrap_runtime_filter(std::move(bloom_impl), bloom_node, filter_id++);
+        if (is_string_type(spec.primitive_type)) {
+            EXPECT_TRUE(bloom_conjunct->root()->can_execute_on_raw_binary_values(type, 0))
+                    << type->get_name();
+        } else {
+            EXPECT_TRUE(bloom_conjunct->root()->can_execute_on_raw_fixed_values(type, 0))
+                    << type->get_name();
+        }
     }
 }
 
@@ -808,6 +1062,24 @@ std::shared_ptr<arrow::Array> build_int64_array(const std::vector<int64_t>& valu
     return finish_array(&builder);
 }
 
+std::shared_ptr<arrow::Array> build_int8_array(const std::vector<int8_t>& values) {
+    arrow::Int8Builder builder;
+    for (const auto value : values) {
+        EXPECT_TRUE(builder.Append(value).ok());
+    }
+    return finish_array(&builder);
+}
+
+std::shared_ptr<arrow::Array> build_decimal128_array(const std::vector<int64_t>& scaled_values,
+                                                     int precision, int scale) {
+    arrow::Decimal128Builder builder(arrow::decimal128(precision, scale),
+                                     arrow::default_memory_pool());
+    for (const auto scaled_value : scaled_values) {
+        EXPECT_TRUE(builder.Append(arrow::Decimal128(scaled_value)).ok());
+    }
+    return finish_array(&builder);
+}
+
 std::shared_ptr<arrow::Array> build_uint32_array(const std::vector<uint32_t>& values) {
     arrow::UInt32Builder builder;
     for (const auto value : values) {
@@ -820,6 +1092,19 @@ std::shared_ptr<arrow::Array> build_string_array(const std::vector<std::string>&
     arrow::StringBuilder builder;
     for (const auto& value : values) {
         EXPECT_TRUE(builder.Append(value).ok());
+    }
+    return finish_array(&builder);
+}
+
+std::shared_ptr<arrow::Array> build_nullable_string_array(
+        const std::vector<std::optional<std::string>>& values) {
+    arrow::StringBuilder builder;
+    for (const auto& value : values) {
+        if (value.has_value()) {
+            EXPECT_TRUE(builder.Append(*value).ok());
+        } else {
+            EXPECT_TRUE(builder.AppendNull().ok());
+        }
     }
     return finish_array(&builder);
 }
@@ -939,6 +1224,23 @@ void write_int_pair_parquet_file(const std::string& file_path, int64_t row_group
     write_table(file_path, table, row_group_size, false, false, enable_statistics, encoding);
 }
 
+void write_tinyint_pair_parquet_file(const std::string& file_path) {
+    auto schema = arrow::schema({arrow::field("id", arrow::int8(), false),
+                                 arrow::field("score", arrow::int32(), false)});
+    auto table = arrow::Table::Make(schema, {build_int8_array({1, 2, 3, 4, 5, 6}),
+                                             build_int32_array({10, 20, 30, 40, 50, 60})});
+    write_table(file_path, table, 6, false, false, false);
+}
+
+void write_decimal_pair_parquet_file(const std::string& file_path) {
+    const auto decimal_type = arrow::decimal128(10, 2);
+    auto schema = arrow::schema({arrow::field("amount", decimal_type, false),
+                                 arrow::field("score", arrow::int32(), false)});
+    auto table = arrow::Table::Make(schema, {build_decimal128_array({100, 200, 300, 400}, 10, 2),
+                                             build_int32_array({10, 20, 30, 40})});
+    write_table(file_path, table, 4, false, false, false);
+}
+
 void write_dictionary_int_pair_parquet_file(const std::string& file_path) {
     auto schema = arrow::schema({
             arrow::field("id", arrow::int32(), false),
@@ -978,6 +1280,17 @@ void write_string_pair_parquet_file(const std::string& file_path) {
     auto table =
             arrow::Table::Make(schema, {build_string_array({"alpha", "bravo", "charlie", "delta"}),
                                         build_int32_array({10, 20, 30, 40})});
+    write_table(file_path, table, 4, false, false, false);
+}
+
+void write_nullable_string_pair_parquet_file(const std::string& file_path) {
+    auto schema = arrow::schema({
+            arrow::field("text", arrow::utf8(), true),
+            arrow::field("score", arrow::int32(), false),
+    });
+    auto table = arrow::Table::Make(
+            schema, {build_nullable_string_array({"alpha", std::nullopt, "charlie", std::nullopt}),
+                     build_int32_array({10, 20, 30, 40})});
     write_table(file_path, table, 4, false, false, false);
 }
 
@@ -2099,6 +2412,70 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainRuntimeFiltersUsePhysicalDirectPath) {
     EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectRows"), 6);
 }
 
+TEST_F(ParquetScanTest, PredicateOnlyTinyIntConversionUsesDecoderDirectPath) {
+    write_tinyint_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    ASSERT_EQ(remove_nullable(schema[0].type)->get_primitive_type(), TYPE_TINYINT);
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    request->conjuncts.push_back(create_tinyint_function_conjunct(0, "gt", TExprOpcode::GT, 2));
+    request->conjuncts.push_back(create_tinyint_runtime_in_conjunct(0, {3, 5, 6}, 19));
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 3);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {30, 50, 60}));
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyBinaryDecimalConversionUsesDecoderDirectPath) {
+    write_decimal_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    ASSERT_EQ(remove_nullable(schema[0].type)->get_primitive_type(), TYPE_DECIMAL64);
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    request->conjuncts.push_back(create_decimal64_function_conjunct(0, "gt", TExprOpcode::GT, 150));
+    request->conjuncts.push_back(create_decimal64_runtime_in_conjunct(0, {200, 400}, 20));
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 2);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {20, 40}));
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+}
+
 TEST_F(ParquetScanTest, PredicateOnlyPlainBloomRuntimeFilterUsesPhysicalDirectPath) {
     write_int_pair_parquet_file(_file_path, 6, false);
     RuntimeProfile profile("profile");
@@ -2156,8 +2533,9 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringBloomRuntimeFilterUsesDirectRead
     ASSERT_EQ(rows, 2);
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {20, 40}));
-    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
-    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectRows"), 4);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
     EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
     conjunct->close();
 }
@@ -2170,10 +2548,8 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringAllRuntimeFilterKindsUseDirectRe
         std::vector<int32_t> expected_scores;
     };
     const std::vector<TestCase> cases {
-            {FilterKind::IN, {20, 40}},
-            {FilterKind::BLOOM, {20, 40}},
-            {FilterKind::MIN, {20, 30, 40}},
-            {FilterKind::MAX, {10, 20, 30}},
+            {FilterKind::IN, {20, 40}},      {FilterKind::BLOOM, {20, 40}},
+            {FilterKind::MIN, {20, 30, 40}}, {FilterKind::MAX, {10, 20, 30}},
             {FilterKind::MINMAX, {20, 30}},
     };
 
@@ -2203,18 +2579,18 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringAllRuntimeFilterKindsUseDirectRe
                     create_string_runtime_bloom_conjunct(0, {"bravo", "delta"}, filter_id++));
             break;
         case FilterKind::MIN:
-            conjuncts.push_back(create_string_runtime_comparison_conjunct(
-                    0, "gt", TExprOpcode::GT, "alpha", filter_id++));
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(0, "gt", TExprOpcode::GT,
+                                                                          "alpha", filter_id++));
             break;
         case FilterKind::MAX:
-            conjuncts.push_back(create_string_runtime_comparison_conjunct(
-                    0, "lt", TExprOpcode::LT, "delta", filter_id++));
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(0, "lt", TExprOpcode::LT,
+                                                                          "delta", filter_id++));
             break;
         case FilterKind::MINMAX:
-            conjuncts.push_back(create_string_runtime_comparison_conjunct(
-                    0, "gt", TExprOpcode::GT, "alpha", filter_id++));
-            conjuncts.push_back(create_string_runtime_comparison_conjunct(
-                    0, "lt", TExprOpcode::LT, "delta", filter_id++));
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(0, "gt", TExprOpcode::GT,
+                                                                          "alpha", filter_id++));
+            conjuncts.push_back(create_string_runtime_comparison_conjunct(0, "lt", TExprOpcode::LT,
+                                                                          "delta", filter_id++));
             break;
         }
         for (const auto& conjunct : conjuncts) {
@@ -2231,18 +2607,120 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringAllRuntimeFilterKindsUseDirectRe
         bool eof = false;
         ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
         ASSERT_EQ(rows, test_case.expected_scores.size());
-        const auto& actual_scores =
-                int32_data_column(*block.get_by_position(1).column).get_data();
+        const auto& actual_scores = int32_data_column(*block.get_by_position(1).column).get_data();
         ASSERT_EQ(actual_scores.size(), test_case.expected_scores.size());
         for (size_t row = 0; row < actual_scores.size(); ++row) {
             EXPECT_EQ(actual_scores[row], test_case.expected_scores[row]);
         }
-        EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
-        EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectRows"), 4);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
+        EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
         EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
         for (const auto& conjunct : conjuncts) {
             conjunct->close();
         }
+    }
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyPlainStringComparisonUsesRawValueDirectPath) {
+    write_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    request->conjuncts.push_back(
+            create_string_function_conjunct(0, "gt", TExprOpcode::GT, "alpha"));
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 3);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {20, 30, 40}));
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyPlainStringInAndNotInUseRawValueDirectPath) {
+    for (const bool is_not_in : {false, true}) {
+        write_string_pair_parquet_file(_file_path);
+        RuntimeProfile profile("profile");
+        auto reader = create_reader(0, -1, &profile);
+        RuntimeState state {TQueryOptions(), TQueryGlobals()};
+        ASSERT_TRUE(reader->init(&state).ok());
+
+        std::vector<format::ColumnDefinition> schema;
+        ASSERT_TRUE(reader->get_schema(&schema).ok());
+        auto request = std::make_shared<format::FileScanRequest>();
+        format::FileScanRequestBuilder request_builder(request.get());
+        ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+        ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+        request->predicate_only_columns.push_back(format::LocalColumnId(0));
+        auto conjunct = create_string_in_conjunct(0, {"bravo", "delta"}, is_not_in);
+        ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+        ASSERT_TRUE(conjunct->open(&state).ok());
+        request->conjuncts.push_back(conjunct);
+        ASSERT_TRUE(reader->open(request).ok());
+
+        Block block = build_file_block(schema);
+        size_t rows = 0;
+        bool eof = false;
+        ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+        ASSERT_EQ(rows, 2);
+        const auto expected =
+                is_not_in ? ColumnInt32::Container {10, 30} : ColumnInt32::Container {20, 40};
+        EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(), expected);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
+        EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+        conjunct->close();
+    }
+}
+
+TEST_F(ParquetScanTest, PredicateOnlyPlainStringNullPredicatesUseDefinitionLevelDirectPath) {
+    for (const bool is_null : {true, false}) {
+        write_nullable_string_pair_parquet_file(_file_path);
+        RuntimeProfile profile("profile");
+        auto reader = create_reader(0, -1, &profile);
+        RuntimeState state {TQueryOptions(), TQueryGlobals()};
+        ASSERT_TRUE(reader->init(&state).ok());
+
+        std::vector<format::ColumnDefinition> schema;
+        ASSERT_TRUE(reader->get_schema(&schema).ok());
+        auto request = std::make_shared<format::FileScanRequest>();
+        format::FileScanRequestBuilder request_builder(request.get());
+        ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+        ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+        request->predicate_only_columns.push_back(format::LocalColumnId(0));
+        auto conjunct = create_string_null_conjunct(0, is_null);
+        ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+        ASSERT_TRUE(conjunct->open(&state).ok());
+        request->conjuncts.push_back(conjunct);
+        ASSERT_TRUE(reader->open(request).ok());
+
+        Block block = build_file_block(schema);
+        size_t rows = 0;
+        bool eof = false;
+        ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+        ASSERT_EQ(rows, 2);
+        const auto expected =
+                is_null ? ColumnInt32::Container {20, 40} : ColumnInt32::Container {10, 30};
+        EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(), expected);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
+        EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+        conjunct->close();
     }
 }
 
@@ -2702,7 +3180,7 @@ TEST_F(ParquetScanTest, PlainPredicateDirectPathCrossesScratchProbeCadence) {
     EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), ROWS);
 }
 
-TEST_F(ParquetScanTest, PredicateOnlyUint32FallsBackBeforeRawPlainDecode) {
+TEST_F(ParquetScanTest, PredicateOnlyUint32UsesConvertedDecoderDirectPath) {
     write_uint32_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -2730,7 +3208,12 @@ TEST_F(ParquetScanTest, PredicateOnlyUint32FallsBackBeforeRawPlainDecode) {
     ASSERT_EQ(rows, 2);
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {20, 30}));
-    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 0);
+    // The predicate must see widened unsigned BIGINT values, not the signed INT32 carrier, while
+    // still avoiding an intermediate logical column.
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
 }
 
 TEST_F(ParquetScanTest, FixedWidthPredicateReportsUnsupportedEncodingAfterProgress) {

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -3045,6 +3045,41 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringNullPredicatesUseDefinitionLevel
     }
 }
 
+TEST_F(ParquetScanTest, PredicateOnlyDictionaryIntNullPredicatesUseDefinitionLevels) {
+    for (const bool is_null : {true, false}) {
+        write_dictionary_int_pair_parquet_file(_file_path);
+        RuntimeProfile profile("profile");
+        auto reader = create_reader(0, -1, &profile);
+        RuntimeState state {TQueryOptions(), TQueryGlobals()};
+        ASSERT_TRUE(reader->init(&state).ok());
+
+        std::vector<format::ColumnDefinition> schema;
+        ASSERT_TRUE(reader->get_schema(&schema).ok());
+        auto request = std::make_shared<format::FileScanRequest>();
+        format::FileScanRequestBuilder request_builder(request.get());
+        ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+        ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+        request->predicate_only_columns.push_back(format::LocalColumnId(0));
+        auto conjunct = create_null_conjunct(0, schema[0].type, is_null);
+        ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+        ASSERT_TRUE(conjunct->open(&state).ok());
+        request->conjuncts.push_back(conjunct);
+        ASSERT_TRUE(reader->open(request).ok());
+
+        Block block = build_file_block(schema);
+        size_t rows = 0;
+        bool eof = false;
+        const auto status = reader->get_block(&block, &rows, &eof);
+        ASSERT_TRUE(status.ok()) << status;
+        ASSERT_EQ(rows, is_null ? 0 : 6);
+        if (!is_null) {
+            EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+                      (ColumnInt32::Container {10, 20, 30, 40, 50, 60}));
+        }
+        conjunct->close();
+    }
+}
+
 TEST_F(ParquetScanTest, DefinitionOnlyDatePredicatePreservesConversionSemantics) {
     for (const bool dictionary : {false, true}) {
         write_required_invalid_date_pair_parquet_file(_file_path, dictionary);

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -569,8 +570,8 @@ VExprContextSPtr create_string_in_conjunct(int column_id, const std::vector<std:
     return VExprContext::create_shared(std::move(root));
 }
 
-VExprContextSPtr create_string_null_conjunct(int column_id, bool is_null) {
-    const auto nullable_string_type = make_nullable(std::make_shared<DataTypeString>());
+VExprContextSPtr create_null_conjunct(int column_id, const DataTypePtr& data_type, bool is_null) {
+    const auto nullable_type = make_nullable(remove_nullable(data_type));
     const auto result_type = std::make_shared<DataTypeUInt8>();
     const std::string function_name = is_null ? "is_null_pred" : "is_not_null_pred";
     TFunctionName fn_name;
@@ -578,7 +579,7 @@ VExprContextSPtr create_string_null_conjunct(int column_id, bool is_null) {
     TFunction fn;
     fn.__set_name(fn_name);
     fn.__set_binary_type(TFunctionBinaryType::BUILTIN);
-    fn.__set_arg_types({nullable_string_type->to_thrift()});
+    fn.__set_arg_types({nullable_type->to_thrift()});
     fn.__set_ret_type(result_type->to_thrift());
     fn.__set_has_var_args(false);
     TExprNode node;
@@ -588,9 +589,12 @@ VExprContextSPtr create_string_null_conjunct(int column_id, bool is_null) {
     node.__set_num_children(1);
     node.__set_is_nullable(false);
     auto root = VectorizedFnCall::create_shared(node);
-    root->add_child(
-            VSlotRef::create_shared(column_id, column_id, -1, nullable_string_type, "plain_text"));
+    root->add_child(VSlotRef::create_shared(column_id, column_id, -1, nullable_type, "null_slot"));
     return VExprContext::create_shared(std::move(root));
+}
+
+VExprContextSPtr create_string_null_conjunct(int column_id, bool is_null) {
+    return create_null_conjunct(column_id, std::make_shared<DataTypeString>(), is_null);
 }
 
 VExprContextSPtr create_int32_mod_greater_than_conjunct(int column_id) {
@@ -895,7 +899,8 @@ struct PreparedTopNConjunct {
 };
 
 PreparedTopNConjunct create_topn_conjunct(RuntimeState* state, int column_id,
-                                          const DataTypePtr& data_type, const Field& bound) {
+                                          const DataTypePtr& data_type, const Field& bound,
+                                          bool publish_bound = true) {
     DORIS_CHECK(state != nullptr);
     DORIS_CHECK(data_type != nullptr);
     TExpr target_expr;
@@ -920,7 +925,9 @@ PreparedTopNConjunct create_topn_conjunct(RuntimeState* state, int column_id,
     auto& predicate = query_context->get_runtime_predicate(10);
     predicate.set_detected_source();
     DORIS_CHECK(predicate.init_target(20, {}, -1).ok());
-    DORIS_CHECK(predicate.update(bound).ok());
+    if (publish_bound) {
+        DORIS_CHECK(predicate.update(bound).ok());
+    }
 
     TExprNode topn_node;
     topn_node.__set_type(std::make_shared<DataTypeUInt8>()->to_thrift());
@@ -1008,6 +1015,23 @@ TEST(ParquetRuntimeFilterDirectReaderTest, CompoundPredicatesPreserveRawSelectio
                                 sizeof(int32_t), type, 0, matches.data())
                         .ok());
     EXPECT_EQ(matches, (IColumn::Filter {0, 0, 0, 1}));
+}
+
+TEST(ParquetRuntimeFilterDirectReaderTest, NullableCompoundNotUsesSemanticFallback) {
+    const auto child = create_int32_function_conjunct(0, "eq", TExprOpcode::EQ, 5);
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::COMPOUND_PRED);
+    node.__set_opcode(TExprOpcode::COMPOUND_NOT);
+    node.__set_type(make_nullable(std::make_shared<DataTypeUInt8>())->to_thrift());
+    node.__set_num_children(1);
+    node.__set_is_nullable(true);
+    auto predicate = VCompoundPred::create_shared(node);
+    predicate->add_child(child->root());
+
+    // Physical NULL rows never reach the raw child kernel, so negating its false placeholder would
+    // not be equivalent to the nullable expression's three-valued result.
+    EXPECT_FALSE(predicate->can_execute_on_raw_fixed_values(
+            make_nullable(std::make_shared<DataTypeInt32>()), 0));
 }
 
 TEST(ParquetRuntimeFilterDirectReaderTest, EveryRuntimeFilterScalarTypeIsEligible) {
@@ -1299,6 +1323,42 @@ void write_required_adjusted_time_parquet_file(const std::string& file_path) {
     writer->Close();
 }
 
+void write_required_invalid_date_pair_parquet_file(const std::string& file_path,
+                                                   bool enable_dictionary) {
+    auto file_result = arrow::io::FileOutputStream::Open(file_path);
+    ASSERT_TRUE(file_result.ok()) << file_result.status();
+    std::shared_ptr<arrow::io::FileOutputStream> out = *file_result;
+
+    const auto date = ::parquet::schema::PrimitiveNode::Make(
+            "event_date", ::parquet::Repetition::REQUIRED, ::parquet::LogicalType::Date(),
+            ::parquet::Type::INT32);
+    const auto score = ::parquet::schema::PrimitiveNode::Make(
+            "score", ::parquet::Repetition::REQUIRED, ::parquet::LogicalType::None(),
+            ::parquet::Type::INT32);
+    const auto schema_node = ::parquet::schema::GroupNode::Make(
+            "schema", ::parquet::Repetition::REQUIRED, {date, score});
+    const auto schema = std::static_pointer_cast<::parquet::schema::GroupNode>(schema_node);
+    ::parquet::WriterProperties::Builder properties;
+    if (enable_dictionary) {
+        properties.enable_dictionary();
+    } else {
+        properties.disable_dictionary();
+    }
+    properties.compression(::parquet::Compression::UNCOMPRESSED);
+    auto writer = ::parquet::ParquetFileWriter::Open(out, schema, properties.build());
+    auto* row_group = writer->AppendRowGroup();
+    auto* date_writer = static_cast<::parquet::Int32Writer*>(row_group->NextColumn());
+    const int32_t dates[] = {0, std::numeric_limits<int32_t>::min(), 1};
+    EXPECT_EQ(date_writer->WriteBatch(3, nullptr, nullptr, dates), 3);
+    date_writer->Close();
+    auto* score_writer = static_cast<::parquet::Int32Writer*>(row_group->NextColumn());
+    const int32_t scores[] = {10, 20, 30};
+    EXPECT_EQ(score_writer->WriteBatch(3, nullptr, nullptr, scores), 3);
+    score_writer->Close();
+    row_group->Close();
+    writer->Close();
+}
+
 void write_int_pair_parquet_file(const std::string& file_path, int64_t row_group_size = 2,
                                  bool enable_statistics = true,
                                  std::optional<::parquet::Encoding::type> encoding = std::nullopt) {
@@ -1370,6 +1430,23 @@ void write_string_pair_parquet_file(const std::string& file_path) {
     write_table(file_path, table, 4, false, false, false);
 }
 
+void write_multi_page_string_pair_parquet_file(const std::string& file_path) {
+    std::vector<std::string> values;
+    std::vector<int32_t> scores;
+    for (int32_t row = 0; row < 64; ++row) {
+        values.push_back("value_" + std::string(row < 10 ? "00" : "0") + std::to_string(row) +
+                         std::string(64, 'x'));
+        scores.push_back(row);
+    }
+    auto schema = arrow::schema({
+            arrow::field("text", arrow::utf8(), false),
+            arrow::field("score", arrow::int32(), false),
+    });
+    auto table =
+            arrow::Table::Make(schema, {build_string_array(values), build_int32_array(scores)});
+    write_table(file_path, table, 64, false, true, false);
+}
+
 void write_nullable_string_pair_parquet_file(const std::string& file_path) {
     auto schema = arrow::schema({
             arrow::field("text", arrow::utf8(), true),
@@ -1379,6 +1456,17 @@ void write_nullable_string_pair_parquet_file(const std::string& file_path) {
             schema, {build_nullable_string_array({"alpha", std::nullopt, "charlie", std::nullopt}),
                      build_int32_array({10, 20, 30, 40})});
     write_table(file_path, table, 4, false, false, false);
+}
+
+void write_nullable_dictionary_string_pair_parquet_file(const std::string& file_path) {
+    auto schema = arrow::schema({
+            arrow::field("text", arrow::utf8(), true),
+            arrow::field("score", arrow::int32(), false),
+    });
+    auto table = arrow::Table::Make(
+            schema, {build_nullable_string_array({"alpha", std::nullopt, "charlie", std::nullopt}),
+                     build_int32_array({10, 20, 30, 40})});
+    write_table(file_path, table, 4, true, false, false);
 }
 
 void write_int_triple_parquet_file(const std::string& file_path) {
@@ -1393,7 +1481,8 @@ void write_int_triple_parquet_file(const std::string& file_path) {
     write_table(file_path, table, 6, false, false, false);
 }
 
-void write_int_columns_parquet_file(const std::string& file_path, int column_count) {
+void write_int_columns_parquet_file(const std::string& file_path, int column_count,
+                                    bool enable_dictionary = false) {
     std::vector<std::shared_ptr<arrow::Field>> fields;
     std::vector<std::shared_ptr<arrow::Array>> columns;
     fields.reserve(column_count);
@@ -1403,7 +1492,7 @@ void write_int_columns_parquet_file(const std::string& file_path, int column_cou
         columns.push_back(build_int32_array({1, 2, 3, 4, 5, 6}));
     }
     write_table(file_path, arrow::Table::Make(arrow::schema(std::move(fields)), std::move(columns)),
-                6, false, false, false);
+                6, enable_dictionary, false, false);
 }
 
 void write_int_pair_and_string_parquet_file(const std::string& file_path) {
@@ -2812,6 +2901,77 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringComparisonUsesRawValueDirectPath
     EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
 }
 
+TEST_F(ParquetScanTest, ProjectedMultiPageStringComparisonUsesRawValueDirectPath) {
+    write_multi_page_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->conjuncts.push_back(create_string_function_conjunct(
+            0, "gt", TExprOpcode::GT, "value_031" + std::string(64, 'x')));
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 32);
+    const auto& strings = string_data_column(*block.get_by_position(0).column);
+    ASSERT_EQ(strings.size(), 32);
+    EXPECT_EQ(strings.get_data_at(0).to_string(), "value_032" + std::string(64, 'x'));
+    EXPECT_EQ(strings.get_data_at(31).to_string(), "value_063" + std::string(64, 'x'));
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data().front(), 32);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data().back(), 63);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 64);
+}
+
+TEST_F(ParquetScanTest, FragmentedMultiPageStringOrReusesRawMasks) {
+    write_multi_page_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto below = create_string_function_conjunct(0, "lt", TExprOpcode::LT,
+                                                 "value_005" + std::string(64, 'x'));
+    auto above = create_string_function_conjunct(0, "gt", TExprOpcode::GT,
+                                                 "value_060" + std::string(64, 'x'));
+    auto disjunction =
+            create_compound_conjunct(TExprOpcode::COMPOUND_OR, below->root(), above->root());
+    ASSERT_TRUE(disjunction->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(disjunction->open(&state).ok());
+
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->predicate_only_columns.push_back(format::LocalColumnId(0));
+    request->conjuncts.push_back(disjunction);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 8);
+    const auto& scores = int32_data_column(*block.get_by_position(1).column).get_data();
+    EXPECT_EQ(scores.front(), 0);
+    EXPECT_EQ(scores.back(), 63);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 64);
+    disjunction->close();
+}
+
 TEST_F(ParquetScanTest, PredicateOnlyPlainStringInAndNotInUseRawValueDirectPath) {
     for (const bool is_not_in : {false, true}) {
         write_string_pair_parquet_file(_file_path);
@@ -2877,10 +3037,56 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringNullPredicatesUseDefinitionLevel
         const auto expected =
                 is_null ? ColumnInt32::Container {20, 40} : ColumnInt32::Container {10, 30};
         EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(), expected);
-        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
-        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 0);
+        EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 0);
+        EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 0);
         EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
         conjunct->close();
+    }
+}
+
+TEST_F(ParquetScanTest, DefinitionOnlyDatePredicatePreservesConversionSemantics) {
+    for (const bool dictionary : {false, true}) {
+        write_required_invalid_date_pair_parquet_file(_file_path, dictionary);
+        for (const bool strict : {false, true}) {
+            SCOPED_TRACE(testing::Message()
+                         << "dictionary=" << dictionary << ", strict=" << strict);
+            RuntimeProfile profile("profile");
+            auto reader = create_reader(0, -1, &profile);
+            TQueryOptions options;
+            options.__set_enable_strict_cast(strict);
+            RuntimeState state {options, TQueryGlobals()};
+            ASSERT_TRUE(reader->init(&state).ok());
+
+            std::vector<format::ColumnDefinition> schema;
+            ASSERT_TRUE(reader->get_schema(&schema).ok());
+            auto request = std::make_shared<format::FileScanRequest>();
+            format::FileScanRequestBuilder request_builder(request.get());
+            ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+            ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+            request->predicate_only_columns.push_back(format::LocalColumnId(0));
+            auto conjunct = create_null_conjunct(0, schema[0].type, true);
+            ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+            ASSERT_TRUE(conjunct->open(&state).ok());
+            request->conjuncts.push_back(conjunct);
+            ASSERT_TRUE(reader->open(request).ok());
+
+            Block block = build_file_block(schema);
+            size_t rows = 0;
+            bool eof = false;
+            const auto status = reader->get_block(&block, &rows, &eof);
+            if (strict) {
+                EXPECT_TRUE(status.is<ErrorCode::DATA_QUALITY_ERROR>()) << status;
+            } else {
+                ASSERT_TRUE(status.ok()) << status;
+                ASSERT_EQ(rows, 1);
+                EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+                          (ColumnInt32::Container {20}));
+                EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 0);
+                EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 0);
+            }
+            conjunct->close();
+        }
     }
 }
 
@@ -2951,6 +3157,81 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryTopNUsesDictionaryIds) {
     EXPECT_EQ(counter_value(profile, "DictFilterCandidateColumns"), 1);
     EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
     EXPECT_EQ(counter_value(profile, "RowsFilteredByDictFilter"), 3);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
+    prepared.conjunct->close();
+}
+
+TEST_F(ParquetScanTest, WideRuntimeFilterSlotUsesSparseDictionaryPlaceholders) {
+    constexpr int COLUMN_COUNT = 128;
+    constexpr int FILTER_COLUMN = COLUMN_COUNT - 1;
+    write_int_columns_parquet_file(_file_path, COLUMN_COUNT, true);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    for (int column = 0; column < FILTER_COLUMN; ++column) {
+        ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(column)).ok());
+    }
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(FILTER_COLUMN)).ok());
+    auto conjunct = create_int32_runtime_in_conjunct(FILTER_COLUMN, {3, 5, 6}, 127);
+    conjunct->_prepared = false;
+    conjunct->_opened = false;
+    ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(conjunct->open(&state).ok());
+    request->conjuncts.push_back(conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 3);
+    EXPECT_EQ(int32_data_column(*block.get_by_position(0).column).get_data(),
+              (ColumnInt32::Container {3, 5, 6}));
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
+    conjunct->close();
+}
+
+TEST_F(ParquetScanTest, DictionaryTopNPreservesNullBeforeLateBound) {
+    write_nullable_dictionary_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    reader->set_batch_size(2);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    auto prepared =
+            create_topn_conjunct(&state, 0, schema[0].type,
+                                 Field::create_field<TYPE_STRING>(std::string("charlie")), false);
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    request->conjuncts.push_back(prepared.conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block first = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&first, &rows, &eof).ok());
+    ASSERT_EQ(rows, 2);
+    EXPECT_EQ(int32_data_column(*first.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {10, 20}));
+
+    auto& predicate = prepared.query_context->get_runtime_predicate(10);
+    ASSERT_TRUE(predicate.update(Field::create_field<TYPE_STRING>(std::string("charlie"))).ok());
+    Block second = build_file_block(schema);
+    ASSERT_TRUE(reader->get_block(&second, &rows, &eof).ok());
+    ASSERT_EQ(rows, 1);
+    EXPECT_EQ(int32_data_column(*second.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {30}));
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
     prepared.conjunct->close();
 }

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -394,6 +394,37 @@ private:
     const std::string _expr_name = "AlwaysTrueSingleColumnExpr";
 };
 
+class ReaderValuesStringGreaterExpr final : public VExpr {
+public:
+    ReaderValuesStringGreaterExpr(int column_id, std::string lower_bound)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _column_id(column_id),
+              _lower_bound(std::move(lower_bound)) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+
+    Status execute_column_impl(VExprContext*, const Block* block, const Selector*, size_t count,
+                               ColumnPtr& result_column) const override {
+        DORIS_CHECK(block != nullptr);
+        const auto& input = string_data_column(*block->get_by_position(_column_id).column);
+        auto result = ColumnUInt8::create(count, 0);
+        for (size_t row = 0; row < count; ++row) {
+            result->get_data()[row] = input.get_data_at(row).to_string_view() > _lower_bound;
+        }
+        result_column = std::move(result);
+        return Status::OK();
+    }
+
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_column_id);
+    }
+
+private:
+    int _column_id;
+    std::string _lower_bound;
+    const std::string _expr_name = "ReaderValuesStringGreaterExpr";
+};
+
 VExprContextSPtr create_int32_zonemap_conjunct(int column_id, Int32ZoneMapExpr::Op op,
                                                int32_t value) {
     return VExprContext::create_shared(std::make_shared<Int32ZoneMapExpr>(column_id, op, value));
@@ -844,6 +875,16 @@ VExprContextSPtr create_string_runtime_comparison_conjunct(int column_id,
     node.__set_type(std::make_shared<DataTypeUInt8>()->to_thrift());
     node.__set_is_nullable(false);
     return wrap_runtime_filter(impl_context->root(), node, filter_id);
+}
+
+VExprContextSPtr create_reader_values_string_runtime_conjunct(int column_id,
+                                                              const std::string& lower_bound,
+                                                              int filter_id) {
+    auto impl = std::make_shared<ReaderValuesStringGreaterExpr>(column_id, lower_bound);
+    impl->add_child(VSlotRef::create_shared(column_id, column_id, -1,
+                                            make_nullable(std::make_shared<DataTypeString>()),
+                                            "runtime_reader_value_key"));
+    return wrap_runtime_filter(std::move(impl), make_runtime_in_node(), filter_id);
 }
 
 template <PrimitiveType T>
@@ -2537,6 +2578,47 @@ TEST_F(ParquetScanTest, PredicateOnlyPlainStringBloomRuntimeFilterUsesDirectRead
     EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 4);
     EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
     EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+    conjunct->close();
+}
+
+TEST_F(ParquetScanTest, ProjectedTypedRuntimeFilterPreservesNullableOutputColumn) {
+    write_string_pair_parquet_file(_file_path);
+    RuntimeProfile profile("profile");
+    auto reader = create_reader(0, -1, &profile);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    ASSERT_TRUE(schema[0].type->is_nullable());
+    auto request = std::make_shared<format::FileScanRequest>();
+    format::FileScanRequestBuilder request_builder(request.get());
+    ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
+    ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
+    auto conjunct = create_reader_values_string_runtime_conjunct(0, "bravo", 16);
+    conjunct->_prepared = false;
+    conjunct->_opened = false;
+    ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(conjunct->open(&state).ok());
+    request->conjuncts.push_back(conjunct);
+    ASSERT_TRUE(reader->open(request).ok());
+
+    // Doris exposes the required Parquet field through a nullable scan slot, matching schema
+    // evolution readers that allow older files to omit the field.
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    ASSERT_TRUE(reader->get_block(&block, &rows, &eof).ok());
+    ASSERT_EQ(rows, 2);
+    ASSERT_TRUE(is_column_nullable(*block.get_by_position(0).column));
+    const auto& text = string_data_column(*block.get_by_position(0).column);
+    ASSERT_EQ(text.size(), 2);
+    EXPECT_EQ(text.get_data_at(0).to_string_view(), "charlie");
+    EXPECT_EQ(text.get_data_at(1).to_string_view(), "delta");
+    EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
+              (ColumnInt32::Container {30, 40}));
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
     conjunct->close();
 }
 

--- a/be/test/runtime/runtime_predicate_test.cpp
+++ b/be/test/runtime/runtime_predicate_test.cpp
@@ -209,6 +209,7 @@ TEST(RuntimePredicateTest, TopNPredicateKeepsDirectCapabilityBeforeFirstBound) {
     IColumn::Filter matches(values.size(), 1);
 
     ASSERT_TRUE(context->root()->can_execute_on_raw_fixed_values(type, 0));
+    EXPECT_TRUE(context->root()->raw_predicate_result_for_null());
     ASSERT_TRUE(context->root()
                         ->execute_on_raw_fixed_values(
                                 reinterpret_cast<const uint8_t*>(values.data()), values.size(),
@@ -218,6 +219,7 @@ TEST(RuntimePredicateTest, TopNPredicateKeepsDirectCapabilityBeforeFirstBound) {
 
     auto& predicate = state.get_query_ctx()->get_runtime_predicate(SOURCE_NODE_ID);
     ASSERT_TRUE(predicate.update(Field::create_field<TYPE_INT>(2)).ok());
+    EXPECT_FALSE(context->root()->raw_predicate_result_for_null());
     ASSERT_TRUE(context->root()
                         ->execute_on_raw_fixed_values(
                                 reinterpret_cast<const uint8_t*>(values.data()), values.size(),
@@ -292,13 +294,14 @@ TEST(RuntimePredicateTest, DescTopNPredicateFiltersRawValuesUsingCurrentBound) {
     context->close();
 }
 
-TEST(RuntimePredicateTest, NullableNullsFirstTopNUsesSemanticFallback) {
+TEST(RuntimePredicateTest, NullableNullsFirstTopNSupportsRawNullSemantics) {
     MockRuntimeState state;
     const auto type = make_nullable(std::make_shared<DataTypeInt32>());
     auto context =
             create_prepared_topn_expr(&state, type, Field::create_field<TYPE_INT>(3), true, true);
 
-    EXPECT_FALSE(context->root()->can_execute_on_raw_fixed_values(type, 0));
+    EXPECT_TRUE(context->root()->can_execute_on_raw_fixed_values(type, 0));
+    EXPECT_TRUE(context->root()->raw_predicate_result_for_null());
     EXPECT_FALSE(context->root()->can_evaluate_dictionary_filter());
     context->close();
 }

--- a/be/test/runtime/runtime_predicate_test.cpp
+++ b/be/test/runtime/runtime_predicate_test.cpp
@@ -19,10 +19,18 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include "core/data_type/data_type_factory.hpp"
+#include "core/data_type/data_type_number.h"
 #include "core/field.h"
 #include "exec/pipeline/thrift_builder.h"
+#include "exprs/expr_zonemap_filter.h"
+#include "exprs/vexpr_context.h"
+#include "exprs/vtopn_pred.h"
 #include "runtime/descriptors.h"
+#include "runtime/query_context.h"
+#include "testutil/mock/mock_runtime_state.h"
 
 namespace doris {
 namespace {
@@ -31,13 +39,15 @@ constexpr TPlanNodeId SOURCE_NODE_ID = 10;
 constexpr TPlanNodeId TARGET_NODE_ID = 20;
 constexpr SlotId SLOT_ID = 0;
 
-TTopnFilterDesc create_topn_filter_desc() {
+TTopnFilterDesc create_topn_filter_desc(PrimitiveType type = TYPE_INT, bool is_asc = true,
+                                        bool nulls_first = false) {
     auto target_expr = TRuntimeFilterDescBuilder::get_default_expr();
+    target_expr.nodes[0].__set_type(create_type_desc(type));
 
     TTopnFilterDesc desc;
     desc.__set_source_node_id(SOURCE_NODE_ID);
-    desc.__set_is_asc(true);
-    desc.__set_null_first(false);
+    desc.__set_is_asc(is_asc);
+    desc.__set_null_first(nulls_first);
     desc.__set_target_node_id_to_target_expr({{TARGET_NODE_ID, target_expr}});
     return desc;
 }
@@ -48,6 +58,31 @@ SlotDescriptor create_int_slot_descriptor() {
     slot_desc._col_name = "k1";
     slot_desc._type = DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_INT, false);
     return slot_desc;
+}
+
+VExprContextSPtr create_prepared_topn_expr(MockRuntimeState* state, const DataTypePtr& data_type,
+                                           const Field& top_value = Field(), bool is_asc = true,
+                                           bool nulls_first = false) {
+    DORIS_CHECK(state != nullptr);
+    DORIS_CHECK(data_type != nullptr);
+    auto desc = create_topn_filter_desc(data_type->get_primitive_type(), is_asc, nulls_first);
+    state->get_query_ctx()->init_runtime_predicates({desc});
+    auto& predicate = state->get_query_ctx()->get_runtime_predicate(SOURCE_NODE_ID);
+    predicate.set_detected_source();
+    DORIS_CHECK(predicate.init_target(TARGET_NODE_ID, {}, -1).ok());
+    if (!top_value.is_null()) {
+        DORIS_CHECK(predicate.update(top_value).ok());
+    }
+
+    TExprNode node;
+    node.__set_type(create_type_desc(PrimitiveType::TYPE_BOOLEAN));
+    node.__set_is_nullable(false);
+    auto expr = VTopNPred::create_shared(node, SOURCE_NODE_ID, nullptr);
+    expr->add_child(VSlotRef::create_shared(SLOT_ID, 0, -1, data_type, "topn_column"));
+    auto context = VExprContext::create_shared(std::move(expr));
+    DORIS_CHECK(context->prepare(state, RowDescriptor()).ok());
+    DORIS_CHECK(context->open(state).ok());
+    return context;
 }
 
 } // namespace
@@ -81,6 +116,191 @@ TEST(RuntimePredicateTest, init_target_without_column_predicate_still_enables_ru
     ASSERT_TRUE(predicate.update(top_value).ok());
     EXPECT_TRUE(predicate.has_value());
     EXPECT_EQ(top_value, predicate.get_value());
+}
+
+TEST(RuntimePredicateTest, TopNPredicateFiltersRawFixedValuesUsingCurrentBound) {
+    MockRuntimeState state;
+    const auto type = std::make_shared<DataTypeInt32>();
+    auto context = create_prepared_topn_expr(&state, type, Field::create_field<TYPE_INT>(3));
+    const std::array<int32_t, 4> values {1, 3, 4, 2};
+    IColumn::Filter matches(values.size(), 1);
+
+    ASSERT_TRUE(context->root()->can_execute_on_raw_fixed_values(type, 0));
+    ASSERT_TRUE(context->root()
+                        ->execute_on_raw_fixed_values(
+                                reinterpret_cast<const uint8_t*>(values.data()), values.size(),
+                                sizeof(int32_t), type, 0, matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {1, 1, 0, 1}));
+    context->close();
+}
+
+TEST(RuntimePredicateTest, TopNPredicateEvaluatesDictionaryValuesUsingCurrentBound) {
+    MockRuntimeState state;
+    const auto type = std::make_shared<DataTypeInt32>();
+    auto context = create_prepared_topn_expr(&state, type, Field::create_field<TYPE_INT>(3));
+    DictionaryEvalContext dictionary_ctx;
+    dictionary_ctx.slots.emplace(0, DictionaryEvalContext::SlotDictionary {
+                                            .data_type = type,
+                                            .values = {Field::create_field<TYPE_INT>(4),
+                                                       Field::create_field<TYPE_INT>(5)}});
+
+    ASSERT_TRUE(context->root()->can_evaluate_dictionary_filter());
+    EXPECT_EQ(context->root()->evaluate_dictionary_filter(dictionary_ctx),
+              ZoneMapFilterResult::kNoMatch);
+    dictionary_ctx.slots.at(0).values.push_back(Field::create_field<TYPE_INT>(2));
+    EXPECT_EQ(context->root()->evaluate_dictionary_filter(dictionary_ctx),
+              ZoneMapFilterResult::kMayMatch);
+    context->close();
+}
+
+TEST(RuntimePredicateTest, TopNPredicateFiltersRawBinaryValuesUsingCurrentBound) {
+    MockRuntimeState state;
+    const auto type = DataTypeFactory::instance().create_data_type(TYPE_STRING, false);
+    auto context =
+            create_prepared_topn_expr(&state, type, Field::create_field<TYPE_STRING>("middle"));
+    const std::array<StringRef, 3> values {StringRef("alpha"), StringRef("middle"),
+                                           StringRef("zulu")};
+    IColumn::Filter matches(values.size(), 1);
+
+    ASSERT_TRUE(context->root()->can_execute_on_raw_binary_values(type, 0));
+    ASSERT_TRUE(context->root()
+                        ->execute_on_raw_binary_values(values.data(), values.size(), type, 0,
+                                                       matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {1, 1, 0}));
+    context->close();
+}
+
+TEST(RuntimePredicateTest, TopNPredicateFiltersRawVarbinaryAndDictionaryValues) {
+    MockRuntimeState state;
+    const auto type = DataTypeFactory::instance().create_data_type(TYPE_VARBINARY, false);
+    auto context = create_prepared_topn_expr(
+            &state, type, Field::create_field<TYPE_VARBINARY>(StringView("middle")));
+    const std::array<StringRef, 3> values {StringRef("alpha"), StringRef("middle"),
+                                           StringRef("zulu")};
+    IColumn::Filter matches(values.size(), 1);
+
+    ASSERT_TRUE(context->root()
+                        ->execute_on_raw_binary_values(values.data(), values.size(), type, 0,
+                                                       matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {1, 1, 0}));
+
+    DictionaryEvalContext dictionary_ctx;
+    dictionary_ctx.slots.emplace(
+            0, DictionaryEvalContext::SlotDictionary {
+                       .data_type = type,
+                       .values = {Field::create_field<TYPE_VARBINARY>(StringView("zulu"))}});
+    EXPECT_EQ(context->root()->evaluate_dictionary_filter(dictionary_ctx),
+              ZoneMapFilterResult::kNoMatch);
+    dictionary_ctx.slots.at(0).values.push_back(
+            Field::create_field<TYPE_VARBINARY>(StringView("alpha")));
+    EXPECT_EQ(context->root()->evaluate_dictionary_filter(dictionary_ctx),
+              ZoneMapFilterResult::kMayMatch);
+    context->close();
+}
+
+TEST(RuntimePredicateTest, TopNPredicateKeepsDirectCapabilityBeforeFirstBound) {
+    MockRuntimeState state;
+    const auto type = std::make_shared<DataTypeInt32>();
+    auto context = create_prepared_topn_expr(&state, type);
+    const std::array<int32_t, 2> values {1, 4};
+    IColumn::Filter matches(values.size(), 1);
+
+    ASSERT_TRUE(context->root()->can_execute_on_raw_fixed_values(type, 0));
+    ASSERT_TRUE(context->root()
+                        ->execute_on_raw_fixed_values(
+                                reinterpret_cast<const uint8_t*>(values.data()), values.size(),
+                                sizeof(int32_t), type, 0, matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {1, 1}));
+
+    auto& predicate = state.get_query_ctx()->get_runtime_predicate(SOURCE_NODE_ID);
+    ASSERT_TRUE(predicate.update(Field::create_field<TYPE_INT>(2)).ok());
+    ASSERT_TRUE(context->root()
+                        ->execute_on_raw_fixed_values(
+                                reinterpret_cast<const uint8_t*>(values.data()), values.size(),
+                                sizeof(int32_t), type, 0, matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {1, 0}));
+    context->close();
+}
+
+TEST(RuntimePredicateTest, TopNPredicateAdvertisesDirectCapabilityForEverySupportedType) {
+    struct TypeSpec {
+        PrimitiveType type;
+        int precision = 0;
+        int scale = 0;
+        bool binary = false;
+    };
+    const std::array<TypeSpec, 23> supported_types {{
+            {TYPE_BOOLEAN},
+            {TYPE_TINYINT},
+            {TYPE_SMALLINT},
+            {TYPE_INT},
+            {TYPE_BIGINT},
+            {TYPE_LARGEINT},
+            {TYPE_DATE},
+            {TYPE_DATETIME},
+            {TYPE_DATEV2},
+            {TYPE_DATETIMEV2},
+            {TYPE_TIMESTAMPTZ},
+            {TYPE_TIMEV2},
+            {TYPE_DECIMAL32, 9, 2},
+            {TYPE_DECIMAL64, 18, 2},
+            {TYPE_DECIMALV2, 27, 9},
+            {TYPE_DECIMAL128I, 38, 2},
+            {TYPE_DECIMAL256, 76, 2},
+            {TYPE_IPV4},
+            {TYPE_IPV6},
+            {TYPE_CHAR, 0, 0, true},
+            {TYPE_STRING, 0, 0, true},
+            {TYPE_VARCHAR, 0, 0, true},
+            {TYPE_VARBINARY, 0, 0, true},
+    }};
+
+    for (const auto& spec : supported_types) {
+        SCOPED_TRACE(type_to_string(spec.type));
+        MockRuntimeState state;
+        const auto data_type = DataTypeFactory::instance().create_data_type(
+                spec.type, false, spec.precision, spec.scale);
+        auto context = create_prepared_topn_expr(&state, data_type);
+        if (spec.binary) {
+            EXPECT_TRUE(context->root()->can_execute_on_raw_binary_values(data_type, 0));
+        } else {
+            EXPECT_TRUE(context->root()->can_execute_on_raw_fixed_values(data_type, 0));
+        }
+        EXPECT_TRUE(context->root()->can_evaluate_dictionary_filter());
+        context->close();
+    }
+}
+
+TEST(RuntimePredicateTest, DescTopNPredicateFiltersRawValuesUsingCurrentBound) {
+    MockRuntimeState state;
+    const auto type = std::make_shared<DataTypeInt32>();
+    auto context = create_prepared_topn_expr(&state, type, Field::create_field<TYPE_INT>(3), false);
+    const std::array<int32_t, 3> values {1, 3, 4};
+    IColumn::Filter matches(values.size(), 1);
+
+    ASSERT_TRUE(context->root()
+                        ->execute_on_raw_fixed_values(
+                                reinterpret_cast<const uint8_t*>(values.data()), values.size(),
+                                sizeof(int32_t), type, 0, matches.data())
+                        .ok());
+    EXPECT_EQ(matches, (IColumn::Filter {0, 1, 1}));
+    context->close();
+}
+
+TEST(RuntimePredicateTest, NullableNullsFirstTopNUsesSemanticFallback) {
+    MockRuntimeState state;
+    const auto type = make_nullable(std::make_shared<DataTypeInt32>());
+    auto context =
+            create_prepared_topn_expr(&state, type, Field::create_field<TYPE_INT>(3), true, true);
+
+    EXPECT_FALSE(context->root()->can_execute_on_raw_fixed_values(type, 0));
+    EXPECT_FALSE(context->root()->can_evaluate_dictionary_filter());
+    context->close();
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #66032

Problem Summary:

After #66032, Parquet V2 still materialized predicate columns and evaluated expressions for dictionary values and most non-dictionary logical or binary values. This change evaluates eligible predicates while decoding and projects only surviving rows.

The reader now supports:

- Full-dictionary, non-null-aware runtime filters by evaluating dictionary entries once and filtering dictionary IDs.
- Non-dictionary physical-value direct filtering for identity fixed-width values and strings.
- Non-dictionary decoder-to-logical-POD direct filtering for date/time, decimal, wide integer, and converted fixed-width values, without building an IColumn.
- Binary comparisons, IN/NOT IN, all runtime-filter kinds, IS NULL/IS NOT NULL, eq_for_null, and composable AND/OR/NOT when every child is eligible for the same direct mode.

Runtime-filter kinds covered are IN, BLOOM, IN_OR_BLOOM, MIN, MAX, and MINMAX. Null-aware runtime filters, multi-column expressions, casts, UDFs, LIKE/REGEXP/MATCH, and nested types retain the typed fallback path.

Validation:

- 203 Parquet V2, native decoder, SerDe, and runtime-filter tests passed under ASAN UT.
- Runtime-filter coverage includes IN, Bloom, MIN, and MAX for every supported scalar runtime-filter type.
- Full Release BE build passed with 128-way C++ parallelism.
- Clang-format 16 dry-run, git diff --check, and per-commit git show --check passed.
- The branch is based on the merged #66032 commit on branch-4.1 and contains only the three commits from this PR.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
