### PR TITLE
[improvement](fe) Add connector property validators

### DIFF
--- a/fe/fe-filesystem/fe-filesystem-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/properties/HdfsProperties.java
+++ b/fe/fe-filesystem/fe-filesystem-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/properties/HdfsProperties.java
@@ -19,6 +19,7 @@ package org.apache.doris.filesystem.hdfs.properties;
 
 import org.apache.doris.filesystem.FileSystemType;
 import org.apache.doris.foundation.property.ConnectorProperty;
+import org.apache.doris.foundation.property.NoPathTraversalValidator;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.collections4.MapUtils;
@@ -45,6 +46,7 @@ public class HdfsProperties extends HdfsCompatibleProperties {
 
     @ConnectorProperty(names = {"hadoop.config.resources"},
             required = false,
+            validator = NoPathTraversalValidator.class,
             description = "The xml files of Hadoop configuration.")
     private String hadoopConfigResources = "";
 

--- a/fe/fe-filesystem/fe-filesystem-hdfs/src/test/java/org/apache/doris/filesystem/hdfs/properties/HdfsPropertiesTest.java
+++ b/fe/fe-filesystem/fe-filesystem-hdfs/src/test/java/org/apache/doris/filesystem/hdfs/properties/HdfsPropertiesTest.java
@@ -112,6 +112,20 @@ class HdfsPropertiesTest {
     }
 
     @Test
+    void xmlResourcesRejectParentDirectoryTraversal(@TempDir Path tmp) {
+        Map<String, String> raw = new HashMap<>();
+        raw.put("fs.defaultFS", "hdfs://ns");
+        raw.put("hadoop.config.resources", "../outside.xml");
+        raw.put("_HADOOP_CONFIG_DIR_", tmp.toString() + "/");
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> resolve(raw));
+
+        Assertions.assertTrue(exception.getMessage().contains("parent-directory references"),
+                exception.getMessage());
+    }
+
+    @Test
     void translationIsIdempotentOnAlreadyResolvedMap() {
         Map<String, String> raw = new HashMap<>();
         raw.put("fs.defaultFS", "hdfs://ns");

--- a/fe/fe-filesystem/fe-filesystem-jfs/src/main/java/org/apache/doris/filesystem/jfs/properties/JfsProperties.java
+++ b/fe/fe-filesystem/fe-filesystem-jfs/src/main/java/org/apache/doris/filesystem/jfs/properties/JfsProperties.java
@@ -21,6 +21,7 @@ import org.apache.doris.filesystem.FileSystemType;
 import org.apache.doris.filesystem.hdfs.properties.HdfsCompatibleProperties;
 import org.apache.doris.filesystem.hdfs.properties.HdfsPropertiesUtils;
 import org.apache.doris.foundation.property.ConnectorProperty;
+import org.apache.doris.foundation.property.NoPathTraversalValidator;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.collections4.MapUtils;
@@ -45,6 +46,7 @@ public class JfsProperties extends HdfsCompatibleProperties {
     private String fsDefaultFS = "";
 
     @ConnectorProperty(names = {"hadoop.config.resources"}, required = false,
+            validator = NoPathTraversalValidator.class,
             description = "The xml files of Hadoop configuration.")
     private String hadoopConfigResources = "";
 

--- a/fe/fe-filesystem/fe-filesystem-oss-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/properties/OssHdfsProperties.java
+++ b/fe/fe-filesystem/fe-filesystem-oss-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/properties/OssHdfsProperties.java
@@ -19,6 +19,7 @@ package org.apache.doris.filesystem.hdfs.properties;
 
 import org.apache.doris.filesystem.FileSystemType;
 import org.apache.doris.foundation.property.ConnectorProperty;
+import org.apache.doris.foundation.property.NoPathTraversalValidator;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
@@ -94,6 +95,7 @@ public class OssHdfsProperties extends HdfsCompatibleProperties {
 
     @ConnectorProperty(names = {"oss.hdfs.hadoop.config.resources"},
             required = false,
+            validator = NoPathTraversalValidator.class,
             description = "The xml files of Hadoop configuration.")
     private String hadoopConfigResources = "";
 

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/ConnectorPropertiesUtils.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/ConnectorPropertiesUtils.java
@@ -23,12 +23,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Utility class for handling fields annotated with {@link ConnectorProperty}.
  * Provides methods to extract supported connector properties from a class and bind them to an object instance.
  */
 public class ConnectorPropertiesUtils {
+    private static final Map<Class<? extends ConnectorPropertyValidator>, ConnectorPropertyValidator> VALIDATORS =
+            new ConcurrentHashMap<>();
 
     /**
      * Retrieves all fields annotated with {@link ConnectorProperty} from the given class and its superclasses,
@@ -74,6 +77,7 @@ public class ConnectorPropertiesUtils {
                 try {
                     Object rawValue = props.get(matchedName);
                     Object convertedValue = convertValue(rawValue, field.getType());
+                    validateValue(target, field, matchedName, convertedValue, props);
                     field.set(target, convertedValue);
                 } catch (Exception e) {
                     throw new IllegalArgumentException(
@@ -82,6 +86,25 @@ public class ConnectorPropertiesUtils {
                     );
                 }
             }
+        }
+    }
+
+    private static void validateValue(Object target, Field field, String propertyName, Object value,
+            Map<String, String> props) {
+        Class<? extends ConnectorPropertyValidator> validatorClass =
+                field.getAnnotation(ConnectorProperty.class).validator();
+        ConnectorPropertyValidator validator = VALIDATORS.computeIfAbsent(
+                validatorClass, ConnectorPropertiesUtils::createValidator);
+        validator.validate(target, field, propertyName, value, props);
+    }
+
+    private static ConnectorPropertyValidator createValidator(
+            Class<? extends ConnectorPropertyValidator> validatorClass) {
+        try {
+            return validatorClass.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException(
+                    "Failed to create connector property validator " + validatorClass.getName(), e);
         }
     }
 

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/ConnectorProperty.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/ConnectorProperty.java
@@ -31,4 +31,6 @@ public @interface ConnectorProperty {
     boolean sensitive() default false;
 
     boolean isRegionField() default false;
+
+    Class<? extends ConnectorPropertyValidator> validator() default ConnectorPropertyValidator.None.class;
 }

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/ConnectorPropertyValidator.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/ConnectorPropertyValidator.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.foundation.property;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * Validates a converted connector property before it is assigned to its target field.
+ *
+ * <p>Implementations must be stateless because one validator instance may be reused across
+ * property bindings.
+ */
+public interface ConnectorPropertyValidator {
+
+    /**
+     * Validates one connector property value.
+     *
+     * @param target target object being populated
+     * @param field annotated target field
+     * @param propertyName matched property name
+     * @param value converted property value
+     * @param properties complete raw property map
+     * @throws IllegalArgumentException if the value is invalid
+     */
+    void validate(Object target, Field field, String propertyName, Object value, Map<String, String> properties);
+
+    /** Default validator used by properties that do not declare validation rules. */
+    final class None implements ConnectorPropertyValidator {
+        @Override
+        public void validate(Object target, Field field, String propertyName, Object value,
+                Map<String, String> properties) {
+        }
+    }
+}

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/NoPathTraversalValidator.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/property/NoPathTraversalValidator.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.foundation.property;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * Rejects parent-directory path components in a string property.
+ *
+ * <p>Both slash forms are treated as separators so a value cannot become unsafe when it is
+ * forwarded to a platform or library with different path-separator semantics. Comma-separated
+ * resource lists are supported naturally because commas cannot hide a path component.
+ */
+public final class NoPathTraversalValidator implements ConnectorPropertyValidator {
+
+    @Override
+    public void validate(Object target, Field field, String propertyName, Object value,
+            Map<String, String> properties) {
+        if (!(value instanceof String)) {
+            throw new IllegalArgumentException("Path property must be a string");
+        }
+        for (String component : ((String) value).split("[,/\\\\]")) {
+            if ("..".equals(component.trim())) {
+                throw new IllegalArgumentException(
+                        "Property " + propertyName + " must not contain parent-directory references");
+            }
+        }
+    }
+}

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/property/ConnectorPropertiesUtilsTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/property/ConnectorPropertiesUtilsTest.java
@@ -105,6 +105,30 @@ public class ConnectorPropertiesUtilsTest {
     }
 
     @Test
+    void testPropertyValidatorRejectsInvalidValue() {
+        Map<String, String> props = new HashMap<>();
+        props.put("path.key", "core-site.xml, ..\\secret.xml");
+
+        SampleConfig config = new SampleConfig();
+        IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ConnectorPropertiesUtils.bindConnectorProperties(config, props));
+
+        Assertions.assertTrue(ex.getMessage().contains("parent-directory references"), ex.getMessage());
+        Assertions.assertNull(config.getPathValue());
+    }
+
+    @Test
+    void testPropertyValidatorAcceptsSafeValue() {
+        Map<String, String> props = new HashMap<>();
+        props.put("path.key", "conf/core-site.xml");
+
+        SampleConfig config = new SampleConfig();
+        ConnectorPropertiesUtils.bindConnectorProperties(config, props);
+
+        Assertions.assertEquals("conf/core-site.xml", config.getPathValue());
+    }
+
+    @Test
     void testGetConnectorPropertiesIncludesSuperclassFields() {
         List<java.lang.reflect.Field> fields = ConnectorPropertiesUtils.getConnectorProperties(SampleConfig.class);
         Assertions.assertTrue(fields.stream().anyMatch(field -> field.getName().equals("baseValue")));
@@ -188,6 +212,9 @@ public class ConnectorPropertiesUtilsTest {
         @ConnectorProperty(names = {"secret.key", "secret.alias"}, sensitive = true)
         private String secretValue;
 
+        @ConnectorProperty(names = {"path.key"}, validator = NoPathTraversalValidator.class)
+        private String pathValue;
+
         public String getStringValue() {
             return stringValue;
         }
@@ -222,6 +249,10 @@ public class ConnectorPropertiesUtilsTest {
 
         public String getSecretValue() {
             return secretValue;
+        }
+
+        public String getPathValue() {
+            return pathValue;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`ConnectorProperty` currently describes property names, aliases, required fields, supported fields, and sensitive values, while property-specific value checks have to be implemented separately by each connector.

This PR adds a reusable validation extension point to the connector property binding framework. A validator receives the target object, annotated field, matched property name, converted value, and the complete raw property map. Validation runs after type conversion and before field assignment. Validator instances are stateless and reused across bindings.

To add validation to a connector property, implement `ConnectorPropertyValidator`:

```java
public final class ExampleValidator implements ConnectorPropertyValidator {
    @Override
    public void validate(Object target, Field field, String propertyName,
            Object value, Map<String, String> properties) {
        if (!isValid(value)) {
            throw new IllegalArgumentException("Invalid property " + propertyName);
        }
    }
}
```

Then declare it on the property:

```java
@ConnectorProperty(
        names = {"example.property"},
        validator = ExampleValidator.class)
private String exampleProperty;
```

Properties without a validator retain the existing behavior through the default no-op validator.

The PR also provides `NoPathTraversalValidator` as the first reusable implementation. It rejects parent-directory components in path values and comma-separated resource lists. Hadoop, JFS, OSS-HDFS, and Hive XML resource properties now use this validator.

### Release note

Add connector property validators and validate parent-directory components in Hadoop and Hive XML resource paths.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.foundation.property.ConnectorPropertiesUtilsTest,org.apache.doris.filesystem.hdfs.properties.HdfsPropertiesTest`
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Hadoop and Hive XML resource properties reject parent-directory components.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
