### PR TITLE
[refactor](storage) extract MowKeyProbe and HistoricalRowFetcher 

### DIFF
--- a/be/src/storage/key/row_key_encoder.cpp
+++ b/be/src/storage/key/row_key_encoder.cpp
@@ -46,13 +46,22 @@ void RowKeyEncoder::_init_mow(const TabletSchema& schema) {
         _seq_col_length = column.length();
     }
 
+    // Which columns each view ends up holding:
+    //
+    //                     _sort_key_coders    _primary_key_coders
+    //   no cluster key    key columns         key columns
+    //   cluster keys      cluster key cols    key columns
+    //
+    // The primary key index is built on the schema key columns whatever the segment sorts by, so
+    // every mow table gets that view, not just the ones with cluster keys. The sort-key view
+    // follows the segment's own order, which is the only column set that differs between the two.
+    for (size_t cid = 0; cid < schema.num_key_columns(); ++cid) {
+        _primary_key_coders.push_back(get_key_coder(schema.column(cid).type()));
+    }
+
     if (schema.cluster_key_uids().empty()) {
         _add_default_sort_key_columns(schema);
         return;
-    }
-
-    for (size_t cid = 0; cid < schema.num_key_columns(); ++cid) {
-        _primary_key_coders.push_back(get_key_coder(schema.column(cid).type()));
     }
     _rowid_coder = get_key_coder(FieldType::OLAP_FIELD_TYPE_UNSIGNED_INT);
     for (auto uid : schema.cluster_key_uids()) {

--- a/be/src/storage/key/row_key_encoder.h
+++ b/be/src/storage/key/row_key_encoder.h
@@ -41,9 +41,9 @@ public:
     std::string full_encode(const std::vector<IOlapColumnDataAccessor*>& key_columns,
                             size_t pos) const;
 
-    // For a mow table with cluster keys, encode the primary key columns at
-    // `pos` with full length, producing the key stored in and probed against
-    // the primary key index.
+    // Encode the primary key columns at `pos` with full length, producing the key stored in and
+    // probed against the primary key index. Every mow table builds this view; a table with cluster
+    // keys is the case where it differs from full_encode(), which follows the segment's sort order.
     std::string full_encode_primary_keys(const std::vector<IOlapColumnDataAccessor*>& key_columns,
                                          size_t pos) const;
 
@@ -79,9 +79,9 @@ private:
     // full_encode() and encode_short_keys().
     std::vector<const KeyCoder*> _sort_key_coders;
     std::vector<uint16_t> _sort_key_index_size;
-    // The separate primary-key view used by mow tables with cluster keys. The
-    // segment sorts by cluster key columns while its primary key index remains
-    // based on the schema key columns.
+    // The primary-key view, built for every mow table. It coincides with the
+    // sort-key view unless the table has cluster keys, where the segment sorts
+    // by those while its primary key index stays on the schema key columns.
     std::vector<const KeyCoder*> _primary_key_coders;
     // Mow-only suffix coders for the primary key index.
     const KeyCoder* _seq_coder = nullptr;

--- a/be/src/storage/mow/historical_row_fetcher.cpp
+++ b/be/src/storage/mow/historical_row_fetcher.cpp
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/mow/historical_row_fetcher.h"
+
+#include "storage/rowset/rowset.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris {
+
+HistoricalRowFetcher::HistoricalRowFetcher(segment_v2::HistoricalRowRetrieverContext context)
+        : _context(std::move(context)),
+          _flexible_plan(_context.tablet_schema->has_row_store_for_all_columns()) {}
+
+void HistoricalRowFetcher::pin_rowset(const RowsetSharedPtr& rowset) {
+    _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
+}
+
+void HistoricalRowFetcher::plan_fixed_read(const RowLocation& loc, size_t dst_pos) {
+    _fixed_plan.prepare_to_read(loc, dst_pos);
+}
+
+void HistoricalRowFetcher::plan_flexible_read(const RowLocation& loc, size_t dst_pos,
+                                              const BitmapValue& skip_bitmap) {
+    _flexible_plan.prepare_to_read(loc, dst_pos, skip_bitmap);
+}
+
+Status HistoricalRowFetcher::fill_missing_columns(
+        const TabletSchema& tablet_schema, Block& full_block,
+        const std::vector<bool>& use_default_or_null_flag, bool has_default_or_nullable,
+        uint32_t segment_start_pos, const Block* block,
+        std::vector<signed char>* old_delete_signs) const {
+    return _fixed_plan.fill_missing_columns(_context, _rsid_to_rowset, tablet_schema, full_block,
+                                            use_default_or_null_flag, has_default_or_nullable,
+                                            segment_start_pos, block, old_delete_signs);
+}
+
+Status HistoricalRowFetcher::fill_old_delete_signs(
+        const Block& old_value_block, const std::map<uint32_t, uint32_t>& read_index,
+        size_t num_rows, std::vector<signed char>* old_delete_signs) const {
+    return _fixed_plan.fill_old_delete_signs(old_value_block, read_index, num_rows,
+                                             old_delete_signs);
+}
+
+Status HistoricalRowFetcher::fill_non_primary_key_columns(
+        const TabletSchema& tablet_schema, Block& full_block,
+        const std::vector<bool>& use_default_or_null_flag, bool has_default_or_nullable,
+        uint32_t segment_start_pos, uint32_t block_start_pos, const Block* block,
+        std::vector<BitmapValue>* skip_bitmaps) const {
+    return _flexible_plan.fill_non_primary_key_columns(
+            _context, _rsid_to_rowset, tablet_schema, full_block, use_default_or_null_flag,
+            has_default_or_nullable, segment_start_pos, block_start_pos, block, skip_bitmaps);
+}
+
+Status HistoricalRowFetcher::read_columns(const TabletSchema& tablet_schema,
+                                          std::vector<uint32_t> cids_to_read, Block& dst_block,
+                                          std::map<uint32_t, uint32_t>* read_index,
+                                          bool force_read_old_delete_signs,
+                                          const signed char* __restrict cur_delete_signs) const {
+    return _fixed_plan.read_columns_by_plan(tablet_schema, std::move(cids_to_read), _rsid_to_rowset,
+                                            dst_block, read_index, force_read_old_delete_signs,
+                                            cur_delete_signs);
+}
+
+} // namespace doris

--- a/be/src/storage/mow/historical_row_fetcher.h
+++ b/be/src/storage/mow/historical_row_fetcher.h
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "common/status.h"
+#include "storage/partial_update_info.h"
+#include "storage/rowset/rowset_fwd.h"
+#include "storage/segment/historical_row_retriever.h"
+
+namespace doris {
+class Block;
+class TabletSchema;
+
+// Reads old-row column values for merge-on-write loads. One instance for each block appended to a
+// segment writer; it owns the rowset pins and the read plans that the MowKeyProbe outcomes feed.
+class HistoricalRowFetcher {
+public:
+    // The per-method `tablet_schema` below is the schema of the block being filled; `context` also
+    // carries one, used only to decide up front whether the flexible plan reads the row store.
+    explicit HistoricalRowFetcher(segment_v2::HistoricalRowRetrieverContext context);
+
+    // Keep `rowset` alive until fill/read is done.
+    void pin_rowset(const RowsetSharedPtr& rowset);
+
+    // Plan building. `dst_pos` is where the old row lands: read_columns() only uses it as the key
+    // of *read_index, but both fill methods below index the block by it, so they require
+    // `segment_start_pos + i` for the i-th row of the block.
+    void plan_fixed_read(const RowLocation& loc, size_t dst_pos);
+    void plan_flexible_read(const RowLocation& loc, size_t dst_pos, const BitmapValue& skip_bitmap);
+
+    // Fixed partial update and the binlog AFTER image. Same behavior as
+    // FixedReadPlan::fill_missing_columns, including its default / null / auto-inc order and its
+    // handling of delete-signed old rows.
+    Status fill_missing_columns(const TabletSchema& tablet_schema, Block& full_block,
+                                const std::vector<bool>& use_default_or_null_flag,
+                                bool has_default_or_nullable, uint32_t segment_start_pos,
+                                const Block* block,
+                                std::vector<signed char>* old_delete_signs = nullptr) const;
+
+    // Collects the old rows' delete signs out of a block read by read_columns(), indexed by the
+    // caller's row position. Rows with no old row keep a zero sign.
+    Status fill_old_delete_signs(const Block& old_value_block,
+                                 const std::map<uint32_t, uint32_t>& read_index, size_t num_rows,
+                                 std::vector<signed char>* old_delete_signs) const;
+
+    // Flexible partial update. Same behavior as FlexibleReadPlan::fill_non_primary_key_columns,
+    // which fills per cell, driven by the skip bitmap.
+    Status fill_non_primary_key_columns(const TabletSchema& tablet_schema, Block& full_block,
+                                        const std::vector<bool>& use_default_or_null_flag,
+                                        bool has_default_or_nullable, uint32_t segment_start_pos,
+                                        uint32_t block_start_pos, const Block* block,
+                                        std::vector<BitmapValue>* skip_bitmaps) const;
+
+    // A raw read on the fixed plan: no fill steps at all. Used by the binlog BEFORE image, where
+    // rows missing from *read_index stay NULL.
+    Status read_columns(const TabletSchema& tablet_schema, std::vector<uint32_t> cids_to_read,
+                        Block& dst_block, std::map<uint32_t, uint32_t>* read_index,
+                        bool force_read_old_delete_signs,
+                        const signed char* __restrict cur_delete_signs = nullptr) const;
+
+    const std::map<RowsetId, RowsetSharedPtr>& pinned_rowsets() const { return _rsid_to_rowset; }
+
+    // True when no fixed read was planned, i.e. no row needs an old value.
+    bool empty() const { return _fixed_plan.empty(); }
+
+private:
+    // _context must stay declared before _flexible_plan, whose constructor argument reads
+    // _context.tablet_schema.
+    segment_v2::HistoricalRowRetrieverContext _context;
+    FixedReadPlan _fixed_plan;
+    FlexibleReadPlan _flexible_plan;
+    std::map<RowsetId, RowsetSharedPtr> _rsid_to_rowset;
+};
+
+} // namespace doris

--- a/be/src/storage/mow/key_probe.cpp
+++ b/be/src/storage/mow/key_probe.cpp
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/mow/key_probe.h"
+
+#include "common/cast_set.h"
+#include "common/config.h"
+#include "common/logging.h"
+#include "service/point_query_executor.h"
+#include "storage/key/row_key_encoder.h"
+#include "storage/partial_update_info.h"
+#include "storage/tablet/base_tablet.h"
+#include "storage/tablet/tablet_meta.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris::segment_v2 {
+
+using namespace ErrorCode;
+
+MowKeyProbe::MowKeyProbe(BaseTablet* tablet, TabletSchema* lookup_schema, bool has_sequence_col,
+                         std::shared_ptr<MowContext> mow_context, const RowsetId& writing_rowset_id,
+                         uint32_t writing_segment_id, Policy policy)
+        : _tablet(tablet),
+          _lookup_schema(lookup_schema),
+          _has_sequence_col(has_sequence_col),
+          _mow_context(std::move(mow_context)),
+          _writing_rowset_id(writing_rowset_id),
+          _writing_segment_id(writing_segment_id),
+          _policy(policy) {}
+
+Result<ProbeOutcome> MowKeyProbe::probe(
+        const std::string& key, size_t segment_pos, bool key_has_seq_suffix, bool have_delete_sign,
+        const std::vector<RowsetSharedPtr>& specified_rowsets,
+        std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
+        PartialUpdateStats& stats) const {
+    RowLocation loc;
+    // save rowset shared ptr so this rowset wouldn't delete
+    RowsetSharedPtr rowset;
+    auto st = _tablet->lookup_row_key(key, _lookup_schema, key_has_seq_suffix, specified_rowsets,
+                                      &loc, _mow_context->max_version, segment_caches, &rowset,
+                                      /*with_rowid=*/false);
+    if (st.is<KEY_NOT_FOUND>()) {
+        ++stats.num_rows_new_added;
+        return ProbeOutcome {KeyProbeResult::NOT_FOUND, {}, nullptr, /*use_default_or_null=*/true};
+    }
+    if (!st.ok() && !st.is<KEY_ALREADY_EXISTS>()) {
+        LOG(WARNING) << "failed to lookup row key, tablet_id=" << _tablet->tablet_id()
+                     << ", txn_id=" << _mow_context->txn_id << ", error: " << st;
+        return ResultError(std::move(st));
+    }
+
+    // Stored row's seq is larger, so the incoming row loses.
+    bool seq_loses = st.is<KEY_ALREADY_EXISTS>();
+    // A delete-signed row's value columns are never read back, so there is nothing to carry
+    // forward -- except when the table has a sequence column, whose value must still be read or the
+    // merge-on-read compaction policy produces wrong results.
+    // TODO(bobhan1): only read seq col rather than all columns in this situation for partial update
+    // and flexible partial update
+    bool delete_sign_skip =
+            have_delete_sign && !_has_sequence_col && _policy.use_defaults_for_delete_signed;
+    // Flexible PU insert-after-delete: an earlier row of this same load already deleted the old
+    // row, so the insert counts as a brand-new row. Its sequence value, if the input does not carry
+    // one, is filled by BlockAggregator::aggregate_for_insert_after_delete().
+    // Evaluated last so the two cheap rules above short-circuit the delete bitmap lookup.
+    auto in_load_deleted = [&] {
+        return _policy.use_defaults_for_in_load_deleted &&
+               _mow_context->delete_bitmap->contains(
+                       {loc.rowset_id, loc.segment_id, DeleteBitmap::TEMP_VERSION_COMMON},
+                       loc.row_id);
+    };
+    // Skip reading the old row (fill defaults) in any of these cases.
+    bool use_default = (seq_loses && _policy.use_defaults_for_seq_loser) || delete_sign_skip ||
+                       in_load_deleted();
+    ProbeOutcome outcome {seq_loses ? KeyProbeResult::FOUND_NEWER : KeyProbeResult::FOUND, loc,
+                          std::move(rowset), use_default};
+
+    // Apply the delete-bitmap marks right away -- see class comment (segcompaction).
+    if (seq_loses) {
+        if (_policy.mark_deleted == MarkDeleted::OLD_AND_LOSING_ROW) {
+            // although we need to mark delete current row, we still need to read missing columns
+            // for this row, we need to ensure that each column is aligned
+            _mow_context->delete_bitmap->add(
+                    {_writing_rowset_id, _writing_segment_id, DeleteBitmap::TEMP_VERSION_COMMON},
+                    cast_set<uint32_t>(segment_pos));
+            ++stats.num_rows_deleted;
+        }
+    } else if (_policy.mark_deleted != MarkDeleted::NONE) {
+        _mow_context->delete_bitmap->add(
+                {loc.rowset_id, loc.segment_id, DeleteBitmap::TEMP_VERSION_COMMON}, loc.row_id);
+        ++stats.num_rows_updated;
+    }
+    return outcome;
+}
+
+Result<PrevSeqProbe> MowKeyProbe::probe_previous_seq_value(
+        const std::string& key, const std::vector<RowsetSharedPtr>& specified_rowsets,
+        std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches) const {
+    RowLocation loc;
+    RowsetSharedPtr rowset;
+    PrevSeqProbe result;
+    // Unlike probe() above, this lookup keeps with_rowid: its callers encode the key from the
+    // sort-key view, which for a cluster-key table carries the trailing rowid that has to be
+    // stripped again. Such a table can not reach this path today -- partial update on a cluster-key
+    // table is rejected up front -- but the encoding, not the probe, decides the flag.
+    auto st =
+            _tablet->lookup_row_key(key, _lookup_schema, /*with_seq_col=*/false, specified_rowsets,
+                                    &loc, _mow_context->max_version, segment_caches, &rowset,
+                                    /*with_rowid=*/true, &result.encoded_seq_value);
+    if (st.is<KEY_NOT_FOUND>()) {
+        // lookup_row_key writes the sequence value before it checks the delete bitmap, so a key
+        // whose only row is already marked deleted lands here with that row's value attached.
+        result.encoded_seq_value.clear();
+        result.outcome = ProbeOutcome {KeyProbeResult::NOT_FOUND,
+                                       {},
+                                       nullptr,
+                                       /*use_default_or_null=*/true};
+        return result;
+    }
+    if (!st.ok()) {
+        return ResultError(std::move(st));
+    }
+    result.outcome.result = KeyProbeResult::FOUND;
+    result.outcome.loc = loc;
+    result.outcome.rowset = std::move(rowset);
+    result.outcome.use_default_or_null = false;
+    return result;
+}
+
+void MowKeyProbe::maybe_invalidate_row_cache(int64_t tablet_id, const TabletSchema& schema,
+                                             DataWriteType write_type, const std::string& key) {
+    // Just invalid row cache for simplicity, since the rowset is not visible at present. If we
+    // update/insert cache, if load failed rowset will not be visible but cached data will be
+    // visible, and lead to inconsistency.
+    if (!config::disable_storage_row_cache && schema.has_row_store_for_all_columns() &&
+        write_type == DataWriteType::TYPE_DIRECT) {
+        // invalidate cache
+        RowCache::instance()->erase({tablet_id, key});
+    }
+}
+
+std::string encode_mow_key_invalidate_cache(
+        const RowKeyEncoder& key_encoder, const std::vector<IOlapColumnDataAccessor*>& key_columns,
+        const IOlapColumnDataAccessor* seq_column, size_t pos, bool row_has_seq, int64_t tablet_id,
+        const TabletSchema& schema, DataWriteType write_type) {
+    std::string key = key_encoder.full_encode_primary_keys(key_columns, pos);
+    // the row cache uses the key without the seq as its key, so invalidate before the suffix
+    MowKeyProbe::maybe_invalidate_row_cache(tablet_id, schema, write_type, key);
+    if (row_has_seq) {
+        key_encoder.append_seq_suffix(&key, seq_column, pos);
+    }
+    return key;
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/mow/key_probe.h
+++ b/be/src/storage/mow/key_probe.h
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset_fwd.h"
+#include "storage/utils.h"
+
+namespace doris {
+class BaseTablet;
+class IOlapColumnDataAccessor;
+class RowKeyEncoder;
+class TabletSchema;
+class SegmentCacheHandle;
+struct MowContext;
+struct PartialUpdateStats;
+
+namespace segment_v2 {
+
+// Result of looking up one primary key in a merge-on-write load.
+enum class KeyProbeResult : uint8_t {
+    // Key absent: brand-new row.
+    NOT_FOUND = 0,
+    // Key exists; the incoming row replaces the old one.
+    FOUND = 1,
+    // Stored row has a larger sequence value, so the incoming row loses.
+    FOUND_NEWER = 2,
+};
+
+struct ProbeOutcome {
+    KeyProbeResult result {KeyProbeResult::NOT_FOUND};
+    // Only meaningful when result != NOT_FOUND; a miss leaves it default-constructed.
+    RowLocation loc;
+    // Keeps the rowset holding `loc` alive while the caller reads old-row columns.
+    RowsetSharedPtr rowset;
+    // true  -> cells not given in the input take their default/null value
+    // false -> the old row at `loc` must be read into the fill plan
+    bool use_default_or_null {true};
+};
+
+// The old row plus its encoded sequence value, returned by probe_previous_seq_value. The sequence
+// value is empty unless outcome.result is FOUND.
+struct PrevSeqProbe {
+    ProbeOutcome outcome;
+    std::string encoded_seq_value;
+};
+
+// IMPORTANT: probe() applies delete-bitmap marks right away (not batched), using
+// TEMP_VERSION_COMMON. Segcompaction and the pre-commit checks read these TEMP marks mid-load, so
+// delaying them would lose deletes.
+class MowKeyProbe {
+public:
+    // Which rows this probe marks deleted in mow_context->delete_bitmap.
+    enum class MarkDeleted : uint8_t {
+        // Pure lookup: marking is somebody else's job (the row binlog history read).
+        NONE = 0,
+        // Mark the old row, i.e. the row already in the table that the incoming row replaces. On a
+        // sequence loss nothing is marked at all: the caller of this mode drops the losing row
+        // itself instead of writing it into the segment.
+        OLD_ROW = 1,
+        // Mark the old row, and the incoming row too when it loses on sequence: the writer has
+        // already written that row into the segment, so it cannot just be dropped.
+        OLD_AND_LOSING_ROW = 2,
+    };
+
+    // The use_defaults_* flags list the situations in which the probe sets
+    // ProbeOutcome::use_default_or_null instead of asking for the old row's values.
+    struct Policy {
+        MarkDeleted mark_deleted {MarkDeleted::OLD_AND_LOSING_ROW};
+        // Only without a sequence column: that one must survive for merge-on-read compaction.
+        bool use_defaults_for_delete_signed {true};
+        // A row that loses on sequence does not take effect, so nothing fills it.
+        bool use_defaults_for_seq_loser {true};
+        // Flexible partial update: the old row was already deleted earlier in this same load, so
+        // the incoming row is brand new.
+        bool use_defaults_for_in_load_deleted {false};
+    };
+
+    // lookup_schema goes to BaseTablet::lookup_row_key; has_sequence_col comes from the input's
+    // schema and drives use_defaults_for_delete_signed; writing_rowset_id/writing_segment_id
+    // identify the segment being written, used only to mark a sequence loser.
+    MowKeyProbe(BaseTablet* tablet, TabletSchema* lookup_schema, bool has_sequence_col,
+                std::shared_ptr<MowContext> mow_context, const RowsetId& writing_rowset_id,
+                uint32_t writing_segment_id, Policy policy);
+
+    // The partial update fill paths: mark the old row, or the incoming row when it loses on
+    // sequence, and read the old row's values for the columns the input does not carry. Two cases
+    // take defaults instead: a losing row (it never takes effect) and a delete-signed row without a
+    // sequence column (its values are never read back). `flexible` adds the insert-after-delete
+    // rule.
+    static MowKeyProbe for_partial_update(BaseTablet* tablet, TabletSchema* lookup_schema,
+                                          bool has_sequence_col,
+                                          std::shared_ptr<MowContext> mow_context,
+                                          const RowsetId& writing_rowset_id,
+                                          uint32_t writing_segment_id, bool flexible) {
+        return MowKeyProbe {tablet,
+                            lookup_schema,
+                            has_sequence_col,
+                            std::move(mow_context),
+                            writing_rowset_id,
+                            writing_segment_id,
+                            Policy {
+                                    .mark_deleted = MarkDeleted::OLD_AND_LOSING_ROW,
+                                    .use_defaults_for_delete_signed = true,
+                                    .use_defaults_for_seq_loser = true,
+                                    .use_defaults_for_in_load_deleted = flexible,
+                            }};
+    }
+
+    // The row binlog history lookup: marks nothing, and keeps the old values of a sequence loser,
+    // and of a delete-signed row when a __BEFORE__* image is wanted.
+    static MowKeyProbe for_row_binlog(BaseTablet* tablet, TabletSchema* lookup_schema,
+                                      bool has_sequence_col,
+                                      std::shared_ptr<MowContext> mow_context, bool write_before) {
+        return MowKeyProbe {tablet,
+                            lookup_schema,
+                            has_sequence_col,
+                            std::move(mow_context),
+                            RowsetId {},
+                            0,
+                            Policy {
+                                    .mark_deleted = MarkDeleted::NONE,
+                                    .use_defaults_for_delete_signed = !write_before,
+                                    .use_defaults_for_seq_loser = false,
+                                    .use_defaults_for_in_load_deleted = false,
+                            }};
+    }
+
+    // Probe one row. `key` is the full encoded key (with seq suffix when key_has_seq_suffix).
+    // `segment_pos` is the row's position in the segment being written (self-mark only). `stats`
+    // counts new/updated/deleted rows, except under MarkDeleted::NONE which counts nothing; a
+    // caller that doesn't track partial-update counts passes a throwaway.
+    //
+    // On NOT_FOUND it bumps stats.num_rows_new_added, but PartialUpdateInfo::handle_new_key() needs
+    // caller-side state, so the partial update callers still run it themselves.
+    Result<ProbeOutcome> probe(const std::string& key, size_t segment_pos, bool key_has_seq_suffix,
+                               bool have_delete_sign,
+                               const std::vector<RowsetSharedPtr>& specified_rowsets,
+                               std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
+                               PartialUpdateStats& stats) const;
+
+    // Lookup without the seq suffix; returns the old row plus its encoded sequence value
+    // (BlockAggregator). Never touches the delete bitmap, and ignores the policy entirely.
+    Result<PrevSeqProbe> probe_previous_seq_value(
+            const std::string& key, const std::vector<RowsetSharedPtr>& specified_rowsets,
+            std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches) const;
+
+    // Erase the row-cache entry. Erase-only: the rowset isn't visible yet, so inserting could
+    // expose uncommitted data if the load fails.
+    static void maybe_invalidate_row_cache(int64_t tablet_id, const TabletSchema& schema,
+                                           DataWriteType write_type, const std::string& key);
+
+private:
+    BaseTablet* _tablet = nullptr;
+    TabletSchema* _lookup_schema = nullptr;
+    bool _has_sequence_col = false;
+    std::shared_ptr<MowContext> _mow_context;
+    RowsetId _writing_rowset_id;
+    uint32_t _writing_segment_id = 0;
+    Policy _policy;
+};
+
+std::string encode_mow_key_invalidate_cache(
+        const RowKeyEncoder& key_encoder, const std::vector<IOlapColumnDataAccessor*>& key_columns,
+        const IOlapColumnDataAccessor* seq_column, size_t pos, bool row_has_seq, int64_t tablet_id,
+        const TabletSchema& schema, DataWriteType write_type);
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/src/storage/segment/historical_row_retriever.cpp
+++ b/be/src/storage/segment/historical_row_retriever.cpp
@@ -31,11 +31,12 @@
 #include "core/data_type/data_type.h"
 #include "core/string_ref.h"
 #include "runtime/exec_env.h"
-#include "service/point_query_executor.h"
 #include "storage/binlog.h"
 #include "storage/data_dir.h"
 #include "storage/iterator/olap_data_convertor.h"
-#include "storage/key_coder.h"
+#include "storage/key/row_key_encoder.h"
+#include "storage/mow/historical_row_fetcher.h"
+#include "storage/mow/key_probe.h"
 #include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_reader_context.h"
@@ -68,22 +69,29 @@ void insert_value_to_nullable_column(IColumn* dst_column, const IColumn& src_col
 Status PrimaryKeyModelRowRetriever::init(const HistoricalRowRetrieverContext& context) {
     _context = context;
     _key_columns.resize(_context.tablet_schema->num_key_columns());
-    auto& tablet_schema = _context.tablet_schema;
-    for (size_t cid = 0; cid < tablet_schema->num_key_columns(); ++cid) {
-        const auto& column = tablet_schema->column(cid);
-        _key_coders.push_back(get_key_coder(column.type()));
-    }
-    // encode the sequence id into the primary key index
-    if (tablet_schema->has_sequence_col()) {
-        const auto& column = tablet_schema->column(tablet_schema->sequence_col_idx());
-        _seq_coder = const_cast<KeyCoder*>(get_key_coder(column.type()));
-    }
+    _key_encoder = std::make_unique<RowKeyEncoder>(*_context.tablet_schema, /*mow=*/true);
+    _row_fetcher = std::make_unique<HistoricalRowFetcher>(_context);
     return Status::OK();
+}
+
+PrimaryKeyModelRowRetriever::PrimaryKeyModelRowRetriever() = default;
+
+PrimaryKeyModelRowRetriever::~PrimaryKeyModelRowRetriever() = default;
+
+void PrimaryKeyModelRowRetriever::clear() {
+    _key_columns.clear();
+    _seq_column = nullptr;
+    _use_default_or_null_flag.clear();
+    _has_default_or_nullable = false;
+    _operators.clear();
+    _old_delete_signs.clear();
+    // drops the previous block's rowset pins and read plan
+    DCHECK(_context.tablet_schema != nullptr) << "clear() before init()";
+    _row_fetcher = std::make_unique<HistoricalRowFetcher>(_context);
 }
 
 Status PrimaryKeyModelRowRetriever::retrieve_historical_row(const Int8* delete_sign_column_data,
                                                             size_t row_pos, size_t num_rows) {
-    auto* tablet = static_cast<Tablet*>(_context.tablet.get());
     auto& tablet_schema = _context.tablet_schema;
 
     std::vector<RowsetSharedPtr> specified_rowsets;
@@ -93,60 +101,51 @@ Status PrimaryKeyModelRowRetriever::retrieve_historical_row(const Int8* delete_s
     }
     std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
 
+    CHECK(_context.rowset_writer_ctx != nullptr);
+    bool write_before =
+            _context.rowset_writer_ctx->write_binlog_opt().write_binlog_config().write_before;
+    // The lookup uses the tablet's latest schema, the delete-sign rule the source schema. Hold the
+    // shared pointer: tablet_schema() hands out a copy and the probe only borrows it.
+    TabletSchemaSPtr lookup_schema = _context.tablet->tablet_schema();
+    MowKeyProbe probe = MowKeyProbe::for_row_binlog(_context.tablet.get(), lookup_schema.get(),
+                                                    tablet_schema->has_sequence_col(), _mow_context,
+                                                    write_before);
+    // the binlog retriever reports no partial update counters
+    PartialUpdateStats discarded_stats;
+
     for (size_t block_pos = row_pos; block_pos < row_pos + num_rows; block_pos++) {
         // After converting to olap column, [0, num_rows) in the result column is corresponding to
         // [row_pos, row_pos + num_rows) in the original block
         size_t delta_pos = block_pos - row_pos;
-        std::string key = _full_encode_keys(_key_columns, delta_pos);
-
-        _maybe_invalid_row_cache(key);
-        if (_seq_column != nullptr) {
-            _encode_seq_column(_seq_column, delta_pos, &key);
-        }
+        std::string key = encode_mow_key_invalidate_cache(
+                *_key_encoder, _key_columns, _seq_column, delta_pos, _seq_column != nullptr,
+                _context.tablet->tablet_id(), *tablet_schema, _context.write_type);
 
         // mark key with delete sign as deleted.
         bool have_delete_sign =
                 (delete_sign_column_data != nullptr && delete_sign_column_data[block_pos] != 0);
 
-        RowLocation loc;
-        // save rowset shared ptr so this rowset wouldn't delete
-        RowsetSharedPtr rowset;
-        auto st = tablet->lookup_row_key(key, tablet->tablet_schema().get(), _seq_column != nullptr,
-                                         specified_rowsets, &loc, _mow_context->max_version,
-                                         segment_caches, &rowset);
-        if (st.is<KEY_NOT_FOUND>()) {
+        ProbeOutcome outcome = DORIS_TRY(probe.probe(key, /*segment_pos=*/0, _seq_column != nullptr,
+                                                     have_delete_sign, specified_rowsets,
+                                                     segment_caches, discarded_stats));
+        if (outcome.result == KeyProbeResult::NOT_FOUND) {
             // it's an insert row
             _has_default_or_nullable = true;
             _use_default_or_null_flag.emplace_back(true);
             _operators.emplace_back(have_delete_sign ? ROW_BINLOG_DELETE : ROW_BINLOG_APPEND);
             continue;
         }
-        if (!st.ok() && !st.is<KEY_ALREADY_EXISTS>()) {
-            LOG(WARNING) << "failed to lookup row key, error: " << st;
-            return st;
-        }
-
-        CHECK(_context.rowset_writer_ctx != nullptr);
-        bool write_before =
-                _context.rowset_writer_ctx->write_binlog_opt().write_binlog_config().write_before;
-        // 1. if the delete sign is marked, it means that the value columns of the row will not
-        //    be read. So we don't need to read the missing values from the previous rows.
-        // 2. the one exception is when there are sequence columns in the table, we need to read
-        //    the sequence columns, otherwise it may cause the merge-on-read based compaction
-        //    policy to produce incorrect results.
-        // 3. if row binlog needs BEFORE image, delete rows must still read historical values so
-        //    __BEFORE__* columns can be populated.
-        if (have_delete_sign && !tablet_schema->has_sequence_col() && !write_before) {
+        if (outcome.use_default_or_null) {
             _has_default_or_nullable = true;
             _use_default_or_null_flag.emplace_back(true);
             _operators.emplace_back(ROW_BINLOG_DELETE);
         } else {
             // partial update should not contain invisible columns
             _use_default_or_null_flag.emplace_back(false);
-            _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
+            _row_fetcher->pin_rowset(outcome.rowset);
             // currently we think row_pos must be zero, so we won't consider row_pos > 0
             DCHECK(row_pos == 0);
-            _rssid_to_rid.prepare_to_read(loc, delta_pos);
+            _row_fetcher->plan_fixed_read(outcome.loc, delta_pos);
             _operators.emplace_back(have_delete_sign ? ROW_BINLOG_DELETE : ROW_BINLOG_UPDATE);
         }
     }
@@ -165,9 +164,9 @@ Status PrimaryKeyModelRowRetriever::build_after_block(Block* block, size_t row_p
     if (_context.partial_update_info == nullptr) {
         return Status::InternalError("partial update info is null");
     }
-    return _rssid_to_rid.fill_missing_columns(
-            _context, _rsid_to_rowset, *_context.tablet_schema, *block, _use_default_or_null_flag,
-            _has_default_or_nullable, cast_set<uint32_t>(row_pos), block, &_old_delete_signs);
+    return _row_fetcher->fill_missing_columns(
+            *_context.tablet_schema, *block, _use_default_or_null_flag, _has_default_or_nullable,
+            cast_set<uint32_t>(row_pos), block, &_old_delete_signs);
 }
 
 Status PrimaryKeyModelRowRetriever::build_before_block(Block* before_block,
@@ -190,9 +189,8 @@ Status PrimaryKeyModelRowRetriever::build_before_block(Block* before_block,
 
     // key: logical row index in current batch; value: index in old_value_block
     std::map<uint32_t, uint32_t> read_index;
-    RETURN_IF_ERROR(_rssid_to_rid.read_columns_by_plan(*tablet_schema, value_cids, _rsid_to_rowset,
-                                                       old_value_block, &read_index, true,
-                                                       nullptr));
+    RETURN_IF_ERROR(_row_fetcher->read_columns(*tablet_schema, value_cids, old_value_block,
+                                               &read_index, /*force_read_old_delete_signs=*/true));
     RETURN_IF_ERROR(_fill_old_delete_signs(old_value_block, read_index, num_rows));
 
     {
@@ -223,7 +221,7 @@ Status PrimaryKeyModelRowRetriever::build_before_block(Block* before_block,
 }
 
 Status PrimaryKeyModelRowRetriever::revise_operators_by_old_delete_sign(size_t num_rows) {
-    if (_operators.empty() || _rssid_to_rid.empty()) {
+    if (_operators.empty() || _row_fetcher->empty()) {
         return Status::OK();
     }
     DCHECK_EQ(_operators.size(), num_rows);
@@ -232,9 +230,10 @@ Status PrimaryKeyModelRowRetriever::revise_operators_by_old_delete_sign(size_t n
         // If no BEFORE/missing column was read, read only old delete signs here.
         Block old_delete_sign_block;
         std::map<uint32_t, uint32_t> read_index;
-        RETURN_IF_ERROR(_rssid_to_rid.read_columns_by_plan(
-                *_context.tablet_schema, std::vector<uint32_t> {}, _rsid_to_rowset,
-                old_delete_sign_block, &read_index, true, nullptr));
+        RETURN_IF_ERROR(_row_fetcher->read_columns(*_context.tablet_schema,
+                                                   std::vector<uint32_t> {}, old_delete_sign_block,
+                                                   &read_index,
+                                                   /*force_read_old_delete_signs=*/true));
         RETURN_IF_ERROR(_fill_old_delete_signs(old_delete_sign_block, read_index, num_rows));
     }
     DCHECK_EQ(_old_delete_signs.size(), num_rows);
@@ -250,67 +249,8 @@ Status PrimaryKeyModelRowRetriever::revise_operators_by_old_delete_sign(size_t n
 Status PrimaryKeyModelRowRetriever::_fill_old_delete_signs(
         const Block& old_value_block, const std::map<uint32_t, uint32_t>& read_index,
         size_t num_rows) {
-    return _rssid_to_rid.fill_old_delete_signs(old_value_block, read_index, num_rows,
+    return _row_fetcher->fill_old_delete_signs(old_value_block, read_index, num_rows,
                                                &_old_delete_signs);
 }
 
-std::string PrimaryKeyModelRowRetriever::_full_encode_keys(
-        const std::vector<IOlapColumnDataAccessor*>& key_columns, size_t pos, bool null_first) {
-    return _full_encode_keys(_key_coders, key_columns, pos, null_first);
-}
-
-std::string PrimaryKeyModelRowRetriever::_full_encode_keys(
-        const std::vector<const KeyCoder*>& key_coders,
-        const std::vector<IOlapColumnDataAccessor*>& key_columns, size_t pos, bool null_first) {
-    assert(key_columns.size() == key_coders.size());
-
-    std::string encoded_keys;
-    size_t cid = 0;
-    for (const auto& column : key_columns) {
-        auto field = column->get_data_at(pos);
-        if (UNLIKELY(!field)) {
-            if (null_first) {
-                encoded_keys.push_back(KeyConsts::KEY_NULL_FIRST_MARKER);
-            } else {
-                encoded_keys.push_back(KeyConsts::KEY_NORMAL_MARKER);
-            }
-            ++cid;
-            continue;
-        }
-        encoded_keys.push_back(KeyConsts::KEY_NORMAL_MARKER);
-        DCHECK(key_coders[cid] != nullptr);
-        key_coders[cid]->full_encode_ascending(field, &encoded_keys);
-        ++cid;
-    }
-    return encoded_keys;
-}
-
-void PrimaryKeyModelRowRetriever::_encode_seq_column(const IOlapColumnDataAccessor* seq_column,
-                                                     size_t pos, std::string* encoded_keys) {
-    auto field = seq_column->get_data_at(pos);
-    // To facilitate the use of the primary key index, encode the seq column
-    // to the minimum value of the corresponding length when the seq column
-    // is null
-    if (UNLIKELY(!field)) {
-        auto& tablet_schema = _context.tablet_schema;
-        encoded_keys->push_back(KeyConsts::KEY_NULL_FIRST_MARKER);
-        size_t seq_col_length = tablet_schema->column(tablet_schema->sequence_col_idx()).length();
-        encoded_keys->append(seq_col_length, KeyConsts::KEY_MINIMAL_MARKER);
-        return;
-    }
-    encoded_keys->push_back(KeyConsts::KEY_NORMAL_MARKER);
-    _seq_coder->full_encode_ascending(field, encoded_keys);
-}
-
-void PrimaryKeyModelRowRetriever::_maybe_invalid_row_cache(const std::string& key) {
-    // Just invalid row cache for simplicity, since the rowset is not visible at present.
-    // If we update/insert cache, if load failed rowset will not be visible but cached data
-    // will be visible, and lead to inconsistency.
-    if (!config::disable_storage_row_cache &&
-        _context.tablet_schema->has_row_store_for_all_columns() &&
-        _context.write_type == DataWriteType::TYPE_DIRECT) {
-        // invalidate cache
-        RowCache::instance()->erase({_context.tablet->tablet_id(), key});
-    }
-}
 } // namespace doris::segment_v2

--- a/be/src/storage/segment/historical_row_retriever.h
+++ b/be/src/storage/segment/historical_row_retriever.h
@@ -26,7 +26,8 @@
 
 namespace doris {
 struct RowsetWriterContext;
-class KeyCoder;
+class HistoricalRowFetcher;
+class RowKeyEncoder;
 struct MowContext;
 
 namespace segment_v2 {
@@ -63,6 +64,10 @@ protected:
 
 class PrimaryKeyModelRowRetriever : public HistoricalRowRetriever {
 public:
+    // Out of line: _row_fetcher/_key_encoder are held by unique_ptr to types this header only
+    // forward-declares.
+    PrimaryKeyModelRowRetriever();
+    ~PrimaryKeyModelRowRetriever() override;
     Status init(const HistoricalRowRetrieverContext& context) override;
 
     Status prepare_lookup_plan_from_source_columns(
@@ -84,16 +89,8 @@ public:
 
     Status revise_operators_by_old_delete_sign(size_t num_rows);
 
-    void clear() override {
-        _key_columns.clear();
-        _seq_column = nullptr;
-        _use_default_or_null_flag.clear();
-        _has_default_or_nullable = false;
-        _rssid_to_rid.clear();
-        _rsid_to_rowset.clear();
-        _operators.clear();
-        _old_delete_signs.clear();
-    }
+    // The binlog writer reuses one retriever for every appended block.
+    void clear() override;
 
     std::vector<int64_t>& get_operators() override { return _operators; };
 
@@ -101,32 +98,14 @@ private:
     Status _fill_old_delete_signs(const Block& old_value_block,
                                   const std::map<uint32_t, uint32_t>& read_index, size_t num_rows);
 
-    void _maybe_invalid_row_cache(const std::string& key);
-
-    // used for unique-key with merge on write and segment min_max key
-    std::string _full_encode_keys(const std::vector<IOlapColumnDataAccessor*>& key_columns,
-                                  size_t pos, bool null_first = true);
-
-    std::string _full_encode_keys(const std::vector<const KeyCoder*>& key_coders,
-                                  const std::vector<IOlapColumnDataAccessor*>& key_columns,
-                                  size_t pos, bool null_first = true);
-
-    // used for unique-key with merge on write
-    void _encode_seq_column(const IOlapColumnDataAccessor* seq_column, size_t pos,
-                            std::string* encoded_keys);
-
     // get key_columns, seq column, delete data from source block, prepare for searching historial data
     std::vector<IOlapColumnDataAccessor*> _key_columns;
     const IOlapColumnDataAccessor* _seq_column = nullptr;
     std::shared_ptr<MowContext> _mow_context;
-    // used for building primary key index during vectorized write.
-    // for mow table with cluster keys, this is cluster keys
-    std::vector<const KeyCoder*> _key_coders;
-    KeyCoder* _seq_coder = nullptr;
+    std::unique_ptr<RowKeyEncoder> _key_encoder;
 
-    // group every rowset-segment row id to speed up reader
-    FixedReadPlan _rssid_to_rid;
-    std::map<RowsetId, RowsetSharedPtr> _rsid_to_rowset;
+    // owns the rowset pins and the read plan fed by the probe outcomes
+    std::unique_ptr<HistoricalRowFetcher> _row_fetcher;
 
     // cache flags for filling missing columns
     std::vector<bool> _use_default_or_null_flag;

--- a/be/src/storage/segment/segment_writer.cpp
+++ b/be/src/storage/segment/segment_writer.cpp
@@ -47,7 +47,6 @@
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
-#include "service/point_query_executor.h"
 #include "storage/data_dir.h"
 #include "storage/index/index_file_writer.h"
 #include "storage/index/index_writer.h"
@@ -56,6 +55,8 @@
 #include "storage/index/short_key_index.h"
 #include "storage/iterator/olap_data_convertor.h"
 #include "storage/key_coder.h"
+#include "storage/mow/historical_row_fetcher.h"
+#include "storage/mow/key_probe.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/partial_update_info.h"
@@ -335,17 +336,6 @@ Status SegmentWriter::_create_writers(const TabletSchemaSPtr& tablet_schema,
     return Status::OK();
 }
 
-void SegmentWriter::_maybe_invalid_row_cache(const std::string& key) {
-    // Just invalid row cache for simplicity, since the rowset is not visible at present.
-    // If we update/insert cache, if load failed rowset will not be visible but cached data
-    // will be visible, and lead to inconsistency.
-    if (!config::disable_storage_row_cache && _tablet_schema->has_row_store_for_all_columns() &&
-        _opts.write_type == DataWriteType::TYPE_DIRECT) {
-        // invalidate cache
-        RowCache::instance()->erase({_opts.rowset_ctx->tablet_id, key});
-    }
-}
-
 void SegmentWriter::_serialize_block_to_row_column(Block& block) {
     if (block.rows() == 0) {
         return;
@@ -373,62 +363,31 @@ void SegmentWriter::_serialize_block_to_row_column(Block& block) {
 }
 
 Status SegmentWriter::probe_key_for_mow(
-        std::string key, std::size_t segment_pos, bool have_input_seq_column, bool have_delete_sign,
+        const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
+        bool have_input_seq_column, bool have_delete_sign,
         const std::vector<RowsetSharedPtr>& specified_rowsets,
         std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
         bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
-        const std::function<void(const RowLocation& loc)>& found_cb,
+        const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>& found_cb,
         const std::function<Status()>& not_found_cb, PartialUpdateStats& stats) {
-    RowLocation loc;
-    // save rowset shared ptr so this rowset wouldn't delete
-    RowsetSharedPtr rowset;
-    auto st = _tablet->lookup_row_key(
-            key, _tablet_schema.get(), have_input_seq_column, specified_rowsets, &loc,
-            cast_set<uint32_t>(_mow_context->max_version), segment_caches, &rowset);
-    if (st.is<KEY_NOT_FOUND>()) {
+    ProbeOutcome outcome =
+            DORIS_TRY(probe.probe(key, segment_pos, have_input_seq_column, have_delete_sign,
+                                  specified_rowsets, segment_caches, stats));
+    if (outcome.result == KeyProbeResult::NOT_FOUND) {
         if (!have_delete_sign) {
             RETURN_IF_ERROR(not_found_cb());
         }
-        ++stats.num_rows_new_added;
         has_default_or_nullable = true;
         use_default_or_null_flag.emplace_back(true);
         return Status::OK();
     }
-    if (!st.ok() && !st.is<KEY_ALREADY_EXISTS>()) {
-        LOG(WARNING) << "failed to lookup row key, error: " << st;
-        return st;
-    }
-
-    // 1. if the delete sign is marked, it means that the value columns of the row will not
-    //    be read. So we don't need to read the missing values from the previous rows.
-    // 2. the one exception is when there are sequence columns in the table, we need to read
-    //    the sequence columns, otherwise it may cause the merge-on-read based compaction
-    //    policy to produce incorrect results
-    // TODO(bobhan1): only read seq col rather than all columns in this situation for
-    // partial update and flexible partial update
-
-    // TODO(bobhan1): handle sequence column here
-    if (st.is<KEY_ALREADY_EXISTS>() || (have_delete_sign && !_tablet_schema->has_sequence_col())) {
+    if (outcome.use_default_or_null) {
         has_default_or_nullable = true;
         use_default_or_null_flag.emplace_back(true);
     } else {
         // partial update should not contain invisible columns
         use_default_or_null_flag.emplace_back(false);
-        _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
-        found_cb(loc);
-    }
-
-    if (st.is<KEY_ALREADY_EXISTS>()) {
-        // although we need to mark delete current row, we still need to read missing columns
-        // for this row, we need to ensure that each column is aligned
-        _mow_context->delete_bitmap->add(
-                {_opts.rowset_ctx->rowset_id, _segment_id, DeleteBitmap::TEMP_VERSION_COMMON},
-                cast_set<uint32_t>(segment_pos));
-        ++stats.num_rows_deleted;
-    } else {
-        _mow_context->delete_bitmap->add(
-                {loc.rowset_id, loc.segment_id, DeleteBitmap::TEMP_VERSION_COMMON}, loc.row_id);
-        ++stats.num_rows_updated;
+        found_cb(outcome.loc, outcome.rowset);
     }
     return Status::OK();
 }
@@ -538,7 +497,12 @@ Status SegmentWriter::append_block_with_partial_content(const Block* block, size
     const std::vector<RowsetSharedPtr>& specified_rowsets = _mow_context->rowset_ptrs;
     std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
 
-    FixedReadPlan read_plan;
+    // the horizontal writer never runs flexible partial update
+    MowKeyProbe probe = MowKeyProbe::for_partial_update(
+            _tablet.get(), _tablet_schema.get(), _tablet_schema->has_sequence_col(), _mow_context,
+            _opts.rowset_ctx->rowset_id, _segment_id, /*flexible=*/false);
+    // owns the rowset pins and the read plan for the historical read below
+    HistoricalRowFetcher fetcher {_opts.rowset_ctx->make_historical_row_retriever_context()};
 
     // locate rows in base data
     PartialUpdateStats stats;
@@ -552,11 +516,9 @@ Status SegmentWriter::append_block_with_partial_content(const Block* block, size
         // here row_pos = 2, num_rows = 4.
         size_t delta_pos = block_pos - row_pos;
         size_t segment_pos = segment_start_pos + delta_pos;
-        std::string key = _key_encoder.full_encode(key_columns, delta_pos);
-        _maybe_invalid_row_cache(key);
-        if (have_input_seq_column) {
-            _key_encoder.append_seq_suffix(&key, seq_column, delta_pos);
-        }
+        std::string key = encode_mow_key_invalidate_cache(
+                _key_encoder, key_columns, seq_column, delta_pos, have_input_seq_column,
+                _opts.rowset_ctx->tablet_id, *_tablet_schema, _opts.write_type);
         // If the table have sequence column, and the include-cids don't contain the sequence
         // column, we need to update the primary key index builder at the end of this method.
         // At that time, we have a valid sequence column to encode the key with seq col.
@@ -574,10 +536,12 @@ Status SegmentWriter::append_block_with_partial_content(const Block* block, size
                                 block_pos, cast_set<int>(_key_encoder.num_sort_key_columns()));
                     });
         };
-        auto update_read_plan = [&](const RowLocation& loc) {
-            read_plan.prepare_to_read(loc, segment_pos);
+        auto update_read_plan = [&](const RowLocation& loc, const RowsetSharedPtr& rowset) {
+            // keep the rowset alive until the historical read below is done
+            fetcher.pin_rowset(rowset);
+            fetcher.plan_fixed_read(loc, segment_pos);
         };
-        RETURN_IF_ERROR(probe_key_for_mow(std::move(key), segment_pos, have_input_seq_column,
+        RETURN_IF_ERROR(probe_key_for_mow(probe, std::move(key), segment_pos, have_input_seq_column,
                                           have_delete_sign, specified_rowsets, segment_caches,
                                           has_default_or_nullable, use_default_or_null_flag,
                                           update_read_plan, not_found_cb, stats));
@@ -590,10 +554,9 @@ Status SegmentWriter::append_block_with_partial_content(const Block* block, size
     }
 
     // read to fill full block
-    RETURN_IF_ERROR(read_plan.fill_missing_columns(
-            _opts.rowset_ctx->make_historical_row_retriever_context(), _rsid_to_rowset,
-            *_tablet_schema, full_block, use_default_or_null_flag, has_default_or_nullable,
-            cast_set<uint32_t>(segment_start_pos), block));
+    RETURN_IF_ERROR(fetcher.fill_missing_columns(*_tablet_schema, full_block,
+                                                 use_default_or_null_flag, has_default_or_nullable,
+                                                 cast_set<uint32_t>(segment_start_pos), block));
 
     if (_tablet_schema->num_variant_columns() > 0) {
         RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
@@ -1080,11 +1043,10 @@ Status SegmentWriter::_generate_primary_key_index(
     if (!need_sort) { // mow table without cluster key
         std::string last_key;
         for (size_t pos = 0; pos < num_rows; pos++) {
-            std::string key = _key_encoder.full_encode(primary_key_columns, pos);
-            _maybe_invalid_row_cache(key);
-            if (_tablet_schema->has_sequence_col()) {
-                _key_encoder.append_seq_suffix(&key, seq_column, pos);
-            }
+            std::string key = encode_mow_key_invalidate_cache(
+                    _key_encoder, primary_key_columns, seq_column, pos,
+                    _tablet_schema->has_sequence_col(), _opts.rowset_ctx->tablet_id,
+                    *_tablet_schema, _opts.write_type);
             DCHECK(key.compare(last_key) > 0)
                     << "found duplicate key or key is not sorted! current key: " << key
                     << ", last key: " << last_key;
@@ -1095,7 +1057,8 @@ Status SegmentWriter::_generate_primary_key_index(
         // generate primary keys in memory
         for (uint32_t pos = 0; pos < num_rows; pos++) {
             std::string key = _key_encoder.full_encode_primary_keys(primary_key_columns, pos);
-            _maybe_invalid_row_cache(key);
+            MowKeyProbe::maybe_invalidate_row_cache(_opts.rowset_ctx->tablet_id, *_tablet_schema,
+                                                    _opts.write_type, key);
             if (_tablet_schema->has_sequence_col()) {
                 _key_encoder.append_seq_suffix(&key, seq_column, pos);
             }

--- a/be/src/storage/segment/segment_writer.h
+++ b/be/src/storage/segment/segment_writer.h
@@ -33,6 +33,7 @@
 #include "storage/index/index_file_writer.h"
 #include "storage/key/row_key_encoder.h"
 #include "storage/olap_define.h"
+#include "storage/partial_update_info.h"
 #include "storage/segment/column_writer.h"
 #include "storage/segment/segment_index_file_cache_loader.h"
 #include "storage/tablet/tablet.h"
@@ -65,6 +66,7 @@ extern const char* k_segment_magic;
 extern const uint32_t k_segment_magic_length;
 
 class VariantStatsCaculator;
+class MowKeyProbe;
 
 struct SegmentWriterOptions {
     uint32_t num_rows_per_block = 1024;
@@ -92,15 +94,18 @@ public:
     virtual Status init(const std::vector<uint32_t>& col_ids, bool has_key);
 
     virtual Status append_block(const Block* block, size_t row_pos, size_t num_rows);
-    Status probe_key_for_mow(std::string key, std::size_t segment_pos, bool have_input_seq_column,
-                             bool have_delete_sign,
-                             const std::vector<RowsetSharedPtr>& specified_rowsets,
-                             std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-                             bool& has_default_or_nullable,
-                             std::vector<bool>& use_default_or_null_flag,
-                             const std::function<void(const RowLocation& loc)>& found_cb,
-                             const std::function<Status()>& not_found_cb,
-                             PartialUpdateStats& stats);
+    // Thin wrapper over MowKeyProbe that translates a ProbeOutcome back into the out-parameters the
+    // partial update fill loop uses. `found_cb` receives the rowset that holds `loc` and must keep
+    // it alive for the historical read.
+    Status probe_key_for_mow(
+            const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
+            bool have_input_seq_column, bool have_delete_sign,
+            const std::vector<RowsetSharedPtr>& specified_rowsets,
+            std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
+            bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
+            const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>&
+                    found_cb,
+            const std::function<Status()>& not_found_cb, PartialUpdateStats& stats);
     Status partial_update_preconditions_check(size_t row_pos);
     Status append_block_with_partial_content(const Block* block, size_t row_pos, size_t num_rows);
 
@@ -167,7 +172,6 @@ private:
     Status _write_primary_key_index();
     Status _write_footer();
     Status _write_raw_data(const std::vector<Slice>& slices);
-    void _maybe_invalid_row_cache(const std::string& key);
     void set_min_max_key(const Slice& key);
     void set_min_key(const Slice& key);
     void set_max_key(const Slice& key);
@@ -237,8 +241,6 @@ protected:
     faststring _max_key;
 
     std::shared_ptr<MowContext> _mow_context;
-    // group every rowset-segment row id to speed up reader
-    std::map<RowsetId, RowsetSharedPtr> _rsid_to_rowset;
     std::vector<std::string> _primary_keys;
     uint64_t _primary_keys_size = 0;
     // variant statistics calculator for efficient stats collection

--- a/be/src/storage/segment/vertical_segment_writer.cpp
+++ b/be/src/storage/segment/vertical_segment_writer.cpp
@@ -52,7 +52,6 @@
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
-#include "service/point_query_executor.h"
 #include "storage/data_dir.h"
 #include "storage/index/index_file_writer.h"
 #include "storage/index/inverted/inverted_index_desc.h"
@@ -61,6 +60,8 @@
 #include "storage/index/short_key_index.h"
 #include "storage/iterator/olap_data_convertor.h"
 #include "storage/key_coder.h"
+#include "storage/mow/historical_row_fetcher.h"
+#include "storage/mow/key_probe.h"
 #include "storage/olap_common.h"
 #include "storage/partial_update_info.h"
 #include "storage/row_cursor.h" // RowCursor // IWYU pragma: keep
@@ -320,17 +321,6 @@ Status VerticalSegmentWriter::init() {
     return Status::OK();
 }
 
-void VerticalSegmentWriter::_maybe_invalid_row_cache(const std::string& key) const {
-    // Just invalid row cache for simplicity, since the rowset is not visible at present.
-    // If we update/insert cache, if load failed rowset will not be visible but cached data
-    // will be visible, and lead to inconsistency.
-    if (!config::disable_storage_row_cache && _tablet_schema->has_row_store_for_all_columns() &&
-        _opts.write_type == DataWriteType::TYPE_DIRECT) {
-        // invalidate cache
-        RowCache::instance()->erase({_opts.rowset_ctx->tablet_id, key});
-    }
-}
-
 Status VerticalSegmentWriter::_append_row_store_column(const Block& block, size_t row_pos,
                                                        size_t num_rows, uint32_t cid) {
     DCHECK(_tablet_schema->column(cid).is_row_store_column());
@@ -371,66 +361,31 @@ Status VerticalSegmentWriter::_append_row_store_column(const Block& block, size_
 }
 
 Status VerticalSegmentWriter::_probe_key_for_mow(
-        std::string key, std::size_t segment_pos, bool have_input_seq_column, bool have_delete_sign,
+        const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
+        bool have_input_seq_column, bool have_delete_sign,
         const std::vector<RowsetSharedPtr>& specified_rowsets,
         std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
         bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
-        const std::function<void(const RowLocation& loc)>& found_cb,
+        const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>& found_cb,
         const std::function<Status()>& not_found_cb, PartialUpdateStats& stats) {
-    RowLocation loc;
-    // save rowset shared ptr so this rowset wouldn't delete
-    RowsetSharedPtr rowset;
-    auto st = _tablet->lookup_row_key(key, _tablet_schema.get(), have_input_seq_column,
-                                      specified_rowsets, &loc, _mow_context->max_version,
-                                      segment_caches, &rowset);
-    if (st.is<KEY_NOT_FOUND>()) {
+    ProbeOutcome outcome =
+            DORIS_TRY(probe.probe(key, segment_pos, have_input_seq_column, have_delete_sign,
+                                  specified_rowsets, segment_caches, stats));
+    if (outcome.result == KeyProbeResult::NOT_FOUND) {
         if (!have_delete_sign) {
             RETURN_IF_ERROR(not_found_cb());
         }
-        ++stats.num_rows_new_added;
         has_default_or_nullable = true;
         use_default_or_null_flag.emplace_back(true);
         return Status::OK();
     }
-    if (!st.ok() && !st.is<KEY_ALREADY_EXISTS>()) {
-        LOG(WARNING) << "failed to lookup row key, error: " << st;
-        return st;
-    }
-
-    // 1. if the delete sign is marked, it means that the value columns of the row will not
-    //    be read. So we don't need to read the missing values from the previous rows.
-    // 2. the one exception is when there are sequence columns in the table, we need to read
-    //    the sequence columns, otherwise it may cause the merge-on-read based compaction
-    //    policy to produce incorrect results
-
-    // 3. In flexible partial update, we may delete the existing rows before if there exists
-    //    insert after delete in one load. In this case, the insert should also be treated
-    //    as newly inserted rows, note that the sequence column value is filled in
-    //    BlockAggregator::aggregate_for_insert_after_delete() if this row doesn't specify the sequence column
-    if (st.is<KEY_ALREADY_EXISTS>() || (have_delete_sign && !_tablet_schema->has_sequence_col()) ||
-        (_opts.rowset_ctx->partial_update_info->is_flexible_partial_update() &&
-         _mow_context->delete_bitmap->contains(
-                 {loc.rowset_id, loc.segment_id, DeleteBitmap::TEMP_VERSION_COMMON}, loc.row_id))) {
+    if (outcome.use_default_or_null) {
         has_default_or_nullable = true;
         use_default_or_null_flag.emplace_back(true);
     } else {
         // partial update should not contain invisible columns
         use_default_or_null_flag.emplace_back(false);
-        _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
-        found_cb(loc);
-    }
-
-    if (st.is<KEY_ALREADY_EXISTS>()) {
-        // although we need to mark delete current row, we still need to read missing columns
-        // for this row, we need to ensure that each column is aligned
-        _mow_context->delete_bitmap->add(
-                {_opts.rowset_ctx->rowset_id, _segment_id, DeleteBitmap::TEMP_VERSION_COMMON},
-                cast_set<uint32_t>(segment_pos));
-        ++stats.num_rows_deleted;
-    } else {
-        _mow_context->delete_bitmap->add(
-                {loc.rowset_id, loc.segment_id, DeleteBitmap::TEMP_VERSION_COMMON}, loc.row_id);
-        ++stats.num_rows_updated;
+        found_cb(outcome.loc, outcome.rowset);
     }
     return Status::OK();
 }
@@ -575,7 +530,11 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
     const std::vector<RowsetSharedPtr>& specified_rowsets = _mow_context->rowset_ptrs;
     std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
 
-    FixedReadPlan read_plan;
+    MowKeyProbe probe = MowKeyProbe::for_partial_update(
+            _tablet.get(), _tablet_schema.get(), _tablet_schema->has_sequence_col(), _mow_context,
+            _opts.rowset_ctx->rowset_id, _segment_id, /*flexible=*/false);
+    // owns the rowset pins and the read plan for the historical read below
+    HistoricalRowFetcher fetcher {_opts.rowset_ctx->make_historical_row_retriever_context()};
 
     // locate rows in base data
     PartialUpdateStats stats;
@@ -589,11 +548,9 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
         // here row_pos = 2, num_rows = 4.
         size_t delta_pos = block_pos - data.row_pos;
         size_t segment_pos = segment_start_pos + delta_pos;
-        std::string key = _key_encoder.full_encode(key_columns, delta_pos);
-        _maybe_invalid_row_cache(key);
-        if (have_input_seq_column) {
-            _key_encoder.append_seq_suffix(&key, seq_column, delta_pos);
-        }
+        std::string key = encode_mow_key_invalidate_cache(
+                _key_encoder, key_columns, seq_column, delta_pos, have_input_seq_column,
+                _opts.rowset_ctx->tablet_id, *_tablet_schema, _opts.write_type);
         // If the table have sequence column, and the include-cids don't contain the sequence
         // column, we need to update the primary key index builder at the end of this method.
         // At that time, we have a valid sequence column to encode the key with seq col.
@@ -611,13 +568,15 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
                                 block_pos, cast_set<int>(_key_encoder.num_sort_key_columns()));
                     });
         };
-        auto update_read_plan = [&](const RowLocation& loc) {
-            read_plan.prepare_to_read(loc, segment_pos);
+        auto update_read_plan = [&](const RowLocation& loc, const RowsetSharedPtr& rowset) {
+            // keep the rowset alive until the historical read below is done
+            fetcher.pin_rowset(rowset);
+            fetcher.plan_fixed_read(loc, segment_pos);
         };
-        RETURN_IF_ERROR(_probe_key_for_mow(std::move(key), segment_pos, have_input_seq_column,
-                                           have_delete_sign, specified_rowsets, segment_caches,
-                                           has_default_or_nullable, use_default_or_null_flag,
-                                           update_read_plan, not_found_cb, stats));
+        RETURN_IF_ERROR(_probe_key_for_mow(
+                probe, std::move(key), segment_pos, have_input_seq_column, have_delete_sign,
+                specified_rowsets, segment_caches, has_default_or_nullable,
+                use_default_or_null_flag, update_read_plan, not_found_cb, stats));
     }
     CHECK_EQ(use_default_or_null_flag.size(), data.num_rows);
 
@@ -627,10 +586,9 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
     }
 
     // read to fill full_block
-    RETURN_IF_ERROR(read_plan.fill_missing_columns(
-            _opts.rowset_ctx->make_historical_row_retriever_context(), _rsid_to_rowset,
-            *_tablet_schema, full_block, use_default_or_null_flag, has_default_or_nullable,
-            segment_start_pos, data.block));
+    RETURN_IF_ERROR(fetcher.fill_missing_columns(*_tablet_schema, full_block,
+                                                 use_default_or_null_flag, has_default_or_nullable,
+                                                 segment_start_pos, data.block));
 
     if (_tablet_schema->num_variant_columns() > 0) {
         RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
@@ -918,18 +876,19 @@ Status VerticalSegmentWriter::_generate_flexible_read_plan(
             (_tablet_schema->has_sequence_col()
                      ? _tablet_schema->column(_tablet_schema->sequence_col_idx()).unique_id()
                      : -1);
+    MowKeyProbe probe = MowKeyProbe::for_partial_update(
+            _tablet.get(), _tablet_schema.get(), _tablet_schema->has_sequence_col(), _mow_context,
+            _opts.rowset_ctx->rowset_id, _segment_id, /*flexible=*/true);
     for (size_t block_pos = data.row_pos; block_pos < data.row_pos + data.num_rows; block_pos++) {
         size_t delta_pos = block_pos - data.row_pos;
         size_t segment_pos = segment_start_pos + delta_pos;
         auto& skip_bitmap = skip_bitmaps->at(block_pos);
 
-        std::string key = _key_encoder.full_encode(key_columns, delta_pos);
-        _maybe_invalid_row_cache(key);
         bool row_has_sequence_col =
                 (schema_has_sequence_col && !skip_bitmap.contains(seq_col_unique_id));
-        if (row_has_sequence_col) {
-            _key_encoder.append_seq_suffix(&key, seq_column, delta_pos);
-        }
+        std::string key = encode_mow_key_invalidate_cache(
+                _key_encoder, key_columns, seq_column, delta_pos, row_has_sequence_col,
+                _opts.rowset_ctx->tablet_id, *_tablet_schema, _opts.write_type);
 
         // mark key with delete sign as deleted.
         bool have_delete_sign =
@@ -944,11 +903,14 @@ Status VerticalSegmentWriter::_generate_flexible_read_plan(
                     },
                     &skip_bitmap);
         };
-        auto update_read_plan = [&](const RowLocation& loc) {
+        auto update_read_plan = [&](const RowLocation& loc, const RowsetSharedPtr& rowset) {
+            // the flexible fill still reads through the writer's pin map, which the block
+            // aggregator also feeds
+            _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
             read_plan.prepare_to_read(loc, segment_pos, skip_bitmap);
         };
 
-        RETURN_IF_ERROR(_probe_key_for_mow(std::move(key), segment_pos, row_has_sequence_col,
+        RETURN_IF_ERROR(_probe_key_for_mow(probe, std::move(key), segment_pos, row_has_sequence_col,
                                            have_delete_sign, specified_rowsets, segment_caches,
                                            has_default_or_nullable, use_default_or_null_flag,
                                            update_read_plan, not_found_cb, stats));
@@ -1125,11 +1087,10 @@ Status VerticalSegmentWriter::_generate_primary_key_index(
     if (!need_sort) { // mow table without cluster key
         std::string last_key;
         for (size_t pos = 0; pos < num_rows; pos++) {
-            std::string key = _key_encoder.full_encode(primary_key_columns, pos);
-            _maybe_invalid_row_cache(key);
-            if (_tablet_schema->has_sequence_col()) {
-                _key_encoder.append_seq_suffix(&key, seq_column, pos);
-            }
+            std::string key = encode_mow_key_invalidate_cache(
+                    _key_encoder, primary_key_columns, seq_column, pos,
+                    _tablet_schema->has_sequence_col(), _opts.rowset_ctx->tablet_id,
+                    *_tablet_schema, _opts.write_type);
             DCHECK(key.compare(last_key) > 0)
                     << "found duplicate key or key is not sorted! current key: " << key
                     << ", last key: " << last_key;
@@ -1141,7 +1102,8 @@ Status VerticalSegmentWriter::_generate_primary_key_index(
         std::vector<std::string> primary_keys;
         for (uint32_t pos = 0; pos < num_rows; pos++) {
             std::string key = _key_encoder.full_encode_primary_keys(primary_key_columns, pos);
-            _maybe_invalid_row_cache(key);
+            MowKeyProbe::maybe_invalidate_row_cache(_opts.rowset_ctx->tablet_id, *_tablet_schema,
+                                                    _opts.write_type, key);
             if (_tablet_schema->has_sequence_col()) {
                 _key_encoder.append_seq_suffix(&key, seq_column, pos);
             }

--- a/be/src/storage/segment/vertical_segment_writer.h
+++ b/be/src/storage/segment/vertical_segment_writer.h
@@ -59,6 +59,7 @@ class FileSystem;
 } // namespace io
 namespace segment_v2 {
 class IndexFileWriter;
+class MowKeyProbe;
 
 struct VerticalSegmentWriterOptions {
     uint32_t num_rows_per_block = 1024;
@@ -147,21 +148,24 @@ private:
     Status _write_primary_key_index();
     Status _write_footer();
     Status _write_raw_data(const std::vector<Slice>& slices);
-    void _maybe_invalid_row_cache(const std::string& key) const;
     void _set_min_max_key(const Slice& key);
     void _set_min_key(const Slice& key);
     void _set_max_key(const Slice& key);
     Status _append_row_store_column(const Block& block, size_t row_pos, size_t num_rows,
                                     uint32_t cid);
-    Status _probe_key_for_mow(std::string key, std::size_t segment_pos, bool have_input_seq_column,
-                              bool have_delete_sign,
-                              const std::vector<RowsetSharedPtr>& specified_rowsets,
-                              std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-                              bool& has_default_or_nullable,
-                              std::vector<bool>& use_default_or_null_flag,
-                              const std::function<void(const RowLocation& loc)>& found_cb,
-                              const std::function<Status()>& not_found_cb,
-                              PartialUpdateStats& stats);
+    // Thin wrapper over MowKeyProbe that translates a ProbeOutcome back into the out-parameters the
+    // partial update fill loops use. `found_cb` receives the rowset that holds `loc`: the fixed
+    // path pins it in its HistoricalRowFetcher, the flexible path in `_rsid_to_rowset`, which its
+    // fill still reads from.
+    Status _probe_key_for_mow(
+            const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
+            bool have_input_seq_column, bool have_delete_sign,
+            const std::vector<RowsetSharedPtr>& specified_rowsets,
+            std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
+            bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
+            const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>&
+                    found_cb,
+            const std::function<Status()>& not_found_cb, PartialUpdateStats& stats);
     Status _partial_update_preconditions_check(size_t row_pos, bool is_flexible_update);
     Status _append_block_with_partial_content(RowsInBlock& data, Block& full_block);
     Status _append_block_with_flexible_partial_content(RowsInBlock& data, Block& full_block);

--- a/be/test/storage/key/row_key_encoder_test.cpp
+++ b/be/test/storage/key/row_key_encoder_test.cpp
@@ -1071,6 +1071,77 @@ TEST_F(RowKeyEncoderTest, SeqSuffix) {
     }
 }
 
+// full_encode_primary_keys() is the primary key index's view. With cluster keys the segment sorts
+// by those instead, so this is where the two views come apart: the probe side must encode the
+// primary key columns, not whatever full_encode() happens to give.
+TEST_F(RowKeyEncoderTest, PrimaryKeyViewDiffersFromSortKeyViewWithClusterKeys) {
+    auto schema = different_key_count_schema(); // key uid 0, cluster keys uid 1..4
+    build(schema, 2, [&](MutableColumns& c) {
+        fill_int(c, 0, {1, 2});
+        fill_int(c, 1, {10, 20});
+        fill_int(c, 2, {30, 40});
+        fill_int(c, 3, {50, 60});
+        fill_int(c, 4, {70, 80});
+    });
+    ASSERT_EQ(_schema->num_key_columns(), 1);
+    ASSERT_EQ(_schema->cluster_key_uids().size(), 4);
+
+    RowKeyEncoder encoder(*_schema, /*mow=*/true);
+    std::vector<IOlapColumnDataAccessor*> primary_key_columns {acc(0)};
+    std::vector<IOlapColumnDataAccessor*> sort_key_columns {acc(1), acc(2), acc(3), acc(4)};
+    for (size_t row = 0; row < 2; ++row) {
+        const std::string primary_key = encoder.full_encode_primary_keys(primary_key_columns, row);
+        EXPECT_FALSE(primary_key.empty());
+        EXPECT_NE(to_hex(encoder.full_encode(sort_key_columns, row)), to_hex(primary_key));
+    }
+}
+
+// Without cluster keys the two views coincide, and the primary-key one still has to be built --
+// that is what lets the probe side call full_encode_primary_keys() for every mow table instead of
+// branching on the table's shape.
+TEST_F(RowKeyEncoderTest, PrimaryKeyViewEqualsSortKeyViewWithoutClusterKeys) {
+    auto schema = std::make_shared<TabletSchema>();
+    schema->append_column(*create_int_key(0));
+    schema->append_column(*create_int_key(1));
+    schema->append_column(
+            *create_int_value(2, FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE));
+    schema->_keys_type = UNIQUE_KEYS;
+    schema->_num_short_key_columns = 1;
+    build(schema, 2, [&](MutableColumns& c) {
+        fill_int(c, 0, {1, 2});
+        fill_int(c, 1, {10, 20});
+        fill_int(c, 2, {0, 0});
+    });
+    ASSERT_TRUE(_schema->cluster_key_uids().empty());
+
+    RowKeyEncoder encoder(*_schema, /*mow=*/true);
+    std::vector<IOlapColumnDataAccessor*> key_columns {acc(0), acc(1)};
+    for (size_t row = 0; row < 2; ++row) {
+        const std::string sort_key = encoder.full_encode(key_columns, row);
+        EXPECT_FALSE(sort_key.empty());
+        EXPECT_EQ(to_hex(encoder.full_encode_primary_keys(key_columns, row)), to_hex(sort_key));
+    }
+}
+
+// A non-mow encoder has no primary key index to build, so it builds no primary-key view either.
+TEST_F(RowKeyEncoderTest, NonMowBuildsNoPrimaryKeyView) {
+    auto schema = std::make_shared<TabletSchema>();
+    schema->append_column(*create_int_key(0));
+    schema->append_column(
+            *create_int_value(1, FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE));
+    schema->_keys_type = DUP_KEYS;
+    schema->_num_short_key_columns = 1;
+    build(schema, 1, [&](MutableColumns& c) {
+        fill_int(c, 0, {1});
+        fill_int(c, 1, {0});
+    });
+
+    RowKeyEncoder encoder(*_schema, /*mow=*/false);
+    std::vector<IOlapColumnDataAccessor*> key_columns {acc(0)};
+    EXPECT_FALSE(encoder.full_encode(key_columns, 0).empty());
+    EXPECT_TRUE(encoder.full_encode_primary_keys({}, 0).empty());
+}
+
 // A cluster-key segment may contain several rows with the same primary key and
 // sequence value. Their primary-index prefixes are identical, so rowid is the
 // only tie-breaker. The chosen rowids cross every relevant byte/sign boundary

--- a/be/test/storage/mow/historical_row_fetcher_test.cpp
+++ b/be/test/storage/mow/historical_row_fetcher_test.cpp
@@ -1,0 +1,142 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/mow/historical_row_fetcher.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "storage/mow/mow_transform_test_base.h"
+#include "storage/partial_update_info.h"
+
+namespace doris {
+
+class HistoricalRowFetcherTest : public MowTransformTestBase {
+protected:
+    // A fixed partial update that carries only the key column, so `v` is the missing column the
+    // fetcher has to fill.
+    std::shared_ptr<PartialUpdateInfo> key_only_partial_update(const TabletSchemaSPtr& schema) {
+        auto info = std::make_shared<PartialUpdateInfo>();
+        EXPECT_TRUE(info->init(kTabletId, /*txn_id=*/1, *schema,
+                               UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                               PartialUpdateNewRowPolicyPB::APPEND, {"k"}, /*is_strict_mode=*/false,
+                               /*timestamp_ms=*/0, /*nano_seconds=*/0, "UTC", "")
+                            .ok());
+        return info;
+    }
+
+    // A narrow input block holding just the key column.
+    static Block key_block(const TabletSchemaSPtr& schema, const std::vector<int32_t>& keys) {
+        Block block = schema->create_block_by_cids({0});
+        auto* column = block.get_by_position(0).column->assert_mutable().get();
+        for (int32_t k : keys) {
+            column->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        }
+        return block;
+    }
+};
+
+// The raw read path: whatever rows were planned come back, addressed through read_index by the
+// destination position the caller planned them under.
+TEST_F(HistoricalRowFetcherTest, ReadColumnsReturnsThePlannedRows) {
+    auto schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 5001, 2, {{1, 11}, {2, 22}, {3, 33}}, &tablet);
+
+    HistoricalRowFetcher fetcher {make_fetcher_ctx(schema, tablet)};
+    fetcher.pin_rowset(rowset);
+    // planned out of segment order, the way a load's incoming rows arrive
+    fetcher.plan_fixed_read(RowLocation {rowset->rowset_id(), 0, 2}, /*dst_pos=*/0);
+    fetcher.plan_fixed_read(RowLocation {rowset->rowset_id(), 0, 0}, /*dst_pos=*/1);
+    ASSERT_EQ(fetcher.pinned_rowsets().size(), 1);
+
+    std::vector<uint32_t> cids {1};
+    Block old_values = schema->create_block_by_cids(cids);
+    std::map<uint32_t, uint32_t> read_index;
+    auto st = fetcher.read_columns(*schema, cids, old_values, &read_index,
+                                   /*force_read_old_delete_signs=*/false);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(old_values.rows(), 2);
+    ASSERT_EQ(read_index.size(), 2);
+    EXPECT_EQ(read_int(old_values, 0, read_index[0]), 33); // dst 0 <- row 2
+    EXPECT_EQ(read_int(old_values, 0, read_index[1]), 11); // dst 1 <- row 0
+}
+
+// The fixed partial update fill: rows flagged for a historical read take the old value, rows
+// flagged use-default take the column default.
+TEST_F(HistoricalRowFetcherTest, FillMissingColumnsMixesHistoryAndDefaults) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 5011, 2, {{1, 11}, {2, 22}, {3, 33}}, &tablet);
+
+    HistoricalRowFetcher fetcher {
+            make_fetcher_ctx(schema, tablet, key_only_partial_update(schema))};
+    fetcher.pin_rowset(rowset);
+    // input rows are keys 1, 3 and the brand-new 99
+    fetcher.plan_fixed_read(RowLocation {rowset->rowset_id(), 0, 0}, /*dst_pos=*/0);
+    fetcher.plan_fixed_read(RowLocation {rowset->rowset_id(), 0, 2}, /*dst_pos=*/1);
+
+    Block input = key_block(schema, {1, 3, 99});
+    Block full_block = schema->create_block();
+    full_block.replace_by_position(0, input.get_by_position(0).column);
+    std::vector<bool> use_default_or_null_flag {false, false, true};
+
+    auto st = fetcher.fill_missing_columns(*schema, full_block, use_default_or_null_flag,
+                                           /*has_default_or_nullable=*/true,
+                                           /*segment_start_pos=*/0, &input);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(full_block.rows(), 3);
+    EXPECT_EQ(read_int(full_block, 1, 0), 11);
+    EXPECT_EQ(read_int(full_block, 1, 1), 33);
+    EXPECT_EQ(read_int(full_block, 1, 2), 0); // column default, not NULL
+    EXPECT_FALSE(read_is_null(full_block, 1, 2));
+}
+
+// A row whose historical value sits behind a delete sign gets the default instead: the old row is
+// gone, there is nothing to carry forward.
+TEST_F(HistoricalRowFetcherTest, FillMissingColumnsSkipsDeletedHistory) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 5021, 2, {{1, 11, 0, 0}, {2, 22, 0, 1}}, &tablet);
+
+    HistoricalRowFetcher fetcher {
+            make_fetcher_ctx(schema, tablet, key_only_partial_update(schema))};
+    fetcher.pin_rowset(rowset);
+    fetcher.plan_fixed_read(RowLocation {rowset->rowset_id(), 0, 0}, /*dst_pos=*/0);
+    fetcher.plan_fixed_read(RowLocation {rowset->rowset_id(), 0, 1}, /*dst_pos=*/1);
+
+    Block input = key_block(schema, {1, 2});
+    Block full_block = schema->create_block();
+    full_block.replace_by_position(0, input.get_by_position(0).column);
+    std::vector<bool> use_default_or_null_flag {false, false};
+
+    auto st = fetcher.fill_missing_columns(*schema, full_block, use_default_or_null_flag,
+                                           /*has_default_or_nullable=*/true,
+                                           /*segment_start_pos=*/0, &input);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(full_block.rows(), 2);
+    EXPECT_EQ(read_int(full_block, 1, 0), 11); // live old row
+    EXPECT_EQ(read_int(full_block, 1, 1), 0);  // old row was delete-signed
+}
+
+} // namespace doris

--- a/be/test/storage/mow/key_probe_test.cpp
+++ b/be/test/storage/mow/key_probe_test.cpp
@@ -1,0 +1,586 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/mow/key_probe.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/config.h"
+#include "runtime/exec_env.h"
+#include "service/point_query_executor.h"
+#include "storage/key/row_key_encoder.h"
+#include "storage/mow/mow_transform_test_base.h"
+#include "storage/partial_update_info.h"
+#include "storage/segment/segment_loader.h"
+#include "storage/tablet/tablet_meta.h"
+
+namespace doris {
+
+using segment_v2::KeyProbeResult;
+using segment_v2::MowKeyProbe;
+
+class KeyProbeTest : public MowTransformTestBase {
+protected:
+    static constexpr int64_t kWritingRowsetId = 4002;
+
+    MowKeyProbe make_probe(const TabletSchemaSPtr& schema, const TabletSharedPtr& tablet,
+                           const std::shared_ptr<MowContext>& mow, MowKeyProbe::Policy policy,
+                           uint32_t writing_segment_id = 0) {
+        RowsetId writing_rowset_id;
+        writing_rowset_id.init(kWritingRowsetId);
+        return MowKeyProbe {tablet.get(), schema.get(),      schema->has_sequence_col(),
+                            mow,          writing_rowset_id, writing_segment_id,
+                            policy};
+    }
+
+    // Built through the factory both segment writers call, so a policy field drifting away from
+    // the fill paths fails these tests rather than silently changing production behavior.
+    MowKeyProbe make_fill_probe(const TabletSchemaSPtr& schema, const TabletSharedPtr& tablet,
+                                const std::shared_ptr<MowContext>& mow, bool flexible = false,
+                                uint32_t writing_segment_id = 0) {
+        return MowKeyProbe::for_partial_update(tablet.get(), schema.get(),
+                                               schema->has_sequence_col(), mow, writing_rowset_id(),
+                                               writing_segment_id, flexible);
+    }
+
+    // The policy both partial update fill paths use, for the tests that then flip one field to
+    // show what that field alone controls.
+    static MowKeyProbe::Policy fill_policy() {
+        return MowKeyProbe::Policy {
+                .mark_deleted = MowKeyProbe::MarkDeleted::OLD_AND_LOSING_ROW,
+                .use_defaults_for_delete_signed = true,
+                .use_defaults_for_seq_loser = true,
+                .use_defaults_for_in_load_deleted = false,
+        };
+    }
+
+    // True iff the delete bitmap has `row_id` marked under the TEMP version for {rowset_id,
+    // segment_id}.
+    static bool marked(const std::shared_ptr<MowContext>& mow, const RowsetId& rsid,
+                       uint32_t segment_id, uint32_t row_id) {
+        return mow->delete_bitmap->contains({rsid, segment_id, DeleteBitmap::TEMP_VERSION_COMMON},
+                                            row_id);
+    }
+
+    static RowsetId writing_rowset_id() {
+        RowsetId rsid;
+        rsid.init(kWritingRowsetId);
+        return rsid;
+    }
+};
+
+// A key that no rowset holds: brand-new row, nothing marked, and the caller is told to fill
+// defaults.
+TEST_F(KeyProbeTest, NotFoundReportsNewRow) {
+    auto schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4001, 2, {{1, 11}, {2, 22}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto probe = make_fill_probe(schema, tablet, mow);
+
+    auto result = probe.probe(encode_key(schema, encoder, 99), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/false, /*have_delete_sign=*/false, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::NOT_FOUND);
+    EXPECT_TRUE(result->use_default_or_null);
+    EXPECT_EQ(result->rowset, nullptr);
+    EXPECT_EQ(stats.num_rows_new_added, 1);
+    EXPECT_EQ(stats.num_rows_updated, 0);
+    EXPECT_EQ(stats.num_rows_deleted, 0);
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U);
+}
+
+// An existing key: the old row is located and marked deleted, its rowset is handed back so the
+// caller can pin it, and the old values must be read.
+TEST_F(KeyProbeTest, FoundMarksOldRowAndReturnsItsRowset) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4011, 2, {{1, 11}, {2, 22}, {3, 33}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto probe = make_fill_probe(schema, tablet, mow);
+
+    auto result = probe.probe(encode_key(schema, encoder, 2), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/false, /*have_delete_sign=*/false, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::FOUND);
+    EXPECT_FALSE(result->use_default_or_null);
+    ASSERT_NE(result->rowset, nullptr);
+    EXPECT_EQ(result->rowset->rowset_id(), rowset->rowset_id());
+    EXPECT_EQ(result->loc.rowset_id, rowset->rowset_id());
+    EXPECT_EQ(result->loc.segment_id, 0);
+    EXPECT_EQ(result->loc.row_id, 1U); // key 2 is the second row of the segment
+
+    EXPECT_EQ(stats.num_rows_updated, 1);
+    EXPECT_EQ(stats.num_rows_new_added, 0);
+    EXPECT_EQ(stats.num_rows_deleted, 0);
+    // only the old row is marked; the row being written stays alive
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 1));
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+}
+
+// The row being written carries the larger sequence value, so it wins: the old row is marked and
+// its values are still read for the missing columns.
+TEST_F(KeyProbeTest, HigherSequenceWins) {
+    auto schema = create_mow_schema(/*has_seq=*/true); // k(0) v(1) seq(2) delete_sign(3)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4101, 2, {{1, 11, 5, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto probe = make_fill_probe(schema, tablet, mow);
+
+    auto result = probe.probe(encode_key_with_seq(schema, encoder, 1, 10), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::FOUND);
+    EXPECT_FALSE(result->use_default_or_null);
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0));
+    EXPECT_FALSE(marked(mow, writing_rowset_id(), 0, 0));
+    EXPECT_EQ(stats.num_rows_updated, 1);
+    EXPECT_EQ(stats.num_rows_deleted, 0);
+}
+
+// Equal sequence values are not a loss: the incoming row still replaces the old one. This pins the
+// boundary of the "old row is newer" comparison.
+TEST_F(KeyProbeTest, EqualSequenceIsFoundNotFoundNewer) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4111, 2, {{2, 22, 10, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto probe = make_fill_probe(schema, tablet, mow);
+
+    auto result = probe.probe(encode_key_with_seq(schema, encoder, 2, 10), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::FOUND);
+    EXPECT_FALSE(result->use_default_or_null);
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0));
+    EXPECT_EQ(stats.num_rows_updated, 1);
+}
+
+// A delete of a key that does not exist yet: still a brand-new row. The probe counts it, and
+// deciding whether to reject it (handle_new_key) stays with the caller, which skips that call for
+// delete-signed rows.
+TEST_F(KeyProbeTest, DeleteSignOnMissingKeyIsStillANewRow) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4121, 2, {{1, 11}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto probe = make_fill_probe(schema, tablet, mow);
+
+    auto result = probe.probe(encode_key(schema, encoder, 99), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/false, /*have_delete_sign=*/true, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::NOT_FOUND);
+    EXPECT_EQ(result->rowset, nullptr);
+    EXPECT_EQ(stats.num_rows_new_added, 1);
+    EXPECT_EQ(stats.num_rows_updated, 0);
+    EXPECT_EQ(stats.num_rows_deleted, 0);
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U);
+}
+
+// The old row has the larger sequence value, so the row being written loses: it is the one marked
+// deleted (in the segment under construction), and with use_defaults_for_seq_loser the caller does
+// not read the old values.
+TEST_F(KeyProbeTest, FoundNewerMarksTheIncomingRow) {
+    auto schema = create_mow_schema(/*has_seq=*/true); // k(0) v(1) seq(2) delete_sign(3)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4021, 2, {{1, 11, 10, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    // a segment id other than 0, so the mark has to come from the probe's writing_segment_id
+    auto probe = make_fill_probe(schema, tablet, mow, /*flexible=*/false, /*writing_segment_id=*/3);
+
+    // incoming seq 5 < the old row seq 10
+    auto result = probe.probe(encode_key_with_seq(schema, encoder, 1, 5), /*segment_pos=*/7,
+                              /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::FOUND_NEWER);
+    EXPECT_TRUE(result->use_default_or_null);
+    EXPECT_EQ(stats.num_rows_deleted, 1);
+    EXPECT_EQ(stats.num_rows_updated, 0);
+    // the losing row of the segment being written is marked, the old row is not
+    EXPECT_TRUE(marked(mow, writing_rowset_id(), 3, 7));
+    EXPECT_FALSE(marked(mow, writing_rowset_id(), 0, 7));
+    EXPECT_FALSE(marked(mow, rowset->rowset_id(), 0, 0));
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+}
+
+// Same losing row, but with use_defaults_for_seq_loser off (the row binlog policy): the surviving
+// old row still has to be read, so its rowset comes back.
+TEST_F(KeyProbeTest, FoundNewerReadsOldRowWhenDefaultsForSeqLoserIsOff) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4031, 2, {{1, 11, 10, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto policy = fill_policy();
+    policy.use_defaults_for_seq_loser = false;
+    auto probe = make_probe(schema, tablet, mow, policy);
+
+    auto result = probe.probe(encode_key_with_seq(schema, encoder, 1, 5), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::FOUND_NEWER);
+    EXPECT_FALSE(result->use_default_or_null);
+    ASSERT_NE(result->rowset, nullptr);
+    EXPECT_EQ(result->loc.row_id, 0U);
+}
+
+// A delete-signed row needs no old values -- but only when the schema has no sequence column, since
+// the sequence value must survive for merge-on-read.
+TEST_F(KeyProbeTest, DeleteSignTakesDefaultsOnlyWithoutSequenceColumn) {
+    for (bool has_seq : {false, true}) {
+        auto schema = create_mow_schema(has_seq);
+        TabletSharedPtr tablet;
+        auto rowset = write_rowset(schema, has_seq ? 4041 : 4042, 2, {{1, 11, 3, 0}}, &tablet);
+        auto mow = make_mow_context(100, {rowset});
+        RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+        std::vector<RowsetSharedPtr> rowsets {rowset};
+        std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+        PartialUpdateStats stats;
+        auto probe = make_fill_probe(schema, tablet, mow);
+
+        auto result = probe.probe(encode_key(schema, encoder, 1), /*segment_pos=*/0,
+                                  /*key_has_seq_suffix=*/false, /*have_delete_sign=*/true, rowsets,
+                                  caches, stats);
+        ASSERT_TRUE(result.has_value()) << result.error();
+        EXPECT_EQ(result->result, KeyProbeResult::FOUND);
+        EXPECT_EQ(result->use_default_or_null, !has_seq) << "has_seq=" << has_seq;
+        // either way the old row is replaced by the delete
+        EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0));
+        EXPECT_EQ(stats.num_rows_updated, 1);
+    }
+}
+
+// The row binlog retriever keeps the old values of a delete-signed row so it can emit the
+// __BEFORE__ image: use_defaults_for_delete_signed off flips that same case.
+TEST_F(KeyProbeTest, DeleteSignReadsHistoryWhenDefaultsForDeleteSignedIsOff) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4051, 2, {{1, 11}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    auto policy = fill_policy();
+    policy.use_defaults_for_delete_signed = false;
+    auto probe = make_probe(schema, tablet, mow, policy);
+
+    auto result = probe.probe(encode_key(schema, encoder, 1), /*segment_pos=*/0,
+                              /*key_has_seq_suffix=*/false, /*have_delete_sign=*/true, rowsets,
+                              caches, stats);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->result, KeyProbeResult::FOUND);
+    EXPECT_FALSE(result->use_default_or_null);
+    ASSERT_NE(result->rowset, nullptr);
+}
+
+// MarkDeleted::NONE is a pure lookup: no delete bitmap writes, no delete counters.
+TEST_F(KeyProbeTest, MarkNoneLeavesTheDeleteBitmapAlone) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4061, 2, {{1, 11, 10, 0}, {2, 22, 10, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    // through the factory the row binlog retriever calls, so its MarkDeleted::NONE is pinned here
+    auto probe = MowKeyProbe::for_row_binlog(tablet.get(), schema.get(), schema->has_sequence_col(),
+                                             mow, /*write_before=*/true);
+
+    // a replaced row ...
+    auto found = probe.probe(encode_key_with_seq(schema, encoder, 1, 20), /*segment_pos=*/0,
+                             /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                             caches, stats);
+    ASSERT_TRUE(found.has_value()) << found.error();
+    EXPECT_EQ(found->result, KeyProbeResult::FOUND);
+    // ... and a row that loses on sequence
+    auto loser = probe.probe(encode_key_with_seq(schema, encoder, 2, 1), /*segment_pos=*/1,
+                             /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                             caches, stats);
+    ASSERT_TRUE(loser.has_value()) << loser.error();
+    EXPECT_EQ(loser->result, KeyProbeResult::FOUND_NEWER);
+
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U);
+    EXPECT_EQ(stats.num_rows_updated, 0);
+    EXPECT_EQ(stats.num_rows_deleted, 0);
+}
+
+// MarkDeleted::OLD_ROW marks the old row but never the row being written: the caller of this mode
+// (the block aggregator) drops the losing row itself.
+TEST_F(KeyProbeTest, OldRowModeNeverMarksTheIncomingRow) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4071, 2, {{1, 11, 10, 0}, {2, 22, 10, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    PartialUpdateStats stats;
+    MowKeyProbe::Policy policy {
+            .mark_deleted = MowKeyProbe::MarkDeleted::OLD_ROW,
+            .use_defaults_for_delete_signed = true,
+            .use_defaults_for_seq_loser = true,
+            .use_defaults_for_in_load_deleted = false,
+    };
+    auto probe = make_probe(schema, tablet, mow, policy);
+
+    auto found = probe.probe(encode_key_with_seq(schema, encoder, 1, 20), /*segment_pos=*/0,
+                             /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                             caches, stats);
+    ASSERT_TRUE(found.has_value()) << found.error();
+    EXPECT_EQ(found->result, KeyProbeResult::FOUND);
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0));
+    EXPECT_EQ(stats.num_rows_updated, 1);
+
+    auto loser = probe.probe(encode_key_with_seq(schema, encoder, 2, 1), /*segment_pos=*/1,
+                             /*key_has_seq_suffix=*/true, /*have_delete_sign=*/false, rowsets,
+                             caches, stats);
+    ASSERT_TRUE(loser.has_value()) << loser.error();
+    EXPECT_EQ(loser->result, KeyProbeResult::FOUND_NEWER);
+    EXPECT_FALSE(marked(mow, writing_rowset_id(), 0, 1));
+    EXPECT_EQ(stats.num_rows_deleted, 0);
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+}
+
+// Flexible partial update, insert after delete in one load: the old row was already deleted earlier
+// in this same load, so the insert counts as brand new and its old values must not be read back.
+TEST_F(KeyProbeTest, InLoadDeletedTreatsReinsertAsNewRow) {
+    for (bool use_defaults_for_in_load_deleted : {false, true}) {
+        auto schema = create_mow_schema(/*has_seq=*/false);
+        TabletSharedPtr tablet;
+        auto rowset = write_rowset(schema, use_defaults_for_in_load_deleted ? 4081 : 4082, 2,
+                                   {{1, 11}}, &tablet);
+        auto mow = make_mow_context(100, {rowset});
+        RowKeyEncoder encoder {*schema, /*mow=*/true};
+        // an earlier row of this load already deleted the old row
+        mow->delete_bitmap->add({rowset->rowset_id(), 0, DeleteBitmap::TEMP_VERSION_COMMON}, 0);
+
+        std::vector<RowsetSharedPtr> rowsets {rowset};
+        std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+        PartialUpdateStats stats;
+        auto probe =
+                make_fill_probe(schema, tablet, mow, /*flexible=*/use_defaults_for_in_load_deleted);
+
+        auto result = probe.probe(encode_key(schema, encoder, 1), /*segment_pos=*/0,
+                                  /*key_has_seq_suffix=*/false, /*have_delete_sign=*/false, rowsets,
+                                  caches, stats);
+        ASSERT_TRUE(result.has_value()) << result.error();
+        EXPECT_EQ(result->result, KeyProbeResult::FOUND);
+        EXPECT_EQ(result->use_default_or_null, use_defaults_for_in_load_deleted)
+                << "use_defaults_for_in_load_deleted=" << use_defaults_for_in_load_deleted;
+    }
+}
+
+// The aggregator's lookup: no sequence suffix on the probe key, the old row's sequence value comes
+// back encoded, and nothing is marked deleted.
+TEST_F(KeyProbeTest, ProbePreviousSeqValueReturnsTheOldRowSequence) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 4091, 2, {{1, 11, 7, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    std::vector<RowsetSharedPtr> rowsets {rowset};
+    std::vector<std::unique_ptr<SegmentCacheHandle>> caches(rowsets.size());
+    auto probe = make_fill_probe(schema, tablet, mow);
+
+    auto hit = probe.probe_previous_seq_value(encode_key(schema, encoder, 1), rowsets, caches);
+    ASSERT_TRUE(hit.has_value()) << hit.error();
+    EXPECT_EQ(hit->outcome.result, KeyProbeResult::FOUND);
+    EXPECT_FALSE(hit->outcome.use_default_or_null);
+    ASSERT_NE(hit->outcome.rowset, nullptr);
+    // the encoded suffix of the old row: marker byte + the value bytes of seq=7
+    std::string expected = encode_key(schema, encoder, 1);
+    std::string with_suffix = encode_key_with_seq(schema, encoder, 1, 7);
+    EXPECT_EQ(hit->encoded_seq_value, with_suffix.substr(expected.size()));
+
+    auto miss = probe.probe_previous_seq_value(encode_key(schema, encoder, 42), rowsets, caches);
+    ASSERT_TRUE(miss.has_value()) << miss.error();
+    EXPECT_EQ(miss->outcome.result, KeyProbeResult::NOT_FOUND);
+    EXPECT_TRUE(miss->outcome.use_default_or_null);
+
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U);
+}
+
+// Row cache invalidation. The cache is keyed by the encoded key *without* the sequence suffix, so
+// encode_mow_key_invalidate_cache must invalidate before it appends the suffix -- and it must still
+// return the key with the suffix.
+class RowCacheProbeTest : public KeyProbeTest {
+protected:
+    void SetUp() override {
+        KeyProbeTest::SetUp();
+        _saved_cache = ExecEnv::GetInstance()->get_row_cache();
+        _cache = new RowCache(1024 * 1024, 1);
+        ExecEnv::GetInstance()->_row_cache = _cache;
+        _saved_disable_row_cache = config::disable_storage_row_cache;
+        config::disable_storage_row_cache = false;
+    }
+
+    void TearDown() override {
+        config::disable_storage_row_cache = _saved_disable_row_cache;
+        ExecEnv::GetInstance()->_row_cache = _saved_cache;
+        delete _cache;
+        KeyProbeTest::TearDown();
+    }
+
+    static bool cached(int64_t tablet_id, const std::string& key) {
+        RowCache::CacheHandle handle;
+        return RowCache::instance()->lookup({tablet_id, Slice {key}}, &handle);
+    }
+
+    static void cache_row(int64_t tablet_id, const std::string& key) {
+        RowCache::instance()->insert({tablet_id, Slice {key}}, Slice {"row"});
+    }
+
+    // encode_mow_key_invalidate_cache the way the fill loops call it: the column accessors must
+    // outlive the call, so the convertor stays alive here.
+    std::string encode_and_invalidate(const TabletSchemaSPtr& schema, const RowKeyEncoder& encoder,
+                                      int32_t k, bool row_has_seq, int32_t seq,
+                                      DataWriteType write_type) {
+        const auto seq_idx = static_cast<uint32_t>(schema->sequence_col_idx());
+        Block block = row_has_seq ? schema->create_block_by_cids({0, seq_idx})
+                                  : schema->create_block_by_cids({0});
+        block.get_by_position(0).column->assert_mutable()->insert_data(
+                reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        OlapBlockDataConvertor convertor;
+        convertor.add_column_data_convertor(schema->column(0));
+        if (row_has_seq) {
+            block.get_by_position(1).column->assert_mutable()->insert_data(
+                    reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+            convertor.add_column_data_convertor(schema->column(seq_idx));
+        }
+        convertor.set_source_content(&block, 0, 1);
+        auto [key_st, key_accessor] = convertor.convert_column_data(0);
+        EXPECT_TRUE(key_st.ok()) << key_st;
+        IOlapColumnDataAccessor* seq_accessor = nullptr;
+        if (row_has_seq) {
+            auto [seq_st, accessor] = convertor.convert_column_data(1);
+            EXPECT_TRUE(seq_st.ok()) << seq_st;
+            seq_accessor = accessor;
+        }
+        std::vector<IOlapColumnDataAccessor*> key_columns {key_accessor};
+        return segment_v2::encode_mow_key_invalidate_cache(
+                encoder, key_columns, seq_accessor, 0, row_has_seq, kTabletId, *schema, write_type);
+    }
+
+    RowCache* _cache = nullptr;
+    RowCache* _saved_cache = nullptr;
+    bool _saved_disable_row_cache = false;
+};
+
+TEST_F(RowCacheProbeTest, InvalidatesTheSeqlessKeyAndReturnsTheSuffixedKey) {
+    auto schema = create_row_store_schema(/*has_seq=*/true);
+    RowKeyEncoder encoder {*schema, /*mow=*/true};
+
+    const std::string seqless_key = encode_key(schema, encoder, 1);
+    const std::string suffixed_key = encode_key_with_seq(schema, encoder, 1, 9);
+    ASSERT_GT(suffixed_key.size(), seqless_key.size());
+
+    cache_row(kTabletId, seqless_key);
+    cache_row(kTabletId, suffixed_key);
+    ASSERT_TRUE(cached(kTabletId, seqless_key));
+
+    std::string key = encode_and_invalidate(schema, encoder, 1, /*row_has_seq=*/true, 9,
+                                            DataWriteType::TYPE_DIRECT);
+    EXPECT_EQ(key, suffixed_key);
+    // the cache entry of the row itself is gone ...
+    EXPECT_FALSE(cached(kTabletId, seqless_key));
+    // ... and the suffixed key was never used as a cache key
+    EXPECT_TRUE(cached(kTabletId, suffixed_key));
+}
+
+TEST_F(RowCacheProbeTest, KeepsTheCacheForNonDirectWritesAndNonRowStoreSchemas) {
+    auto row_store_schema = create_row_store_schema();
+    RowKeyEncoder row_store_encoder {*row_store_schema, /*mow=*/true};
+    const std::string key = encode_key(row_store_schema, row_store_encoder, 1);
+
+    // compaction output is not visible through the row cache, so it must not invalidate anything
+    cache_row(kTabletId, key);
+    static_cast<void>(encode_and_invalidate(row_store_schema, row_store_encoder, 1,
+                                            /*row_has_seq=*/false, 0,
+                                            DataWriteType::TYPE_COMPACTION));
+    EXPECT_TRUE(cached(kTabletId, key));
+
+    // a schema without the row store column never populates the cache either. Key 2, so this
+    // sub-case owns a cache entry of its own: both schemas start with the same INT key column, so
+    // key 1 would encode to the exact bytes the sub-case above cached.
+    auto plain_schema = create_mow_schema(/*has_seq=*/false);
+    RowKeyEncoder plain_encoder {*plain_schema, /*mow=*/true};
+    const std::string plain_key = encode_key(plain_schema, plain_encoder, 2);
+    ASSERT_NE(plain_key, key);
+    cache_row(kTabletId, plain_key);
+    static_cast<void>(encode_and_invalidate(plain_schema, plain_encoder, 2, /*row_has_seq=*/false,
+                                            0, DataWriteType::TYPE_DIRECT));
+    EXPECT_TRUE(cached(kTabletId, plain_key));
+
+    // the direct write of a row-store schema still invalidates
+    static_cast<void>(encode_and_invalidate(row_store_schema, row_store_encoder, 1,
+                                            /*row_has_seq=*/false, 0, DataWriteType::TYPE_DIRECT));
+    EXPECT_FALSE(cached(kTabletId, key));
+}
+
+} // namespace doris

--- a/be/test/storage/mow/mow_transform_test_base.h
+++ b/be/test/storage/mow/mow_transform_test_base.h
@@ -1,0 +1,343 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/consts.h"
+#include "common/status.h"
+#include "core/assert_cast.h"
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_vector.h"
+#include "io/fs/local_file_system.h"
+#include "runtime/exec_env.h"
+#include "storage/data_dir.h"
+#include "storage/iterator/olap_data_convertor.h"
+#include "storage/key/row_key_encoder.h"
+#include "storage/olap_common.h"
+#include "storage/options.h"
+#include "storage/partial_update_info.h"
+#include "storage/rowset/beta_rowset.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/segment/historical_row_retriever.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet/tablet.h"
+#include "storage/tablet/tablet_meta.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris {
+
+// One input row for a MoW unique-key tablet with layout: k INT (key), v INT (value), [seq INT],
+// __DORIS_DELETE_SIGN__ TINYINT. `seq` is only meaningful when the schema was built with has_seq.
+struct MowRow {
+    int32_t k;
+    int32_t v;
+    int32_t seq = 0;
+    int8_t delete_sign = 0;
+};
+
+// Shared fixture for the MoW transform-chain test layers (key probe, historical row fetcher,
+// partial update fill). Sets up a real StorageEngine + DataDir, and can write committed MoW rowsets
+// whose primary key index BaseTablet:: lookup_row_key (and therefore MowKeyProbe) can query.
+class MowTransformTestBase : public testing::Test {
+public:
+    void SetUp() override {
+        char buffer[1024];
+        EXPECT_NE(getcwd(buffer, sizeof(buffer)), nullptr);
+        _root = std::string(buffer) + "/mow_transform_ut";
+        config::storage_root_path = _root;
+
+        auto fs = io::global_local_filesystem();
+        ASSERT_TRUE(fs->delete_directory(_root).ok());
+        ASSERT_TRUE(fs->create_directory(_root).ok());
+
+        std::vector<StorePath> paths;
+        paths.emplace_back(_root, -1);
+        EngineOptions options;
+        options.store_paths = paths;
+        auto engine = std::make_unique<StorageEngine>(options);
+        ASSERT_TRUE(engine->open().ok());
+        _engine = engine.get();
+        ExecEnv::GetInstance()->set_storage_engine(std::move(engine));
+
+        _data_dir = std::make_unique<DataDir>(*_engine, _root);
+        static_cast<void>(_data_dir->update_capacity());
+    }
+
+    void TearDown() override {
+        _engine = nullptr;
+        ExecEnv::GetInstance()->set_storage_engine(nullptr);
+        static_cast<void>(io::global_local_filesystem()->delete_directory(_root));
+    }
+
+protected:
+    // (k INT key, v INT, [seq INT], delete-sign) UNIQUE_KEYS MoW schema.
+    TabletSchemaSPtr create_mow_schema(bool has_seq) {
+        TabletSchemaPB pb;
+        pb.set_keys_type(UNIQUE_KEYS);
+        pb.set_num_short_key_columns(1);
+        pb.set_num_rows_per_row_block(1024);
+        pb.set_compress_kind(COMPRESS_LZ4);
+        pb.set_next_column_unique_id(10);
+
+        auto add_col = [&](int uid, const std::string& name, const std::string& type, bool is_key,
+                           bool nullable, const std::string& def = "") {
+            ColumnPB* c = pb.add_column();
+            c->set_unique_id(uid);
+            c->set_name(name);
+            c->set_type(type);
+            c->set_is_key(is_key);
+            c->set_length(type == "TINYINT" ? 1 : 4);
+            c->set_index_length(type == "TINYINT" ? 1 : 4);
+            c->set_is_nullable(nullable);
+            c->set_is_bf_column(false);
+            c->set_aggregation("NONE");
+            if (!def.empty()) {
+                c->set_default_value(def);
+            }
+        };
+
+        add_col(0, "k", "INT", true, false);
+        add_col(1, "v", "INT", false, true, std::to_string(0));
+        int next_uid = 2;
+        int seq_idx = -1;
+        if (has_seq) {
+            seq_idx = pb.column_size();
+            add_col(next_uid++, SEQUENCE_COL, "INT", false, false, std::to_string(0));
+        }
+        // delete sign column (hidden) -- value 1 means the row is a delete.
+        add_col(next_uid++, DELETE_SIGN, "TINYINT", false, false, std::to_string(0));
+        if (seq_idx >= 0) {
+            pb.set_sequence_col_idx(seq_idx);
+        }
+
+        auto schema = std::make_shared<TabletSchema>();
+        schema->init_from_pb(pb);
+        return schema;
+    }
+
+    // (k INT key, v INT, [seq INT], delete-sign, __DORIS_ROW_STORE_COL__ STRING) with the hidden
+    // full row-store column enabled -- the only shape for which the write path touches the row
+    // cache.
+    TabletSchemaSPtr create_row_store_schema(bool has_seq = false) {
+        TabletSchemaPB pb;
+        pb.set_keys_type(UNIQUE_KEYS);
+        pb.set_num_short_key_columns(1);
+        pb.set_num_rows_per_row_block(1024);
+        pb.set_compress_kind(COMPRESS_LZ4);
+        pb.set_next_column_unique_id(10);
+        pb.set_store_row_column(true);
+
+        auto add = [&](int uid, const std::string& name, const std::string& type, bool is_key,
+                       int len, const std::string& def = "") {
+            ColumnPB* c = pb.add_column();
+            c->set_unique_id(uid);
+            c->set_name(name);
+            c->set_type(type);
+            c->set_is_key(is_key);
+            c->set_length(len);
+            c->set_index_length(type == "STRING" ? 4 : len);
+            // the hidden row-store column must be non-nullable: its writer static_casts the built
+            // column to a plain ColumnString. The delete-sign and sequence columns are also
+            // non-nullable (NOT NULL with default 0 in real schemas) -- get_delete_sign_column_data
+            // assert_casts the former to a plain ColumnVector<Int8>.
+            c->set_is_nullable(!is_key && name != BeConsts::ROW_STORE_COL && name != DELETE_SIGN &&
+                               name != SEQUENCE_COL);
+            c->set_is_bf_column(false);
+            c->set_aggregation("NONE");
+            if (!def.empty()) {
+                c->set_default_value(def);
+            }
+        };
+        add(0, "k", "INT", true, 4);
+        add(1, "v", "INT", false, 4, std::to_string(0));
+        int next_uid = 2;
+        if (has_seq) {
+            pb.set_sequence_col_idx(pb.column_size());
+            add(next_uid++, SEQUENCE_COL, "INT", false, 4, std::to_string(0));
+        }
+        add(next_uid++, DELETE_SIGN, "TINYINT", false, 1, std::to_string(0));
+        add(next_uid++, BeConsts::ROW_STORE_COL, "STRING", false, 2147483643);
+
+        auto schema = std::make_shared<TabletSchema>();
+        schema->init_from_pb(pb);
+        return schema;
+    }
+
+    void make_rowset_ctx(const TabletSchemaSPtr& schema, int64_t rowset_numeric_id, int64_t version,
+                         RowsetWriterContext* ctx, TabletSharedPtr* out_tablet) {
+        RowsetId rid;
+        rid.init(rowset_numeric_id);
+        ctx->rowset_id = rid;
+        ctx->tablet_id = kTabletId;
+        ctx->tablet_schema_hash = 1;
+        ctx->partition_id = 10;
+        ctx->rowset_type = BETA_ROWSET;
+        ctx->tablet_path = _root;
+        ctx->rowset_state = VISIBLE;
+        ctx->tablet_schema = schema;
+        ctx->version = {version, version};
+        ctx->enable_unique_key_merge_on_write = true;
+        ctx->write_type = DataWriteType::TYPE_DIRECT;
+
+        TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+        tablet_meta->_tablet_id = kTabletId;
+        static_cast<void>(tablet_meta->set_partition_id(10));
+        tablet_meta->_schema = schema;
+        tablet_meta->_enable_unique_key_merge_on_write = true;
+        auto tablet = std::make_shared<Tablet>(*_engine, tablet_meta, _data_dir.get(), "mow_ut");
+        ctx->tablet = tablet;
+        *out_tablet = tablet;
+    }
+
+    // Builds and commits a MoW rowset containing `rows` (must be sorted unique by key, like a real
+    // flushed segment). Returns the committed rowset.
+    RowsetSharedPtr write_rowset(const TabletSchemaSPtr& schema, int64_t rowset_numeric_id,
+                                 int64_t version, const std::vector<MowRow>& rows,
+                                 TabletSharedPtr* out_tablet) {
+        RowsetWriterContext ctx;
+        make_rowset_ctx(schema, rowset_numeric_id, version, &ctx, out_tablet);
+
+        auto rw = RowsetFactory::create_rowset_writer(*_engine, ctx, false);
+        EXPECT_TRUE(rw.has_value()) << rw.error();
+        auto writer = std::move(rw).value();
+
+        Block block = schema->create_block();
+        std::vector<IColumn*> mcols;
+        for (size_t i = 0; i < block.columns(); ++i) {
+            mcols.push_back(block.get_by_position(i).column->assert_mutable().get());
+        }
+        const bool has_seq = schema->has_sequence_col();
+        for (const auto& r : rows) {
+            size_t c = 0;
+            mcols[c++]->insert_data(reinterpret_cast<const char*>(&r.k), sizeof(int32_t));
+            mcols[c++]->insert_data(reinterpret_cast<const char*>(&r.v), sizeof(int32_t));
+            if (has_seq) {
+                mcols[c++]->insert_data(reinterpret_cast<const char*>(&r.seq), sizeof(int32_t));
+            }
+            mcols[c++]->insert_data(reinterpret_cast<const char*>(&r.delete_sign), sizeof(int8_t));
+        }
+        // Fill any trailing columns not described by MowRow (e.g. the flexible skip-bitmap column)
+        // with defaults so every column has the same height.
+        for (size_t cid = (has_seq ? 4 : 3); cid < mcols.size(); ++cid) {
+            mcols[cid]->insert_many_defaults(rows.size());
+        }
+        EXPECT_TRUE(writer->add_block(&block).ok());
+        EXPECT_TRUE(writer->flush().ok());
+        RowsetSharedPtr rowset;
+        EXPECT_TRUE(writer->build(rowset).ok());
+        EXPECT_TRUE(rowset != nullptr);
+        return rowset;
+    }
+
+    std::shared_ptr<MowContext> make_mow_context(int64_t version,
+                                                 const std::vector<RowsetSharedPtr>& rowsets) {
+        auto rsids = std::make_shared<RowsetIdUnorderedSet>();
+        for (const auto& rs : rowsets) {
+            rsids->insert(rs->rowset_id());
+        }
+        auto delete_bitmap = std::make_shared<DeleteBitmap>(kTabletId);
+        return std::make_shared<MowContext>(version, /*txn_id=*/1, rsids, rowsets, delete_bitmap);
+    }
+
+    // Encodes a primary key (single INT key column = `k`) the same way the fill stage does: convert
+    // a 1-row block then RowKeyEncoder::full_encode_primary_keys.
+    std::string encode_key(const TabletSchemaSPtr& schema, const RowKeyEncoder& encoder,
+                           int32_t k) {
+        Block block = schema->create_block_by_cids({0});
+        block.get_by_position(0).column->assert_mutable()->insert_data(
+                reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        OlapBlockDataConvertor convertor;
+        convertor.add_column_data_convertor(schema->column(0));
+        convertor.set_source_content(&block, 0, 1);
+        auto [st, accessor] = convertor.convert_column_data(0);
+        EXPECT_TRUE(st.ok()) << st;
+        std::vector<IOlapColumnDataAccessor*> key_columns {accessor};
+        return encoder.full_encode_primary_keys(key_columns, 0);
+    }
+
+    // Encodes a primary key plus its sequence suffix (incoming seq value), the way
+    // MowKeyProbe::probe expects when key_has_seq_suffix is true.
+    std::string encode_key_with_seq(const TabletSchemaSPtr& schema, const RowKeyEncoder& encoder,
+                                    int32_t k, int32_t seq) {
+        const auto seq_idx = static_cast<uint32_t>(schema->sequence_col_idx());
+        Block block = schema->create_block_by_cids({0, seq_idx});
+        block.get_by_position(0).column->assert_mutable()->insert_data(
+                reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        block.get_by_position(1).column->assert_mutable()->insert_data(
+                reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+        OlapBlockDataConvertor convertor;
+        convertor.add_column_data_convertor(schema->column(0));
+        convertor.add_column_data_convertor(schema->column(seq_idx));
+        convertor.set_source_content(&block, 0, 1);
+        auto [st0, key_acc] = convertor.convert_column_data(0);
+        EXPECT_TRUE(st0.ok()) << st0;
+        auto [st1, seq_acc] = convertor.convert_column_data(1);
+        EXPECT_TRUE(st1.ok()) << st1;
+        std::vector<IOlapColumnDataAccessor*> key_columns {key_acc};
+        std::string key = encoder.full_encode_primary_keys(key_columns, 0);
+        encoder.append_seq_suffix(&key, seq_acc, 0);
+        return key;
+    }
+
+    segment_v2::HistoricalRowRetrieverContext make_fetcher_ctx(
+            const TabletSchemaSPtr& schema, const TabletSharedPtr& tablet,
+            std::shared_ptr<PartialUpdateInfo> pui = nullptr) {
+        return segment_v2::HistoricalRowRetrieverContext {.tablet = tablet,
+                                                          .tablet_schema = schema,
+                                                          .rowset_writer_ctx = nullptr,
+                                                          .partial_update_info = std::move(pui),
+                                                          .is_transient_rowset_writer = false,
+                                                          .write_type = DataWriteType::TYPE_DIRECT};
+    }
+
+    // Reads an int32 cell from a (possibly nullable) INT column of `block`.
+    static int32_t read_int(const Block& block, size_t col_pos, size_t row) {
+        const IColumn* col = block.get_by_position(col_pos).column.get();
+        if (col->is_nullable()) {
+            col = &assert_cast<const ColumnNullable&>(*col).get_nested_column();
+        }
+        return assert_cast<const ColumnInt32&>(*col).get_data()[row];
+    }
+
+    // True iff the cell is SQL NULL. A non-nullable column is never null. Use alongside read_int to
+    // distinguish "value X" from "null with X left in the nested column".
+    static bool read_is_null(const Block& block, size_t col_pos, size_t row) {
+        const IColumn* col = block.get_by_position(col_pos).column.get();
+        if (!col->is_nullable()) {
+            return false;
+        }
+        return assert_cast<const ColumnNullable&>(*col).is_null_at(row);
+    }
+
+    static constexpr int64_t kTabletId = 90001;
+
+    StorageEngine* _engine = nullptr;
+    std::unique_ptr<DataDir> _data_dir;
+    std::string _root;
+};
+
+} // namespace doris

--- a/be/test/storage/segment/historical_row_retriever_test.cpp
+++ b/be/test/storage/segment/historical_row_retriever_test.cpp
@@ -26,12 +26,268 @@
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "storage/binlog.h"
-#include "storage/olap_common.h"
-#include "storage/utils.h"
+#include "storage/mow/historical_row_fetcher.h"
+#include "storage/mow/mow_transform_test_base.h"
+#include "storage/partial_update_info.h"
+#include "storage/rowset/rowset_writer_context.h"
 
-namespace doris::segment_v2 {
+namespace doris {
 
-TEST(HistoricalRowRetrieverTest, ReviseOperatorWithOldDeleteSign) {
+using segment_v2::PrimaryKeyModelRowRetriever;
+
+// The row-binlog retriever probes the primary key index for every incoming row to decide the binlog
+// operator and, when needed, to read the old row.
+class HistoricalRowRetrieverTest : public MowTransformTestBase {
+protected:
+    // Keeps the converted key column accessors alive for as long as the retriever needs them.
+    class KeyAccessors {
+    public:
+        // `block` holds the key column, and the sequence column too when `with_seq` is set (the
+        // retriever then probes with a seq suffix).
+        KeyAccessors(const TabletSchemaSPtr& schema, Block* block, size_t num_rows,
+                     bool with_seq = false) {
+            _convertor.add_column_data_convertor(schema->column(0));
+            if (with_seq) {
+                _convertor.add_column_data_convertor(
+                        schema->column(static_cast<uint32_t>(schema->sequence_col_idx())));
+            }
+            _convertor.set_source_content(block, 0, num_rows);
+            auto [st, accessor] = _convertor.convert_column_data(0);
+            EXPECT_TRUE(st.ok()) << st;
+            _accessors.push_back(accessor);
+            if (with_seq) {
+                auto [seq_st, seq] = _convertor.convert_column_data(1);
+                EXPECT_TRUE(seq_st.ok()) << seq_st;
+                _seq_column = seq;
+            }
+        }
+
+        const std::vector<IOlapColumnDataAccessor*>& get() const { return _accessors; }
+        IOlapColumnDataAccessor* seq_column() const { return _seq_column; }
+
+    private:
+        OlapBlockDataConvertor _convertor;
+        std::vector<IOlapColumnDataAccessor*> _accessors;
+        IOlapColumnDataAccessor* _seq_column = nullptr;
+    };
+
+    std::shared_ptr<PartialUpdateInfo> key_only_partial_update(const TabletSchemaSPtr& schema) {
+        auto info = std::make_shared<PartialUpdateInfo>();
+        EXPECT_TRUE(info->init(kTabletId, /*txn_id=*/1, *schema,
+                               UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                               PartialUpdateNewRowPolicyPB::APPEND, {"k"}, /*is_strict_mode=*/false,
+                               /*timestamp_ms=*/0, /*nano_seconds=*/0, "UTC", "")
+                            .ok());
+        return info;
+    }
+
+    void fill_rowset_ctx(RowsetWriterContext* ctx, const TabletSchemaSPtr& schema,
+                         const TabletSharedPtr& tablet,
+                         const std::shared_ptr<PartialUpdateInfo>& info, bool need_before) {
+        ctx->tablet_id = kTabletId;
+        ctx->tablet = tablet;
+        ctx->tablet_schema = schema;
+        ctx->partial_update_info = info;
+        ctx->write_type = DataWriteType::TYPE_DIRECT;
+        ctx->write_binlog_opt().enable = true;
+        ctx->write_binlog_opt().set_need_before(need_before);
+    }
+
+    // A block holding the key column and the sequence column, in that order.
+    static Block key_seq_block(const TabletSchemaSPtr& schema, int32_t key, int32_t seq) {
+        Block block = schema->create_block_by_cids(
+                {0, static_cast<uint32_t>(schema->sequence_col_idx())});
+        block.get_by_position(0).column->assert_mutable()->insert_data(
+                reinterpret_cast<const char*>(&key), sizeof(int32_t));
+        block.get_by_position(1).column->assert_mutable()->insert_data(
+                reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+        return block;
+    }
+
+    // A block holding only the key column, plus the full-width block the AFTER image is built into.
+    static Block key_block(const TabletSchemaSPtr& schema, const std::vector<int32_t>& keys) {
+        Block block = schema->create_block_by_cids({0});
+        auto* column = block.get_by_position(0).column->assert_mutable().get();
+        for (int32_t k : keys) {
+            column->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        }
+        return block;
+    }
+};
+
+// An existing key becomes an update whose old value is read, a missing key becomes an append that
+// takes the column default.
+TEST_F(HistoricalRowRetrieverTest, UpdateReadsHistoryAndAppendTakesDefault) {
+    auto schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 6001, 2, {{1, 11}, {2, 22}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    auto info = key_only_partial_update(schema);
+
+    RowsetWriterContext rowset_ctx;
+    fill_rowset_ctx(&rowset_ctx, schema, tablet, info, /*need_before=*/false);
+
+    Block input = key_block(schema, {1, 99});
+    KeyAccessors keys {schema, &input, 2};
+
+    PrimaryKeyModelRowRetriever retriever;
+    ASSERT_TRUE(retriever.init(rowset_ctx.make_historical_row_retriever_context()).ok());
+    ASSERT_TRUE(retriever.prepare_lookup_plan_from_source_columns(keys.get(), nullptr, mow).ok());
+    auto st = retriever.retrieve_historical_row(/*delete_sign_column_data=*/nullptr, 0, 2);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(retriever.get_operators().size(), 2);
+    EXPECT_EQ(retriever.get_operators()[0], ROW_BINLOG_UPDATE);
+    EXPECT_EQ(retriever.get_operators()[1], ROW_BINLOG_APPEND);
+    // a read-only probe: the load's delete bitmap must stay untouched
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U);
+
+    Block after_block = schema->create_block();
+    after_block.replace_by_position(0, input.get_by_position(0).column);
+    st = retriever.build_after_block(&after_block, 0, 2);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(read_int(after_block, 1, 0), 11); // old value of key 1
+    EXPECT_EQ(read_int(after_block, 1, 1), 0);  // brand-new key 99 -> default
+}
+
+// A delete-signed row: without the BEFORE image there is nothing to read back, with it the old row
+// must still be fetched so __BEFORE__* can be filled.
+TEST_F(HistoricalRowRetrieverTest, DeleteReadsHistoryOnlyWhenBeforeImageIsWanted) {
+    for (bool need_before : {false, true}) {
+        auto schema = create_mow_schema(/*has_seq=*/false);
+        TabletSharedPtr tablet;
+        auto rowset = write_rowset(schema, need_before ? 6011 : 6012, 2, {{1, 11}}, &tablet);
+        auto mow = make_mow_context(100, {rowset});
+        auto info = key_only_partial_update(schema);
+
+        RowsetWriterContext rowset_ctx;
+        fill_rowset_ctx(&rowset_ctx, schema, tablet, info, need_before);
+
+        Block input = key_block(schema, {1});
+        KeyAccessors keys {schema, &input, 1};
+        std::vector<Int8> delete_signs {1};
+
+        PrimaryKeyModelRowRetriever retriever;
+        ASSERT_TRUE(retriever.init(rowset_ctx.make_historical_row_retriever_context()).ok());
+        ASSERT_TRUE(
+                retriever.prepare_lookup_plan_from_source_columns(keys.get(), nullptr, mow).ok());
+        auto st = retriever.retrieve_historical_row(delete_signs.data(), 0, 1);
+        ASSERT_TRUE(st.ok()) << st;
+
+        ASSERT_EQ(retriever.get_operators().size(), 1);
+        EXPECT_EQ(retriever.get_operators()[0], ROW_BINLOG_DELETE);
+
+        Block before_block = schema->create_block_by_cids({1});
+        st = retriever.build_before_block(&before_block, {1}, 0, 1);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(before_block.rows(), 1);
+        EXPECT_EQ(read_is_null(before_block, 0, 0), !need_before) << "need_before=" << need_before;
+        if (need_before) {
+            EXPECT_EQ(read_int(before_block, 0, 0), 11);
+        }
+    }
+}
+
+// A row that loses on sequence: the writers would stop reading the old row here, the retriever must
+// not — the surviving old row is what the binlog reports. This is the retriever's
+// `use_defaults_for_seq_loser = false`.
+TEST_F(HistoricalRowRetrieverTest, RowLosingOnSequenceStillReadsTheStoredRow) {
+    auto schema = create_mow_schema(/*has_seq=*/true); // k(0) v(1) seq(2) delete_sign(3)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 6031, 2, {{1, 11, 10, 0}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    auto info = key_only_partial_update(schema);
+
+    RowsetWriterContext rowset_ctx;
+    fill_rowset_ctx(&rowset_ctx, schema, tablet, info, /*need_before=*/false);
+
+    // incoming sequence 5 < stored 10
+    Block input = key_seq_block(schema, /*key=*/1, /*seq=*/5);
+    KeyAccessors keys {schema, &input, 1, /*with_seq=*/true};
+
+    PrimaryKeyModelRowRetriever retriever;
+    ASSERT_TRUE(retriever.init(rowset_ctx.make_historical_row_retriever_context()).ok());
+    ASSERT_TRUE(
+            retriever.prepare_lookup_plan_from_source_columns(keys.get(), keys.seq_column(), mow)
+                    .ok());
+    auto st = retriever.retrieve_historical_row(nullptr, 0, 1);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(retriever.get_operators().size(), 1);
+    EXPECT_EQ(retriever.get_operators()[0], ROW_BINLOG_UPDATE);
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U); // MarkDeleted::NONE: nothing is marked
+
+    Block before_block = schema->create_block_by_cids({1});
+    ASSERT_TRUE(retriever.build_before_block(&before_block, {1}, 0, 1).ok());
+    ASSERT_EQ(before_block.rows(), 1);
+    EXPECT_FALSE(read_is_null(before_block, 0, 0));
+    EXPECT_EQ(read_int(before_block, 0, 0), 11); // the row that survives
+}
+
+// clear() runs between two appended blocks of the same load. The first block goes through the
+// production order -- AFTER then BEFORE, both served by the same read plan -- and the second block
+// is a miss, so a plan that survived clear() is observable: its stale entry would be read back into
+// the BEFORE image of a row that has no history at all.
+TEST_F(HistoricalRowRetrieverTest, ClearResetsThePerBlockState) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 6021, 2, {{1, 11}, {2, 22}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+    auto info = key_only_partial_update(schema);
+
+    RowsetWriterContext rowset_ctx;
+    fill_rowset_ctx(&rowset_ctx, schema, tablet, info, /*need_before=*/true);
+
+    PrimaryKeyModelRowRetriever retriever;
+    ASSERT_TRUE(retriever.init(rowset_ctx.make_historical_row_retriever_context()).ok());
+
+    Block first = key_block(schema, {1});
+    {
+        KeyAccessors keys {schema, &first, 1};
+        ASSERT_TRUE(
+                retriever.prepare_lookup_plan_from_source_columns(keys.get(), nullptr, mow).ok());
+        ASSERT_TRUE(retriever.retrieve_historical_row(nullptr, 0, 1).ok());
+        ASSERT_EQ(retriever.get_operators().size(), 1);
+        EXPECT_EQ(retriever.get_operators()[0], ROW_BINLOG_UPDATE);
+
+        Block after_block = schema->create_block();
+        after_block.replace_by_position(0, first.get_by_position(0).column);
+        ASSERT_TRUE(retriever.build_after_block(&after_block, 0, 1).ok());
+        EXPECT_EQ(read_int(after_block, 1, 0), 11);
+        // the same plan still serves the BEFORE image after the AFTER image consumed it
+        Block before_block = schema->create_block_by_cids({1});
+        ASSERT_TRUE(retriever.build_before_block(&before_block, {1}, 0, 1).ok());
+        ASSERT_EQ(before_block.rows(), 1);
+        EXPECT_FALSE(read_is_null(before_block, 0, 0));
+        EXPECT_EQ(read_int(before_block, 0, 0), 11);
+    }
+    retriever.clear();
+
+    // key 99 is in no rowset, so nothing may be planned for it
+    Block second = key_block(schema, {99});
+    KeyAccessors keys {schema, &second, 1};
+    ASSERT_TRUE(retriever.prepare_lookup_plan_from_source_columns(keys.get(), nullptr, mow).ok());
+    ASSERT_TRUE(retriever.retrieve_historical_row(nullptr, 0, 1).ok());
+    ASSERT_EQ(retriever.get_operators().size(), 1);
+    EXPECT_EQ(retriever.get_operators()[0], ROW_BINLOG_APPEND);
+
+    Block before_block = schema->create_block_by_cids({1});
+    ASSERT_TRUE(retriever.build_before_block(&before_block, {1}, 0, 1).ok());
+    ASSERT_EQ(before_block.rows(), 1);
+    // key 1's retained plan entry would land here, since both blocks plan destination position 0
+    EXPECT_TRUE(read_is_null(before_block, 0, 0));
+
+    Block after_block = schema->create_block();
+    after_block.replace_by_position(0, second.get_by_position(0).column);
+    ASSERT_TRUE(retriever.build_after_block(&after_block, 0, 1).ok());
+    ASSERT_EQ(after_block.rows(), 1);
+    EXPECT_EQ(read_int(after_block, 1, 0), 0); // brand-new key -> column default
+}
+
+// Insert -> delete -> insert inside one load: the lookup still finds the tombstone row, so the
+// operator this retriever first reported as UPDATE has to be corrected to APPEND. Rows the read
+// plan never reached keep a zero old delete sign and their operator.
+TEST_F(HistoricalRowRetrieverTest, ReviseOperatorWithOldDeleteSign) {
     auto delete_sign_column = ColumnInt8::create();
     delete_sign_column->insert_value(1);
     delete_sign_column->insert_value(0);
@@ -41,21 +297,28 @@ TEST(HistoricalRowRetrieverTest, ReviseOperatorWithOldDeleteSign) {
     old_value_block.insert(
             {std::move(delete_sign_column), std::make_shared<DataTypeInt8>(), DELETE_SIGN});
 
+    // row 2 of the batch has no old row, so it is absent from the read index
     std::map<uint32_t, uint32_t> read_index {
             {0, 0},
             {1, 1},
             {3, 2},
     };
 
+    // init() is what hands the retriever its fetcher; only the schema is read here
+    segment_v2::HistoricalRowRetrieverContext context;
+    context.tablet_schema = create_mow_schema(/*has_seq=*/false);
     PrimaryKeyModelRowRetriever retriever;
+    ASSERT_TRUE(retriever.init(context).ok());
+
     ASSERT_TRUE(retriever._fill_old_delete_signs(old_value_block, read_index, 4).ok());
     ASSERT_EQ((std::vector<signed char> {1, 0, 0, 1}), retriever._old_delete_signs);
 
     retriever._operators = {ROW_BINLOG_UPDATE, ROW_BINLOG_UPDATE, ROW_BINLOG_UPDATE,
                             ROW_BINLOG_DELETE};
+    // a planned read is what tells revise() that old rows were looked up at all
     RowsetId rowset_id;
     rowset_id.init(1);
-    retriever._rssid_to_rid.prepare_to_read(RowLocation(rowset_id, 0, 0), 0);
+    retriever._row_fetcher->plan_fixed_read(RowLocation(rowset_id, 0, 0), 0);
     ASSERT_TRUE(retriever.revise_operators_by_old_delete_sign(4).ok());
 
     EXPECT_EQ(ROW_BINLOG_APPEND, retriever._operators[0]);
@@ -64,4 +327,4 @@ TEST(HistoricalRowRetrieverTest, ReviseOperatorWithOldDeleteSign) {
     EXPECT_EQ(ROW_BINLOG_DELETE, retriever._operators[3]);
 }
 
-} // namespace doris::segment_v2
+} // namespace doris


### PR DESCRIPTION
- `MowKeyProbe` — one probe behind a `Policy`: which rows to mark in the delete bitmap, whether a delete-signed row or a row that loses on sequence still needs its old values read, and flexible partial update's insert-after-delete rule.
  Those are exactly the rules the three copies differed by.
- `HistoricalRowFetcher` — owns the rowset pins and the read plans used to read those old values.

Both segment writers and the row binlog retriever now delegate to them，`RowKeyEncoder` gains a second constructor for the probe side, since the key the primary key index is probed with is always the schema key columns while the
writer's encoder builds whatever the segment sorn wrapper, deleted when the partial-update fills move into the transform chain in he follow-ups.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

