### PR TITLE
[fix](ci) Use only valid Codex review auth

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -105,11 +105,7 @@ jobs:
           install -m 700 -d "$RUNNER_TEMP/codex-home"
           printf 'CODEX_HOME=%s\n' "$RUNNER_TEMP/codex-home" >> "$GITHUB_ENV"
 
-          auth_object="$(printf '%s\n' \
-            'oss://doris-community-ci/codex/auth.json.2' \
-            'oss://doris-community-ci/codex/auth.json.3' \
-            'oss://doris-community-ci/codex/auth.json.4' \
-            | shuf -n 1)"
+          auth_object='oss://doris-community-ci/codex/auth.json.4'
           printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$auth_object" >> "$GITHUB_ENV"
           echo "Selected Codex auth object: ${auth_object##*/}"
           ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$auth_object" "$RUNNER_TEMP/codex-home/auth.json"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The automated code review runner randomly selected `auth.json.2`, `auth.json.3`, or `auth.json.4`. The first two credentials now have revoked refresh tokens and cause reviews to fail with HTTP 401. This change temporarily restricts review runs to the currently valid `auth.json.4` credential.

### Release note

None

### Check List (For Author)

- Test: Manual test
  - Parsed `.github/workflows/code-review-runner.yml` as YAML
  - Ran `git diff --check`
- Behavior changed: Yes. Automated code reviews temporarily use only `auth.json.4`.
- Does this need documentation: No
