### PR TITLE
[feat](cloud) cross compute group peer read routing with peer cache I/O optimization (#63818)

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -300,10 +300,16 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         LOG(INFO) << "set config cloud_unique_id " << master_info.cloud_unique_id << " " << st;
     }
 
-    if (master_info.__isset.cloud_cluster_info &&
-        master_info.cloud_cluster_info.__isset.isStandby) {
+    if (master_info.__isset.cloud_cluster_info) {
         auto* cloud_cluster_info = static_cast<CloudClusterInfo*>(_cluster_info);
-        cloud_cluster_info->set_is_in_standby(master_info.cloud_cluster_info.isStandby);
+        if (master_info.cloud_cluster_info.__isset.isStandby) {
+            cloud_cluster_info->set_is_in_standby(master_info.cloud_cluster_info.isStandby);
+        }
+        if (master_info.cloud_cluster_info.__isset.cloud_compute_group_id &&
+            !master_info.cloud_cluster_info.cloud_compute_group_id.empty()) {
+            cloud_cluster_info->set_cloud_compute_group_id(
+                    master_info.cloud_cluster_info.cloud_compute_group_id);
+        }
     }
 
     if (master_info.__isset.tablet_report_inactive_duration_ms) {

--- a/be/src/cloud/cloud_backend_service.cpp
+++ b/be/src/cloud/cloud_backend_service.cpp
@@ -195,8 +195,7 @@ static Status run_rpc_get_file_cache_meta(std::shared_ptr<PBackendService_Stub> 
     return Status::OK();
 }
 
-void CloudBackendService::_warm_up_cache(TWarmUpCacheAsyncResponse& response,
-                                         const TWarmUpCacheAsyncRequest& request) {
+void CloudBackendService::_warm_up_cache(const TWarmUpCacheAsyncRequest& request) {
     std::ostringstream oss;
     oss << "[";
     for (size_t i = 0; i < request.tablet_ids.size() && i < 10; ++i) {
@@ -210,8 +209,13 @@ void CloudBackendService::_warm_up_cache(TWarmUpCacheAsyncResponse& response,
 
     auto& manager = ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager();
     // Record each tablet in manager
+    std::string compute_group_id;
+    if (request.__isset.cloud_compute_group_id) {
+        compute_group_id = request.cloud_compute_group_id;
+    }
     for (int64_t tablet_id : request.tablet_ids) {
-        manager.record_balanced_tablet(tablet_id, request.host, request.brpc_port);
+        manager.record_balanced_tablet(tablet_id, request.host, request.brpc_port,
+                                       compute_group_id);
     }
 
     std::string host = request.host;
@@ -245,8 +249,18 @@ void CloudBackendService::_warm_up_cache(TWarmUpCacheAsyncResponse& response,
     Status rpc_status = run_rpc_get_file_cache_meta(brpc_stub, brpc_addr, std::move(brpc_request),
                                                     brpc_response);
     if (rpc_status.ok()) {
-        _engine.file_cache_block_downloader().submit_download_task(
-                std::move(*brpc_response.mutable_file_cache_block_metas()));
+        auto& file_cache_block_metas = *brpc_response.mutable_file_cache_block_metas();
+        if (!file_cache_block_metas.empty()) {
+            _engine.file_cache_block_downloader().submit_download_task(
+                    std::move(file_cache_block_metas));
+            LOG(INFO) << "warm_up_cache_async: successfully submitted download task for tablets="
+                      << oss.str();
+        } else {
+            // Source BE is reachable but has no hot blocks to download right now. Keep the
+            // peer mapping so future peer reads can still try the source.
+            LOG(INFO) << "warm_up_cache_async: no file cache block meta found, addr=" << brpc_addr
+                      << ", keeping peer mapping for future peer reads";
+        }
     } else {
         LOG(WARNING) << "warm_up_cache_async: rpc failed for addr=" << brpc_addr
                      << ", status=" << rpc_status;
@@ -256,7 +270,7 @@ void CloudBackendService::_warm_up_cache(TWarmUpCacheAsyncResponse& response,
 void CloudBackendService::warm_up_cache_async(TWarmUpCacheAsyncResponse& response,
                                               const TWarmUpCacheAsyncRequest& request) {
     // just submit the task to the thread pool, no need to wait for the result
-    auto do_warm_up = [this, request, &response]() { this->_warm_up_cache(response, request); };
+    auto do_warm_up = [this, request]() { this->_warm_up_cache(request); };
     g_file_cache_warm_up_cache_async_submitted_task_num << 1;
     Status submit_st = _engine.warmup_cache_async_thread_pool().submit_func(std::move(do_warm_up));
     if (!submit_st.ok()) {

--- a/be/src/cloud/cloud_backend_service.h
+++ b/be/src/cloud/cloud_backend_service.h
@@ -57,8 +57,7 @@ public:
                                 int64_t last_stream_record_time) override;
 
 private:
-    void _warm_up_cache(TWarmUpCacheAsyncResponse& response,
-                        const TWarmUpCacheAsyncRequest& request);
+    void _warm_up_cache(const TWarmUpCacheAsyncRequest& request);
 
     CloudStorageEngine& _engine;
 };

--- a/be/src/cloud/cloud_cluster_info.h
+++ b/be/src/cloud/cloud_cluster_info.h
@@ -85,12 +85,15 @@ public:
     // Check if this cluster should skip compaction for the given tablet
     // Returns true if should skip (i.e., another cluster should do the compaction)
     bool should_skip_compaction(CloudTablet* tablet) const;
+    const std::string& cloud_compute_group_id() const { return _cloud_compute_group_id; }
+    void set_cloud_compute_group_id(const std::string& id) { _cloud_compute_group_id = id; }
 
 private:
     void _bg_worker_func();
     void _refresh_cluster_status();
 
     bool _is_in_standby = false;
+    std::string _cloud_compute_group_id;
 
     mutable std::shared_mutex _mutex;
     std::string _my_cluster_id;

--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -17,7 +17,10 @@
 
 #include "cloud/cloud_internal_service.h"
 
+#include <brpc/controller.h>
 #include <bthread/countdown_event.h>
+#include <butil/iobuf.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <chrono>
@@ -27,6 +30,7 @@
 #include <optional>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
@@ -37,8 +41,10 @@
 #include "io/cache/block_file_cache.h"
 #include "io/cache/block_file_cache_downloader.h"
 #include "io/cache/block_file_cache_factory.h"
+#include "io/fs/path.h"
 #include "runtime/thread_context.h"
 #include "runtime/workload_management/io_throttle.h"
+#include "storage/storage_policy.h"
 #include "util/async_io.h"
 #include "util/bvar_windowed_adder.h"
 #include "util/debug_points.h"
@@ -55,8 +61,54 @@ bvar::LatencyRecorder g_file_cache_get_by_peer_server_latency(
         "file_cache_get_by_peer_server_latency");
 bvar::LatencyRecorder g_file_cache_get_by_peer_read_cache_file_latency(
         "file_cache_get_by_peer_read_cache_file_latency");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_offer_failed_num(
+        "file_cache_get_by_peer_offer_failed_num");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_queue_timeout_num(
+        "file_cache_get_by_peer_queue_timeout_num");
+bvar::LatencyRecorder g_file_cache_get_by_peer_queue_wait_latency(
+        "file_cache_get_by_peer_queue_wait_latency");
+bvar::LatencyRecorder g_file_cache_get_by_peer_handle_cache_block_req_latency(
+        "file_cache_get_by_peer_handle_cache_block_req_latency");
+bvar::LatencyRecorder g_file_cache_get_by_peer_get_cache_latency(
+        "file_cache_get_by_peer_get_cache_latency");
+bvar::LatencyRecorder g_file_cache_get_by_peer_get_or_set_latency(
+        "file_cache_get_by_peer_get_or_set_latency");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_get_or_set_calls(
+        "file_cache_get_by_peer_get_or_set_calls");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_get_or_set_blocks_total(
+        "file_cache_get_by_peer_get_or_set_blocks_total");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_request_blocks_total(
+        "file_cache_get_by_peer_request_blocks_total");
+bvar::LatencyRecorder g_file_cache_get_by_peer_request_blocks_per_rpc(
+        "file_cache_get_by_peer_request_blocks_per_rpc");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_response_blocks_total(
+        "file_cache_get_by_peer_response_blocks_total");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_response_bytes_total(
+        "file_cache_get_by_peer_response_bytes_total");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_not_downloaded_block_num(
+        "file_cache_get_by_peer_not_downloaded_block_num");
+bvar::LatencyRecorder g_file_cache_get_by_peer_read_file_block_total_latency(
+        "file_cache_get_by_peer_read_file_block_total_latency");
+bvar::LatencyRecorder g_file_cache_get_by_peer_set_response_data_latency(
+        "file_cache_get_by_peer_set_response_data_latency");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_attachment_response_num(
+        "file_cache_get_by_peer_attachment_response_num");
+bvar::Adder<uint64_t> g_file_cache_get_by_peer_pb_response_num(
+        "file_cache_get_by_peer_pb_response_num");
+
+bvar::Adder<int64_t> g_peer_server_fill_requested("peer_server_fill_requested");
+bvar::Adder<int64_t> g_peer_server_fill_success("peer_server_fill_success");
+bvar::Adder<int64_t> g_peer_server_fill_timeout("peer_server_fill_timeout");
+bvar::Adder<int64_t> g_peer_server_fill_rejected("peer_server_fill_rejected");
+bvar::LatencyRecorder g_peer_server_fill_latency("peer_server_fill_latency");
 bvar::LatencyRecorder g_cloud_internal_service_get_file_cache_meta_by_tablet_id_latency(
         "cloud_internal_service_get_file_cache_meta_by_tablet_id_latency");
+
+// Concurrency guard for server-side S3 pull-through fills.
+static std::atomic<int32_t> g_active_server_fills {0};
+bvar::PassiveStatus<int32_t> g_peer_active_fills(
+        "peer_active_fills",
+        [](void*) { return g_active_server_fills.load(std::memory_order_relaxed); }, nullptr);
 
 CloudInternalServiceImpl::CloudInternalServiceImpl(CloudStorageEngine& engine, ExecEnv* exec_env)
         : PInternalService(exec_env), _engine(engine) {}
@@ -217,10 +269,90 @@ void CloudInternalServiceImpl::get_file_cache_meta_by_tablet_id(
 
 namespace {
 // Helper functions for fetch_peer_data
+inline int64_t elapsed_us(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() -
+                                                                 start)
+            .count();
+}
+
+int64_t get_rowset_meta_tablet_id_from_request(const PFetchPeerDataRequest* request) {
+    return request->has_rowset_meta() && request->rowset_meta().has_tablet_id()
+                   ? request->rowset_meta().tablet_id()
+                   : -1;
+}
+
+std::string get_rowset_meta_resource_id_from_request(const PFetchPeerDataRequest* request) {
+    if (request->has_rowset_meta() && request->rowset_meta().has_resource_id()) {
+        return request->rowset_meta().resource_id();
+    }
+    return "";
+}
+
+std::string get_peer_cache_filename(std::string_view path) {
+    return io::Path(std::string(path)).filename().native();
+}
+
+std::string format_peer_request_context(const PFetchPeerDataRequest* request,
+                                        const io::UInt128Wrapper& hash, size_t file_size) {
+    const std::string file_size_str =
+            request->has_file_size() ? std::to_string(request->file_size()) : "unknown";
+    return fmt::format(
+            "type={}, path={}, cache_hash={}, request_fill={}, fill_tablet_id={}, "
+            "fill_remote_path={}, fill_resource_id={}, file_size={}, resolved_file_size={}, "
+            "cache_req_count={}, support_attachment={}",
+            request->type(), request->path(), hash.to_string(),
+            request->has_request_cache_fill() && request->request_cache_fill(),
+            get_rowset_meta_tablet_id_from_request(request), request->path(),
+            get_rowset_meta_resource_id_from_request(request), file_size_str,
+            file_size == std::numeric_limits<size_t>::max() ? std::string("unknown")
+                                                            : std::to_string(file_size),
+            request->cache_req_size(),
+            request->has_support_attachment() && request->support_attachment());
+}
+
+std::string format_peer_cache_block_context(const PFetchPeerDataRequest* request,
+                                            const CacheBlockReqest& cb_req,
+                                            const io::FileBlockSPtr& fb,
+                                            const io::UInt128Wrapper& hash, size_t file_size,
+                                            bool do_fill) {
+    return fmt::format("{}, req_block=[offset={}, size={}], do_fill={}, block={}, cache_file={}",
+                       format_peer_request_context(request, hash, file_size), cb_req.block_offset(),
+                       cb_req.block_size(), do_fill, fb->get_info_for_log(), fb->get_cache_file());
+}
+
+std::string format_peer_fill_context(const io::FileBlockSPtr& fb, int64_t fill_tablet_id,
+                                     const std::string& filename, const std::string& resource_id,
+                                     const std::string& remote_path, int64_t file_size,
+                                     int64_t offset, int64_t size, int32_t timeout_ms) {
+    return fmt::format(
+            "tablet_id={}, filename={}, resource_id={}, remote_path={}, file_size={}, "
+            "request_range=[offset={}, size={}], timeout_ms={}, block={}, cache_file={}",
+            fill_tablet_id, filename, resource_id.empty() ? "<unknown>" : resource_id,
+            remote_path.empty() ? "<unknown>" : remote_path, file_size, offset, size, timeout_ms,
+            fb->get_info_for_log(), fb->get_cache_file());
+}
+
+bool wait_for_file_block_state(const io::FileBlockSPtr& fb, int32_t timeout_ms) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (true) {
+        const auto state = fb->state();
+        if (state == io::FileBlock::State::DOWNLOADED ||
+            state == io::FileBlock::State::SKIP_CACHE || state == io::FileBlock::State::EMPTY) {
+            return true;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return false;
+        }
+        fb->wait();
+    }
+}
 
 Status handle_peer_file_range_request(const std::string& path, PFetchPeerDataResponse* response) {
+    // Legacy path: PEER_FILE_RANGE still returns payload via protobuf bytes.
+    // Keep this for compatibility until range path is migrated to attachment mode.
     // Read specific range [file_offset, file_offset+file_size) across cached blocks
-    auto datas = io::FileCacheFactory::instance()->get_cache_data_by_path(path);
+    auto datas =
+            io::FileCacheFactory::instance()->get_cache_data_by_path(get_peer_cache_filename(path));
     for (auto& cb : datas) {
         *(response->add_datas()) = std::move(cb);
     }
@@ -232,9 +364,37 @@ void set_error_response(PFetchPeerDataResponse* response, const std::string& err
     response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
 }
 
+void set_too_many_tasks_response(PFetchPeerDataResponse* response, const std::string& error_msg) {
+    response->mutable_status()->add_error_msgs(error_msg);
+    response->mutable_status()->set_status_code(TStatusCode::TOO_MANY_TASKS);
+}
+
+bool try_reject_if_queue_timed_out(std::chrono::steady_clock::time_point enqueue_ts,
+                                   PFetchPeerDataResponse* response) {
+    auto wait_us = elapsed_us(enqueue_ts);
+    g_file_cache_get_by_peer_queue_wait_latency << wait_us;
+    auto wait_ms = wait_us / 1000;
+    if (wait_ms <= config::peer_fetch_queue_timeout_ms) {
+        return false;
+    }
+
+    const std::string msg = fmt::format("fetch peer data queue timeout, wait_ms={}, timeout_ms={}",
+                                        wait_ms, config::peer_fetch_queue_timeout_ms);
+    g_file_cache_get_by_peer_queue_timeout_num << 1;
+    set_too_many_tasks_response(response, msg);
+    return true;
+}
+
 Status read_file_block(const std::shared_ptr<io::FileBlock>& file_block, size_t file_size,
-                       doris::CacheBlockPB* output) {
-    std::string data;
+                       doris::CacheBlockPB* output, butil::IOBuf* response_attachment) {
+    auto total_start = std::chrono::steady_clock::now();
+    int64_t set_data_us = 0;
+    Defer report {[&]() {
+        g_file_cache_get_by_peer_read_file_block_total_latency << elapsed_us(total_start);
+        if (set_data_us > 0) {
+            g_file_cache_get_by_peer_set_response_data_latency << set_data_us;
+        }
+    }};
     // ATTN: calculate the rightmost boundary value of the block, due to inaccurate current block meta information.
     // see CachedRemoteFileReader::read_at_impl for more details.
     // Ensure file_size >= file_block->offset() to avoid underflow
@@ -245,38 +405,228 @@ Status read_file_block(const std::shared_ptr<io::FileBlock>& file_block, size_t 
     }
     size_t read_size = std::min(static_cast<size_t>(file_size - file_block->offset()),
                                 file_block->range().size());
-    data.resize(read_size);
-
-    auto begin_read_file_ts = std::chrono::duration_cast<std::chrono::microseconds>(
-                                      std::chrono::steady_clock::now().time_since_epoch())
-                                      .count();
-
-    SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->s3_file_buffer_tracker());
-    Slice slice(data.data(), data.size());
-    Status read_st = file_block->read(slice, /*read_offset=*/0);
-
-    auto end_read_file_ts = std::chrono::duration_cast<std::chrono::microseconds>(
-                                    std::chrono::steady_clock::now().time_since_epoch())
-                                    .count();
-    g_file_cache_get_by_peer_read_cache_file_latency << (end_read_file_ts - begin_read_file_ts);
-
-    if (read_st.ok()) {
-        output->set_block_offset(static_cast<int64_t>(file_block->offset()));
-        output->set_block_size(static_cast<int64_t>(read_size));
-        output->set_data(std::move(data));
+    output->set_block_offset(static_cast<int64_t>(file_block->offset()));
+    output->set_block_size(static_cast<int64_t>(read_size));
+    if (read_size == 0) {
         return Status::OK();
-    } else {
-        g_file_cache_get_by_peer_failed_num << 1;
-        LOG(WARNING) << "read cache block failed: " << read_st;
-        return read_st;
     }
+
+    Status read_st = Status::OK();
+    // Attachment payload mode: protobuf carries metadata only, payload goes to attachment.
+    // This allows FS cache to use a file-descriptor->IOBuf path directly.
+    if (response_attachment != nullptr) {
+        size_t bytes_read = 0;
+        auto begin_read_file_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                                          std::chrono::steady_clock::now().time_since_epoch())
+                                          .count();
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->s3_file_buffer_tracker());
+        read_st = file_block->read_to_iobuf(response_attachment, /*read_offset=*/0, read_size,
+                                            &bytes_read);
+        auto end_read_file_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                                        std::chrono::steady_clock::now().time_since_epoch())
+                                        .count();
+        g_file_cache_get_by_peer_read_cache_file_latency << (end_read_file_ts - begin_read_file_ts);
+
+        if (read_st.ok()) {
+            if (bytes_read != read_size) {
+                return Status::InternalError<false>(
+                        "peer cache read short data, expected={}, actual={}", read_size,
+                        bytes_read);
+            }
+            g_file_cache_get_by_peer_response_bytes_total << bytes_read;
+            return Status::OK();
+        }
+    } else {
+        std::string data;
+        data.resize(read_size);
+        auto begin_read_file_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                                          std::chrono::steady_clock::now().time_since_epoch())
+                                          .count();
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->s3_file_buffer_tracker());
+        Slice slice(data.data(), data.size());
+        read_st = file_block->read(slice, /*read_offset=*/0);
+        auto end_read_file_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                                        std::chrono::steady_clock::now().time_since_epoch())
+                                        .count();
+        g_file_cache_get_by_peer_read_cache_file_latency << (end_read_file_ts - begin_read_file_ts);
+
+        if (read_st.ok()) {
+            auto set_data_start = std::chrono::steady_clock::now();
+            output->set_data(std::move(data));
+            set_data_us = elapsed_us(set_data_start);
+            g_file_cache_get_by_peer_response_bytes_total << read_size;
+            return Status::OK();
+        }
+    }
+
+    g_file_cache_get_by_peer_failed_num << 1;
+    LOG(WARNING) << "read cache block failed, file_size=" << file_size
+                 << ", block=" << file_block->get_info_for_log()
+                 << ", cache_file=" << file_block->get_cache_file() << ", err=" << read_st;
+    return read_st;
+}
+
+// Trigger S3 -> local cache fill for the given file block.
+// Returns OK when the block is DOWNLOADED after the fill.
+// Returns TOO_MANY_TASKS when the fill slot is exhausted (server healthy but overloaded):
+//   client should not rotate or evict, just fall back to S3 and retry same candidate later.
+// Returns NOT_FOUND for soft misses (tablet not found, fill incomplete, timeout):
+//   client should rotate the candidate to try a different CG next time.
+// The peer uses request.path as the full remote path. tablet_id/filename are kept for logging.
+Status trigger_peer_server_fill(io::FileBlockSPtr& fb, int64_t fill_tablet_id,
+                                const std::string& filename, const std::string& resource_id,
+                                const std::string& remote_path, int64_t file_size, int64_t offset,
+                                int64_t size, int32_t timeout_ms) {
+    g_peer_server_fill_requested << 1;
+
+    // Concurrency guard: atomically reserve a fill slot.
+    // Excess requests are rejected so the client falls back to its own S3 read.
+    // Return NOT_FOUND so the client rotates the candidate instead of evicting it.
+    if (g_active_server_fills.fetch_add(1, std::memory_order_relaxed) >=
+        config::max_concurrent_peer_server_fills) {
+        g_active_server_fills.fetch_sub(1, std::memory_order_relaxed);
+        g_peer_server_fill_rejected << 1;
+        VLOG_DEBUG << "trigger_peer_server_fill: rejected (concurrency limit "
+                   << config::max_concurrent_peer_server_fills << "), tablet_id=" << fill_tablet_id;
+        // TOO_MANY_TASKS: server is healthy but overloaded. Client must not rotate or evict;
+        // just fall back to S3 for this request and retry the same candidate next time.
+        return Status::Error<ErrorCode::TOO_MANY_TASKS, false>("fill slot exhausted");
+    }
+    // RAII decrement: runs on every return path below.
+    Defer fill_guard {[]() { g_active_server_fills.fetch_sub(1, std::memory_order_relaxed); }};
+
+    if (remote_path.empty() || resource_id.empty()) {
+        const std::string ctx =
+                format_peer_fill_context(fb, fill_tablet_id, filename, resource_id, remote_path,
+                                         file_size, offset, size, timeout_ms);
+        LOG(WARNING) << "trigger_peer_server_fill: missing remote_path or resource_id, " << ctx;
+        g_peer_server_fill_rejected << 1;
+        return Status::NotFound<false>("fill: missing remote_path or resource_id, {}", ctx);
+    }
+    auto storage_resource = doris::get_storage_resource(resource_id);
+    if (!storage_resource.has_value()) {
+        const std::string ctx =
+                format_peer_fill_context(fb, fill_tablet_id, filename, resource_id, remote_path,
+                                         file_size, offset, size, timeout_ms);
+        LOG(WARNING) << "trigger_peer_server_fill: storage resource not found, " << ctx;
+        g_peer_server_fill_rejected << 1;
+        return Status::NotFound<false>("fill: storage resource not found, {}", ctx);
+    }
+    auto fs = storage_resource->first.fs;
+
+    const auto initial_state = fb->state();
+    if (initial_state == io::FileBlock::State::DOWNLOADING) {
+        // Another thread already owns the block downloader. Wait up to the request timeout instead
+        // of the shorter per-wait timeout in FileBlock::wait().
+        [[maybe_unused]] const bool completed = wait_for_file_block_state(fb, timeout_ms);
+        const std::string ctx =
+                format_peer_fill_context(fb, fill_tablet_id, filename, resource_id, remote_path,
+                                         file_size, offset, size, timeout_ms);
+        return fb->state() == io::FileBlock::State::DOWNLOADED
+                       ? Status::OK()
+                       : Status::NotFound<false>("fill: concurrent download incomplete, {}", ctx);
+    }
+    if (initial_state != io::FileBlock::State::EMPTY) {
+        const std::string ctx =
+                format_peer_fill_context(fb, fill_tablet_id, filename, resource_id, remote_path,
+                                         file_size, offset, size, timeout_ms);
+        return initial_state == io::FileBlock::State::DOWNLOADED
+                       ? Status::OK()
+                       : Status::NotFound<false>("fill: unexpected initial block state, {}", ctx);
+    }
+
+    auto fill_start = std::chrono::steady_clock::now();
+    auto fill_done = std::make_shared<bthread::CountdownEvent>(1);
+    auto fill_status = std::make_shared<Status>(Status::OK());
+    io::DownloadFileMeta download_meta {
+            .path = remote_path,
+            .file_size = file_size,
+            .offset = offset,
+            .download_size = size,
+            .file_system = fs,
+            .ctx = {.is_dryrun = config::enable_reader_dryrun_when_download_file_cache,
+                    // Pull-through fill must go straight to remote storage. If this download
+                    // re-enters peer race, the original block can remain DOWNLOADING for the
+                    // duration of nested peer retries and timeouts.
+                    .is_warmup = false,
+                    .bypass_peer_read = true},
+            .download_done =
+                    [fill_done, fill_status](Status st) {
+                        *fill_status = std::move(st);
+                        fill_done->signal();
+                    },
+            .tablet_id = fill_tablet_id,
+    };
+
+    io::DownloadTask task(std::move(download_meta));
+    ExecEnv::GetInstance()
+            ->storage_engine()
+            .to_cloud()
+            .file_cache_block_downloader()
+            .submit_download_task(std::move(task));
+
+    const timespec due_time = butil::milliseconds_from_now(timeout_ms);
+    const bool timed_out = fill_done->timed_wait(due_time) != 0;
+
+    int64_t fill_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - fill_start)
+                              .count();
+    g_peer_server_fill_latency << fill_ms * 1000; // LatencyRecorder takes microseconds
+
+    if (!timed_out && fill_status->ok() && fb->state() == io::FileBlock::State::DOWNLOADING) {
+        const int32_t settle_timeout_ms =
+                std::max<int32_t>(1, timeout_ms - static_cast<int32_t>(fill_ms));
+        [[maybe_unused]] const bool settled = wait_for_file_block_state(fb, settle_timeout_ms);
+    }
+
+    auto final_state = fb->state();
+    if (final_state == io::FileBlock::State::DOWNLOADED) {
+        g_peer_server_fill_success << 1;
+        return Status::OK();
+    }
+    if (timed_out) {
+        LOG(WARNING) << "trigger_peer_server_fill: fill timeout, elapsed_ms=" << fill_ms << ", "
+                     << format_peer_fill_context(fb, fill_tablet_id, filename, resource_id,
+                                                 remote_path, file_size, offset, size, timeout_ms);
+        g_peer_server_fill_timeout << 1;
+    } else if (!fill_status->ok()) {
+        LOG(WARNING) << "trigger_peer_server_fill: fill failed, elapsed_ms=" << fill_ms
+                     << ", status=" << fill_status->to_string() << ", "
+                     << format_peer_fill_context(fb, fill_tablet_id, filename, resource_id,
+                                                 remote_path, file_size, offset, size, timeout_ms);
+    }
+    // Any non-DOWNLOADED outcome is a soft failure: the server is otherwise healthy so the
+    // client should rotate the candidate rather than evict it.
+    return Status::NotFound<false>(
+            "fill: block not downloaded, {}",
+            format_peer_fill_context(fb, fill_tablet_id, filename, resource_id, remote_path,
+                                     file_size, offset, size, timeout_ms));
 }
 
 Status handle_peer_file_cache_block_request(const PFetchPeerDataRequest* request,
-                                            PFetchPeerDataResponse* response) {
+                                            PFetchPeerDataResponse* response,
+                                            brpc::Controller* cntl) {
+    auto handle_start = std::chrono::steady_clock::now();
+    const uint64_t request_blocks = request->cache_req_size();
+    uint64_t response_blocks = 0;
+    uint64_t get_or_set_calls = 0;
+    uint64_t get_or_set_blocks = 0;
+    int64_t get_cache_us = 0;
+    Defer report {[&]() {
+        g_file_cache_get_by_peer_handle_cache_block_req_latency << elapsed_us(handle_start);
+        g_file_cache_get_by_peer_get_cache_latency << get_cache_us;
+        g_file_cache_get_by_peer_get_or_set_calls << get_or_set_calls;
+        g_file_cache_get_by_peer_get_or_set_blocks_total << get_or_set_blocks;
+        g_file_cache_get_by_peer_request_blocks_total << request_blocks;
+        g_file_cache_get_by_peer_request_blocks_per_rpc << request_blocks;
+        g_file_cache_get_by_peer_response_blocks_total << response_blocks;
+    }};
     const auto& path = request->path();
-    auto hash = io::BlockFileCache::hash(path);
+    const auto cache_key_path = get_peer_cache_filename(path);
+    auto hash = io::BlockFileCache::hash(cache_key_path);
+    auto get_cache_start = std::chrono::steady_clock::now();
     auto* cache = io::FileCacheFactory::instance()->get_by_path(hash);
+    get_cache_us = elapsed_us(get_cache_start);
     if (cache == nullptr) {
         g_file_cache_get_by_peer_failed_num << 1;
         set_error_response(response, "can't get file cache instance");
@@ -286,27 +636,140 @@ Status handle_peer_file_cache_block_request(const PFetchPeerDataRequest* request
     io::CacheContext ctx {};
     io::ReadStatistics local_stats;
     ctx.stats = &local_stats;
+    const size_t file_size =
+            request->has_file_size()
+                    ? static_cast<size_t>(std::max<int64_t>(0, request->file_size()))
+                    : std::numeric_limits<size_t>::max();
+    // Enable attachment mode only when client advertises support.
+    // This keeps mixed-version rolling upgrades safe.
+    const bool use_attachment =
+            cntl != nullptr && request->has_support_attachment() && request->support_attachment();
+    response->set_data_in_attachment(use_attachment);
+    if (use_attachment) {
+        g_file_cache_get_by_peer_attachment_response_num << 1;
+    } else {
+        g_file_cache_get_by_peer_pb_response_num << 1;
+    }
+
+    const bool do_fill = request->has_request_cache_fill() && request->request_cache_fill() &&
+                         config::enable_peer_server_cache_fill;
 
     for (const auto& cb_req : request->cache_req()) {
         size_t offset = static_cast<size_t>(std::max<int64_t>(0, cb_req.block_offset()));
         size_t size = static_cast<size_t>(std::max<int64_t>(0, cb_req.block_size()));
+        if (offset >= file_size) {
+            continue;
+        }
+        // Clip tail requests before get_or_set so peer reads do not synthesize EMPTY blocks past
+        // EOF and then fail the whole RPC.
+        size = std::min(size, file_size - offset);
+        if (size == 0) {
+            continue;
+        }
+        DBUG_EXECUTE_IF(
+                "CloudInternalServiceImpl::handle_peer_file_cache_block_request_hold_before_get_or_"
+                "set",
+                {
+                    int sleep_ms = dp->param<int>("sleep_ms", 300);
+                    bthread_usleep(sleep_ms * 1000);
+                });
+        auto get_or_set_start = std::chrono::steady_clock::now();
         auto holder = cache->get_or_set(hash, offset, size, ctx);
+        g_file_cache_get_by_peer_get_or_set_latency << elapsed_us(get_or_set_start);
+        ++get_or_set_calls;
+        get_or_set_blocks += holder.file_blocks.size();
 
         for (auto& fb : holder.file_blocks) {
-            if (fb->state() != io::FileBlock::State::DOWNLOADED) {
+            auto fb_state = fb->state();
+            if (fb_state == io::FileBlock::State::DOWNLOADING) {
+                if (do_fill) {
+                    // Only peer fill requests should wait longer here. Plain peer-cache reads keep
+                    // the short wait semantics so they can fail fast and let the client race S3.
+                    [[maybe_unused]] const bool completed = wait_for_file_block_state(
+                            fb, config::peer_server_cache_fill_timeout_ms);
+                    fb_state = fb->state();
+                } else {
+                    // Wait for in-progress download to complete using the normal short timeout.
+                    fb_state = fb->wait();
+                }
+            }
+            if (fb_state == io::FileBlock::State::EMPTY) {
+                if (!do_fill) {
+                    const std::string msg =
+                            fmt::format("cache block not downloaded, {}",
+                                        format_peer_cache_block_context(request, cb_req, fb, hash,
+                                                                        file_size, do_fill));
+                    g_file_cache_get_by_peer_failed_num << 1;
+                    g_file_cache_get_by_peer_not_downloaded_block_num << 1;
+                    LOG(WARNING) << msg;
+                    // Use NOT_FOUND so the client can distinguish "block not cached"
+                    // from an actual RPC/server error.  On NOT_FOUND the client rotates
+                    // the candidate to the end of its list (trying another CG next time)
+                    // rather than incrementing the RPC-failure eviction counter.
+                    response->mutable_status()->add_error_msgs(msg);
+                    response->mutable_status()->set_status_code(TStatusCode::NOT_FOUND);
+                    return Status::NotFound<false>(msg);
+                }
+                // Server-side fill: request.path already carries the full remote path.
+                auto fill_st = trigger_peer_server_fill(
+                        fb, get_rowset_meta_tablet_id_from_request(request), cache_key_path,
+                        get_rowset_meta_resource_id_from_request(request), path,
+                        request->has_file_size() ? request->file_size() : -1,
+                        static_cast<int64_t>(fb->range().left),
+                        static_cast<int64_t>(fb->range().size()),
+                        config::peer_server_cache_fill_timeout_ms);
+                if (!fill_st.ok()) {
+                    g_file_cache_get_by_peer_failed_num << 1;
+                    g_file_cache_get_by_peer_not_downloaded_block_num << 1;
+                    if (fill_st.is<ErrorCode::TOO_MANY_TASKS>()) {
+                        // Server slot exhausted: healthy but overloaded. Client must not rotate
+                        // or evict — just fall back to S3 and retry same candidate next time.
+                        response->mutable_status()->add_error_msgs(std::string(fill_st.msg()));
+                        response->mutable_status()->set_status_code(TStatusCode::TOO_MANY_TASKS);
+                    } else if (fill_st.is<ErrorCode::NOT_FOUND>()) {
+                        // Soft miss (fill incomplete, timeout, unexpected state) — client rotates,
+                        // not evicts.
+                        response->mutable_status()->add_error_msgs(std::string(fill_st.msg()));
+                        response->mutable_status()->set_status_code(TStatusCode::NOT_FOUND);
+                    } else {
+                        LOG(WARNING) << "cache block fill failed, status=" << fill_st << ", "
+                                     << format_peer_cache_block_context(request, cb_req, fb, hash,
+                                                                        file_size, do_fill);
+                        set_error_response(response, "cache block not ready");
+                    }
+                    return fill_st;
+                }
+                fb_state = io::FileBlock::State::DOWNLOADED;
+            }
+            if (fb_state != io::FileBlock::State::DOWNLOADED) {
+                // A concurrent download was in progress (DOWNLOADING at request time) but its
+                // wait() returned a non-DOWNLOADED state (e.g., timed-out while still
+                // DOWNLOADING, or some other non-EMPTY intermediate state).  The server is
+                // healthy; the block just isn't available yet.  Return NOT_FOUND so the client
+                // rotates the candidate instead of evicting it.
+                const std::string msg =
+                        fmt::format("cache block not ready after wait, {}",
+                                    format_peer_cache_block_context(request, cb_req, fb, hash,
+                                                                    file_size, do_fill));
                 g_file_cache_get_by_peer_failed_num << 1;
-                LOG(WARNING) << "read cache block failed, state=" << fb->state();
-                set_error_response(response, "read cache file error");
-                return Status::InternalError<false>("cache block not downloaded");
+                g_file_cache_get_by_peer_not_downloaded_block_num << 1;
+                LOG(WARNING) << msg;
+                response->mutable_status()->add_error_msgs(msg);
+                response->mutable_status()->set_status_code(TStatusCode::NOT_FOUND);
+                return Status::NotFound<false>(msg);
             }
 
             g_file_cache_get_by_peer_blocks_num << 1;
             doris::CacheBlockPB* out = response->add_datas();
-            Status read_status = read_file_block(fb, request->file_size(), out);
+            // In attachment mode, metadata order must match attachment append order because the
+            // client consumes attachment payload sequentially using resp.datas() order.
+            Status read_status = read_file_block(
+                    fb, file_size, out, use_attachment ? &cntl->response_attachment() : nullptr);
             if (!read_status.ok()) {
                 set_error_response(response, "read cache file error");
                 return read_status;
             }
+            ++response_blocks;
         }
     }
 
@@ -314,14 +777,34 @@ Status handle_peer_file_cache_block_request(const PFetchPeerDataRequest* request
 }
 } // namespace
 
-void CloudInternalServiceImpl::fetch_peer_data(google::protobuf::RpcController* controller
-                                               [[maybe_unused]],
+#ifdef BE_TEST
+Status test_handle_peer_file_cache_block_request(const PFetchPeerDataRequest* request,
+                                                 PFetchPeerDataResponse* response,
+                                                 brpc::Controller* cntl) {
+    return handle_peer_file_cache_block_request(request, response, cntl);
+}
+
+bool test_try_reject_if_queue_timed_out(std::chrono::steady_clock::time_point enqueue_ts,
+                                        PFetchPeerDataResponse* response) {
+    return try_reject_if_queue_timed_out(enqueue_ts, response);
+}
+#endif
+
+void CloudInternalServiceImpl::fetch_peer_data(google::protobuf::RpcController* controller,
                                                const PFetchPeerDataRequest* request,
                                                PFetchPeerDataResponse* response,
                                                google::protobuf::Closure* done) {
-    bool ret = _heavy_work_pool.try_offer([request, response, done]() {
+    auto enqueue_ts = std::chrono::steady_clock::now();
+    // Lifetime: cntl is owned by brpc framework and valid until done->Run() is called.
+    // The ClosureGuard inside the lambda ensures done->Run() happens after all cntl usage,
+    // so capturing the raw pointer by value is safe.
+    auto* cntl = static_cast<brpc::Controller*>(controller);
+    bool ret = _peer_fetch_pool.try_offer([request, response, done, enqueue_ts, cntl]() {
         brpc::ClosureGuard closure_guard(done);
         g_file_cache_get_by_peer_num << 1;
+        if (try_reject_if_queue_timed_out(enqueue_ts, response)) {
+            return;
+        }
 
         if (!config::enable_file_cache) {
             LOG_WARNING("try to access file cache data, but file cache not enabled");
@@ -340,12 +823,28 @@ void CloudInternalServiceImpl::fetch_peer_data(google::protobuf::RpcController* 
         if (type == PFetchPeerDataRequest_Type_PEER_FILE_RANGE) {
             status = handle_peer_file_range_request(path, response);
         } else if (type == PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK) {
-            status = handle_peer_file_cache_block_request(request, response);
+            status = handle_peer_file_cache_block_request(request, response, cntl);
         }
 
         if (!status.ok()) {
-            LOG(WARNING) << "fetch peer data failed: " << status.to_string();
-            set_error_response(response, status.to_string());
+            const std::string msg =
+                    "fetch peer data failed: " + status.to_string() + ", " +
+                    format_peer_request_context(
+                            request, io::BlockFileCache::hash(get_peer_cache_filename(path)),
+                            request->has_file_size() ? static_cast<size_t>(std::max<int64_t>(
+                                                               0, request->file_size()))
+                                                     : std::numeric_limits<size_t>::max());
+            if (status.is<ErrorCode::NOT_FOUND>() || status.is<ErrorCode::TOO_MANY_TASKS>()) {
+                VLOG_DEBUG << msg;
+            } else {
+                LOG(WARNING) << msg;
+            }
+            auto* resp_status = response->mutable_status();
+            if (resp_status->status_code() == TStatusCode::OK) {
+                set_error_response(response, status.to_string());
+            } else if (resp_status->error_msgs().empty()) {
+                resp_status->add_error_msgs(status.to_string());
+            }
         }
 
         DBUG_EXECUTE_IF("CloudInternalServiceImpl::fetch_peer_data_slower", {
@@ -357,17 +856,29 @@ void CloudInternalServiceImpl::fetch_peer_data(google::protobuf::RpcController* 
         auto end_ts = std::chrono::duration_cast<std::chrono::microseconds>(
                               std::chrono::steady_clock::now().time_since_epoch())
                               .count();
+        // Latency covers every completed callback (including failures) so the
+        // server-side fail-fast paths still show up in the latency histogram.
+        // success_num must only count actual OK results, otherwise dedup
+        // TOO_MANY_TASKS / NOT_FOUND / handler errors all fall through here
+        // and the success rate is meaningless. Use file_cache_get_by_peer_num
+        // for the total completed-callback count.
         g_file_cache_get_by_peer_server_latency << (end_ts - begin_ts);
-        g_file_cache_get_by_peer_success_num << 1;
+        if (status.ok()) {
+            g_file_cache_get_by_peer_success_num << 1;
+        }
 
         VLOG_DEBUG << "fetch cache request=" << request->DebugString()
                    << ", response=" << response->DebugString();
     });
 
     if (!ret) {
+        g_file_cache_get_by_peer_offer_failed_num << 1;
         brpc::ClosureGuard closure_guard(done);
-        LOG(WARNING) << "fail to offer fetch peer data request to the work pool, pool="
-                     << _heavy_work_pool.get_info();
+        const std::string msg = fmt::format(
+                "fail to offer fetch peer data request to the peer fetch work pool, pool={}",
+                _peer_fetch_pool.get_info());
+        set_too_many_tasks_response(response, msg);
+        LOG(WARNING) << msg;
     }
 }
 

--- a/be/src/cloud/cloud_internal_service.h
+++ b/be/src/cloud/cloud_internal_service.h
@@ -17,11 +17,25 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "service/internal_service.h"
+
+namespace brpc {
+class Controller;
+}
 
 namespace doris {
 
 class CloudStorageEngine;
+
+#ifdef BE_TEST
+Status test_handle_peer_file_cache_block_request(const PFetchPeerDataRequest* request,
+                                                 PFetchPeerDataResponse* response,
+                                                 brpc::Controller* cntl);
+bool test_try_reject_if_queue_timed_out(std::chrono::steady_clock::time_point enqueue_ts,
+                                        PFetchPeerDataResponse* response);
+#endif
 
 class CloudInternalServiceImpl final : public PInternalService {
 public:

--- a/be/src/cloud/cloud_snapshot_loader.cpp
+++ b/be/src/cloud/cloud_snapshot_loader.cpp
@@ -164,6 +164,7 @@ Status CloudSnapshotLoader::download(const std::map<std::string, std::string>& s
                 .is_doris_table = false,
                 .cache_base_path = "",
                 .file_size = static_cast<int64_t>(hdr_file_len),
+                .storage_resource_id {},
         };
         LOG(INFO) << "download hdr file: " << full_remote_hdr_path;
         io::FileReaderSPtr hdr_reader = nullptr;
@@ -209,6 +210,7 @@ Status CloudSnapshotLoader::download(const std::map<std::string, std::string>& s
                     .is_doris_table = false,
                     .cache_base_path = "",
                     .file_size = static_cast<int64_t>(file_stat.size),
+                    .storage_resource_id {},
             };
             io::FileReaderSPtr file_reader = nullptr;
             RETURN_IF_ERROR(_remote_fs->open_file(full_remote_file, &file_reader, &reader_options));

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -233,7 +233,7 @@ Status CloudStorageEngine::open() {
 
     _file_cache_block_downloader = std::make_unique<io::FileCacheBlockDownloader>(*this);
 
-    _cloud_warm_up_manager = std::make_unique<CloudWarmUpManager>(*this);
+    _cloud_warm_up_manager = std::make_shared<CloudWarmUpManager>(*this);
 
     _tablet_hotspot = std::make_unique<TabletHotspot>();
 
@@ -295,6 +295,12 @@ void CloudStorageEngine::stop() {
 bool CloudStorageEngine::stopped() {
     return _stopped;
 }
+
+#ifdef BE_TEST
+void CloudStorageEngine::set_cloud_warm_up_manager(std::unique_ptr<CloudWarmUpManager> manager) {
+    _cloud_warm_up_manager = std::shared_ptr<CloudWarmUpManager>(std::move(manager));
+}
+#endif
 
 Result<BaseTabletSPtr> CloudStorageEngine::get_tablet(int64_t tablet_id,
                                                       SyncRowsetStats* sync_stats,

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -166,6 +166,9 @@ public:
     }
 
     CloudWarmUpManager& cloud_warm_up_manager() const { return *_cloud_warm_up_manager; }
+    std::shared_ptr<CloudWarmUpManager> cloud_warm_up_manager_ptr() const {
+        return _cloud_warm_up_manager;
+    }
 
     TabletHotspot& tablet_hotspot() const { return *_tablet_hotspot; }
 
@@ -193,6 +196,8 @@ public:
     void set_startup_timepoint(const std::chrono::time_point<std::chrono::system_clock>& tp) {
         _startup_timepoint = tp;
     }
+
+    void set_cloud_warm_up_manager(std::unique_ptr<CloudWarmUpManager> manager);
 #endif
 
 private:
@@ -226,7 +231,7 @@ private:
     // Components for cache warmup
     std::unique_ptr<io::FileCacheBlockDownloader> _file_cache_block_downloader;
     // Depended by `FileCacheBlockDownloader`
-    std::unique_ptr<CloudWarmUpManager> _cloud_warm_up_manager;
+    std::shared_ptr<CloudWarmUpManager> _cloud_warm_up_manager;
     std::unique_ptr<TabletHotspot> _tablet_hotspot;
     std::unique_ptr<ThreadPool> _sync_load_for_tablets_thread_pool;
     std::unique_ptr<ThreadPool> _warmup_cache_async_thread_pool;

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -25,22 +25,26 @@
 #include <bvar/reducer.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <list>
 #include <string>
 #include <tuple>
 #include <vector>
 
+#include "bthread/mutex.h"
 #include "bvar/bvar.h"
 #include "cloud/cloud_tablet.h"
 #include "cloud/cloud_tablet_mgr.h"
 #include "cloud/config.h"
 #include "common/cast_set.h"
+#include "common/check.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "cpp/sync_point.h"
 #include "io/cache/block_file_cache_downloader.h"
 #include "runtime/exec_env.h"
+#include "service/backend_options.h"
 #include "storage/index/inverted/inverted_index_desc.h"
 #include "storage/rowset/beta_rowset.h"
 #include "storage/tablet/tablet.h"
@@ -54,6 +58,19 @@
 
 namespace doris {
 #include "common/compile_check_begin.h"
+
+// Peer candidate management statistics
+bvar::Adder<uint64_t> g_peer_candidate_cache_hit("peer_candidate_cache_hit");
+bvar::Adder<uint64_t> g_peer_candidate_cache_miss("peer_candidate_cache_miss");
+bvar::Adder<uint64_t> g_peer_lazy_fetch_total("peer_lazy_fetch_total");
+bvar::Adder<uint64_t> g_peer_lazy_fetch_success("peer_lazy_fetch_success");
+bvar::Adder<uint64_t> g_peer_lazy_fetch_failed("peer_lazy_fetch_failed");
+bvar::LatencyRecorder g_peer_lazy_fetch_latency("peer_lazy_fetch_latency");
+bvar::Adder<uint64_t> g_peer_rpc_failure_eviction("peer_rpc_failure_eviction");
+bvar::Adder<uint64_t> g_peer_candidate_expiry_eviction("peer_candidate_expiry_eviction");
+bvar::Adder<uint64_t> g_peer_candidate_rotate("peer_candidate_rotate");
+bvar::Adder<uint64_t> g_peer_tablet_cooldown_entered("peer_tablet_cooldown_entered");
+bvar::Adder<uint64_t> g_peer_tablet_cooldown_skipped("peer_tablet_cooldown_skipped");
 
 bvar::Adder<uint64_t> g_file_cache_event_driven_warm_up_skipped_rowset_num(
         "file_cache_event_driven_warm_up_skipped_rowset_num");
@@ -119,26 +136,40 @@ MBvarWindowedAdder g_warmup_ed_requested_index_size("warmup_ed_requested_index_s
 bvar::MultiDimension<bvar::Status<int64_t>> g_warmup_ed_last_trigger_ts({"job_id"});
 
 CloudWarmUpManager::CloudWarmUpManager(CloudStorageEngine& engine) : _engine(engine) {
-    _download_thread = std::thread(&CloudWarmUpManager::handle_jobs, this);
-    static_cast<void>(ThreadPoolBuilder("CloudWarmUpManagerThreadPool")
-                              .set_min_threads(1)
-                              .set_max_threads(config::warm_up_manager_thread_pool_size)
-                              .build(&_thread_pool));
+    auto st = ThreadPoolBuilder("CloudWarmUpManagerThreadPool")
+                      .set_min_threads(config::warm_up_manager_thread_pool_size)
+                      .set_max_threads(config::warm_up_manager_thread_pool_size)
+                      .build(&_thread_pool);
+    DORIS_CHECK(st.ok()) << st;
     _thread_pool_token = _thread_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    DORIS_CHECK(_thread_pool_token != nullptr);
+    _download_thread = std::thread(&CloudWarmUpManager::handle_jobs, this);
+    _cleanup_thread = std::thread(&CloudWarmUpManager::run_cleanup_loop, this);
 }
 
 CloudWarmUpManager::~CloudWarmUpManager() {
     {
+        // Set _closed under both mutexes so that both threads' wait predicates see it.
         std::lock_guard lock(_mtx);
+        std::lock_guard<std::mutex> cleanup_lock(_cleanup_mtx);
         _closed = true;
     }
     _cond.notify_all();
+    _cleanup_cond.notify_all();
     if (_download_thread.joinable()) {
         _download_thread.join();
     }
+    if (_cleanup_thread.joinable()) {
+        _cleanup_thread.join();
+    }
+
+    _thread_pool_token->shutdown();
+    _thread_pool_token.reset();
+    _thread_pool->shutdown();
+    _thread_pool.reset();
 
     for (auto& shard : _balanced_tablets_shards) {
-        std::lock_guard<std::mutex> lock(shard.mtx);
+        std::unique_lock<bthread::Mutex> lock(shard.mtx);
         shard.tablets.clear();
     }
 }
@@ -573,13 +604,13 @@ std::vector<JobReplicaInfo> CloudWarmUpManager::get_replica_info(int64_t tablet_
                     cache_hit = true;
                     continue;
                 } else {
-                    LOG(INFO) << "get_replica_info: cache expired, tablet_id=" << tablet_id
-                              << ", job_id=" << job_id;
+                    VLOG_DEBUG << "get_replica_info: cache expired, tablet_id=" << tablet_id
+                               << ", job_id=" << job_id;
                     cache.erase(it);
                 }
             }
-            LOG(INFO) << "get_replica_info: cache miss, tablet_id=" << tablet_id
-                      << ", job_id=" << job_id;
+            VLOG_DEBUG << "get_replica_info: cache miss, tablet_id=" << tablet_id
+                       << ", job_id=" << job_id;
         }
 
         if (!cache_hit) {
@@ -616,7 +647,7 @@ std::vector<JobReplicaInfo> CloudWarmUpManager::get_replica_info(int64_t tablet_
             continue;
         }
 
-        auto st = Status::create(result.status);
+        auto st = Status::create<false>(result.status);
         if (!st.ok()) {
             if (st.is<ErrorCode::CANCELLED>()) {
                 LOG(INFO) << "get_replica_info: warm up job cancelled, tablet_id=" << tablet_id
@@ -893,7 +924,7 @@ Status CloudWarmUpManager::_do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table
             }
             g_file_cache_warm_up_rowset_wait_for_compaction_latency << cost_us;
         }
-        auto status = Status::create(response.status());
+        auto status = Status::create<false>(response.status());
         if (response.has_status() && !status.ok()) {
             LOG(INFO) << "warm_up_rowset failed, tablet_id=" << rs_meta.tablet_id()
                       << ", rowset_id=" << rs_meta.rowset_id().to_string()
@@ -976,61 +1007,54 @@ void CloudWarmUpManager::_recycle_cache(int64_t tablet_id,
 
 // Balance warm up cache management methods implementation
 void CloudWarmUpManager::record_balanced_tablet(int64_t tablet_id, const std::string& host,
-                                                int32_t brpc_port) {
-    auto& shard = get_shard(tablet_id);
-    std::lock_guard<std::mutex> lock(shard.mtx);
-    JobMeta meta;
-    meta.be_ip = host;
-    meta.brpc_port = brpc_port;
-    shard.tablets.emplace(tablet_id, std::move(meta));
-    g_balance_tablet_be_mapping_size << 1;
-    schedule_remove_balanced_tablet(tablet_id);
-    VLOG_DEBUG << "Recorded balanced warm up cache tablet: tablet_id=" << tablet_id
-               << ", host=" << host << ":" << brpc_port;
-}
+                                                int32_t brpc_port,
+                                                const std::string& compute_group_id) {
+    int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
 
-void CloudWarmUpManager::schedule_remove_balanced_tablet(int64_t tablet_id) {
-    // Use std::make_unique to avoid raw pointer allocation
-    auto tablet_id_ptr = std::make_unique<int64_t>(tablet_id);
-    unsigned long expired_ms = g_tablet_report_inactive_duration_ms;
-    if (doris::config::cache_read_from_peer_expired_seconds > 0 &&
-        doris::config::cache_read_from_peer_expired_seconds <=
-                g_tablet_report_inactive_duration_ms / 1000) {
-        expired_ms = doris::config::cache_read_from_peer_expired_seconds * 1000;
+    PeerCandidate candidate;
+    candidate.host = host;
+    candidate.brpc_port = brpc_port;
+    candidate.compute_group_id = compute_group_id;
+    candidate.last_access_time_ms = now_ms;
+    candidate.consecutive_rpc_failures = 0;
+
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+
+    auto [it, inserted] = shard.tablets.try_emplace(tablet_id);
+    if (inserted) {
+        // Only increment the gauge counter on first insertion.
+        g_balance_tablet_be_mapping_size << 1;
     }
-    bthread_timer_t timer_id;
-    // ATTN: The timer callback will reclaim ownership of the tablet_id_ptr, so we need to release it after the timer is added.
-    if (const int rc = bthread_timer_add(&timer_id, butil::milliseconds_from_now(expired_ms),
-                                         clean_up_expired_mappings, tablet_id_ptr.get());
-        rc == 0) {
-        tablet_id_ptr.release();
+
+    auto& cands = it->second.candidates;
+    // Warmup rebalance: a tablet has at most one warm-up peer (the current rebalance source).
+    // Upsert: replace existing same-CG entry if present, otherwise prepend.
+    auto same_cg_it = std::find_if(cands.begin(), cands.end(), [&](const PeerCandidate& c) {
+        return c.compute_group_id == compute_group_id;
+    });
+
+    if (same_cg_it != cands.end()) {
+        // Update in-place, preserve position (already at or near front from prior insert).
+        same_cg_it->host = std::move(candidate.host);
+        same_cg_it->brpc_port = candidate.brpc_port;
+        same_cg_it->last_access_time_ms = candidate.last_access_time_ms;
+        same_cg_it->consecutive_rpc_failures = 0;
     } else {
-        LOG(WARNING) << "Fail to add timer for clean up expired mappings for tablet_id="
-                     << tablet_id << " rc=" << rc;
+        // New CG entry: insert at front (warmup has highest priority).
+        cands.insert(cands.begin(), std::move(candidate));
     }
-}
 
-void CloudWarmUpManager::clean_up_expired_mappings(void* arg) {
-    std::unique_ptr<int64_t> tid(static_cast<int64_t*>(arg));
-    auto& manager = ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager();
-    manager.remove_balanced_tablet(*tid);
-    VLOG_DEBUG << "Removed expired balanced warm up cache tablet: tablet_id=" << *tid;
-}
-
-std::optional<std::pair<std::string, int32_t>> CloudWarmUpManager::get_balanced_tablet_info(
-        int64_t tablet_id) {
-    auto& shard = get_shard(tablet_id);
-    std::lock_guard<std::mutex> lock(shard.mtx);
-    auto it = shard.tablets.find(tablet_id);
-    if (it == shard.tablets.end()) {
-        return std::nullopt;
-    }
-    return std::make_pair(it->second.be_ip, it->second.brpc_port);
+    VLOG_DEBUG << "Recorded balanced warm up cache tablet: tablet_id=" << tablet_id
+               << ", host=" << host << ":" << brpc_port
+               << ", compute_group_id=" << compute_group_id;
 }
 
 void CloudWarmUpManager::remove_balanced_tablet(int64_t tablet_id) {
     auto& shard = get_shard(tablet_id);
-    std::lock_guard<std::mutex> lock(shard.mtx);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
     auto it = shard.tablets.find(tablet_id);
     if (it != shard.tablets.end()) {
         shard.tablets.erase(it);
@@ -1051,7 +1075,7 @@ void CloudWarmUpManager::remove_balanced_tablets(const std::vector<int64_t>& tab
         if (shard_groups[i].empty()) continue;
 
         auto& shard = _balanced_tablets_shards[i];
-        std::lock_guard<std::mutex> lock(shard.mtx);
+        std::unique_lock<bthread::Mutex> lock(shard.mtx);
         for (int64_t tablet_id : shard_groups[i]) {
             auto it = shard.tablets.find(tablet_id);
             if (it != shard.tablets.end()) {
@@ -1063,23 +1087,388 @@ void CloudWarmUpManager::remove_balanced_tablets(const std::vector<int64_t>& tab
     }
 }
 
-std::unordered_map<int64_t, std::pair<std::string, int32_t>>
-CloudWarmUpManager::get_all_balanced_tablets() const {
-    std::unordered_map<int64_t, std::pair<std::string, int32_t>> result;
+// Cleanup loop: runs on a dedicated pthread, wakes up periodically to evict
+// expired peer candidates and empty tablet entries.
+void CloudWarmUpManager::run_cleanup_loop() {
+    while (true) {
+        {
+            std::unique_lock<std::mutex> lock(_cleanup_mtx);
+            _cleanup_cond.wait_for(lock,
+                                   std::chrono::seconds(config::peer_candidate_cleanup_interval_s),
+                                   [this]() { return _closed; });
+            if (_closed) break;
+        }
 
-    // Lock all shards to get consistent snapshot
-    std::array<std::unique_lock<std::mutex>, SHARD_COUNT> locks;
-    for (size_t i = 0; i < SHARD_COUNT; ++i) {
-        locks[i] = std::unique_lock<std::mutex>(_balanced_tablets_shards[i].mtx);
+        int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::system_clock::now().time_since_epoch())
+                                 .count();
+        int64_t expiry_ms = config::peer_candidate_expiry_s * 1000LL;
+
+        for (auto& shard : _balanced_tablets_shards) {
+            std::unique_lock<bthread::Mutex> lock(shard.mtx);
+            auto tablet_it = shard.tablets.begin();
+            while (tablet_it != shard.tablets.end()) {
+                auto& tpc = tablet_it->second;
+                // Remove expired candidates
+                auto& cands = tpc.candidates;
+                size_t cands_before = cands.size();
+                cands.erase(std::remove_if(cands.begin(), cands.end(),
+                                           [&](const PeerCandidate& c) {
+                                               return (now_ms - c.last_access_time_ms) >= expiry_ms;
+                                           }),
+                            cands.end());
+                size_t removed = cands_before - cands.size();
+                if (removed > 0) {
+                    g_peer_candidate_expiry_eviction << removed;
+                }
+                // Remove the tablet entry if no candidates remain
+                if (cands.empty()) {
+                    tablet_it = shard.tablets.erase(tablet_it);
+                    g_balance_tablet_be_mapping_size << -1;
+                } else {
+                    ++tablet_it;
+                }
+            }
+        }
+    }
+}
+
+// fetch_candidates_from_fe: lazy fetch path — appends candidates to the end
+// (lower priority than warmup-inserted ones).  Uses singleflight to avoid
+// duplicate concurrent RPCs for the same tablet.
+void CloudWarmUpManager::fetch_candidates_from_fe(int64_t tablet_id) {
+    // --- singleflight check ---
+    {
+        auto& shard = get_shard(tablet_id);
+        std::unique_lock<bthread::Mutex> lock(shard.mtx);
+        auto it = shard.tablets.find(tablet_id);
+        if (it != shard.tablets.end() && it->second.fetching_from_fe) {
+            return; // another fetch is already in flight
+        }
+        // Increment gauge when we create a genuinely new tablet entry
+        if (it == shard.tablets.end()) {
+            g_balance_tablet_be_mapping_size << 1;
+        }
+        // Mark as fetching (creates entry if not present).
+        shard.tablets[tablet_id].fetching_from_fe = true;
     }
 
-    for (const auto& shard : _balanced_tablets_shards) {
-        for (const auto& [tablet_id, entry] : shard.tablets) {
-            result.emplace(tablet_id, std::make_pair(entry.be_ip, entry.brpc_port));
+    // Use Defer to absolutely guarantee we reset the fetching flag on return
+    Defer defer_fetching_reset {[this, tablet_id]() {
+        auto& shard = get_shard(tablet_id);
+        std::unique_lock<bthread::Mutex> lock(shard.mtx);
+        auto it = shard.tablets.find(tablet_id);
+        if (it != shard.tablets.end()) {
+            it->second.fetching_from_fe = false;
+        }
+    }};
+
+    // --- RPC to FE (without warm_up_job_id) ---
+    ClusterInfo* cluster_info = ExecEnv::GetInstance()->cluster_info();
+    if (cluster_info == nullptr) {
+        LOG(WARNING) << "fetch_candidates_from_fe: have not got FE Master heartbeat yet"
+                     << ", tablet_id=" << tablet_id;
+        return;
+    }
+    TNetworkAddress master_addr = cluster_info->master_fe_addr;
+    if (master_addr.hostname.empty() || master_addr.port == 0) {
+        LOG(WARNING) << "fetch_candidates_from_fe: FE master address unknown"
+                     << ", tablet_id=" << tablet_id;
+        return;
+    }
+
+    TGetTabletReplicaInfosRequest request;
+    TGetTabletReplicaInfosResult result;
+    // No warm_up_job_id — lazy fetch path
+    request.tablet_ids.emplace_back(tablet_id);
+
+    g_peer_lazy_fetch_total << 1;
+    const auto rpc_start = std::chrono::steady_clock::now();
+    Status rpc_st = ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master_addr.hostname, master_addr.port,
+            [&request, &result](FrontendServiceConnection& client) {
+                client->getTabletReplicaInfos(result, request);
+            });
+    g_peer_lazy_fetch_latency << std::chrono::duration_cast<std::chrono::microseconds>(
+                                         std::chrono::steady_clock::now() - rpc_start)
+                                         .count();
+
+    if (!rpc_st.ok()) {
+        LOG(WARNING) << "fetch_candidates_from_fe: rpc failed, tablet_id=" << tablet_id
+                     << ", error=" << rpc_st;
+        g_peer_lazy_fetch_failed << 1;
+        return;
+    }
+
+    auto st = Status::create<false>(result.status);
+    if (!st.ok()) {
+        LOG(WARNING) << "fetch_candidates_from_fe: FE returned error, tablet_id=" << tablet_id
+                     << ", status=" << st;
+        g_peer_lazy_fetch_failed << 1;
+        return;
+    }
+
+    int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
+
+    // Parse the results OUTSIDE the lock
+    std::vector<PeerCandidate> new_candidates;
+    const std::string& self_host = BackendOptions::get_localhost();
+    const int32_t self_brpc_port = config::brpc_port;
+
+    auto it_res = result.tablet_replica_infos.find(tablet_id);
+    if (it_res != result.tablet_replica_infos.end()) {
+        const auto& replicas = it_res->second;
+        // Pre-allocate memory since we know the upper bound of candidates
+        new_candidates.reserve(replicas.size());
+
+        for (const auto& replica : replicas) {
+            // Skip self: a BE must not peer-read from its own file cache
+            if (replica.host == self_host && replica.brpc_port == self_brpc_port) {
+                VLOG_DEBUG << "fetch_candidates_from_fe: skipping self candidate " << replica.host
+                           << ":" << replica.brpc_port << " for tablet_id=" << tablet_id;
+                continue;
+            }
+
+            PeerCandidate& candidate = new_candidates.emplace_back();
+            candidate.host = replica.host;
+            candidate.brpc_port = replica.brpc_port;
+            if (replica.__isset.cloud_compute_group_id) {
+                candidate.compute_group_id = replica.cloud_compute_group_id;
+            }
+            candidate.last_access_time_ms = now_ms;
+            candidate.consecutive_rpc_failures = 0;
+        }
+    }
+
+    g_peer_lazy_fetch_success << 1;
+
+    // --- Merge results back into shard ---
+    // Acquire lock only to append to the candidates vector
+    {
+        auto& shard = get_shard(tablet_id);
+        std::unique_lock<bthread::Mutex> lock(shard.mtx);
+        auto it = shard.tablets.find(tablet_id);
+        // Safely check if tablet is still there
+        if (it != shard.tablets.end()) {
+            auto& tpc = it->second;
+            tpc.candidates.insert(tpc.candidates.end(),
+                                  std::make_move_iterator(new_candidates.begin()),
+                                  std::make_move_iterator(new_candidates.end()));
+            LOG(INFO) << "fetch_candidates_from_fe: tablet_id=" << tablet_id << " got "
+                      << tpc.candidates.size() << " total candidates from FE";
+            VLOG_DEBUG << "fetch_candidates_from_fe: added " << new_candidates.size()
+                       << " candidates for tablet_id=" << tablet_id;
+        }
+    }
+}
+
+std::vector<PeerCandidate> CloudWarmUpManager::get_peer_candidates(int64_t tablet_id) {
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        g_peer_candidate_cache_miss << 1;
+        return {};
+    }
+    // Update last_access_time_ms for all candidates to keep them alive
+    int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
+    for (auto& c : it->second.candidates) {
+        c.last_access_time_ms = now_ms;
+    }
+    auto& tpc = it->second;
+    // Cooldown check: if this tablet is in cooldown, return empty to skip peer.
+    if (tpc.cooldown_until_ms > 0 && now_ms < tpc.cooldown_until_ms) {
+        g_peer_tablet_cooldown_skipped << 1;
+        return {};
+    }
+    // Cooldown expired — reset for next cycle.
+    if (tpc.cooldown_until_ms > 0) {
+        tpc.cooldown_until_ms = 0;
+        tpc.consecutive_all_miss = 0;
+    }
+    auto result = tpc.candidates;
+    if (result.empty()) {
+        g_peer_candidate_cache_miss << 1;
+    } else {
+        g_peer_candidate_cache_hit << 1;
+        // Apply compute group affinity: if a previous read succeeded from a particular
+        // compute group, move its candidates to the front so the next read tries it first.
+        // stable_partition preserves relative order within each group.
+        //
+        // Example:
+        // Candidates: [A(CG1), B(CG2), C(CG1), D(CG3)]
+        // pref = "CG1"
+        // After stable_partition: [A(CG1), C(CG1), B(CG2), D(CG3)]
+        // (A remains before C, and B remains before D)
+        if (!tpc.last_successful_compute_group_id.empty()) {
+            const std::string& pref = tpc.last_successful_compute_group_id;
+            std::stable_partition(result.begin(), result.end(), [&pref](const PeerCandidate& c) {
+                return c.compute_group_id == pref;
+            });
         }
     }
     return result;
 }
 
 #include "common/compile_check_end.h"
+void CloudWarmUpManager::update_peer_candidate_on_success(int64_t tablet_id,
+                                                          const std::string& compute_group_id) {
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        return;
+    }
+    it->second.last_successful_compute_group_id = compute_group_id;
+    it->second.consecutive_all_miss = 0;
+    it->second.cooldown_until_ms = 0;
+}
+
+void CloudWarmUpManager::update_peer_candidate_on_rpc_failure(int64_t tablet_id,
+                                                              const std::string& host,
+                                                              int32_t brpc_port) {
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        return;
+    }
+    auto& cands = it->second.candidates;
+    for (auto cit = cands.begin(); cit != cands.end(); ++cit) {
+        if (cit->host == host && cit->brpc_port == brpc_port) {
+            ++cit->consecutive_rpc_failures;
+            if (cit->consecutive_rpc_failures >= config::peer_rpc_failure_eviction_threshold) {
+                LOG(INFO) << "Evicting peer candidate due to consecutive RPC failures"
+                          << ", tablet_id=" << tablet_id << ", host=" << host << ":" << brpc_port
+                          << ", failures=" << cit->consecutive_rpc_failures;
+                g_peer_rpc_failure_eviction << 1;
+                cands.erase(cit);
+                // If all candidates have been evicted, remove the tablet entry
+                // entirely so that the gauge stays accurate.
+                if (cands.empty()) {
+                    shard.tablets.erase(it);
+                    g_balance_tablet_be_mapping_size << -1;
+                }
+            }
+            break;
+        }
+    }
+}
+
+void CloudWarmUpManager::rotate_peer_candidate_on_cache_miss(int64_t tablet_id,
+                                                             const std::string& host,
+                                                             int32_t brpc_port) {
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        return;
+    }
+    auto& cands = it->second.candidates;
+    auto cit = std::find_if(cands.begin(), cands.end(), [&](const PeerCandidate& c) {
+        return c.host == host && c.brpc_port == brpc_port;
+    });
+    if (cit != cands.end() && std::next(cit) != cands.end()) {
+        // Move this candidate to the end so the next read tries a different one.
+        // This ensures that if the first N candidates are all cache-miss, the system
+        // gradually converges to whichever compute group actually has the data.
+        //
+        // Example:
+        // cands: [B, C, D],  cit points to B (front, cache miss)
+        // std::rotate(B, C, end) → [C, D, B]
+        // Next read tries C first instead of B.
+        //
+        // Also clear affinity if the rotated candidate belongs to the currently preferred
+        // compute group.  Without this, get_peer_candidates() would stable_partition that
+        // CG back to the front on the very next call — completely undoing the rotate.
+        if (it->second.last_successful_compute_group_id == cit->compute_group_id) {
+            it->second.last_successful_compute_group_id.clear();
+        }
+        std::rotate(cit, std::next(cit), cands.end());
+    }
+    // Always count the metric when the candidate is found, even if it is the
+    // last (or only) element where rotation is a no-op.
+    if (cit != cands.end()) {
+        g_peer_candidate_rotate << 1;
+    }
+}
+
+bool CloudWarmUpManager::is_peer_cooldown(int64_t tablet_id) const {
+    const auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        return false;
+    }
+    if (it->second.cooldown_until_ms <= 0) {
+        return false;
+    }
+    int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
+    return now_ms < it->second.cooldown_until_ms;
+}
+
+void CloudWarmUpManager::record_peer_all_miss(int64_t tablet_id) {
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        return;
+    }
+    auto& tpc = it->second;
+    tpc.consecutive_all_miss++;
+    if (tpc.consecutive_all_miss >= config::peer_all_miss_cooldown_threshold) {
+        int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::system_clock::now().time_since_epoch())
+                                 .count();
+        tpc.cooldown_until_ms = now_ms + config::peer_all_miss_cooldown_duration_s * 1000;
+        g_peer_tablet_cooldown_entered << 1;
+        LOG(INFO) << "Peer read cooldown entered for tablet_id=" << tablet_id << " after "
+                  << tpc.consecutive_all_miss << " consecutive all-miss races"
+                  << ", cooldown_duration_s=" << config::peer_all_miss_cooldown_duration_s;
+    }
+}
+
+std::optional<TabletPeerCandidates> CloudWarmUpManager::get_tablet_peer_info(
+        int64_t tablet_id) const {
+    const auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto it = shard.tablets.find(tablet_id);
+    if (it == shard.tablets.end()) {
+        return std::nullopt;
+    }
+    return it->second; // copy under lock
+}
+
+std::vector<std::pair<int64_t, TabletPeerCandidates>> CloudWarmUpManager::get_all_peer_info(
+        int64_t limit) const {
+    std::vector<std::pair<int64_t, TabletPeerCandidates>> result;
+    for (size_t i = 0; i < SHARD_COUNT; ++i) {
+        const auto& shard = _balanced_tablets_shards[i];
+        std::unique_lock<bthread::Mutex> lock(shard.mtx);
+        for (const auto& [tid, tpc] : shard.tablets) {
+            result.emplace_back(tid, tpc);
+            if (limit > 0 && static_cast<int64_t>(result.size()) >= limit) {
+                return result;
+            }
+        }
+    }
+    return result;
+}
+
+void CloudWarmUpManager::set_tablet_peer_candidates(int64_t tablet_id,
+                                                    TabletPeerCandidates candidates) {
+    auto& shard = get_shard(tablet_id);
+    std::unique_lock<bthread::Mutex> lock(shard.mtx);
+    auto [it, inserted] = shard.tablets.insert_or_assign(tablet_id, std::move(candidates));
+    if (inserted) {
+        g_balance_tablet_be_mapping_size << 1;
+    }
+}
+
 } // namespace doris

--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -18,12 +18,15 @@
 #pragma once
 
 #include <bthread/countdown_event.h>
+#include <bthread/mutex.h>
 #include <gen_cpp/BackendService.h>
 
+#include <array>
 #include <condition_variable>
 #include <cstddef>
 #include <deque>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_set>
@@ -35,6 +38,8 @@
 #include "util/threadpool.h"
 
 namespace doris {
+
+struct RecycledRowsets;
 
 enum class DownloadType {
     BE,
@@ -58,6 +63,29 @@ struct JobMeta {
     std::string be_ip;
     int32_t brpc_port;
     std::vector<int64_t> tablet_ids;
+};
+
+// Represents a single peer candidate for cross compute group peer read
+struct PeerCandidate {
+    std::string host;
+    int32_t brpc_port {0};
+    std::string compute_group_id;
+    int64_t last_access_time_ms {0}; // ms since epoch, used for expiry
+    int32_t consecutive_rpc_failures {0};
+};
+
+// Holds all peer candidates for a single tablet
+struct TabletPeerCandidates {
+    // candidates[0] is the highest priority (warmup-inserted candidates go to front)
+    std::vector<PeerCandidate> candidates;
+    // last successful compute group used for this tablet
+    std::string last_successful_compute_group_id;
+    // singleflight guard: true while an async fetch from FE is in progress
+    bool fetching_from_fe {false};
+    // Cooldown: consecutive all-miss count and cooldown deadline.
+    // When all candidates miss N times in a row, temporarily skip peer for this tablet.
+    int32_t consecutive_all_miss {0};
+    int64_t cooldown_until_ms {0}; // ms since epoch; 0 = not in cooldown
 };
 
 // manager for
@@ -103,12 +131,37 @@ public:
     void recycle_cache(int64_t tablet_id, const std::vector<RecycledRowsets>& rowsets);
 
     // Balance warm up cache management methods
-    void record_balanced_tablet(int64_t tablet_id, const std::string& host, int32_t brpc_port);
-    std::optional<std::pair<std::string, int32_t>> get_balanced_tablet_info(int64_t tablet_id);
+    // compute_group_id defaults to "" for backward compatibility
+    void record_balanced_tablet(int64_t tablet_id, const std::string& host, int32_t brpc_port,
+                                const std::string& compute_group_id = "");
     void remove_balanced_tablet(int64_t tablet_id);
     void remove_balanced_tablets(const std::vector<int64_t>& tablet_ids);
-    bool is_balanced_tablet_expired(const std::chrono::system_clock::time_point& ctime) const;
-    std::unordered_map<int64_t, std::pair<std::string, int32_t>> get_all_balanced_tablets() const;
+
+    // Cross compute group peer read candidate management
+    void fetch_candidates_from_fe(int64_t tablet_id);
+    std::vector<PeerCandidate> get_peer_candidates(int64_t tablet_id);
+    void update_peer_candidate_on_success(int64_t tablet_id, const std::string& compute_group_id);
+    void update_peer_candidate_on_rpc_failure(int64_t tablet_id, const std::string& host,
+                                              int32_t brpc_port);
+    // Rotate a cache-miss candidate to the end of the list so next read tries a different one.
+    void rotate_peer_candidate_on_cache_miss(int64_t tablet_id, const std::string& host,
+                                             int32_t brpc_port);
+    // Record that all candidates missed for this tablet in a single race.
+    // After consecutive_all_miss reaches threshold, sets a cooldown period during which
+    // get_peer_candidates returns empty to avoid wasting peer RPCs.
+    void record_peer_all_miss(int64_t tablet_id);
+    // Check if peer read is in cooldown for this tablet (all candidates repeatedly missed).
+    bool is_peer_cooldown(int64_t tablet_id) const;
+
+    // ---- HTTP debug/admin API ----
+    // Read-only snapshot of TabletPeerCandidates for a single tablet.
+    // Returns nullopt if the tablet has no peer candidates.
+    std::optional<TabletPeerCandidates> get_tablet_peer_info(int64_t tablet_id) const;
+    // Snapshot of all tablets with peer candidates. If limit > 0, returns at most that many.
+    std::vector<std::pair<int64_t, TabletPeerCandidates>> get_all_peer_info(
+            int64_t limit = 0) const;
+    // Force-set the full TabletPeerCandidates for a tablet (admin override).
+    void set_tablet_peer_candidates(int64_t tablet_id, TabletPeerCandidates candidates);
 
 private:
     struct WarmUpRowsetFailure {
@@ -120,9 +173,8 @@ private:
                                                size_t replica_count, int64_t tablet_id,
                                                int64_t table_id, const std::string& rowset_id);
 
-    void schedule_remove_balanced_tablet(int64_t tablet_id);
-    static void clean_up_expired_mappings(void* arg);
     void handle_jobs();
+    void run_cleanup_loop();
 
     Status _do_warm_up_rowset(RowsetMeta& rs_meta, int64_t table_id,
                               std::vector<JobReplicaInfo>& replicas, int64_t sync_wait_timeout_ms,
@@ -162,10 +214,11 @@ private:
     std::unique_ptr<ThreadPoolToken> _thread_pool_token;
 
     // Sharded lock for better performance
+    // bthread::Mutex is used because peer read path runs in bthread context
     static constexpr size_t SHARD_COUNT = 10240;
     struct Shard {
-        mutable std::mutex mtx;
-        std::unordered_map<int64_t, JobMeta> tablets;
+        mutable bthread::Mutex mtx;
+        std::unordered_map<int64_t, TabletPeerCandidates> tablets;
     };
     std::array<Shard, SHARD_COUNT> _balanced_tablets_shards;
 
@@ -176,6 +229,15 @@ private:
     Shard& get_shard(int64_t tablet_id) {
         return _balanced_tablets_shards[get_shard_index(tablet_id)];
     }
+
+    const Shard& get_shard(int64_t tablet_id) const {
+        return _balanced_tablets_shards[get_shard_index(tablet_id)];
+    }
+
+    // Cleanup thread and its synchronization primitives
+    std::thread _cleanup_thread;
+    std::mutex _cleanup_mtx;
+    std::condition_variable _cleanup_cond;
 };
 
 } // namespace doris

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -159,17 +159,37 @@ DEFINE_mInt64(cluster_status_cache_refresh_interval_sec, "60");
 // When version count exceeds this ratio of max_tablet_version_num, force compaction
 // even on read-only clusters (safety valve)
 DEFINE_mDouble(compaction_rw_separation_version_threshold_ratio, "0.8");
-
-DEFINE_mBool(enable_cache_read_from_peer, "true");
-
 // Rate limit for warmup download in bytes per second, default 100MB/s
 // <= 0 means no limit
 DEFINE_mInt64(file_cache_warmup_download_rate_limit_bytes_per_second, "104857600");
 
-// Cache the expiration time of the peer address.
-// This can be configured to be less than the `rehash_tablet_after_be_dead_seconds` setting in the `fe` configuration.
-// If the value is -1, use the `rehash_tablet_after_be_dead_seconds` setting in the `fe` configuration as the expiration time.
-DEFINE_mInt64(cache_read_from_peer_expired_seconds, "-1");
+// Cross compute group peer read candidate management
+DEFINE_mInt64(peer_candidate_cleanup_interval_s, "3600"); // cleanup interval, 1 hour
+DEFINE_mInt64(peer_candidate_expiry_s, "3600");           // candidate expiry, 1 hour
+DEFINE_mInt32(peer_rpc_failure_eviction_threshold, "3");  // consecutive failures to evict
+DEFINE_mInt32(peer_all_miss_cooldown_threshold,
+              "5"); // consecutive all-miss races to trigger cooldown
+DEFINE_mInt64(peer_all_miss_cooldown_duration_s, "300"); // cooldown duration, 5 minutes
+
+DEFINE_mBool(enable_cache_read_from_peer, "false");
+
+// Winner race between peer read and S3 read for cross compute group scenarios
+DEFINE_mBool(enable_peer_s3_race, "true");
+DEFINE_mInt32(max_concurrent_peer_races, "64");
+DEFINE_mInt32(peer_race_hedge_delay_ms, "20");
+DEFINE_mString(peer_cache_fill_compute_group_id, "");
+DEFINE_mBool(enable_peer_server_cache_fill, "true");
+// Peer server fill pulls the missing block from remote storage before serving it back to the
+// requesting BE. Small remote reads can still exceed 500ms in docker/cloud regression, so keep
+// this comfortably above the normal block-cache wait timeout to avoid premature fallback.
+DEFINE_mInt32(peer_server_cache_fill_timeout_ms, "6000");
+// Maximum number of concurrent server-side S3 pull-through fills. Each fill ties up a
+// download task slot and waits up to peer_server_cache_fill_timeout_ms. Without this
+// limit a burst of cross-CG cold misses can saturate the fill server's download pool.
+// Excess requests are rejected immediately so the client falls back to S3.
+DEFINE_mInt32(max_concurrent_peer_server_fills, "32");
+// Reject queued peer fetch tasks that wait too long in the peer fetch pool.
+DEFINE_mInt32(peer_fetch_queue_timeout_ms, "100");
 
 DEFINE_mBool(enable_file_cache_write_base_compaction_index_only, "false");
 DEFINE_mBool(enable_file_cache_write_cumu_compaction_index_only, "false");

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -202,14 +202,30 @@ DECLARE_mInt64(cluster_status_cache_refresh_interval_sec);
 // When version count exceeds this ratio of max_tablet_version_num, force compaction
 // even on read-only clusters (safety valve to prevent unbounded version growth)
 DECLARE_mDouble(compaction_rw_separation_version_threshold_ratio);
-
-DECLARE_mBool(enable_cache_read_from_peer);
-
 // Rate limit for warmup download in bytes per second, default 100MB/s
 // <= 0 means no limit
 DECLARE_mInt64(file_cache_warmup_download_rate_limit_bytes_per_second);
 
-DECLARE_mInt64(cache_read_from_peer_expired_seconds);
+DECLARE_mInt64(peer_candidate_cleanup_interval_s);
+DECLARE_mInt64(peer_candidate_expiry_s);
+DECLARE_mInt32(peer_rpc_failure_eviction_threshold);
+DECLARE_mInt32(peer_all_miss_cooldown_threshold);
+DECLARE_mInt64(peer_all_miss_cooldown_duration_s);
+
+DECLARE_mBool(enable_cache_read_from_peer);
+
+DECLARE_mBool(enable_peer_s3_race);
+DECLARE_mInt32(max_concurrent_peer_races);
+// When > 0, S3 read is delayed by this many ms after peer bthread launch so peer gets a head
+// start.  Useful in low-latency environments where peer is consistently faster than S3.
+// Default 0 disables the delay (both paths launch simultaneously).
+DECLARE_mInt32(peer_race_hedge_delay_ms);
+DECLARE_mString(peer_cache_fill_compute_group_id);
+DECLARE_mBool(enable_peer_server_cache_fill);
+DECLARE_mInt32(peer_server_cache_fill_timeout_ms);
+DECLARE_mInt32(max_concurrent_peer_server_fills);
+// Reject queued peer fetch tasks that wait too long in the peer fetch pool.
+DECLARE_mInt32(peer_fetch_queue_timeout_ms);
 
 // Base compaction output: only write index files to file cache, not data files
 DECLARE_mBool(enable_file_cache_write_base_compaction_index_only);

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -412,6 +412,7 @@ DEFINE_String(storage_page_cache_limit, "20%");
 // Shard size for page cache, the value must be power of two.
 // It's recommended to set it to a value close to the number of BE cores in order to reduce lock contentions.
 DEFINE_Int32(storage_page_cache_shard_size, "256");
+DEFINE_mInt32(file_cache_mem_storage_shard_num, "1024");
 // Percentage for index page cache
 // all storage page cache will be divided into data_page_cache and index_page_cache
 DEFINE_Int32(index_page_cache_percentage, "10");
@@ -615,8 +616,10 @@ DEFINE_mInt64(load_error_log_reserve_hours, "48");
 DEFINE_mInt64(load_error_log_limit_bytes, "209715200");
 
 DEFINE_Int32(brpc_heavy_work_pool_threads, "-1");
+DEFINE_Int32(brpc_peer_fetch_pool_threads, "-1");
 DEFINE_Int32(brpc_light_work_pool_threads, "-1");
 DEFINE_Int32(brpc_heavy_work_pool_max_queue_size, "-1");
+DEFINE_Int32(brpc_peer_fetch_pool_max_queue_size, "-1");
 DEFINE_Int32(brpc_light_work_pool_max_queue_size, "-1");
 DEFINE_mBool(enable_bthread_transmit_block, "true");
 DEFINE_Int32(brpc_arrow_flight_work_pool_threads, "-1");
@@ -1072,6 +1075,9 @@ DEFINE_String(tmp_file_dir, "tmp");
 
 DEFINE_Int32(min_s3_file_system_thread_num, "16");
 DEFINE_Int32(max_s3_file_system_thread_num, "64");
+
+DEFINE_Int32(min_peer_race_s3_thread_num, "0");
+DEFINE_Int32(max_peer_race_s3_thread_num, "32"); // aligned with default max_concurrent_peer_races
 
 DEFINE_Bool(enable_time_lut, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -474,6 +474,7 @@ DECLARE_String(storage_page_cache_limit);
 // Shard size for page cache, the value must be power of two.
 // It's recommended to set it to a value close to the number of BE cores in order to reduce lock contentions.
 DECLARE_Int32(storage_page_cache_shard_size);
+DECLARE_mInt32(file_cache_mem_storage_shard_num);
 // Percentage for index page cache
 // all storage page cache will be divided into data_page_cache and index_page_cache
 DECLARE_Int32(index_page_cache_percentage);
@@ -681,9 +682,11 @@ DECLARE_mInt64(load_error_log_limit_bytes);
 // each category has diffrent thread number
 // threads to handle heavy api interface, such as transmit_block etc
 DECLARE_Int32(brpc_heavy_work_pool_threads);
+DECLARE_Int32(brpc_peer_fetch_pool_threads);
 // threads to handle light api interface, such as exec_plan_fragment_prepare/exec_plan_fragment_start
 DECLARE_Int32(brpc_light_work_pool_threads);
 DECLARE_Int32(brpc_heavy_work_pool_max_queue_size);
+DECLARE_Int32(brpc_peer_fetch_pool_max_queue_size);
 DECLARE_Int32(brpc_light_work_pool_max_queue_size);
 DECLARE_mBool(enable_bthread_transmit_block);
 DECLARE_Int32(brpc_arrow_flight_work_pool_threads);
@@ -1133,6 +1136,11 @@ DECLARE_mInt32(cold_data_compaction_score_threshold);
 
 DECLARE_Int32(min_s3_file_system_thread_num);
 DECLARE_Int32(max_s3_file_system_thread_num);
+
+// Thread pool for S3 reads in cross-CG peer winner race.
+// Max should match max_concurrent_peer_races so the pool never fills up under normal operation.
+DECLARE_Int32(min_peer_race_s3_thread_num);
+DECLARE_Int32(max_peer_race_s3_thread_num);
 
 DECLARE_Bool(enable_time_lut);
 DECLARE_mBool(enable_simdjson_reader);

--- a/be/src/common/metrics/doris_metrics.h
+++ b/be/src/common/metrics/doris_metrics.h
@@ -228,12 +228,16 @@ public:
 
     UIntGauge* light_work_pool_queue_size = nullptr;
     UIntGauge* heavy_work_pool_queue_size = nullptr;
+    UIntGauge* peer_fetch_work_pool_queue_size = nullptr;
     UIntGauge* heavy_work_active_threads = nullptr;
+    UIntGauge* peer_fetch_work_active_threads = nullptr;
     UIntGauge* light_work_active_threads = nullptr;
 
     UIntGauge* heavy_work_pool_max_queue_size = nullptr;
+    UIntGauge* peer_fetch_work_pool_max_queue_size = nullptr;
     UIntGauge* light_work_pool_max_queue_size = nullptr;
     UIntGauge* heavy_work_max_threads = nullptr;
+    UIntGauge* peer_fetch_work_max_threads = nullptr;
     UIntGauge* light_work_max_threads = nullptr;
 
     UIntGauge* arrow_flight_work_pool_queue_size = nullptr;

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -627,13 +627,18 @@ Status OlapScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
             for (auto& split : _read_sources[scan_range_idx].rs_splits) {
                 split.rs_reader = split.rs_reader->clone();
             }
-            auto scanner = OlapScanner::create_shared(
-                    this, OlapScanner::Params {
-                                  state(), _scanner_profile.get(), scanner_ranges,
-                                  _tablets[scan_range_idx].tablet, version,
-                                  _read_sources[scan_range_idx], {}, p._limit,
-                                  p._olap_scan_node.is_preaggregation,
-                          });
+            auto scanner =
+                    OlapScanner::create_shared(this, OlapScanner::Params {
+                                                             state(),
+                                                             _scanner_profile.get(),
+                                                             scanner_ranges,
+                                                             _tablets[scan_range_idx].tablet,
+                                                             version,
+                                                             _read_sources[scan_range_idx],
+                                                             {},
+                                                             p._limit,
+                                                             p._olap_scan_node.is_preaggregation,
+                                                     });
             RETURN_IF_ERROR(scanner->init(state(), _conjuncts));
             scanners->push_back(std::move(scanner));
         }

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -627,17 +627,13 @@ Status OlapScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
             for (auto& split : _read_sources[scan_range_idx].rs_splits) {
                 split.rs_reader = split.rs_reader->clone();
             }
-            auto scanner =
-                    OlapScanner::create_shared(this, OlapScanner::Params {
-                                                             state(),
-                                                             _scanner_profile.get(),
-                                                             scanner_ranges,
-                                                             _tablets[scan_range_idx].tablet,
-                                                             version,
-                                                             _read_sources[scan_range_idx],
-                                                             p._limit,
-                                                             p._olap_scan_node.is_preaggregation,
-                                                     });
+            auto scanner = OlapScanner::create_shared(
+                    this, OlapScanner::Params {
+                                  state(), _scanner_profile.get(), scanner_ranges,
+                                  _tablets[scan_range_idx].tablet, version,
+                                  _read_sources[scan_range_idx], {}, p._limit,
+                                  p._olap_scan_node.is_preaggregation,
+                          });
             RETURN_IF_ERROR(scanner->init(state(), _conjuncts));
             scanners->push_back(std::move(scanner));
         }

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -94,7 +94,8 @@ OlapScanner::OlapScanner(ScanLocalStateBase* parent, OlapScanner::Params&& param
                                  .score_runtime {},
                                  .collection_statistics {},
                                  .ann_topn_runtime {},
-                                 .condition_cache_digest = parent->get_condition_cache_digest()}) {
+                                 .condition_cache_digest = parent->get_condition_cache_digest()}),
+          _initial_file_cache_stats(std::move(params.initial_file_cache_stats)) {
     _tablet_reader_params.set_read_source(std::move(params.read_source),
                                           _state->skip_delete_bitmap());
     _has_prepared = false;
@@ -294,6 +295,7 @@ Status OlapScanner::_open_impl(RuntimeState* state) {
                    ", backend=" + BackendOptions::get_localhost());
         return res;
     }
+    _tablet_reader->mutable_stats()->file_cache_stats.merge_from(_initial_file_cache_stats);
 
     // Do not hold rs_splits any more to release memory.
     _tablet_reader_params.rs_splits.clear();

--- a/be/src/exec/scan/olap_scanner.h
+++ b/be/src/exec/scan/olap_scanner.h
@@ -63,6 +63,7 @@ public:
         BaseTabletSPtr tablet;
         int64_t version;
         TabletReadSource read_source;
+        io::FileCacheStatistics initial_file_cache_stats;
         int64_t limit;
         bool aggregation;
     };
@@ -103,6 +104,7 @@ public:
     std::vector<ColumnId> _return_columns;
 
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
+    io::FileCacheStatistics _initial_file_cache_stats;
 
     // This three fields are copied from OlapScanLocalState.
     std::map<SlotId, VExprContextSPtr> _slot_id_to_virtual_column_expr;

--- a/be/src/exec/scan/parallel_scanner_builder.cpp
+++ b/be/src/exec/scan/parallel_scanner_builder.cpp
@@ -237,8 +237,8 @@ Status ParallelScannerBuilder::_build_scanners_by_segment(std::list<ScannerSPtr>
                             {.rs_splits = std::move(partitial_read_source.rs_splits),
                              .delete_predicates = entire_read_source.delete_predicates,
                              .delete_bitmap = entire_read_source.delete_bitmap},
-                            take_initial_file_cache_stats(
-                                    &_tablet_preload_file_cache_stats, tablet->tablet_id())));
+                            take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                          tablet->tablet_id())));
 
                     // Reset for next scanner
                     partitial_read_source = TabletReadSource();
@@ -274,9 +274,8 @@ Status ParallelScannerBuilder::_build_scanners_by_segment(std::list<ScannerSPtr>
                                    {.rs_splits = std::move(partitial_read_source.rs_splits),
                                     .delete_predicates = entire_read_source.delete_predicates,
                                     .delete_bitmap = entire_read_source.delete_bitmap},
-                                   take_initial_file_cache_stats(
-                                           &_tablet_preload_file_cache_stats,
-                                           tablet->tablet_id())));
+                                   take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                                 tablet->tablet_id())));
         }
     }
 

--- a/be/src/exec/scan/parallel_scanner_builder.cpp
+++ b/be/src/exec/scan/parallel_scanner_builder.cpp
@@ -31,6 +31,21 @@
 
 namespace doris {
 
+namespace {
+
+io::FileCacheStatistics take_initial_file_cache_stats(
+        std::unordered_map<int64_t, io::FileCacheStatistics>* preload_stats, int64_t tablet_id) {
+    auto it = preload_stats->find(tablet_id);
+    if (it == preload_stats->end()) {
+        return {};
+    }
+    auto stats = std::move(it->second);
+    preload_stats->erase(it);
+    return stats;
+}
+
+} // namespace
+
 Status ParallelScannerBuilder::build_scanners(std::list<ScannerSPtr>& scanners) {
     RETURN_IF_ERROR(_load());
     if (_scan_parallelism_by_segment) {
@@ -112,7 +127,9 @@ Status ParallelScannerBuilder::_build_scanners_by_rowid(std::list<ScannerSPtr>& 
                                 tablet, version, _key_ranges,
                                 {.rs_splits = std::move(partitial_read_source.rs_splits),
                                  .delete_predicates = entire_read_source.delete_predicates,
-                                 .delete_bitmap = entire_read_source.delete_bitmap}));
+                                 .delete_bitmap = entire_read_source.delete_bitmap},
+                                take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                              tablet->tablet_id())));
 
                         partitial_read_source = {};
                         split = RowSetSplits(reader->clone());
@@ -157,7 +174,9 @@ Status ParallelScannerBuilder::_build_scanners_by_rowid(std::list<ScannerSPtr>& 
                     _build_scanner(tablet, version, _key_ranges,
                                    {.rs_splits = std::move(partitial_read_source.rs_splits),
                                     .delete_predicates = entire_read_source.delete_predicates,
-                                    .delete_bitmap = entire_read_source.delete_bitmap}));
+                                    .delete_bitmap = entire_read_source.delete_bitmap},
+                                   take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                                 tablet->tablet_id())));
         }
     }
 
@@ -217,7 +236,9 @@ Status ParallelScannerBuilder::_build_scanners_by_segment(std::list<ScannerSPtr>
                             tablet, version, _key_ranges,
                             {.rs_splits = std::move(partitial_read_source.rs_splits),
                              .delete_predicates = entire_read_source.delete_predicates,
-                             .delete_bitmap = entire_read_source.delete_bitmap}));
+                             .delete_bitmap = entire_read_source.delete_bitmap},
+                            take_initial_file_cache_stats(
+                                    &_tablet_preload_file_cache_stats, tablet->tablet_id())));
 
                     // Reset for next scanner
                     partitial_read_source = TabletReadSource();
@@ -252,7 +273,10 @@ Status ParallelScannerBuilder::_build_scanners_by_segment(std::list<ScannerSPtr>
                     _build_scanner(tablet, version, _key_ranges,
                                    {.rs_splits = std::move(partitial_read_source.rs_splits),
                                     .delete_predicates = entire_read_source.delete_predicates,
-                                    .delete_bitmap = entire_read_source.delete_bitmap}));
+                                    .delete_bitmap = entire_read_source.delete_bitmap},
+                                   take_initial_file_cache_stats(
+                                           &_tablet_preload_file_cache_stats,
+                                           tablet->tablet_id())));
         }
     }
 
@@ -279,8 +303,10 @@ Status ParallelScannerBuilder::_load() {
 
             auto beta_rowset = std::dynamic_pointer_cast<BetaRowset>(rowset);
             std::vector<uint32_t> segment_rows;
+            OlapReaderStatistics preload_stats;
             RETURN_IF_ERROR(beta_rowset->get_segment_num_rows(&segment_rows, enable_segment_cache,
-                                                              &_builder_stats));
+                                                              &preload_stats));
+            _tablet_preload_file_cache_stats[tablet_id].merge_from(preload_stats.file_cache_stats);
             auto segment_count = rowset->num_segments();
             for (int64_t i = 0; i != segment_count; i++) {
                 _all_segments_rows[rowset_id].emplace_back(segment_rows[i]);
@@ -298,9 +324,18 @@ Status ParallelScannerBuilder::_load() {
 
 std::shared_ptr<OlapScanner> ParallelScannerBuilder::_build_scanner(
         BaseTabletSPtr tablet, int64_t version, const std::vector<OlapScanRange*>& key_ranges,
-        TabletReadSource&& read_source) {
-    OlapScanner::Params params {_state,  _scanner_profile.get(), key_ranges, std::move(tablet),
-                                version, std::move(read_source), _limit,     _is_preaggregation};
+        TabletReadSource&& read_source, io::FileCacheStatistics&& initial_file_cache_stats) {
+    OlapScanner::Params params {
+            _state,
+            _scanner_profile.get(),
+            key_ranges,
+            std::move(tablet),
+            version,
+            std::move(read_source),
+            std::move(initial_file_cache_stats),
+            _limit,
+            _is_preaggregation,
+    };
     return OlapScanner::create_shared(_parent, std::move(params));
 }
 

--- a/be/src/exec/scan/parallel_scanner_builder.h
+++ b/be/src/exec/scan/parallel_scanner_builder.h
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "exec/scan/olap_scanner.h"
+#include "io/io_common.h"
 #include "storage/rowset/rowset_fwd.h"
 #include "storage/segment/row_ranges.h"
 #include "storage/segment/segment_loader.h"
@@ -75,7 +76,8 @@ private:
 
     std::shared_ptr<OlapScanner> _build_scanner(BaseTabletSPtr tablet, int64_t version,
                                                 const std::vector<OlapScanRange*>& key_ranges,
-                                                TabletReadSource&& read_source);
+                                                TabletReadSource&& read_source,
+                                                io::FileCacheStatistics&& initial_file_cache_stats);
 
     OlapScanLocalState* _parent;
 
@@ -90,6 +92,7 @@ private:
     size_t _rows_per_scanner {_min_rows_per_scanner};
 
     std::map<RowsetId, std::vector<size_t>> _all_segments_rows;
+    std::unordered_map<int64_t, io::FileCacheStatistics> _tablet_preload_file_cache_stats;
 
     // Force building one scanner per segment when true.
     bool _scan_parallelism_by_segment {false};

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -177,6 +177,16 @@ size_t NeedUpdateLRUBlocks::shard_index(FileBlock* ptr) const {
     return std::hash<FileBlock*> {}(ptr)&kShardMask;
 }
 
+namespace {
+
+int64_t steady_clock_seconds() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+                   std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+}
+
+} // namespace
+
 BlockFileCache::BlockFileCache(const std::string& cache_base_path,
                                const FileCacheSettings& cache_settings)
         : _cache_base_path(cache_base_path),
@@ -1473,9 +1483,7 @@ bool BlockFileCache::try_reserve_for_lru(const UInt128Wrapper& hash,
                                          const CacheContext& context, size_t offset, size_t size,
                                          std::lock_guard<std::mutex>& cache_lock,
                                          bool evict_in_advance) {
-    int64_t cur_time = std::chrono::duration_cast<std::chrono::seconds>(
-                               std::chrono::steady_clock::now().time_since_epoch())
-                               .count();
+    int64_t cur_time = steady_clock_seconds();
     if (!try_reserve_from_other_queue(context.cache_type, size, cur_time, cache_lock,
                                       evict_in_advance)) {
         auto& queue = get_queue(context.cache_type);

--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -20,9 +20,6 @@
 
 #include "io/cache/block_file_cache_downloader.h"
 
-#include <bthread/bthread.h>
-#include <bthread/countdown_event.h>
-#include <bthread/unstable.h>
 #include <bvar/bvar.h>
 #include <fmt/core.h>
 #include <gen_cpp/internal_service.pb.h>
@@ -33,7 +30,6 @@
 #include <variant>
 
 #include "cloud/cloud_tablet_mgr.h"
-#include "cloud/cloud_warm_up_manager.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "cpp/sync_point.h"
@@ -277,8 +273,20 @@ void FileCacheBlockDownloader::download_file_cache_block(
 }
 
 void FileCacheBlockDownloader::download_segment_file(const DownloadFileMeta& meta) {
-    LOG(INFO) << "download_segment_file: start, path=" << meta.path << ", offset=" << meta.offset
-              << ", download_size=" << meta.download_size << ", file_size=" << meta.file_size;
+    VLOG_DEBUG << "download_segment_file: start, path=" << meta.path << ", offset=" << meta.offset
+               << ", download_size=" << meta.download_size << ", file_size=" << meta.file_size;
+    DBUG_EXECUTE_IF("FileCacheBlockDownloader::download_segment_file.skip_warmup", {
+        if (meta.ctx.is_warmup) {
+            LOG(INFO) << "download_segment_file: skip warmup download by debug point, path="
+                      << meta.path << ", offset=" << meta.offset
+                      << ", download_size=" << meta.download_size;
+            if (meta.download_done) {
+                meta.download_done(Status::OK());
+            }
+            return;
+        }
+    });
+
     FileReaderSPtr file_reader;
     FileReaderOptions opts {
             .cache_type = FileCachePolicy::FILE_BLOCK_CACHE,
@@ -286,6 +294,7 @@ void FileCacheBlockDownloader::download_segment_file(const DownloadFileMeta& met
             .cache_base_path {},
             .file_size = meta.file_size,
             .tablet_id = meta.tablet_id,
+            .storage_resource_id = meta.file_system->id(),
     };
     auto st = meta.file_system->open_file(meta.path, &file_reader, &opts);
     if (!st.ok()) {
@@ -305,11 +314,13 @@ void FileCacheBlockDownloader::download_segment_file(const DownloadFileMeta& met
     std::unique_ptr<char[]> buffer(new char[one_single_task_size]);
 
     DBUG_EXECUTE_IF("FileCacheBlockDownloader::download_segment_file_sleep", {
-        auto sleep_time = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
-                "FileCacheBlockDownloader::download_segment_file_sleep", "sleep_time", 3);
-        LOG(INFO) << "FileCacheBlockDownloader::download_segment_file_sleep: sleep_time="
-                  << sleep_time;
-        sleep(sleep_time);
+        if (meta.ctx.is_warmup) {
+            auto sleep_time = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                    "FileCacheBlockDownloader::download_segment_file_sleep", "sleep_time", 3);
+            LOG(INFO) << "FileCacheBlockDownloader::download_segment_file_sleep: sleep_time="
+                      << sleep_time;
+            sleep(sleep_time);
+        }
     });
 
     size_t task_offset = 0;

--- a/be/src/io/cache/block_file_cache_profile.cpp
+++ b/be/src/io/cache/block_file_cache_profile.cpp
@@ -199,6 +199,27 @@ FileCacheProfileReporter::FileCacheProfileReporter(RuntimeProfile* profile,
             profile, "SegmentFooterIndexRemoteIOUseTimer", cache_profile, 1);
     segment_footer_index_peer_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(
             profile, "SegmentFooterIndexPeerIOUseTimer", cache_profile, 1);
+
+    num_cross_cg_peer_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "CrossCGPeerIOTotal",
+                                                              TUnit::UNIT, cache_profile, 1);
+    bytes_scanned_from_cross_cg_peer = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "CrossCGPeerBytesRead",
+                                                                    TUnit::BYTES, cache_profile, 1);
+    cross_cg_peer_io_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "CrossCGPeerIOTime", cache_profile, 1);
+    num_same_cg_peer_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "SameCGPeerIOTotal",
+                                                             TUnit::UNIT, cache_profile, 1);
+    bytes_scanned_from_same_cg_peer = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "SameCGPeerBytesRead",
+                                                                   TUnit::BYTES, cache_profile, 1);
+    same_cg_peer_io_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "SameCGPeerIOTime", cache_profile, 1);
+    num_peer_race_peer_win =
+            ADD_CHILD_COUNTER_WITH_LEVEL(profile, "PeerRaceWin", TUnit::UNIT, cache_profile, 1);
+    num_peer_race_s3_win =
+            ADD_CHILD_COUNTER_WITH_LEVEL(profile, "S3RaceWin", TUnit::UNIT, cache_profile, 1);
+    num_peer_lazy_fetch =
+            ADD_CHILD_COUNTER_WITH_LEVEL(profile, "PeerLazyFetch", TUnit::UNIT, cache_profile, 1);
+    peer_lazy_fetch_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "PeerLazyFetchTime", cache_profile, 1);
 }
 
 void FileCacheProfileReporter::update(const FileCacheStatistics* statistics) const {
@@ -261,6 +282,28 @@ void FileCacheProfileReporter::update(const FileCacheStatistics* statistics) con
                    statistics->segment_footer_index_remote_io_timer);
     COUNTER_UPDATE(segment_footer_index_peer_io_timer,
                    statistics->segment_footer_index_peer_io_timer);
+
+    COUNTER_UPDATE(num_cross_cg_peer_io_total, statistics->num_cross_cg_peer_io_total);
+    COUNTER_UPDATE(bytes_scanned_from_cross_cg_peer, statistics->bytes_read_from_cross_cg_peer);
+    COUNTER_UPDATE(cross_cg_peer_io_timer, statistics->cross_cg_peer_io_timer);
+    COUNTER_UPDATE(num_same_cg_peer_io_total, statistics->num_same_cg_peer_io_total);
+    COUNTER_UPDATE(bytes_scanned_from_same_cg_peer, statistics->bytes_read_from_same_cg_peer);
+    COUNTER_UPDATE(same_cg_peer_io_timer, statistics->same_cg_peer_io_timer);
+    COUNTER_UPDATE(num_peer_race_peer_win, statistics->num_peer_race_peer_win);
+    COUNTER_UPDATE(num_peer_race_s3_win, statistics->num_peer_race_s3_win);
+    COUNTER_UPDATE(num_peer_lazy_fetch, statistics->num_peer_lazy_fetch);
+    COUNTER_UPDATE(peer_lazy_fetch_timer, statistics->peer_lazy_fetch_timer);
+
+    if (!statistics->peer_hosts.empty() && _profile != nullptr) {
+        std::string peer_nodes;
+        for (const auto& host : statistics->peer_hosts) {
+            if (!peer_nodes.empty()) {
+                peer_nodes += ", ";
+            }
+            peer_nodes += host;
+        }
+        _profile->add_info_string("PeerCacheNodes", peer_nodes);
+    }
 }
 
 } // namespace doris::io

--- a/be/src/io/cache/block_file_cache_profile.h
+++ b/be/src/io/cache/block_file_cache_profile.h
@@ -115,6 +115,18 @@ struct FileCacheProfileReporter {
     explicit FileCacheProfileReporter(
             RuntimeProfile* profile,
             const std::string& parent_counter = RuntimeProfile::ROOT_COUNTER);
+    // Cross-CG / Same-CG peer read counters
+    RuntimeProfile::Counter* num_cross_cg_peer_io_total = nullptr;
+    RuntimeProfile::Counter* bytes_scanned_from_cross_cg_peer = nullptr;
+    RuntimeProfile::Counter* cross_cg_peer_io_timer = nullptr;
+    RuntimeProfile::Counter* num_same_cg_peer_io_total = nullptr;
+    RuntimeProfile::Counter* bytes_scanned_from_same_cg_peer = nullptr;
+    RuntimeProfile::Counter* same_cg_peer_io_timer = nullptr;
+    RuntimeProfile::Counter* num_peer_race_peer_win = nullptr;
+    RuntimeProfile::Counter* num_peer_race_s3_win = nullptr;
+    RuntimeProfile::Counter* num_peer_lazy_fetch = nullptr;
+    RuntimeProfile::Counter* peer_lazy_fetch_timer = nullptr;
+
     void update(const FileCacheStatistics* statistics) const;
 };
 

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -18,6 +18,9 @@
 #include "io/cache/cached_remote_file_reader.h"
 
 #include <brpc/controller.h>
+#include <bthread/bthread.h>
+#include <bthread/condition_variable.h>
+#include <bthread/mutex.h>
 #include <fmt/format.h>
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/internal_service.pb.h>
@@ -34,17 +37,17 @@
 #include <thread>
 #include <vector>
 
+#include "cloud/cloud_cluster_info.h"
 #include "cloud/cloud_warm_up_manager.h"
 #include "cloud/config.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/config.h"
+#include "common/metrics/doris_metrics.h"
 #include "cpp/sync_point.h"
-#include "cpp/token_bucket_rate_limiter.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/block_file_cache_factory.h"
 #include "io/cache/block_file_cache_profile.h"
 #include "io/cache/file_block.h"
-#include "io/cache/file_cache_common.h"
 #include "io/cache/peer_file_cache_reader.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/local_file_system.h"
@@ -56,9 +59,11 @@
 #include "service/backend_options.h"
 #include "util/bit_util.h"
 #include "util/brpc_client_cache.h" // BrpcClientCache
+#include "util/bthread_utils.h"
 #include "util/client_cache.h"
 #include "util/concurrency_stats.h"
 #include "util/debug_points.h"
+#include "util/defer_op.h"
 
 namespace doris::io {
 
@@ -89,39 +94,74 @@ bvar::Window<bvar::Adder<uint64_t>> g_read_cache_indirect_total_bytes_1min_windo
 bvar::Adder<uint64_t> g_failed_get_peer_addr_counter(
         "cached_remote_reader_failed_get_peer_addr_counter");
 
+static std::atomic<int> g_active_peer_races {0};
+bvar::PassiveStatus<int> g_active_peer_races_bvar(
+        "peer_race_active_count",
+        [](void*) { return g_active_peer_races.load(std::memory_order_relaxed); }, nullptr);
+// Cross-CG peer read race statistics
+bvar::Adder<uint64_t> g_peer_race_peer_win("peer_race_peer_win");
+bvar::Adder<uint64_t> g_peer_race_s3_win("peer_race_s3_win");
+bvar::Adder<uint64_t> g_peer_race_both_fail("peer_race_both_fail");
+bvar::Adder<uint64_t> g_peer_cross_compute_group_read("peer_cross_compute_group_read");
+bvar::Adder<uint64_t> g_peer_same_compute_group_read("peer_same_compute_group_read");
+bvar::Adder<uint64_t> g_peer_lazy_fetch_triggered("peer_lazy_fetch_triggered");
+
 CachedRemoteFileReader::CachedRemoteFileReader(FileReaderSPtr remote_file_reader,
                                                const FileReaderOptions& opts)
-        : _tablet_id(opts.tablet_id), _remote_file_reader(std::move(remote_file_reader)) {
-    DCHECK(!opts.is_doris_table || _tablet_id > 0);
-    _is_doris_table = opts.is_doris_table;
+        : _is_doris_table(opts.is_doris_table),
+          _tablet_id(opts.tablet_id),
+          _storage_resource_id(opts.storage_resource_id),
+          _remote_file_reader(std::move(remote_file_reader)) {
+    DCHECK(!_is_doris_table || _tablet_id > 0);
     if (_is_doris_table) {
-        _cache_hash = BlockFileCache::hash(path().filename().native());
-        _cache = FileCacheFactory::instance()->get_by_path(_cache_hash);
-        if (config::enable_read_cache_file_directly) {
-            // this is designed for and test in doris table, external table need extra tests
-            _cache_file_readers = _cache->get_blocks_by_key(_cache_hash);
-        }
+        _init_doris_table_cache();
     } else {
-        // Use path and modification time to build cache key
-        std::string unique_path = fmt::format("{}:{}", path().native(), opts.mtime);
-        _cache_hash = BlockFileCache::hash(unique_path);
-        if (opts.cache_base_path.empty()) {
-            // if cache path is not specified by session variable, chose randomly.
-            _cache = FileCacheFactory::instance()->get_by_path(_cache_hash);
-        } else {
-            // from query session variable: file_cache_base_path
-            _cache = FileCacheFactory::instance()->get_by_path(opts.cache_base_path);
-            if (_cache == nullptr) {
-                LOG(WARNING) << "Can't get cache from base path: " << opts.cache_base_path
-                             << ", using random instead.";
-                _cache = FileCacheFactory::instance()->get_by_path(_cache_hash);
-            }
-        }
+        _init_external_table_cache(opts);
     }
 }
 
+void CachedRemoteFileReader::_init_doris_table_cache() {
+    _cache_hash = BlockFileCache::hash(path().filename().native());
+    _cache = FileCacheFactory::instance()->get_by_path(_cache_hash);
+    if (_can_read_cache_file_directly()) {
+        // this is designed for and test in doris table, external table need extra tests
+        _cache_file_readers = _cache->get_blocks_by_key(_cache_hash);
+    }
+}
+
+void CachedRemoteFileReader::_init_external_table_cache(const FileReaderOptions& opts) {
+    // Use path and modification time to build cache key.
+    std::string unique_path = fmt::format("{}:{}", path().native(), opts.mtime);
+    _cache_hash = BlockFileCache::hash(unique_path);
+    if (opts.cache_base_path.empty()) {
+        // If cache path is not specified by session variable, choose randomly.
+        _cache = FileCacheFactory::instance()->get_by_path(_cache_hash);
+        return;
+    }
+
+    // From query session variable: file_cache_base_path.
+    _cache = FileCacheFactory::instance()->get_by_path(opts.cache_base_path);
+    if (_cache != nullptr) {
+        return;
+    }
+
+    LOG(WARNING) << "Can't get cache from base path: " << opts.cache_base_path
+                 << ", using random instead.";
+    _cache = FileCacheFactory::instance()->get_by_path(_cache_hash);
+}
+
+bool CachedRemoteFileReader::_can_read_cache_file_directly() const {
+    return _is_doris_table && config::enable_read_cache_file_directly;
+}
+
+bool CachedRemoteFileReader::_should_read_from_peer(const IOContext* io_ctx) const {
+    return doris::config::is_cloud_mode() && _is_doris_table && _tablet_id > 0 &&
+           !io_ctx->is_warmup && !io_ctx->bypass_peer_read &&
+           doris::config::enable_cache_read_from_peer;
+}
+
 void CachedRemoteFileReader::_insert_file_reader(FileBlockSPtr file_block) {
-    if (_is_doris_table && config::enable_read_cache_file_directly) {
+    if (_can_read_cache_file_directly()) {
         std::lock_guard lock(_mtx);
         DCHECK(file_block->state() == FileBlock::State::DOWNLOADED);
         file_block->_owned_by_cached_reader = true;
@@ -158,51 +198,91 @@ std::pair<size_t, size_t> CachedRemoteFileReader::s_align_size(size_t offset, si
 }
 
 namespace {
-// Execute S3 read
-Status execute_s3_read(size_t empty_start, size_t& size, std::unique_ptr<char[]>& buffer,
-                       ReadStatistics& stats, const IOContext* io_ctx,
-                       FileReaderSPtr remote_file_reader) {
-    s3_read_counter << 1;
-    SCOPED_RAW_TIMER(&stats.remote_read_timer);
-    stats.from_peer_cache = false;
-    return remote_file_reader->read_at(empty_start, Slice(buffer.get(), size), &size, io_ctx);
+struct PeerFetchLayout {
+    std::vector<size_t> block_offsets;
+    std::vector<size_t> block_sizes;
+    size_t total_size = 0;
+};
+
+bool is_fill_not_found(const Status& st, bool request_fill) {
+    return request_fill && st.is<ErrorCode::NOT_FOUND>();
 }
 
-// Get peer connection info from tablet_id
-std::pair<std::string, int> get_peer_connection_info(int64_t tablet_id,
-                                                     const std::string& file_path) {
-    std::string host = "";
-    int port = 0;
+bool contains_file_block(const PeerFetchedBlockSet& fetched_blocks, const FileBlockSPtr& block) {
+    return fetched_blocks.contains(block.get());
+}
 
-    DCHECK(tablet_id > 0);
-    auto& manager = ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager();
-    if (auto tablet_info = manager.get_balanced_tablet_info(tablet_id)) {
-        host = tablet_info->first;
-        port = tablet_info->second;
-    } else {
-        LOG_EVERY_N(WARNING, 100) << "get peer connection info not found"
-                                  << ", tablet_id=" << tablet_id << ", file_path=" << file_path;
+size_t clip_peer_block_size(const FileBlock::Range& range, size_t file_size) {
+    if (range.left >= file_size) {
+        return 0;
     }
-
-    DBUG_EXECUTE_IF("PeerFileCacheReader::_fetch_from_peer_cache_blocks", {
-        host = dp->param<std::string>("host", "127.0.0.1");
-        port = dp->param("port", 9060);
-        LOG_WARNING("debug point PeerFileCacheReader::_fetch_from_peer_cache_blocks")
-                .tag("host", host)
-                .tag("port", port);
-    });
-
-    return {host, port};
+    return std::min(file_size - range.left, range.size());
 }
 
-// Execute peer read with fallback to S3
-// file_size is the size of the file
-// used to calculate the rightmost boundary value of the block, due to inaccurate current block meta information.
-Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start,
-                         size_t& size, std::unique_ptr<char[]>& buffer,
-                         const std::string& file_path, size_t file_size, bool is_doris_table,
-                         int64_t tablet_id, ReadStatistics& stats, const IOContext* io_ctx) {
-    auto [host, port] = get_peer_connection_info(tablet_id, file_path);
+PeerFetchLayout build_peer_fetch_layout(const std::vector<FileBlockSPtr>& blocks,
+                                        size_t file_size) {
+    PeerFetchLayout layout;
+    layout.block_offsets.reserve(blocks.size());
+    layout.block_sizes.reserve(blocks.size());
+    for (const auto& block : blocks) {
+        const size_t block_size = clip_peer_block_size(block->range(), file_size);
+        layout.block_offsets.push_back(layout.total_size);
+        layout.block_sizes.push_back(block_size);
+        layout.total_size += block_size;
+    }
+    return layout;
+}
+
+Status write_peer_payloads_into_block(const FileBlockSPtr& block,
+                                      std::vector<const PeerFetchChunk*>& chunks,
+                                      size_t* block_size) {
+    if (block_size == nullptr) {
+        return Status::InvalidArgument("peer block write requires non-null block_size");
+    }
+    *block_size = 0;
+    if (chunks.empty()) {
+        return Status::OK();
+    }
+    std::sort(chunks.begin(), chunks.end(),
+              [](const PeerFetchChunk* lhs, const PeerFetchChunk* rhs) {
+                  return lhs->block_offset < rhs->block_offset;
+              });
+    butil::IOBuf payload;
+    for (const auto* chunk : chunks) {
+        *block_size += chunk->payload.length();
+        payload.append(chunk->payload);
+    }
+    DCHECK(*block_size != 0);
+    return block->append_iobuf(payload);
+}
+
+void copy_peer_chunk_to_result(const PeerFetchChunk& chunk, size_t offset, size_t right_offset,
+                               size_t already_read, Slice result, size_t& indirect_read_bytes,
+                               SourceReadBreakdown& source_read_breakdown) {
+    const size_t payload_size = chunk.payload.length();
+    if (payload_size == 0) {
+        return;
+    }
+    const size_t chunk_left = chunk.block_offset;
+    const size_t chunk_right = chunk_left + payload_size - 1;
+    const size_t copy_left_offset = std::max(offset + already_read, chunk_left);
+    const size_t copy_right_offset = std::min(right_offset, chunk_right);
+    if (copy_left_offset > copy_right_offset) {
+        return;
+    }
+    const size_t copy_offset = copy_left_offset - chunk_left;
+    const size_t copy_size = copy_right_offset - copy_left_offset + 1;
+    char* dst = result.data + (copy_left_offset - offset);
+    chunk.payload.copy_to(dst, copy_size, copy_offset);
+    indirect_read_bytes += copy_size;
+    source_read_breakdown.peer_bytes += copy_size;
+}
+
+// Execute peer read targeting a specific host:port.
+Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks,
+                         PeerFetchResult* peer_result, const std::string& file_path,
+                         size_t file_size, bool is_doris_table, ReadStatistics& stats,
+                         const IOContext* io_ctx, const std::string& host, int32_t port) {
     VLOG_DEBUG << "PeerFileCacheReader read from peer, host=" << host << ", port=" << port
                << ", file_path=" << file_path;
 
@@ -216,201 +296,503 @@ Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t 
     SCOPED_RAW_TIMER(&stats.peer_read_timer);
     peer_read_counter << 1;
     PeerFileCacheReader peer_reader(file_path, is_doris_table, host, port);
-    auto st = peer_reader.fetch_blocks(empty_blocks, empty_start, Slice(buffer.get(), size), &size,
-                                       file_size, io_ctx);
+    // Serial peer read: source BE has the data from rebalance warm-up; no fill needed.
+    auto st = peer_reader.fetch_blocks(empty_blocks, peer_result, file_size, io_ctx,
+                                       /*request_fill=*/false);
     if (!st.ok()) {
-        LOG_EVERY_N(WARNING, 100) << "PeerFileCacheReader read from peer failed"
-                                  << ", host=" << host << ", port=" << port
-                                  << ", error=" << st.msg();
+        LOG_WARNING("PeerFileCacheReader read from peer failed")
+                .tag("host", host)
+                .tag("port", port)
+                .tag("error", st.msg());
     }
-    stats.from_peer_cache = true;
+    stats.from_peer_cache = st.ok();
     return st;
+}
+
+// Execute S3 read
+Status execute_s3_read(size_t empty_start, size_t& size, std::unique_ptr<char[]>& buffer,
+                       ReadStatistics& stats, const IOContext* io_ctx,
+                       FileReaderSPtr remote_file_reader) {
+    s3_read_counter << 1;
+    SCOPED_RAW_TIMER(&stats.remote_read_timer);
+    stats.from_peer_cache = false;
+    return remote_file_reader->read_at(empty_start, Slice(buffer.get(), size), &size, io_ctx);
+}
+
+CloudWarmUpManager& get_warm_up_manager() {
+    return ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager();
+}
+
+// Shared state for peer-vs-S3 winner race.
+// Uses bthread primitives — never std::mutex/condition_variable in bthread context.
+struct RaceState {
+    bthread::Mutex mtx;
+    bthread::ConditionVariable cv;
+    int winner = -1; // 0=peer won, 1=s3 won, -1=undecided, -2=both failed
+    bool peer_done = false;
+    bool s3_done = false;
+    Status peer_status;
+    Status s3_status;
+    std::unique_ptr<char[]> s3_buf;
+    PeerFetchResult peer_res;
+    std::string peer_winner_cg_id; // compute_group_id of the winning peer candidate
+    std::string peer_winner_host;  // host of the winning peer candidate
+    int64_t peer_elapsed_ns = 0;   // wall-clock time of the entire peer path (including retries)
+    int64_t peer_winner_io_ns = 0; // I/O time of the winning candidate only
+};
+
+// Peer race logic: try candidates sequentially until one succeeds or all fail.
+// NOTE: Do NOT capture io_ctx here — it points into the caller's stack which may be destroyed
+// when S3 wins the race and the caller returns before this bthread finishes.
+void run_peer_race(std::shared_ptr<RaceState> race, std::vector<FileBlockSPtr> empty_blocks,
+                   const std::string& file_path, size_t file_sz, bool is_doris,
+                   std::shared_ptr<CloudWarmUpManager> manager,
+                   std::vector<doris::PeerCandidate> candidates, int64_t tablet_id,
+                   std::string resource_id, std::shared_ptr<ResourceContext> parent_resource_ctx) {
+    std::unique_ptr<AttachTask> attach_task;
+    if (parent_resource_ctx != nullptr) {
+        attach_task = std::make_unique<AttachTask>(parent_resource_ctx);
+    }
+
+    bool all_tried = true;
+    MonotonicStopWatch peer_sw;
+    peer_sw.start();
+
+    for (size_t i = 0; i < candidates.size(); ++i) {
+        // Before issuing the next RPC, check if S3 already won.
+        if (i > 0) {
+            TEST_SYNC_POINT("run_peer_race::between_candidates");
+            std::unique_lock<bthread::Mutex> lk(race->mtx);
+            if (race->winner > 0) {
+                // S3 already won — stop, but not all candidates were tried.
+                all_tried = false;
+                break;
+            }
+        }
+
+        const auto& cand = candidates[i];
+        peer_read_counter << 1;
+        PeerFileCacheReader peer_reader(file_path, is_doris, cand.host, cand.brpc_port);
+        PeerFetchResult local_peer_res;
+        const bool request_fill =
+                !config::peer_cache_fill_compute_group_id.empty() &&
+                cand.compute_group_id == config::peer_cache_fill_compute_group_id &&
+                !resource_id.empty() && !file_path.empty();
+        MonotonicStopWatch cand_sw;
+        cand_sw.start();
+        auto st = peer_reader.fetch_blocks(empty_blocks, &local_peer_res, file_sz,
+                                           /*ctx=*/nullptr, request_fill, tablet_id, resource_id);
+        if (st.ok()) {
+            manager->update_peer_candidate_on_success(tablet_id, cand.compute_group_id);
+            std::unique_lock<bthread::Mutex> lk(race->mtx);
+            if (race->winner < 0) {
+                race->winner = 0;
+                race->peer_res = std::move(local_peer_res);
+                race->peer_winner_cg_id = cand.compute_group_id;
+                race->peer_winner_host = cand.host;
+                race->peer_elapsed_ns = peer_sw.elapsed_time();
+                race->peer_winner_io_ns = cand_sw.elapsed_time();
+            }
+            race->peer_done = true;
+            race->peer_status = Status::OK();
+            race->cv.notify_all();
+            return;
+        }
+
+        // Handle per-candidate failure.
+        if (st.template is<ErrorCode::TOO_MANY_TASKS>()) {
+            all_tried = false;
+            break;
+        }
+        if (is_fill_not_found(st, request_fill)) {
+            // Pull-through fill already told us this designated fill CG could not serve the block
+            // in time. Do not serially retry additional candidates in the same race; let S3 win
+            // instead of paying more peer RPC latency.
+            manager->rotate_peer_candidate_on_cache_miss(tablet_id, cand.host, cand.brpc_port);
+            all_tried = false;
+            break;
+        }
+        if (st.template is<ErrorCode::NOT_FOUND>()) {
+            manager->rotate_peer_candidate_on_cache_miss(tablet_id, cand.host, cand.brpc_port);
+        } else {
+            manager->update_peer_candidate_on_rpc_failure(tablet_id, cand.host, cand.brpc_port);
+        }
+    }
+
+    if (all_tried) {
+        manager->record_peer_all_miss(tablet_id);
+    }
+    std::unique_lock<bthread::Mutex> lk(race->mtx);
+    race->peer_done = true;
+    race->peer_status = Status::InternalError<false>("peer: all candidates failed");
+    if (race->winner < 0 && race->s3_done) {
+        race->winner = race->s3_status.ok() ? 1 : -2;
+    }
+    race->cv.notify_all();
+}
+
+// Apply hedge delay, then submit S3 read to the thread pool (or run inline).
+void launch_s3_race(std::shared_ptr<RaceState> race, size_t empty_start, size_t span_size,
+                    const IOContext* io_ctx, FileReaderSPtr remote_reader,
+                    std::shared_ptr<ResourceContext> parent_resource_ctx,
+                    std::shared_ptr<CachedRemoteFileReader> owner) {
+    // Raw S3 read body.
+    // `owner` keeps the CachedRemoteFileReader alive until the S3 task finishes,
+    // preventing close() from being called on remote_reader while we are still reading.
+    // Do NOT capture io_ctx: it points into the caller's stack/iterator which may be
+    // destroyed when the query is cancelled before this background task runs. The S3
+    // leg of the race is a best-effort background task whose result is discarded if the
+    // peer wins; passing nullptr is safe because S3FileReader::read_at_impl ignores it.
+    auto do_s3_read = [race, empty_start, span_size, remote_reader, owner]() {
+        (void)owner;
+        auto s3_buf = std::make_unique<char[]>(span_size);
+        size_t read_size = span_size;
+        s3_read_counter << 1;
+        TEST_SYNC_POINT("CachedRemoteFileReader::_execute_winner_race::s3_before_read");
+        auto st = remote_reader->read_at(empty_start, Slice(s3_buf.get(), span_size), &read_size,
+                                         nullptr);
+        std::unique_lock<bthread::Mutex> lk(race->mtx);
+        race->s3_done = true;
+        race->s3_status = st;
+        if (st.ok() && race->winner < 0) {
+            race->winner = 1;
+            race->s3_buf = std::move(s3_buf);
+        }
+        race->cv.notify_all();
+    };
+
+    // Hedge delay: give peer a head start, but wake up early if peer finishes.
+    // Uses cv.wait_for() instead of bthread_usleep() so the calling thread is
+    // unblocked as soon as the peer bthread signals completion, avoiding the
+    // unconditional 20ms sleep that dominated latency on cache-miss-heavy queries.
+    bool peer_already_won = false;
+    if (config::peer_race_hedge_delay_ms > 0) {
+        std::unique_lock<bthread::Mutex> lk(race->mtx);
+        if (!race->peer_done) {
+            race->cv.wait_for(lk, static_cast<long>(config::peer_race_hedge_delay_ms) * 1000);
+        }
+        peer_already_won = (race->winner == 0);
+        if (peer_already_won) {
+            race->s3_done = true;
+            race->s3_status = Status::InternalError<false>("skipped: peer won during hedge delay");
+        }
+    }
+
+    if (!peer_already_won) {
+        auto s3_fn = [do_s3_read, parent_resource_ctx]() mutable {
+            std::unique_ptr<AttachTask> attach_task;
+            if (parent_resource_ctx != nullptr) {
+                attach_task = std::make_unique<AttachTask>(parent_resource_ctx);
+            }
+            do_s3_read();
+        };
+        auto* s3_pool = ExecEnv::GetInstance()->peer_race_s3_thread_pool();
+        if (s3_pool == nullptr || !s3_pool->submit_func(s3_fn).ok()) {
+            do_s3_read();
+        }
+    }
+}
+
+// Wait for the race to finish and populate the output accordingly.
+Status collect_race_result(std::shared_ptr<RaceState> race, size_t span_size,
+                           std::unique_ptr<char[]>& buffer, PeerFetchResult* peer_result,
+                           ReadStatistics& stats, const IOContext* io_ctx) {
+    {
+        std::unique_lock<bthread::Mutex> lk(race->mtx);
+        while (race->winner < 0 && !(race->peer_done && race->s3_done)) {
+            race->cv.wait(lk);
+        }
+    }
+    g_active_peer_races.fetch_sub(1, std::memory_order_relaxed);
+
+    const std::string self_cg_id =
+            static_cast<CloudClusterInfo*>(ExecEnv::GetInstance()->cluster_info())
+                    ->cloud_compute_group_id();
+
+    if (race->winner == 0) {
+        // Peer won.
+        if (peer_result != nullptr) {
+            *peer_result = std::move(race->peer_res);
+        }
+        stats.from_peer_cache = true;
+        stats.peer_read_timer += race->peer_elapsed_ns;
+        g_peer_race_peer_win << 1;
+        const bool is_cross_cg =
+                !race->peer_winner_cg_id.empty() && race->peer_winner_cg_id != self_cg_id;
+        if (is_cross_cg) {
+            g_peer_cross_compute_group_read << 1;
+        } else {
+            g_peer_same_compute_group_read << 1;
+        }
+        if (io_ctx != nullptr && io_ctx->file_cache_stats != nullptr) {
+            io_ctx->file_cache_stats->num_peer_race_peer_win++;
+            io_ctx->file_cache_stats->peer_hosts.insert(race->peer_winner_host);
+            if (is_cross_cg) {
+                io_ctx->file_cache_stats->num_cross_cg_peer_io_total++;
+                io_ctx->file_cache_stats->bytes_read_from_cross_cg_peer += span_size;
+                io_ctx->file_cache_stats->cross_cg_peer_io_timer += race->peer_winner_io_ns;
+            } else {
+                io_ctx->file_cache_stats->num_same_cg_peer_io_total++;
+                io_ctx->file_cache_stats->bytes_read_from_same_cg_peer += span_size;
+                io_ctx->file_cache_stats->same_cg_peer_io_timer += race->peer_winner_io_ns;
+            }
+        }
+        return Status::OK();
+    } else if (race->winner == 1) {
+        // S3 won.
+        buffer = std::move(race->s3_buf);
+        stats.from_peer_cache = false;
+        g_peer_race_s3_win << 1;
+        if (io_ctx != nullptr && io_ctx->file_cache_stats != nullptr) {
+            io_ctx->file_cache_stats->num_peer_race_s3_win++;
+        }
+        return Status::OK();
+    }
+    g_peer_race_both_fail << 1;
+    return Status::InternalError<false>("peer race: both peer and s3 failed");
 }
 
 } // anonymous namespace
 
-Status CachedRemoteFileReader::_execute_remote_read(const std::vector<FileBlockSPtr>& empty_blocks,
-                                                    size_t empty_start, size_t& size,
+Status CachedRemoteFileReader::_execute_s3_fallback(size_t empty_start, size_t span_size,
                                                     std::unique_ptr<char[]>& buffer,
+                                                    PeerFetchResult* peer_result,
                                                     ReadStatistics& stats,
                                                     const IOContext* io_ctx) {
-    DBUG_EXECUTE_IF("CachedRemoteFileReader.read_at_impl.change_type", {
-        // Determine read type from debug point or default to S3
-        std::string read_type = "s3";
-        read_type = dp->param<std::string>("type", "s3");
-        LOG_WARNING("CachedRemoteFileReader.read_at_impl.change_type")
-                .tag("path", path().native())
-                .tag("off", empty_start)
-                .tag("size", size)
-                .tag("type", read_type);
-        // Execute appropriate read strategy
-        if (read_type == "s3") {
-            return execute_s3_read(empty_start, size, buffer, stats, io_ctx, _remote_file_reader);
-        } else {
-            return execute_peer_read(empty_blocks, empty_start, size, buffer, path().native(),
-                                     this->size(), _is_doris_table, _tablet_id, stats, io_ctx);
-        }
-    });
+    if (peer_result != nullptr) {
+        peer_result->clear();
+    }
+    buffer.reset(new char[span_size]);
+    size_t read_size = span_size;
+    return execute_s3_read(empty_start, read_size, buffer, stats, io_ctx, _remote_file_reader);
+}
 
-    if (!doris::config::is_cloud_mode() || !_is_doris_table || io_ctx->is_warmup ||
-        !doris::config::enable_cache_read_from_peer) {
-        return execute_s3_read(empty_start, size, buffer, stats, io_ctx, _remote_file_reader);
-    } else {
-        // first try peer read, if peer failed, fallback to S3
-        // peer timeout is 5 seconds
-        // TODO(dx): here peer and s3 reader need to get data in parallel, and take the one that is correct and returns first
-        // ATTN: Save original size before peer read, as it may be modified by fetch_blocks, read peer ref size
-        size_t original_size = size;
-        auto st = execute_peer_read(empty_blocks, empty_start, size, buffer, path().native(),
-                                    this->size(), _is_doris_table, _tablet_id, stats, io_ctx);
-        if (!st.ok()) {
-            // Restore original size for S3 fallback, as peer read may have modified it
-            size = original_size;
-            // Fallback to S3
-            return execute_s3_read(empty_start, size, buffer, stats, io_ctx, _remote_file_reader);
+Status CachedRemoteFileReader::_execute_sequential_peer_read(
+        const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start, size_t span_size,
+        std::unique_ptr<char[]>& buffer, PeerFetchResult* peer_result, ReadStatistics& stats,
+        const IOContext* io_ctx, const std::vector<doris::PeerCandidate>& candidates,
+        int64_t tablet_id) {
+    // candidates[0] already reflects last_successful_compute_group_id affinity:
+    // get_peer_candidates() applies stable_partition before returning.
+    if (candidates.empty()) {
+        return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
+    }
+
+    auto& manager = get_warm_up_manager();
+    PeerFetchResult serial_res;
+    const int64_t timer_before = stats.peer_read_timer;
+    auto st = execute_peer_read(empty_blocks, &serial_res, path().native(), this->size(),
+                                _is_doris_table, stats, io_ctx, candidates[0].host,
+                                candidates[0].brpc_port);
+    if (st.ok()) {
+        manager.update_peer_candidate_on_success(tablet_id, candidates[0].compute_group_id);
+        if (peer_result != nullptr) {
+            *peer_result = std::move(serial_res);
+        }
+        // Update profile counters for cross/same CG stats.
+        const std::string self_cg_id =
+                static_cast<CloudClusterInfo*>(ExecEnv::GetInstance()->cluster_info())
+                        ->cloud_compute_group_id();
+        const bool is_cross_cg = !candidates[0].compute_group_id.empty() &&
+                                 candidates[0].compute_group_id != self_cg_id;
+        if (is_cross_cg) {
+            g_peer_cross_compute_group_read << 1;
+        } else {
+            g_peer_same_compute_group_read << 1;
+        }
+        if (io_ctx != nullptr && io_ctx->file_cache_stats != nullptr) {
+            io_ctx->file_cache_stats->peer_hosts.insert(candidates[0].host);
+            if (is_cross_cg) {
+                io_ctx->file_cache_stats->num_cross_cg_peer_io_total++;
+                io_ctx->file_cache_stats->bytes_read_from_cross_cg_peer += span_size;
+                io_ctx->file_cache_stats->cross_cg_peer_io_timer +=
+                        stats.peer_read_timer - timer_before;
+            } else {
+                io_ctx->file_cache_stats->num_same_cg_peer_io_total++;
+                io_ctx->file_cache_stats->bytes_read_from_same_cg_peer += span_size;
+                io_ctx->file_cache_stats->same_cg_peer_io_timer +=
+                        stats.peer_read_timer - timer_before;
+            }
         }
         return st;
     }
+    // Track failure so affinity / eviction logic stays consistent with the race path.
+    if (st.is<ErrorCode::TOO_MANY_TASKS>()) {
+        // Server healthy but overloaded — don't penalize candidate.
+    } else if (st.is<ErrorCode::NOT_FOUND>()) {
+        manager.rotate_peer_candidate_on_cache_miss(tablet_id, candidates[0].host,
+                                                    candidates[0].brpc_port);
+    } else {
+        manager.update_peer_candidate_on_rpc_failure(tablet_id, candidates[0].host,
+                                                     candidates[0].brpc_port);
+    }
+    return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
 }
 
-Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
-                                            const IOContext* io_ctx) {
-    size_t already_read = 0;
-    SCOPED_CONCURRENCY_COUNT(ConcurrencyStatsManager::instance().cached_remote_reader_read_at);
-
-    const IOContext default_io_ctx;
-    if (io_ctx == nullptr) {
-        io_ctx = &default_io_ctx;
-    }
-    DCHECK(io_ctx);
-    const bool is_dryrun = io_ctx->is_dryrun;
-    DCHECK(!closed());
-    if (offset > size()) {
-        return Status::InvalidArgument(
-                fmt::format("offset exceeds file size(offset: {}, file size: {}, path: {})", offset,
-                            size(), path().native()));
-    }
-    size_t bytes_req = result.size;
-    bytes_req = std::min(bytes_req, size() - offset);
-    if (UNLIKELY(bytes_req == 0)) {
-        *bytes_read = 0;
-        return Status::OK();
+Status CachedRemoteFileReader::_execute_remote_read(const std::vector<FileBlockSPtr>& empty_blocks,
+                                                    size_t empty_start, size_t span_size,
+                                                    std::unique_ptr<char[]>& buffer,
+                                                    PeerFetchResult* peer_result,
+                                                    ReadStatistics& stats,
+                                                    const IOContext* io_ctx) {
+    // --- Non-peer path: direct S3 ---
+    if (!_should_read_from_peer(io_ctx)) {
+        return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
     }
 
-    ReadStatistics stats;
-    stats.bytes_read += bytes_req;
-    bool read_success = false;
-    MonotonicStopWatch read_at_sw;
-    read_at_sw.start();
-    auto defer_func = [&](int*) {
-        if (config::print_stack_when_cache_miss) {
-            if (io_ctx->file_cache_stats == nullptr && !stats.hit_cache && !io_ctx->is_warmup) {
-                LOG_INFO("[verbose] {}", Status::InternalError<true>("not hit cache"));
-            }
+    // --- UT debug point: injected peer address ---
+    DBUG_EXECUTE_IF("PeerFileCacheReader::_fetch_from_peer_cache_blocks", {
+        std::string dp_host = dp->param<std::string>("host", "127.0.0.1");
+        int32_t dp_port = dp->param("port", 9060);
+        buffer.reset();
+        DCHECK(peer_result != nullptr);
+        peer_result->clear();
+        auto st = execute_peer_read(empty_blocks, peer_result, path().native(), this->size(),
+                                    _is_doris_table, stats, io_ctx, dp_host, dp_port);
+        if (st.ok()) return st;
+        return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
+    });
+
+    // --- Resolve tablet and obtain peer candidates ---
+    int64_t tablet_id = _tablet_id;
+    auto& manager = get_warm_up_manager();
+    auto candidates = manager.get_peer_candidates(tablet_id);
+    if (candidates.empty()) {
+        if (!manager.is_peer_cooldown(tablet_id)) {
+            // Cold miss: trigger background FE fetch and fall back to S3.
+            g_peer_lazy_fetch_triggered << 1;
+            auto manager_ptr =
+                    ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager_ptr();
+            start_bthread([manager_ptr = std::move(manager_ptr), tablet_id]() {
+                manager_ptr->fetch_candidates_from_fe(tablet_id);
+            });
         }
-        if (!stats.hit_cache && config::read_cluster_cache_opt_verbose_log) {
-            LOG_INFO(
-                    "[verbose] not hit cache, path: {}, offset: {}, size: {}, cost: {} ms, warmup: "
-                    "{}",
-                    path().native(), offset, bytes_req, read_at_sw.elapsed_time_milliseconds(),
-                    io_ctx->is_warmup);
-        }
-        if (is_dryrun) {
-            return;
-        }
-        if (!read_success) {
-            return;
-        }
-        if (!io_ctx->is_warmup) {
-            // update stats increment in this reading procedure for file cache metrics
-            const auto file_cache_read_type =
-                    io_ctx->is_inverted_index
-                            ? FileCacheReadType::INVERTED_INDEX
-                            : (io_ctx->is_index_data ? FileCacheReadType::SEGMENT_FOOTER_INDEX
-                                                     : FileCacheReadType::DATA);
-            FileCacheStatistics fcache_stats_increment;
-            _update_stats(stats, &fcache_stats_increment, file_cache_read_type);
-            io::FileCacheMetrics::instance().update(&fcache_stats_increment);
-        }
-        if (io_ctx->file_cache_stats) {
-            // update stats in io_ctx, for query profile
-            const auto file_cache_read_type =
-                    io_ctx->is_inverted_index
-                            ? FileCacheReadType::INVERTED_INDEX
-                            : (io_ctx->is_index_data ? FileCacheReadType::SEGMENT_FOOTER_INDEX
-                                                     : FileCacheReadType::DATA);
-            _update_stats(stats, io_ctx->file_cache_stats, file_cache_read_type);
-        }
-    };
-    std::unique_ptr<int, decltype(defer_func)> defer((int*)0x01, std::move(defer_func));
-    if (_is_doris_table && config::enable_read_cache_file_directly) {
-        // read directly
-        SCOPED_RAW_TIMER(&stats.read_cache_file_directly_timer);
-        size_t need_read_size = bytes_req;
-        std::shared_lock lock(_mtx);
-        if (!_cache_file_readers.empty()) {
-            // find the last offset > offset.
-            auto iter = _cache_file_readers.upper_bound(offset);
-            if (iter != _cache_file_readers.begin()) {
-                iter--;
-            }
-            size_t cur_offset = offset;
-            while (need_read_size != 0 && iter != _cache_file_readers.end()) {
-                if (iter->second->offset() > cur_offset ||
-                    iter->second->range().right < cur_offset) {
-                    break;
-                }
-                size_t file_offset = cur_offset - iter->second->offset();
-                size_t reserve_bytes =
-                        std::min(need_read_size, iter->second->range().size() - file_offset);
-                if (is_dryrun) [[unlikely]] {
-                    g_skip_local_cache_io_sum_bytes << reserve_bytes;
-                } else {
-                    SCOPED_RAW_TIMER(&stats.local_read_timer);
-                    if (!iter->second
-                                 ->read(Slice(result.data + (cur_offset - offset), reserve_bytes),
-                                        file_offset)
-                                 .ok()) { //TODO: maybe read failed because block evict, should handle error
-                        break;
-                    }
-                    stats.bytes_read_from_local += reserve_bytes;
-                }
-                _cache->add_need_update_lru_block(iter->second);
-                need_read_size -= reserve_bytes;
-                cur_offset += reserve_bytes;
-                already_read += reserve_bytes;
-                iter++;
-            }
-            if (need_read_size == 0) {
-                *bytes_read = bytes_req;
-                stats.hit_cache = true;
-                g_read_cache_direct_whole_num << 1;
-                g_read_cache_direct_whole_bytes << bytes_req;
-                read_success = true;
-                return Status::OK();
-            } else {
-                g_read_cache_direct_partial_num << 1;
-                g_read_cache_direct_partial_bytes << already_read;
-            }
-        }
+        return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
     }
-    // read from cache or remote
-    g_read_cache_indirect_num << 1;
-    size_t indirect_read_bytes = 0;
-    auto [align_left, align_size] =
-            s_align_size(offset + already_read, bytes_req - already_read, size());
-    CacheContext cache_context(io_ctx);
-    cache_context.stats = &stats;
-    cache_context.tablet_id = _tablet_id;
-    MonotonicStopWatch sw;
-    sw.start();
 
-    ConcurrencyStatsManager::instance().cached_remote_reader_get_or_set->increment();
-    FileBlocksHolder holder =
-            _cache->get_or_set(_cache_hash, align_left, align_size, cache_context);
-    ConcurrencyStatsManager::instance().cached_remote_reader_get_or_set->decrement();
+    // --- Dispatch: concurrent race or sequential fallback ---
+    // Candidates are already sorted by last_successful_compute_group_id affinity
+    // (stable_partition in get_peer_candidates), so the winner race peer bthread
+    // naturally tries the most promising candidate first — whether same-CG or cross-CG.
+    if (config::enable_peer_s3_race) {
+        return _execute_winner_race(empty_blocks, empty_start, span_size, buffer, peer_result,
+                                    stats, io_ctx, candidates, tablet_id);
+    }
+    return _execute_sequential_peer_read(empty_blocks, empty_start, span_size, buffer, peer_result,
+                                         stats, io_ctx, candidates, tablet_id);
+}
 
-    stats.cache_get_or_set_timer += sw.elapsed_time();
+Status CachedRemoteFileReader::_execute_winner_race(
+        const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start, size_t span_size,
+        std::unique_ptr<char[]>& buffer, PeerFetchResult* peer_result, ReadStatistics& stats,
+        const IOContext* io_ctx, const std::vector<doris::PeerCandidate>& candidates,
+        int64_t tablet_id) {
+    // Reserve a race slot; degrade to sequential if at limit.
+    if (g_active_peer_races.fetch_add(1, std::memory_order_relaxed) >=
+        config::max_concurrent_peer_races) {
+        g_active_peer_races.fetch_sub(1, std::memory_order_relaxed);
+        return _execute_sequential_peer_read(empty_blocks, empty_start, span_size, buffer,
+                                             peer_result, stats, io_ctx, candidates, tablet_id);
+    }
+
+    auto race = std::make_shared<RaceState>();
+    auto manager = ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager_ptr();
+
+    // Capture context for child threads.
+    const std::string file_path = path().native();
+    const size_t file_sz = this->size();
+    const bool is_doris = _is_doris_table;
+    auto remote_reader = _remote_file_reader;
+    std::shared_ptr<ResourceContext> parent_resource_ctx;
+    auto* parent_thread_context = thread_context();
+    if (parent_thread_context != nullptr && parent_thread_context->is_attach_task()) {
+        parent_resource_ctx = parent_thread_context->resource_ctx();
+    }
+
+    // Launch peer bthread.
+    start_bthread(
+            [race, empty_blocks = std::move(empty_blocks), file_path, file_sz, is_doris,
+             manager = std::move(manager), candidates = std::move(candidates), tablet_id,
+             resource_id = _storage_resource_id, parent_resource_ctx]() mutable {
+                run_peer_race(race, std::move(empty_blocks), file_path, file_sz, is_doris,
+                              std::move(manager), std::move(candidates), tablet_id,
+                              std::move(resource_id), parent_resource_ctx);
+            },
+            /*init_thread_ctx=*/true);
+
+    // Launch S3 (with optional hedge delay).
+    // Pass shared_from_this() so the background S3 task holds a reference to this
+    // reader, preventing destruction (and close()) until the S3 task completes.
+    launch_s3_race(race, empty_start, span_size, io_ctx, remote_reader, parent_resource_ctx,
+                   shared_from_this());
+
+    // Collect race result.
+    return collect_race_result(race, span_size, buffer, peer_result, stats, io_ctx);
+}
+
+bool CachedRemoteFileReader::_try_read_from_cached_files_directly(
+        size_t offset, Slice result, size_t bytes_req, bool is_dryrun, ReadStatistics& stats,
+        SourceReadBreakdown& source_read_breakdown, size_t& already_read, size_t* bytes_read) {
+    if (!_can_read_cache_file_directly()) {
+        return false;
+    }
+
+    SCOPED_RAW_TIMER(&stats.read_cache_file_directly_timer);
+    size_t need_read_size = bytes_req;
+    std::shared_lock lock(_mtx);
+    if (_cache_file_readers.empty()) {
+        return false;
+    }
+
+    auto iter = _cache_file_readers.upper_bound(offset);
+    if (iter != _cache_file_readers.begin()) {
+        --iter;
+    }
+
+    size_t current_offset = offset;
+    while (need_read_size != 0 && iter != _cache_file_readers.end()) {
+        if (iter->second->offset() > current_offset ||
+            iter->second->range().right < current_offset) {
+            break;
+        }
+
+        size_t file_offset = current_offset - iter->second->offset();
+        size_t reserve_bytes = std::min(need_read_size, iter->second->range().size() - file_offset);
+        if (is_dryrun) [[unlikely]] {
+            g_skip_local_cache_io_sum_bytes << reserve_bytes;
+        } else {
+            SCOPED_RAW_TIMER(&stats.local_read_timer);
+            if (!iter->second
+                         ->read(Slice(result.data + (current_offset - offset), reserve_bytes),
+                                file_offset)
+                         .ok()) { // TODO: maybe read failed because block evict, should handle error
+                break;
+            }
+            source_read_breakdown.local_bytes += reserve_bytes;
+        }
+
+        _cache->add_need_update_lru_block(iter->second);
+        need_read_size -= reserve_bytes;
+        current_offset += reserve_bytes;
+        already_read += reserve_bytes;
+        ++iter;
+    }
+
+    if (need_read_size == 0) {
+        *bytes_read = bytes_req;
+        stats.hit_cache = true;
+        g_read_cache_direct_whole_num << 1;
+        g_read_cache_direct_whole_bytes << bytes_req;
+        return true;
+    }
+
+    g_read_cache_direct_partial_num << 1;
+    g_read_cache_direct_partial_bytes << already_read;
+    return false;
+}
+
+std::vector<FileBlockSPtr> CachedRemoteFileReader::_collect_remote_read_blocks(
+        const FileBlocksHolder& holder, ReadStatistics& stats) {
     std::vector<FileBlockSPtr> empty_blocks;
     for (auto& block : holder.file_blocks) {
         switch (block->state()) {
@@ -442,89 +824,143 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
             break;
         }
     }
-    size_t empty_start = 0;
-    size_t empty_end = 0;
-    if (!empty_blocks.empty()) {
-        empty_start = empty_blocks.front()->range().left;
-        empty_end = empty_blocks.back()->range().right;
-        size_t size = empty_end - empty_start + 1;
-        std::unique_ptr<char[]> buffer(new char[size]);
+    return empty_blocks;
+}
 
-        // Apply rate limiting for warmup download tasks (node level)
-        // Rate limiting is applied before remote read to limit both S3 read and local cache write
-        if (io_ctx->is_warmup) {
-            auto* rate_limiter = ExecEnv::GetInstance()->warmup_download_rate_limiter();
-            if (rate_limiter != nullptr) {
-                rate_limiter->add(size);
-            }
+Status CachedRemoteFileReader::_read_remote_blocks_into_cache(
+        const std::vector<FileBlockSPtr>& empty_blocks, size_t offset, size_t bytes_req,
+        size_t already_read, Slice result, bool is_dryrun, ReadStatistics& stats,
+        SourceReadBreakdown& source_read_breakdown, const IOContext* io_ctx,
+        size_t& indirect_read_bytes, size_t& empty_start, size_t& empty_end,
+        PeerFetchedBlockSet& peer_fetched_blocks) {
+    empty_start = 0;
+    empty_end = 0;
+    peer_fetched_blocks.clear();
+    if (empty_blocks.empty()) {
+        return Status::OK();
+    }
+
+    empty_start = empty_blocks.front()->range().left;
+    empty_end = empty_blocks.back()->range().right;
+    const size_t span_read_size = empty_end - empty_start + 1;
+    const auto peer_fetch_layout = build_peer_fetch_layout(empty_blocks, size());
+    std::unique_ptr<char[]> buffer;
+    PeerFetchResult peer_result;
+
+    RETURN_IF_ERROR(_execute_remote_read(empty_blocks, empty_start, span_read_size, buffer,
+                                         &peer_result, stats, io_ctx));
+
+    std::vector<std::vector<const PeerFetchChunk*>> peer_chunks_by_block;
+    if (stats.from_peer_cache) {
+        // Peer returns sparse payloads; remember the exact sparse blocks that were filled.
+        peer_fetched_blocks.reserve(empty_blocks.size());
+        for (const auto& block : empty_blocks) {
+            peer_fetched_blocks.insert(block.get());
         }
-
-        // Determine read type and execute remote read
-        RETURN_IF_ERROR(
-                _execute_remote_read(empty_blocks, empty_start, size, buffer, stats, io_ctx));
-        bool empty_blocks_from_peer_cache = stats.from_peer_cache;
-
-        {
-            SCOPED_CONCURRENCY_COUNT(
-                    ConcurrencyStatsManager::instance().cached_remote_reader_write_back);
-            for (auto& block : empty_blocks) {
-                if (block->state() == FileBlock::State::SKIP_CACHE) {
-                    continue;
-                }
-                SCOPED_RAW_TIMER(&stats.local_write_timer);
-                char* cur_ptr = buffer.get() + block->range().left - empty_start;
-                size_t block_size = block->range().size();
-                Status st = block->append(Slice(cur_ptr, block_size));
-                if (st.ok()) {
-                    st = block->finalize();
-                }
-                if (!st.ok()) {
-                    LOG_EVERY_N(WARNING, 100)
-                            << "Write data to file cache failed. err=" << st.msg();
-                } else {
-                    _insert_file_reader(block);
-                }
-                stats.bytes_write_into_file_cache += block_size;
-            }
-        }
-        // copy from memory directly
-        size_t right_offset = offset + bytes_req - 1;
-        if (empty_start <= right_offset && empty_end >= offset + already_read && !is_dryrun) {
-            size_t copy_left_offset = std::max(offset + already_read, empty_start);
-            size_t copy_right_offset = std::min(right_offset, empty_end);
-            char* dst = result.data + (copy_left_offset - offset);
-            char* src = buffer.get() + (copy_left_offset - empty_start);
-            size_t copy_size = copy_right_offset - copy_left_offset + 1;
-            memcpy(dst, src, copy_size);
-            indirect_read_bytes += copy_size;
-            if (empty_blocks_from_peer_cache) {
-                stats.bytes_read_from_peer += copy_size;
-            } else {
-                stats.bytes_read_from_remote += copy_size;
-            }
+        peer_chunks_by_block.resize(empty_blocks.size());
+        for (const auto& chunk : peer_result.chunks) {
+            DCHECK_LT(chunk.block_index, empty_blocks.size());
+            peer_chunks_by_block[chunk.block_index].push_back(&chunk);
         }
     }
 
-    size_t current_offset = offset + already_read;
+    SCOPED_CONCURRENCY_COUNT(ConcurrencyStatsManager::instance().cached_remote_reader_write_back);
+    for (size_t idx = 0; idx < empty_blocks.size(); ++idx) {
+        auto& block = empty_blocks[idx];
+        if (block->state() == FileBlock::State::SKIP_CACHE) {
+            continue;
+        }
+
+        SCOPED_RAW_TIMER(&stats.local_write_timer);
+        size_t block_size = block->range().size();
+        Status st;
+        if (stats.from_peer_cache) {
+            block_size = peer_fetch_layout.block_sizes[idx];
+            if (block_size == 0) {
+                continue;
+            }
+            st = write_peer_payloads_into_block(block, peer_chunks_by_block[idx], &block_size);
+        } else {
+            char* current_ptr = buffer.get() + block->range().left - empty_start;
+            st = block->append(Slice(current_ptr, block_size));
+        }
+        if (st.ok()) {
+            st = block->finalize();
+        }
+        if (!st.ok()) {
+            LOG(WARNING) << "write data to file cache failed, source="
+                         << (stats.from_peer_cache ? "peer" : "remote")
+                         << ", path=" << path().native() << ", tablet_id=" << _tablet_id
+                         << ", file_size=" << size() << ", cache_hash=" << _cache_hash.to_string()
+                         << ", write_block_size=" << block_size
+                         << ", block=" << block->get_info_for_log()
+                         << ", cache_file=" << block->get_cache_file() << ", err=" << st;
+        } else {
+            _insert_file_reader(block);
+            stats.bytes_write_into_file_cache += block_size;
+        }
+    }
+
+    const size_t right_offset = offset + bytes_req - 1;
+    if (stats.from_peer_cache) {
+        if (is_dryrun) {
+            return Status::OK();
+        }
+        for (const auto& chunk : peer_result.chunks) {
+            copy_peer_chunk_to_result(chunk, offset, right_offset, already_read, result,
+                                      indirect_read_bytes, source_read_breakdown);
+        }
+        return Status::OK();
+    }
+
+    if (empty_start <= right_offset && empty_end >= offset + already_read && !is_dryrun) {
+        size_t copy_left_offset = std::max(offset + already_read, empty_start);
+        size_t copy_right_offset = std::min(right_offset, empty_end);
+        char* dst = result.data + (copy_left_offset - offset);
+        char* src = buffer.get() + (copy_left_offset - empty_start);
+        size_t copy_size = copy_right_offset - copy_left_offset + 1;
+        memcpy(dst, src, copy_size);
+        indirect_read_bytes += copy_size;
+        source_read_breakdown.remote_bytes += copy_size;
+    }
+    return Status::OK();
+}
+
+Status CachedRemoteFileReader::_read_remaining_blocks_from_cache(
+        const FileBlocksHolder& holder, size_t offset, size_t bytes_req, Slice result,
+        bool is_dryrun, size_t empty_start, size_t empty_end,
+        const PeerFetchedBlockSet& peer_fetched_blocks, ReadStatistics& stats,
+        SourceReadBreakdown& source_read_breakdown, size_t& indirect_read_bytes, size_t* bytes_read,
+        const IOContext* io_ctx) {
+    size_t current_offset = offset + *bytes_read;
     size_t end_offset = offset + bytes_req - 1;
     bool need_self_heal = false;
-    *bytes_read = already_read;
     for (auto& block : holder.file_blocks) {
         if (current_offset > end_offset) {
             break;
         }
+
         size_t left = block->range().left;
         size_t right = block->range().right;
-        if (right < current_offset) {
+        if (right < offset) {
             continue;
         }
+
         size_t read_size =
                 end_offset > right ? right - current_offset + 1 : end_offset - current_offset + 1;
-        if (empty_start <= left && right <= empty_end) {
+        if (!peer_fetched_blocks.empty() && contains_file_block(peer_fetched_blocks, block)) {
+            // For sparse peer reads, skip only blocks fetched from peer. Other blocks inside the
+            // enclosing span may still come from local cache.
             *bytes_read += read_size;
             current_offset = right + 1;
             continue;
         }
+        if (peer_fetched_blocks.empty() && empty_start <= left && right <= empty_end) {
+            *bytes_read += read_size;
+            current_offset = right + 1;
+            continue;
+        }
+
         FileBlock::State block_state = block->state();
         int64_t wait_time = 0;
         static int64_t max_wait_time = 10;
@@ -534,7 +970,6 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
                     ConcurrencyStatsManager::instance().cached_remote_reader_blocking);
             do {
                 SCOPED_RAW_TIMER(&stats.remote_wait_timer);
-                SCOPED_RAW_TIMER(&stats.remote_read_timer);
                 TEST_SYNC_POINT_CALLBACK("CachedRemoteFileReader::DOWNLOADING");
                 block_state = block->wait();
                 if (block_state != FileBlock::State::DOWNLOADING) {
@@ -545,161 +980,177 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
         if (wait_time == max_wait_time) [[unlikely]] {
             LOG_WARNING("Waiting too long for the download to complete");
         }
-        {
-            Status st;
-            /*
-             * If block_state == EMPTY, the thread reads the data from remote.
-             * If block_state == DOWNLOADED, when the cache file is deleted by the other process,
-             * the thread reads the data from remote too.
-             */
-            if (block_state == FileBlock::State::DOWNLOADED) {
-                if (is_dryrun) [[unlikely]] {
-                    g_skip_local_cache_io_sum_bytes << read_size;
-                } else {
-                    size_t file_offset = current_offset - left;
-                    SCOPED_RAW_TIMER(&stats.local_read_timer);
-                    SCOPED_CONCURRENCY_COUNT(
-                            ConcurrencyStatsManager::instance().cached_remote_reader_local_read);
-                    st = block->read(Slice(result.data + (current_offset - offset), read_size),
-                                     file_offset);
-                    if (st.ok()) {
-                        indirect_read_bytes += read_size;
-                        stats.bytes_read_from_local += read_size;
-                    }
+
+        Status st;
+        /*
+         * If block_state == EMPTY, the thread reads the data from remote.
+         * If block_state == DOWNLOADED, when the cache file is deleted by the other process,
+         * the thread reads the data from remote too.
+         */
+        if (block_state == FileBlock::State::DOWNLOADED) {
+            if (is_dryrun) [[unlikely]] {
+                g_skip_local_cache_io_sum_bytes << read_size;
+            } else {
+                size_t file_offset = current_offset - left;
+                SCOPED_RAW_TIMER(&stats.local_read_timer);
+                SCOPED_CONCURRENCY_COUNT(
+                        ConcurrencyStatsManager::instance().cached_remote_reader_local_read);
+                st = block->read(Slice(result.data + (current_offset - offset), read_size),
+                                 file_offset);
+                indirect_read_bytes += read_size;
+                if (st.ok()) {
+                    source_read_breakdown.local_bytes += read_size;
                 }
             }
-            if (!st || block_state != FileBlock::State::DOWNLOADED) {
-                if (is_dryrun) [[unlikely]] {
-                    // dryrun mode uses a null buffer, skip actual remote IO
-                } else {
-                    if (block_state == FileBlock::State::DOWNLOADED &&
-                        st.is<ErrorCode::NOT_FOUND>()) {
-                        need_self_heal = true;
-                        g_read_cache_self_heal_on_not_found << 1;
-                        LOG_EVERY_N(WARNING, 100)
-                                << "Cache block file is missing, will self-heal by clearing cache "
-                                   "hash. "
-                                << "path=" << path().native()
-                                << ", hash=" << _cache_hash.to_string() << ", offset=" << left
-                                << ", err=" << st.msg();
-                    }
-                    LOG(WARNING) << "Read data failed from file cache downloaded by others. err="
-                                 << st.msg() << ", block state=" << block_state;
-                    size_t bytes_read {0};
-                    stats.hit_cache = false;
-                    stats.from_peer_cache = false;
-                    s3_read_counter << 1;
-                    SCOPED_RAW_TIMER(&stats.remote_read_timer);
-                    RETURN_IF_ERROR(_remote_file_reader->read_at(
-                            current_offset,
-                            Slice(result.data + (current_offset - offset), read_size),
-                            &bytes_read));
-                    indirect_read_bytes += read_size;
-                    DCHECK(bytes_read == read_size);
-                    stats.bytes_read_from_remote += bytes_read;
-                }
+            if (block_state == FileBlock::State::DOWNLOADED && st.is<ErrorCode::NOT_FOUND>()) {
+                need_self_heal = true;
+                g_read_cache_self_heal_on_not_found << 1;
+                LOG_EVERY_N(WARNING, 100)
+                        << "Cache block file is missing, will self-heal by clearing cache hash. "
+                        << "path=" << path().native() << ", hash=" << _cache_hash.to_string()
+                        << ", offset=" << left << ", err=" << st.msg();
             }
         }
+        if (!st || block_state != FileBlock::State::DOWNLOADED) {
+            if (is_dryrun) [[unlikely]] {
+                *bytes_read += read_size;
+                current_offset = right + 1;
+                continue;
+            }
+            LOG(WARNING) << "Read data failed from file cache downloaded by others. err="
+                         << st.msg() << ", block state=" << block_state;
+            size_t remote_bytes_read {0};
+            stats.hit_cache = false;
+            stats.from_peer_cache = false;
+            s3_read_counter << 1;
+            SCOPED_RAW_TIMER(&stats.remote_read_timer);
+            RETURN_IF_ERROR(_remote_file_reader->read_at(
+                    current_offset, Slice(result.data + (current_offset - offset), read_size),
+                    &remote_bytes_read, io_ctx));
+            indirect_read_bytes += read_size;
+            source_read_breakdown.remote_bytes += remote_bytes_read;
+            DCHECK(remote_bytes_read == read_size);
+        }
+
         *bytes_read += read_size;
         current_offset = right + 1;
     }
     if (need_self_heal && _cache != nullptr) {
         _cache->remove_if_cached_async(_cache_hash);
     }
-    g_read_cache_indirect_bytes << indirect_read_bytes;
-    g_read_cache_indirect_total_bytes << *bytes_read;
-
-    DCHECK(*bytes_read == bytes_req);
-    if (!is_dryrun) {
-        DCHECK_EQ(stats.bytes_read_from_local + stats.bytes_read_from_remote +
-                          stats.bytes_read_from_peer,
-                  bytes_req);
-    }
-    read_success = true;
     return Status::OK();
 }
 
-void CachedRemoteFileReader::_update_stats(const ReadStatistics& read_stats,
-                                           FileCacheStatistics* statis,
-                                           FileCacheReadType read_type) const {
-    if (statis == nullptr) {
-        return;
-    }
-    if (read_stats.bytes_read_from_local > 0) {
-        statis->num_local_io_total++;
-        statis->bytes_read_from_local += read_stats.bytes_read_from_local;
-    }
-    if (read_stats.bytes_read_from_remote > 0) {
-        statis->num_remote_io_total++;
-        statis->bytes_read_from_remote += read_stats.bytes_read_from_remote;
-        statis->remote_io_timer += read_stats.remote_read_timer;
-    }
-    if (read_stats.bytes_read_from_peer > 0) {
-        statis->num_peer_io_total++;
-        statis->bytes_read_from_peer += read_stats.bytes_read_from_peer;
-        statis->peer_io_timer += read_stats.peer_read_timer;
-    }
-    statis->remote_wait_timer += read_stats.remote_wait_timer;
-    statis->local_io_timer += read_stats.local_read_timer;
-    statis->num_skip_cache_io_total += read_stats.skip_cache;
-    statis->bytes_write_into_cache += read_stats.bytes_write_into_file_cache;
-    statis->write_cache_io_timer += read_stats.local_write_timer;
+Status CachedRemoteFileReader::_read_from_indirect_cache(size_t offset, Slice result,
+                                                         size_t bytes_req, size_t already_read,
+                                                         bool is_dryrun, size_t* bytes_read,
+                                                         ReadStatistics& stats,
+                                                         SourceReadBreakdown& source_read_breakdown,
+                                                         const IOContext* io_ctx) {
+    g_read_cache_indirect_num << 1;
+    size_t indirect_read_bytes = 0;
+    auto [align_left, align_size] =
+            s_align_size(offset + already_read, bytes_req - already_read, size());
+    CacheContext cache_context(io_ctx);
+    cache_context.stats = &stats;
+    MonotonicStopWatch sw;
+    sw.start();
+    ConcurrencyStatsManager::instance().cached_remote_reader_get_or_set->increment();
+    FileBlocksHolder holder =
+            _cache->get_or_set(_cache_hash, align_left, align_size, cache_context);
+    ConcurrencyStatsManager::instance().cached_remote_reader_get_or_set->decrement();
+    stats.cache_get_or_set_timer += sw.elapsed_time();
 
-    statis->read_cache_file_directly_timer += read_stats.read_cache_file_directly_timer;
-    statis->cache_get_or_set_timer += read_stats.cache_get_or_set_timer;
-    statis->lock_wait_timer += read_stats.lock_wait_timer;
-    statis->get_timer += read_stats.get_timer;
-    statis->set_timer += read_stats.set_timer;
+    auto empty_blocks = _collect_remote_read_blocks(holder, stats);
+    size_t empty_start = 0;
+    size_t empty_end = 0;
+    PeerFetchedBlockSet peer_fetched_blocks;
+    RETURN_IF_ERROR(_read_remote_blocks_into_cache(empty_blocks, offset, bytes_req, already_read,
+                                                   result, is_dryrun, stats, source_read_breakdown,
+                                                   io_ctx, indirect_read_bytes, empty_start,
+                                                   empty_end, peer_fetched_blocks));
+    *bytes_read = already_read;
+    RETURN_IF_ERROR(_read_remaining_blocks_from_cache(holder, offset, bytes_req, result, is_dryrun,
+                                                      empty_start, empty_end, peer_fetched_blocks,
+                                                      stats, source_read_breakdown,
+                                                      indirect_read_bytes, bytes_read, io_ctx));
+    g_read_cache_indirect_bytes << indirect_read_bytes;
+    g_read_cache_indirect_total_bytes << *bytes_read;
+    DCHECK(*bytes_read == bytes_req);
+    return Status::OK();
+}
 
-    auto update_index_stats = [&](int64_t& num_local_io_total, int64_t& num_remote_io_total,
-                                  int64_t& num_peer_io_total, int64_t& bytes_read_from_local,
-                                  int64_t& bytes_read_from_remote, int64_t& bytes_read_from_peer,
-                                  int64_t& local_io_timer, int64_t& remote_io_timer,
-                                  int64_t& peer_io_timer) {
-        if (read_stats.bytes_read_from_local > 0) {
-            num_local_io_total++;
-            bytes_read_from_local += read_stats.bytes_read_from_local;
+Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                                            const IOContext* io_ctx) {
+    SCOPED_CONCURRENCY_COUNT(ConcurrencyStatsManager::instance().cached_remote_reader_read_at);
+    IOContext default_io_ctx;
+    if (io_ctx == nullptr) {
+        io_ctx = &default_io_ctx;
+    }
+    DCHECK(io_ctx);
+    DCHECK(!closed());
+
+    const bool is_dryrun = io_ctx->is_dryrun;
+    if (offset > size()) {
+        return Status::InvalidArgument(
+                fmt::format("offset exceeds file size(offset: {}, file size: {}, path: {})", offset,
+                            size(), path().native()));
+    }
+
+    size_t bytes_req = std::min(result.size, size() - offset);
+    if (UNLIKELY(bytes_req == 0)) {
+        *bytes_read = 0;
+        return Status::OK();
+    }
+
+    ReadStatistics stats;
+    SourceReadBreakdown source_read_breakdown;
+    Status read_st = Status::OK();
+    MonotonicStopWatch read_at_sw;
+    read_at_sw.start();
+    stats.bytes_read += bytes_req;
+    Defer defer {[&]() {
+        if (config::print_stack_when_cache_miss) {
+            if (io_ctx->file_cache_stats == nullptr && !stats.hit_cache && !io_ctx->is_warmup) {
+                LOG_INFO("[verbose] {}", Status::InternalError<true>("not hit cache"));
+            }
         }
-        if (read_stats.bytes_read_from_remote > 0) {
-            num_remote_io_total++;
-            bytes_read_from_remote += read_stats.bytes_read_from_remote;
-            remote_io_timer += read_stats.remote_read_timer;
+        if (!stats.hit_cache && config::read_cluster_cache_opt_verbose_log) {
+            LOG_INFO(
+                    "[verbose] not hit cache, path: {}, offset: {}, size: {}, cost: {} ms, warmup: "
+                    "{}",
+                    path().native(), offset, bytes_req, read_at_sw.elapsed_time_milliseconds(),
+                    io_ctx->is_warmup);
         }
-        if (read_stats.bytes_read_from_peer > 0) {
-            num_peer_io_total++;
-            bytes_read_from_peer += read_stats.bytes_read_from_peer;
-            peer_io_timer += read_stats.peer_read_timer;
+        if (read_st.ok() && !is_dryrun) {
+            // Only successful reads contribute to query profile and file-cache metrics.
+            const auto file_cache_read_type =
+                    io_ctx->is_inverted_index
+                            ? FileCacheReadType::INVERTED_INDEX
+                            : (io_ctx->is_index_data ? FileCacheReadType::SEGMENT_FOOTER_INDEX
+                                                     : FileCacheReadType::DATA);
+            if (io_ctx->file_cache_stats) {
+                _update_stats(stats, source_read_breakdown, io_ctx->file_cache_stats,
+                              file_cache_read_type);
+            }
+            if (!io_ctx->is_warmup) {
+                FileCacheStatistics fcache_stats_increment;
+                _update_stats(stats, source_read_breakdown, &fcache_stats_increment,
+                              file_cache_read_type);
+                io::FileCacheMetrics::instance().update(&fcache_stats_increment);
+            }
         }
-        local_io_timer += read_stats.local_read_timer;
-    };
+    }};
 
-    switch (read_type) {
-    case FileCacheReadType::DATA:
-        break;
-    case FileCacheReadType::INVERTED_INDEX:
-        update_index_stats(
-                statis->inverted_index_num_local_io_total,
-                statis->inverted_index_num_remote_io_total,
-                statis->inverted_index_num_peer_io_total,
-                statis->inverted_index_bytes_read_from_local,
-                statis->inverted_index_bytes_read_from_remote,
-                statis->inverted_index_bytes_read_from_peer, statis->inverted_index_local_io_timer,
-                statis->inverted_index_remote_io_timer, statis->inverted_index_peer_io_timer);
-        break;
-    case FileCacheReadType::SEGMENT_FOOTER_INDEX:
-        update_index_stats(statis->segment_footer_index_num_local_io_total,
-                           statis->segment_footer_index_num_remote_io_total,
-                           statis->segment_footer_index_num_peer_io_total,
-                           statis->segment_footer_index_bytes_read_from_local,
-                           statis->segment_footer_index_bytes_read_from_remote,
-                           statis->segment_footer_index_bytes_read_from_peer,
-                           statis->segment_footer_index_local_io_timer,
-                           statis->segment_footer_index_remote_io_timer,
-                           statis->segment_footer_index_peer_io_timer);
-        break;
+    size_t already_read = 0;
+    if (_try_read_from_cached_files_directly(offset, result, bytes_req, is_dryrun, stats,
+                                             source_read_breakdown, already_read, bytes_read)) {
+        return Status::OK();
     }
 
-    g_skip_cache_sum << read_stats.skip_cache;
+    read_st = _read_from_indirect_cache(offset, result, bytes_req, already_read, is_dryrun,
+                                        bytes_read, stats, source_read_breakdown, io_ctx);
+    return read_st;
 }
 
 void CachedRemoteFileReader::prefetch_range(size_t offset, size_t size, const IOContext* io_ctx) {
@@ -732,7 +1183,7 @@ void CachedRemoteFileReader::prefetch_range(size_t offset, size_t size, const IO
         if (self == nullptr) {
             return;
         }
-        size_t bytes_read;
+        size_t bytes_read = 0;
         Slice dummy_buffer((char*)nullptr, size);
         (void)self->read_at_impl(offset, dummy_buffer, &bytes_read, &dryrun_ctx);
         LOG_IF(INFO, config::enable_segment_prefetch_verbose_log)
@@ -744,6 +1195,123 @@ void CachedRemoteFileReader::prefetch_range(size_t offset, size_t size, const IO
         VLOG_DEBUG << "Failed to submit prefetch task for offset=" << offset << " size=" << size
                    << " error=" << st.to_string();
     }
+}
+
+void CachedRemoteFileReader::_update_stats(const ReadStatistics& read_stats,
+                                           const SourceReadBreakdown& source_read_breakdown,
+                                           FileCacheStatistics* statis,
+                                           FileCacheReadType read_type) const {
+    if (statis == nullptr) {
+        return;
+    }
+    const bool has_source_bytes = source_read_breakdown.local_bytes != 0 ||
+                                  source_read_breakdown.remote_bytes != 0 ||
+                                  source_read_breakdown.peer_bytes != 0;
+    if (has_source_bytes) {
+        if (source_read_breakdown.local_bytes != 0) {
+            statis->num_local_io_total++;
+            statis->bytes_read_from_local += source_read_breakdown.local_bytes;
+        }
+        if (source_read_breakdown.peer_bytes != 0 || read_stats.from_peer_cache) {
+            // Count peer IO whenever peer was used, even if its fetched blocks were entirely
+            // outside the copy range (e.g., backward-aligned prefetch block before
+            // offset+already_read).  In that case peer_bytes==0 but the peer RPC did happen
+            // and wrote data into the local file cache.
+            statis->num_peer_io_total++;
+            statis->bytes_read_from_peer += source_read_breakdown.peer_bytes;
+            statis->peer_io_timer += read_stats.peer_read_timer;
+        }
+        if (source_read_breakdown.remote_bytes != 0) {
+            statis->num_remote_io_total++;
+            statis->bytes_read_from_remote += source_read_breakdown.remote_bytes;
+            statis->remote_io_timer += read_stats.remote_read_timer;
+        }
+    } else if (read_stats.hit_cache) {
+        statis->num_local_io_total++;
+        statis->bytes_read_from_local += read_stats.bytes_read;
+    } else if (read_stats.from_peer_cache) {
+        statis->num_peer_io_total++;
+        statis->bytes_read_from_peer += read_stats.bytes_read;
+        statis->peer_io_timer += read_stats.peer_read_timer;
+    } else {
+        statis->num_remote_io_total++;
+        statis->bytes_read_from_remote += read_stats.bytes_read;
+        statis->remote_io_timer += read_stats.remote_read_timer;
+    }
+    statis->remote_wait_timer += read_stats.remote_wait_timer;
+    statis->local_io_timer += read_stats.local_read_timer;
+    statis->num_skip_cache_io_total += read_stats.skip_cache;
+    statis->bytes_write_into_cache += read_stats.bytes_write_into_file_cache;
+    statis->write_cache_io_timer += read_stats.local_write_timer;
+
+    statis->read_cache_file_directly_timer += read_stats.read_cache_file_directly_timer;
+    statis->cache_get_or_set_timer += read_stats.cache_get_or_set_timer;
+    statis->lock_wait_timer += read_stats.lock_wait_timer;
+    statis->get_timer += read_stats.get_timer;
+    statis->set_timer += read_stats.set_timer;
+
+    auto update_index_stats = [&](int64_t& num_local_io_total, int64_t& num_remote_io_total,
+                                  int64_t& num_peer_io_total, int64_t& bytes_read_from_local,
+                                  int64_t& bytes_read_from_remote, int64_t& bytes_read_from_peer,
+                                  int64_t& local_io_timer, int64_t& remote_io_timer,
+                                  int64_t& peer_io_timer) {
+        if (has_source_bytes) {
+            if (source_read_breakdown.local_bytes != 0) {
+                num_local_io_total++;
+                bytes_read_from_local += source_read_breakdown.local_bytes;
+            }
+            if (source_read_breakdown.peer_bytes != 0 || read_stats.from_peer_cache) {
+                num_peer_io_total++;
+                bytes_read_from_peer += source_read_breakdown.peer_bytes;
+                peer_io_timer += read_stats.peer_read_timer;
+            }
+            if (source_read_breakdown.remote_bytes != 0) {
+                num_remote_io_total++;
+                bytes_read_from_remote += source_read_breakdown.remote_bytes;
+                remote_io_timer += read_stats.remote_read_timer;
+            }
+        } else if (read_stats.hit_cache) {
+            num_local_io_total++;
+            bytes_read_from_local += read_stats.bytes_read;
+        } else if (read_stats.from_peer_cache) {
+            num_peer_io_total++;
+            bytes_read_from_peer += read_stats.bytes_read;
+            peer_io_timer += read_stats.peer_read_timer;
+        } else {
+            num_remote_io_total++;
+            bytes_read_from_remote += read_stats.bytes_read;
+            remote_io_timer += read_stats.remote_read_timer;
+        }
+        local_io_timer += read_stats.local_read_timer;
+    };
+
+    switch (read_type) {
+    case FileCacheReadType::DATA:
+        break;
+    case FileCacheReadType::INVERTED_INDEX:
+        update_index_stats(
+                statis->inverted_index_num_local_io_total,
+                statis->inverted_index_num_remote_io_total,
+                statis->inverted_index_num_peer_io_total,
+                statis->inverted_index_bytes_read_from_local,
+                statis->inverted_index_bytes_read_from_remote,
+                statis->inverted_index_bytes_read_from_peer, statis->inverted_index_local_io_timer,
+                statis->inverted_index_remote_io_timer, statis->inverted_index_peer_io_timer);
+        break;
+    case FileCacheReadType::SEGMENT_FOOTER_INDEX:
+        update_index_stats(statis->segment_footer_index_num_local_io_total,
+                           statis->segment_footer_index_num_remote_io_total,
+                           statis->segment_footer_index_num_peer_io_total,
+                           statis->segment_footer_index_bytes_read_from_local,
+                           statis->segment_footer_index_bytes_read_from_remote,
+                           statis->segment_footer_index_bytes_read_from_peer,
+                           statis->segment_footer_index_local_io_timer,
+                           statis->segment_footer_index_remote_io_timer,
+                           statis->segment_footer_index_peer_io_timer);
+        break;
+    }
+
+    g_skip_cache_sum << read_stats.skip_cache;
 }
 
 } // namespace doris::io

--- a/be/src/io/cache/cached_remote_file_reader.h
+++ b/be/src/io/cache/cached_remote_file_reader.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <map>
 #include <shared_mutex>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -36,24 +37,60 @@
 namespace doris::io {
 struct IOContext;
 struct FileCacheStatistics;
+struct PeerFetchResult;
+
+} // namespace doris::io
+
+namespace doris {
+struct PeerCandidate;
+}
+
+namespace doris::io {
+struct SourceReadBreakdown {
+    int64_t local_bytes = 0;
+    int64_t remote_bytes = 0;
+    int64_t peer_bytes = 0;
+};
+using PeerFetchedBlockSet = std::unordered_set<const FileBlock*>;
 
 class CachedRemoteFileReader final : public FileReader,
                                      public std::enable_shared_from_this<CachedRemoteFileReader> {
 public:
+    /// Construct a cached reader on top of a remote reader.
+    /// @param[in] remote_file_reader Underlying reader used for remote/peer fallback reads.
+    /// @param[in] opts File reader options used to initialize cache identity and policy.
+    /// @return None.
     CachedRemoteFileReader(FileReaderSPtr remote_file_reader, const FileReaderOptions& opts);
 
+    /// Destroy the cached reader and release direct cache-file ownership tracked by this reader.
+    /// @return None.
     ~CachedRemoteFileReader() override;
 
+    /// Close the underlying remote reader.
+    /// @return OK on success; otherwise the close error from the underlying reader.
     Status close() override;
 
+    /// Get the path of the underlying file.
+    /// @return Reference to the remote reader path.
     const Path& path() const override { return _remote_file_reader->path(); }
 
+    /// Get the logical size of the underlying file.
+    /// @return File size in bytes.
     size_t size() const override { return _remote_file_reader->size(); }
 
+    /// Check whether the underlying reader has been closed.
+    /// @return true if the underlying reader is closed; otherwise false.
     bool closed() const override { return _remote_file_reader->closed(); }
 
+    /// Expose the wrapped remote reader.
+    /// @return Raw pointer to the underlying reader owned by this object.
     FileReader* get_remote_reader() { return _remote_file_reader.get(); }
 
+    /// Align a read range to file-cache block boundaries.
+    /// @param[in] offset Requested read offset in bytes.
+    /// @param[in] size Requested read size in bytes.
+    /// @param[in] length Total file length in bytes.
+    /// @return Pair of aligned start offset and aligned size.
     static std::pair<size_t, size_t> s_align_size(size_t offset, size_t size, size_t length);
 
     int64_t mtime() const override { return _remote_file_reader->mtime(); }
@@ -71,6 +108,12 @@ public:
     void prefetch_range(size_t offset, size_t size, const IOContext* io_ctx = nullptr);
 
 protected:
+    /// Read bytes from cache when possible and fall back to peer/S3 when needed.
+    /// @param[in] offset Start offset in the file.
+    /// @param[out] result Destination buffer for the requested bytes.
+    /// @param[out] bytes_read Number of bytes copied into result.
+    /// @param[in] io_ctx IO context carrying dry-run, warmup and statistics options.
+    /// @return OK on success; otherwise an error from cache lookup or remote read.
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* io_ctx) override;
 
@@ -81,21 +124,190 @@ private:
         SEGMENT_FOOTER_INDEX,
     };
 
+    /// Initialize cache metadata for Doris-table files.
+    /// @return None.
+    void _init_doris_table_cache();
+
+    /// Initialize cache metadata for external-table files.
+    /// @param[in] opts Reader options used to choose cache key and cache base path.
+    /// @return None.
+    void _init_external_table_cache(const FileReaderOptions& opts);
+
+    /// Check whether this reader can read cache files directly without get_or_set.
+    /// @return true when direct cache-file reads are enabled for Doris-table files.
+    bool _can_read_cache_file_directly() const;
+
+    /// Decide whether remote cache miss reads should try peer cache first.
+    /// @param[in] io_ctx IO context for warmup and request-mode checks.
+    /// @return true if peer read is enabled for this request; otherwise false.
+    bool _should_read_from_peer(const IOContext* io_ctx) const;
+
+    /// Register a downloaded block in the direct-read map owned by this reader.
+    /// @param[in] file_block Downloaded cache block to insert.
+    /// @return None.
     void _insert_file_reader(FileBlockSPtr file_block);
 
-    // Execute remote read (S3 or peer).
-    Status _execute_remote_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start,
-                                size_t& size, std::unique_ptr<char[]>& buffer,
+    /// Try to satisfy the request by reading already downloaded cache files directly.
+    /// @param[in] offset Requested file offset.
+    /// @param[out] result Destination buffer for the request.
+    /// @param[in] bytes_req Requested byte count.
+    /// @param[in] is_dryrun True if local cache IO should be skipped.
+    /// @param[in,out] stats Read statistics updated during the attempt.
+    /// @param[in,out] already_read Bytes already filled into result by direct cache reads.
+    /// @param[out] bytes_read Total bytes read when the whole request is satisfied directly.
+    /// @return true if the whole request is completed by direct cache-file reads; otherwise false.
+    bool _try_read_from_cached_files_directly(size_t offset, Slice result, size_t bytes_req,
+                                              bool is_dryrun, ReadStatistics& stats,
+                                              SourceReadBreakdown& source_read_breakdown,
+                                              size_t& already_read, size_t* bytes_read);
+
+    /// Collect blocks that still need remote data and update cache-hit statistics.
+    /// @param[in] holder Cache blocks covering the aligned request range.
+    /// @param[in,out] stats Read statistics updated according to block states.
+    /// @return Blocks that should be fetched from peer/S3 by the current reader.
+    std::vector<FileBlockSPtr> _collect_remote_read_blocks(const FileBlocksHolder& holder,
+                                                           ReadStatistics& stats);
+
+    /// Fetch missing blocks from peer/S3, write them into cache, and copy the overlap to result.
+    /// @param[in] empty_blocks Blocks selected for remote fetch.
+    /// @param[in] offset Original request offset.
+    /// @param[in] bytes_req Original request size.
+    /// @param[in] already_read Bytes already produced before this step.
+    /// @param[out] result Destination buffer for the original request.
+    /// @param[in] is_dryrun True if cache-file writes and local buffer copies should be skipped.
+    /// @param[in,out] stats Read statistics updated for remote and local cache work.
+    /// @param[in] io_ctx IO context passed to peer/S3 reads.
+    /// @param[in,out] indirect_read_bytes Bytes copied into result through the indirect path.
+    /// @param[out] empty_start Left boundary of the fetched contiguous empty range.
+    /// @param[out] empty_end Right boundary of the fetched contiguous empty range.
+    /// @param[out] peer_fetched_blocks Exact blocks fetched by peer in sparse mode; empty for S3.
+    /// @return OK on success; otherwise an error from peer/S3 read.
+    Status _read_remote_blocks_into_cache(const std::vector<FileBlockSPtr>& empty_blocks,
+                                          size_t offset, size_t bytes_req, size_t already_read,
+                                          Slice result, bool is_dryrun, ReadStatistics& stats,
+                                          SourceReadBreakdown& source_read_breakdown,
+                                          const IOContext* io_ctx, size_t& indirect_read_bytes,
+                                          size_t& empty_start, size_t& empty_end,
+                                          PeerFetchedBlockSet& peer_fetched_blocks);
+
+    /// Read cached blocks that were not covered by the remote-fetch range, with remote fallback.
+    /// @param[in] holder Cache blocks covering the aligned request range.
+    /// @param[in] offset Original request offset.
+    /// @param[in] bytes_req Original request size.
+    /// @param[out] result Destination buffer for the original request.
+    /// @param[in] is_dryrun True if local cache IO should be skipped.
+    /// @param[in] empty_start Left boundary of the range already handled by remote fetch.
+    /// @param[in] empty_end Right boundary of the range already handled by remote fetch.
+    /// @param[in] peer_fetched_blocks Exact blocks already filled by peer; empty for S3 path.
+    /// @param[in,out] stats Read statistics updated for wait, cache, and remote fallback paths.
+    /// @param[in,out] indirect_read_bytes Bytes copied into result through this indirect stage.
+    /// @param[out] bytes_read Total bytes covered for the original request after this stage.
+    /// @return OK on success; otherwise an error from cache read or remote fallback read.
+    Status _read_remaining_blocks_from_cache(const FileBlocksHolder& holder, size_t offset,
+                                             size_t bytes_req, Slice result, bool is_dryrun,
+                                             size_t empty_start, size_t empty_end,
+                                             const PeerFetchedBlockSet& peer_fetched_blocks,
+                                             ReadStatistics& stats,
+                                             SourceReadBreakdown& source_read_breakdown,
+                                             size_t& indirect_read_bytes, size_t* bytes_read,
+                                             const IOContext* io_ctx);
+
+    /// Read through the block-cache metadata path when direct cache-file reads are insufficient.
+    /// @param[in] offset Original request offset.
+    /// @param[out] result Destination buffer for the original request.
+    /// @param[in] bytes_req Original request size.
+    /// @param[in] already_read Bytes already produced by direct cache-file reads.
+    /// @param[in] is_dryrun True if local cache IO should be skipped.
+    /// @param[out] bytes_read Total bytes read for the request.
+    /// @param[in,out] stats Read statistics updated across the indirect path.
+    /// @param[in] io_ctx IO context passed to cache lookup and remote read.
+    /// @return OK on success; otherwise an error from cache lookup or remote read.
+    Status _read_from_indirect_cache(size_t offset, Slice result, size_t bytes_req,
+                                     size_t already_read, bool is_dryrun, size_t* bytes_read,
+                                     ReadStatistics& stats,
+                                     SourceReadBreakdown& source_read_breakdown,
+                                     const IOContext* io_ctx);
+
+    /// Fall back to S3: clear peer_result, allocate buffer, and read from remote storage.
+    /// @param[in] empty_start Start offset of the contiguous remote-read range.
+    /// @param[in] span_size Size of the remote-read range in bytes.
+    /// @param[in,out] buffer Span buffer that receives S3 data.
+    /// @param[in,out] peer_result Cleared when non-null.
+    /// @param[in,out] stats Read statistics updated for S3 execution.
+    /// @param[in] io_ctx IO context passed to the remote reader.
+    /// @return OK on success; otherwise the S3 read error.
+    Status _execute_s3_fallback(size_t empty_start, size_t span_size,
+                                std::unique_ptr<char[]>& buffer, PeerFetchResult* peer_result,
                                 ReadStatistics& stats, const IOContext* io_ctx);
 
-    void _update_stats(const ReadStatistics& stats, FileCacheStatistics* state,
+    /// Sequential peer-then-S3 fallback: try the best peer candidate, update affinity on
+    /// success/failure, and fall back to S3 if peer fails.
+    /// @param[in] empty_blocks Blocks whose data is missing from local cache.
+    /// @param[in] empty_start Start offset of the contiguous remote-read range.
+    /// @param[in] span_size Size of the remote-read range in bytes.
+    /// @param[in,out] buffer Span buffer that receives S3 data on S3 fallback.
+    /// @param[in,out] peer_result Peer payloads populated on peer success.
+    /// @param[in,out] stats Read statistics updated for peer/S3 execution.
+    /// @param[in] io_ctx IO context passed to the remote reader.
+    /// @param[in] candidates Peer candidates sorted by affinity.
+    /// @param[in] tablet_id Tablet ID for affinity tracking.
+    /// @return OK on success; otherwise the S3 read error.
+    Status _execute_sequential_peer_read(const std::vector<FileBlockSPtr>& empty_blocks,
+                                         size_t empty_start, size_t span_size,
+                                         std::unique_ptr<char[]>& buffer,
+                                         PeerFetchResult* peer_result, ReadStatistics& stats,
+                                         const IOContext* io_ctx,
+                                         const std::vector<doris::PeerCandidate>& candidates,
+                                         int64_t tablet_id);
+
+    /// Execute a remote fetch for the contiguous empty range, trying peer first when enabled.
+    /// @param[in] empty_blocks Blocks whose data is missing from local cache.
+    /// @param[in] empty_start Start offset of the contiguous remote-read range for S3 fallback.
+    /// @param[in] span_size Size of the enclosing contiguous remote-read range for S3 fallback.
+    /// @param[in,out] buffer Temporary span buffer receiving S3 data.
+    /// @param[in,out] peer_result Segmented peer payloads when the peer path succeeds.
+    /// @param[in,out] stats Read statistics updated for peer/S3 execution.
+    /// @param[in] io_ctx IO context passed to the remote reader.
+    /// @return OK on success; otherwise the peer/S3 read error.
+    Status _execute_remote_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start,
+                                size_t span_size, std::unique_ptr<char[]>& buffer,
+                                PeerFetchResult* peer_result, ReadStatistics& stats,
+                                const IOContext* io_ctx);
+
+    /// Execute a winner race between peer read and S3 read for cross compute group scenarios.
+    /// Launches both peer and S3 reads concurrently in bthreads and returns the first successful
+    /// result. Uses bthread::Mutex and bthread::ConditionVariable for synchronization.
+    /// @param[in] empty_blocks Blocks whose data is missing from local cache.
+    /// @param[in] empty_start Start offset of the contiguous remote-read range.
+    /// @param[in] span_size Size of the contiguous range for the S3 fallback read.
+    /// @param[in,out] buffer Temporary span buffer that receives S3 data on S3 win.
+    /// @param[out] peer_result Peer fetch payloads populated when peer wins.
+    /// @param[in,out] stats Read statistics updated for the winning path.
+    /// @param[in] io_ctx IO context passed to both peer and S3 reads.
+    /// @param[in] candidates All peer candidates for the tablet.
+    /// @return OK on success with buffer or peer_result populated; otherwise an error.
+    Status _execute_winner_race(const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start,
+                                size_t span_size, std::unique_ptr<char[]>& buffer,
+                                PeerFetchResult* peer_result, ReadStatistics& stats,
+                                const IOContext* io_ctx,
+                                const std::vector<doris::PeerCandidate>& candidates,
+                                int64_t tablet_id);
+
+    /// Merge per-read statistics into the external file-cache statistics accumulator.
+    /// @param[in] stats Statistics produced by the current read.
+    /// @param[in,out] state Destination statistics accumulator; ignored when null.
+    /// @param[in] read_type Logical file-cache read type used for fine-grained profile counters.
+    /// @return None.
+    void _update_stats(const ReadStatistics& stats,
+                       const SourceReadBreakdown& source_read_breakdown, FileCacheStatistics* state,
                        FileCacheReadType read_type) const;
 
     bool _is_doris_table = false;
     int64_t _tablet_id = -1;
+    std::string _storage_resource_id;
     FileReaderSPtr _remote_file_reader;
     UInt128Wrapper _cache_hash;
-    BlockFileCache* _cache;
+    BlockFileCache* _cache = nullptr;
     std::shared_mutex _mtx;
     std::map<size_t, FileBlockSPtr> _cache_file_readers;
 };

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -17,6 +17,7 @@
 
 #include "io/cache/file_block.h"
 
+#include <butil/iobuf.h>
 #include <glog/logging.h>
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
@@ -27,9 +28,25 @@
 #include "common/status.h"
 #include "cpp/sync_point.h"
 #include "io/cache/block_file_cache.h"
+#include "io/cache/fs_file_cache_storage.h"
+#include "io/cache/mem_file_cache_storage.h"
 
 namespace doris {
 namespace io {
+
+namespace {
+
+Status abort_pending_cache_write(FileCacheStorage* storage, const FileCacheKey& key) {
+    if (auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(storage); fs_storage != nullptr) {
+        return fs_storage->abort(key);
+    }
+    if (auto* mem_storage = dynamic_cast<MemFileCacheStorage*>(storage); mem_storage != nullptr) {
+        return mem_storage->abort(key);
+    }
+    return Status::OK();
+}
+
+} // namespace
 
 std::ostream& operator<<(std::ostream& os, const FileBlock::State& value) {
     os << FileBlock::state_to_string(value);
@@ -102,7 +119,8 @@ void FileBlock::reset_downloader_impl(std::lock_guard<std::mutex>& block_lock) {
     if (_downloaded_size == range().size()) {
         Status st = set_downloaded(block_lock);
         if (!st.ok()) {
-            LOG(WARNING) << "reset downloader error" << st;
+            LOG(WARNING) << "reset downloader failed, err=" << st
+                         << ", block=" << get_info_for_log_impl(block_lock);
         }
     } else {
         _downloaded_size = 0;
@@ -111,11 +129,13 @@ void FileBlock::reset_downloader_impl(std::lock_guard<std::mutex>& block_lock) {
     }
 }
 
-Status FileBlock::set_downloaded(std::lock_guard<std::mutex>& /* block_lock */) {
+Status FileBlock::set_downloaded(std::lock_guard<std::mutex>& block_lock) {
     DCHECK(_download_state != State::DOWNLOADED);
     if (_downloaded_size == 0) {
         _download_state = State::EMPTY;
         _downloader_id = 0;
+        LOG(WARNING) << "set file cache block downloaded failed: empty block, block="
+                     << get_info_for_log_impl(block_lock);
         return Status::InternalError("Try to set empty block {} as downloaded",
                                      _block_range.to_string());
     }
@@ -123,6 +143,10 @@ Status FileBlock::set_downloaded(std::lock_guard<std::mutex>& /* block_lock */) 
     if (status.ok()) [[likely]] {
         _download_state = State::DOWNLOADED;
     } else {
+        auto abort_st = abort_pending_cache_write(_mgr->_storage.get(), _key);
+        LOG(WARNING) << "finalize file cache block failed, err=" << status
+                     << ", abort_status=" << abort_st
+                     << ", block=" << get_info_for_log_impl(block_lock);
         _download_state = State::EMPTY;
         _downloaded_size = 0;
     }
@@ -145,9 +169,39 @@ bool FileBlock::is_downloader_impl(std::lock_guard<std::mutex>& /* block_lock */
 }
 
 Status FileBlock::append(Slice data) {
-    DCHECK(data.size != 0) << "Writing zero size is not allowed";
-    RETURN_IF_ERROR(_mgr->_storage->append(_key, data));
-    _downloaded_size += data.size;
+    return appendv(&data, 1);
+}
+
+Status FileBlock::appendv(const Slice* data, size_t data_cnt) {
+    size_t appended_size = 0;
+    for (size_t idx = 0; idx < data_cnt; ++idx) {
+        appended_size += data[idx].size;
+    }
+    DCHECK(appended_size != 0) << "Writing zero size is not allowed";
+    auto st = _mgr->_storage->appendv(_key, data, data_cnt);
+    if (!st.ok()) {
+        auto abort_st = abort_pending_cache_write(_mgr->_storage.get(), _key);
+        LOG(WARNING) << "appendv file cache block failed, append_size=" << appended_size
+                     << ", slice_count=" << data_cnt << ", err=" << st
+                     << ", abort_status=" << abort_st << ", block=" << get_info_for_log();
+        return st;
+    }
+    _downloaded_size += appended_size;
+    return Status::OK();
+}
+
+Status FileBlock::append_iobuf(const butil::IOBuf& data) {
+    const size_t appended_size = data.length();
+    DCHECK(appended_size != 0) << "Writing zero size is not allowed";
+    auto st = _mgr->_storage->append_iobuf(_key, data);
+    if (!st.ok()) {
+        auto abort_st = abort_pending_cache_write(_mgr->_storage.get(), _key);
+        LOG(WARNING) << "append_iobuf file cache block failed, append_size=" << appended_size
+                     << ", err=" << st << ", abort_status=" << abort_st
+                     << ", block=" << get_info_for_log();
+        return st;
+    }
+    _downloaded_size += appended_size;
     return Status::OK();
 }
 
@@ -157,6 +211,8 @@ Status FileBlock::finalize() {
         _download_state = State::EMPTY;
         _downloader_id = 0;
         _cv.notify_all();
+        LOG(WARNING) << "finalize file cache block failed: empty block, block="
+                     << get_info_for_log_impl(block_lock);
         return Status::InternalError("Try to finalize an empty file block {}",
                                      _block_range.to_string());
     }
@@ -175,6 +231,11 @@ Status FileBlock::finalize() {
 
 Status FileBlock::read(Slice buffer, size_t read_offset) {
     return _mgr->_storage->read(_key, read_offset, buffer);
+}
+
+Status FileBlock::read_to_iobuf(butil::IOBuf* out, size_t read_offset, size_t bytes_req,
+                                size_t* bytes_read) {
+    return _mgr->_storage->read_to_iobuf(_key, read_offset, bytes_req, out, bytes_read);
 }
 
 Status FileBlock::change_cache_type(FileCacheType new_type) {
@@ -229,10 +290,19 @@ std::string FileBlock::get_info_for_log() const {
 std::string FileBlock::get_info_for_log_impl(std::lock_guard<std::mutex>& block_lock) const {
     std::stringstream info;
     info << "File block: " << range().to_string() << ", ";
+    info << "hash: " << _key.hash.to_string() << ", ";
+    info << "cache_type: " << cache_type_to_string(_key.meta.type) << ", ";
     info << "state: " << state_to_string(_download_state) << ", ";
     info << "size: " << _block_range.size() << ", ";
+    info << "downloaded_size: " << _downloaded_size << ", ";
     info << "downloader id: " << _downloader_id << ", ";
-    info << "caller id: " << get_caller_id();
+    info << "caller id: " << get_caller_id() << ", ";
+
+    std::string cache_file = "<unknown>";
+    if (_mgr != nullptr && _mgr->_storage != nullptr) {
+        cache_file = _mgr->_storage->get_local_file(_key);
+    }
+    info << "cache_file: " << cache_file;
 
     return info.str();
 }

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -32,6 +32,10 @@
 #include "io/cache/file_cache_common.h"
 #include "util/slice.h"
 
+namespace butil {
+class IOBuf;
+}
+
 namespace doris {
 namespace io {
 
@@ -97,9 +101,13 @@ public:
 
     // append data to cache file
     [[nodiscard]] Status append(Slice data);
+    [[nodiscard]] Status appendv(const Slice* data, size_t data_cnt);
+    [[nodiscard]] Status append_iobuf(const butil::IOBuf& data);
 
     // read data from cache file
     [[nodiscard]] Status read(Slice buffer, size_t read_offset);
+    [[nodiscard]] Status read_to_iobuf(butil::IOBuf* out, size_t read_offset, size_t bytes_req,
+                                       size_t* bytes_read);
 
     // finish write, release the file writer
     [[nodiscard]] Status finalize();

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -170,11 +170,11 @@ struct CacheContext {
         return query_id == rhs.query_id && cache_type == rhs.cache_type &&
                expiration_time == rhs.expiration_time && is_cold_data == rhs.is_cold_data;
     }
-    TUniqueId query_id;
-    FileCacheType cache_type;
+    TUniqueId query_id {};
+    FileCacheType cache_type {FileCacheType::NORMAL};
     int64_t expiration_time {0};
     bool is_cold_data {false};
-    ReadStatistics* stats;
+    ReadStatistics* stats {nullptr};
     bool is_warmup {false};
     int64_t tablet_id {0};
 };

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -17,8 +17,17 @@
 
 #pragma once
 
+#include <butil/iobuf.h>
+
+#include <mutex>
+
+#include "common/status.h"
 #include "io/cache/file_cache_common.h"
 #include "util/slice.h"
+
+namespace butil {
+class IOBuf;
+}
 
 namespace doris::io {
 
@@ -40,6 +49,13 @@ struct FileWriterMapKeyHash {
     }
 };
 
+struct MemBlock {
+    std::shared_ptr<char[]> addr;
+    butil::IOBuf payload;
+    size_t size {0};
+    bool use_iobuf {false};
+};
+
 // The interface is for organizing datas in disk
 class FileCacheStorage {
 public:
@@ -49,10 +65,15 @@ public:
     virtual Status init(BlockFileCache* _mgr) = 0;
     // append datas into block
     virtual Status append(const FileCacheKey& key, const Slice& value) = 0;
+    virtual Status appendv(const FileCacheKey& key, const Slice* values, size_t value_cnt) = 0;
+    virtual Status append_iobuf(const FileCacheKey& key, const butil::IOBuf& value) = 0;
     // finalize the block
     virtual Status finalize(const FileCacheKey& key, const size_t size) = 0;
     // read the block
     virtual Status read(const FileCacheKey& key, size_t value_offset, Slice result) = 0;
+    // read the block and append bytes into iobuf
+    virtual Status read_to_iobuf(const FileCacheKey& key, size_t value_offset, size_t bytes_req,
+                                 butil::IOBuf* out, size_t* bytes_read) = 0;
     // remove the block
     virtual Status remove(const FileCacheKey& key) = 0;
     // change the block meta

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -17,6 +17,7 @@
 
 #include "io/cache/fs_file_cache_storage.h"
 
+#include <butil/iobuf.h>
 #include <fmt/core.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
@@ -82,6 +83,12 @@ struct BatchLoadArgs {
     std::string offset_path;
     bool is_tmp;
 };
+
+FSFileCacheStorage::FSFileCacheStorage() {
+    for (auto& shard : _writer_shards) {
+        shard = std::make_unique<WriterShard>();
+    }
+}
 
 FDCache* FDCache::instance() {
     return ExecEnv::GetInstance()->file_cache_open_fd_cache();
@@ -184,37 +191,114 @@ Status FSFileCacheStorage::init(BlockFileCache* mgr) {
 }
 
 Status FSFileCacheStorage::append(const FileCacheKey& key, const Slice& value) {
+    return appendv(key, &value, 1);
+}
+
+Status FSFileCacheStorage::get_or_create_file_writer(const FileCacheKey& key, FileWriter** writer) {
+    if (writer == nullptr) {
+        return Status::InvalidArgument("file cache writer output is null");
+    }
+    *writer = nullptr;
+    auto file_writer_map_key = std::make_pair(key.hash, key.offset);
+    auto& shard = shard_of(file_writer_map_key);
+    std::lock_guard lock(shard.mtx);
+    if (auto iter = shard.map.find(file_writer_map_key); iter != shard.map.end()) {
+        *writer = iter->second.get();
+        return Status::OK();
+    }
+
+    std::string dir = get_path_in_local_cache_v3(key.hash);
+    auto st = fs->create_directory(dir, false);
+    if (!st.ok() && !st.is<ErrorCode::ALREADY_EXIST>()) {
+        return st;
+    }
+    std::string tmp_file = get_path_in_local_cache_v3(dir, key.offset, true);
+    FileWriterPtr file_writer;
+    FileWriterOptions opts {.sync_file_data = false};
+    RETURN_IF_ERROR(fs->create_file(tmp_file, &file_writer, &opts));
+    *writer = file_writer.get();
+    shard.map.emplace(file_writer_map_key, std::move(file_writer));
+    return Status::OK();
+}
+
+Status FSFileCacheStorage::appendv(const FileCacheKey& key, const Slice* values, size_t value_cnt) {
     FileWriter* writer = nullptr;
-    {
-        std::lock_guard lock(_mtx);
-        auto file_writer_map_key = std::make_pair(key.hash, key.offset);
-        if (auto iter = _key_to_writer.find(file_writer_map_key); iter != _key_to_writer.end()) {
-            writer = iter->second.get();
-        } else {
-            std::string dir = get_path_in_local_cache_v3(key.hash);
-            auto st = fs->create_directory(dir, false);
-            if (!st.ok() && !st.is<ErrorCode::ALREADY_EXIST>()) {
-                return st;
+    RETURN_IF_ERROR(get_or_create_file_writer(key, &writer));
+    DCHECK_NE(writer, nullptr);
+    auto st = writer->appendv(values, value_cnt);
+    if (!st.ok()) {
+        // Clean up partially-written writer to prevent a later finalize from
+        // persisting an incomplete cache file.
+        static_cast<void>(abort(key));
+    }
+    return st;
+}
+
+Status FSFileCacheStorage::append_iobuf(const FileCacheKey& key, const butil::IOBuf& value) {
+    FileWriter* writer = nullptr;
+    RETURN_IF_ERROR(get_or_create_file_writer(key, &writer));
+    DCHECK_NE(writer, nullptr);
+    // Disk cache files are created by LocalFileSystem, so this writer can forward the shared
+    // IOBuf payload to the fd path directly instead of flattening it first.
+    Status st;
+    auto* local_writer = dynamic_cast<LocalFileWriter*>(writer);
+    if (LIKELY(local_writer != nullptr)) {
+        st = local_writer->append_iobuf(value);
+    } else {
+        std::vector<Slice> slices;
+        slices.reserve(value.backing_block_num());
+        for (size_t idx = 0; idx < value.backing_block_num(); ++idx) {
+            auto piece = value.backing_block(idx);
+            if (!piece.empty()) {
+                slices.emplace_back(piece.data(), piece.size());
             }
-            std::string tmp_file = get_path_in_local_cache_v3(dir, key.offset, true);
-            FileWriterPtr file_writer;
-            FileWriterOptions opts {.sync_file_data = false};
-            RETURN_IF_ERROR(fs->create_file(tmp_file, &file_writer, &opts));
-            writer = file_writer.get();
-            _key_to_writer.emplace(file_writer_map_key, std::move(file_writer));
+        }
+        st = writer->appendv(slices.data(), slices.size());
+    }
+    if (!st.ok()) {
+        // Clean up partially-written writer to prevent a later finalize from
+        // persisting an incomplete cache file.
+        static_cast<void>(abort(key));
+    }
+    return st;
+}
+
+Status FSFileCacheStorage::abort(const FileCacheKey& key) {
+    FileWriterPtr file_writer;
+    {
+        auto file_writer_map_key = std::make_pair(key.hash, key.offset);
+        auto& shard = shard_of(file_writer_map_key);
+        std::lock_guard lock(shard.mtx);
+        if (auto iter = shard.map.find(file_writer_map_key); iter != shard.map.end()) {
+            file_writer = std::move(iter->second);
+            shard.map.erase(iter);
         }
     }
-    DCHECK_NE(writer, nullptr);
-    return writer->append(value);
+
+    const std::string tmp_file = [&]() {
+        if (file_writer != nullptr) {
+            return file_writer->path().native();
+        }
+        const std::string dir = get_path_in_local_cache_v3(key.hash);
+        return FSFileCacheStorage::get_path_in_local_cache_v3(dir, key.offset, true);
+    }();
+
+    file_writer.reset();
+    auto st = fs->delete_file(tmp_file);
+    if (!st.ok() && !st.is<ErrorCode::NOT_FOUND>()) {
+        return st;
+    }
+    return Status::OK();
 }
 
 Status FSFileCacheStorage::finalize(const FileCacheKey& key, const size_t size) {
     FileWriterPtr file_writer;
     {
-        std::lock_guard lock(_mtx);
         auto file_writer_map_key = std::make_pair(key.hash, key.offset);
-        auto iter = _key_to_writer.find(file_writer_map_key);
-        if (iter == _key_to_writer.end()) {
+        auto& shard = shard_of(file_writer_map_key);
+        std::lock_guard lock(shard.mtx);
+        auto iter = shard.map.find(file_writer_map_key);
+        if (iter == shard.map.end()) {
             return Status::InternalError(
                     "file cache finalize missing writer, hash={}, offset={}, type={}, "
                     "expiration={}",
@@ -222,7 +306,7 @@ Status FSFileCacheStorage::finalize(const FileCacheKey& key, const size_t size) 
                     key.meta.expiration_time);
         }
         file_writer = std::move(iter->second);
-        _key_to_writer.erase(iter);
+        shard.map.erase(iter);
     }
     if (file_writer->state() != FileWriter::State::CLOSED) {
         RETURN_IF_ERROR(file_writer->close());
@@ -242,31 +326,8 @@ Status FSFileCacheStorage::finalize(const FileCacheKey& key, const size_t size) 
 }
 
 Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Slice buffer) {
-    AccessKeyAndOffset fd_key = std::make_pair(key.hash, key.offset);
-    FileReaderSPtr file_reader = FDCache::instance()->get_file_reader(fd_key);
-    if (!file_reader) {
-        std::string file =
-                get_path_in_local_cache_v3(get_path_in_local_cache_v3(key.hash), key.offset);
-        Status s = fs->open_file(file, &file_reader);
-        if (!s.ok()) {
-            if (s.is<ErrorCode::NOT_FOUND>()) {
-                // Try to open file with old v2 format
-                std::string dir = get_path_in_local_cache_v2(key.hash, key.meta.expiration_time);
-                std::string v2_file = get_path_in_local_cache_v2(dir, key.offset, key.meta.type);
-                Status s2 = fs->open_file(v2_file, &file_reader);
-                if (!s2.ok()) {
-                    LOG(WARNING) << "open file failed with both v3 and v2 format, v3_file=" << file
-                                 << ", v2_file=" << v2_file << ", error=" << s2.to_string();
-                    return s2;
-                }
-            } else {
-                LOG(WARNING) << "open file failed, file=" << file << ", error=" << s.to_string();
-                return s;
-            }
-        }
-
-        FDCache::instance()->insert_file_reader(fd_key, file_reader);
-    }
+    FileReaderSPtr file_reader;
+    RETURN_IF_ERROR(get_or_open_file_reader(key, &file_reader));
     size_t bytes_read = 0;
     auto s = file_reader->read_at(value_offset, buffer, &bytes_read);
     if (!s.ok()) {
@@ -275,6 +336,68 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
         return s;
     }
     DCHECK(bytes_read == buffer.get_size());
+    return Status::OK();
+}
+
+Status FSFileCacheStorage::read_to_iobuf(const FileCacheKey& key, size_t value_offset,
+                                         size_t bytes_req, butil::IOBuf* out, size_t* bytes_read) {
+    if (out == nullptr || bytes_read == nullptr) {
+        return Status::InvalidArgument("read_to_iobuf requires non-null out and bytes_read");
+    }
+    FileReaderSPtr file_reader;
+    RETURN_IF_ERROR(get_or_open_file_reader(key, &file_reader));
+    auto s = file_reader->read_at_iobuf(value_offset, bytes_req, out, bytes_read);
+    if (!s.ok()) {
+        LOG(WARNING) << "read file to iobuf failed, file=" << file_reader->path()
+                     << ", error=" << s.to_string();
+        return s;
+    }
+    DCHECK(*bytes_read == bytes_req);
+    if (*bytes_read != bytes_req) {
+        return Status::InternalError<false>("short read from file cache, expected={}, actual={}",
+                                            bytes_req, *bytes_read);
+    }
+    return Status::OK();
+}
+
+Status FSFileCacheStorage::get_or_open_file_reader(const FileCacheKey& key,
+                                                   FileReaderSPtr* file_reader) {
+    if (file_reader == nullptr) {
+        return Status::InvalidArgument("get_or_open_file_reader requires non-null file_reader");
+    }
+
+    const AccessKeyAndOffset fd_key = std::make_pair(key.hash, key.offset);
+    *file_reader = FDCache::instance()->get_file_reader(fd_key);
+    if (*file_reader) {
+        return Status::OK();
+    }
+
+    const std::string dir = get_path_in_local_cache_v3(key.hash);
+    const std::string file = get_path_in_local_cache_v3(dir, key.offset);
+    Status st = fs->open_file(file, file_reader);
+
+    // Handle the case that the file is not found but actually exists in other type format.
+    // TODO(zhengyu): eliminate type encoding in file name.
+    if (!st.ok() && !st.is<ErrorCode::NOT_FOUND>()) {
+        LOG(WARNING) << "open file failed, file=" << file << ", error=" << st.to_string();
+        return st;
+    }
+    if (!st.ok()) {
+        const std::string v2_dir = get_path_in_local_cache_v2(key.hash, key.meta.expiration_time);
+        auto candidates = get_path_in_local_cache_all_candidates(v2_dir, key.offset);
+        for (auto& candidate : candidates) {
+            st = fs->open_file(candidate, file_reader);
+            if (st.ok()) {
+                break;
+            }
+        }
+        if (!st.ok()) {
+            LOG(WARNING) << "open file failed, file=" << file << ", error=" << st.to_string();
+            return st;
+        }
+    }
+
+    FDCache::instance()->insert_file_reader(fd_key, *file_reader);
     return Status::OK();
 }
 
@@ -329,6 +452,17 @@ Status FSFileCacheStorage::change_key_meta_type(const FileCacheKey& key, const F
         _meta_store->put(mkey, meta);
     }
     return Status::OK();
+}
+
+std::vector<std::string> FSFileCacheStorage::get_path_in_local_cache_all_candidates(
+        const std::string& dir, size_t offset) {
+    std::vector<std::string> candidates;
+    std::string base = get_path_in_local_cache_v2(dir, offset, FileCacheType::NORMAL);
+    candidates.push_back(base);
+    candidates.push_back(base + "_idx");
+    candidates.push_back(base + "_ttl");
+    candidates.push_back(base + "_disposable");
+    return candidates;
 }
 
 std::string FSFileCacheStorage::get_path_in_local_cache_v3(const std::string& dir, size_t offset,

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -22,6 +22,7 @@
 #include <sys/statvfs.h>
 #include <sys/types.h>
 
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
@@ -71,12 +72,17 @@ public:
     static constexpr int KEY_PREFIX_LENGTH = 3;
     static constexpr std::string META_DIR_NAME = "meta";
 
-    FSFileCacheStorage() = default;
+    FSFileCacheStorage();
     ~FSFileCacheStorage() override;
     Status init(BlockFileCache* _mgr) override;
     Status append(const FileCacheKey& key, const Slice& value) override;
+    Status appendv(const FileCacheKey& key, const Slice* values, size_t value_cnt) override;
+    Status append_iobuf(const FileCacheKey& key, const butil::IOBuf& value) override;
+    Status abort(const FileCacheKey& key);
     Status finalize(const FileCacheKey& key, const size_t size) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
+    Status read_to_iobuf(const FileCacheKey& key, size_t value_offset, size_t bytes_req,
+                         butil::IOBuf* out, size_t* bytes_read) override;
     Status remove(const FileCacheKey& key) override;
     Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
                                 const size_t size) override;
@@ -156,6 +162,11 @@ private:
                                      size_t new_size, int64_t tablet_id,
                                      std::lock_guard<std::mutex>& cache_lock) const;
 
+    [[nodiscard]] std::vector<std::string> get_path_in_local_cache_all_candidates(
+            const std::string& dir, size_t offset);
+    Status get_or_open_file_reader(const FileCacheKey& key, FileReaderSPtr* file_reader);
+    Status get_or_create_file_writer(const FileCacheKey& key, FileWriter** writer);
+
 private:
     // Helper function to count files in cache directory using inode stats
     size_t estimate_file_count_from_inode() const;
@@ -188,9 +199,17 @@ private:
     std::condition_variable _leak_cleaner_cv;
     std::mutex _leak_cleaner_mutex;
     const std::shared_ptr<LocalFileSystem>& fs = global_local_filesystem();
-    // TODO(Lchangliang): use a more efficient data structure
-    std::mutex _mtx;
-    std::unordered_map<FileWriterMapKey, FileWriterPtr, FileWriterMapKeyHash> _key_to_writer;
+    struct WriterShard {
+        std::mutex mtx;
+        std::unordered_map<FileWriterMapKey, FileWriterPtr, FileWriterMapKeyHash> map;
+    };
+    static constexpr size_t kWriterShardNum = 1024;
+    static constexpr size_t kWriterShardMask = kWriterShardNum - 1;
+    static_assert((kWriterShardNum & kWriterShardMask) == 0);
+    inline WriterShard& shard_of(const FileWriterMapKey& key) const {
+        return *_writer_shards[(FileWriterMapKeyHash {}(key)) & kWriterShardMask];
+    }
+    std::array<std::unique_ptr<WriterShard>, kWriterShardNum> _writer_shards;
     std::shared_ptr<bvar::LatencyRecorder> _iterator_dir_retry_cnt;
     std::shared_ptr<bvar::Adder<size_t>> _leak_scan_removed_files;
     std::unique_ptr<CacheBlockMetaStore> _meta_store;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -135,6 +135,13 @@ public:
                 count_inodes_override;
     };
     static void set_inode_estimation_test_hooks(InodeEstimationTestHooks* hooks);
+
+    void set_file_writer_for_test(const FileCacheKey& key, FileWriterPtr writer) {
+        auto file_writer_map_key = std::make_pair(key.hash, key.offset);
+        auto& shard = shard_of(file_writer_map_key);
+        std::lock_guard lock(shard.mtx);
+        shard.map[file_writer_map_key] = std::move(writer);
+    }
 #endif
 
 private:

--- a/be/src/io/cache/mem_file_cache_storage.cpp
+++ b/be/src/io/cache/mem_file_cache_storage.cpp
@@ -17,49 +17,63 @@
 
 #include "io/cache/mem_file_cache_storage.h"
 
+#include <butil/iobuf.h>
+
 #include <filesystem>
 #include <mutex>
 #include <system_error>
 
+#include "common/config.h"
 #include "common/logging.h"
 #include "exec/common/hex.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/file_block.h"
 #include "io/cache/file_cache_common.h"
+#include "io/cache/file_cache_storage.h"
+#include "io/cache/shard_mem_cache.h"
 #include "runtime/exec_env.h"
 
 namespace doris::io {
 
-MemFileCacheStorage::~MemFileCacheStorage() {}
+MemFileCacheStorage::~MemFileCacheStorage() = default;
 
 Status MemFileCacheStorage::init(BlockFileCache* _mgr) {
     LOG_INFO("init in-memory file cache storage");
     _mgr->_async_open_done = true; // no data to load for memory storage
+
+    _shard_nums = config::file_cache_mem_storage_shard_num;
+    if ((_shard_nums & (_shard_nums - 1)) != 0) {
+        return Status::InternalError(
+                "The shard number of memory storage should be power of 2, but currently is {}",
+                _shard_nums);
+    }
+    _shard_mask = _shard_nums - 1;
+
+    for (uint64_t i = 0; i < _shard_nums; i++) {
+        _shard_cache_map.emplace_back(std::make_shared<ShardMemHashTable>());
+    }
+
     return Status::OK();
 }
 
 Status MemFileCacheStorage::append(const FileCacheKey& key, const Slice& value) {
-    std::lock_guard<std::mutex> lock(_cache_map_mtx);
+    uint64_t shard_num = get_shard_num(FileWriterMapKey {std::pair {key.hash, key.offset}});
+    return _shard_cache_map[shard_num]->append(key, value);
+}
 
-    auto map_key = std::make_pair(key.hash, key.offset);
-    auto iter = _cache_map.find(map_key);
-    if (iter != _cache_map.end()) {
-        // despite the name append, it is indeed a put, so the key should not exist
-        LOG_WARNING("key already exists in in-memory cache map")
-                .tag("hash", key.hash.to_string())
-                .tag("offset", key.offset);
-        DCHECK(false);
-        return Status::IOError("key already exists in in-memory cache map");
-    }
-    // TODO(zhengyu): allocate in mempool
-    auto mem_block =
-            MemBlock {std::shared_ptr<char[]>(new char[value.size], std::default_delete<char[]>())};
-    DCHECK(mem_block.addr != nullptr);
-    _cache_map[map_key] = mem_block;
-    char* dst = mem_block.addr.get();
-    // TODO(zhengyu): zero copy!
-    memcpy(dst, value.data, value.size);
+Status MemFileCacheStorage::appendv(const FileCacheKey& key, const Slice* values,
+                                    size_t value_cnt) {
+    uint64_t shard_num = get_shard_num(FileWriterMapKey {std::pair {key.hash, key.offset}});
+    return _shard_cache_map[shard_num]->appendv(key, values, value_cnt);
+}
 
+Status MemFileCacheStorage::append_iobuf(const FileCacheKey& key, const butil::IOBuf& value) {
+    uint64_t shard_num = get_shard_num(FileWriterMapKey {std::pair {key.hash, key.offset}});
+    return _shard_cache_map[shard_num]->append_iobuf(key, value);
+}
+
+Status MemFileCacheStorage::abort(const FileCacheKey& key) {
+    (void)key;
     return Status::OK();
 }
 
@@ -70,38 +84,20 @@ Status MemFileCacheStorage::finalize(const FileCacheKey& key, const size_t size)
 }
 
 Status MemFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Slice buffer) {
-    std::lock_guard<std::mutex> lock(_cache_map_mtx);
-    auto map_key = std::make_pair(key.hash, key.offset);
-    auto iter = _cache_map.find(map_key);
-    if (iter == _cache_map.end()) {
-        LOG_WARNING("key not found in cache map")
-                .tag("hash", key.hash.to_string())
-                .tag("offset", key.offset);
-        return Status::IOError("key not found in in-memory cache map when read");
-    }
-    auto mem_block = iter->second;
-    DCHECK(mem_block.addr != nullptr);
-    char* src = mem_block.addr.get();
-    char* dst = buffer.data;
-    size_t size = buffer.size;
-    memcpy(dst, src, size);
-    return Status::OK();
+    uint64_t shard_num = get_shard_num(FileWriterMapKey {std::pair {key.hash, key.offset}});
+    return _shard_cache_map[shard_num]->read(key, value_offset, buffer);
+}
+
+Status MemFileCacheStorage::read_to_iobuf(const FileCacheKey& key, size_t value_offset,
+                                          size_t bytes_req, butil::IOBuf* out, size_t* bytes_read) {
+    uint64_t shard_num = get_shard_num(FileWriterMapKey {std::pair {key.hash, key.offset}});
+    return _shard_cache_map[shard_num]->read_to_iobuf(key, value_offset, bytes_req, out,
+                                                      bytes_read);
 }
 
 Status MemFileCacheStorage::remove(const FileCacheKey& key) {
-    // find and clear the one in _cache_map
-    std::lock_guard<std::mutex> lock(_cache_map_mtx);
-    auto map_key = std::make_pair(key.hash, key.offset);
-    auto iter = _cache_map.find(map_key);
-    if (iter == _cache_map.end()) {
-        LOG_WARNING("key not found in cache map")
-                .tag("hash", key.hash.to_string())
-                .tag("offset", key.offset);
-        return Status::IOError("key not found in in-memory cache map when remove");
-    }
-    _cache_map.erase(iter);
-
-    return Status::OK();
+    uint64_t shard_num = get_shard_num(FileWriterMapKey {std::pair {key.hash, key.offset}});
+    return _shard_cache_map[shard_num]->remove(key);
 }
 
 Status MemFileCacheStorage::change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
@@ -117,8 +113,13 @@ void MemFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* _mgr,
 }
 
 Status MemFileCacheStorage::clear(std::string& msg) {
-    std::lock_guard<std::mutex> lock(_cache_map_mtx);
-    _cache_map.clear();
+    for (auto& shard_cache : _shard_cache_map) {
+        Status s = shard_cache->clear();
+        if (!s) {
+            return s;
+        }
+    }
+
     return Status::OK();
 }
 

--- a/be/src/io/cache/mem_file_cache_storage.h
+++ b/be/src/io/cache/mem_file_cache_storage.h
@@ -23,12 +23,9 @@
 
 #include "io/cache/file_cache_common.h"
 #include "io/cache/file_cache_storage.h"
+#include "io/cache/shard_mem_cache.h"
 
 namespace doris::io {
-
-struct MemBlock {
-    std::shared_ptr<char[]> addr;
-};
 
 class MemFileCacheStorage : public FileCacheStorage {
 public:
@@ -36,8 +33,13 @@ public:
     ~MemFileCacheStorage() override;
     Status init(BlockFileCache* _mgr) override;
     Status append(const FileCacheKey& key, const Slice& value) override;
+    Status appendv(const FileCacheKey& key, const Slice* values, size_t value_cnt) override;
+    Status append_iobuf(const FileCacheKey& key, const butil::IOBuf& value) override;
+    Status abort(const FileCacheKey& key);
     Status finalize(const FileCacheKey& key, const size_t size) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
+    Status read_to_iobuf(const FileCacheKey& key, size_t value_offset, size_t bytes_req,
+                         butil::IOBuf* out, size_t* bytes_read) override;
     Status remove(const FileCacheKey& key) override;
     Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
                                 const size_t size) override;
@@ -49,8 +51,17 @@ public:
     FileCacheStorageType get_type() override { return MEMORY; }
 
 private:
-    std::unordered_map<FileWriterMapKey, MemBlock, FileWriterMapKeyHash> _cache_map;
-    std::mutex _cache_map_mtx;
+    uint64_t get_shard_num(const FileWriterMapKey& key) const {
+        FileWriterMapKeyHash hash_func;
+        std::size_t hash = hash_func(key);
+
+        return hash & _shard_mask;
+    }
+
+    // new code
+    uint64_t _shard_nums = 1;
+    uint64_t _shard_mask = 0;
+    std::vector<std::shared_ptr<ShardMemHashTable>> _shard_cache_map;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/peer_file_cache_reader.cpp
+++ b/be/src/io/cache/peer_file_cache_reader.cpp
@@ -17,6 +17,7 @@
 #include "io/cache/peer_file_cache_reader.h"
 
 #include <brpc/controller.h>
+#include <butil/iobuf.h>
 #include <bvar/latency_recorder.h>
 #include <bvar/reducer.h>
 #include <fmt/format.h>
@@ -38,6 +39,93 @@
 #include "util/network_util.h"
 
 namespace doris::io {
+
+namespace {
+
+struct ExpectedPeerFetch {
+    std::vector<FileBlock::Range> expected_ranges;
+    std::vector<FileBlock::Range> pending_ranges;
+    std::vector<size_t> expected_block_indexes;
+    size_t expected_bytes = 0;
+};
+
+size_t clip_requested_range(const FileBlock::Range& range, size_t file_size) {
+    if (range.left >= file_size) {
+        return 0;
+    }
+    return std::min(file_size - range.left, range.size());
+}
+
+ExpectedPeerFetch build_expected_peer_fetch(const std::vector<FileBlockSPtr>& blocks,
+                                            size_t file_size, PFetchPeerDataRequest* req) {
+    ExpectedPeerFetch expected;
+    for (size_t block_idx = 0; block_idx < blocks.size(); ++block_idx) {
+        const auto& blk = blocks[block_idx];
+        auto* cb = req->add_cache_req();
+        cb->set_block_offset(static_cast<int64_t>(blk->range().left));
+        cb->set_block_size(static_cast<int64_t>(blk->range().size()));
+        const size_t clipped_size = clip_requested_range(blk->range(), file_size);
+        if (clipped_size == 0) {
+            continue;
+        }
+        expected.expected_block_indexes.push_back(block_idx);
+        expected.expected_ranges.emplace_back(blk->range().left,
+                                              blk->range().left + clipped_size - 1);
+        expected.pending_ranges.emplace_back(expected.expected_ranges.back());
+        expected.expected_bytes += clipped_size;
+    }
+    return expected;
+}
+
+Status cut_attachment_payload(butil::IOBuf* attachment, size_t size, butil::IOBuf* out) {
+    const size_t cut_size = attachment->cutn(out, size);
+    if (cut_size != size) {
+        return Status::InternalError<false>(
+                "peer cache read incomplete attachment: need={}, got={}", size, cut_size);
+    }
+    return Status::OK();
+}
+
+bool subtract_pending_range(std::vector<FileBlock::Range>& pending_ranges,
+                            const FileBlock::Range& response_range) {
+    for (size_t idx = 0; idx < pending_ranges.size(); ++idx) {
+        auto pending_range = pending_ranges[idx];
+        if (response_range.left < pending_range.left ||
+            response_range.right > pending_range.right) {
+            continue;
+        }
+
+        if (response_range.left == pending_range.left &&
+            response_range.right == pending_range.right) {
+            pending_ranges.erase(pending_ranges.begin() + idx);
+        } else if (response_range.left == pending_range.left) {
+            pending_ranges[idx].left = response_range.right + 1;
+        } else if (response_range.right == pending_range.right) {
+            pending_ranges[idx].right = response_range.left - 1;
+        } else {
+            auto right_remain = FileBlock::Range(response_range.right + 1, pending_range.right);
+            pending_ranges[idx].right = response_range.left - 1;
+            pending_ranges.insert(pending_ranges.begin() + idx + 1, right_remain);
+        }
+        return true;
+    }
+    return false;
+}
+
+int find_expected_range_idx(const std::vector<FileBlock::Range>& expected_ranges,
+                            const FileBlock::Range& response_range) {
+    for (size_t idx = 0; idx < expected_ranges.size(); ++idx) {
+        const auto& expected_range = expected_ranges[idx];
+        if (response_range.left >= expected_range.left &&
+            response_range.right <= expected_range.right) {
+            return static_cast<int>(idx);
+        }
+    }
+    return -1;
+}
+
+} // namespace
+
 // read from peer
 
 bvar::Adder<uint64_t> peer_cache_reader_failed_counter("peer_cache_reader", "failed_counter");
@@ -65,13 +153,17 @@ PeerFileCacheReader::~PeerFileCacheReader() {
     peer_cache_being_read << -1;
 }
 
-Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& blocks, size_t off,
-                                         Slice s, size_t* bytes_read, size_t file_size,
-                                         const IOContext* ctx) {
-    VLOG_DEBUG << "enter PeerFileCacheReader::fetch_blocks, off=" << off
-               << " bytes_read=" << *bytes_read;
+Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& blocks,
+                                         PeerFetchResult* result, size_t file_size,
+                                         const IOContext* ctx, bool request_fill, int64_t tablet_id,
+                                         std::string resource_id) {
+    (void)ctx;
+    if (result == nullptr) {
+        return Status::InvalidArgument("peer cache fetch requires non-null result");
+    }
+    result->clear();
+    VLOG_DEBUG << "enter PeerFileCacheReader::fetch_blocks";
     if (blocks.empty()) {
-        *bytes_read = 0;
         return Status::OK();
     }
     if (!_is_doris_table) {
@@ -80,12 +172,26 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
 
     PFetchPeerDataRequest req;
     req.set_type(PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK);
-    req.set_path(_path.filename().native());
+    req.set_path(_path.native());
     req.set_file_size(static_cast<int64_t>(file_size));
-    for (const auto& blk : blocks) {
-        auto* cb = req.add_cache_req();
-        cb->set_block_offset(static_cast<int64_t>(blk->range().left));
-        cb->set_block_size(static_cast<int64_t>(blk->range().size()));
+    auto* rowset_meta_pb = req.mutable_rowset_meta();
+    rowset_meta_pb->Clear();
+    // RowsetMetaPB still has deprecated proto2 required rowset_id. Set a dummy value so
+    // the RPC can be serialized; current peer read/fill paths only read tablet_id/resource_id.
+    rowset_meta_pb->set_rowset_id(0);
+    rowset_meta_pb->set_resource_id(resource_id);
+    rowset_meta_pb->set_tablet_id(tablet_id);
+    if (request_fill) {
+        // Ask the peer server to pull missing blocks from remote storage before serving them.
+        // Only set for cross-CG reads targeting the designated fill compute group
+        // (peer_cache_fill_compute_group_id). Server still gates with enable_peer_server_cache_fill.
+        req.set_request_cache_fill(true);
+    }
+    // Always advertise attachment support. Older peers can still reply in protobuf mode.
+    req.set_support_attachment(true);
+    auto expected = build_expected_peer_fetch(blocks, file_size, &req);
+    if (expected.expected_bytes == 0) {
+        return Status::OK();
     }
 
     std::string realhost = _host;
@@ -113,6 +219,9 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
         st = Status::RpcError<false>("Address {} is wrong", brpc_addr);
         return st;
     }
+
+    size_t filled = 0;
+    size_t* bytes_read = &filled;
     LIMIT_REMOTE_SCAN_IO(bytes_read);
     int64_t begin_ts = std::chrono::duration_cast<std::chrono::microseconds>(
                                std::chrono::system_clock::now().time_since_epoch())
@@ -125,7 +234,9 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
     }};
 
     brpc::Controller cntl;
-    cntl.set_timeout_ms(5000);
+    // Use a longer timeout when fill is requested: server may spend up to
+    // peer_server_cache_fill_timeout_ms (default 6000ms) pulling from S3 before responding.
+    cntl.set_timeout_ms(request_fill ? 7000 : 5000);
     PFetchPeerDataResponse resp;
     peer_cache_reader_read_counter << 1;
     brpc_stub->fetch_peer_data(&cntl, &req, &resp, nullptr);
@@ -138,33 +249,78 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
         if (!st2.ok()) return st2;
     }
 
-    size_t filled = 0;
+    // Metadata stays in resp.datas(); payload may come from protobuf bytes or BRPC attachment.
+    const bool use_attachment = resp.has_data_in_attachment() && resp.data_in_attachment();
+    butil::IOBuf remaining_attachment(cntl.response_attachment());
+    result->chunks.reserve(resp.datas_size());
     for (const auto& data : resp.datas()) {
-        if (data.data().empty()) {
+        if (data.block_offset() < 0 || data.block_size() < 0) {
             peer_cache_reader_failed_counter << 1;
-            LOG(WARNING) << "peer cache read empty data" << data.block_offset();
-            return Status::InternalError<false>("peer cache read empty data");
+            result->clear();
+            return Status::InternalError<false>(
+                    "peer cache read invalid block metadata: offset={}, size={}",
+                    data.block_offset(), data.block_size());
         }
-        int64_t block_off = data.block_offset();
-        size_t rel = block_off > static_cast<int64_t>(off)
-                             ? static_cast<size_t>(block_off - static_cast<int64_t>(off))
-                             : 0;
-        size_t can_copy = std::min(s.size - rel, static_cast<size_t>(data.data().size()));
-        VLOG_DEBUG << "peer cache read data=" << data.block_offset()
-                   << " size=" << data.data().size() << " off=" << rel << " can_copy=" << can_copy;
-        std::memcpy(s.data + rel, data.data().data(), can_copy);
-        filled += can_copy;
+        const size_t block_off = static_cast<size_t>(data.block_offset());
+        const size_t payload_size =
+                use_attachment ? static_cast<size_t>(data.block_size()) : data.data().size();
+        if (payload_size == 0) {
+            continue;
+        }
+        const auto response_range = FileBlock::Range(block_off, block_off + payload_size - 1);
+        const int expected_idx = find_expected_range_idx(expected.expected_ranges, response_range);
+        if (expected_idx < 0) {
+            peer_cache_reader_failed_counter << 1;
+            result->clear();
+            return Status::InternalError<false>(
+                    "peer cache read block out of requested ranges: off={}, size={}", block_off,
+                    payload_size);
+        }
+        // Attachment payload is a single byte stream. Consume it in resp.datas() order so the
+        // peer can split or reorder requested ranges without forcing a fallback.
+        if (!subtract_pending_range(expected.pending_ranges, response_range)) {
+            peer_cache_reader_failed_counter << 1;
+            result->clear();
+            return Status::InternalError<false>("peer cache read unexpected block range: [{}, {}]",
+                                                response_range.left, response_range.right);
+        }
+
+        PeerFetchChunk chunk;
+        chunk.block_index = expected.expected_block_indexes[expected_idx];
+        chunk.block_offset = response_range.left;
+        VLOG_DEBUG << "peer cache read data=" << data.block_offset() << " size=" << payload_size
+                   << " block_idx=" << chunk.block_index;
+        if (use_attachment) {
+            auto cut_st =
+                    cut_attachment_payload(&remaining_attachment, payload_size, &chunk.payload);
+            if (!cut_st.ok()) {
+                peer_cache_reader_failed_counter << 1;
+                result->clear();
+                return cut_st;
+            }
+        } else if (chunk.payload.append(data.data().data(), payload_size) != 0) {
+            peer_cache_reader_failed_counter << 1;
+            result->clear();
+            return Status::InternalError<false>(
+                    "failed to append protobuf payload into iobuf: size={}", payload_size);
+        }
+        filled += payload_size;
+        result->chunks.emplace_back(std::move(chunk));
     }
     VLOG_DEBUG << "peer cache read filled=" << filled;
+    // Sparse reads are complete only when all requested block ranges are covered exactly.
+    if (!expected.pending_ranges.empty() || filled != expected.expected_bytes ||
+        (use_attachment && !remaining_attachment.empty())) {
+        peer_cache_reader_failed_counter << 1;
+        result->clear();
+        return Status::InternalError<false>(
+                "peer cache read incomplete: need={}, got={}, attachment_left={}",
+                expected.expected_bytes, filled, remaining_attachment.size());
+    }
     peer_bytes_read_total << filled;
     peer_bytes_per_read << filled;
-    if (filled != s.size) {
-        peer_cache_reader_failed_counter << 1;
-        return Status::InternalError<false>("peer cache read incomplete: need={}, got={}", s.size,
-                                            filled);
-    }
     peer_cache_reader_succ_counter << 1;
-    *bytes_read = filled;
+    result->bytes_read = filled;
     return Status::OK();
 }
 

--- a/be/src/io/cache/peer_file_cache_reader.h
+++ b/be/src/io/cache/peer_file_cache_reader.h
@@ -17,9 +17,12 @@
 
 #pragma once
 
+#include <butil/iobuf.h>
+
 #include <atomic>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "common/status.h"
 #include "io/cache/file_block.h"
@@ -27,13 +30,28 @@
 #include "io/fs/file_system.h"
 #include "io/fs/path.h"
 #include "io/fs/s3_file_system.h"
-#include "util/slice.h"
 
 namespace doris {
 class RuntimeProfile;
 
 namespace io {
 struct IOContext;
+
+struct PeerFetchChunk {
+    size_t block_index = 0;
+    size_t block_offset = 0;
+    butil::IOBuf payload;
+};
+
+struct PeerFetchResult {
+    std::vector<PeerFetchChunk> chunks;
+    size_t bytes_read = 0;
+
+    void clear() {
+        chunks.clear();
+        bytes_read = 0;
+    }
+};
 
 class PeerFileCacheReader final {
 public:
@@ -49,28 +67,28 @@ public:
     PeerFileCacheReader(const io::Path& file_path, bool is_doris_table, std::string host, int port);
     ~PeerFileCacheReader();
     /**
-     * Fetch data blocks from a peer and write them into the provided buffer.
+     * Fetch data blocks from a peer into a PeerFetchResult.
      *
      * Behavior:
      * - Supports only Doris table segment files (is_doris_table=true); otherwise returns NotSupported.
      * - Builds a BRPC request to invoke peer fetch_peer_data using the given blocks.
-     * - Copies returned block data into the contiguous buffer Slice s, using 'off' as the base offset.
-     * - Succeeds only if exactly s.size bytes are written; otherwise returns an Incomplete error.
+     * - Advertises attachment support and accepts either protobuf payload mode or attachment mode.
+     * - Populates result with sparse PeerFetchChunk entries matching the requested block ranges.
+     * - Succeeds only if the peer response exactly covers all requested block ranges.
      *
      * Params:
      * - blocks: List of file blocks to fetch (global file offsets, inclusive ranges).
-     * - off: Base file offset corresponding to the start of Slice s.
-     * - s: Destination buffer; must be large enough to hold all requested block bytes.
-     * - bytes_read: Output number of bytes read.
+     * - result: Output structure holding sparse chunks and total bytes_read.
      * - file_size: Size of the file to be read.
      * - ctx: IO context (kept for interface symmetry).
      *
      * Returns:
-     * - OK: Successfully wrote exactly s.size bytes into the buffer.
+     * - OK: Successfully populated all requested block bytes into the result.
      * - NotSupported: The file is not a Doris table segment.
      */
-    Status fetch_blocks(const std::vector<FileBlockSPtr>& blocks, size_t off, Slice s,
-                        size_t* bytes_read, size_t file_size, const IOContext* ctx);
+    Status fetch_blocks(const std::vector<FileBlockSPtr>& blocks, PeerFetchResult* result,
+                        size_t file_size, const IOContext* ctx, bool request_fill = false,
+                        int64_t tablet_id = 0, std::string resource_id = {});
 
 private:
     io::Path _path;

--- a/be/src/io/cache/shard_mem_cache.cpp
+++ b/be/src/io/cache/shard_mem_cache.cpp
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "io/cache/shard_mem_cache.h"
+
+#include <bvar/bvar.h>
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+
+#include "common/logging.h"
+
+namespace doris::io {
+
+bvar::Adder<uint64_t> g_mem_file_cache_duplicate_key_replace_num(
+        "file_cache", "memory_duplicate_key_replace_num");
+
+Status ShardMemHashTable::remove(const FileCacheKey& key) {
+    std::unique_lock<std::shared_mutex> lock(_shard_mt);
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    if (iter == _cache_map.end()) {
+        LOG_WARNING("key not found in cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset);
+        return Status::IOError("key not found in in-memory cache map when remove");
+    }
+    _cache_map.erase(iter);
+    return Status::OK();
+}
+
+Status ShardMemHashTable::append(const FileCacheKey& key, const Slice& value) {
+    return appendv(key, &value, 1);
+}
+
+Status ShardMemHashTable::appendv(const FileCacheKey& key, const Slice* values, size_t value_cnt) {
+    std::unique_lock<std::shared_mutex> lock(_shard_mt);
+
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    size_t total_size = 0;
+    for (size_t idx = 0; idx < value_cnt; ++idx) {
+        total_size += values[idx].size;
+    }
+    if (total_size == 0) {
+        return Status::InvalidArgument("appendv requires non-empty slices");
+    }
+
+    MemBlock mem_block;
+    mem_block.addr = std::shared_ptr<char[]>(new char[total_size], std::default_delete<char[]>());
+    mem_block.size = total_size;
+    DCHECK(mem_block.addr != nullptr);
+    char* dst = mem_block.addr.get();
+    for (size_t idx = 0; idx < value_cnt; ++idx) {
+        memcpy(dst, values[idx].data, values[idx].size);
+        dst += values[idx].size;
+    }
+    if (iter != _cache_map.end()) {
+        g_mem_file_cache_duplicate_key_replace_num << 1;
+        LOG_WARNING("replace duplicate key in in-memory cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset)
+                .tag("old_size", iter->second.size)
+                .tag("new_size", total_size);
+        // Replacing the payload keeps existing readers alive while reusing the same key.
+        iter->second = std::move(mem_block);
+        return Status::OK();
+    }
+
+    _cache_map.emplace(map_key, std::move(mem_block));
+    return Status::OK();
+}
+
+Status ShardMemHashTable::append_iobuf(const FileCacheKey& key, const butil::IOBuf& value) {
+    std::unique_lock<std::shared_mutex> lock(_shard_mt);
+
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+
+    const size_t total_size = value.length();
+    if (total_size == 0) {
+        return Status::InvalidArgument("append_iobuf requires non-empty payload");
+    }
+
+    MemBlock mem_block;
+    mem_block.payload.append(value);
+    mem_block.size = total_size;
+    mem_block.use_iobuf = true;
+    if (iter != _cache_map.end()) {
+        g_mem_file_cache_duplicate_key_replace_num << 1;
+        LOG_WARNING("replace duplicate key in in-memory cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset)
+                .tag("old_size", iter->second.size)
+                .tag("new_size", total_size);
+        iter->second = std::move(mem_block);
+        return Status::OK();
+    }
+
+    _cache_map.emplace(map_key, std::move(mem_block));
+    return Status::OK();
+}
+
+Status ShardMemHashTable::read(const FileCacheKey& key, size_t value_offset, Slice buffer) {
+    std::shared_lock<std::shared_mutex> lock(_shard_mt);
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    if (iter == _cache_map.end()) {
+        LOG_WARNING("key not found in cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset);
+        return Status::IOError("key not found in in-memory cache map when read");
+    }
+
+    const auto& mem_block = iter->second;
+    if (value_offset > mem_block.size || buffer.size > mem_block.size - value_offset) {
+        return Status::InternalError(
+                "read buffer exceeds cached block, key={}, offset={}, request_offset={}, "
+                "request_size={}, cached_size={}",
+                key.hash.to_string(), key.offset, value_offset, buffer.size, mem_block.size);
+    }
+    if (mem_block.use_iobuf) {
+        const size_t copied = mem_block.payload.copy_to(buffer.data, buffer.size, value_offset);
+        if (copied != buffer.size) {
+            return Status::InternalError(
+                    "short read from iobuf cache block, key={}, offset={}, request_offset={}, "
+                    "request_size={}, actual_size={}",
+                    key.hash.to_string(), key.offset, value_offset, buffer.size, copied);
+        }
+        return Status::OK();
+    }
+    DCHECK(mem_block.addr != nullptr);
+    memcpy(buffer.data, mem_block.addr.get() + value_offset, buffer.size);
+    return Status::OK();
+}
+
+Status ShardMemHashTable::read_to_iobuf(const FileCacheKey& key, size_t value_offset,
+                                        size_t bytes_req, butil::IOBuf* out, size_t* bytes_read) {
+    if (out == nullptr || bytes_read == nullptr) {
+        return Status::InvalidArgument("read_to_iobuf requires non-null out and bytes_read");
+    }
+    std::shared_lock<std::shared_mutex> lock(_shard_mt);
+    auto map_key = std::make_pair(key.hash, key.offset);
+    auto iter = _cache_map.find(map_key);
+    if (iter == _cache_map.end()) {
+        LOG_WARNING("key not found in cache map")
+                .tag("hash", key.hash.to_string())
+                .tag("offset", key.offset);
+        return Status::IOError("key not found in in-memory cache map when read_to_iobuf");
+    }
+    const auto& mem_block = iter->second;
+    if (value_offset > mem_block.size || bytes_req > mem_block.size - value_offset) {
+        return Status::InternalError(
+                "read iobuf exceeds cached block, key={}, offset={}, request_offset={}, "
+                "request_size={}, cached_size={}",
+                key.hash.to_string(), key.offset, value_offset, bytes_req, mem_block.size);
+    }
+    if (mem_block.use_iobuf) {
+        const size_t appended = mem_block.payload.append_to(out, bytes_req, value_offset);
+        if (appended != bytes_req) {
+            return Status::InternalError(
+                    "short append_to from iobuf cache block, key={}, offset={}, request_offset={}, "
+                    "request_size={}, actual_size={}",
+                    key.hash.to_string(), key.offset, value_offset, bytes_req, appended);
+        }
+    } else {
+        DCHECK(mem_block.addr != nullptr);
+        out->append(mem_block.addr.get() + value_offset, bytes_req);
+    }
+    *bytes_read = bytes_req;
+    return Status::OK();
+}
+
+Status ShardMemHashTable::clear() {
+    std::unique_lock<std::shared_mutex> lock(_shard_mt);
+    _cache_map.clear();
+    return Status::OK();
+}
+
+} // namespace doris::io

--- a/be/src/io/cache/shard_mem_cache.h
+++ b/be/src/io/cache/shard_mem_cache.h
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <shared_mutex>
+#include <unordered_map>
+
+#include "io/cache/file_cache_storage.h"
+
+namespace doris::io {
+
+class ShardMemHashTable {
+public:
+    ShardMemHashTable() = default;
+
+    Status remove(const FileCacheKey& key);
+    Status append(const FileCacheKey& key, const Slice& value);
+    Status appendv(const FileCacheKey& key, const Slice* values, size_t value_cnt);
+    Status append_iobuf(const FileCacheKey& key, const butil::IOBuf& value);
+    Status read(const FileCacheKey& key, size_t value_offset, Slice buffer);
+    Status read_to_iobuf(const FileCacheKey& key, size_t value_offset, size_t bytes_req,
+                         butil::IOBuf* out, size_t* bytes_read);
+    Status clear();
+
+private:
+    std::shared_mutex _shard_mt;
+    std::unordered_map<FileWriterMapKey, MemBlock, FileWriterMapKeyHash> _cache_map;
+};
+} // namespace doris::io

--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -64,6 +64,7 @@ io::FileReaderOptions FileFactory::get_reader_options(const TQueryOptions& optio
             .cache_base_path {},
             .file_size = fd.file_size,
             .mtime = fd.mtime,
+            .storage_resource_id {},
     };
     if (config::enable_file_cache && option.__isset.enable_file_cache && option.enable_file_cache &&
         fd.file_cache_admission) {

--- a/be/src/io/fs/file_reader.cpp
+++ b/be/src/io/fs/file_reader.cpp
@@ -18,6 +18,7 @@
 #include "io/fs/file_reader.h"
 
 #include <bthread/bthread.h>
+#include <butil/iobuf.h>
 #include <glog/logging.h>
 
 #include "io/cache/cached_remote_file_reader.h"
@@ -36,6 +37,28 @@ Status FileReader::read_at(size_t offset, Slice result, size_t* bytes_read,
         LOG(WARNING) << st;
     }
     return st;
+}
+
+Status FileReader::read_at_iobuf(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                 size_t* bytes_read, const IOContext* io_ctx) {
+    DCHECK(bthread_self() == 0);
+    Status st = read_at_iobuf_impl(offset, bytes_req, out, bytes_read, io_ctx);
+    if (!st) {
+        LOG(WARNING) << st;
+    }
+    return st;
+}
+
+Status FileReader::read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                      size_t* bytes_read, const IOContext* io_ctx) {
+    if (out == nullptr || bytes_read == nullptr) {
+        return Status::InvalidArgument("read_at_iobuf requires non-null out and bytes_read");
+    }
+    *bytes_read = 0;
+    (void)offset;
+    (void)bytes_req;
+    (void)io_ctx;
+    return Status::NotSupported("read_at_iobuf is not supported by current FileReader");
 }
 
 Result<FileReaderSPtr> create_cached_file_reader(FileReaderSPtr raw_reader,

--- a/be/src/io/fs/file_reader.h
+++ b/be/src/io/fs/file_reader.h
@@ -28,6 +28,10 @@
 #include "util/profile_collector.h"
 #include "util/slice.h"
 
+namespace butil {
+class IOBuf;
+}
+
 namespace doris {
 
 namespace io {
@@ -60,6 +64,9 @@ struct FileReaderOptions {
     int64_t mtime = 0;
     // Used to query the location of the file cache
     int64_t tablet_id = -1;
+    // Storage resource id of the remote file system. Used by peer fill to reconstruct
+    // the source file system without scanning tablet rowsets on the peer.
+    std::string storage_resource_id;
 
     static const FileReaderOptions DEFAULT;
 };
@@ -80,6 +87,12 @@ public:
     /// the caller must ensure that the IOContext exists during the left cycle of read_at()
     Status read_at(size_t offset, Slice result, size_t* bytes_read,
                    const IOContext* io_ctx = nullptr);
+    /// Read up to bytes_req bytes from offset and append them to out.
+    /// bytes_read is always set to the actual number of bytes appended on success; reading past
+    /// EOF is clamped to the file size and returns OK with fewer bytes. out and bytes_read must be
+    /// non-null. Readers that do not override the IOBuf path return NotSupported.
+    Status read_at_iobuf(size_t offset, size_t bytes_req, butil::IOBuf* out, size_t* bytes_read,
+                         const IOContext* io_ctx = nullptr);
 
     virtual Status close() = 0;
 
@@ -97,6 +110,10 @@ public:
 protected:
     virtual Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                 const IOContext* io_ctx) = 0;
+    // Default implementation returns NotSupported. Override this in readers that can
+    // fill iobuf directly.
+    virtual Status read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                      size_t* bytes_read, const IOContext* io_ctx);
 };
 
 using FileReaderSPtr = std::shared_ptr<FileReader>;

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -18,6 +18,7 @@
 #include "io/fs/local_file_reader.h"
 
 #include <bthread/bthread.h>
+#include <butil/iobuf.h>
 // IWYU pragma: no_include <bthread/errno.h>
 #include <bvar/bvar.h>
 #include <errno.h> // IWYU pragma: keep
@@ -190,6 +191,51 @@ Status LocalFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_
             *bytes_read += res;
         }
     }
+    DorisMetrics::instance()->local_bytes_read_total->increment(*bytes_read);
+    return Status::OK();
+}
+
+Status LocalFileReader::read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                           size_t* bytes_read, const IOContext* /*io_ctx*/) {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileReader::read_at_iobuf_impl",
+                                      Status::IOError("inject io error"));
+    if (out == nullptr || bytes_read == nullptr) {
+        return Status::InvalidArgument("read_at_iobuf requires non-null out and bytes_read");
+    }
+    if (closed()) [[unlikely]] {
+        return Status::InternalError("read closed file: ", _path.native());
+    }
+
+    if (offset > _file_size) {
+        return Status::InternalError(
+                "offset exceeds file size(offset: {}, file size: {}, path: {})", offset, _file_size,
+                _path.native());
+    }
+    bytes_req = std::min(bytes_req, _file_size - offset);
+    *bytes_read = 0;
+    if (bytes_req == 0) {
+        return Status::OK();
+    }
+
+    LIMIT_LOCAL_SCAN_IO(get_data_dir_path(), bytes_read);
+
+    butil::IOPortal portal;
+    while (bytes_req != 0) {
+        ssize_t res =
+                portal.pappend_from_file_descriptor(_fd, static_cast<off_t>(offset), bytes_req);
+        if (UNLIKELY(-1 == res && errno != EINTR)) {
+            return localfs_error(errno, fmt::format("failed to read {}", _path.native()));
+        }
+        if (UNLIKELY(res == 0)) {
+            return Status::InternalError("cannot read from {}: unexpected EOF", _path.native());
+        }
+        if (res > 0) {
+            offset += static_cast<size_t>(res);
+            bytes_req -= static_cast<size_t>(res);
+            *bytes_read += static_cast<size_t>(res);
+        }
+    }
+    out->append(portal);
     DorisMetrics::instance()->local_bytes_read_total->increment(*bytes_read);
     return Status::OK();
 }

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -68,6 +68,8 @@ public:
 private:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* io_ctx) override;
+    Status read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                              size_t* bytes_read, const IOContext* io_ctx) override;
 
 private:
     int _fd = -1; // owned

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -17,6 +17,8 @@
 
 #include "io/fs/local_file_writer.h"
 
+#include <butil/iobuf.h>
+
 // IWYU pragma: no_include <bthread/errno.h>
 #include <errno.h> // IWYU pragma: keep
 #include <fcntl.h>
@@ -184,6 +186,47 @@ Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
         n_left -= res;
     }
     DCHECK_EQ(0, n_left);
+    _bytes_appended += bytes_req;
+    return Status::OK();
+}
+
+Status LocalFileWriter::append_iobuf(const butil::IOBuf& data) {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileWriter::append_iobuf",
+                                      Status::IOError("inject io error"));
+    if (_state != State::OPENED) [[unlikely]] {
+        return Status::InternalError("append to closed file: {}", _path.native());
+    }
+    if (data.empty()) {
+        return Status::OK();
+    }
+    _dirty = true;
+
+    butil::IOBuf payload(data);
+    const size_t bytes_req = payload.length();
+    while (!payload.empty()) {
+        const size_t size_hint = payload.length();
+        ssize_t res =
+                SYNC_POINT_HOOK_RETURN_VALUE(payload.cut_into_file_descriptor(_fd, size_hint),
+                                             "LocalFileWriter::cut_into_file_descriptor", _fd);
+        DBUG_EXECUTE_IF("LocalFileWriter::append_iobuf.io_error", {
+            auto sub_path = dp->param<std::string>("sub_path", "");
+            if ((sub_path.empty() && _path.filename().compare(kTestFilePath)) ||
+                (!sub_path.empty() && _path.native().find(sub_path) != std::string::npos)) {
+                res = -1;
+                errno = EIO;
+                LOG(WARNING) << Status::IOError("debug write io error: {}", _path.native());
+            }
+        });
+        if (UNLIKELY(res < 0)) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return localfs_error(errno, fmt::format("failed to write {}", _path.native()));
+        }
+        if (UNLIKELY(res == 0)) {
+            return Status::IOError("failed to write {}, zero bytes written", _path.native());
+        }
+    }
     _bytes_appended += bytes_req;
     return Status::OK();
 }

--- a/be/src/io/fs/local_file_writer.h
+++ b/be/src/io/fs/local_file_writer.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <butil/iobuf.h>
+
 #include <cstddef>
 
 #include "common/status.h"
@@ -32,6 +34,7 @@ public:
     ~LocalFileWriter() override;
 
     Status appendv(const Slice* data, size_t data_cnt) override;
+    Status append_iobuf(const butil::IOBuf& data);
     const Path& path() const override { return _path; }
     size_t bytes_appended() const override;
     State state() const override { return _state; }

--- a/be/src/io/fs/remote_file_system.cpp
+++ b/be/src/io/fs/remote_file_system.cpp
@@ -54,11 +54,12 @@ Status RemoteFileSystem::download(const Path& remote_file, const Path& local) {
 Status RemoteFileSystem::open_file_impl(const Path& path, FileReaderSPtr* reader,
                                         const FileReaderOptions* opts) {
     FileReaderSPtr raw_reader;
-    if (!opts) {
-        opts = &FileReaderOptions::DEFAULT;
+    FileReaderOptions effective_opts = opts ? *opts : FileReaderOptions::DEFAULT;
+    if (effective_opts.storage_resource_id.empty()) {
+        effective_opts.storage_resource_id = id();
     }
-    RETURN_IF_ERROR(open_file_internal(path, &raw_reader, *opts));
-    *reader = DORIS_TRY(create_cached_file_reader(raw_reader, *opts));
+    RETURN_IF_ERROR(open_file_internal(path, &raw_reader, effective_opts));
+    *reader = DORIS_TRY(create_cached_file_reader(raw_reader, effective_opts));
     return Status::OK();
 }
 

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -19,6 +19,9 @@
 
 #include <gen_cpp/Types_types.h>
 
+#include <set>
+#include <string>
+
 namespace doris {
 
 enum class ReaderType : uint8_t {
@@ -83,6 +86,20 @@ struct FileCacheStatistics {
     int64_t segment_footer_index_remote_io_timer = 0;
     int64_t segment_footer_index_peer_io_timer = 0;
 
+    // Cross-CG / Same-CG peer read statistics
+    int64_t num_cross_cg_peer_io_total = 0;
+    int64_t bytes_read_from_cross_cg_peer = 0;
+    int64_t cross_cg_peer_io_timer = 0; // nanoseconds
+    int64_t num_same_cg_peer_io_total = 0;
+    int64_t bytes_read_from_same_cg_peer = 0;
+    int64_t same_cg_peer_io_timer = 0; // nanoseconds
+    int64_t num_peer_race_peer_win = 0;
+    int64_t num_peer_race_s3_win = 0;
+    int64_t num_peer_lazy_fetch = 0;
+    int64_t peer_lazy_fetch_timer = 0; // nanoseconds
+
+    std::set<std::string> peer_hosts;
+
     void merge_from(const FileCacheStatistics& other) {
         num_local_io_total += other.num_local_io_total;
         num_remote_io_total += other.num_remote_io_total;
@@ -102,6 +119,7 @@ struct FileCacheStatistics {
         lock_wait_timer += other.lock_wait_timer;
         get_timer += other.get_timer;
         set_timer += other.set_timer;
+
         inverted_index_num_local_io_total += other.inverted_index_num_local_io_total;
         inverted_index_num_remote_io_total += other.inverted_index_num_remote_io_total;
         inverted_index_num_peer_io_total += other.inverted_index_num_peer_io_total;
@@ -112,6 +130,7 @@ struct FileCacheStatistics {
         inverted_index_remote_io_timer += other.inverted_index_remote_io_timer;
         inverted_index_peer_io_timer += other.inverted_index_peer_io_timer;
         inverted_index_io_timer += other.inverted_index_io_timer;
+
         segment_footer_index_num_local_io_total += other.segment_footer_index_num_local_io_total;
         segment_footer_index_num_remote_io_total += other.segment_footer_index_num_remote_io_total;
         segment_footer_index_num_peer_io_total += other.segment_footer_index_num_peer_io_total;
@@ -124,6 +143,19 @@ struct FileCacheStatistics {
         segment_footer_index_local_io_timer += other.segment_footer_index_local_io_timer;
         segment_footer_index_remote_io_timer += other.segment_footer_index_remote_io_timer;
         segment_footer_index_peer_io_timer += other.segment_footer_index_peer_io_timer;
+
+        num_cross_cg_peer_io_total += other.num_cross_cg_peer_io_total;
+        bytes_read_from_cross_cg_peer += other.bytes_read_from_cross_cg_peer;
+        cross_cg_peer_io_timer += other.cross_cg_peer_io_timer;
+        num_same_cg_peer_io_total += other.num_same_cg_peer_io_total;
+        bytes_read_from_same_cg_peer += other.bytes_read_from_same_cg_peer;
+        same_cg_peer_io_timer += other.same_cg_peer_io_timer;
+        num_peer_race_peer_win += other.num_peer_race_peer_win;
+        num_peer_race_s3_win += other.num_peer_race_s3_win;
+        num_peer_lazy_fetch += other.num_peer_lazy_fetch;
+        peer_lazy_fetch_timer += other.peer_lazy_fetch_timer;
+
+        peer_hosts.insert(other.peer_hosts.begin(), other.peer_hosts.end());
     }
 };
 
@@ -152,6 +184,8 @@ struct IOContext {
     // output filtering already records its own unselected rows; this counter carries the rows that
     // were filtered before the block returned to Scanner.
     int64_t predicate_filtered_rows = 0;
+    // if true, bypass peer read / peer-vs-S3 race and read directly from remote storage
+    bool bypass_peer_read {false};
 };
 
 } // namespace io

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -265,6 +265,7 @@ public:
     ThreadPool* s3_file_system_thread_pool() { return _s3_file_system_thread_pool.get(); }
     ThreadPool* udf_close_workers_pool() { return _udf_close_workers_thread_pool.get(); }
     ThreadPool* segment_prefetch_thread_pool() { return _segment_prefetch_thread_pool.get(); }
+    ThreadPool* peer_race_s3_thread_pool() { return _peer_race_s3_thread_pool.get(); }
 
     void init_file_cache_factory(std::vector<doris::CachePath>& cache_paths);
     io::FileCacheFactory* file_cache_factory() { return _file_cache_factory; }
@@ -498,6 +499,7 @@ private:
     std::unique_ptr<ThreadPool> _udf_close_workers_thread_pool;
     // Threadpool used to prefetch segment file cache blocks
     std::unique_ptr<ThreadPool> _segment_prefetch_thread_pool;
+    std::unique_ptr<ThreadPool> _peer_race_s3_thread_pool;
 
     FragmentMgr* _fragment_mgr = nullptr;
     WorkloadGroupMgr* _workload_group_manager = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -306,6 +306,10 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .set_min_threads(config::min_s3_file_system_thread_num)
                               .set_max_threads(config::max_s3_file_system_thread_num)
                               .build(&_s3_file_system_thread_pool));
+    static_cast<void>(ThreadPoolBuilder("PeerRaceS3ThreadPool")
+                              .set_min_threads(config::min_peer_race_s3_thread_num)
+                              .set_max_threads(config::max_peer_race_s3_thread_num)
+                              .build(&_peer_race_s3_thread_pool));
     RETURN_IF_ERROR(init_mem_env());
 
     // NOTE: runtime query statistics mgr could be visited by query and daemon thread
@@ -884,6 +888,7 @@ void ExecEnv::destroy() {
     SAFE_SHUTDOWN(_lazy_release_obj_pool);
     SAFE_SHUTDOWN(_non_block_close_thread_pool);
     SAFE_SHUTDOWN(_s3_file_system_thread_pool);
+    SAFE_SHUTDOWN(_peer_race_s3_thread_pool);
     SAFE_SHUTDOWN(_send_batch_thread_pool);
     SAFE_SHUTDOWN(_udf_close_workers_thread_pool);
     SAFE_SHUTDOWN(_send_table_stats_thread_pool);
@@ -939,6 +944,7 @@ void ExecEnv::destroy() {
     _lazy_release_obj_pool.reset(nullptr);
     _non_block_close_thread_pool.reset(nullptr);
     _s3_file_system_thread_pool.reset(nullptr);
+    _peer_race_s3_thread_pool.reset(nullptr);
     _send_table_stats_thread_pool.reset(nullptr);
     _buffered_reader_prefetch_thread_pool.reset(nullptr);
     _segment_prefetch_thread_pool.reset(nullptr);

--- a/be/src/service/http/action/peer_cache_action.cpp
+++ b/be/src/service/http/action/peer_cache_action.cpp
@@ -1,0 +1,267 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "service/http/action/peer_cache_action.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <string>
+
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_warm_up_manager.h"
+#include "service/http/http_channel.h"
+#include "service/http/http_headers.h"
+#include "service/http/http_request.h"
+#include "service/http/http_status.h"
+
+namespace doris {
+
+static constexpr std::string_view HEADER_JSON = "application/json";
+
+// Serialize a single TabletPeerCandidates into a rapidjson object
+static void tablet_peer_to_json(int64_t tablet_id, const TabletPeerCandidates& tpc,
+                                rapidjson::Writer<rapidjson::StringBuffer>& writer) {
+    writer.StartObject();
+    writer.Key("tablet_id");
+    writer.Int64(tablet_id);
+
+    writer.Key("candidates");
+    writer.StartArray();
+    for (const auto& c : tpc.candidates) {
+        writer.StartObject();
+        writer.Key("host");
+        writer.String(c.host.c_str());
+        writer.Key("brpc_port");
+        writer.Int(c.brpc_port);
+        writer.Key("compute_group_id");
+        writer.String(c.compute_group_id.c_str());
+        writer.Key("last_access_time_ms");
+        writer.Int64(c.last_access_time_ms);
+        writer.Key("consecutive_rpc_failures");
+        writer.Int(c.consecutive_rpc_failures);
+        writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.Key("last_successful_compute_group_id");
+    writer.String(tpc.last_successful_compute_group_id.c_str());
+    writer.Key("fetching_from_fe");
+    writer.Bool(tpc.fetching_from_fe);
+    writer.Key("consecutive_all_miss");
+    writer.Int(tpc.consecutive_all_miss);
+    writer.Key("cooldown_until_ms");
+    writer.Int64(tpc.cooldown_until_ms);
+
+    writer.EndObject();
+}
+
+static int64_t parse_tablet_id(HttpRequest* req) {
+    const std::string& tablet_id_str = req->param("tablet_id");
+    if (tablet_id_str.empty()) {
+        return -1;
+    }
+    try {
+        return std::stoll(tablet_id_str);
+    } catch (...) {
+        return -1;
+    }
+}
+
+Status PeerCacheAction::_handle_show(HttpRequest* req, std::string* result) {
+    int64_t tablet_id = parse_tablet_id(req);
+    if (tablet_id < 0) {
+        return Status::InvalidArgument("missing or invalid parameter: tablet_id");
+    }
+
+    auto& mgr = _engine.cloud_warm_up_manager();
+    auto opt = mgr.get_tablet_peer_info(tablet_id);
+    if (!opt.has_value()) {
+        return Status::NotFound("tablet_id {} has no peer candidates", tablet_id);
+    }
+
+    rapidjson::StringBuffer buf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    tablet_peer_to_json(tablet_id, opt.value(), writer);
+    *result = buf.GetString();
+    return Status::OK();
+}
+
+Status PeerCacheAction::_handle_show_all(HttpRequest* req, std::string* result) {
+    int64_t limit = 1000; // default
+    const std::string& limit_str = req->param("limit");
+    if (!limit_str.empty()) {
+        try {
+            limit = std::stoll(limit_str);
+        } catch (...) {
+            return Status::InvalidArgument("invalid parameter: limit");
+        }
+    }
+
+    auto& mgr = _engine.cloud_warm_up_manager();
+    auto all = mgr.get_all_peer_info(limit);
+
+    rapidjson::StringBuffer buf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    writer.StartObject();
+    writer.Key("total");
+    writer.Int64(static_cast<int64_t>(all.size()));
+    writer.Key("tablets");
+    writer.StartArray();
+    for (const auto& [tid, tpc] : all) {
+        tablet_peer_to_json(tid, tpc, writer);
+    }
+    writer.EndArray();
+    writer.EndObject();
+    *result = buf.GetString();
+    return Status::OK();
+}
+
+Status PeerCacheAction::_handle_set(HttpRequest* req, std::string* result) {
+    int64_t tablet_id = parse_tablet_id(req);
+    if (tablet_id < 0) {
+        return Status::InvalidArgument("missing or invalid parameter: tablet_id");
+    }
+
+    const std::string& body = req->get_request_body();
+    if (body.empty()) {
+        return Status::InvalidArgument("missing request body (JSON expected)");
+    }
+
+    rapidjson::Document doc;
+    doc.Parse(body.c_str(), body.size());
+    if (doc.HasParseError()) {
+        return Status::InvalidArgument("invalid JSON body: parse error at offset {}",
+                                       doc.GetErrorOffset());
+    }
+
+    TabletPeerCandidates tpc;
+
+    // Parse candidates array
+    if (doc.HasMember("candidates") && doc["candidates"].IsArray()) {
+        for (const auto& item : doc["candidates"].GetArray()) {
+            PeerCandidate c;
+            if (item.HasMember("host") && item["host"].IsString()) {
+                c.host = item["host"].GetString();
+            }
+            if (item.HasMember("brpc_port") && item["brpc_port"].IsInt()) {
+                c.brpc_port = item["brpc_port"].GetInt();
+            }
+            if (item.HasMember("compute_group_id") && item["compute_group_id"].IsString()) {
+                c.compute_group_id = item["compute_group_id"].GetString();
+            }
+            if (item.HasMember("last_access_time_ms") && item["last_access_time_ms"].IsInt64()) {
+                c.last_access_time_ms = item["last_access_time_ms"].GetInt64();
+            }
+            if (item.HasMember("consecutive_rpc_failures") &&
+                item["consecutive_rpc_failures"].IsInt()) {
+                c.consecutive_rpc_failures = item["consecutive_rpc_failures"].GetInt();
+            }
+            // If last_access_time_ms not provided, set to current time
+            if (c.last_access_time_ms == 0) {
+                c.last_access_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                std::chrono::system_clock::now().time_since_epoch())
+                                                .count();
+            }
+            tpc.candidates.push_back(std::move(c));
+        }
+    }
+
+    if (doc.HasMember("last_successful_compute_group_id") &&
+        doc["last_successful_compute_group_id"].IsString()) {
+        tpc.last_successful_compute_group_id = doc["last_successful_compute_group_id"].GetString();
+    }
+    if (doc.HasMember("consecutive_all_miss") && doc["consecutive_all_miss"].IsInt()) {
+        tpc.consecutive_all_miss = doc["consecutive_all_miss"].GetInt();
+    }
+    if (doc.HasMember("cooldown_until_ms") && doc["cooldown_until_ms"].IsInt64()) {
+        tpc.cooldown_until_ms = doc["cooldown_until_ms"].GetInt64();
+    }
+
+    auto& mgr = _engine.cloud_warm_up_manager();
+    mgr.set_tablet_peer_candidates(tablet_id, std::move(tpc));
+
+    *result = R"({"status":"OK","msg":"peer candidates set successfully"})";
+    return Status::OK();
+}
+
+Status PeerCacheAction::_handle_remove(HttpRequest* req, std::string* result) {
+    int64_t tablet_id = parse_tablet_id(req);
+    if (tablet_id < 0) {
+        return Status::InvalidArgument("missing or invalid parameter: tablet_id");
+    }
+
+    auto& mgr = _engine.cloud_warm_up_manager();
+    mgr.remove_balanced_tablet(tablet_id);
+
+    *result = R"({"status":"OK","msg":"peer candidates removed"})";
+    return Status::OK();
+}
+
+Status PeerCacheAction::_handle_reset_cooldown(HttpRequest* req, std::string* result) {
+    int64_t tablet_id = parse_tablet_id(req);
+    if (tablet_id < 0) {
+        return Status::InvalidArgument("missing or invalid parameter: tablet_id");
+    }
+
+    auto& mgr = _engine.cloud_warm_up_manager();
+    auto opt = mgr.get_tablet_peer_info(tablet_id);
+    if (!opt.has_value()) {
+        return Status::NotFound("tablet_id {} has no peer candidates", tablet_id);
+    }
+
+    // Reset cooldown fields and write back
+    auto tpc = std::move(opt.value());
+    tpc.consecutive_all_miss = 0;
+    tpc.cooldown_until_ms = 0;
+    mgr.set_tablet_peer_candidates(tablet_id, std::move(tpc));
+
+    *result = R"({"status":"OK","msg":"cooldown reset"})";
+    return Status::OK();
+}
+
+void PeerCacheAction::handle(HttpRequest* req) {
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.data());
+
+    const std::string& op = req->param("op");
+    std::string result;
+    Status st;
+
+    if (op == "show") {
+        st = _handle_show(req, &result);
+    } else if (op == "show_all") {
+        st = _handle_show_all(req, &result);
+    } else if (op == "set") {
+        st = _handle_set(req, &result);
+    } else if (op == "remove") {
+        st = _handle_remove(req, &result);
+    } else if (op == "reset_cooldown") {
+        st = _handle_reset_cooldown(req, &result);
+    } else {
+        st = Status::InvalidArgument(
+                "unknown op '{}', supported: show, show_all, set, remove, reset_cooldown", op);
+    }
+
+    if (st.ok()) {
+        HttpChannel::send_reply(req, HttpStatus::OK, result);
+    } else {
+        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, st.to_json());
+    }
+}
+
+} // namespace doris

--- a/be/src/service/http/action/peer_cache_action.h
+++ b/be/src/service/http/action/peer_cache_action.h
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+#include "common/status.h"
+#include "service/http/http_handler_with_auth.h"
+
+namespace doris {
+
+class HttpRequest;
+class ExecEnv;
+class CloudStorageEngine;
+
+// HTTP action for viewing and force-setting peer cache candidates.
+//
+// GET  /api/peer_cache?op=show&tablet_id=12345
+//   Show TabletPeerCandidates for a specific tablet.
+//
+// GET  /api/peer_cache?op=show_all[&limit=100]
+//   Show all tablets with peer candidates (default limit 1000).
+//
+// POST /api/peer_cache?op=set&tablet_id=12345
+//   Body (JSON):
+//   {
+//     "candidates": [
+//       {"host":"10.0.0.1","brpc_port":8060,"compute_group_id":"cg1"}
+//     ],
+//     "last_successful_compute_group_id": "cg1",
+//     "consecutive_all_miss": 0,
+//     "cooldown_until_ms": 0
+//   }
+//
+// POST /api/peer_cache?op=remove&tablet_id=12345
+//   Remove all peer candidates for a tablet.
+//
+// POST /api/peer_cache?op=reset_cooldown&tablet_id=12345
+//   Reset cooldown state for a tablet.
+class PeerCacheAction : public HttpHandlerWithAuth {
+public:
+    PeerCacheAction(ExecEnv* exec_env, CloudStorageEngine& engine)
+            : HttpHandlerWithAuth(exec_env), _engine(engine) {}
+
+    ~PeerCacheAction() override = default;
+
+    void handle(HttpRequest* req) override;
+
+private:
+    Status _handle_show(HttpRequest* req, std::string* result);
+    Status _handle_show_all(HttpRequest* req, std::string* result);
+    Status _handle_set(HttpRequest* req, std::string* result);
+    Status _handle_remove(HttpRequest* req, std::string* result);
+    Status _handle_reset_cooldown(HttpRequest* req, std::string* result);
+
+    CloudStorageEngine& _engine;
+};
+
+} // namespace doris

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -61,6 +61,7 @@
 #include "service/http/action/meta_action.h"
 #include "service/http/action/metrics_action.h"
 #include "service/http/action/pad_rowset_action.h"
+#include "service/http/action/peer_cache_action.h"
 #include "service/http/action/pipeline_task_action.h"
 #include "service/http/action/pprof_actions.h"
 #include "service/http/action/reload_tablet_action.h"
@@ -535,6 +536,12 @@ void HttpService::register_cloud_handler(CloudStorageEngine& engine) {
             _pool.add(new CheckEncryptionAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ALL));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/check_tablet_encryption",
                                       check_encryption_action);
+
+    // Peer cache admin/debug endpoints
+    PeerCacheAction* peer_cache_get = _pool.add(new PeerCacheAction(_env, engine));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/peer_cache", peer_cache_get);
+    PeerCacheAction* peer_cache_post = _pool.add(new PeerCacheAction(_env, engine));
+    _ev_http_server->register_handler(HttpMethod::POST, "/api/peer_cache", peer_cache_post);
 }
 // NOLINTEND(readability-function-size)
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -146,13 +146,17 @@ using namespace ErrorCode;
 const uint32_t DOWNLOAD_FILE_MAX_RETRY = 3;
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(peer_fetch_work_pool_queue_size, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_pool_queue_size, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_active_threads, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(peer_fetch_work_active_threads, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_active_threads, MetricUnit::NOUNIT);
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_pool_max_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(peer_fetch_work_pool_max_queue_size, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_pool_max_queue_size, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_max_threads, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(peer_fetch_work_max_threads, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_max_threads, MetricUnit::NOUNIT);
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(arrow_flight_work_pool_queue_size, MetricUnit::NOUNIT);
@@ -166,6 +170,17 @@ bthread_key_t btls_key;
 
 static void thread_context_deleter(void* d) {
     delete static_cast<ThreadContext*>(d);
+}
+
+static int32_t resolved_brpc_peer_fetch_pool_threads() {
+    return config::brpc_peer_fetch_pool_threads != -1 ? config::brpc_peer_fetch_pool_threads
+                                                      : std::max(64, CpuInfo::num_cores() * 2);
+}
+
+static int32_t resolved_brpc_peer_fetch_pool_max_queue_size() {
+    return config::brpc_peer_fetch_pool_max_queue_size != -1
+                   ? config::brpc_peer_fetch_pool_max_queue_size
+                   : std::max(4096, CpuInfo::num_cores() * 128);
 }
 
 template <typename T>
@@ -221,6 +236,9 @@ PInternalService::PInternalService(ExecEnv* exec_env)
                                    ? config::brpc_heavy_work_pool_max_queue_size
                                    : std::max(10240, CpuInfo::num_cores() * 320),
                            "brpc_heavy"),
+          // peer fetch threadpool isolates fetch_peer_data from heavy load traffic to avoid peer reads starving imports.
+          _peer_fetch_pool(resolved_brpc_peer_fetch_pool_threads(),
+                           resolved_brpc_peer_fetch_pool_max_queue_size(), "brpc_peer_fetch"),
 
           // light threadpool should be only used in query processing logic. All hanlers should be very light, not locked, not access disk.
           _light_work_pool(config::brpc_light_work_pool_threads != -1
@@ -239,19 +257,27 @@ PInternalService::PInternalService(ExecEnv* exec_env)
                                   "brpc_arrow_flight") {
     REGISTER_HOOK_METRIC(heavy_work_pool_queue_size,
                          [this]() { return _heavy_work_pool.get_queue_size(); });
+    REGISTER_HOOK_METRIC(peer_fetch_work_pool_queue_size,
+                         [this]() { return _peer_fetch_pool.get_queue_size(); });
     REGISTER_HOOK_METRIC(light_work_pool_queue_size,
                          [this]() { return _light_work_pool.get_queue_size(); });
     REGISTER_HOOK_METRIC(heavy_work_active_threads,
                          [this]() { return _heavy_work_pool.get_active_threads(); });
+    REGISTER_HOOK_METRIC(peer_fetch_work_active_threads,
+                         [this]() { return _peer_fetch_pool.get_active_threads(); });
     REGISTER_HOOK_METRIC(light_work_active_threads,
                          [this]() { return _light_work_pool.get_active_threads(); });
 
     REGISTER_HOOK_METRIC(heavy_work_pool_max_queue_size,
                          []() { return config::brpc_heavy_work_pool_max_queue_size; });
+    REGISTER_HOOK_METRIC(peer_fetch_work_pool_max_queue_size,
+                         []() { return resolved_brpc_peer_fetch_pool_max_queue_size(); });
     REGISTER_HOOK_METRIC(light_work_pool_max_queue_size,
                          []() { return config::brpc_light_work_pool_max_queue_size; });
     REGISTER_HOOK_METRIC(heavy_work_max_threads,
                          []() { return config::brpc_heavy_work_pool_threads; });
+    REGISTER_HOOK_METRIC(peer_fetch_work_max_threads,
+                         []() { return resolved_brpc_peer_fetch_pool_threads(); });
     REGISTER_HOOK_METRIC(light_work_max_threads,
                          []() { return config::brpc_light_work_pool_threads; });
 
@@ -277,13 +303,17 @@ PInternalServiceImpl::~PInternalServiceImpl() = default;
 
 PInternalService::~PInternalService() {
     DEREGISTER_HOOK_METRIC(heavy_work_pool_queue_size);
+    DEREGISTER_HOOK_METRIC(peer_fetch_work_pool_queue_size);
     DEREGISTER_HOOK_METRIC(light_work_pool_queue_size);
     DEREGISTER_HOOK_METRIC(heavy_work_active_threads);
+    DEREGISTER_HOOK_METRIC(peer_fetch_work_active_threads);
     DEREGISTER_HOOK_METRIC(light_work_active_threads);
 
     DEREGISTER_HOOK_METRIC(heavy_work_pool_max_queue_size);
+    DEREGISTER_HOOK_METRIC(peer_fetch_work_pool_max_queue_size);
     DEREGISTER_HOOK_METRIC(light_work_pool_max_queue_size);
     DEREGISTER_HOOK_METRIC(heavy_work_max_threads);
+    DEREGISTER_HOOK_METRIC(peer_fetch_work_max_threads);
     DEREGISTER_HOOK_METRIC(light_work_max_threads);
 
     DEREGISTER_HOOK_METRIC(arrow_flight_work_pool_queue_size);

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -274,6 +274,7 @@ protected:
     // define the interface for reading and writing data as heavy interface
     // otherwise as light interface
     FifoThreadPool _heavy_work_pool;
+    FifoThreadPool _peer_fetch_pool;
     FifoThreadPool _light_work_pool;
     FifoThreadPool _arrow_flight_work_pool;
 };

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -274,6 +274,7 @@ Status BetaRowset::load_segment(int64_t seg_id, OlapReaderStatistics* stats,
             .cache_base_path = "",
             .file_size = _rowset_meta->segment_file_size(static_cast<int>(seg_id)),
             .tablet_id = _rowset_meta->tablet_id(),
+            .storage_resource_id = _rowset_meta->resource_id(),
     };
 
     auto s = segment_v2::Segment::open(
@@ -634,6 +635,7 @@ Status BetaRowset::check_current_rowset_segment() {
                 .cache_base_path {},
                 .file_size = _rowset_meta->segment_file_size(seg_id),
                 .tablet_id = _rowset_meta->tablet_id(),
+                .storage_resource_id = _rowset_meta->resource_id(),
         };
 
         auto s = segment_v2::Segment::open(fs, seg_path, _rowset_meta->tablet_id(), seg_id,

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -503,6 +503,7 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
             .is_doris_table = true,
             .cache_base_path {},
             .tablet_id = _rowset_meta->tablet_id(),
+            .storage_resource_id = _rowset_meta->resource_id(),
     };
     auto s = segment_v2::Segment::open(fs, path, _rowset_meta->tablet_id(), segment_id, rowset_id(),
                                        _context.tablet_schema, reader_options, &segment);
@@ -674,6 +675,7 @@ Status BetaRowsetWriter::_remove_segment_footer_cache(const uint32_t seg_id,
                 .cache_base_path = "",
                 .file_size = _rowset_meta->segment_file_size(static_cast<int>(seg_id)),
                 .tablet_id = _rowset_meta->tablet_id(),
+                .storage_resource_id = _rowset_meta->resource_id(),
         };
         RETURN_IF_ERROR(fs->open_file(segment_path, &file_reader, &reader_options));
         DCHECK(file_reader != nullptr);

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -169,7 +169,7 @@ io::FileSystemSPtr RowsetMeta::fs() {
 
 Result<const StorageResource*> RowsetMeta::remote_storage_resource() {
     if (is_local()) {
-        return ResultError(Status::InternalError(
+        return ResultError(Status::InternalError<false>(
                 "local rowset has no storage resource. tablet_id={} rowset_id={}", tablet_id(),
                 _rowset_id.to_string()));
     }
@@ -188,8 +188,8 @@ Result<const StorageResource*> RowsetMeta::remote_storage_resource() {
                     return &_storage_resource;
                 }
             }
-            return ResultError(Status::InternalError("cannot find storage resource. resource_id={}",
-                                                     resource_id()));
+            return ResultError(Status::InternalError<false>(
+                    "cannot find storage resource. resource_id={}", resource_id()));
         }
     }
     return &_storage_resource;

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -23,8 +23,8 @@
 
 #include <cstddef> // for size_t
 #include <cstdint> // for uint32_t
-#include <memory>  // for unique_ptr
-#include <mutex>
+#include <map>
+#include <memory> // for unique_ptr
 #include <string>
 #include <utility>
 #include <vector>

--- a/be/src/util/bthread_utils.h
+++ b/be/src/util/bthread_utils.h
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <bthread/bthread.h>
+
+#include <functional>
+#include <memory>
+
+#include "runtime/thread_context.h"
+
+namespace doris {
+
+// Launch a callable in a background bthread (fire-and-forget).
+// The callable is heap-allocated and deleted after execution.
+// Returns true on success, false if bthread creation failed (callable is still deleted).
+//
+// init_thread_ctx: when true, initialises the bthread's thread-local ThreadContext via
+// ScopedInitThreadContext before invoking fn.  Set this when the bthread needs memory-tracker
+// or workload-group context (e.g. attaches an AttachTask inside fn).  Defaults to false so
+// existing call-sites that do not need thread-context initialisation are unaffected.
+template <typename Fn>
+bool start_bthread(Fn&& fn, bool init_thread_ctx = false, const bthread_attr_t* attr = nullptr) {
+    struct Args {
+        std::function<void()> fn;
+        bool init_thread_ctx;
+    };
+    auto args = std::make_unique<Args>(Args {std::forward<Fn>(fn), init_thread_ctx});
+    auto entry = [](void* arg) -> void* {
+        // Reclaim ownership so Args is deleted when this scope exits.
+        auto a = std::unique_ptr<Args>(reinterpret_cast<Args*>(arg));
+        std::optional<ScopedInitThreadContext> scoped;
+        if (a->init_thread_ctx) {
+            scoped.emplace();
+        }
+        a->fn();
+        return nullptr;
+    };
+    bthread_t tid;
+    if (bthread_start_background(&tid, attr, entry, args.get()) != 0) {
+        return false; // args unique_ptr destructs here, no leak
+    }
+    args.release(); // bthread entry now owns the pointer
+    return true;
+}
+
+} // namespace doris

--- a/be/test/cloud/cloud_warm_up_manager_peer_test.cpp
+++ b/be/test/cloud/cloud_warm_up_manager_peer_test.cpp
@@ -1,0 +1,527 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Unit tests for CloudWarmUpManager peer candidate management.
+// Tests cover record_balanced_tablet, get_peer_candidates,
+// update_peer_candidate_on_success, update_peer_candidate_on_rpc_failure,
+// and remove_balanced_tablet.
+
+#include <gtest/gtest.h>
+
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_warm_up_manager.h"
+#include "cloud/config.h"
+#include "util/defer_op.h"
+
+namespace doris {
+
+// ============================================================
+// Test fixture
+// ============================================================
+
+class CloudWarmUpManagerPeerTest : public testing::Test {
+public:
+    CloudWarmUpManagerPeerTest()
+            : _engine(CloudStorageEngine(EngineOptions {})),
+              _mgr(std::make_unique<CloudWarmUpManager>(_engine)) {}
+
+protected:
+    CloudStorageEngine _engine;
+    std::unique_ptr<CloudWarmUpManager> _mgr;
+};
+
+// ============================================================
+// record_balanced_tablet / get_peer_candidates
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, get_peer_candidates_unknown_tablet_returns_empty) {
+    auto candidates = _mgr->get_peer_candidates(99999);
+    EXPECT_TRUE(candidates.empty());
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, record_single_candidate_and_retrieve) {
+    constexpr int64_t tablet_id = 100;
+    _mgr->record_balanced_tablet(tablet_id, "192.168.0.1", 9060, "cg_a");
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates.size(), 1u);
+    EXPECT_EQ(candidates[0].host, "192.168.0.1");
+    EXPECT_EQ(candidates[0].brpc_port, 9060);
+    EXPECT_EQ(candidates[0].compute_group_id, "cg_a");
+    EXPECT_EQ(candidates[0].consecutive_rpc_failures, 0);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, record_warmup_candidate_upserts_same_cg) {
+    // Warm-up rebalance: a tablet has at most one warm-up peer (the current rebalance source).
+    // Repeated calls with the same compute_group_id should upsert (update) not accumulate.
+    constexpr int64_t tablet_id = 200;
+    _mgr->record_balanced_tablet(tablet_id, "host_first", 9060, "cg_self");
+    _mgr->record_balanced_tablet(tablet_id, "host_second", 9061, "cg_self");
+    _mgr->record_balanced_tablet(tablet_id, "host_third", 9062, "cg_self");
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    // Still only 1 candidate — latest rebalance source wins.
+    ASSERT_EQ(candidates.size(), 1u);
+    EXPECT_EQ(candidates[0].host, "host_third");
+    EXPECT_EQ(candidates[0].brpc_port, 9062);
+    EXPECT_EQ(candidates[0].compute_group_id, "cg_self");
+    EXPECT_EQ(candidates[0].consecutive_rpc_failures, 0);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, record_with_empty_compute_group_id) {
+    constexpr int64_t tablet_id = 300;
+    _mgr->record_balanced_tablet(tablet_id, "10.0.0.1", 9060);
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates.size(), 1u);
+    EXPECT_TRUE(candidates[0].compute_group_id.empty());
+}
+
+// ============================================================
+// update_peer_candidate_on_success
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, update_on_success_sets_last_successful_cg) {
+    constexpr int64_t tablet_id = 400;
+    _mgr->record_balanced_tablet(tablet_id, "10.0.0.2", 9060, "cg_peer");
+
+    // Verify candidates are present.
+    auto candidates_before = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_FALSE(candidates_before.empty());
+
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_peer");
+
+    // get_peer_candidates still returns the same candidates.
+    auto candidates_after = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates_after.size(), 1u);
+    EXPECT_EQ(candidates_after[0].compute_group_id, "cg_peer");
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, update_on_success_noop_for_unknown_tablet) {
+    // Should not crash or throw.
+    _mgr->update_peer_candidate_on_success(99998, "cg_x");
+}
+
+// ============================================================
+// update_peer_candidate_on_rpc_failure
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, rpc_failure_increments_counter) {
+    constexpr int64_t tablet_id = 500;
+    _mgr->record_balanced_tablet(tablet_id, "10.0.0.3", 9060, "cg_b");
+
+    _mgr->update_peer_candidate_on_rpc_failure(tablet_id, "10.0.0.3", 9060);
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates.size(), 1u);
+    EXPECT_EQ(candidates[0].consecutive_rpc_failures, 1);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rpc_failure_evicts_at_threshold) {
+    constexpr int64_t tablet_id = 600;
+    const int threshold = config::peer_rpc_failure_eviction_threshold;
+    ASSERT_GT(threshold, 0) << "threshold must be positive";
+
+    _mgr->record_balanced_tablet(tablet_id, "10.0.0.4", 9060, "cg_c");
+
+    // Apply (threshold - 1) failures: candidate should still be present.
+    for (int i = 0; i < threshold - 1; ++i) {
+        _mgr->update_peer_candidate_on_rpc_failure(tablet_id, "10.0.0.4", 9060);
+        auto candidates = _mgr->get_peer_candidates(tablet_id);
+        ASSERT_EQ(candidates.size(), 1u) << "candidate evicted too early on iteration " << i + 1;
+        EXPECT_EQ(candidates[0].consecutive_rpc_failures, i + 1);
+    }
+
+    // One more failure should trigger eviction.
+    _mgr->update_peer_candidate_on_rpc_failure(tablet_id, "10.0.0.4", 9060);
+    auto candidates_after = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_TRUE(candidates_after.empty()) << "candidate should have been evicted";
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rpc_failure_evicts_matching_candidate_only) {
+    constexpr int64_t tablet_id = 700;
+    const int threshold = config::peer_rpc_failure_eviction_threshold;
+
+    _mgr->record_balanced_tablet(tablet_id, "host_keep", 9060, "cg_keep");
+    _mgr->record_balanced_tablet(tablet_id, "host_evict", 9061, "cg_evict");
+
+    // Exhaust failures only for host_evict.
+    for (int i = 0; i < threshold; ++i) {
+        _mgr->update_peer_candidate_on_rpc_failure(tablet_id, "host_evict", 9061);
+    }
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates.size(), 1u);
+    EXPECT_EQ(candidates[0].host, "host_keep");
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rpc_failure_noop_for_unknown_tablet) {
+    // Should not crash.
+    _mgr->update_peer_candidate_on_rpc_failure(99997, "1.2.3.4", 9060);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rpc_failure_noop_for_unmatched_host_port) {
+    constexpr int64_t tablet_id = 750;
+    _mgr->record_balanced_tablet(tablet_id, "10.0.0.5", 9060, "cg_d");
+
+    // Different host/port — should not modify the existing candidate.
+    _mgr->update_peer_candidate_on_rpc_failure(tablet_id, "10.0.0.5", 9999);
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates.size(), 1u);
+    EXPECT_EQ(candidates[0].consecutive_rpc_failures, 0);
+}
+
+// ============================================================
+// remove_balanced_tablet
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, remove_balanced_tablet_clears_entry) {
+    constexpr int64_t tablet_id = 800;
+    _mgr->record_balanced_tablet(tablet_id, "10.0.0.6", 9060, "cg_e");
+
+    auto before = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_FALSE(before.empty());
+
+    _mgr->remove_balanced_tablet(tablet_id);
+
+    auto after = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_TRUE(after.empty());
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, remove_balanced_tablet_noop_for_unknown) {
+    // Should not crash.
+    _mgr->remove_balanced_tablet(99996);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, remove_does_not_affect_other_tablets) {
+    _mgr->record_balanced_tablet(1001, "h1", 9060, "cg_1");
+    _mgr->record_balanced_tablet(1002, "h2", 9060, "cg_2");
+
+    _mgr->remove_balanced_tablet(1001);
+
+    EXPECT_TRUE(_mgr->get_peer_candidates(1001).empty());
+    auto other = _mgr->get_peer_candidates(1002);
+    ASSERT_EQ(other.size(), 1u);
+    EXPECT_EQ(other[0].host, "h2");
+}
+
+// ============================================================
+// affinity: get_peer_candidates reorders by last_successful_cg (Issue 3)
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, affinity_puts_preferred_cg_first) {
+    constexpr int64_t tablet_id = 1100;
+    // Register two candidates from different CGs.
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+
+    // Initially no preference: verify both are present.
+    auto before = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(before.size(), 2u);
+
+    // Simulate a successful read from cg_b.
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_b");
+
+    // After affinity update, cg_b candidate should be at the front.
+    auto after = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(after.size(), 2u);
+    EXPECT_EQ(after[0].compute_group_id, "cg_b")
+            << "preferred CG must be moved to front by stable_partition";
+    EXPECT_EQ(after[1].compute_group_id, "cg_a");
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, affinity_noop_when_already_first) {
+    constexpr int64_t tablet_id = 1200;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+
+    // host_b was inserted last → it is at front.
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_b");
+    auto result = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(result[0].compute_group_id, "cg_b");
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, affinity_unchanged_by_get_only) {
+    constexpr int64_t tablet_id = 1300;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+
+    // Reading candidates must NOT persist the reordering into the stored list.
+    // get_peer_candidates returns a copy; calling it again should yield the same order.
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_a");
+    auto first_call = _mgr->get_peer_candidates(tablet_id);
+    auto second_call = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(first_call.size(), second_call.size());
+    for (size_t i = 0; i < first_call.size(); ++i) {
+        EXPECT_EQ(first_call[i].compute_group_id, second_call[i].compute_group_id)
+                << "candidate order must be stable across repeated get calls";
+    }
+}
+
+// ============================================================
+// rotate_peer_candidate_on_cache_miss (Issue 3)
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, rotate_on_cache_miss_moves_candidate_to_end) {
+    constexpr int64_t tablet_id = 1400;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+    _mgr->record_balanced_tablet(tablet_id, "host_c", 9062, "cg_c");
+
+    // Candidates are [host_c, host_b, host_a] (newest inserted first).
+    // Rotate the front candidate (host_c).
+    auto before = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(before.size(), 3u);
+    const std::string front_host = before[0].host;
+    _mgr->rotate_peer_candidate_on_cache_miss(tablet_id, front_host, before[0].brpc_port);
+
+    auto after = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(after.size(), 3u);
+    // front_host must have moved to the end.
+    EXPECT_EQ(after[2].host, front_host) << "cache-miss candidate must be rotated to end of list";
+    EXPECT_NE(after[0].host, front_host) << "front of list must have changed after rotate";
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rotate_on_cache_miss_noop_for_last_element) {
+    constexpr int64_t tablet_id = 1500;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+
+    auto candidates = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(candidates.size(), 2u);
+    // Rotate the last candidate → should be a noop.
+    const auto& last = candidates.back();
+    _mgr->rotate_peer_candidate_on_cache_miss(tablet_id, last.host, last.brpc_port);
+
+    auto after = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(after.size(), 2u);
+    EXPECT_EQ(after[0].host, candidates[0].host);
+    EXPECT_EQ(after[1].host, candidates[1].host);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rotate_on_cache_miss_noop_for_unknown_tablet) {
+    // Should not crash.
+    _mgr->rotate_peer_candidate_on_cache_miss(99993, "1.2.3.4", 9060);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rotate_on_cache_miss_noop_for_unmatched_host) {
+    constexpr int64_t tablet_id = 1600;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+
+    auto before = _mgr->get_peer_candidates(tablet_id);
+    // Rotate with a host/port that doesn't match → noop.
+    _mgr->rotate_peer_candidate_on_cache_miss(tablet_id, "nonexistent", 9999);
+
+    auto after = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(after.size(), before.size());
+    for (size_t i = 0; i < before.size(); ++i) {
+        EXPECT_EQ(after[i].host, before[i].host);
+    }
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, rotate_distributes_over_all_candidates) {
+    // Verifies that repeatedly rotating the front candidate cycles through all CGs.
+    constexpr int64_t tablet_id = 1700;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9061, "cg_b");
+    _mgr->record_balanced_tablet(tablet_id, "host_c", 9062, "cg_c");
+
+    std::set<std::string> seen_front;
+    // After N rotations of the front element every candidate should have been at front.
+    for (int round = 0; round < 3; ++round) {
+        auto cands = _mgr->get_peer_candidates(tablet_id);
+        ASSERT_EQ(cands.size(), 3u);
+        seen_front.insert(cands[0].host);
+        _mgr->rotate_peer_candidate_on_cache_miss(tablet_id, cands[0].host, cands[0].brpc_port);
+    }
+    EXPECT_EQ(seen_front.size(), 3u) << "each of the 3 candidates must appear at front once";
+}
+
+// Regression test for the rotate+affinity deadlock (Issue 3).
+//
+// Before fix: rotate_peer_candidate_on_cache_miss() moved the preferred CG to the end of
+// the storage list, but get_peer_candidates() applies stable_partition every time using the
+// unchanged last_successful_compute_group_id. On the very next call, stable_partition would
+// promote the preferred CG back to the front — completely undoing the rotate.
+//
+// Fix: rotate also clears last_successful_compute_group_id when the rotated candidate belongs
+// to the currently preferred CG.
+TEST_F(CloudWarmUpManagerPeerTest, rotate_on_cache_miss_clears_affinity_for_preferred_cg) {
+    constexpr int64_t tablet_id = 1800;
+    // storage after inserts (last inserted goes to front):
+    //   [cg_b@host_b, cg_a@host_a]
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9070, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9071, "cg_b");
+
+    // Simulate a prior successful read from cg_b: cg_b is now the preferred CG.
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_b");
+
+    // get_peer_candidates() with affinity: cg_b moves to front → [cg_b, cg_a].
+    auto cands_before = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(cands_before.size(), 2u);
+    EXPECT_EQ(cands_before[0].compute_group_id, "cg_b") << "affinity must promote cg_b to front";
+
+    // cg_b now misses its cache: rotate it away.
+    _mgr->rotate_peer_candidate_on_cache_miss(tablet_id, "host_b", 9071);
+
+    // After rotate: cg_b should no longer be at the front AND the affinity for cg_b must have
+    // been cleared.  Without the fix, get_peer_candidates() would stable_partition cg_b back
+    // to front and the rotate would be a no-op from the caller's perspective.
+    auto cands_after = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(cands_after.size(), 2u);
+    EXPECT_EQ(cands_after[0].compute_group_id, "cg_a")
+            << "after rotating preferred CG on miss, the other CG must appear first";
+    EXPECT_NE(cands_after[0].compute_group_id, "cg_b")
+            << "cg_b must not reappear at front after rotate cleared its affinity";
+}
+
+// Verify that rotate does NOT clear affinity when a non-preferred CG is rotated.
+TEST_F(CloudWarmUpManagerPeerTest, rotate_non_preferred_cg_preserves_affinity) {
+    constexpr int64_t tablet_id = 1900;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9080, "cg_a");
+    _mgr->record_balanced_tablet(tablet_id, "host_b", 9081, "cg_b");
+
+    // cg_a is preferred.
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_a");
+
+    // Rotate cg_b (non-preferred) on cache miss — affinity for cg_a must be preserved.
+    _mgr->rotate_peer_candidate_on_cache_miss(tablet_id, "host_b", 9081);
+
+    // cg_a is still preferred; get_peer_candidates() promotes it to front.
+    auto cands = _mgr->get_peer_candidates(tablet_id);
+    ASSERT_EQ(cands.size(), 2u);
+    EXPECT_EQ(cands[0].compute_group_id, "cg_a")
+            << "affinity for cg_a must survive a rotate of a different CG";
+}
+
+// ============================================================
+// Tablet-level cooldown (consecutive all-miss)
+// ============================================================
+
+TEST_F(CloudWarmUpManagerPeerTest, cooldown_not_triggered_below_threshold) {
+    constexpr int64_t tablet_id = 2000;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    config::peer_all_miss_cooldown_threshold = 3;
+    Defer restore {[old_threshold]() { config::peer_all_miss_cooldown_threshold = old_threshold; }};
+
+    // Record 2 all-miss (below threshold of 3) — should NOT enter cooldown.
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->record_peer_all_miss(tablet_id);
+
+    EXPECT_FALSE(_mgr->is_peer_cooldown(tablet_id));
+    auto cands = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_EQ(cands.size(), 1u) << "below threshold: candidates must still be returned";
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, cooldown_triggered_at_threshold) {
+    constexpr int64_t tablet_id = 2001;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    const int64_t old_duration = config::peer_all_miss_cooldown_duration_s;
+    config::peer_all_miss_cooldown_threshold = 3;
+    config::peer_all_miss_cooldown_duration_s = 600; // 10 minutes
+    Defer restore {[old_threshold, old_duration]() {
+        config::peer_all_miss_cooldown_threshold = old_threshold;
+        config::peer_all_miss_cooldown_duration_s = old_duration;
+    }};
+
+    // Hit threshold exactly.
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->record_peer_all_miss(tablet_id);
+
+    EXPECT_TRUE(_mgr->is_peer_cooldown(tablet_id));
+    auto cands = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_TRUE(cands.empty()) << "cooldown active: get_peer_candidates must return empty";
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, cooldown_reset_by_success) {
+    constexpr int64_t tablet_id = 2002;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    config::peer_all_miss_cooldown_threshold = 3;
+    Defer restore {[old_threshold]() { config::peer_all_miss_cooldown_threshold = old_threshold; }};
+
+    // Accumulate 2 misses, then a success resets the counter.
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_a");
+
+    // 2 more misses — still below threshold (counter was reset).
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->record_peer_all_miss(tablet_id);
+
+    EXPECT_FALSE(_mgr->is_peer_cooldown(tablet_id));
+    auto cands = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_EQ(cands.size(), 1u);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, cooldown_success_clears_active_cooldown) {
+    constexpr int64_t tablet_id = 2003;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    config::peer_all_miss_cooldown_threshold = 2;
+    Defer restore {[old_threshold]() { config::peer_all_miss_cooldown_threshold = old_threshold; }};
+
+    // Enter cooldown.
+    _mgr->record_peer_all_miss(tablet_id);
+    _mgr->record_peer_all_miss(tablet_id);
+    ASSERT_TRUE(_mgr->is_peer_cooldown(tablet_id));
+
+    // A success while in cooldown clears it immediately.
+    _mgr->update_peer_candidate_on_success(tablet_id, "cg_a");
+    EXPECT_FALSE(_mgr->is_peer_cooldown(tablet_id));
+    auto cands = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_EQ(cands.size(), 1u);
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, cooldown_expires_after_duration) {
+    constexpr int64_t tablet_id = 2004;
+    _mgr->record_balanced_tablet(tablet_id, "host_a", 9060, "cg_a");
+
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    const int64_t old_duration = config::peer_all_miss_cooldown_duration_s;
+    config::peer_all_miss_cooldown_threshold = 1;
+    config::peer_all_miss_cooldown_duration_s = 0; // expire immediately
+    Defer restore {[old_threshold, old_duration]() {
+        config::peer_all_miss_cooldown_threshold = old_threshold;
+        config::peer_all_miss_cooldown_duration_s = old_duration;
+    }};
+
+    _mgr->record_peer_all_miss(tablet_id);
+    // cooldown_duration_s = 0 → cooldown_until_ms = now + 0 → already expired.
+    // is_peer_cooldown checks now < cooldown_until_ms, which is false.
+    EXPECT_FALSE(_mgr->is_peer_cooldown(tablet_id));
+    auto cands = _mgr->get_peer_candidates(tablet_id);
+    EXPECT_EQ(cands.size(), 1u) << "expired cooldown: candidates must be returned";
+}
+
+TEST_F(CloudWarmUpManagerPeerTest, cooldown_noop_for_unknown_tablet) {
+    // Should not crash or create phantom entries.
+    _mgr->record_peer_all_miss(99999);
+    EXPECT_FALSE(_mgr->is_peer_cooldown(99999));
+}
+
+} // namespace doris

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -18,17 +18,20 @@
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Interpreters/tests/gtest_lru_file_cache.cpp
 // and modified by Doris
 
+#include <butil/iobuf.h>
+
 #include <atomic>
 #include <future>
 
 #include "io/cache/block_file_cache_test_common.h"
+#include "io/cache/shard_mem_cache.h"
 #include "io/fs/buffered_reader.h"
 #include "storage/olap_define.h"
-
+#include "util/debug_points.h"
+#include "util/defer_op.h"
 namespace doris::io {
 
 class FileBlockTestAccessor {
-public:
     static void set_state(FileBlock& block, FileBlock::State state) {
         block._download_state = state;
     }
@@ -36,12 +39,188 @@ public:
     static void set_downloaded_size(FileBlock& block, size_t size) {
         block._downloaded_size = size;
     }
-
     static Status call_set_downloaded(FileBlock& block) {
         std::lock_guard<std::mutex> lock(block._mutex);
         return block.set_downloaded(lock);
     }
 };
+
+namespace {
+
+constexpr size_t kCachedRemoteReaderTinyBlockSize = 4;
+
+io::FileCacheSettings create_cached_remote_reader_tiny_settings(size_t block_size,
+                                                                std::string storage = "disk") {
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 64;
+    settings.query_queue_elements = 16;
+    settings.index_queue_size = 64;
+    settings.index_queue_elements = 16;
+    settings.disposable_queue_size = 64;
+    settings.disposable_queue_elements = 16;
+    settings.capacity = 64;
+    settings.max_file_block_size = block_size;
+    settings.max_query_cache_size = 0;
+    settings.storage = std::move(storage);
+    return settings;
+}
+
+void clear_cached_remote_reader_factory() {
+    FileCacheFactory::instance()->_caches.clear();
+    FileCacheFactory::instance()->_path_to_cache.clear();
+    FileCacheFactory::instance()->_capacity = 0;
+}
+
+io::BlockFileCache* create_cached_remote_reader_test_cache(const fs::path& cache_path,
+                                                           size_t block_size,
+                                                           std::string storage = "disk") {
+    std::error_code ec;
+    fs::remove_all(cache_path, ec);
+    if (storage != "memory") {
+        fs::create_directories(cache_path);
+    }
+    const std::string cache_base_path = storage == "memory" ? "memory" : cache_path.string();
+    auto st = FileCacheFactory::instance()->create_file_cache(
+            cache_base_path,
+            create_cached_remote_reader_tiny_settings(block_size, std::move(storage)));
+    CHECK(st.ok()) << st;
+    auto* cache = FileCacheFactory::instance()->_path_to_cache[cache_base_path];
+    CHECK(cache != nullptr) << cache_base_path;
+    wait_until_cache_ready(*cache);
+    return cache;
+}
+
+fs::path create_cached_remote_reader_test_file(const std::string& name, std::string_view content) {
+    fs::path file_path = caches_dir / name;
+    std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
+    CHECK(out.is_open()) << file_path;
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    out.close();
+    return file_path;
+}
+
+io::CacheContext create_cached_remote_reader_context(ReadStatistics* stats) {
+    io::CacheContext context;
+    context.stats = stats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    return context;
+}
+
+void append_cached_remote_reader_block(io::FileBlockSPtr file_block, std::string_view content) {
+    ASSERT_EQ(file_block->get_or_set_downloader(), io::FileBlock::get_caller_id());
+    const size_t left = file_block->range().left;
+    const size_t size = file_block->range().size();
+    ASSERT_LE(left + size, content.size());
+    // content stores the whole file payload, so this block appends only its own byte range.
+    ASSERT_TRUE(file_block->append(Slice(content.data() + left, size)).ok());
+    ASSERT_TRUE(file_block->finalize().ok());
+}
+
+void append_cached_remote_reader_blockv(io::FileBlockSPtr file_block,
+                                        const std::vector<std::string_view>& parts) {
+    ASSERT_EQ(file_block->get_or_set_downloader(), io::FileBlock::get_caller_id());
+    std::vector<Slice> slices;
+    slices.reserve(parts.size());
+    size_t total_size = 0;
+    for (const auto& part : parts) {
+        slices.emplace_back(part.data(), part.size());
+        total_size += part.size();
+    }
+    ASSERT_EQ(total_size, file_block->range().size());
+    ASSERT_TRUE(file_block->appendv(slices.data(), slices.size()).ok());
+    ASSERT_TRUE(file_block->finalize().ok());
+}
+
+void append_cached_remote_reader_block_iobuf(io::FileBlockSPtr file_block,
+                                             const std::vector<std::string_view>& parts) {
+    ASSERT_EQ(file_block->get_or_set_downloader(), io::FileBlock::get_caller_id());
+    butil::IOBuf payload;
+    size_t total_size = 0;
+    for (const auto& part : parts) {
+        payload.append(part.data(), part.size());
+        total_size += part.size();
+    }
+    ASSERT_EQ(total_size, file_block->range().size());
+    ASSERT_TRUE(file_block->append_iobuf(payload).ok());
+    ASSERT_TRUE(file_block->finalize().ok());
+}
+
+size_t count_cached_remote_reader_tmp_files(const fs::path& cache_path) {
+    std::error_code ec;
+    if (!fs::exists(cache_path, ec)) {
+        return 0;
+    }
+
+    size_t tmp_file_count = 0;
+    for (fs::recursive_directory_iterator it(cache_path, ec), end; it != end && !ec;
+         it.increment(ec)) {
+        if (!it->is_regular_file()) {
+            continue;
+        }
+        const auto file_name = it->path().filename().string();
+        if (file_name.size() >= 4 && file_name.compare(file_name.size() - 4, 4, "_tmp") == 0) {
+            ++tmp_file_count;
+        }
+    }
+    return tmp_file_count;
+}
+
+FileCacheKey make_test_file_cache_key(std::string_view key_name, size_t offset = 0) {
+    return FileCacheKey {.hash = io::BlockFileCache::hash(std::string(key_name)),
+                         .offset = offset,
+                         .meta = {.expiration_time = 0, .type = FileCacheType::NORMAL}};
+}
+
+struct MockFallbackAppendvWriterState {
+    int appendv_call_count = 0;
+    size_t appendv_slice_count = 0;
+    std::string captured;
+    size_t bytes_appended = 0;
+    FileWriter::State state = FileWriter::State::OPENED;
+    bool destroyed = false;
+};
+
+class MockFallbackAppendvWriter final : public FileWriter {
+public:
+    explicit MockFallbackAppendvWriter(
+            Status appendv_status = Status::OK(),
+            std::shared_ptr<MockFallbackAppendvWriterState> observed_state =
+                    std::make_shared<MockFallbackAppendvWriterState>())
+            : _appendv_status(std::move(appendv_status)),
+              _observed_state(std::move(observed_state)) {}
+
+    ~MockFallbackAppendvWriter() override { _observed_state->destroyed = true; }
+
+    Status close(bool non_block = false) override {
+        (void)non_block;
+        _observed_state->state = State::CLOSED;
+        return Status::OK();
+    }
+
+    Status appendv(const Slice* data, size_t data_cnt) override {
+        ++_observed_state->appendv_call_count;
+        _observed_state->appendv_slice_count = data_cnt;
+        if (!_appendv_status.ok()) {
+            return _appendv_status;
+        }
+        for (size_t idx = 0; idx < data_cnt; ++idx) {
+            _observed_state->captured.append(data[idx].data, data[idx].size);
+            _observed_state->bytes_appended += data[idx].size;
+        }
+        return Status::OK();
+    }
+
+    const Path& path() const override { return _path; }
+    size_t bytes_appended() const override { return _observed_state->bytes_appended; }
+    State state() const override { return _observed_state->state; }
+
+private:
+    Path _path {"mock_fallback_appendv_writer"};
+    Status _appendv_status;
+    std::shared_ptr<MockFallbackAppendvWriterState> _observed_state;
+};
+
+} // namespace
 
 fs::path caches_dir = fs::current_path() / "lru_cache_test";
 std::string cache_base_path = caches_dir / "cache1" / "";
@@ -4129,6 +4308,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_error_handle) {
         ASSERT_TRUE(
                 reader.read_at(0, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
         EXPECT_EQ(std::string(64_kb, '0'), buffer);
+        EXPECT_EQ(stats.bytes_write_into_cache, 0);
     }
     {
         Defer defer {[sp] { sp->clear_call_back("LocalFileWriter::close"); }};
@@ -4145,6 +4325,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_error_handle) {
         ASSERT_TRUE(
                 reader.read_at(0, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
         EXPECT_EQ(std::string(64_kb, '0'), buffer);
+        EXPECT_EQ(stats.bytes_write_into_cache, 0);
     }
     EXPECT_TRUE(reader.close().ok());
     EXPECT_TRUE(reader.closed());
@@ -4573,6 +4754,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_init) {
     io::FileReaderOptions opts;
     opts.cache_type = io::cache_type_from_string("file_block_cache");
     opts.is_doris_table = false;
+    opts.tablet_id = 10086;
     {
         opts.mtime = UnixSeconds() - 1000;
         CachedRemoteFileReader reader(local_reader, opts);
@@ -4637,6 +4819,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_concurrent) {
     opts.is_doris_table = true;
     opts.tablet_id = 10086;
     bool flag1 = false;
+    opts.tablet_id = 10086;
     auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
     auto sp = SyncPoint::get_instance();
     sp->enable_processing();
@@ -4875,6 +5058,37 @@ TEST_F(BlockFileCacheTest, test_async_load_with_error_file_1) {
     context.stats = &rstats;
     context.cache_type = io::FileCacheType::INDEX;
     auto key = io::BlockFileCache::hash("key1");
+    auto key_str = key.to_string();
+    auto dir = fs::path(cache_base_path) / key_str.substr(0, 3) / (key_str + "_0");
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "BlockFileCache::TmpFile1",
+            [&](auto&&) {
+                FileWriterPtr writer;
+                ASSERT_TRUE(global_local_filesystem()->create_file(dir / "error", &writer).ok());
+                ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
+                ASSERT_TRUE(writer->close().ok());
+
+                ASSERT_TRUE(
+                        global_local_filesystem()->create_file(dir / "10086_tmp", &writer).ok());
+                ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
+                ASSERT_TRUE(writer->close().ok());
+
+                ASSERT_TRUE(
+                        global_local_filesystem()->create_file(dir / "20086_idx", &writer).ok());
+                ASSERT_TRUE(writer->close().ok());
+
+                ASSERT_TRUE(
+                        global_local_filesystem()->create_file(dir / "30086_idx", &writer).ok());
+                ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
+                ASSERT_TRUE(writer->close().ok());
+            },
+            &guard1);
+    sp->set_call_back("BlockFileCache::REMOVE_FILE", [&](auto&& args) {
+        if (*try_any_cast<std::string*>(args[0]) == "30086_idx") {
+            static_cast<void>(global_local_filesystem()->delete_file(dir / "30086_idx"));
+        }
+    });
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
@@ -4883,40 +5097,12 @@ TEST_F(BlockFileCacheTest, test_async_load_with_error_file_1) {
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    std::string dir;
-    if (auto storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
-        storage != nullptr) {
-        dir = storage->get_path_in_local_cache_v2(key, 0);
-    }
-    sp->set_call_back("BlockFileCache::TmpFile1", [&](auto&&) {
-        FileWriterPtr writer;
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "error", &writer).ok());
-        ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
-        ASSERT_TRUE(writer->close().ok());
-
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "10086_tmp", &writer).ok());
-        ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
-        ASSERT_TRUE(writer->close().ok());
-
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "20086_idx", &writer).ok());
-        ASSERT_TRUE(writer->close().ok());
-
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "30086_idx", &writer).ok());
-        ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
-        ASSERT_TRUE(writer->close().ok());
-    });
-    sp->set_call_back("BlockFileCache::REMOVE_FILE", [&](auto&& args) {
-        if (*try_any_cast<std::string*>(args[0]) == "30086_idx") {
-            static_cast<void>(global_local_filesystem()->delete_file(dir / "30086_idx"));
-        }
-    });
     auto holder = cache.get_or_set(key, 100, 1, context); /// Add range [9, 9]
     auto blocks = fromHolder(holder);
     ASSERT_EQ(blocks.size(), 1);
     assert_range(1, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::EMPTY);
     ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
-    auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
                   (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
@@ -4959,40 +5145,48 @@ TEST_F(BlockFileCacheTest, test_async_load_with_error_file_2) {
     }
     std::atomic_bool flag1 = false;
     std::atomic_bool flag2 = false;
-    sp->set_call_back("BlockFileCache::TmpFile1", [&](auto&&) {
-        FileWriterPtr writer;
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "error", &writer).ok());
-        ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
-        ASSERT_TRUE(writer->close().ok());
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "BlockFileCache::TmpFile1",
+            [&](auto&&) {
+                FileWriterPtr writer;
+                ASSERT_TRUE(global_local_filesystem()->create_file(dir / "error", &writer).ok());
+                ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
+                ASSERT_TRUE(writer->close().ok());
 
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "10086_tmp", &writer).ok());
-        ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
-        ASSERT_TRUE(writer->close().ok());
+                ASSERT_TRUE(
+                        global_local_filesystem()->create_file(dir / "10086_tmp", &writer).ok());
+                ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
+                ASSERT_TRUE(writer->close().ok());
 
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "20086_idx", &writer).ok());
-        ASSERT_TRUE(writer->close().ok());
+                ASSERT_TRUE(
+                        global_local_filesystem()->create_file(dir / "20086_idx", &writer).ok());
+                ASSERT_TRUE(writer->close().ok());
 
-        ASSERT_TRUE(global_local_filesystem()->create_file(dir / "30086_idx", &writer).ok());
-        ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
-        ASSERT_TRUE(writer->close().ok());
-        flag2 = true;
-        while (!flag1) {
-        }
-    });
+                ASSERT_TRUE(
+                        global_local_filesystem()->create_file(dir / "30086_idx", &writer).ok());
+                ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
+                ASSERT_TRUE(writer->close().ok());
+                while (!flag1) {
+                }
+            },
+            &guard1);
+    SyncPoint::CallbackGuard guard2;
+    sp->set_call_back(
+            "BlockFileCache::TmpFile2", [&](auto&&) { flag2 = true; }, &guard2);
     sp->set_call_back("BlockFileCache::REMOVE_FILE", [&](auto&& args) {
         if (*try_any_cast<std::string*>(args[0]) == "30086_idx") {
             static_cast<void>(global_local_filesystem()->delete_file(dir / "30086_idx"));
         }
     });
-    while (!flag2) {
-    }
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
     auto holder = cache.get_or_set(key, 100, 1, context); /// Add range [9, 9]
     auto blocks = fromHolder(holder);
     ASSERT_EQ(blocks.size(), 1);
     assert_range(1, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::EMPTY);
     ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
     assert_range(2, blocks[0], io::FileBlock::Range(100, 100), io::FileBlock::State::DOWNLOADING);
-    auto key_str = key.to_string();
     auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
                   (key_str + "_" + std::to_string(blocks[0]->expiration_time()));
     ASSERT_TRUE(fs::exists(subdir));
@@ -5002,6 +5196,10 @@ TEST_F(BlockFileCacheTest, test_async_load_with_error_file_2) {
     ASSERT_TRUE(blocks[0]->append(result));
     ASSERT_TRUE(blocks[0]->finalize());
     flag1 = true;
+    for (int i = 0; i < 100 && !flag2; i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(flag2);
     for (int i = 0; i < 100; i++) {
         if (cache.get_async_open_success()) {
             break;
@@ -7325,6 +7523,62 @@ TEST_F(BlockFileCacheTest, evict_in_advance) {
     }
 }
 
+TEST_F(BlockFileCacheTest, evict_in_advance_skip_warmup_blocks) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.ttl_queue_size = 5000000;
+    settings.ttl_queue_elements = 50000;
+    settings.query_queue_size = 3000000;
+    settings.query_queue_elements = 30000;
+    settings.index_queue_size = 1000000;
+    settings.index_queue_elements = 10000;
+    settings.disposable_queue_size = 1000000;
+    settings.disposable_queue_elements = 10000;
+    settings.capacity = 10000000;
+    settings.max_file_block_size = 100000;
+    settings.max_query_cache_size = 30;
+
+    const auto origin_enable = config::enable_evict_file_cache_in_advance;
+    const auto origin_batch = config::file_cache_evict_in_advance_batch_bytes;
+    Defer defer {[&]() {
+        config::enable_evict_file_cache_in_advance = origin_enable;
+        config::file_cache_evict_in_advance_batch_bytes = origin_batch;
+        if (fs::exists(cache_base_path)) {
+            fs::remove_all(cache_base_path);
+        }
+    }};
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    wait_until_cache_ready(cache);
+
+    cache._need_evict_cache_in_advance = true;
+    config::enable_evict_file_cache_in_advance = true;
+    config::file_cache_evict_in_advance_batch_bytes = 100000;
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    context.is_warmup = true;
+
+    auto key = io::BlockFileCache::hash("warmup-key");
+    auto holder = cache.get_or_set(key, 0, 100000, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    download(blocks[0]);
+    blocks.clear();
+
+    ASSERT_EQ(cache.get_stats_unsafe()["normal_queue_curr_size"], 100000);
+    std::this_thread::sleep_for(
+            std::chrono::milliseconds(config::file_cache_evict_in_advance_interval_ms * 2));
+    ASSERT_EQ(cache.get_stats_unsafe()["normal_queue_curr_size"], 100000);
+}
+
 TEST_F(BlockFileCacheTest, test_check_need_evict_cache_in_advance) {
     std::string cache_base_path = "./ut_file_cache_dir";
     fs::create_directories(cache_base_path);
@@ -7467,6 +7721,7 @@ TEST_F(BlockFileCacheTest, test_evict_cache_in_advance_skip) {
     int64_t origin_enter = config::file_cache_enter_need_evict_cache_in_advance_percent;
     int64_t origin_exit = config::file_cache_exit_need_evict_cache_in_advance_percent;
     int64_t origin_threshold = config::file_cache_evict_in_advance_recycle_keys_num_threshold;
+    int64_t origin_gc_interval_ms = config::file_cache_background_gc_interval_ms;
     config::file_cache_enter_need_evict_cache_in_advance_percent = 70;
     config::file_cache_exit_need_evict_cache_in_advance_percent = 65;
     config::file_cache_background_gc_interval_ms = 10000000; // no gc at all
@@ -7543,6 +7798,14 @@ TEST_F(BlockFileCacheTest, test_evict_cache_in_advance_skip) {
     config::file_cache_enter_need_evict_cache_in_advance_percent = origin_enter;
     config::file_cache_exit_need_evict_cache_in_advance_percent = origin_exit;
     config::file_cache_evict_in_advance_recycle_keys_num_threshold = origin_threshold;
+    // Restore the GC interval so subsequent tests don't inherit the
+    // "no gc at all" value (10000000ms): a stale value here makes
+    // ~BlockFileCache wait close to ~3 hours on a benign destructor race
+    // (see block_file_cache.cpp:run_background_gc and the wait_for without
+    // predicate). Restoring here keeps the latent race harmless for other
+    // tests; the underlying race in the production wait_for should still be
+    // fixed independently.
+    config::file_cache_background_gc_interval_ms = origin_gc_interval_ms;
 }
 
 TEST_F(BlockFileCacheTest, validate_get_or_set_crash) {
@@ -8685,23 +8948,6 @@ TEST_F(BlockFileCacheTest, finalize_partial_block) {
     }
 }
 
-TEST_F(BlockFileCacheTest, fs_file_cache_storage_finalize_missing_writer_returns_error) {
-    FSFileCacheStorage storage;
-    FileCacheKey key;
-    key.hash = io::BlockFileCache::hash("finalize-missing-writer");
-    key.offset = 4096;
-    key.meta.type = io::FileCacheType::NORMAL;
-    key.meta.expiration_time = 0;
-    key.meta.tablet_id = 0;
-
-    auto st = storage.finalize(key, 4096);
-
-    EXPECT_TRUE(st.is<ErrorCode::INTERNAL_ERROR>()) << st;
-    EXPECT_TRUE(st.to_string().find("file cache finalize missing writer") != std::string::npos)
-            << st;
-    EXPECT_TRUE(st.to_string().find("offset=4096") != std::string::npos) << st;
-}
-
 TEST_F(BlockFileCacheTest, set_downloaded_empty_block_branch) {
     FileCacheKey key;
     key.hash = io::BlockFileCache::hash("set_downloaded_empty_block_branch");
@@ -8721,79 +8967,373 @@ TEST_F(BlockFileCacheTest, set_downloaded_empty_block_branch) {
     ASSERT_EQ(block.get_downloader(), 0);
 }
 
-// Reproduces OPENSOURCE-325: when fs_file_cache_storage's directory scan reads
-// a file size via std::filesystem::directory_entry::file_size(ec) and the
-// underlying syscall fails (e.g. file removed concurrently by clear/GC), the
-// returned value is (uintmax_t)-1 == UINT64_MAX. Before the fix, that bogus
-// size flowed into BlockFileCache::add_cell, which only logged a WARNING and
-// then registered the cell, polluting _files, the LRU queue's cache_size, and
-// _cur_cache_size. After the fix, add_cell rejects sizes > 1GiB and returns
-// nullptr without touching any internal state.
-TEST_F(BlockFileCacheTest, add_cell_rejects_oversized_size) {
-    if (fs::exists(cache_base_path)) {
-        fs::remove_all(cache_base_path);
+TEST_F(BlockFileCacheTest, cached_remote_file_reader_try_read_from_cached_files_directly_full_hit) {
+    const bool old_enable_direct = config::enable_read_cache_file_directly;
+    config::enable_read_cache_file_directly = false;
+    Defer restore {[&]() { config::enable_read_cache_file_directly = old_enable_direct; }};
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_cached_remote_reader_test_file("cached_remote_reader_direct_full_hit", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_direct_full_hit_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.tablet_id = 10086;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("direct-full-hit"), 0, 8, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 2);
+
+    config::enable_read_cache_file_directly = true;
+    for (auto& block : blocks) {
+        append_cached_remote_reader_block(block, content);
+        reader._insert_file_reader(block);
     }
-    fs::create_directories(cache_base_path);
 
-    io::FileCacheSettings settings;
-    settings.query_queue_size = 30_mb;
-    settings.query_queue_elements = 30;
-    settings.capacity = 30_mb;
-    settings.max_file_block_size = 1_mb;
-    settings.max_query_cache_size = 30;
+    std::string buffer(6, '#');
+    size_t bytes_read = 0;
+    size_t already_read = 0;
+    ReadStatistics read_stats;
+    SourceReadBreakdown source_read_breakdown;
+    EXPECT_TRUE(reader._try_read_from_cached_files_directly(
+            1, Slice(buffer.data(), buffer.size()), buffer.size(), false, read_stats,
+            source_read_breakdown, already_read, &bytes_read));
+    EXPECT_EQ(buffer, "bcdefg");
+    EXPECT_EQ(already_read, buffer.size());
+    EXPECT_EQ(bytes_read, buffer.size());
+    EXPECT_TRUE(read_stats.hit_cache);
+}
 
-    io::BlockFileCache cache(cache_base_path, settings);
-    ASSERT_TRUE(cache.initialize());
-    for (int i = 0; i < 100; ++i) {
-        if (cache.get_async_open_success()) {
-            break;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    ASSERT_TRUE(cache.get_async_open_success());
+TEST_F(BlockFileCacheTest,
+       cached_remote_file_reader_try_read_from_cached_files_directly_partial_and_dryrun) {
+    const bool old_enable_direct = config::enable_read_cache_file_directly;
+    config::enable_read_cache_file_directly = false;
+    Defer restore {[&]() { config::enable_read_cache_file_directly = old_enable_direct; }};
 
-    auto hash = io::BlockFileCache::hash("opensource_325_key");
-    io::CacheContext ctx;
-    TUniqueId qid;
-    qid.hi = 1;
-    qid.lo = 1;
-    ctx.query_id = qid;
-    ctx.cache_type = io::FileCacheType::NORMAL;
-    ReadStatistics rstats;
-    ctx.stats = &rstats;
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cached_remote_reader_test_file(
+            "cached_remote_reader_direct_partial_and_dryrun", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
 
-    const size_t kBadSize = std::numeric_limits<size_t>::max(); // (uintmax_t)-1
-    const size_t kOffset = 1128267776;                          // matches the JIRA report
+    const fs::path cache_path = caches_dir / "cached_remote_reader_direct_partial_and_dryrun_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
 
-    size_t cur_cache_size_before = 0;
-    size_t normal_queue_size_before = 0;
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.tablet_id = 10086;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    auto key = io::BlockFileCache::hash("direct-partial-gap");
+
+    FileBlocksHolder first_holder = cache->get_or_set(key, 0, 4, context);
+    auto first_blocks = fromHolder(first_holder);
+    ASSERT_EQ(first_blocks.size(), 1);
+
+    FileBlocksHolder second_holder = cache->get_or_set(key, 8, 4, context);
+    auto second_blocks = fromHolder(second_holder);
+    ASSERT_EQ(second_blocks.size(), 1);
+
+    config::enable_read_cache_file_directly = true;
+    append_cached_remote_reader_block(first_blocks[0], content);
+    append_cached_remote_reader_block(second_blocks[0], content);
+    reader._insert_file_reader(first_blocks[0]);
+    reader._insert_file_reader(second_blocks[0]);
+
+    std::string partial_buffer(7, '#');
+    size_t partial_bytes_read = 99;
+    size_t partial_already_read = 0;
+    ReadStatistics partial_stats;
+    SourceReadBreakdown partial_source_read_breakdown;
+    EXPECT_FALSE(reader._try_read_from_cached_files_directly(
+            2, Slice(partial_buffer.data(), partial_buffer.size()), partial_buffer.size(), false,
+            partial_stats, partial_source_read_breakdown, partial_already_read,
+            &partial_bytes_read));
+    EXPECT_EQ(partial_buffer, "cd#####");
+    EXPECT_EQ(partial_already_read, 2);
+    EXPECT_EQ(partial_bytes_read, 99);
+
+    std::string dryrun_buffer(4, '#');
+    size_t dryrun_bytes_read = 0;
+    size_t dryrun_already_read = 0;
+    ReadStatistics dryrun_stats;
+    SourceReadBreakdown dryrun_source_read_breakdown;
+    EXPECT_TRUE(reader._try_read_from_cached_files_directly(
+            8, Slice(dryrun_buffer.data(), dryrun_buffer.size()), dryrun_buffer.size(), true,
+            dryrun_stats, dryrun_source_read_breakdown, dryrun_already_read, &dryrun_bytes_read));
+    EXPECT_EQ(dryrun_buffer, "####");
+    EXPECT_EQ(dryrun_already_read, dryrun_buffer.size());
+    EXPECT_EQ(dryrun_bytes_read, dryrun_buffer.size());
+    EXPECT_TRUE(dryrun_stats.hit_cache);
+}
+
+TEST_F(BlockFileCacheTest, file_block_appendv_persists_segmented_payload_to_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_appendv_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("appendv-fs"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_blockv(blocks[0], {"ab", "cd"});
+
+    std::string buffer(4, '#');
+    ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+    EXPECT_EQ(buffer, "abcd");
+}
+
+TEST_F(BlockFileCacheTest, file_block_append_iobuf_persists_payload_to_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("append-iobuf-fs"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_block_iobuf(blocks[0], {"ab", "cd"});
+
+    std::string buffer(4, '#');
+    ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+    EXPECT_EQ(buffer, "abcd");
+}
+
+TEST_F(BlockFileCacheTest, file_block_append_iobuf_persists_payload_to_memory_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_memory_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache = create_cached_remote_reader_test_cache(
+            cache_path, kCachedRemoteReaderTinyBlockSize, "memory");
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("append-iobuf-memory"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_block_iobuf(blocks[0], {"ab", "cd"});
+
+    std::string buffer(4, '#');
+    ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+    EXPECT_EQ(buffer, "abcd");
+}
+
+TEST_F(BlockFileCacheTest, file_block_append_iobuf_bypasses_appendv_for_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_bypass_appendv_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+        DebugPoints::instance()->clear();
+    }};
+
+    const bool old_enable_debug_points = config::enable_debug_points;
+    Defer restore_debug_points {[&]() { config::enable_debug_points = old_enable_debug_points; }};
+    config::enable_debug_points = true;
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    DebugPoints::instance()->add_with_params("LocalFileWriter::appendv.io_error",
+                                             {{"sub_path", cache_path.string()}});
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder = cache->get_or_set(
+            io::BlockFileCache::hash("append-iobuf-bypass-appendv-fs"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_block_iobuf(blocks[0], {"ab", "cd"});
+
+    std::string buffer(4, '#');
+    ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+    EXPECT_EQ(buffer, "abcd");
+}
+
+TEST_F(BlockFileCacheTest, fs_file_cache_storage_append_iobuf_falls_back_to_appendv) {
+    FSFileCacheStorage storage;
+    const auto key = make_test_file_cache_key("append-iobuf-fallback");
+
+    auto fallback_state = std::make_shared<MockFallbackAppendvWriterState>();
+    auto* fallback_writer = new MockFallbackAppendvWriter(Status::OK(), fallback_state);
+    storage.set_file_writer_for_test(key, FileWriterPtr(fallback_writer));
+
+    butil::IOBuf payload;
+    payload.append("ab", 2);
+    payload.append("cd", 2);
+    ASSERT_TRUE(storage.append_iobuf(key, payload).ok());
+
+    EXPECT_EQ(fallback_state->appendv_call_count, 1);
+    EXPECT_EQ(fallback_state->captured, "abcd");
+    EXPECT_EQ(fallback_state->bytes_appended, 4);
+    EXPECT_FALSE(fallback_state->destroyed);
+}
+
+TEST_F(BlockFileCacheTest, fs_file_cache_storage_append_iobuf_propagates_fallback_appendv_error) {
+    FSFileCacheStorage storage;
+    const auto key = make_test_file_cache_key("append-iobuf-fallback-error");
+
+    auto fallback_state = std::make_shared<MockFallbackAppendvWriterState>();
+    auto* fallback_writer = new MockFallbackAppendvWriter(
+            Status::IOError("mock fallback appendv error"), fallback_state);
+    storage.set_file_writer_for_test(key, FileWriterPtr(fallback_writer));
+
+    butil::IOBuf payload;
+    payload.append("ab", 2);
+    payload.append("cd", 2);
+    auto st = storage.append_iobuf(key, payload);
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(fallback_state->appendv_call_count, 1);
+    EXPECT_EQ(fallback_state->captured, "");
+    EXPECT_EQ(fallback_state->bytes_appended, 0);
+    EXPECT_TRUE(fallback_state->destroyed);
+}
+
+TEST_F(BlockFileCacheTest,
+       file_block_append_iobuf_propagates_local_writer_iobuf_error_for_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_error_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "LocalFileWriter::append_iobuf",
+            [&](auto&& values) {
+                std::pair<Status, bool>* pairs =
+                        try_any_cast<std::pair<Status, bool>*>(values.back());
+                pairs->second = true;
+            },
+            &guard1);
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("append-iobuf-error-fs"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+
+    butil::IOBuf payload;
+    payload.append("ab", 2);
+    payload.append("cd", 2);
+    EXPECT_FALSE(blocks[0]->append_iobuf(payload).ok());
+}
+
+TEST_F(BlockFileCacheTest, file_block_appendv_failure_cleans_tmp_writer_for_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_appendv_failure_cleanup_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "LocalFileWriter::appendv",
+            [&](auto&& values) {
+                std::pair<Status, bool>* pairs =
+                        try_any_cast<std::pair<Status, bool>*>(values.back());
+                pairs->second = true;
+            },
+            &guard1);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    const auto cache_key = io::BlockFileCache::hash("appendv-failure-cleanup-fs");
+
     {
-        std::lock_guard<std::mutex> cache_lock(cache._mutex);
-        cur_cache_size_before = cache._cur_cache_size;
-        normal_queue_size_before =
-                cache.get_queue(io::FileCacheType::NORMAL).get_capacity(cache_lock);
+        FileBlocksHolder holder = cache->get_or_set(cache_key, 0, 4, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        EXPECT_FALSE(blocks[0]->append(Slice("abcd", 4)).ok());
     }
+
+    EXPECT_EQ(count_cached_remote_reader_tmp_files(cache_path), 0);
+    sp->clear_call_back("LocalFileWriter::appendv");
 
     {
-        std::lock_guard<std::mutex> cache_lock(cache._mutex);
-        auto* cell = cache.add_cell(hash, ctx, kOffset, kBadSize, io::FileBlock::State::DOWNLOADED,
-                                    cache_lock);
-        // Defensive guard must reject oversized blocks instead of polluting state.
-        ASSERT_EQ(cell, nullptr);
-    }
-
-    {
-        std::lock_guard<std::mutex> cache_lock(cache._mutex);
-        // _files index untouched: no entry for (hash, kOffset).
-        ASSERT_EQ(cache._files.find(hash), cache._files.end());
-        // Global and per-queue size counters untouched (no UINT64_MAX added).
-        ASSERT_EQ(cache._cur_cache_size, cur_cache_size_before);
-        ASSERT_EQ(cache.get_queue(io::FileCacheType::NORMAL).get_capacity(cache_lock),
-                  normal_queue_size_before);
-    }
-
-    if (fs::exists(cache_base_path)) {
-        fs::remove_all(cache_base_path);
+        FileBlocksHolder holder = cache->get_or_set(cache_key, 0, 4, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        append_cached_remote_reader_block(blocks[0], "abcd");
+        EXPECT_EQ(fs::file_size(blocks[0]->get_cache_file()), 4);
     }
 }
 
@@ -8866,6 +9406,502 @@ TEST_F(BlockFileCacheTest, lru_restore_size_mismatch_does_not_underflow_on_clear
     if (fs::exists(my_cache_path)) {
         fs::remove_all(my_cache_path);
     }
+}
+
+TEST_F(BlockFileCacheTest, file_block_append_iobuf_failure_cleans_tmp_writer_for_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_failure_cleanup_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "LocalFileWriter::append_iobuf",
+            [&](auto&& values) {
+                std::pair<Status, bool>* pairs =
+                        try_any_cast<std::pair<Status, bool>*>(values.back());
+                pairs->second = true;
+            },
+            &guard1);
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    const auto cache_key = io::BlockFileCache::hash("append-iobuf-failure-cleanup-fs");
+
+    {
+        FileBlocksHolder holder = cache->get_or_set(cache_key, 0, 4, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+
+        butil::IOBuf payload;
+        payload.append("ab", 2);
+        payload.append("cd", 2);
+        EXPECT_FALSE(blocks[0]->append_iobuf(payload).ok());
+    }
+
+    EXPECT_EQ(count_cached_remote_reader_tmp_files(cache_path), 0);
+    sp->clear_call_back("LocalFileWriter::append_iobuf");
+
+    {
+        FileBlocksHolder holder = cache->get_or_set(cache_key, 0, 4, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        append_cached_remote_reader_block_iobuf(blocks[0], {"ab", "cd"});
+        EXPECT_EQ(fs::file_size(blocks[0]->get_cache_file()), 4);
+    }
+}
+
+TEST_F(BlockFileCacheTest, file_block_finalize_failure_cleans_tmp_writer_for_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_finalize_failure_cleanup_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "LocalFileWriter::close",
+            [&](auto&& values) {
+                std::pair<Status, bool>* pairs =
+                        try_any_cast<std::pair<Status, bool>*>(values.back());
+                pairs->second = true;
+            },
+            &guard1);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    const auto cache_key = io::BlockFileCache::hash("finalize-failure-cleanup-fs");
+
+    {
+        FileBlocksHolder holder = cache->get_or_set(cache_key, 0, 4, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_EQ(blocks[0]->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        ASSERT_TRUE(blocks[0]->append(Slice("abcd", 4)).ok());
+        EXPECT_FALSE(blocks[0]->finalize().ok());
+    }
+
+    EXPECT_EQ(count_cached_remote_reader_tmp_files(cache_path), 0);
+    sp->clear_call_back("LocalFileWriter::close");
+
+    {
+        FileBlocksHolder holder = cache->get_or_set(cache_key, 0, 4, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        append_cached_remote_reader_block(blocks[0], "abcd");
+        EXPECT_EQ(fs::file_size(blocks[0]->get_cache_file()), 4);
+    }
+}
+
+TEST_F(BlockFileCacheTest, file_block_append_iobuf_reads_to_iobuf_from_fs_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_read_to_iobuf_fs_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder = cache->get_or_set(
+            io::BlockFileCache::hash("append-iobuf-read-to-iobuf-fs"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_block_iobuf(blocks[0], {"ab", "cd"});
+
+    butil::IOBuf out;
+    size_t bytes_read = 0;
+    ASSERT_TRUE(blocks[0]->read_to_iobuf(&out, 1, 2, &bytes_read).ok());
+    EXPECT_EQ(bytes_read, 2);
+
+    std::string buffer(2, '#');
+    ASSERT_EQ(out.copy_to(buffer.data(), buffer.size()), buffer.size());
+    EXPECT_EQ(buffer, "bc");
+}
+
+TEST_F(BlockFileCacheTest, file_block_append_iobuf_reads_to_iobuf_from_memory_cache) {
+    const fs::path cache_path = caches_dir / "file_block_append_iobuf_read_to_iobuf_memory_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache = create_cached_remote_reader_test_cache(
+            cache_path, kCachedRemoteReaderTinyBlockSize, "memory");
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder = cache->get_or_set(
+            io::BlockFileCache::hash("append-iobuf-read-to-iobuf-memory"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_block_iobuf(blocks[0], {"ab", "cd"});
+
+    butil::IOBuf out;
+    size_t bytes_read = 0;
+    ASSERT_TRUE(blocks[0]->read_to_iobuf(&out, 1, 2, &bytes_read).ok());
+    EXPECT_EQ(bytes_read, 2);
+
+    std::string buffer(2, '#');
+    ASSERT_EQ(out.copy_to(buffer.data(), buffer.size()), buffer.size());
+    EXPECT_EQ(buffer, "bc");
+}
+
+TEST_F(BlockFileCacheTest, file_block_appendv_persists_segmented_payload_to_memory_cache) {
+    const fs::path cache_path = caches_dir / "file_block_appendv_memory_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache = create_cached_remote_reader_test_cache(
+            cache_path, kCachedRemoteReaderTinyBlockSize, "memory");
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("appendv-memory"), 0, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+
+    append_cached_remote_reader_blockv(blocks[0], {"ab", "cd"});
+
+    std::string buffer(4, '#');
+    ASSERT_TRUE(blocks[0]->read(Slice(buffer.data(), buffer.size()), 0).ok());
+    EXPECT_EQ(buffer, "abcd");
+}
+
+TEST_F(BlockFileCacheTest,
+       cached_remote_file_reader_read_remote_blocks_into_cache_copy_boundaries) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cached_remote_reader_test_file(
+            "cached_remote_reader_remote_blocks_copy_boundaries", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_remote_blocks_copy_boundaries_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = false;
+    opts.cache_base_path = cache_path.string();
+    opts.mtime = 1;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("remote-copy-boundary"), 4, 8, context);
+
+    std::vector<FileBlockSPtr> empty_blocks;
+    for (auto& block : holder.file_blocks) {
+        ASSERT_EQ(block->state(), io::FileBlock::State::EMPTY);
+        ASSERT_EQ(block->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        empty_blocks.push_back(block);
+    }
+
+    std::string buffer(8, '#');
+    size_t indirect_read_bytes = 0;
+    size_t empty_start = std::numeric_limits<size_t>::max();
+    size_t empty_end = std::numeric_limits<size_t>::max();
+    PeerFetchedBlockSet peer_fetched_blocks;
+    ReadStatistics read_stats;
+    SourceReadBreakdown source_read_breakdown;
+    IOContext io_ctx;
+    ASSERT_TRUE(reader._read_remote_blocks_into_cache(
+                              empty_blocks, 2, 8, 2, Slice(buffer.data(), buffer.size()), false,
+                              read_stats, source_read_breakdown, &io_ctx, indirect_read_bytes,
+                              empty_start, empty_end, peer_fetched_blocks)
+                        .ok());
+
+    EXPECT_EQ(empty_start, 4);
+    EXPECT_EQ(empty_end, 11);
+    EXPECT_EQ(indirect_read_bytes, 6);
+    EXPECT_EQ(buffer, "##efghij");
+    EXPECT_EQ(read_stats.bytes_write_into_file_cache, 8);
+
+    for (auto& block : empty_blocks) {
+        EXPECT_EQ(block->state(), io::FileBlock::State::DOWNLOADED);
+        std::string block_buffer(block->range().size(), '#');
+        ASSERT_TRUE(block->read(Slice(block_buffer.data(), block_buffer.size()), 0).ok());
+        EXPECT_EQ(block_buffer, content.substr(block->range().left, block->range().size()));
+    }
+}
+
+TEST_F(BlockFileCacheTest, cached_remote_file_reader_read_remote_blocks_into_cache_dryrun_no_copy) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cached_remote_reader_test_file(
+            "cached_remote_reader_remote_blocks_dryrun", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_remote_blocks_dryrun_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = false;
+    opts.cache_base_path = cache_path.string();
+    opts.mtime = 1;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("remote-dryrun"), 0, 4, context);
+
+    std::vector<FileBlockSPtr> empty_blocks;
+    for (auto& block : holder.file_blocks) {
+        ASSERT_EQ(block->get_or_set_downloader(), io::FileBlock::get_caller_id());
+        empty_blocks.push_back(block);
+    }
+
+    std::string buffer(4, '#');
+    size_t indirect_read_bytes = 0;
+    size_t empty_start = 99;
+    size_t empty_end = 99;
+    PeerFetchedBlockSet peer_fetched_blocks;
+    ReadStatistics read_stats;
+    SourceReadBreakdown source_read_breakdown;
+    IOContext io_ctx;
+    ASSERT_TRUE(reader._read_remote_blocks_into_cache(
+                              empty_blocks, 1, 3, 0, Slice(buffer.data(), buffer.size()), true,
+                              read_stats, source_read_breakdown, &io_ctx, indirect_read_bytes,
+                              empty_start, empty_end, peer_fetched_blocks)
+                        .ok());
+
+    EXPECT_EQ(empty_start, 0);
+    EXPECT_EQ(empty_end, 3);
+    EXPECT_EQ(indirect_read_bytes, 0);
+    EXPECT_EQ(buffer, "####");
+    EXPECT_EQ(read_stats.bytes_write_into_file_cache, 4);
+}
+
+TEST_F(BlockFileCacheTest,
+       cached_remote_file_reader_read_remaining_blocks_from_cache_partial_edges) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cached_remote_reader_test_file(
+            "cached_remote_reader_remaining_blocks_partial_edges", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_remaining_blocks_partial_edges_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = false;
+    opts.cache_base_path = cache_path.string();
+    opts.mtime = 1;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("remaining-partial"), 0, 12, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 3);
+    append_cached_remote_reader_block(blocks[0], content);
+    append_cached_remote_reader_block(blocks[2], content);
+
+    std::string buffer(10, '#');
+    IOContext io_ctx;
+    size_t indirect_read_bytes = 0;
+    size_t bytes_read = 0;
+    PeerFetchedBlockSet peer_fetched_blocks;
+    ReadStatistics read_stats;
+    SourceReadBreakdown source_read_breakdown;
+    ASSERT_TRUE(reader._read_remaining_blocks_from_cache(
+                              holder, 1, 10, Slice(buffer.data(), buffer.size()), false, 4, 7,
+                              peer_fetched_blocks, read_stats, source_read_breakdown,
+                              indirect_read_bytes, &bytes_read, &io_ctx)
+                        .ok());
+
+    EXPECT_EQ(buffer, "bcd####ijk");
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(indirect_read_bytes, 6);
+    EXPECT_TRUE(read_stats.hit_cache);
+}
+
+TEST_F(BlockFileCacheTest,
+       cached_remote_file_reader_read_remaining_blocks_from_cache_skips_only_peer_blocks) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cached_remote_reader_test_file(
+            "cached_remote_reader_remaining_blocks_peer_skip", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_remaining_blocks_peer_skip_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = false;
+    opts.cache_base_path = cache_path.string();
+    opts.mtime = 1;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("remaining-peer-skip"), 0, 12, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 3);
+    append_cached_remote_reader_block(blocks[0], content);
+    append_cached_remote_reader_block(blocks[2], content);
+
+    std::string buffer(10, '#');
+    IOContext io_ctx;
+    size_t indirect_read_bytes = 0;
+    size_t bytes_read = 0;
+    PeerFetchedBlockSet peer_fetched_blocks;
+    peer_fetched_blocks.insert(blocks[1].get());
+    ReadStatistics read_stats;
+    SourceReadBreakdown source_read_breakdown;
+    ASSERT_TRUE(reader._read_remaining_blocks_from_cache(
+                              holder, 1, 10, Slice(buffer.data(), buffer.size()), false, 0, 0,
+                              peer_fetched_blocks, read_stats, source_read_breakdown,
+                              indirect_read_bytes, &bytes_read, &io_ctx)
+                        .ok());
+
+    EXPECT_EQ(buffer, "bcd####ijk");
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(indirect_read_bytes, 6);
+    EXPECT_TRUE(read_stats.hit_cache);
+}
+
+TEST_F(BlockFileCacheTest,
+       cached_remote_file_reader_read_remaining_blocks_from_cache_remote_fallback) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cached_remote_reader_test_file(
+            "cached_remote_reader_remaining_blocks_remote_fallback", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_remaining_blocks_remote_fallback_cache";
+    clear_cached_remote_reader_factory();
+    Defer cleanup_cache {[&]() {
+        std::error_code ignore;
+        fs::remove_all(cache_path, ignore);
+        clear_cached_remote_reader_factory();
+    }};
+
+    auto* cache =
+            create_cached_remote_reader_test_cache(cache_path, kCachedRemoteReaderTinyBlockSize);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    io::FileReaderOptions opts;
+    opts.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = false;
+    opts.cache_base_path = cache_path.string();
+    opts.mtime = 1;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    ReadStatistics cache_stats;
+    auto context = create_cached_remote_reader_context(&cache_stats);
+    FileBlocksHolder holder =
+            cache->get_or_set(io::BlockFileCache::hash("remaining-fallback"), 0, 4, context);
+
+    std::string buffer(2, '#');
+    IOContext io_ctx;
+    size_t indirect_read_bytes = 0;
+    size_t bytes_read = 0;
+    PeerFetchedBlockSet peer_fetched_blocks;
+    ReadStatistics read_stats;
+    SourceReadBreakdown source_read_breakdown;
+    ASSERT_TRUE(reader._read_remaining_blocks_from_cache(
+                              holder, 1, 2, Slice(buffer.data(), buffer.size()), false, 0, 0,
+                              peer_fetched_blocks, read_stats, source_read_breakdown,
+                              indirect_read_bytes, &bytes_read, &io_ctx)
+                        .ok());
+
+    EXPECT_EQ(buffer, "bc");
+    EXPECT_EQ(bytes_read, 2);
+    EXPECT_EQ(indirect_read_bytes, 2);
+    EXPECT_FALSE(read_stats.hit_cache);
+    EXPECT_FALSE(read_stats.from_peer_cache);
 }
 
 } // namespace doris::io

--- a/be/test/io/cache/cached_remote_file_reader_peer_test.cpp
+++ b/be/test/io/cache/cached_remote_file_reader_peer_test.cpp
@@ -1,0 +1,3493 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <brpc/details/server_private_accessor.h>
+#include <brpc/server.h>
+#include <butil/endpoint.h>
+#include <butil/iobuf.h>
+#include <bvar/bvar.h>
+#include <gen_cpp/internal_service.pb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "block_file_cache_test_common.h"
+#include "cloud/cloud_warm_up_manager.h"
+#include "cloud/config.h"
+#include "exec/pipeline/task_scheduler.h"
+#include "exec/scan/scanner_scheduler.h"
+#include "io/cache/peer_file_cache_reader.h"
+#include "runtime/exec_env.h"
+#include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/thread_context.h"
+#include "runtime/workload_group/workload_group.h"
+#include "runtime/workload_group/workload_group_metrics.h"
+#include "runtime/workload_management/io_throttle.h"
+#include "util/brpc_client_cache.h"
+#include "util/debug/leak_annotations.h"
+#include "util/debug_points.h"
+#include "util/defer_op.h"
+
+namespace doris {
+extern bvar::Adder<uint64_t> g_file_cache_get_by_peer_queue_timeout_num;
+
+Status test_handle_peer_file_cache_block_request(const PFetchPeerDataRequest* request,
+                                                 PFetchPeerDataResponse* response,
+                                                 brpc::Controller* cntl);
+bool test_try_reject_if_queue_timed_out(std::chrono::steady_clock::time_point enqueue_ts,
+                                        PFetchPeerDataResponse* response);
+} // namespace doris
+
+namespace doris::io {
+
+namespace {
+
+constexpr size_t kPeerTestBlockSize = 4;
+constexpr int64_t kPeerTestTabletId = 10001;
+constexpr int64_t kCrossTabletId = 12345;
+
+std::shared_ptr<WorkloadGroup> create_peer_test_workload_group(int remote_read_bytes_per_second) {
+    static std::atomic<uint64_t> next_workload_group_id {90000};
+    const uint64_t workload_group_id = next_workload_group_id.fetch_add(1);
+    WorkloadGroupInfo info {.id = workload_group_id,
+                            .name = "peer_read_test_wg_" + std::to_string(workload_group_id),
+                            .version = 1,
+                            .remote_read_bytes_per_second = remote_read_bytes_per_second};
+    auto workload_group = std::make_shared<WorkloadGroup>(info);
+    workload_group->upsert_scan_io_throttle(&info);
+    return workload_group;
+}
+
+std::shared_ptr<ResourceContext> create_peer_test_resource_context(
+        const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
+        const std::shared_ptr<WorkloadGroup>& workload_group) {
+    auto resource_context = ResourceContext::create_shared();
+    resource_context->memory_context()->set_mem_tracker(mem_tracker);
+    resource_context->task_controller()->set_task_id(TUniqueId());
+    resource_context->set_workload_group(workload_group);
+    return resource_context;
+}
+
+FileCacheSettings create_peer_test_settings(size_t block_size, std::string storage = "disk") {
+    FileCacheSettings settings;
+    settings.query_queue_size = 64;
+    settings.query_queue_elements = 16;
+    settings.index_queue_size = 64;
+    settings.index_queue_elements = 16;
+    settings.disposable_queue_size = 64;
+    settings.disposable_queue_elements = 16;
+    settings.capacity = 64;
+    settings.max_file_block_size = block_size;
+    settings.max_query_cache_size = 0;
+    settings.storage = std::move(storage);
+    return settings;
+}
+
+void clear_cached_remote_reader_factory() {
+    FileCacheFactory::instance()->_caches.clear();
+    FileCacheFactory::instance()->_path_to_cache.clear();
+    FileCacheFactory::instance()->_capacity = 0;
+}
+
+BlockFileCache* create_peer_test_cache(const fs::path& cache_path, size_t block_size,
+                                       std::string storage = "disk") {
+    std::error_code ec;
+    fs::remove_all(cache_path, ec);
+    if (storage != "memory") {
+        fs::create_directories(cache_path);
+    }
+    const std::string cache_base_path = storage == "memory" ? "memory" : cache_path.string();
+    auto st = FileCacheFactory::instance()->create_file_cache(
+            cache_base_path, create_peer_test_settings(block_size, std::move(storage)));
+    CHECK(st.ok()) << st;
+    auto* cache = FileCacheFactory::instance()->_path_to_cache[cache_base_path];
+    CHECK(cache != nullptr) << cache_base_path;
+    wait_until_cache_ready(*cache);
+    return cache;
+}
+
+fs::path create_peer_test_file(const std::string& name, std::string_view content) {
+    fs::path file_path = caches_dir / name;
+    std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
+    CHECK(out.is_open()) << file_path;
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    out.close();
+    return file_path;
+}
+
+void populate_cache_block_with_content(BlockFileCache* cache, const fs::path& file_path,
+                                       size_t offset, size_t size, std::string_view content) {
+    ReadStatistics stats;
+    CacheContext context;
+    context.stats = &stats;
+    auto hash = BlockFileCache::hash(file_path.filename().native());
+    auto holder = cache->get_or_set(hash, offset, size, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_EQ(blocks[0]->state(), FileBlock::State::EMPTY);
+    ASSERT_EQ(blocks[0]->get_or_set_downloader(), FileBlock::get_caller_id());
+    ASSERT_TRUE(blocks[0]->append(Slice(content.data() + offset, size)).ok());
+    ASSERT_TRUE(blocks[0]->finalize().ok());
+}
+
+PFetchPeerDataRequest create_peer_cache_block_request(const fs::path& file_path, size_t offset,
+                                                      size_t size, size_t file_size) {
+    PFetchPeerDataRequest request;
+    request.set_type(PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK);
+    request.set_path(file_path.filename().native());
+    request.set_file_size(static_cast<int64_t>(file_size));
+    request.set_support_attachment(false);
+    auto* cache_req = request.add_cache_req();
+    cache_req->set_block_offset(offset);
+    cache_req->set_block_size(size);
+    return request;
+}
+
+FileBlockSPtr create_manual_peer_test_block(const fs::path& file_path, size_t offset, size_t size,
+                                            BlockFileCache* cache = nullptr) {
+    FileCacheKey key;
+    key.hash = BlockFileCache::hash(file_path.filename().native());
+    key.offset = offset;
+    key.meta = KeyMeta {.expiration_time = 0, .type = FileCacheType::NORMAL};
+    return std::make_shared<FileBlock>(key, size, cache, FileBlock::State::EMPTY);
+}
+
+butil::EndPoint start_peer_test_server(brpc::Server* server, google::protobuf::Service* service) {
+    CHECK(server != nullptr);
+    CHECK(service != nullptr);
+    CHECK_EQ(server->AddService(service, brpc::SERVER_DOESNT_OWN_SERVICE), 0);
+    brpc::ServerOptions options;
+    options.num_threads = 1;
+    {
+        // BRPC leaves a small shutdown-only allocation from StartInternal() in this UT harness.
+        // Disable LSAN only for server bootstrap so the peer-path assertions stay meaningful.
+        doris::debug::ScopedLSANDisabler lsan_disabler;
+        CHECK_EQ(server->Start(0, &options), 0);
+    }
+
+    auto* acceptor = brpc::ServerPrivateAccessor(server).acceptor();
+    if (acceptor != nullptr) {
+        ANNOTATE_LEAKING_OBJECT_PTR(acceptor);
+    }
+    return server->listen_address();
+}
+
+void stop_peer_test_server(brpc::Server* server) {
+    ASSERT_NE(server, nullptr);
+    ASSERT_EQ(server->Stop(1000), 0);
+    ASSERT_EQ(server->Join(), 0);
+    server->ClearServices();
+}
+
+struct MockPeerCacheServiceOptions {
+    bool use_attachment = false;
+    bool drop_last_block = false;
+    bool reverse_response_order = false;
+    bool duplicate_first_block = false;
+    bool negative_block_offset = false;
+    bool fail_status = false;
+    bool append_trailing_attachment = false;
+    size_t truncate_trailing_attachment_bytes = 0;
+    int64_t response_offset_delta = 0;
+    // Return TStatusCode::NOT_FOUND to simulate a server-side cache miss.
+    // Distinct from fail_status (INTERNAL_ERROR): the client must rotate the candidate
+    // on NOT_FOUND, not increment the RPC-failure eviction counter.
+    bool cache_miss_status = false;
+};
+
+class MockPeerCacheService : public PBackendService {
+public:
+    explicit MockPeerCacheService(std::string content, MockPeerCacheServiceOptions options = {})
+            : _content(std::move(content)), _options(options) {}
+
+    bool wait_for_rpc_count_at_least(int expected_count, std::chrono::milliseconds timeout) {
+        std::unique_lock lock(_rpc_mu);
+        return _rpc_cv.wait_for(lock, timeout, [&] {
+            return rpc_count.load(std::memory_order_acquire) >= expected_count;
+        });
+    }
+
+    void fetch_peer_data(google::protobuf::RpcController* controller,
+                         const PFetchPeerDataRequest* request, PFetchPeerDataResponse* response,
+                         google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        auto* cntl = static_cast<brpc::Controller*>(controller);
+        ++rpc_count;
+        _rpc_cv.notify_all();
+        request_block_count = request->cache_req_size();
+        support_attachment = request->has_support_attachment() && request->support_attachment();
+        request_fill = request->has_request_cache_fill() && request->request_cache_fill();
+        {
+            std::lock_guard lock(_request_mu);
+            last_fill_resource_id =
+                    request->has_rowset_meta() && request->rowset_meta().has_resource_id()
+                            ? request->rowset_meta().resource_id()
+                            : "";
+        }
+
+        if (_options.fail_status) {
+            response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+            return;
+        }
+        if (_options.cache_miss_status) {
+            // Simulate server-side cache miss (EMPTY block, no fill):
+            // server returns NOT_FOUND so client rotates the candidate instead of evicting.
+            response->mutable_status()->add_error_msgs("cache block not downloaded");
+            response->mutable_status()->set_status_code(TStatusCode::NOT_FOUND);
+            return;
+        }
+        response->mutable_status()->set_status_code(TStatusCode::OK);
+        EXPECT_EQ(request->type(), PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK);
+        EXPECT_FALSE(request->path().empty());
+        const bool use_attachment = _options.use_attachment && support_attachment.load();
+        response->set_data_in_attachment(use_attachment);
+
+        std::vector<int> request_indexes(request->cache_req_size());
+        for (int idx = 0; idx < request->cache_req_size(); ++idx) {
+            request_indexes[idx] = idx;
+        }
+        if (_options.reverse_response_order) {
+            std::reverse(request_indexes.begin(), request_indexes.end());
+        }
+
+        const size_t file_size =
+                request->has_file_size()
+                        ? static_cast<size_t>(std::max<int64_t>(0, request->file_size()))
+                        : _content.size();
+        auto append_response = [&](int64_t response_block_offset, size_t block_offset,
+                                   size_t readable_size) {
+            auto* data = response->add_datas();
+            data->set_block_offset(response_block_offset);
+            data->set_block_size(readable_size);
+            if (readable_size == 0) {
+                return;
+            }
+            if (use_attachment) {
+                cntl->response_attachment().append(_content.data() + block_offset, readable_size);
+            } else {
+                data->set_data(_content.substr(block_offset, readable_size));
+            }
+        };
+        for (int order_idx = 0; order_idx < request->cache_req_size(); ++order_idx) {
+            const int idx = request_indexes[order_idx];
+            const auto& block_req = request->cache_req(idx);
+            EXPECT_GE(block_req.block_offset(), 0);
+            EXPECT_GE(block_req.block_size(), 0);
+            size_t block_offset = static_cast<size_t>(block_req.block_offset());
+            size_t block_size = static_cast<size_t>(block_req.block_size());
+            const size_t readable_size =
+                    block_offset >= file_size ? 0 : std::min(block_size, file_size - block_offset);
+            if (readable_size > 0) {
+                ASSERT_LE(block_offset + readable_size, _content.size());
+            }
+            if (_options.drop_last_block && idx == request->cache_req_size() - 1) {
+                continue;
+            }
+
+            const int64_t response_block_offset =
+                    _options.negative_block_offset
+                            ? -1
+                            : block_req.block_offset() + _options.response_offset_delta;
+            append_response(response_block_offset, block_offset, readable_size);
+        }
+        if (_options.duplicate_first_block && request->cache_req_size() > 0) {
+            const auto& first_req = request->cache_req(0);
+            EXPECT_GE(first_req.block_offset(), 0);
+            EXPECT_GE(first_req.block_size(), 0);
+            const size_t block_offset = static_cast<size_t>(first_req.block_offset());
+            const size_t block_size = static_cast<size_t>(first_req.block_size());
+            const size_t readable_size =
+                    block_offset >= file_size ? 0 : std::min(block_size, file_size - block_offset);
+            if (readable_size > 0) {
+                ASSERT_LE(block_offset + readable_size, _content.size());
+            }
+            append_response(first_req.block_offset(), block_offset, readable_size);
+        }
+        if (use_attachment && _options.append_trailing_attachment) {
+            cntl->response_attachment().append("x", 1);
+        }
+        if (use_attachment && _options.truncate_trailing_attachment_bytes != 0) {
+            const size_t attachment_size = cntl->response_attachment().length();
+            ASSERT_GE(attachment_size, _options.truncate_trailing_attachment_bytes);
+            butil::IOBuf trimmed_attachment;
+            const size_t kept_size = attachment_size - _options.truncate_trailing_attachment_bytes;
+            ASSERT_EQ(cntl->response_attachment().cutn(&trimmed_attachment, kept_size), kept_size);
+            cntl->response_attachment().swap(trimmed_attachment);
+        }
+    }
+
+    std::atomic<int> rpc_count {0};
+    std::atomic<int> request_block_count {0};
+    std::atomic<bool> support_attachment {false};
+    std::atomic<bool> request_fill {false};
+    std::string get_last_fill_resource_id() const {
+        std::lock_guard lock(_request_mu);
+        return last_fill_resource_id;
+    }
+
+private:
+    std::string _content;
+    MockPeerCacheServiceOptions _options;
+    std::mutex _rpc_mu;
+    std::condition_variable _rpc_cv;
+    mutable std::mutex _request_mu;
+    std::string last_fill_resource_id;
+};
+
+class InspectingRemoteFileReader final : public FileReader {
+public:
+    InspectingRemoteFileReader(std::string content, Path path,
+                               std::shared_ptr<WorkloadGroup> expected_workload_group)
+            : _content(std::move(content)),
+              _path(std::move(path)),
+              _expected_workload_group(std::move(expected_workload_group)) {}
+
+    void set_expected_thread_id(std::thread::id thread_id) { _expected_thread_id = thread_id; }
+
+    bool observed_expected_workload_group() const {
+        return _observed_expected_workload_group.load(std::memory_order_acquire);
+    }
+
+    bool observed_non_orphan_tracker() const {
+        return _observed_non_orphan_tracker.load(std::memory_order_acquire);
+    }
+
+    bool ran_on_expected_thread() const {
+        return _ran_on_expected_thread.load(std::memory_order_acquire);
+    }
+
+    int read_call_count() const { return _read_call_count.load(std::memory_order_acquire); }
+
+    int64_t throttle_wait_ms() const { return _throttle_wait_ms.load(std::memory_order_acquire); }
+
+    Status close() override {
+        _closed = true;
+        return Status::OK();
+    }
+
+    const Path& path() const override { return _path; }
+
+    size_t size() const override { return _content.size(); }
+
+    bool closed() const override { return _closed; }
+
+    int64_t mtime() const override { return 0; }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const IOContext* /*io_ctx*/) override {
+        ++_read_call_count;
+
+        auto* current_thread_context = thread_context();
+        std::shared_ptr<WorkloadGroup> workload_group =
+                current_thread_context->resource_ctx()->workload_group();
+        _observed_expected_workload_group.store(
+                workload_group != nullptr && workload_group.get() == _expected_workload_group.get(),
+                std::memory_order_release);
+        _observed_non_orphan_tracker.store(
+                current_thread_context->thread_mem_tracker_mgr->limiter_mem_tracker()->label() !=
+                        "Orphan",
+                std::memory_order_release);
+        _ran_on_expected_thread.store(std::this_thread::get_id() == _expected_thread_id,
+                                      std::memory_order_release);
+
+        if (offset > _content.size()) {
+            return Status::InternalError("offset exceeds file size(offset: {}, file size: {})",
+                                         offset, _content.size());
+        }
+
+        const size_t readable_size = std::min(result.size, _content.size() - offset);
+        const auto start = std::chrono::steady_clock::now();
+        LIMIT_REMOTE_SCAN_IO(bytes_read);
+        std::copy_n(_content.data() + offset, readable_size, result.data);
+        *bytes_read = readable_size;
+        _throttle_wait_ms.store(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                        std::chrono::steady_clock::now() - start)
+                                        .count(),
+                                std::memory_order_release);
+        return Status::OK();
+    }
+
+private:
+    std::string _content;
+    Path _path;
+    std::shared_ptr<WorkloadGroup> _expected_workload_group;
+    std::thread::id _expected_thread_id;
+    std::atomic<bool> _observed_expected_workload_group {false};
+    std::atomic<bool> _observed_non_orphan_tracker {false};
+    std::atomic<bool> _ran_on_expected_thread {false};
+    std::atomic<int> _read_call_count {0};
+    std::atomic<int64_t> _throttle_wait_ms {0};
+    bool _closed = false;
+};
+
+class RealPeerCacheService : public PBackendService {
+public:
+    void fetch_peer_data(google::protobuf::RpcController* controller,
+                         const PFetchPeerDataRequest* request, PFetchPeerDataResponse* response,
+                         google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        auto* cntl = static_cast<brpc::Controller*>(controller);
+        ++rpc_count;
+        request_block_count = request->cache_req_size();
+        support_attachment = request->has_support_attachment() && request->support_attachment();
+        response->mutable_status()->set_status_code(TStatusCode::OK);
+        std::thread worker([&]() {
+            auto st = doris::test_handle_peer_file_cache_block_request(request, response, cntl);
+            if (!st.ok()) {
+                response->mutable_status()->clear_error_msgs();
+                response->mutable_status()->add_error_msgs(st.to_string());
+                response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+            }
+        });
+        worker.join();
+    }
+
+    std::atomic<int> rpc_count {0};
+    std::atomic<int> request_block_count {0};
+    std::atomic<bool> support_attachment {false};
+};
+
+class SlowFailingPeerCacheService : public PBackendService {
+public:
+    explicit SlowFailingPeerCacheService(int delay_ms) : _delay_ms(delay_ms) {}
+
+    void fetch_peer_data(google::protobuf::RpcController* /*controller*/,
+                         const PFetchPeerDataRequest* request, PFetchPeerDataResponse* response,
+                         google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        ++rpc_count;
+        request_block_count = request->cache_req_size();
+        started.store(true, std::memory_order_release);
+        std::this_thread::sleep_for(std::chrono::milliseconds(_delay_ms));
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        finished.store(true, std::memory_order_release);
+    }
+
+    std::atomic<int> rpc_count {0};
+    std::atomic<int> request_block_count {0};
+    std::atomic<bool> started {false};
+    std::atomic<bool> finished {false};
+
+private:
+    int _delay_ms;
+};
+
+class CachedRemoteFileReaderPeerTest : public BlockFileCacheTest {
+protected:
+    void SetUp() override {
+        _old_deploy_mode = config::deploy_mode;
+        _old_cloud_unique_id = config::cloud_unique_id;
+        _old_enable_cache_read_from_peer = config::enable_cache_read_from_peer;
+        _old_enable_debug_points = config::enable_debug_points;
+        _old_file_cache_each_block_size = config::file_cache_each_block_size;
+        _old_internal_client_cache = ExecEnv::GetInstance()->_internal_client_cache;
+
+        config::deploy_mode = "cloud";
+        config::cloud_unique_id.clear();
+        config::enable_cache_read_from_peer = true;
+        config::enable_debug_points = true;
+        config::file_cache_each_block_size = kPeerTestBlockSize;
+        DebugPoints::instance()->clear();
+
+        if (ExecEnv::GetInstance()->_internal_client_cache == nullptr) {
+            ExecEnv::GetInstance()->_internal_client_cache =
+                    new BrpcClientCache<PBackendService_Stub>();
+            _owned_internal_client_cache = true;
+        }
+    }
+
+    void TearDown() override {
+        DebugPoints::instance()->clear();
+        clear_cached_remote_reader_factory();
+
+        if (_owned_internal_client_cache) {
+            delete ExecEnv::GetInstance()->_internal_client_cache;
+            ExecEnv::GetInstance()->_internal_client_cache = nullptr;
+        } else {
+            ExecEnv::GetInstance()->_internal_client_cache = _old_internal_client_cache;
+        }
+
+        config::deploy_mode = _old_deploy_mode;
+        config::cloud_unique_id = _old_cloud_unique_id;
+        config::enable_cache_read_from_peer = _old_enable_cache_read_from_peer;
+        config::enable_debug_points = _old_enable_debug_points;
+        config::file_cache_each_block_size = _old_file_cache_each_block_size;
+    }
+
+private:
+    std::string _old_deploy_mode;
+    std::string _old_cloud_unique_id;
+    bool _old_enable_cache_read_from_peer = false;
+    bool _old_enable_debug_points = false;
+    int64_t _old_file_cache_each_block_size = 0;
+    BrpcClientCache<PBackendService_Stub>* _old_internal_client_cache = nullptr;
+    bool _owned_internal_client_cache = false;
+};
+
+} // namespace
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_peer_cache_when_available) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_success.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_success_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 3);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 0);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 10);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_peer_dryrun_downloads_cache_without_copying_result) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_dryrun.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_dryrun_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string dryrun_buffer(10, '#');
+    size_t dryrun_bytes_read = 0;
+    IOContext dryrun_ctx;
+    dryrun_ctx.is_dryrun = true;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(dryrun_buffer.data(), dryrun_buffer.size()),
+                               &dryrun_bytes_read, &dryrun_ctx)
+                        .ok());
+
+    EXPECT_EQ(dryrun_buffer, std::string(10, '#'));
+    EXPECT_EQ(dryrun_bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 3);
+    EXPECT_TRUE(service.support_attachment.load());
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(cache_stats.num_local_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 10);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_warmup_skips_peer_attempt) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_warmup_skip_peer.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_warmup_skip_peer_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    io_ctx.is_warmup = true;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 0);
+    EXPECT_EQ(cache_stats.num_local_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 0);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_bypass_peer_skips_peer_attempt) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_bypass_peer.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_bypass_peer_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.tablet_id = kCrossTabletId;
+    opts.mtime = 1;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    io_ctx.bypass_peer_read = true;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 0);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_fill_request_waits_for_concurrent_download_beyond_block_wait_timeout) {
+    const bool old_enable_file_cache = config::enable_file_cache;
+    const int64_t old_block_wait_timeout_ms = config::block_cache_wait_timeout_ms;
+    const int32_t old_peer_fill_timeout_ms = config::peer_server_cache_fill_timeout_ms;
+    const bool old_enable_peer_server_cache_fill = config::enable_peer_server_cache_fill;
+    Defer restore_config {[&]() {
+        config::enable_file_cache = old_enable_file_cache;
+        config::block_cache_wait_timeout_ms = old_block_wait_timeout_ms;
+        config::peer_server_cache_fill_timeout_ms = old_peer_fill_timeout_ms;
+        config::enable_peer_server_cache_fill = old_enable_peer_server_cache_fill;
+    }};
+    config::enable_file_cache = true;
+    config::block_cache_wait_timeout_ms = 100;
+    config::peer_server_cache_fill_timeout_ms = 1500;
+    config::enable_peer_server_cache_fill = true;
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_waits_for_downloading.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_peer_waits_for_downloading_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    ReadStatistics stats;
+    CacheContext context;
+    context.stats = &stats;
+    auto hash = BlockFileCache::hash(file_path.filename().native());
+    auto holder = cache->get_or_set(hash, 0, kPeerTestBlockSize, context);
+    auto cached_blocks = fromHolder(holder);
+    ASSERT_EQ(cached_blocks.size(), 1);
+    ASSERT_EQ(cached_blocks[0]->state(), FileBlock::State::EMPTY);
+    ASSERT_EQ(cached_blocks[0]->get_or_set_downloader(), FileBlock::get_caller_id());
+
+    PFetchPeerDataRequest request;
+    request.set_type(PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK);
+    request.set_path(file_path.filename().native());
+    request.set_file_size(static_cast<int64_t>(content.size()));
+    request.set_support_attachment(false);
+    request.set_request_cache_fill(true);
+    auto* fill_meta = request.mutable_rowset_meta();
+    fill_meta->set_resource_id("peer_fill_resource");
+    fill_meta->set_tablet_id(kCrossTabletId);
+    auto* cache_req = request.add_cache_req();
+    cache_req->set_block_offset(0);
+    cache_req->set_block_size(kPeerTestBlockSize);
+
+    PFetchPeerDataResponse response;
+    brpc::Controller cntl;
+    Status request_status = Status::OK();
+    std::thread request_thread([&]() {
+        request_status =
+                doris::test_handle_peer_file_cache_block_request(&request, &response, &cntl);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_TRUE(cached_blocks[0]->append(Slice(content.data(), kPeerTestBlockSize)).ok());
+    ASSERT_TRUE(cached_blocks[0]->finalize().ok());
+
+    request_thread.join();
+
+    ASSERT_TRUE(request_status.ok()) << request_status;
+    ASSERT_EQ(response.datas_size(), 1);
+    EXPECT_EQ(response.datas(0).block_offset(), 0);
+    EXPECT_EQ(response.datas(0).data(), content.substr(0, kPeerTestBlockSize));
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_fill_request_includes_remote_path_and_resource_id) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_fill_request_fields.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_fill_request_fields_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {
+            create_manual_peer_test_block(file_path, 0, kPeerTestBlockSize)};
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+    const std::string resource_id = "peer_fill_resource";
+
+    ASSERT_TRUE(peer_reader
+                        .fetch_blocks(blocks, &result, content.size(), &io_ctx,
+                                      /*request_fill=*/true, kCrossTabletId, resource_id)
+                        .ok());
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_TRUE(service.request_fill.load());
+    EXPECT_EQ(service.get_last_fill_resource_id(), resource_id);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_fill_returns_not_found_when_resource_id_is_unknown_without_tablet_lookup) {
+    const bool old_enable_file_cache = config::enable_file_cache;
+    const bool old_enable_peer_server_cache_fill = config::enable_peer_server_cache_fill;
+    Defer restore_config {[&]() {
+        config::enable_file_cache = old_enable_file_cache;
+        config::enable_peer_server_cache_fill = old_enable_peer_server_cache_fill;
+    }};
+    config::enable_file_cache = true;
+    config::enable_peer_server_cache_fill = true;
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_fill_unknown_resource.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_peer_fill_unknown_resource_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    ReadStatistics stats;
+    CacheContext context;
+    context.stats = &stats;
+    auto hash = BlockFileCache::hash(file_path.filename().native());
+    auto holder = cache->get_or_set(hash, 0, kPeerTestBlockSize, context);
+    auto cached_blocks = fromHolder(holder);
+    ASSERT_EQ(cached_blocks.size(), 1);
+    ASSERT_EQ(cached_blocks[0]->state(), FileBlock::State::EMPTY);
+
+    PFetchPeerDataRequest request;
+    request.set_type(PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK);
+    request.set_path(file_path.filename().native());
+    request.set_file_size(static_cast<int64_t>(content.size()));
+    request.set_support_attachment(false);
+    request.set_request_cache_fill(true);
+    auto* fill_meta = request.mutable_rowset_meta();
+    fill_meta->set_resource_id("missing_peer_fill_resource");
+    fill_meta->set_tablet_id(kCrossTabletId);
+    auto* cache_req = request.add_cache_req();
+    cache_req->set_block_offset(0);
+    cache_req->set_block_size(kPeerTestBlockSize);
+
+    PFetchPeerDataResponse response;
+    brpc::Controller cntl;
+    auto st = doris::test_handle_peer_file_cache_block_request(&request, &response, &cntl);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::NOT_FOUND>());
+    EXPECT_EQ(response.status().status_code(), TStatusCode::NOT_FOUND);
+    ASSERT_GE(response.status().error_msgs_size(), 1);
+    EXPECT_NE(response.status().error_msgs(0).find("storage resource not found"),
+              std::string::npos);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_handler_allows_cached_block_read) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_cached_block_read.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_cached_block_read_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 0, kPeerTestBlockSize, content);
+
+    auto request =
+            create_peer_cache_block_request(file_path, 0, kPeerTestBlockSize, content.size());
+    PFetchPeerDataResponse response;
+    brpc::Controller cntl;
+
+    auto st = doris::test_handle_peer_file_cache_block_request(&request, &response, &cntl);
+
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(response.status().status_code(), TStatusCode::OK);
+    ASSERT_EQ(response.datas_size(), 1);
+    EXPECT_EQ(response.datas(0).block_offset(), 0);
+    EXPECT_EQ(response.datas(0).data(), content.substr(0, kPeerTestBlockSize));
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_fetch_queue_timeout_rejects_expired_request) {
+    const int32_t old_peer_fetch_queue_timeout_ms = config::peer_fetch_queue_timeout_ms;
+    Defer restore_config {
+            [&]() { config::peer_fetch_queue_timeout_ms = old_peer_fetch_queue_timeout_ms; }};
+    config::peer_fetch_queue_timeout_ms = 500;
+
+    PFetchPeerDataResponse response;
+    const uint64_t before_queue_timeout =
+            doris::g_file_cache_get_by_peer_queue_timeout_num.get_value();
+
+    bool rejected = doris::test_try_reject_if_queue_timed_out(
+            std::chrono::steady_clock::now() - std::chrono::seconds(2), &response);
+
+    ASSERT_TRUE(rejected);
+    EXPECT_EQ(response.status().status_code(), TStatusCode::TOO_MANY_TASKS);
+    EXPECT_EQ(doris::g_file_cache_get_by_peer_queue_timeout_num.get_value() - before_queue_timeout,
+              1);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_fetch_queue_timeout_allows_fresh_request) {
+    const int32_t old_peer_fetch_queue_timeout_ms = config::peer_fetch_queue_timeout_ms;
+    Defer restore_config {
+            [&]() { config::peer_fetch_queue_timeout_ms = old_peer_fetch_queue_timeout_ms; }};
+    config::peer_fetch_queue_timeout_ms = 500;
+
+    PFetchPeerDataResponse response;
+    const uint64_t before_queue_timeout =
+            doris::g_file_cache_get_by_peer_queue_timeout_num.get_value();
+
+    bool rejected =
+            doris::test_try_reject_if_queue_timed_out(std::chrono::steady_clock::now(), &response);
+
+    ASSERT_FALSE(rejected);
+    EXPECT_EQ(response.status().status_code(), TStatusCode::OK);
+    EXPECT_EQ(response.status().error_msgs_size(), 0);
+    EXPECT_EQ(doris::g_file_cache_get_by_peer_queue_timeout_num.get_value() - before_queue_timeout,
+              0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_clips_tail_block_by_file_size) {
+    const std::string content = "abcdefghijklmn";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_tail_clip.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_tail_clip_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    ReadStatistics stats;
+    CacheContext context;
+    context.stats = &stats;
+    auto hash = BlockFileCache::hash(file_path.filename().native());
+    auto holder = cache->get_or_set(hash, 12, 4, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    EXPECT_EQ(blocks[0]->range().left, 12);
+    EXPECT_EQ(blocks[0]->range().right, 15);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx).ok());
+
+    ASSERT_EQ(result.chunks.size(), 1);
+    EXPECT_EQ(result.bytes_read, 2);
+    EXPECT_EQ(result.chunks[0].block_index, 0);
+    EXPECT_EQ(result.chunks[0].block_offset, 12);
+    std::string payload(2, '#');
+    ASSERT_EQ(result.chunks[0].payload.copy_to(payload.data(), payload.size()), payload.size());
+    EXPECT_EQ(payload, content.substr(12, 2));
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 1);
+    EXPECT_TRUE(service.support_attachment.load());
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_returns_ok_for_empty_blocks) {
+    PeerFileCacheReader peer_reader(Path("unused"), true, "127.0.0.1", 0);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks({}, &result, 0, &io_ctx).ok());
+    EXPECT_EQ(result.bytes_read, 0);
+    EXPECT_TRUE(result.chunks.empty());
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_rejects_non_doris_table_segments) {
+    const std::string content = "abcd";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_not_supported.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_not_supported_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 0, 4)};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), false, "127.0.0.1", 0);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    auto st = peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.msg().find("supports doris table"), std::string::npos);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_returns_ok_when_all_blocks_are_clipped_by_file_size) {
+    const std::string content = "abcdefghijklmn";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_all_clipped.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_all_clipped_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> clipped_blocks {create_manual_peer_test_block(file_path, 16, 4)};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", 0);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(clipped_blocks, &result, content.size(), &io_ctx).ok());
+
+    EXPECT_EQ(result.bytes_read, 0);
+    EXPECT_TRUE(result.chunks.empty());
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_ignores_zero_sized_response_blocks) {
+    const std::string content = "abcdefghijklmn";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_zero_sized_tail.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_zero_sized_tail_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 12, 4),
+                                       create_manual_peer_test_block(file_path, 16, 4)};
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx).ok());
+
+    ASSERT_EQ(result.chunks.size(), 1);
+    EXPECT_EQ(result.bytes_read, 2);
+    EXPECT_EQ(result.chunks[0].block_index, 0);
+    EXPECT_EQ(result.chunks[0].block_offset, 12);
+    std::string payload(2, '#');
+    ASSERT_EQ(result.chunks[0].payload.copy_to(payload.data(), payload.size()), payload.size());
+    EXPECT_EQ(payload, content.substr(12, 2));
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_rejects_negative_block_metadata) {
+    const std::string content = "abcdefgh";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_negative_metadata.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_negative_metadata_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 0, 4)};
+
+    MockPeerCacheServiceOptions options;
+    options.negative_block_offset = true;
+    MockPeerCacheService service(content, options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    auto st = peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.msg().find("invalid block metadata"), std::string::npos);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_rejects_response_out_of_requested_ranges) {
+    const std::string content = "abcdefgh";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_out_of_range.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_out_of_range_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 0, 4)};
+
+    MockPeerCacheServiceOptions options;
+    options.response_offset_delta = 1;
+    MockPeerCacheService service(content, options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    auto st = peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.msg().find("out of requested ranges"), std::string::npos);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_rejects_duplicate_ranges) {
+    const std::string content = "abcdefgh";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_duplicate_range.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_duplicate_range_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 0, 4)};
+
+    MockPeerCacheServiceOptions options;
+    options.duplicate_first_block = true;
+    MockPeerCacheService service(content, options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    auto st = peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.msg().find("unexpected block range"), std::string::npos);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, peer_file_cache_reader_propagates_peer_error_status) {
+    const std::string content = "abcdefgh";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_error_status.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_error_status_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 0, 4)};
+
+    MockPeerCacheServiceOptions options;
+    options.fail_status = true;
+    MockPeerCacheService service(content, options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    auto st = peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx);
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(service.rpc_count.load(), 1);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_reads_attachment_payload_from_cloud_internal_service_disk_cache) {
+    const bool old_enable_file_cache = config::enable_file_cache;
+    Defer restore_file_cache {[&]() { config::enable_file_cache = old_enable_file_cache; }};
+    config::enable_file_cache = true;
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_real_peer_attachment_disk.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_real_peer_attachment_disk_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 0, kPeerTestBlockSize, content);
+    populate_cache_block_with_content(cache, file_path, 8, kPeerTestBlockSize, content);
+
+    RealPeerCacheService service;
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    std::vector<FileBlockSPtr> blocks {
+            create_manual_peer_test_block(file_path, 0, kPeerTestBlockSize),
+            create_manual_peer_test_block(file_path, 8, kPeerTestBlockSize)};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx).ok());
+
+    ASSERT_EQ(result.chunks.size(), 2);
+    EXPECT_EQ(result.bytes_read, 8);
+    EXPECT_EQ(result.chunks[0].block_index, 0);
+    EXPECT_EQ(result.chunks[0].block_offset, 0);
+    EXPECT_EQ(result.chunks[1].block_index, 1);
+    EXPECT_EQ(result.chunks[1].block_offset, 8);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+
+    std::string first(4, '#');
+    ASSERT_EQ(result.chunks[0].payload.copy_to(first.data(), first.size()), first.size());
+    EXPECT_EQ(first, content.substr(0, 4));
+
+    std::string second(4, '#');
+    ASSERT_EQ(result.chunks[1].payload.copy_to(second.data(), second.size()), second.size());
+    EXPECT_EQ(second, content.substr(8, 4));
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_reads_attachment_payload_from_cloud_internal_service_memory_cache) {
+    const bool old_enable_file_cache = config::enable_file_cache;
+    Defer restore_file_cache {[&]() { config::enable_file_cache = old_enable_file_cache; }};
+    config::enable_file_cache = true;
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_real_peer_attachment_memory.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_real_peer_attachment_memory_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize, "memory");
+    populate_cache_block_with_content(cache, file_path, 0, kPeerTestBlockSize, content);
+    populate_cache_block_with_content(cache, file_path, 8, kPeerTestBlockSize, content);
+
+    RealPeerCacheService service;
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    std::vector<FileBlockSPtr> blocks {
+            create_manual_peer_test_block(file_path, 0, kPeerTestBlockSize),
+            create_manual_peer_test_block(file_path, 8, kPeerTestBlockSize)};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx).ok());
+
+    ASSERT_EQ(result.chunks.size(), 2);
+    EXPECT_EQ(result.bytes_read, 8);
+    EXPECT_EQ(result.chunks[0].block_index, 0);
+    EXPECT_EQ(result.chunks[0].block_offset, 0);
+    EXPECT_EQ(result.chunks[1].block_index, 1);
+    EXPECT_EQ(result.chunks[1].block_offset, 8);
+
+    std::string first(4, '#');
+    ASSERT_EQ(result.chunks[0].payload.copy_to(first.data(), first.size()), first.size());
+    EXPECT_EQ(first, content.substr(0, 4));
+
+    std::string second(4, '#');
+    ASSERT_EQ(result.chunks[1].payload.copy_to(second.data(), second.size()), second.size());
+    EXPECT_EQ(second, content.substr(8, 4));
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_accepts_split_attachment_ranges_from_cloud_internal_service) {
+    const bool old_enable_file_cache = config::enable_file_cache;
+    Defer restore_file_cache {[&]() { config::enable_file_cache = old_enable_file_cache; }};
+    config::enable_file_cache = true;
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_real_peer_attachment_split.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_real_peer_attachment_split_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 0, kPeerTestBlockSize, content);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    RealPeerCacheService service;
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 0, 8)};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx).ok());
+
+    ASSERT_EQ(result.chunks.size(), 2);
+    EXPECT_EQ(result.bytes_read, 8);
+    EXPECT_EQ(result.chunks[0].block_index, 0);
+    EXPECT_EQ(result.chunks[0].block_offset, 0);
+    EXPECT_EQ(result.chunks[1].block_index, 0);
+    EXPECT_EQ(result.chunks[1].block_offset, 4);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 1);
+    EXPECT_TRUE(service.support_attachment.load());
+
+    std::string first(4, '#');
+    ASSERT_EQ(result.chunks[0].payload.copy_to(first.data(), first.size()), first.size());
+    EXPECT_EQ(first, content.substr(0, 4));
+
+    std::string second(4, '#');
+    ASSERT_EQ(result.chunks[1].payload.copy_to(second.data(), second.size()), second.size());
+    EXPECT_EQ(second, content.substr(4, 4));
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       peer_file_cache_reader_clips_tail_request_before_cloud_internal_service_get_or_set) {
+    const bool old_enable_file_cache = config::enable_file_cache;
+    Defer restore_file_cache {[&]() { config::enable_file_cache = old_enable_file_cache; }};
+    config::enable_file_cache = true;
+
+    const std::string content = "abcdefghijklmn";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_real_peer_tail_clip.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_real_peer_tail_clip_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    ReadStatistics stats;
+    CacheContext context;
+    context.stats = &stats;
+    auto hash = BlockFileCache::hash(file_path.filename().native());
+    auto holder = cache->get_or_set(hash, 12, 4, context);
+    auto cached_blocks = fromHolder(holder);
+    ASSERT_EQ(cached_blocks.size(), 1);
+    ASSERT_EQ(cached_blocks[0]->state(), FileBlock::State::EMPTY);
+    ASSERT_EQ(cached_blocks[0]->get_or_set_downloader(), FileBlock::get_caller_id());
+    ASSERT_TRUE(cached_blocks[0]->append(Slice(content.data() + 12, 2)).ok());
+    ASSERT_TRUE(cached_blocks[0]->finalize().ok());
+    EXPECT_EQ(cached_blocks[0]->range().left, 12);
+    EXPECT_EQ(cached_blocks[0]->range().right, 13);
+
+    RealPeerCacheService service;
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    std::vector<FileBlockSPtr> blocks {create_manual_peer_test_block(file_path, 12, 4)};
+
+    PeerFileCacheReader peer_reader(Path(file_path.string()), true, "127.0.0.1", addr.port);
+    PeerFetchResult result;
+    IOContext io_ctx;
+
+    ASSERT_TRUE(peer_reader.fetch_blocks(blocks, &result, content.size(), &io_ctx).ok());
+
+    ASSERT_EQ(result.chunks.size(), 1);
+    EXPECT_EQ(result.bytes_read, 2);
+    EXPECT_EQ(result.chunks[0].block_index, 0);
+    EXPECT_EQ(result.chunks[0].block_offset, 12);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 1);
+    EXPECT_TRUE(service.support_attachment.load());
+
+    std::string tail(2, '#');
+    ASSERT_EQ(result.chunks[0].payload.copy_to(tail.data(), tail.size()), tail.size());
+    EXPECT_EQ(tail, content.substr(12, 2));
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_single_peer_rpc_for_sparse_blocks_pb_payload) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_sparse_pb.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_sparse_pb_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 4);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 6);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       read_at_uses_single_peer_rpc_for_sparse_blocks_pb_payload_memory_cache) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_sparse_pb_memory.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_sparse_pb_memory_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize, "memory");
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(12, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(0, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(0, 12));
+    EXPECT_EQ(bytes_read, 12);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 4);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 8);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_accepts_reordered_attachment_response_blocks) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_attachment_reorder.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_attachment_reorder_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheServiceOptions reorder_options;
+    reorder_options.use_attachment = true;
+    reorder_options.reverse_response_order = true;
+    MockPeerCacheService service(content, reorder_options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 4);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 6);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       read_at_uses_single_peer_rpc_for_sparse_blocks_attachment_payload_memory_cache) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_peer_test_file(
+            "cached_remote_reader_peer_sparse_attachment_memory.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path =
+            caches_dir / "cached_remote_reader_peer_sparse_attachment_memory_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize, "memory");
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheServiceOptions attachment_options;
+    attachment_options.use_attachment = true;
+    MockPeerCacheService service(content, attachment_options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(12, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(0, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(0, 12));
+    EXPECT_EQ(bytes_read, 12);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 4);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 8);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       read_at_uses_single_peer_rpc_for_sparse_blocks_attachment_payload) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_sparse_attachment.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_sparse_attachment_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheServiceOptions attachment_options;
+    attachment_options.use_attachment = true;
+    MockPeerCacheService service(content, attachment_options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(12, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(0, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(0, 12));
+    EXPECT_EQ(bytes_read, 12);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 4);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 8);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_falls_back_when_attachment_payload_is_truncated) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_attachment_truncated.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_attachment_truncated_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheServiceOptions attachment_options;
+    attachment_options.use_attachment = true;
+    attachment_options.truncate_trailing_attachment_bytes = 1;
+    MockPeerCacheService service(content, attachment_options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 0);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_falls_back_when_attachment_has_trailing_bytes) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_attachment_trailing.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_attachment_trailing_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheServiceOptions attachment_options;
+    attachment_options.use_attachment = true;
+    attachment_options.append_trailing_attachment = true;
+    MockPeerCacheService service(content, attachment_options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 0);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_falls_back_when_peer_response_is_incomplete) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_incomplete.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_incomplete_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    BlockFileCache* cache = create_peer_test_cache(cache_path, kPeerTestBlockSize);
+    populate_cache_block_with_content(cache, file_path, 4, kPeerTestBlockSize, content);
+
+    MockPeerCacheServiceOptions incomplete_options;
+    incomplete_options.use_attachment = true;
+    incomplete_options.drop_last_block = true;
+    MockPeerCacheService service(content, incomplete_options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    DebugPoints::instance()->add_with_params(
+            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(service.request_block_count.load(), 2);
+    EXPECT_TRUE(service.support_attachment.load());
+    EXPECT_EQ(cache_stats.num_local_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_local, 0);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_falls_back_to_remote_when_peer_read_fails) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_peer_fallback.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_peer_fallback_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    DebugPoints::instance()->add_with_params("PeerFileCacheReader::_fetch_from_peer_cache_blocks",
+                                             {{"host", "127.0.0.1"}, {"port", "1"}});
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+} // namespace doris::io
+
+// ============================================================
+// Part 2 – Cross-CG winner race tests
+// ============================================================
+// These tests exercise _execute_winner_race() by populating CloudWarmUpManager
+// with cross-CG candidates so that the winner race path is triggered.
+//
+// Requirements:
+//   * ExecEnv must hold a CloudStorageEngine (so to_cloud() works).
+//   * ExecEnv must hold a CloudClusterInfo whose compute_group_id differs
+//     from the candidates' compute_group_id.
+//   * The file path used for CachedRemoteFileReader must be parseable by
+//     extract_tablet_id() – format: "...data/{tablet_id}/{rowset}_{seg}.dat"
+//   * config::enable_peer_s3_race must be true.
+
+#include "cloud/cloud_cluster_info.h"
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_warm_up_manager.h"
+#include "io/cache/cached_remote_file_reader.h"
+#include "util/threadpool.h"
+
+namespace doris::io {
+namespace {
+
+constexpr auto kPeerRpcWaitTimeout = std::chrono::seconds(2);
+
+// Create an actual file at a path parseable by extract_tablet_id():
+// Format: caches_dir/data/{tablet_id}/{name}
+// extract_tablet_id() uses "data/" prefix + 1 slash → version-0 format.
+fs::path create_cross_cg_test_file(const std::string& name, std::string_view content) {
+    fs::path dir = caches_dir / "data" / std::to_string(kCrossTabletId);
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    fs::path file_path = dir / name;
+    std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
+    CHECK(out.is_open()) << file_path;
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    out.close();
+    return file_path;
+}
+
+// ----------------------------------------------------------------
+// Fixture: extends base peer fixture and adds CloudStorageEngine +
+// CloudClusterInfo in ExecEnv so winner-race path is fully reachable.
+// ----------------------------------------------------------------
+class CrossCGWinnerRaceTest : public CachedRemoteFileReaderPeerTest {
+protected:
+    void SetUp() override {
+        // Base SetUp (sets deploy_mode=cloud, enable_cache_read_from_peer, etc.)
+        CachedRemoteFileReaderPeerTest::SetUp();
+
+        // Save old values.
+        _old_enable_peer_s3_race = config::enable_peer_s3_race;
+        _old_max_concurrent_peer_races = config::max_concurrent_peer_races;
+        _old_cluster_info = ExecEnv::GetInstance()->cluster_info();
+
+        // Enable winner race.
+        config::enable_peer_s3_race = true;
+        config::max_concurrent_peer_races = 1024;
+
+        // Install CloudStorageEngine into ExecEnv so to_cloud() works.
+        // Use set_storage_engine so ExecEnv takes ownership (old value nullptr).
+        ExecEnv::GetInstance()->set_storage_engine(
+                std::make_unique<CloudStorageEngine>(EngineOptions {}));
+        auto& cloud_engine = ExecEnv::GetInstance()->storage_engine().to_cloud();
+        cloud_engine.set_cloud_warm_up_manager(std::make_unique<CloudWarmUpManager>(cloud_engine));
+
+        // Install CloudClusterInfo with a self compute_group_id that differs
+        // from the cross-CG candidate compute_group_id "cg_remote".
+        _cluster_info = std::make_unique<CloudClusterInfo>();
+        _cluster_info->set_cloud_compute_group_id("cg_self");
+        ExecEnv::GetInstance()->set_cluster_info(_cluster_info.get());
+
+        // Install peer_race_s3_thread_pool so the winner race exercises the real pool path
+        // (without this, peer_race_s3_thread_pool() returns null and S3 falls back to inline).
+        static_cast<void>(ThreadPoolBuilder("PeerRaceS3ThreadPool")
+                                  .set_min_threads(0)
+                                  .set_max_threads(4)
+                                  .build(&_peer_race_s3_pool));
+        ExecEnv::GetInstance()->_peer_race_s3_thread_pool = std::move(_peer_race_s3_pool);
+    }
+
+    void TearDown() override {
+        // Restore ExecEnv cluster info.
+        ExecEnv::GetInstance()->set_cluster_info(_old_cluster_info);
+
+        // Destroy the CloudStorageEngine installed in SetUp.
+        ExecEnv::GetInstance()->set_storage_engine(nullptr);
+
+        // Tear down peer_race_s3_thread_pool.
+        if (ExecEnv::GetInstance()->_peer_race_s3_thread_pool) {
+            ExecEnv::GetInstance()->_peer_race_s3_thread_pool->shutdown();
+            ExecEnv::GetInstance()->_peer_race_s3_thread_pool.reset(nullptr);
+        }
+
+        // Restore race configs.
+        config::enable_peer_s3_race = _old_enable_peer_s3_race;
+        config::max_concurrent_peer_races = _old_max_concurrent_peer_races;
+
+        CachedRemoteFileReaderPeerTest::TearDown();
+    }
+
+    // Register a cross-CG candidate pointing at brpc addr for kCrossTabletId.
+    void register_cross_cg_candidate(const std::string& host, int32_t port) {
+        ExecEnv::GetInstance()
+                ->storage_engine()
+                .to_cloud()
+                .cloud_warm_up_manager()
+                .record_balanced_tablet(kCrossTabletId, host, port, "cg_remote");
+    }
+
+    // Register a same-CG candidate (compute_group_id == "cg_self").
+    void register_same_cg_candidate(const std::string& host, int32_t port) {
+        ExecEnv::GetInstance()
+                ->storage_engine()
+                .to_cloud()
+                .cloud_warm_up_manager()
+                .record_balanced_tablet(kCrossTabletId, host, port, "cg_self");
+    }
+
+    // Register a second cross-CG candidate from a different remote CG.
+    void register_cross_cg_candidate2(const std::string& host, int32_t port) {
+        ExecEnv::GetInstance()
+                ->storage_engine()
+                .to_cloud()
+                .cloud_warm_up_manager()
+                .record_balanced_tablet(kCrossTabletId, host, port, "cg_remote2");
+    }
+
+    // Inspect the current candidate list for kCrossTabletId.
+    std::vector<doris::PeerCandidate> get_candidates() {
+        return ExecEnv::GetInstance()
+                ->storage_engine()
+                .to_cloud()
+                .cloud_warm_up_manager()
+                .get_peer_candidates(kCrossTabletId);
+    }
+
+private:
+    bool _old_enable_peer_s3_race = false;
+    int32_t _old_max_concurrent_peer_races = 64;
+    ClusterInfo* _old_cluster_info = nullptr;
+
+    std::unique_ptr<CloudClusterInfo> _cluster_info;
+    std::unique_ptr<ThreadPool> _peer_race_s3_pool;
+};
+
+} // namespace
+
+// ----------------------------------------------------------------
+// Test 1: cross-CG peer wins when it has the data (DOWNLOADED block).
+//
+// We use a TEST_SYNC_POINT ("CachedRemoteFileReader::_execute_winner_race::s3_before_read")
+// inserted in the S3 bthread just before its read_at() call to block S3 until peer has won.
+// This guarantees peer always wins regardless of local I/O speed.
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, cross_cg_peer_wins_race) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("peer_wins_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cross_cg_peer_wins_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Start a mock peer server that serves all blocks successfully.
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    // Register candidate pointing at the mock peer server.
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    // Install SyncPoint: block S3 bthread until peer has won.
+    // The callback waits for service.rpc_count > 0 (peer RPC delivered), then sleeps 10 ms
+    // to give the peer bthread time to lock race->mtx and set winner=0. S3 completes after
+    // that, finds winner already set, and discards its result.
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                // Wait until mock peer server has received and processed at least one RPC.
+                service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                // Extra margin: let peer bthread acquire race->mtx and set winner=0.
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // Peer should have been contacted at least once.
+    EXPECT_GE(service.rpc_count.load(), 1);
+    // Data came from peer (cross-CG race: peer won).
+    EXPECT_GE(cache_stats.num_cross_cg_peer_io_total, 1);
+    EXPECT_GE(cache_stats.bytes_read_from_cross_cg_peer, 10u);
+    // Race winner=0 means peer data was returned.
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 1);
+}
+
+TEST_F(CrossCGWinnerRaceTest, cross_cg_peer_race_updates_workload_group_remote_scan_metrics) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("peer_wg_remote_scan_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cross_cg_peer_wg_remote_scan_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    auto workload_group = create_peer_test_workload_group(1024);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                // Keep S3 behind the peer path on purpose. This case is not asserting that
+                // "throttled peer must lose to S3"; it asserts that peer reads still inherit
+                // WG remote-scan throttling inside winner-race execution. Waiting until the peer
+                // RPC is already in flight guarantees the peer branch has first paid the ~500 ms
+                // IOThrottle delay, then adding a small extra sleep keeps the winner stable.
+                service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileCacheStatistics cache_stats;
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    Status read_status = Status::OK();
+    std::thread read_thread {[&]() {
+        auto query_mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::QUERY,
+                                                                  "CrossCGWinnerRaceWGPeerRead");
+        AttachTask attach_task(
+                create_peer_test_resource_context(query_mem_tracker, workload_group));
+
+        FileReaderSPtr local_reader;
+        read_status = global_local_filesystem()->open_file(file_path.string(), &local_reader);
+        if (!read_status.ok()) {
+            return;
+        }
+
+        FileReaderOptions opts;
+        opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+        opts.is_doris_table = true;
+        opts.mtime = 1;
+        opts.tablet_id = kCrossTabletId;
+        auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+        IOContext io_ctx;
+        io_ctx.file_cache_stats = &cache_stats;
+        read_status = reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx);
+    }};
+    read_thread.join();
+
+    ASSERT_TRUE(read_status.ok()) << read_status;
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 1);
+    EXPECT_GE(cache_stats.num_cross_cg_peer_io_total, 1);
+    EXPECT_GE(cache_stats.bytes_read_from_cross_cg_peer, 10u);
+}
+
+TEST_F(CrossCGWinnerRaceTest, cross_cg_peer_race_respects_workload_group_remote_scan_throttle) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("peer_wg_throttle_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cross_cg_peer_wg_throttle_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    auto workload_group = create_peer_test_workload_group(20);
+    auto remote_scan_io_throttle = workload_group->get_remote_scan_io_throttle();
+    ASSERT_NE(remote_scan_io_throttle, nullptr);
+    // IOThrottle gates reads in two phases:
+    //   1. acquire() runs before the read and waits until now > next_io_time.
+    //   2. update_next_io_time(bytes) runs after the read and pushes next_io_time forward by
+    //      bytes / remote_read_bytes_per_second.
+    //
+    // Timeline with remote_read_bytes_per_second = 20 B/s:
+    //   t0: next_io_time = 0, so a first read would pass acquire() immediately.
+    //   t1: seed update_next_io_time(10), which records 10 / 20 s = 0.5 s of throttle debt.
+    //       next_io_time becomes about t1 + 500 ms.
+    //   t2: this test's peer read starts right after t1, so acquire() waits until next_io_time,
+    //       i.e. about 500 ms, before issuing the RPC.
+    remote_scan_io_throttle->update_next_io_time(10);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileCacheStatistics cache_stats;
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    Status read_status = Status::OK();
+    int64_t elapsed_ms = 0;
+    std::thread read_thread {[&]() {
+        auto query_mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::QUERY,
+                                                                  "CrossCGWinnerRaceWGThrottle");
+        AttachTask attach_task(
+                create_peer_test_resource_context(query_mem_tracker, workload_group));
+
+        FileReaderSPtr local_reader;
+        read_status = global_local_filesystem()->open_file(file_path.string(), &local_reader);
+        if (!read_status.ok()) {
+            return;
+        }
+
+        FileReaderOptions opts;
+        opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+        opts.is_doris_table = true;
+        opts.mtime = 1;
+        opts.tablet_id = kCrossTabletId;
+        auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+        IOContext io_ctx;
+        io_ctx.file_cache_stats = &cache_stats;
+        const auto start = std::chrono::steady_clock::now();
+        read_status = reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx);
+        elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::steady_clock::now() - start)
+                             .count();
+    }};
+    read_thread.join();
+
+    ASSERT_TRUE(read_status.ok()) << read_status;
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 1);
+    EXPECT_GE(service.rpc_count.load(), 1);
+    // Timing rationale: 10 bytes / 20 B/s = 500 ms of throttle debt seeded before the read.
+    // The peer bthread must wait ~500 ms in IOThrottle::acquire() before issuing the RPC.
+    // The S3 sync point blocks until the peer RPC fires, so S3 also finishes after ~500 ms.
+    // 400 ms is a conservative lower bound (80% of expected) to tolerate scheduling jitter.
+    EXPECT_GE(elapsed_ms, 400);
+}
+
+TEST_F(CrossCGWinnerRaceTest,
+       cross_cg_s3_inline_fallback_inherits_workload_group_context_when_pool_unavailable) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path cache_path = caches_dir / "cross_cg_s3_inline_fallback_wg_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    auto workload_group = create_peer_test_workload_group(20);
+    auto remote_scan_io_throttle = workload_group->get_remote_scan_io_throttle();
+    ASSERT_NE(remote_scan_io_throttle, nullptr);
+    remote_scan_io_throttle->update_next_io_time(10);
+
+    MockPeerCacheServiceOptions fail_opts;
+    fail_opts.fail_status = true;
+    MockPeerCacheService fail_service(content, fail_opts);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &fail_service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    auto saved_s3_pool = std::move(ExecEnv::GetInstance()->_peer_race_s3_thread_pool);
+    Defer restore_s3_pool {[&]() {
+        ExecEnv::GetInstance()->_peer_race_s3_thread_pool = std::move(saved_s3_pool);
+    }};
+    ASSERT_EQ(ExecEnv::GetInstance()->peer_race_s3_thread_pool(), nullptr);
+
+    auto remote_reader = std::make_shared<InspectingRemoteFileReader>(
+            content,
+            caches_dir / "data" / std::to_string(kCrossTabletId) /
+                    "cross_cg_s3_inline_fallback_wg.dat",
+            workload_group);
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(remote_reader, opts);
+
+    FileCacheStatistics cache_stats;
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    Status read_status = Status::OK();
+    int64_t elapsed_ms = 0;
+    std::thread read_thread {[&]() {
+        auto query_mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::QUERY,
+                                                                  "CrossCGWinnerRaceS3InlineWG");
+        AttachTask attach_task(
+                create_peer_test_resource_context(query_mem_tracker, workload_group));
+        remote_reader->set_expected_thread_id(std::this_thread::get_id());
+
+        IOContext io_ctx;
+        io_ctx.file_cache_stats = &cache_stats;
+        const auto start = std::chrono::steady_clock::now();
+        read_status = reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx);
+        elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::steady_clock::now() - start)
+                             .count();
+    }};
+    read_thread.join();
+
+    ASSERT_TRUE(read_status.ok()) << read_status;
+    EXPECT_TRUE(fail_service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout));
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_GE(fail_service.rpc_count.load(), 1);
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+    EXPECT_EQ(cache_stats.num_cross_cg_peer_io_total, 0);
+    EXPECT_EQ(remote_reader->read_call_count(), 1);
+    EXPECT_TRUE(remote_reader->observed_expected_workload_group());
+    EXPECT_TRUE(remote_reader->observed_non_orphan_tracker());
+    EXPECT_TRUE(remote_reader->ran_on_expected_thread());
+    EXPECT_GE(remote_reader->throttle_wait_ms(), 400);
+    EXPECT_GE(elapsed_ms, 400);
+}
+
+// ----------------------------------------------------------------
+// Test 2: S3 wins when peer mock returns an error.
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, cross_cg_s3_wins_when_peer_fails) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("s3_wins_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cross_cg_s3_wins_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Start a mock peer server that always returns INTERNAL_ERROR.
+    MockPeerCacheServiceOptions fail_opts;
+    fail_opts.fail_status = true;
+    MockPeerCacheService fail_service(content, fail_opts);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &fail_service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    // Register the failing cross-CG candidate.
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    // Read should still succeed via S3 fallback.
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // Peer was contacted but failed.
+    EXPECT_GE(fail_service.rpc_count.load(), 1);
+    // S3 won the race.
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+    EXPECT_EQ(cache_stats.num_cross_cg_peer_io_total, 0);
+}
+
+TEST_F(CrossCGWinnerRaceTest, cross_cg_s3_win_does_not_wait_for_peer_done) {
+    const int delay_ms = 1500;
+    const int32_t old_hedge_delay_ms = config::peer_race_hedge_delay_ms;
+    Defer restore_hedge_delay {[&]() { config::peer_race_hedge_delay_ms = old_hedge_delay_ms; }};
+    config::peer_race_hedge_delay_ms = 0;
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("s3_no_wait_peer_done_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cross_cg_s3_no_wait_peer_done_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    SlowFailingPeerCacheService slow_service(delay_ms);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &slow_service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    MonotonicStopWatch sw;
+    sw.start();
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    const int64_t elapsed_ms = sw.elapsed_time() / 1000000;
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+    EXPECT_LT(elapsed_ms, delay_ms / 2);
+
+    for (int i = 0; i < 40 && !slow_service.finished.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_TRUE(slow_service.started.load(std::memory_order_acquire));
+    EXPECT_TRUE(slow_service.finished.load(std::memory_order_acquire));
+}
+
+TEST_F(CrossCGWinnerRaceTest, fill_not_found_does_not_retry_same_compute_group_candidates) {
+    const int32_t old_hedge_delay_ms = config::peer_race_hedge_delay_ms;
+    const std::string old_fill_cg = config::peer_cache_fill_compute_group_id;
+    Defer restore_config {[&]() {
+        config::peer_race_hedge_delay_ms = old_hedge_delay_ms;
+        config::peer_cache_fill_compute_group_id = old_fill_cg;
+    }};
+    config::peer_race_hedge_delay_ms = 500;
+    config::peer_cache_fill_compute_group_id = "cg_fill";
+
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("fill_not_found_no_retry_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "fill_not_found_no_retry_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheServiceOptions miss_opts;
+    miss_opts.cache_miss_status = true;
+    MockPeerCacheService miss_service1(content, miss_opts);
+    MockPeerCacheService miss_service2(content, miss_opts);
+
+    brpc::Server server1, server2;
+    auto addr1 = start_peer_test_server(&server1, &miss_service1);
+    auto addr2 = start_peer_test_server(&server2, &miss_service2);
+    Defer stop_servers {[&]() {
+        stop_peer_test_server(&server1);
+        stop_peer_test_server(&server2);
+    }};
+
+    TabletPeerCandidates candidates;
+    candidates.candidates = {
+            PeerCandidate {
+                    .host = "127.0.0.1", .brpc_port = addr1.port, .compute_group_id = "cg_fill"},
+            PeerCandidate {
+                    .host = "127.0.0.1", .brpc_port = addr2.port, .compute_group_id = "cg_fill"}};
+    ExecEnv::GetInstance()
+            ->storage_engine()
+            .to_cloud()
+            .cloud_warm_up_manager()
+            .set_tablet_peer_candidates(kCrossTabletId, std::move(candidates));
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    opts.storage_resource_id = "peer_fill_test_resource";
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_TRUE(miss_service1.request_fill.load());
+    EXPECT_EQ(miss_service1.rpc_count.load(), 1);
+    EXPECT_EQ(miss_service2.rpc_count.load(), 0);
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+}
+
+// ----------------------------------------------------------------
+// Test 3: same-CG candidate goes through winner race, peer wins, no cross-CG stats.
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, same_cg_candidate_peer_wins_race_no_cross_cg_stats) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("same_cg_race_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "same_cg_race_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Start a successful peer server.
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    // Register a SAME-CG candidate (compute_group_id == "cg_self").
+    register_same_cg_candidate("127.0.0.1", addr.port);
+
+    // Block S3 until peer finishes to ensure peer wins the race.
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // Same-CG candidate wins race — peer_race_peer_win counted, but NOT cross-CG.
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 1);
+    EXPECT_EQ(cache_stats.num_cross_cg_peer_io_total, 0)
+            << "same-CG peer win must NOT increment cross-CG counter";
+    EXPECT_GE(cache_stats.num_peer_io_total, 1);
+    EXPECT_GE(cache_stats.bytes_read_from_peer, 10u);
+}
+
+// ----------------------------------------------------------------
+// Test: mixed same-CG + cross-CG candidates → peer bthread retries through cross-CG miss
+// to reach same-CG hit; winner reports same-CG (no cross-CG stats).
+// ----------------------------------------------------------------
+// Storage order: [cg_remote@portB (cache miss), cg_self@portA (has data)].
+// Peer bthread tries cg_remote first → NOT_FOUND → retries cg_self → hit → peer wins.
+// After success, last_successful_compute_group_id is set to "cg_self", so subsequent
+// reads try cg_self first (affinity).
+TEST_F(CrossCGWinnerRaceTest, mixed_candidates_peer_retries_to_same_cg_hit) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("mixed_cg_retry_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "mixed_cg_retry_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Same-CG server: has the data.
+    MockPeerCacheService same_cg_service(content);
+    brpc::Server same_cg_server;
+    auto same_cg_addr = start_peer_test_server(&same_cg_server, &same_cg_service);
+    Defer stop_same {[&]() { stop_peer_test_server(&same_cg_server); }};
+
+    // Cross-CG server: simulates a cache miss (EMPTY block on that BE).
+    MockPeerCacheServiceOptions cross_opts;
+    cross_opts.cache_miss_status = true;
+    MockPeerCacheService cross_cg_service(content, cross_opts);
+    brpc::Server cross_cg_server;
+    auto cross_cg_addr = start_peer_test_server(&cross_cg_server, &cross_cg_service);
+    Defer stop_cross {[&]() { stop_peer_test_server(&cross_cg_server); }};
+
+    // Register same-CG FIRST so it lands at index 1 in storage after cross-CG is pushed to front.
+    // storage: [cg_remote@cross_cg_port, cg_self@same_cg_port]
+    register_same_cg_candidate("127.0.0.1", same_cg_addr.port);
+    register_cross_cg_candidate("127.0.0.1", cross_cg_addr.port);
+
+    auto cands = get_candidates();
+    ASSERT_GE(cands.size(), 2u);
+    ASSERT_EQ(cands[0].compute_group_id, "cg_remote")
+            << "cross-CG candidate must be at index 0 (registered last → inserted at front)";
+
+    // Block S3 until cross-CG server has been contacted (peer needs time to retry).
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                cross_cg_service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // Peer won the race via same-CG candidate (after retrying past cross-CG miss).
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 1);
+    EXPECT_EQ(cache_stats.num_cross_cg_peer_io_total, 0)
+            << "winner was same-CG — cross-CG counter must stay 0";
+    EXPECT_GE(cache_stats.num_peer_io_total, 1);
+    EXPECT_GE(cache_stats.bytes_read_from_peer, 10u);
+    // Cross-CG server was contacted (cache miss), then same-CG server was contacted (hit).
+    EXPECT_GE(cross_cg_service.rpc_count.load(), 1)
+            << "cross-CG candidate at index 0 should have been tried first";
+    EXPECT_GE(same_cg_service.rpc_count.load(), 1)
+            << "same-CG candidate should have been tried after cross-CG miss";
+}
+
+// ----------------------------------------------------------------
+// Test: cross-CG cache miss (NOT_FOUND) rotates candidate, does NOT evict it.
+//
+// Before fix: server returned INTERNAL_ERROR for EMPTY blocks; client checked
+// ENTRY_NOT_FOUND (-7002) which never matched TStatusCode::INTERNAL_ERROR.
+// Both eviction and rotate paths were dead. Fix: server returns NOT_FOUND, client
+// checks NOT_FOUND → eviction counter stays 0, candidate is rotated to end.
+//
+// Scenario: two cross-CG candidates.
+//   - cg_remote  (at back after insert order) → mock returns NOT_FOUND (cache miss)
+//   - cg_remote2 (at front) → mock returns actual data
+//   Peer bthread tries cg_remote2 first (hits), reads succeed.
+//   Then on the second read_at we expect cg_remote to appear at the back,
+//   meaning it was rotated or stayed put (and was NOT evicted).
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, cross_cg_cache_miss_rotates_not_evicts_candidate) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("cache_miss_rotate_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cache_miss_rotate_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // cg_remote mock: returns NOT_FOUND (server-side cache miss).
+    MockPeerCacheServiceOptions miss_opts;
+    miss_opts.cache_miss_status = true;
+    MockPeerCacheService miss_service(content, miss_opts);
+    brpc::Server miss_server;
+    auto miss_addr = start_peer_test_server(&miss_server, &miss_service);
+    Defer stop_miss {[&]() { stop_peer_test_server(&miss_server); }};
+
+    // cg_remote2 mock: returns actual data.
+    MockPeerCacheService hit_service(content);
+    brpc::Server hit_server;
+    auto hit_addr = start_peer_test_server(&hit_server, &hit_service);
+    Defer stop_hit {[&]() { stop_peer_test_server(&hit_server); }};
+
+    // Register cg_remote2 first, then cg_remote. record_balanced_tablet inserts at front,
+    // so the last registration becomes index 0:
+    //   after register_cross_cg_candidate2(hit):  [cg_remote2]
+    //   after register_cross_cg_candidate(miss):  [cg_remote, cg_remote2]
+    // cg_remote is at index 0 → peer bthread tries it first → NOT_FOUND → rotate → cg_remote2.
+    // Note: re-registering the same CG does in-place update (no reorder), so we must register
+    // in the correct final order from the start.
+    register_cross_cg_candidate2("127.0.0.1", hit_addr.port); // cg_remote2 → index 0
+    register_cross_cg_candidate("127.0.0.1", miss_addr.port); // cg_remote  → index 0 (front)
+    // storage: [cg_remote, cg_remote2]
+
+    auto candidates_before = get_candidates();
+    ASSERT_EQ(candidates_before.size(), 2);
+    EXPECT_EQ(candidates_before[0].compute_group_id, "cg_remote");
+    EXPECT_EQ(candidates_before[1].compute_group_id, "cg_remote2");
+
+    // Keep S3 behind the peer path until the cache-miss candidate has actually been tried.
+    // This validates rotate semantics without disabling winner race.
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                miss_service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    // read_at: peer tries cg_remote (front, cache miss NOT_FOUND) → rotates to back,
+    // then tries cg_remote2 (now front, data available) → peer wins race.
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // miss_service must have been called at least once (cg_remote was tried first).
+    EXPECT_GE(miss_service.rpc_count.load(), 1) << "cg_remote mock should have been contacted";
+
+    // Key assertion: cg_remote must still be in the candidate list (NOT evicted).
+    auto candidates_after = get_candidates();
+    bool miss_cand_found = false;
+    for (const auto& c : candidates_after) {
+        if (c.compute_group_id == "cg_remote") {
+            miss_cand_found = true;
+            EXPECT_EQ(c.consecutive_rpc_failures, 0)
+                    << "NOT_FOUND (cache miss) must NOT increment consecutive_rpc_failures";
+        }
+    }
+    EXPECT_TRUE(miss_cand_found)
+            << "cg_remote candidate must survive after cache miss: rotate, not evict";
+}
+
+// ----------------------------------------------------------------
+// Test: tablet cooldown — after N consecutive all-miss races, peer is skipped and S3 wins
+// directly without peer RPC overhead.
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, cooldown_skips_peer_after_consecutive_all_miss) {
+    const std::string content = "abcdefghijklmnopqrstuvwxyz0123456789ABCD";
+    const fs::path file_path = create_cross_cg_test_file("cooldown_test_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cooldown_test_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Mock peer server: always returns cache miss (NOT_FOUND).
+    MockPeerCacheServiceOptions miss_opts;
+    miss_opts.cache_miss_status = true;
+    MockPeerCacheService miss_service(content, miss_opts);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &miss_service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    // Set cooldown threshold to 2 for faster test.
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    const int64_t old_duration = config::peer_all_miss_cooldown_duration_s;
+    const int old_hedge_delay_ms = config::peer_race_hedge_delay_ms;
+    config::peer_all_miss_cooldown_threshold = 2;
+    config::peer_all_miss_cooldown_duration_s = 600; // long enough to not expire during test
+    config::peer_race_hedge_delay_ms = 50;
+    Defer restore_config {[old_threshold, old_duration, old_hedge_delay_ms]() {
+        config::peer_all_miss_cooldown_threshold = old_threshold;
+        config::peer_all_miss_cooldown_duration_s = old_duration;
+        config::peer_race_hedge_delay_ms = old_hedge_delay_ms;
+    }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    // Read uncached ranges so each read forces a fresh peer-vs-S3 decision for the same tablet.
+    // The hedge delay gives the peer path a head start, making the all-miss accounting
+    // deterministic instead of racing with the local-reader S3 path.
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+    int rpc_count_after_read1 = miss_service.rpc_count.load();
+    EXPECT_GE(rpc_count_after_read1, 1) << "peer was tried in read 1";
+
+    // Read 2: peer miss again → S3 wins. consecutive_all_miss becomes 2 → cooldown triggered.
+    cache_stats = {};
+    ASSERT_TRUE(
+            reader->read_at(13, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(13, 10));
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+    int rpc_count_after_read2 = miss_service.rpc_count.load();
+    EXPECT_GE(rpc_count_after_read2, rpc_count_after_read1 + 1) << "peer was tried in read 2";
+
+    // Verify cooldown is active.
+    auto& manager = ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager();
+    EXPECT_TRUE(manager.is_peer_cooldown(kCrossTabletId));
+
+    // Read 3: cooldown active → candidates empty → S3 directly, NO peer RPC.
+    cache_stats = {};
+    ASSERT_TRUE(
+            reader->read_at(25, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(25, 10));
+    // No race entered — S3 was called directly via the empty-candidates path.
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 0);
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 0);
+    // No additional peer RPCs were made during cooldown.
+    EXPECT_EQ(miss_service.rpc_count.load(), rpc_count_after_read2)
+            << "peer server must NOT be contacted during cooldown";
+}
+
+// ----------------------------------------------------------------
+// Test: sequential peer read with empty candidates falls back directly to S3.
+// (Covers the _execute_sequential_peer_read empty-candidates path.)
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, sequential_peer_read_falls_back_to_s3_on_empty_candidates) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("seq_empty_cands_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "seq_empty_cands_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Disable race so the sequential path is used.
+    const bool old_race = config::enable_peer_s3_race;
+    config::enable_peer_s3_race = false;
+    Defer restore_race {[old_race]() { config::enable_peer_s3_race = old_race; }};
+
+    // Do NOT register any candidates — get_peer_candidates will return empty.
+    // But we still need to avoid the "cold miss" bthread fetch, which calls
+    // fetch_candidates_from_fe (unimplemented in test). So set cooldown active.
+    auto& manager = ExecEnv::GetInstance()->storage_engine().to_cloud().cloud_warm_up_manager();
+    const int old_threshold = config::peer_all_miss_cooldown_threshold;
+    config::peer_all_miss_cooldown_threshold = 1;
+    Defer restore_threshold {
+            [old_threshold]() { config::peer_all_miss_cooldown_threshold = old_threshold; }};
+    // Record one all-miss to trigger cooldown.
+    manager.record_peer_all_miss(kCrossTabletId);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // S3 was used (no peer, no race).
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 0);
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 0);
+}
+
+// ----------------------------------------------------------------
+// Test: sequential peer read success updates affinity (last_successful_compute_group_id).
+// (Covers the _execute_sequential_peer_read success path with affinity tracking.)
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, sequential_peer_read_updates_affinity_on_success) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("seq_affinity_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "seq_affinity_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    // Disable race so the sequential path is used.
+    const bool old_race = config::enable_peer_s3_race;
+    config::enable_peer_s3_race = false;
+    Defer restore_race {[old_race]() { config::enable_peer_s3_race = old_race; }};
+
+    // Start a mock peer server that serves all blocks successfully.
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+
+    // Peer read was used (sequential path, not race).
+    EXPECT_EQ(cache_stats.num_peer_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 10);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 0);
+
+    // Verify affinity was updated: the successful candidate's CG should be
+    // recorded as last_successful_compute_group_id, placing it at index 0
+    // after a fresh get_peer_candidates call.
+    auto candidates = get_candidates();
+    ASSERT_FALSE(candidates.empty());
+    EXPECT_EQ(candidates[0].compute_group_id, "cg_remote");
+}
+
+// ----------------------------------------------------------------
+// Test: in a race, when S3 wins quickly, the peer bthread stops trying
+// further candidates (no unnecessary RPCs after S3 victory).
+// (Covers the race->winner check in run_peer_race.)
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, race_peer_stops_when_s3_wins) {
+    // Verifies that run_peer_race stops trying further candidates once S3 wins.
+    // Strategy: use sync points to guarantee ordering:
+    //   1. Peer tries candidate 1 → cache miss
+    //   2. Sync point blocks peer between candidates
+    //   3. S3 completes (wins the race)
+    //   4. Release peer → peer sees S3 won → skips candidate 2
+    //   5. Assert: candidate 2 received 0 RPCs
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("peer_stops_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "peer_stops_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheServiceOptions miss_opts;
+    miss_opts.cache_miss_status = true;
+    MockPeerCacheService miss_service1(content, miss_opts);
+    MockPeerCacheService miss_service2(content, miss_opts);
+
+    brpc::Server server1, server2;
+    auto addr1 = start_peer_test_server(&server1, &miss_service1);
+    auto addr2 = start_peer_test_server(&server2, &miss_service2);
+    Defer stop_servers {[&]() {
+        stop_peer_test_server(&server1);
+        stop_peer_test_server(&server2);
+    }};
+
+    // record_balanced_tablet prepends new compute groups, so register candidate 2 first
+    // to make candidate 1 the front entry tried by the race.
+    register_cross_cg_candidate2("127.0.0.1", addr2.port);
+    register_cross_cg_candidate("127.0.0.1", addr1.port);
+
+    auto candidates = get_candidates();
+    ASSERT_EQ(candidates.size(), 2);
+    EXPECT_EQ(candidates[0].compute_group_id, "cg_remote");
+    EXPECT_EQ(candidates[1].compute_group_id, "cg_remote2");
+
+    // Sync point: after candidate 1 fails, block peer bthread until S3 finishes.
+    auto* sp = SyncPoint::get_instance();
+    sp->clear_all_call_backs();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard between_guard;
+    sp->set_call_back(
+            "run_peer_race::between_candidates",
+            [&](auto&&) {
+                // Wait until S3 has completed — by then race->winner == 1.
+                // The S3 path reads from local_reader (fast), so it finishes quickly.
+                // We just need to give it a tiny window to complete.
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            },
+            &between_guard);
+    Defer disable_sp {[&]() {
+        sp->disable_processing();
+        sp->clear_all_call_backs();
+    }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+
+    // S3 won.
+    EXPECT_EQ(cache_stats.num_peer_race_s3_win, 1);
+
+    // Candidate 1 was tried (cache miss), candidate 2 was NOT tried (S3 already won).
+    EXPECT_EQ(miss_service1.rpc_count.load(), 1) << "candidate 1 should have been tried";
+    EXPECT_EQ(miss_service2.rpc_count.load(), 0) << "candidate 2 should be skipped (S3 won)";
+}
+
+// ----------------------------------------------------------------
+// Test: cross-CG peer wins race and timer metrics are non-zero.
+//
+// Verifies that peer_io_timer and cross_cg_peer_io_timer are populated
+// when peer wins the race — regression test for the bug where both
+// timers were always 0 in race mode.
+// ----------------------------------------------------------------
+TEST_F(CrossCGWinnerRaceTest, cross_cg_peer_wins_race_records_timer_metrics) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path = create_cross_cg_test_file("peer_timer_0.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cross_cg_peer_timer_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheService service(content);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    register_cross_cg_candidate("127.0.0.1", addr.port);
+
+    // Block S3 so peer always wins the race.
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard s3_block_guard;
+    sp->set_call_back(
+            "CachedRemoteFileReader::_execute_winner_race::s3_before_read",
+            [&](auto&&) {
+                service.wait_for_rpc_count_at_least(1, kPeerRpcWaitTimeout);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            },
+            &s3_block_guard);
+    Defer disable_sp {[&]() { sp->disable_processing(); }};
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kCrossTabletId;
+    // Use shared_ptr because _execute_winner_race calls shared_from_this().
+    auto reader = std::make_shared<CachedRemoteFileReader>(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader->read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    // Peer won the race.
+    EXPECT_EQ(cache_stats.num_peer_race_peer_win, 1);
+    EXPECT_GE(cache_stats.num_cross_cg_peer_io_total, 1);
+    // Timer metrics must be non-zero when peer read actually occurred.
+    EXPECT_GT(cache_stats.peer_io_timer, 0) << "peer_io_timer should be non-zero after peer win";
+    EXPECT_GT(cache_stats.cross_cg_peer_io_timer, 0)
+            << "cross_cg_peer_io_timer should be non-zero after cross-CG peer win";
+}
+
+} // namespace doris::io

--- a/be/test/io/fs/local_file_system_test.cpp
+++ b/be/test/io/fs/local_file_system_test.cpp
@@ -17,6 +17,7 @@
 
 #include "io/fs/local_file_system.h"
 
+#include <butil/iobuf.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -34,6 +35,7 @@
 #include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_writer.h"
+#include "io/fs/local_file_writer.h"
 #include "util/slice.h"
 
 namespace doris {
@@ -133,6 +135,141 @@ TEST_F(LocalFileSystemTest, WriteRead) {
         st = file_reader->close();
         ASSERT_TRUE(st.ok()) << st;
     }
+}
+
+TEST_F(LocalFileSystemTest, WriteReadIOBuf) {
+    auto fname = fmt::format("{}/append_iobuf", test_dir);
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto* local_writer = dynamic_cast<io::LocalFileWriter*>(file_writer.get());
+    ASSERT_NE(local_writer, nullptr);
+
+    butil::IOBuf payload;
+    payload.append("ab", 2);
+    payload.append("cdef", 4);
+    payload.append("gh", 2);
+    st = local_writer->append_iobuf(payload);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 8);
+
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+
+    int64_t fsize = 0;
+    st = io::global_local_filesystem()->file_size(fname, &fsize);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(fsize, 8);
+
+    io::FileReaderSPtr file_reader;
+    st = io::global_local_filesystem()->open_file(fname, &file_reader);
+    ASSERT_TRUE(st.ok()) << st;
+
+    char buf[8];
+    size_t bytes_read = 0;
+    st = file_reader->read_at(0, {buf, sizeof(buf)}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, sizeof(buf));
+    EXPECT_EQ(std::string_view(buf, sizeof(buf)), "abcdefgh");
+
+    butil::IOBuf read_buf;
+    st = file_reader->read_at_iobuf(2, 4, &read_buf, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, 4);
+    EXPECT_EQ(read_buf.to_string(), "cdef");
+}
+
+TEST_F(LocalFileSystemTest, AppendEmptyIOBuf) {
+    auto fname = fmt::format("{}/append_empty_iobuf", test_dir);
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto* local_writer = dynamic_cast<io::LocalFileWriter*>(file_writer.get());
+    ASSERT_NE(local_writer, nullptr);
+
+    butil::IOBuf payload;
+    st = local_writer->append_iobuf(payload);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 0);
+
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+
+    int64_t fsize = -1;
+    st = io::global_local_filesystem()->file_size(fname, &fsize);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(fsize, 0);
+}
+
+TEST_F(LocalFileSystemTest, AppendIOBufToClosedWriter) {
+    auto fname = fmt::format("{}/append_iobuf_closed", test_dir);
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto* local_writer = dynamic_cast<io::LocalFileWriter*>(file_writer.get());
+    ASSERT_NE(local_writer, nullptr);
+
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+
+    butil::IOBuf payload;
+    payload.append("ab", 2);
+    st = local_writer->append_iobuf(payload);
+    ASSERT_FALSE(st.ok()) << st;
+}
+
+TEST_F(LocalFileSystemTest, AppendIOBufRetriesOnEintr) {
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+
+    auto fname = fmt::format("{}/append_iobuf_eintr", test_dir);
+    io::FileWriterPtr file_writer;
+    auto st = io::global_local_filesystem()->create_file(fname, &file_writer);
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto* local_writer = dynamic_cast<io::LocalFileWriter*>(file_writer.get());
+    ASSERT_NE(local_writer, nullptr);
+
+    int retry = 2;
+    SyncPoint::CallbackGuard guard1;
+    sp->set_call_back(
+            "LocalFileWriter::cut_into_file_descriptor",
+            [&retry](auto&& args) {
+                if (retry-- > 0) {
+                    auto* ret = try_any_cast_ret<ssize_t>(args);
+                    ret->first = -1;
+                    ret->second = true;
+                    errno = EINTR;
+                } else {
+                    auto* ret = try_any_cast_ret<ssize_t>(args);
+                    ret->second = false;
+                }
+            },
+            &guard1);
+
+    butil::IOBuf payload;
+    payload.append("ab", 2);
+    payload.append("cd", 2);
+    st = local_writer->append_iobuf(payload);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(file_writer->bytes_appended(), 4);
+
+    st = file_writer->close();
+    ASSERT_TRUE(st.ok()) << st;
+
+    io::FileReaderSPtr file_reader;
+    st = io::global_local_filesystem()->open_file(fname, &file_reader);
+    ASSERT_TRUE(st.ok()) << st;
+
+    char buf[4];
+    size_t bytes_read = 0;
+    st = file_reader->read_at(0, {buf, sizeof(buf)}, &bytes_read);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(bytes_read, sizeof(buf));
+    EXPECT_EQ(std::string_view(buf, sizeof(buf)), "abcd");
 }
 
 TEST_F(LocalFileSystemTest, Exist) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -133,8 +134,10 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     // groups (e.g. the colocate proc display) fetch each group's backends only once.
     public long getColocatedBeId(String clusterId, List<Backend> clusterBackends) throws ComputeGroupException {
         CloudSystemInfoService infoService = ((CloudSystemInfoService) Env.getCurrentSystemInfo());
-        List<Backend> bes = clusterBackends.stream()
-                .filter(be -> be.isQueryAvailable()).collect(Collectors.toList());
+        // Do not filter by isQueryAvailable() here. Recently-dead BEs must stay in
+        // the hash ring during the grace period to avoid unnecessary full rehash.
+        // Reuse the caller's snapshot when resolving multiple replicas.
+        List<Backend> bes = clusterBackends;
         String clusterName = infoService.getClusterNameByClusterId(clusterId);
         if (bes.isEmpty()) {
             LOG.warn("failed to get available be, cluster: {}-{}", clusterName, clusterId);
@@ -564,6 +567,14 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         secondaryClusterToBackends.remove(cluster);
     }
 
+    /**
+     * Returns the set of compute group IDs that have primary backends for this replica.
+     * Used by lazy fetch path to also collect secondary backends per compute group.
+     */
+    public Set<String> getPrimaryComputeGroupIds() {
+        return primaryClusterToBackend.keySet();
+    }
+
     // ATTN: This func is only used by redundant tablet report clean in bes.
     // Only the master node will do the diff logic,
     // so just only need to clean up secondaryClusterToBackends on the master node.
@@ -585,6 +596,25 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
 
     public List<Backend> getAllPrimaryBes() {
         List<Backend> result = new ArrayList<Backend>();
+        if (isColocated()) {
+            List<String> clusterIds = ((CloudSystemInfoService) Env.getCurrentSystemInfo()).getCloudClusterIds();
+            for (String clusterId : clusterIds) {
+                try {
+                    long beId = getColocatedBeId(clusterId);
+                    if (beId != -1) {
+                        Backend backend = Env.getCurrentSystemInfo().getBackend(beId);
+                        if (backend != null) {
+                            result.add(backend);
+                        }
+                    }
+                } catch (ComputeGroupException e) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("failed to get colocated be for cluster {}, replica {}", clusterId, this, e);
+                    }
+                }
+            }
+            return result;
+        }
         primaryClusterToBackend.forEach((clusterId, beId) -> {
             if (beId != -1) {
                 Backend backend = Env.getCurrentSystemInfo().getBackend(beId);

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -1473,6 +1473,12 @@ public class CloudTabletRebalancer extends MasterDaemon {
             req.setHost(srcBackend.getHost());
             req.setBrpcPort(srcBackend.getBrpcPort());
             req.setTabletIds(new ArrayList<>(tabletIds));
+            // Tell the receiving BE its own compute group id, so it can set _self_compute_group_id.
+            // In normal intra-CG rebalance, src and dest belong to the same compute group.
+            String srcComputeGroupId = srcBackend.getCloudClusterId();
+            if (srcComputeGroupId != null && !srcComputeGroupId.isEmpty()) {
+                req.setCloudComputeGroupId(srcComputeGroupId);
+            }
             TWarmUpCacheAsyncResponse result = client.warmUpCacheAsync(req);
             if (result.getStatus().getStatusCode() != TStatusCode.OK) {
                 LOG.warn("pre cache failed status {} {}", result.getStatus().getStatusCode(),

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -2944,7 +2944,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 if (Config.isCloudMode()) {
                     CloudReplica cloudReplica = (CloudReplica) replica;
                     if (!request.isSetWarmUpJobId()) {
+                        // Lazy fetch path: return primary + secondary BEs from all compute groups.
+                        // This allows the BE to discover peer candidates across warehouses.
                         backends = cloudReplica.getAllPrimaryBes();
+                        // Also collect secondary backends (may have cached data during primary failover)
+                        for (String computeGroupId : cloudReplica.getPrimaryComputeGroupIds()) {
+                            Backend secondaryBe = cloudReplica.getSecondaryBackend(computeGroupId);
+                            if (secondaryBe != null) {
+                                backends.add(secondaryBe);
+                            }
+                        }
                     } else {
                         // On the cloud, the PrimaryBackend of a tablet
                         // indicates the BE where the tablet is stably located,
@@ -2968,6 +2977,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         replicaInfo.setHttpPort(backend.getHttpPort());
                         replicaInfo.setBrpcPort(backend.getBrpcPort());
                         replicaInfo.setReplicaId(replica.getId());
+                        // Fill cloud_compute_group_id so BE can categorize candidates by compute group
+                        if (Config.isCloudMode()) {
+                            String beComputeGroupId = backend.getCloudClusterId();
+                            if (beComputeGroupId != null && !beComputeGroupId.isEmpty()) {
+                                replicaInfo.setCloudComputeGroupId(beComputeGroupId);
+                            }
+                        }
                         replicaInfos.add(replicaInfo);
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -306,6 +306,10 @@ public class HeartbeatMgr extends MasterDaemon {
                     copiedMasterInfo.setTabletReportInactiveDurationMs(reportInterval);
                     TCloudClusterInfo clusterInfo = new TCloudClusterInfo();
                     clusterInfo.setIsStandby(backend.isInStandbyCluster());
+                    String computeGroupId = backend.getCloudClusterId();
+                    if (computeGroupId != null && !computeGroupId.isEmpty()) {
+                        clusterInfo.setCloudComputeGroupId(computeGroupId);
+                    }
                     copiedMasterInfo.setCloudClusterInfo(clusterInfo);
                 }
                 THeartbeatResult result;

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaTest.java
@@ -1,0 +1,332 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.catalog;
+
+import org.apache.doris.catalog.ColocateTableIndex;
+import org.apache.doris.catalog.ColocateTableIndex.GroupId;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.cloud.qe.ComputeGroupException;
+import org.apache.doris.cloud.system.CloudSystemInfoService;
+import org.apache.doris.common.Config;
+import org.apache.doris.system.Backend;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CloudReplicaTest {
+
+    private static final long DB_ID = 10001L;
+    private static final long TABLE_ID = 20001L;
+    private static final long PARTITION_ID = 30001L;
+    private static final long INDEX_ID = 40001L;
+    private static final long REPLICA_ID = 50001L;
+    private static final long IDX = 0;
+
+    private static final String CLUSTER_ID_1 = "cluster_id_1";
+    private static final String CLUSTER_ID_2 = "cluster_id_2";
+    private static final String CLUSTER_NAME_1 = "cluster_1";
+
+    private MockedStatic<Env> envMockedStatic;
+    private Env mockEnv;
+    private ColocateTableIndex mockColocateIndex;
+    private CloudSystemInfoService mockInfoService;
+
+    private int savedRehashSeconds;
+
+    @BeforeEach
+    public void setUp() {
+        savedRehashSeconds = Config.rehash_tablet_after_be_dead_seconds;
+        Config.cloud_unique_id = "test_cloud_unique_id";
+
+        mockEnv = Mockito.mock(Env.class);
+        mockColocateIndex = Mockito.mock(ColocateTableIndex.class);
+        mockInfoService = Mockito.mock(CloudSystemInfoService.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(mockEnv);
+        envMockedStatic.when(Env::getCurrentColocateIndex).thenReturn(mockColocateIndex);
+        envMockedStatic.when(Env::getCurrentSystemInfo).thenReturn(mockInfoService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        envMockedStatic.close();
+        Config.rehash_tablet_after_be_dead_seconds = savedRehashSeconds;
+    }
+
+    private CloudReplica createReplica() {
+        return new CloudReplica(REPLICA_ID, -1L, Replica.ReplicaState.NORMAL, 1, 0,
+                DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, IDX);
+    }
+
+    private Backend createBackend(long id, boolean alive, boolean decommissioned) {
+        Backend be = Mockito.mock(Backend.class);
+        Mockito.when(be.getId()).thenReturn(id);
+        Mockito.when(be.isAlive()).thenReturn(alive);
+        Mockito.when(be.isDecommissioned()).thenReturn(decommissioned);
+        Mockito.when(be.isQueryAvailable()).thenReturn(alive && !decommissioned);
+        Mockito.when(be.getLastUpdateMs()).thenReturn(System.currentTimeMillis());
+        return be;
+    }
+
+    private void setupColocateTable() {
+        Mockito.when(mockColocateIndex.isColocateTableNoLock(TABLE_ID)).thenReturn(true);
+        Mockito.when(mockColocateIndex.getGroupNoLock(TABLE_ID)).thenReturn(new GroupId(DB_ID, TABLE_ID));
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for getColocatedBeId: dead BEs stay in hash ring
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetColocatedBeId_deadBeStaysInHashRing() throws ComputeGroupException {
+        // Verify that a recently-dead BE stays in the hash ring (grace period),
+        // preventing full rehash of all tablets.
+        setupColocateTable();
+        Config.rehash_tablet_after_be_dead_seconds = 600; // 10 min grace
+
+        Backend be1 = createBackend(1001L, true, false);
+        Backend be2 = createBackend(1002L, true, false);
+        Backend be3 = createBackend(1003L, false, false); // dead recently
+        Mockito.when(be3.getLastUpdateMs()).thenReturn(System.currentTimeMillis()); // just died
+
+        List<Backend> allBes = Arrays.asList(be1, be2, be3);
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>(allBes));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn(CLUSTER_NAME_1);
+
+        CloudReplica replica = createReplica();
+        long pickedBeId = replica.getColocatedBeId(CLUSTER_ID_1);
+
+        // The picked BE must be alive (dead BE won't be returned), but
+        // the hash ring should include the dead BE to avoid full rehash.
+        Assertions.assertTrue(pickedBeId == 1001L || pickedBeId == 1002L,
+                "Should pick an alive BE, got: " + pickedBeId);
+    }
+
+    @Test
+    public void testGetColocatedBeId_hashRingStableWithRecentlyDeadBe() throws ComputeGroupException {
+        // When a BE dies recently, the hash result for a tablet should be the same
+        // as when all BEs were alive (if the tablet was on an alive BE).
+        setupColocateTable();
+        Config.rehash_tablet_after_be_dead_seconds = 600;
+
+        Backend be1 = createBackend(1001L, true, false);
+        Backend be2 = createBackend(1002L, true, false);
+        Backend be3 = createBackend(1003L, true, false);
+
+        // First: all alive - get baseline
+        List<Backend> allAlive = Arrays.asList(be1, be2, be3);
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>(allAlive));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn(CLUSTER_NAME_1);
+
+        CloudReplica replica = createReplica();
+        long baselineBeId = replica.getColocatedBeId(CLUSTER_ID_1);
+
+        // Now: be3 dies recently - hash ring includes it in grace period
+        Backend be3Dead = createBackend(1003L, false, false);
+        Mockito.when(be3Dead.getLastUpdateMs()).thenReturn(System.currentTimeMillis());
+        List<Backend> withDeadBe = Arrays.asList(be1, be2, be3Dead);
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>(withDeadBe));
+
+        long afterDeathBeId = replica.getColocatedBeId(CLUSTER_ID_1);
+
+        // If baseline was on be1 or be2 (alive), it should stay there
+        if (baselineBeId == 1001L || baselineBeId == 1002L) {
+            Assertions.assertEquals(baselineBeId, afterDeathBeId,
+                    "Hash ring should be stable for tablets on alive BEs during grace period");
+        }
+        // If baseline was on be3 (now dead), it will rehash to an alive BE - that's OK
+    }
+
+    @Test
+    public void testGetColocatedBeId_longDeadBeCausesRehash() throws ComputeGroupException {
+        // After grace period expires, dead BE should not be in hash ring.
+        setupColocateTable();
+        Config.rehash_tablet_after_be_dead_seconds = 600;
+
+        Backend be1 = createBackend(1001L, true, false);
+        Backend be2 = createBackend(1002L, true, false);
+        Backend be3Dead = createBackend(1003L, false, false);
+        // Dead long ago - past grace period
+        Mockito.when(be3Dead.getLastUpdateMs()).thenReturn(
+                System.currentTimeMillis() - (Config.rehash_tablet_after_be_dead_seconds + 100) * 1000L);
+
+        List<Backend> bes = Arrays.asList(be1, be2, be3Dead);
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>(bes));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn(CLUSTER_NAME_1);
+
+        CloudReplica replica = createReplica();
+        long pickedBeId = replica.getColocatedBeId(CLUSTER_ID_1);
+
+        // Should pick from only alive BEs (be1 or be2), rehashed on 2-node ring
+        Assertions.assertTrue(pickedBeId == 1001L || pickedBeId == 1002L,
+                "Should pick an alive BE after grace period, got: " + pickedBeId);
+    }
+
+    @Test
+    public void testGetColocatedBeId_allDeadThrowsException() {
+        setupColocateTable();
+
+        Backend be1Dead = createBackend(1001L, false, false);
+        Backend be2Dead = createBackend(1002L, false, false);
+
+        List<Backend> bes = Arrays.asList(be1Dead, be2Dead);
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>(bes));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn(CLUSTER_NAME_1);
+
+        CloudReplica replica = createReplica();
+        ComputeGroupException ex = Assertions.assertThrows(ComputeGroupException.class,
+                () -> replica.getColocatedBeId(CLUSTER_ID_1));
+        Assertions.assertTrue(ex.toString().contains(
+                ComputeGroupException.FailedTypeEnum.COMPUTE_GROUPS_NO_ALIVE_BE.name()));
+    }
+
+    @Test
+    public void testGetColocatedBeId_emptyClusterThrowsException() {
+        setupColocateTable();
+
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>());
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn(CLUSTER_NAME_1);
+
+        CloudReplica replica = createReplica();
+        ComputeGroupException ex = Assertions.assertThrows(ComputeGroupException.class,
+                () -> replica.getColocatedBeId(CLUSTER_ID_1));
+        Assertions.assertTrue(ex.toString().contains(
+                ComputeGroupException.FailedTypeEnum.CURRENT_COMPUTE_GROUP_NO_BE.name()));
+    }
+
+    @Test
+    public void testGetColocatedBeId_decommissionedBeUsedAsFallback() throws ComputeGroupException {
+        setupColocateTable();
+
+        Backend beDecommissioned = createBackend(1001L, true, true);
+        List<Backend> bes = Arrays.asList(beDecommissioned);
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1)).thenReturn(new ArrayList<>(bes));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn(CLUSTER_NAME_1);
+
+        CloudReplica replica = createReplica();
+        long pickedBeId = replica.getColocatedBeId(CLUSTER_ID_1);
+        Assertions.assertEquals(1001L, pickedBeId,
+                "Should fall back to decommissioned BE when no normal alive BE");
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for getAllPrimaryBes: colocate table support
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetAllPrimaryBes_colocateTable_dynamicCompute() throws ComputeGroupException {
+        // For colocate tables, primaryClusterToBackends is empty.
+        // getAllPrimaryBes() should dynamically compute backends via getColocatedBeId().
+        setupColocateTable();
+
+        Backend be1 = createBackend(1001L, true, false);
+        Backend be2 = createBackend(2001L, true, false);
+
+        // Two clusters
+        Mockito.when(mockInfoService.getCloudClusterIds())
+                .thenReturn(Arrays.asList(CLUSTER_ID_1, CLUSTER_ID_2));
+
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1))
+                .thenReturn(new ArrayList<>(Arrays.asList(be1)));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn("cluster_1");
+
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_2))
+                .thenReturn(new ArrayList<>(Arrays.asList(be2)));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_2)).thenReturn("cluster_2");
+
+        Mockito.when(mockInfoService.getBackend(1001L)).thenReturn(be1);
+        Mockito.when(mockInfoService.getBackend(2001L)).thenReturn(be2);
+
+        CloudReplica replica = createReplica();
+        // primaryClusterToBackends is empty by default (ConcurrentHashMap)
+
+        List<Backend> primaryBes = replica.getAllPrimaryBes();
+
+        Assertions.assertEquals(2, primaryBes.size(),
+                "Colocate table should return one BE per cluster");
+    }
+
+    @Test
+    public void testGetAllPrimaryBes_colocateTable_clusterWithAllDeadBes() {
+        // If one cluster has all dead BEs, it should be silently skipped.
+        setupColocateTable();
+
+        Backend be1 = createBackend(1001L, true, false);
+        Backend be2Dead = createBackend(2001L, false, false);
+
+        Mockito.when(mockInfoService.getCloudClusterIds())
+                .thenReturn(Arrays.asList(CLUSTER_ID_1, CLUSTER_ID_2));
+
+        // Cluster 1: has alive BE
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_1))
+                .thenReturn(new ArrayList<>(Arrays.asList(be1)));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_1)).thenReturn("cluster_1");
+        Mockito.when(mockInfoService.getBackend(1001L)).thenReturn(be1);
+
+        // Cluster 2: all dead
+        Mockito.when(mockInfoService.getBackendsByClusterId(CLUSTER_ID_2))
+                .thenReturn(new ArrayList<>(Arrays.asList(be2Dead)));
+        Mockito.when(mockInfoService.getClusterNameByClusterId(CLUSTER_ID_2)).thenReturn("cluster_2");
+
+        CloudReplica replica = createReplica();
+        List<Backend> primaryBes = replica.getAllPrimaryBes();
+
+        // Cluster 2 throws ComputeGroupException, should be caught and skipped
+        Assertions.assertEquals(1, primaryBes.size(),
+                "Should only return BE from cluster with alive backends");
+        Assertions.assertEquals(1001L, primaryBes.get(0).getId());
+    }
+
+    @Test
+    public void testGetAllPrimaryBes_nonColocateTable_usesPrimaryMap() {
+        // For non-colocate tables, should use primaryClusterToBackends as before.
+        Mockito.when(mockColocateIndex.isColocateTableNoLock(TABLE_ID)).thenReturn(false);
+
+        Backend be1 = createBackend(1001L, true, false);
+        Mockito.when(mockInfoService.getBackend(1001L)).thenReturn(be1);
+
+        CloudReplica replica = createReplica();
+        // Manually populate primaryClusterToBackends
+        replica.updateClusterToPrimaryBe(CLUSTER_ID_1, 1001L);
+
+        List<Backend> primaryBes = replica.getAllPrimaryBes();
+        Assertions.assertEquals(1, primaryBes.size());
+        Assertions.assertEquals(1001L, primaryBes.get(0).getId());
+    }
+
+    @Test
+    public void testGetAllPrimaryBes_colocateTable_emptyClusterList() {
+        // If no clusters exist, should return empty list.
+        setupColocateTable();
+        Mockito.when(mockInfoService.getCloudClusterIds()).thenReturn(new ArrayList<>());
+
+        CloudReplica replica = createReplica();
+        List<Backend> primaryBes = replica.getAllPrimaryBes();
+        Assertions.assertTrue(primaryBes.isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.cloud.catalog;
 
+import org.apache.doris.catalog.ColocateGroupSchema;
 import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.ColocateTableIndex.GroupId;
 import org.apache.doris.catalog.Env;
@@ -64,7 +65,20 @@ public class CloudReplicaTest {
 
         mockEnv = Mockito.mock(Env.class);
         mockColocateIndex = Mockito.mock(ColocateTableIndex.class);
-        mockInfoService = Mockito.mock(CloudSystemInfoService.class);
+        mockInfoService = Mockito.mock(CloudSystemInfoService.class, Mockito.withSettings()
+                .useConstructor()
+                .defaultAnswer(invocation -> {
+                    String methodName = invocation.getMethod().getName();
+                    if (methodName.equals("getCloudColocateHrwBeId")
+                            || methodName.equals("getCloudColocateBucketsNum")) {
+                        return invocation.callRealMethod();
+                    }
+                    return Mockito.RETURNS_DEFAULTS.answer(invocation);
+                }));
+
+        ColocateGroupSchema mockGroupSchema = Mockito.mock(ColocateGroupSchema.class);
+        Mockito.when(mockGroupSchema.getBucketsNum()).thenReturn(1);
+        Mockito.when(mockColocateIndex.getGroupSchema(Mockito.any(GroupId.class))).thenReturn(mockGroupSchema);
 
         envMockedStatic = Mockito.mockStatic(Env.class);
         envMockedStatic.when(Env::getCurrentEnv).thenReturn(mockEnv);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -1174,6 +1174,15 @@ message PFetchPeerDataRequest {
     optional int64 file_size = 4;
     // PEER_FILE_CACHE_BLOCK
     repeated CacheBlockReqest cache_req = 5;
+    // Client capability for attachment payload mode.
+    // If false (default), server must return payload in datas.data for compatibility.
+    optional bool support_attachment = 6 [default = false];
+    // Client requests server to pull data from S3 and fill local cache on cache miss.
+    // Server only executes fill when this is true AND enable_peer_server_cache_fill config is true.
+    // Only set for the designated fill compute group (peer_cache_fill_compute_group_id).
+    optional bool request_cache_fill = 7 [default = false];
+    // Rowset meta carrier for peer read/fill. The current caller only fills resource_id/tablet_id.
+    optional RowsetMetaPB rowset_meta = 8;
 }
 
 message CacheBlockPB {
@@ -1185,6 +1194,10 @@ message CacheBlockPB {
 message PFetchPeerDataResponse {
     optional PStatus status = 1;
     repeated CacheBlockPB datas = 2;
+    // Response mode flag.
+    // true: payload is in brpc response attachment; datas carries metadata only.
+    // false: payload is in datas[*].data.
+    optional bool data_in_attachment = 3 [default = false];
 }
 
 message PRequestCdcClientRequest {

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -135,6 +135,7 @@ struct TWarmUpCacheAsyncRequest {
     1: required string host
     2: required i32 brpc_port
     3: required list<i64> tablet_ids
+    4: optional string cloud_compute_group_id
 }
 
 struct TWarmUpCacheAsyncResponse {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -31,6 +31,7 @@ struct TFrontendInfo {
 
 struct TCloudClusterInfo {
     1: optional bool isStandby
+    2: optional string cloud_compute_group_id
 }
 
 struct TMasterInfo {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -689,6 +689,7 @@ struct TReplicaInfo {
     5: required TReplicaId replica_id
     6: optional bool is_alive
     7: optional i64 backend_id
+    8: optional string cloud_compute_group_id
 }
 
 struct TResourceInfo {

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
@@ -41,10 +41,15 @@ suite('test_balance_warm_up', 'docker') {
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
-        'cache_read_from_peer_expired_seconds=100',
-        'enable_cache_read_from_peer=true',
         "enable_packed_file=${enablePackedFile}",
         'skip_writing_empty_rowset_metadata=false',
+        'peer_candidate_cleanup_interval_s=10',
+        'peer_candidate_expiry_s=30',
+        'enable_cache_read_from_peer=true',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98'
     ]
     options.setFeNum(1)
     options.setBeNum(1)
@@ -68,6 +73,12 @@ suite('test_balance_warm_up', 'docker') {
     def testCase = { table -> 
         def ms = cluster.getAllMetaservices().get(0)
         def msHttpPort = ms.host + ":" + ms.httpPort
+        def cacheKeyForBackend = { be ->
+            be.HttpPort == null ? be.Host as String : "${be.Host}:${be.HttpPort}"
+        }
+        def cacheDirsForBackend = { dirs, be ->
+            dirs[cacheKeyForBackend(be)] ?: dirs[be.Host]
+        }
         sql """CREATE TABLE $table (
                 `id` BIGINT,
                 `deleted` TINYINT,
@@ -156,7 +167,6 @@ suite('test_balance_warm_up', 'docker') {
         logger.info("before warm up result {}", beforeWarmUpResult)
 
         cluster.addBackend(1, "compute_cluster")
-        def oldBe = sql_return_maparray('show backends').get(0)
         def newAddBe = sql_return_maparray('show backends').get(1)
         // balance tablet
         awaitUntil(500) {
@@ -189,10 +199,9 @@ suite('test_balance_warm_up', 'docker') {
             afterIdxCacheDirVersion3 
         )
         logger.info("after fe tablets {}, be tablets {}, cache dir {}", afterGetFromFe, afterGetFromBe, afterMergedCacheDir)
-        def newAddBeCacheDir = afterMergedCacheDir.get(newAddBe.Host)
+        def newAddBeCacheDir = cacheDirsForBackend(afterMergedCacheDir, newAddBe)
         logger.info("new add be cache dir {}", newAddBeCacheDir)
         assert newAddBeCacheDir.size() != 0
-        assert beforeMergedCacheDir[oldBe.Host].containsAll(afterMergedCacheDir[newAddBe.Host])
 
         def be = cluster.getBeByBackendId(newAddBe.BackendId.toLong())
         def dataPath = new File("${be.path}/storage/file_cache")
@@ -221,9 +230,9 @@ suite('test_balance_warm_up', 'docker') {
             "Available subdirs: ${subDirs}")
         }
 
-        sleep(105 * 1000)
-        // test expired be tablet cache info be removed
-        // after cache_read_from_peer_expired_seconds = 100s
+        // peer_candidate_expiry_s=30s, cleanup runs every 10s → entries evicted within ~40s
+        sleep(45 * 1000)
+        // test that expired peer candidate entries are removed by run_cleanup_loop
         assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "balance_tablet_be_mapping_size"))
         assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
         assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_use_peer_cache.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_use_peer_cache.groovy
@@ -44,10 +44,13 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
-        'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
         "enable_packed_file=${enablePackedFile}",
         'skip_writing_empty_rowset_metadata=false',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98'
     ]
     options.setFeNum(1)
     options.setBeNum(1)
@@ -77,6 +80,12 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
     def testCase = { table -> 
         def ms = cluster.getAllMetaservices().get(0)
         def msHttpPort = ms.host + ":" + ms.httpPort
+        def cacheKeyForBackend = { be ->
+            be.HttpPort == null ? be.Host as String : "${be.Host}:${be.HttpPort}"
+        }
+        def cacheDirsForBackend = { dirs, be ->
+            dirs[cacheKeyForBackend(be)] ?: dirs[be.Host]
+        }
         sql """CREATE TABLE $table (
             `k1` int(11) NULL,
             `v1` VARCHAR(2048)
@@ -121,9 +130,9 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
         // version 4, new rs after warm up task
         def beforeCacheDirVersion4 = getTabletFileCacheDirFromBe(msHttpPort, table, 4)
         logger.info("cache dir version 4 {}", beforeCacheDirVersion4)
-        def afterMerged23CacheDir = [beforeCacheDirVersion2, beforeCacheDirVersion3, beforeCacheDirVersion4]
+        def beforeMerged234CacheDir = [beforeCacheDirVersion2, beforeCacheDirVersion3, beforeCacheDirVersion4]
             .inject([:]) { acc, m -> mergeDirs(acc, m) }
-        logger.info("after version 4 fe tablets {}, be tablets {}, cache dir {}", beforeGetFromFe, beforeGetFromBe, afterMerged23CacheDir)
+        logger.info("after version 4 fe tablets {}, be tablets {}, cache dir {}", beforeGetFromFe, beforeGetFromBe, beforeMerged234CacheDir)
 
         // after cloud_pre_heating_time_limit_sec = 30s 
         sleep(40 * 1000)
@@ -159,10 +168,28 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
             .inject([:]) { acc, m -> mergeDirs(acc, m) }
 
         logger.info("after fe tablets {}, be tablets {}, cache dir {}", afterGetFromFe, afterGetFromBe, afterMergedCacheDir)
-        def newAddBeCacheDir = afterMergedCacheDir.get(newAddBe.Host)
-        logger.info("new add be cache dir {}", newAddBeCacheDir)
+        // All downstream assertions in this case (subset check, "no on-disk file
+        // before SELECT", "on-disk file after SELECT via peer read") only make
+        // sense for versions written BEFORE newBe joined (v2, v3). v4 is
+        // inserted after addBackend; the rebalancer can route the target
+        // tablet's primary BE mapping to newBe within the 5s sleep that
+        // follows, in which case newBe writes the rowset itself and
+        // S3FileWriter populates newBe's local file cache (write_file_cache=1)
+        // with blocks oldBe never saw. That is correct behavior, not a warmup
+        // miss; including v4 hashes here would assert against newBe's own
+        // direct writes and falsely fail. Restricting to v2/v3 keeps the
+        // assertions focused on the actual warmup-via-peer-cache invariant.
+        def beforeWarmableCacheDir = [beforeCacheDirVersion2, beforeCacheDirVersion3]
+            .inject([:]) { acc, m -> mergeDirs(acc, m) }
+        def afterWarmableCacheDir = [afterCacheDirVersion2, afterCacheDirVersion3]
+            .inject([:]) { acc, m -> mergeDirs(acc, m) }
+        def beforeWarmableOldBe = cacheDirsForBackend(beforeWarmableCacheDir, oldBe) ?: []
+        def newAddBeCacheDir = cacheDirsForBackend(afterWarmableCacheDir, newAddBe) ?: []
+        logger.info("new add be cache dir (v2+v3 only) {}", newAddBeCacheDir)
         assert newAddBeCacheDir.size() != 0
-        assert afterMerged23CacheDir[oldBe.Host].containsAll(afterMergedCacheDir[newAddBe.Host])
+        assert beforeWarmableOldBe.containsAll(newAddBeCacheDir) :
+                "newBe v2/v3 cache must be a subset of oldBe's pre-add v2/v3 cache; " +
+                "oldBe pre=${beforeWarmableOldBe}, newBe post=${newAddBeCacheDir}"
 
         def be = cluster.getBeByBackendId(newAddBe.BackendId.toLong())
         def dataPath = new File("${be.path}/storage/file_cache")
@@ -185,12 +212,18 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
         collectDirs(dataPath)
         logger.info("BE {} file_cache subdirs: {}", newAddBe.Host, subDirs)
 
-        // check new be not have version 2,3,4 cache file
+        // check new be does not yet hold the v2/v3 cache files: the
+        // FileCacheBlockDownloader.download_blocks.balance_task DBUG point
+        // suppresses the actual rebalance-driven download, so before the
+        // SELECT below issues a peer read these hashes must NOT be on disk.
         newAddBeCacheDir.each { hashFile ->
-            assertFalse(subDirs.any { subDir -> subDir.startsWith(hashFile) }, 
-            "Expected cache file pattern ${hashFile} should not found in BE ${newAddBe.Host}'s file_cache directory. " + 
+            assertFalse(subDirs.any { subDir -> subDir.startsWith(hashFile) },
+            "Expected cache file pattern ${hashFile} should not found in BE ${newAddBe.Host}'s file_cache directory. " +
             "Available subdirs: ${subDirs}")
         }
+
+        def peerReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read")
+        def crossCgReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "peer_cross_compute_group_read")
 
         // The query triggers reading the file cache from the peer
         profile("test_balance_warm_up_use_peer_cache_profile") {
@@ -210,21 +243,45 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
                     total += matcher.group(1).toInteger()
                     logger.info("NumPeerIOTotal: {}", matcher.group(1))
                 }
+                def remoteMatcher = (profileString =~ /-  NumRemoteIOTotal:\s+(\d+)/)
+                def remoteTotal = 0
+                while (remoteMatcher.find()) {
+                    remoteTotal += remoteMatcher.group(1).toInteger()
+                    logger.info("NumRemoteIOTotal: {}", remoteMatcher.group(1))
+                }
                 assertTrue(total > 0)
+                assertEquals(0, remoteTotal)
+
+                def sameCgMatcher = (profileString =~ /SameCGPeerIOTotal:\s+(\d+)/)
+                def sameCgTotal = 0
+                while (sameCgMatcher.find()) {
+                    sameCgTotal += sameCgMatcher.group(1).toInteger()
+                    logger.info("SameCGPeerIOTotal: {}", sameCgMatcher.group(1))
+                }
+                assertTrue(sameCgTotal > 0, "SameCGPeerIOTotal must be > 0 in profile")
+
+                def nodesMatcher = (profileString =~ /PeerCacheNodes:\s*(.+)/)
+                assertTrue(nodesMatcher.find(), "Profile must contain PeerCacheNodes info")
+                logger.info("PeerCacheNodes found: {}", nodesMatcher.group(1))
             } 
         }
 
         subDirs.clear()
         collectDirs(dataPath)
         logger.info("after query, BE {} file_cache subdirs: {}", newAddBe.Host, subDirs) 
-        // peer read cache, so it should have version 2,3,4 cache file
+        // peer read populated the cache, so the v2/v3 hashes that previously
+        // existed on oldBe must now be present in newBe's file_cache directory.
         newAddBeCacheDir.each { hashFile ->
-            assertTrue(subDirs.any { subDir -> subDir.startsWith(hashFile) }, 
-            "Expected cache file pattern ${hashFile} should found in BE ${newAddBe.Host}'s file_cache directory. " + 
+            assertTrue(subDirs.any { subDir -> subDir.startsWith(hashFile) },
+            "Expected cache file pattern ${hashFile} should found in BE ${newAddBe.Host}'s file_cache directory. " +
             "Available subdirs: ${subDirs}")
         }
-        assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
-        assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))
+        assert(getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read") > peerReadBeforeQuery)
+
+        // regression: same-CG rebalance warm-up must not be counted as cross-CG peer read.
+        assert crossCgReadBeforeQuery == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort,
+                "peer_cross_compute_group_read") :
+               "same-CG peer read must not increase peer_cross_compute_group_read"
     }
 
     docker(options) {

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_with_compaction_use_peer_cache.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_with_compaction_use_peer_cache.groovy
@@ -23,10 +23,6 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         return;
     }
 
-    // Randomly enable or disable packed_file to test both scenarios
-    def enablePackedFile = new Random().nextBoolean()
-    logger.info("Running test with enable_packed_file=${enablePackedFile}")
-
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -38,6 +34,7 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         'cloud_pre_heating_time_limit_sec=30',
         // disable Auto Analysis Job Executor
         'auto_check_statistics_in_minutes=60',
+        'JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=$LOG_DIR/tmp',
     ]
     options.beConfigs += [
         'report_tablet_interval_seconds=1',
@@ -45,9 +42,9 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
         'cumulative_compaction_min_deltas=5',
-        'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
-        "enable_packed_file=${enablePackedFile}",
+        'enable_packed_file=false',
+        'skip_writing_empty_rowset_metadata=false'
     ]
     options.setFeNum(1)
     options.setBeNum(1)
@@ -77,6 +74,12 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
     def testCase = { table -> 
         def ms = cluster.getAllMetaservices().get(0)
         def msHttpPort = ms.host + ":" + ms.httpPort
+        def cacheKeyForBackend = { be ->
+            be.HttpPort == null ? be.Host as String : "${be.Host}:${be.HttpPort}"
+        }
+        def cacheDirsForBackend = { dirs, be ->
+            dirs[cacheKeyForBackend(be)] ?: dirs[be.Host]
+        }
         sql """set enable_file_cache=true"""
         sql """CREATE TABLE $table (
                 `id` BIGINT,
@@ -146,8 +149,8 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         sleep(40 * 1000)
         // after 30s task timeout, check tablet in new be
 
-        def oldBe = sql_return_maparray('show backends').get(0)
-        def newAddBe = sql_return_maparray('show backends').get(1)
+        def backends = sql_return_maparray('show backends')
+        def newAddBe = backends.get(1)
         // balance tablet
         awaitUntil(500) {
             def afterWarmUpTaskTimeoutResult = sql_return_maparray """ADMIN SHOW REPLICA DISTRIBUTION FROM $table"""
@@ -169,11 +172,12 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
             .inject([:]) { acc, m -> mergeDirs(acc, m) }
 
         logger.info("after fe tablets {}, be tablets {}, cache dir {}", afterGetFromFe, afterGetFromBe, afterMergedCacheDir)
-        // calc file cache hash on new added BE, but these cache files should not exist on new BE yet
-        def newAddBeCacheDir = afterMergedCacheDir.get(newAddBe.Host)
+        // Calc file cache hash on the new BE. Compaction can make the old-BE
+        // pre-warmup cache-dir snapshot incomplete, so validate peer-read
+        // behavior with the physical cache and query profile below.
+        def newAddBeCacheDir = cacheDirsForBackend(afterMergedCacheDir, newAddBe) ?: []
         logger.info("new add be cache dir {}", newAddBeCacheDir)
         assert newAddBeCacheDir.size() != 0
-        assert afterMergedVersion7CacheDir[oldBe.Host].containsAll(afterMergedCacheDir[newAddBe.Host])
 
         def be = cluster.getBeByBackendId(newAddBe.BackendId.toLong())
         def dataPath = new File("${be.path}/storage/file_cache")
@@ -203,6 +207,9 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
             "Available subdirs: ${subDirs}")
         }
 
+        def peerReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read")
+        def crossCgReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "peer_cross_compute_group_read")
+
         // The query triggers reading the file cache from the peer
         profile("test_balance_warm_up_with_compaction_use_peer_cache_profile") {
             sql """ set enable_profile = true;"""
@@ -221,7 +228,18 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
                     total += matcher.group(1).toInteger()
                     logger.info("InvertedIndexNumPeerIOTotal: {}", matcher.group(1))
                 }
+                def remoteMatcher = (profileString =~ /-  InvertedIndexNumRemoteIOTotal:\s+(\d+)/)
+                def remoteTotal = 0
+                while (remoteMatcher.find()) {
+                    remoteTotal += remoteMatcher.group(1).toInteger()
+                    logger.info("InvertedIndexNumRemoteIOTotal: {}", remoteMatcher.group(1))
+                }
                 assertTrue(total > 0)
+                assertEquals(0, remoteTotal)
+
+                def nodesMatcher = (profileString =~ /PeerCacheNodes:\s*(.+)/)
+                assertTrue(nodesMatcher.find(), "Profile must contain PeerCacheNodes info")
+                logger.info("PeerCacheNodes found: {}", nodesMatcher.group(1))
             } 
         }
         subDirs.clear()
@@ -233,8 +251,10 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
             "Expected cache file pattern ${hashFile} should found in BE ${newAddBe.Host}'s file_cache directory. " + 
             "Available subdirs: ${subDirs}")
         }
-        assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
-        assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))
+        assert(getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read") > peerReadBeforeQuery)
+        assert crossCgReadBeforeQuery == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort,
+                "peer_cross_compute_group_read") :
+               "same-CG peer read must not increase peer_cross_compute_group_read"
     }
 
     docker(options) {

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_bvar_metrics.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_bvar_metrics.groovy
@@ -1,0 +1,280 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read bvar metrics smoke tests.
+//
+// Verifies that 5 new bvar / config items land and work end-to-end:
+//
+// T_bvar1 – peer_lazy_fetch_total & peer_lazy_fetch_count
+//   CGB has no candidates for the tablet (cold miss). A cross-CG query triggers
+//   fetch_candidates_from_fe() on CGB's BE. Both counters must increase.
+//
+// T_bvar2 – peer_same_compute_group_read
+//   A second BE (BE_A2) is added to CG-A. Rebalance warmup registers BE_A1 as a
+//   same-CG peer candidate on BE_A2 (via record_balanced_tablet). A warmup segment-download
+//   debug point skips cache population while still letting warmup bookkeeping complete.
+//   Queries on CG-A that scan tablets on BE_A2 take the same-CG winner-race path.
+//   Peer should win with the configured hedge delay, so peer_same_compute_group_read
+//   increases on CG-A.
+//
+// T_bvar3 – peer_race_hedge_delay_ms → peer wins reliably
+//   peer_race_hedge_delay_ms=50 is set in beConfigs. CGA has warm cache so the peer
+//   RPC returns in ~5 ms, well within the hedge window. S3 is never submitted;
+//   peer_race_peer_win must increase on CGB's BE.
+//
+// T_bvar4 – peer_race_active_count gauge
+//   After all cross-CG queries complete, verify the active-race gauge returns to 0
+//   (no leaked races).
+//
+// Topology: 1 FE + CG-A (BE_A1, then BE_A2 added in T_bvar2) + CG-B (BE_B).
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.DebugPoint
+import org.apache.doris.regression.util.NodeType
+
+suite('test_cross_cg_bvar_metrics', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+        'rehash_tablet_after_be_dead_seconds=3600',
+        'cloud_warm_up_for_rebalance_type=async_warmup',
+        'cloud_pre_heating_time_limit_sec=20',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+        // Give peer a 50 ms head start before S3 is submitted (T_bvar3).
+        // Peer returns in ~5 ms when CGA cache is warm, so it wins every time.
+        'peer_race_hedge_delay_ms=50',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetric = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_bvar_metrics_tbl"
+
+        // ---- Setup: add CG-B and create table in CG-A ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends (CG-A and CG-B)"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("BE_A (CG-A): host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("BE_B (CG-B): host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b')"
+        sql "INSERT INTO ${tbl} VALUES (3, 'c'), (4, 'd')"
+        // Warm CG-A cache for all existing rows.
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+    // ==================== T_bvar1: peer_lazy_fetch_total & peer_lazy_fetch_count ====================
+        // CGB has no candidates for any tablet (cold start). The first cross-CG query
+        // triggers fetch_candidates_from_fe() on CGB's BE:
+        //   g_peer_lazy_fetch_total  << 1      (before RPC)
+        //   g_peer_lazy_fetch_latency << µs    (after RPC — LatencyRecorder exposes *_count as
+        //   peer_lazy_fetch_count in brpc_metrics / vars)
+        logger.info("=== T_bvar1: peer_lazy_fetch_total and peer_lazy_fetch_count ===")
+
+        def t1_fetchTotalBefore   = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_total")
+        def t1_latencyCountBefore = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_count")
+
+        sql "use @cross_cg_peer_cluster"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+
+        // The singleflight RPC may complete slightly after the query returns.
+        awaitUntil(15) {
+            getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_total") > t1_fetchTotalBefore
+        }
+
+        def t1_fetchTotalAfter   = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_total")
+        def t1_latencyCountAfter = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_count")
+
+        assertTrue(t1_fetchTotalAfter > t1_fetchTotalBefore,
+            "T_bvar1: peer_lazy_fetch_total should increase on CGB after cold-miss cross-CG query " +
+            "(before=${t1_fetchTotalBefore}, after=${t1_fetchTotalAfter})")
+        assertTrue(t1_latencyCountAfter > t1_latencyCountBefore,
+            "T_bvar1: peer_lazy_fetch_count should increase (LatencyRecorder recorded the FE RPC) " +
+            "(before=${t1_latencyCountBefore}, after=${t1_latencyCountAfter})")
+        logger.info("T_bvar1 PASS: lazy_fetch_total={}, latency_count={}",
+            t1_fetchTotalAfter, t1_latencyCountAfter)
+
+        // ==================== T_bvar3: peer_race_hedge_delay_ms → peer wins reliably ====================
+        // peer_race_hedge_delay_ms=50 (set in beConfigs). CGA cache is warm, so the peer
+        // RPC for the new rows returns in ~5 ms — well within the 50 ms hedge window.
+        // S3 is never submitted; peer_race_peer_win must increase on CGB.
+        logger.info("=== T_bvar3: peer_race_hedge_delay_ms=50 → peer_race_peer_win increases ===")
+
+        // Insert new rows on CG-A and warm its cache; CGB has never read them.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (5, 'e'), (6, 'f')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CGA for rows (5, 6)
+        sleep(500)
+
+        sql "use @cross_cg_peer_cluster"
+        def t3_peerWinBefore = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // CGB has no cache for (5, 6). Peer race: CGA warm → peer returns ~5 ms;
+        // hedge delay 50 ms skips S3 entirely → peer wins.
+        def t3_result = sql "SELECT * FROM ${tbl} WHERE k1 IN (5, 6) ORDER BY k1"
+        assertEquals(2, t3_result.size(), "T_bvar3: query should return 2 rows")
+
+        assertTrue(
+            getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t3_peerWinBefore,
+            "T_bvar3: peer_race_peer_win should increase on CGB when CGA cache is warm and " +
+            "hedge delay keeps S3 submission suppressed")
+        logger.info("T_bvar3 PASS: peer_race_peer_win={}",
+            getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_peer_win"))
+
+        // ==================== T_bvar4: peer_race_active_count gauge ====================
+        // After all cross-CG queries above have completed, no races should be in-flight.
+        // Verify that the gauge is exposed and returns to 0 (no leaked races).
+        logger.info("=== T_bvar4: peer_race_active_count gauge (no leaked races) ===")
+        def t4_activeRaces = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_active_count")
+        assertEquals(0L, t4_activeRaces,
+            "T_bvar4: peer_race_active_count should be 0 after queries complete (actual=${t4_activeRaces})")
+        logger.info("T_bvar4 PASS: peer_race_active_count={}", t4_activeRaces)
+
+        // ==================== T_bvar2: peer_same_compute_group_read ====================
+        // Add BE_A2 to CG-A. Skip warmup segment downloads so BE_A2's file cache stays empty.
+        // Rebalance triggers warm_up_cache_async → record_balanced_tablet on BE_A2 with
+        // BE_A1 as same-CG candidate. Once BE_A2 has tablets plus candidate mappings, queries
+        // on CG-A that hit BE_A2 should run same-CG peer-vs-S3 winner race; peer wins due to
+        // the hedge delay, so peer_same_compute_group_read increases.
+        logger.info("=== T_bvar2: peer_same_compute_group_read (same-CG winner race) ===")
+
+        // Hold rebalancer: keep enable_cloud_multi_replica=true so FE won't send
+        // warm_up_cache_async until we've set the skip_warmup debug point on BE_A2.
+        setFeConfig('enable_cloud_multi_replica', true)
+        cluster.addBackend(1, "compute_cluster")
+
+        // Wait briefly to ensure the new BE is fully able to receive debug points.
+        sleep(5000)
+
+        // Set skip_warmup on ALL BEs, including newly added BE_A2, before unblocking rebalancer.
+        GetDebugPoint().enableDebugPointForAllBEs("FileCacheBlockDownloader::download_segment_file.skip_warmup")
+
+        // NOW unblock the rebalancer; warmup RPCs will hit the debug point and skip downloads.
+        setFeConfig('enable_cloud_multi_replica', false)
+
+        def allBackends = sql_return_maparray('show backends')
+        assert allBackends.size() == 3 : "Expected 3 backends total"
+        // Identify BE_A2 by BackendId — BrpcPort is the same (8060) for all BEs in docker.
+        def beA2 = allBackends.find { it.BackendId.toLong() != beA.BackendId.toLong() &&
+                                      it.BackendId.toLong() != beB.BackendId.toLong() }
+        assert beA2 != null : "Could not identify BE_A2"
+        logger.info("T_bvar2: BE_A2 host={} brpcPort={}", beA2.Host, beA2.BrpcPort)
+
+        // Wait until BE_A2 has both accepted tablets and registered same-CG candidates.
+        awaitUntil(120) {
+            def latest = sql_return_maparray('show backends').find {
+                it.BackendId.toLong() == beA2.BackendId.toLong()
+            }
+            latest != null && latest.TabletNum.toInteger() > 0
+        }
+        awaitUntil(120) {
+            getBrpcMetric(beA2.Host, beA2.BrpcPort, "balance_tablet_be_mapping_size") > 0
+        }
+
+        // Give the rebalance warmup workflow a short window to submit and finish the skipped
+        // warmup tasks before query traffic starts.
+        sleep(2000)
+
+        sql "use @compute_cluster"
+        def t2_sameBefore_A1 = getBrpcMetric(beA.Host,  beA.BrpcPort,  "peer_same_compute_group_read")
+        def t2_sameBefore_A2 = getBrpcMetric(beA2.Host, beA2.BrpcPort, "peer_same_compute_group_read")
+
+        awaitUntil(30) {
+            // Run query iteratively; full-table scans should cover tablets rebalanced to BE_A2.
+            // Those scans see: (a) same-CG candidate (BE_A1) registered, (b) empty local cache
+            // after warmup timeout -> same-CG winner race with peer win -> peer_same_compute_group_read++.
+            sql "SELECT * FROM ${tbl} ORDER BY k1"
+            def sameAfterA1 = getBrpcMetric(beA.Host,  beA.BrpcPort,  "peer_same_compute_group_read")
+            def sameAfterA2 = getBrpcMetric(beA2.Host, beA2.BrpcPort, "peer_same_compute_group_read")
+            ((sameAfterA1 - t2_sameBefore_A1) + (sameAfterA2 - t2_sameBefore_A2)) > 0
+        }
+
+        def t2_sameAfter_A1 = getBrpcMetric(beA.Host,  beA.BrpcPort,  "peer_same_compute_group_read")
+        def t2_sameAfter_A2 = getBrpcMetric(beA2.Host, beA2.BrpcPort, "peer_same_compute_group_read")
+        def t2_totalDelta = (t2_sameAfter_A1 - t2_sameBefore_A1) + (t2_sameAfter_A2 - t2_sameBefore_A2)
+
+        assertTrue(t2_totalDelta > 0,
+            "T_bvar2: peer_same_compute_group_read should increase on CG-A BEs " +
+            "(BE_A2 has same-CG candidate and empty local cache after skipped warmup downloads). " +
+            "BE_A1 delta=${t2_sameAfter_A1 - t2_sameBefore_A1}, " +
+            "BE_A2 delta=${t2_sameAfter_A2 - t2_sameBefore_A2}")
+        logger.info("T_bvar2 PASS: peer_same_compute_group_read total delta={}", t2_totalDelta)
+
+        DebugPoint.disableDebugPoint(
+            beA2.Host, beA2.HttpPort.toInteger(), NodeType.BE,
+            "FileCacheBlockDownloader::download_segment_file.skip_warmup")
+        GetDebugPoint().disableDebugPointForAllBEs("FileCacheBlockDownloader::download_segment_file.skip_warmup")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_candidate_management.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_candidate_management.groovy
@@ -1,0 +1,377 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read candidate management tests:
+// consecutive RPC failures → candidate eviction (P1)
+// candidate expiry via cleanup daemon (P1)
+// cache miss (NOT_FOUND from server) rotates candidate, does NOT evict (Issue 3)
+//
+// Topology:
+//   T3/1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+//   add CG-C (1 BE, "cross_cg_peer_cluster_alt") so rotate can actually move to
+//          another remote candidate after CG-A returns NOT_FOUND.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_candidate_management', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        // Eviction threshold = 1 so T3 triggers on the very first RPC failure.
+        // Threshold > 1 cannot be reliably tested in docker: after the first peer RPC failure
+        // S3 fallback fills CG-B's local file cache, so subsequent queries on the same data
+        // are local hits and never issue a second peer RPC to CG-A.
+        'peer_rpc_failure_eviction_threshold=1',
+        // Short expiry so T4 can complete in reasonable time.
+        'peer_candidate_expiry_s=60',
+        'peer_candidate_cleanup_interval_s=5',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        final String CG_A = "compute_cluster"
+        final String CG_B = "cross_cg_peer_cluster"
+        final String CG_C = "cross_cg_peer_cluster_alt"
+        def tbl = "test_cross_cg_candidate_mgmt_tbl"
+
+        // Counter for unique k1 ranges; CG-B will never have local cache for them.
+        def nextK1 = 100
+        // Insert `count` rows into CG-A, warm CG-A's file cache, then switch to CG-B context.
+        def insertAndWarmCGA = { count ->
+            def start = nextK1
+            nextK1 += count
+            def vals = (start..<nextK1).collect { i -> "(${i}, 'row${i}')" }.join(", ")
+            sql "use @${CG_A}"
+            sql "INSERT INTO ${tbl} VALUES ${vals}"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache
+            sleep(1000)
+            sql "use @${CG_B}"
+        }
+
+        def findBackendsByClusterName = { clusterName ->
+            sql_return_maparray('show backends').findAll { backend ->
+                backend.CloudClusterName == clusterName || backend.Tag?.contains(clusterName)
+            }
+        }
+
+        def getSingleBackendByClusterName = { clusterName ->
+            def backendsInCluster = findBackendsByClusterName(clusterName)
+            assertEquals(1, backendsInCluster.size(),
+                "Expected exactly 1 backend in ${clusterName}, got ${backendsInCluster.size()}")
+            backendsInCluster[0]
+        }
+
+        def getBackendNodeIndex = { backend ->
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            assertTrue(node != null, "Backend node not found for BackendId=${backend.BackendId}")
+            node.index
+        }
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, CG_B)
+        awaitUntil(30) {
+            findBackendsByClusterName(CG_A).size() == 1 &&
+                findBackendsByClusterName(CG_B).size() == 1
+        }
+
+        def beA = getSingleBackendByClusterName(CG_A)
+        def beB = getSingleBackendByClusterName(CG_B)
+        def beAIndex = getBackendNodeIndex(beA)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create table and insert data in CG-A ----
+        sql "use @${CG_A}"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b')"
+        sql "INSERT INTO ${tbl} VALUES (3, 'c'), (4, 'd')"
+        // Warm CG-A cache.
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        // Pre-warm CG-B: do a query from CG-B to trigger lazy FE fetch and populate candidates.
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} ORDER BY k1" // cold miss → lazy fetch
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        // Insert a fresh rowset in CG-A so CG-B's local cache won't have it yet.
+        // This allows the subsequent query from CG-B to exercise the peer race path.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (5, 'e'), (6, 'f')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache for the new rowset
+        sleep(1000)
+
+        // One more query from CG-B on the new data to confirm peer wins (candidates in cache).
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        awaitUntil(10) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > 0
+        }
+        logger.info("Setup: CG-B has candidates for CG-A BE and peer wins confirmed")
+
+        // ==================== RPC failure eviction ====================
+        logger.info("=== consecutive RPC failures evict candidate ===")
+
+        def t3_evictionBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction")
+        // Use peer_lazy_fetch_success (monotonically increasing Adder) as the pre-condition signal
+        // rather than balance_tablet_be_mapping_size (an Adder<uint64_t> used as a gauge that
+        // underflows when decrements exceed increments). The setup's awaitUntil already confirmed
+        // lazy fetch succeeded, so this assertion is a documentation-level sanity check.
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0,
+            "pre-condition: candidates should exist (lazy fetch succeeded during setup)")
+
+        // Insert fresh data into CG-A (while it is still running) and warm CG-A's cache.
+        // CG-B has no local cache for these new blocks, so subsequent queries from CG-B will
+        // enter the winner race and attempt peer RPCs — which will fail once CG-A is stopped.
+        insertAndWarmCGA(4)
+
+        // Stop CG-A BE so all peer RPCs fail.
+        sql "use @${CG_A}"  // switch away so queries below route to CG-B
+        cluster.stopBackends(beAIndex)
+        sleep(2000)
+        sql "use @${CG_B}"
+
+        // With threshold=1, each tablet's first peer RPC failure triggers eviction.
+        // Table has BUCKETS 2 → 2 tablets. One query is enough; run 2 to be safe in case
+        // tablet distribution causes one tablet to be missed by a single query.
+        for (int i = 0; i < 2; i++) {
+            sql "SELECT * FROM ${tbl} ORDER BY k1" // peer RPC fails → S3 fallback
+            sleep(500)
+        }
+
+        // Eviction is incremented by the peer bthread, which runs concurrently with the S3
+        // winner path. The query may return (via S3) before the peer bthread has finished
+        // its RPC timeout and incremented the counter. Use awaitUntil to avoid a race.
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction") > t3_evictionBefore
+        }
+        logger.info("peer_rpc_failure_eviction confirmed")
+
+        // Also verify the gauge is back to 0 after eviction. This serves as a regression check
+        // for the fix that moved g_balance_tablet_be_mapping_size << 1 into the singleflight
+        // block (before operator[] creates the placeholder), ensuring increment/decrement are
+        // balanced and the gauge no longer underflows to UINT64_MAX - N.
+        assertEquals(0L,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "balance_tablet_be_mapping_size"),
+            "balance_tablet_be_mapping_size should be 0 after all candidates evicted")
+
+        // Queries should still succeed via S3 fallback.
+        def t3_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertTrue(t3_result.size() > 0, "S3 fallback should return correct data after eviction")
+
+        // Restart CG-A BE before T4.
+        cluster.startBackends(beAIndex)
+        sleep(5000)
+        logger.info("PASS")
+
+        // ==================== Candidate expiry via cleanup daemon ====================
+        logger.info("=== candidate expiry via cleanup daemon ===")
+
+        // CG-A BE is running again (restarted at end of T3).
+        // Insert fresh rows into CG-A that CG-B has NEVER cached.
+        // After T3, CG-B's local file cache already has all old data; querying the same data
+        // would be a local hit and never reach the peer path, so lazy fetch would not fire.
+        // Fresh uncached blocks force CG-B into the peer path → candidates empty (T3 evicted
+        // them) → lazy fetch fires → candidates re-populated.
+        insertAndWarmCGA(4)
+
+        def t4_lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success")
+        def t4_expiryBefore    = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_expiry_eviction")
+
+        sql "SELECT * FROM ${tbl} ORDER BY k1" // new uncached blocks → peer path → lazy fetch
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > t4_lazyFetchBefore
+        }
+        logger.info("candidates re-populated via lazy fetch")
+
+        // Wait for peer_candidate_expiry_s=60s + cleanup_interval=5s to fire.
+        // Total wait: 70 s to be safe.
+        logger.info("sleeping 70s for candidate expiry (expiry_s=60, cleanup_interval=5)...")
+        sleep(70 * 1000)
+
+        // peer_candidate_expiry_eviction increasing is sufficient proof that the cleanup daemon
+        // ran and removed the expired candidates.
+        // Do NOT assert balance_tablet_be_mapping_size == 0 (bvar::Adder<uint64_t> underflows).
+        // Do NOT verify via lazy fetch re-trigger after expiry: CG-B's local cache now has the
+        // fresh data, so subsequent queries are local hits and never reach the peer path.
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_expiry_eviction") > t4_expiryBefore
+        }
+        logger.info("PASS")
+
+        // ==================== cache miss rotates candidate (Issue 3) ====================
+        // After T4, CGB's candidates have all expired (expiry_s=60). Fresh setup needed.
+        //
+        // When CGA is running but its file cache is EMPTY (blocks not yet cached) and
+        // peer_cache_fill_compute_group_id is not set (this suite), CGA returns NOT_FOUND
+        // for the missing blocks.  The client (CGB) should call rotate_peer_candidate_on_cache_miss
+        // rather than incrementing the RPC-failure eviction counter — the peer_candidate_rotate
+        // bvar must increase, and the candidate must NOT be evicted.
+        logger.info("=== cache miss (NOT_FOUND) rotates candidate from CG-A to CG-C on CG-B ===")
+
+        // Step 1: Add a second remote compute group so rotate has a real next candidate.
+        cluster.addBackend(1, CG_C)
+        awaitUntil(30) {
+            findBackendsByClusterName(CG_C).size() == 1
+        }
+        def beC = getSingleBackendByClusterName(CG_C)
+        logger.info("CG-C BE: host={} brpcPort={}", beC.Host, beC.BrpcPort)
+
+        // Step 2: Prime CG-C once before CG-B's lazy fetch so FE records a primary backend for
+        // CG-C as well. Without this, the first lazy fetch may still return only CG-A, which
+        // would reduce rotate to a single-candidate noop.
+        sql "use @${CG_C}"
+        sql "SELECT * FROM ${tbl} WHERE k1 < 800 ORDER BY k1"
+        sleep(1000)
+
+        // Step 3: Trigger a fresh lazy fetch after T4 expiry so CG-B learns both remote
+        // compute groups (CG-A + CG-C) as candidates.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (800, 'fetch1'), (801, 'fetch2')"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 800 AND k1 < 810 ORDER BY k1"
+        sleep(1000)
+
+        def t5_lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success")
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 800 AND k1 < 810 ORDER BY k1"
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > t5_lazyFetchBefore
+        }
+        logger.info("lazy fetch refreshed candidates; CG-B should now know both CG-A and CG-C")
+
+        // Step 4: Seed CG-A as the preferred remote CG using a fresh rowset that CG-B has never
+        // cached. This ensures get_peer_candidates() stable-partitions CG-A to the front before
+        // the rotate verification below.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (820, 'pref1'), (821, 'pref2')"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 820 AND k1 < 900 ORDER BY k1"
+        sleep(1000)
+
+        def t5_peerWinSeedBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 820 AND k1 < 900 ORDER BY k1"
+        awaitUntil(10) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t5_peerWinSeedBefore
+        }
+        logger.info("CG-A became the preferred remote CG for the rotate verification")
+
+        // Step 5: Insert rotate-test rows, keep CG-A and CG-C warm, but leave CG-B cold.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (900, 'rotate1'), (901, 'rotate2')"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"  // keep CG-A warm
+        sql "use @${CG_C}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"  // warm CG-C only
+        sleep(1000)
+
+        // Step 6: Restart CGA with cache deleted → all blocks are EMPTY after restart.
+        // trigger_peer_server_fill is NOT invoked here because peer_cache_fill_compute_group_id
+        // is empty (not configured in this suite), so request_cache_fill=false → server returns
+        // NOT_FOUND for EMPTY blocks → CGB rotate path fires.
+        cluster.stopBackends(beAIndex)
+        sleep(2000)
+        def beA_node5 = cluster.getBeByBackendId(beA.BackendId.toLong())
+        def cacheDir5 = new File("${beA_node5.path}/storage/file_cache")
+        logger.info("Deleting CGA file cache at: {}", cacheDir5.absolutePath)
+        if (cacheDir5.exists()) {
+            cacheDir5.deleteDir()
+            logger.info("CGA file cache deleted — blocks will be EMPTY after restart")
+        }
+        cluster.startBackends(beAIndex)
+        sleep(5000)
+        logger.info("CGA restarted with empty cache while CG-C remains warm")
+
+        // Step 7: CGB queries (900, 901) — CGB has NO local cache for these rows.
+        // Peer bthread first tries the preferred CG-A → EMPTY + request_fill=false → NOT_FOUND
+        // → rotate_peer_candidate_on_cache_miss. The same peer loop then advances to CG-C,
+        // which still has these blocks warm, so this is a real rotate-to-next-candidate path.
+        def t5_rotateBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_rotate")
+        def t5_evictionBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction")
+        def t5_peerWinBefore  = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"
+
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_rotate") > t5_rotateBefore
+        }
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t5_peerWinBefore
+        }
+        logger.info("peer_candidate_rotate increased and peer still won via the next candidate")
+
+        // Key assertion: rotate occurred but eviction counter did NOT move.
+        assertEquals(t5_evictionBefore,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction"),
+            "NOT_FOUND (cache miss) must NOT increment peer_rpc_failure_eviction")
+
+        // Data must still be readable after rotate.
+        def t5_result = sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"
+        assertEquals(2, t5_result.size(), "rotate path must return rotate-test rows")
+
+        // Restart CGA before end of suite (it was started in step 4; should still be running).
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_inverted_index.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_inverted_index.groovy
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// cross-CG peer read works correctly for tables with inverted index (.dat + .idx files).
+// CG-A warms cache for both .dat and .idx segments. CG-B lazy-fetch then reads via peer.
+// Priority: P2
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_inverted_index', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_inverted_index_tbl"
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Create table with inverted index in CG-A ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                id     BIGINT,
+                title  VARCHAR(256),
+                body   STRING,
+                INDEX idx_body (body) USING INVERTED PROPERTIES("parser" = "english")
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql """INSERT INTO ${tbl} VALUES
+            (1, 'hello world',  'the quick brown fox jumps over the lazy dog'),
+            (2, 'foo bar',      'pack my box with five dozen liquor jugs'),
+            (3, 'test case',    'how vexingly quick daft zebras jump')
+        """
+        sql """INSERT INTO ${tbl} VALUES
+            (4, 'more data',    'the five boxing wizards jump quickly'),
+            (5, 'last row',     'sphinx of black quartz judge my vow')
+        """
+
+        // Warm CG-A cache (both .dat segment files and .idx inverted-index files).
+        def warmResult = sql "SELECT * FROM ${tbl} ORDER BY id"
+        assertEquals(5, warmResult.size(), "Setup: CG-A warm query should return 5 rows")
+        sleep(1000)
+
+        // ==================== Cross-CG peer read with inverted index ====================
+        logger.info("=== cross-CG peer read with inverted index ===")
+
+        // Switch to CG-B, trigger cold miss → lazy fetch.
+        sql "use @cross_cg_peer_cluster"
+        def t11_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // First query: cold miss → lazy fetch fires. This populates CG-B's local cache for the
+        // existing rows and triggers async candidate registration for CG-A's BE.
+        sql "SELECT * FROM ${tbl} ORDER BY id"
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+
+        // Insert fresh rows into CG-A and warm CG-A cache (both .dat and .idx files).
+        // CG-B has no local cache for these new blocks, so the MATCH_ALL query below will
+        // enter the winner race and peer-read .dat/.idx blocks from CG-A.
+        sql "use @compute_cluster"
+        sql """INSERT INTO ${tbl} VALUES
+            (6, 'extra row', 'the quick fox is back again'),
+            (7, 'another',  'no matching keyword here')
+        """
+        sql "SELECT * FROM ${tbl} ORDER BY id"  // warm CG-A cache: .dat + .idx for new rows
+        sleep(1000)
+        sql "use @cross_cg_peer_cluster"
+
+        // Second query: new blocks not in CG-B local cache; MATCH_ALL exercises .idx files via peer.
+        def t11_result = sql """
+            SELECT id, title FROM ${tbl}
+            WHERE body MATCH_ALL 'quick'
+            ORDER BY id
+        """
+        assertTrue(t11_result.size() > 0, "MATCH_ALL query should return rows")
+        // Rows containing exact word 'quick': id=1 ("quick brown fox"), id=3 ("vexingly quick"),
+        // id=6 ("the quick fox is back again"). Row 4 has "quickly" which is a different token.
+        def ids = t11_result.collect { it[0] as long }
+        assertTrue(ids.containsAll([1L, 3L, 6L]),
+            "MATCH_ALL 'quick' should match rows 1, 3, 6; got ${ids}")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t11_peerWinBefore,
+            "peer_race_peer_win should increase (peer served .dat and/or .idx blocks)")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > 0,
+            "peer_cross_compute_group_read should be > 0")
+
+        // Insert yet another fresh row with 'quick' into CG-A and warm CG-A, so the profile
+        // query below has uncached blocks on CG-B and will trigger a cross-CG peer read.
+        sql "use @compute_cluster"
+        sql """INSERT INTO ${tbl} VALUES (8, 'profile row', 'quick brown profile test')"""
+        sql "SELECT * FROM ${tbl} ORDER BY id"  // warm CG-A cache including new .idx blocks
+        sleep(1000)
+        sql "use @cross_cg_peer_cluster"
+
+        // Profile check: CrossCGPeerIOTotal should reflect .dat + .idx reads.
+        profile("cross_cg_inverted_index_profile") {
+            sql "set enable_profile = true"
+            sql "set profile_level = 2"
+            run {
+                sql """/* cross_cg_inverted_index_profile */ SELECT id FROM ${tbl}
+                       WHERE body MATCH_ALL 'quick' ORDER BY id"""
+                sleep(500)
+            }
+            check { profileString, exception ->
+                logger.info("profile snippet: {}", profileString.take(2000))
+                def matcher = (profileString =~ /CrossCGPeerIOTotal:\s+(\d+)/)
+                def total = 0
+                while (matcher.find()) {
+                    total += matcher.group(1).toInteger()
+                }
+                assertTrue(total > 0,
+                    "CrossCGPeerIOTotal must be > 0 in profile for inverted-index query")
+
+                def nodesMatcher = (profileString =~ /PeerCacheNodes:\s*(.+)/)
+                assertTrue(nodesMatcher.find(), "Profile must contain PeerCacheNodes info")
+                logger.info("PeerCacheNodes found: {}", nodesMatcher.group(1))
+            }
+        }
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_peer_read_colocate.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_peer_read_colocate.groovy
@@ -1,0 +1,309 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read for colocate tables.
+//
+// Bug: For colocate tables, CloudTabletRebalancer.completeRouteInfo() intentionally
+// keeps primaryClusterToBackends empty because query routing uses dynamic hashing
+// (getColocatedBeId). This caused getAllPrimaryBes() to return an empty list, so
+// peer candidate discovery never found any candidates and cross-CG peer read was
+// silently broken for colocate tables.
+//
+// Fix: getAllPrimaryBes() now dynamically computes backends for colocate tables via
+// getColocatedBeId() for each cluster, allowing peer candidates to be discovered.
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_peer_read_colocate', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'max_concurrent_peer_races=64',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def colocateTbl1 = "test_cross_cg_colocate_tbl1"
+        def colocateTbl2 = "test_cross_cg_colocate_tbl2"
+        def colocateGroup = "test_cross_cg_colocate_group"
+
+        def nextK1 = 100
+        def insertAndWarmCGA = { tbl, count ->
+            def start = nextK1
+            nextK1 += count
+            def vals = (start..<nextK1).collect { i -> "(${i}, 'row${i}')" }.join(", ")
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tbl} VALUES ${vals}"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"
+            sleep(1000)
+            sql "use @cross_cg_peer_cluster"
+        }
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends after adding CG-B"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create colocate tables in CG-A ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${colocateTbl1}"
+        sql "DROP TABLE IF EXISTS ${colocateTbl2}"
+        sql """
+            CREATE TABLE ${colocateTbl1} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES (
+                "replication_num" = "1",
+                "colocate_with" = "${colocateGroup}"
+            )
+        """
+        sql """
+            CREATE TABLE ${colocateTbl2} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES (
+                "replication_num" = "1",
+                "colocate_with" = "${colocateGroup}"
+            )
+        """
+
+        // Verify colocate group is established
+        def groupResult = sql "SHOW PROC '/colocation_group'"
+        logger.info("Colocate groups: {}", groupResult)
+        assertTrue(groupResult.size() > 0, "colocate group should exist")
+
+        // Insert and warm cache in CG-A
+        sql "INSERT INTO ${colocateTbl1} VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')"
+        sql "INSERT INTO ${colocateTbl2} VALUES (10, 'ten'), (20, 'twenty'), (30, 'thirty')"
+        def warmResult1 = sql "SELECT * FROM ${colocateTbl1} ORDER BY k1"
+        def warmResult2 = sql "SELECT * FROM ${colocateTbl2} ORDER BY k1"
+        assertEquals(3, warmResult1.size(), "CG-A warm tbl1 should return 3 rows")
+        assertEquals(3, warmResult2.size(), "CG-A warm tbl2 should return 3 rows")
+        sleep(1000)
+
+        // ==================== Colocate table: cold miss then peer wins ====================
+        logger.info("=== colocate table: cold miss then peer wins ===")
+
+        def lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered")
+
+        // First query from CG-B on colocate table: no candidates yet -> cold miss -> S3
+        sql "use @cross_cg_peer_cluster"
+        def coldResult1 = sql "SELECT * FROM ${colocateTbl1} ORDER BY k1"
+        assertEquals(3, coldResult1.size(), "CG-B cold read of colocate tbl1 should return 3 rows")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered") > lazyFetchBefore,
+            "lazy fetch should be triggered on cold miss for colocate table")
+
+        // Wait for lazy FE fetch to populate candidate cache.
+        // This is the critical part: before the fix, getAllPrimaryBes() returned empty for
+        // colocate tables, so the FE would never return any peer candidates, and
+        // peer_lazy_fetch_success would never increase.
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        logger.info("lazy fetch success confirmed for colocate table - fix is working")
+
+        // Insert fresh rowset in CG-A so CG-B has no local cache for it
+        insertAndWarmCGA(colocateTbl1, 3)
+
+        def peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        def crossCgBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read")
+
+        // Second query from CG-B: candidates now available -> peer should win race
+        def peerResult1 = sql "SELECT * FROM ${colocateTbl1} ORDER BY k1"
+        assertTrue(peerResult1.size() > 3, "CG-B should read fresh rows from colocate tbl1")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > peerWinBefore
+                || getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > crossCgBefore,
+            "peer read counters should increase for colocate table " +
+            "(peer_race_peer_win ${peerWinBefore}->${getBrpcMetrics(beB.Host, beB.BrpcPort, 'peer_race_peer_win')}, " +
+            "peer_cross_compute_group_read ${crossCgBefore}->${getBrpcMetrics(beB.Host, beB.BrpcPort, 'peer_cross_compute_group_read')})")
+        logger.info("PASS: colocate table peer read works")
+
+        // ==================== Second colocate table in same group ====================
+        logger.info("=== second colocate table in same group ===")
+
+        // The second colocate table shares the same colocate group, so it should also
+        // benefit from the fix (same dynamic hashing logic).
+        def coldResult2 = sql "SELECT * FROM ${colocateTbl2} ORDER BY k1"
+        assertEquals(3, coldResult2.size(), "CG-B cold read of colocate tbl2 should return 3 rows")
+
+        // Wait for lazy fetch for tbl2
+        sleep(3000)
+
+        insertAndWarmCGA(colocateTbl2, 3)
+
+        def peerWinBefore2 = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        def crossCgBefore2 = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read")
+
+        def peerResult2 = sql "SELECT * FROM ${colocateTbl2} ORDER BY k1"
+        assertTrue(peerResult2.size() > 3, "CG-B should read fresh rows from colocate tbl2")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > peerWinBefore2
+                || getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > crossCgBefore2,
+            "peer read counters should increase for second colocate table")
+        logger.info("PASS: second colocate table in same group also works")
+
+        // ==================== Colocate join across CG ====================
+        logger.info("=== colocate join query across CG ===")
+
+        sql "use @compute_cluster"
+        // Ensure both tables have overlapping keys for the join
+        sql "INSERT INTO ${colocateTbl1} VALUES (10, 'ten_in_tbl1')"
+        sql "SELECT * FROM ${colocateTbl1} ORDER BY k1"
+        sql "SELECT * FROM ${colocateTbl2} ORDER BY k1"
+        sleep(1000)
+
+        sql "use @cross_cg_peer_cluster"
+        def joinResult = sql """
+            SELECT t1.k1, t1.v1, t2.v1
+            FROM ${colocateTbl1} t1
+            JOIN ${colocateTbl2} t2 ON t1.k1 = t2.k1
+            ORDER BY t1.k1
+        """
+        logger.info("Colocate join result: {}", joinResult)
+        assertTrue(joinResult.size() > 0, "colocate join across CG should return results")
+        // k1=10 exists in both tables
+        def row10 = joinResult.find { it[0] == 10 }
+        assertTrue(row10 != null, "join should find k1=10 in both tables")
+        logger.info("PASS: colocate join across CG works")
+
+        // ==================== Verify profile shows cross-CG metrics + timer accuracy ====================
+        logger.info("=== profile check for colocate peer read ===")
+
+        insertAndWarmCGA(colocateTbl1, 2)
+
+        profile("cross_cg_colocate_profile") {
+            sql "set enable_profile = true"
+            sql "set profile_level = 2"
+            run {
+                sql "/* cross_cg_colocate_profile */ SELECT * FROM ${colocateTbl1} ORDER BY k1"
+                sleep(500)
+            }
+            check { profileString, exception ->
+                logger.info("colocate profile snippet: {}", profileString.take(4000))
+
+                // CrossCGPeerIOTotal counter must be > 0
+                def crossCgMatcher = (profileString =~ /CrossCGPeerIOTotal:\s+(\d+)/)
+                def crossCgTotal = 0
+                while (crossCgMatcher.find()) {
+                    crossCgTotal += crossCgMatcher.group(1).toInteger()
+                }
+                assertTrue(crossCgTotal > 0,
+                    "CrossCGPeerIOTotal must be > 0 in profile for colocate table")
+
+                def nodesMatcher = (profileString =~ /PeerCacheNodes:\s*(.+)/)
+                assertTrue(nodesMatcher.find(), "Profile must contain PeerCacheNodes info")
+                logger.info("PeerCacheNodes found: {}", nodesMatcher.group(1))
+
+                // PeerRaceWin counter must be > 0
+                def raceWinMatcher = (profileString =~ /PeerRaceWin:\s+(\d+)/)
+                def raceWin = 0
+                while (raceWinMatcher.find()) {
+                    raceWin += raceWinMatcher.group(1).toInteger()
+                }
+                assertTrue(raceWin > 0,
+                    "PeerRaceWin must be > 0 in profile for colocate table")
+
+                // CrossCGPeerIOTime must NOT be 0ns — verifies the peer_elapsed_ns
+                // propagation fix (commit b8f5b1ef940). Before the fix this timer was
+                // always reported as 0ns because peer_io_timer was not propagated from
+                // RaceState to ReadStatistics.
+                def crossCgTimeMatcher = (profileString =~ /CrossCGPeerIOTime:\s+(\S+)/)
+                def foundNonZeroCrossCgTime = false
+                while (crossCgTimeMatcher.find()) {
+                    def val = crossCgTimeMatcher.group(1)
+                    if (val != "0ns" && val != "0s" && val != "0.000ns") {
+                        foundNonZeroCrossCgTime = true
+                    }
+                }
+                assertTrue(foundNonZeroCrossCgTime,
+                    "CrossCGPeerIOTime must not be 0ns — timer propagation fix verification")
+
+                // PeerIOUseTimer must NOT be 0ns — same root cause: peer read wall-clock
+                // time was lost in the race winner path.
+                def peerTimerMatcher = (profileString =~ /PeerIOUseTimer:\s+(\S+)/)
+                def foundNonZeroPeerTimer = false
+                while (peerTimerMatcher.find()) {
+                    def val = peerTimerMatcher.group(1)
+                    if (val != "0ns" && val != "0s" && val != "0.000ns") {
+                        foundNonZeroPeerTimer = true
+                    }
+                }
+                assertTrue(foundNonZeroPeerTimer,
+                    "PeerIOUseTimer must not be 0ns — timer propagation fix verification")
+            }
+        }
+        logger.info("PASS: profile shows cross-CG metrics and non-zero timers for colocate table")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_peer_read_core.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_peer_read_core.groovy
@@ -1,0 +1,351 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read core tests:
+// lazy FE fetch + peer wins race (P0)
+// S3 wins when peer BE is down (P0)
+// race disabled falls back to serial (P1)
+// query profile records cross-CG metrics (P0)
+// cold miss S3 first, lazy fetch, then peer wins (P0)
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_peer_read_core', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'max_concurrent_peer_races=64',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1) // CG-A starts with 1 BE
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    // Read a bvar counter from a BE's brpc_metrics endpoint. Returns 0 if the metric is not yet
+    // present (common for counters that haven't been incremented).
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    def getBeConfig = { be, key ->
+        def (code, out, err) = curl("GET",
+            "http://${be.Host}:${be.HttpPort}/api/show_config?conf_item=${key}")
+        assertEquals(0, code, "failed to get ${key} from ${be.Host}:${be.HttpPort}: ${err}")
+        assertTrue(out.contains(key), "show_config response must contain ${key}: ${out}")
+        def rows = parseJson(out)
+        assertEquals(1, rows.size(), "show_config should return one row for ${key}: ${out}")
+        assertEquals(4, rows[0].size(), "unexpected show_config row for ${key}: ${out}")
+        rows[0][2] as String
+    }
+
+    def updateBeConfig = { be, key, value ->
+        def (code, out, err) = curl("POST",
+            "http://${be.Host}:${be.HttpPort}/api/update_config?${key}=${value}")
+        assertEquals(0, code, "failed to set ${key}=${value} on ${be.Host}:${be.HttpPort}: ${err}")
+        assertTrue(out.contains("OK"),
+            "failed to set ${key}=${value} on ${be.Host}:${be.HttpPort}: ${out}")
+    }
+
+    def withBeConfigTemporary = { be, tempConfig, actionSupplier ->
+        def originConfig = [:]
+        tempConfig.each { key, value ->
+            originConfig[key] = getBeConfig(be, key)
+        }
+        try {
+            tempConfig.each { key, value ->
+                updateBeConfig(be, key, value)
+            }
+            actionSupplier()
+        } finally {
+            originConfig.each { key, value ->
+                updateBeConfig(be, key, value)
+            }
+        }
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_peer_read_core_tbl"
+
+        // Counter for unique k1 ranges across inserts; CG-B will never have local cache for them.
+        def nextK1 = 100
+        // Insert `count` rows into CG-A, warm CG-A's file cache, then switch to CG-B context.
+        def insertAndWarmCGA = { count ->
+            def start = nextK1
+            nextK1 += count
+            def vals = (start..<nextK1).collect { i -> "(${i}, 'row${i}')" }.join(", ")
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tbl} VALUES ${vals}"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache
+            sleep(1000)
+            sql "use @cross_cg_peer_cluster"
+        }
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        // Allow BE to register and send heartbeat before we read show backends.
+        sleep(5000)
+
+        // Backends are listed in registration order: index 0 = CG-A BE, index 1 = CG-B BE.
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends after adding CG-B"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create table and insert data in CG-A ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')"
+        sql "INSERT INTO ${tbl} VALUES (4, 'delta'), (5, 'epsilon'), (6, 'zeta')"
+
+        // ---- Warm CG-A file cache by querying once in CG-A ----
+        def warmResult = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(6, warmResult.size(), "Setup: CG-A warm query should return 6 rows")
+        sleep(1000)
+
+        // ==================== Cold miss S3 first, then peer ====================
+        logger.info("=== cold miss S3 first, then peer ===")
+
+        def t10_lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered")
+        def t10_peerWinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // First query from CG-B: no candidates yet → cold miss → S3 wins, async lazy fetch fires.
+        sql "use @cross_cg_peer_cluster"
+        def t10_r1 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(6, t10_r1.size(), "first query (cold miss) should succeed via S3")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered") > t10_lazyFetchBefore,
+            "lazy fetch should be triggered on cold miss")
+
+        // Wait up to 30 s for lazy FE fetch to complete and populate candidate cache.
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        logger.info("lazy fetch success confirmed")
+
+        // Insert a fresh rowset into CG-A so CG-B's local cache doesn't have it yet.
+        // Without new data, the second query would be a local cache hit (CG-B already
+        // cached everything from the first query via S3) and peer_race_peer_win would never increase.
+        insertAndWarmCGA(2)
+
+        // Second query from CG-B: new rowset not in CG-B local cache, candidates available → peer wins race.
+        def t10_r2 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertTrue(t10_r2.size() > 6, "second query (after lazy fetch) should return more than original 6 rows")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t10_peerWinBefore,
+            "peer should win race after lazy fetch populates candidates")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_cache_hit") > 0,
+            "candidate cache should be hit on second query")
+        logger.info("PASS")
+
+        // ==================== + Peer wins, bvar + profile metrics ====================
+        logger.info("=== peer wins bvar + profile ===")
+
+        // Insert another fresh rowset so CG-B has no local cache for the new blocks.
+        insertAndWarmCGA(2)
+
+        def t1_peerWinBefore     = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        def t1_crossCgReadBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read")
+
+        profile("cross_cg_peer_win_profile") {
+            sql "set enable_profile = true"
+            sql "set profile_level = 2"
+            run {
+                sql "/* cross_cg_peer_win_profile */ SELECT * FROM ${tbl} ORDER BY k1"
+                sleep(500)
+            }
+            check { profileString, exception ->
+                logger.info("profile snippet: {}", profileString.take(2000))
+                // CrossCGPeerIOTotal should be > 0 (at least one cross-CG peer IO)
+                def crossCgMatcher = (profileString =~ /CrossCGPeerIOTotal:\s+(\d+)/)
+                def crossCgTotal = 0
+                while (crossCgMatcher.find()) {
+                    crossCgTotal += crossCgMatcher.group(1).toInteger()
+                }
+                assertTrue(crossCgTotal > 0, "CrossCGPeerIOTotal must be > 0 in profile")
+
+                // PeerRaceWin counter should reflect at least one race win
+                def raceWinMatcher = (profileString =~ /PeerRaceWin:\s+(\d+)/)
+                def raceWin = 0
+                while (raceWinMatcher.find()) {
+                    raceWin += raceWinMatcher.group(1).toInteger()
+                }
+                assertTrue(raceWin > 0, "PeerRaceWin must be > 0 in profile")
+
+                def nodesMatcher = (profileString =~ /PeerCacheNodes:\s*(.+)/)
+                assertTrue(nodesMatcher.find(), "Profile must contain PeerCacheNodes info")
+                logger.info("PeerCacheNodes found: {}", nodesMatcher.group(1))
+            }
+        }
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t1_peerWinBefore,
+            "peer_race_peer_win bvar should increase after cross-CG peer read")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > t1_crossCgReadBefore,
+            "peer_cross_compute_group_read bvar should increase")
+        logger.info("PASS")
+
+        // ==================== Race disabled → serial peer path ====================
+        logger.info("=== race disabled, serial peer path ===")
+
+        // enable_peer_s3_race=false: cross-CG candidates go through serial peer→S3, no race counters.
+        withBeConfigTemporary(beB, ['enable_peer_s3_race': 'false']) {
+            sql "use @cross_cg_peer_cluster"
+            def t5_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+            def t5_s3WinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win")
+
+            def t5_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(t5_result.size() > 0, "serial path should return data")
+
+            // Race counters must NOT increase while race is disabled.
+            assertEquals(t5_peerWinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win"),
+                "peer_race_peer_win must not change when race disabled")
+            assertEquals(t5_s3WinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win"),
+                "peer_race_s3_win must not change when race disabled")
+        }
+        logger.info("PASS")
+
+        // ==================== S3 wins when CG-A BE is down ====================
+        logger.info("=== S3 wins when CG-A BE is unreachable ===")
+
+        // Insert fresh rows into CG-A and warm CG-A's cache BEFORE stopping CG-A.
+        // CG-B has no local cache for these new blocks. After CG-A is stopped, the
+        // winner race will try peer (fails: CG-A is down) → S3 wins → peer_race_s3_win increases.
+        // Without fresh uncached blocks, CG-B would serve all data from its own local cache
+        // (populated during T5/T1/T10) and peer_race_s3_win would never move.
+        insertAndWarmCGA(2)
+
+        def t2_s3WinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win")
+        def t2_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // Stop CG-A BE (compose index 1).
+        cluster.stopBackends(1)
+        sleep(3000)
+
+        def t2_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertTrue(t2_result.size() > 0, "S3 fallback should return data when CG-A BE is down")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win") > t2_s3WinBefore,
+            "peer_race_s3_win should increase when peer is unreachable")
+        assertEquals(t2_peerWinBefore,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win"),
+            "peer_race_peer_win should not increase when CG-A BE is down")
+
+        // Restart CG-A BE for cleanup.
+        cluster.startBackends(1)
+        sleep(5000)
+        logger.info("PASS")
+
+        // ==================== max_concurrent_peer_races=0 → degrades to serial ====================
+        logger.info("=== max_concurrent_peer_races=0 disables race ===")
+
+        // When the concurrent-race guard is saturated (limit=0), the reader falls back to the
+        // sequential peer→S3 path, so race counters must not increase.
+        withBeConfigTemporary(beB, ['max_concurrent_peer_races': '0']) {
+            sql "use @cross_cg_peer_cluster"
+            def t6_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+            def t6_s3WinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win")
+
+            def t6_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(t6_result.size() > 0, "degraded path should still return data")
+
+            assertEquals(t6_peerWinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win"),
+                "peer_race_peer_win must not change when race is concurrency-limited to 0")
+            assertEquals(t6_s3WinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win"),
+                "peer_race_s3_win must not change when race is concurrency-limited to 0")
+        }
+        logger.info("PASS")
+
+        // ==================== Comprehensive bvar sanity check ====================
+        // At this point the docker run has exercised all core scenarios, so we can assert
+        // the expected non-zero / zero relationship for every new bvar in aggregate.
+        logger.info("=== comprehensive bvar sanity ===")
+
+        // Candidate discovery layer (on CG-B BE).
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_cache_miss") > 0,
+            "peer_candidate_cache_miss should be > 0 (cold miss in T10)")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered") > 0,
+            "peer_lazy_fetch_triggered should be > 0")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0,
+            "peer_lazy_fetch_success should be > 0")
+        assertEquals(0L, getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_failed"),
+            "peer_lazy_fetch_failed should be 0 (FE always reachable in docker)")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_cache_hit") > 0,
+            "peer_candidate_cache_hit should be > 0 (T1/T10 second query)")
+
+        // Winner race layer (on CG-B BE).
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > 0,
+            "peer_race_peer_win should be > 0")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win") > 0,
+            "peer_race_s3_win should be > 0")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > 0,
+            "peer_cross_compute_group_read should be > 0")
+
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill.groovy
@@ -1,0 +1,319 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read server-side fill test:
+// CG-A BE cache miss → server pulls from S3 (pull-through fill) → returns data to CG-B.
+//      Second query: CG-A already cached → peer hits directly. (P1)
+// max_concurrent_peer_server_fills=0 → all fill requests rejected immediately → (Issue 5)
+//      peer_server_fill_rejected counter increases; query still succeeds via S3 fallback.
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+// CG-A BE does NOT warm its cache before the first cross-CG query, so the server-side fill path
+// is exercised.
+//
+// Note: peer_cache_fill_compute_group_id must be set to CG-A's cluster_id. In the docker
+// environment the default cluster id is "compute_cluster_id".
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_server_fill', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    // CG-A cluster id in the docker environment.
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        // Give S3 fill enough time in docker (latency can be high).
+        'peer_server_cache_fill_timeout_ms=6000',
+        // RPC timeout must exceed fill timeout.
+        // Designate CG-A as the fill compute group so client sets request_cache_fill=true only for CG-A.
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+        // Packed files would obscure per-segment file-cache inspection.
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    def checkBeHttpReady = { be, key ->
+        def cmd = "curl -s --max-time 2 -X GET " +
+            "http://${be.Host}:${be.HttpPort}/api/show_config?conf_item=${key}"
+        def process = cmd.execute()
+        def out = new StringBuilder()
+        def err = new StringBuilder()
+        process.waitForProcessOutput(out, err)
+        process.exitValue() == 0 && out.toString().contains(key)
+    }
+
+    def waitForBeHttpReady = { be, key ->
+        awaitUntil(120) {
+            checkBeHttpReady(be, key)
+        }
+    }
+
+    def updateBeConfig = { be, key, value ->
+        waitForBeHttpReady(be, key)
+        def (code, out, err) = curl("POST",
+            "http://${be.Host}:${be.HttpPort}/api/update_config?${key}=${value}")
+        assertEquals(0, code, "failed to set ${key}=${value} on ${be.Host}:${be.HttpPort}: ${err}")
+        assertTrue(out.contains("OK"),
+            "failed to set ${key}=${value} on ${be.Host}:${be.HttpPort}: ${out}")
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_server_fill_tbl"
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE (fill server): host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE (requester):   host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create table and insert data in CG-A. Do NOT warm CG-A cache. ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (10, 'foo'), (20, 'bar')"
+        sql "INSERT INTO ${tbl} VALUES (30, 'baz'), (40, 'qux')"
+        // Intentionally skip the CG-A warming step so CG-A's file cache is empty.
+        // CG-B query will trigger server-side fill on CG-A.
+        // ---- Step 1: Insert a fill-test rowset into CG-A BEFORE CG-B knows about CG-A ----
+        // CG-A's S3FileWriter will cache these blocks during write (DOWNLOADED on CG-A).
+        // CG-B has never seen this data → no local cache for it.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (50, 'fill1'), (60, 'fill2')"
+        // Warm CG-A's READ cache (the write-path cache from S3FileWriter is already populated,
+        // so this query is a local hit on CG-A — just ensures CG-A has the data accessible).
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        // ---- Step 2: Trigger lazy FE fetch from CG-B for the INITIAL rows only ----
+        // Run a SELECT before CG-A has (50,60) committed to CG-B's view... actually CG-B
+        // will read ALL rows. Insert (50,60) AFTER this cold miss to keep CG-B uncached.
+        // Restructure: trigger lazy fetch with existing rows, then insert fill-test rows.
+        //
+        // Actually, we inserted (50,60) first. The cold miss from CG-B will read ALL rows
+        // including (50,60) → CG-B caches them → can't test fill for (50,60).
+        //
+        // Correct order:
+        //   1. CG-B cold miss on initial rows (10,20,30,40) → lazy fetch, CGB caches initial
+        //   2. Insert fill-test rows (50,60) on CG-A → CGA write-caches them, CGB never reads them
+        //   3. Restart CGA → CGA file cache cleared (including write-cached (50,60))
+        //   4. CGB queries ALL: (10,20,30,40) = local hit; (50,60) = remote needed; CGA EMPTY → fill!
+
+        // Undo: we already inserted (50,60) above. Drop and recreate to get the right order.
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (10, 'foo'), (20, 'bar')"
+        sql "INSERT INTO ${tbl} VALUES (30, 'baz'), (40, 'qux')"
+        // Warm CG-A cache for initial rows.
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        // CG-B cold miss on initial rows (10,20,30,40) → triggers lazy fetch, CGB caches them.
+        sql "use @cross_cg_peer_cluster"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        logger.info("CG-B now has CG-A BE as candidate; CG-B has (10,20,30,40) cached")
+
+        // ---- Step 3: Insert fill-test rows (50,60) into CG-A ----
+        // CG-A's S3FileWriter caches them (DOWNLOADED on CG-A). CG-B has NEVER read them.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (50, 'fill1'), (60, 'fill2')"
+        sleep(1000)
+
+        // ---- Step 4: Restart CG-A and EXPLICITLY delete its disk file cache ----
+        // S3FileWriter populates CGA's local file cache during INSERT (write-time caching).
+        // The file cache is disk-based and survives a BE process restart — blocks come back as
+        // DOWNLOADED, not EMPTY. trigger_peer_server_fill is only called when the block state
+        // is EMPTY. We must delete the cache directory after stopping the process so CGA truly
+        // starts with empty blocks after restart.
+        cluster.stopBackends(1)
+        sleep(2000)
+
+        def beA_node = cluster.getBeByBackendId(beA.BackendId.toLong())
+        def cacheDir = new File("${beA_node.path}/storage/file_cache")
+        logger.info("Deleting CGA file cache at: {}", cacheDir.absolutePath)
+        if (cacheDir.exists()) {
+            cacheDir.deleteDir()
+            logger.info("CGA file cache deleted — blocks will be EMPTY after restart")
+        } else {
+            logger.warn("CGA file cache directory not found at {}", cacheDir.absolutePath)
+        }
+
+        cluster.startBackends(1)
+        sleep(5000)
+        waitForBeHttpReady(beA, "enable_peer_server_cache_fill")
+        logger.info("CG-A restarted — file cache cleared, (50,60) blocks now EMPTY on CG-A")
+
+        // ==================== Server-side pull-through fill ====================
+        logger.info("=== server-side fill (CG-A cache miss → S3 pull-through) ===")
+
+        def t9_fillReqBefore  = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+        def t9_fillSuccBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success")
+
+        // CG-B queries ALL rows:
+        //   (10,20,30,40): CG-B local cache hit → no remote access
+        //   (50,60): CG-B has NO local cache; CG-A has EMPTY blocks (cleared by restart)
+        //            → winner race → peer bthread → RPC to CG-A with request_cache_fill=true
+        //            → CG-A EMPTY → enable_peer_server_cache_fill=true → trigger_peer_server_fill
+        //            → CG-A pulls from S3, returns data → peer_server_fill_requested++
+        sql "use @cross_cg_peer_cluster"
+        def t9_r1 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(6, t9_r1.size(), "first query should return all 6 rows")
+
+        // Verify that CG-A's server-side fill was triggered.
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested") > t9_fillReqBefore,
+            "peer_server_fill_requested should increase on CG-A after first cross-CG query")
+
+        // ---- Second query: verify peer wins now that CG-A has cached the data ----
+        // Insert another fresh rowset so CG-B has no cache for the new blocks.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (70, 'new3'), (80, 'new4')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache
+        sleep(1000)
+        sql "use @cross_cg_peer_cluster"
+        def t9_fillSuccBeforeSecondQuery = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success")
+
+        def t9_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        def t9_r2 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(8, t9_r2.size(), "second query should return 8 rows")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t9_peerWinBefore,
+            "peer should win race on second query (CG-A has data cached)")
+        // (70,80) blocks are already DOWNLOADED on CG-A — no server fill should be triggered.
+        assertEquals(t9_fillSuccBeforeSecondQuery,
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success"),
+            "peer_server_fill_success must NOT increase for (70,80) — CG-A already has them cached")
+
+        // CG-A fill success counter should be positive.
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success") > t9_fillSuccBefore,
+            "peer_server_fill_success should increase on CG-A")
+
+        // ==================== fill concurrency limit (Issue 5) ====================
+        // Set max_concurrent_peer_server_fills=0 on CG-A → every fill request is rejected
+        // immediately (fill slot limit exceeded on the first fetch_add).
+        // CGB issues a query for blocks that CGA has NOT cached, with request_cache_fill=true.
+        // Expected: peer_server_fill_rejected increases; query succeeds via S3 winner fallback.
+        logger.info("=== max_concurrent_peer_server_fills=0 → fill rejected (Issue 5) ===")
+
+        // Insert T10-exclusive rows into CGA.  CGA's write-time caching populates them (DOWNLOADED).
+        // Then delete CGA's file cache so those blocks become EMPTY after restart.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (200, 'limit_test1'), (201, 'limit_test2')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CGA
+        sleep(1000)
+
+        // Restart CGA with cache deleted so (200, 201) blocks are EMPTY.
+        cluster.stopBackends(1)
+        sleep(2000)
+        def beA_node10 = cluster.getBeByBackendId(beA.BackendId.toLong())
+        def cacheDir10 = new File("${beA_node10.path}/storage/file_cache")
+        if (cacheDir10.exists()) {
+            cacheDir10.deleteDir()
+            logger.info("CGA file cache deleted — blocks will be EMPTY after restart")
+        }
+        cluster.startBackends(1)
+        sleep(5000)
+        waitForBeHttpReady(beA, "max_concurrent_peer_server_fills")
+        logger.info("CGA restarted with empty cache")
+
+        // Dynamically set max_concurrent_peer_server_fills=0 on CGA so all fills are rejected.
+        updateBeConfig(beA, "max_concurrent_peer_server_fills", "0")
+        sleep(500)
+
+        def t10_rejectedBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_rejected")
+
+        // CGB queries (200, 201) — CGB has NO local cache; CGA EMPTY, fill rejected (limit=0).
+        // Winner race: peer RPC → CGA EMPTY + fill rejected → NOT_FOUND / error; S3 fallback wins.
+        sql "use @cross_cg_peer_cluster"
+        def t10_result = sql "SELECT * FROM ${tbl} WHERE k1 IN (200, 201) ORDER BY k1"
+        assertEquals(2, t10_result.size(), "S3 fallback must return limit-test rows")
+
+        // Verify fill was rejected on CGA.
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_rejected") > t10_rejectedBefore,
+            "peer_server_fill_rejected must increase when max_concurrent_peer_server_fills=0")
+
+        // Restore the limit to the default.
+        updateBeConfig(beA, "max_concurrent_peer_server_fills", "32")
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_dynamic_config.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_dynamic_config.groovy
@@ -1,0 +1,305 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Dynamic config toggle tests for cross-CG server-side fill.
+//
+// peer_cache_fill_compute_group_id and enable_peer_server_cache_fill are both
+// mutable configs — they can be changed at runtime via the HTTP API without
+// restarting BE.  This suite verifies that toggling them takes effect immediately.
+//
+// Two rounds (each a fresh docker cluster):
+//   Round 1 — enable_peer_server_cache_fill: start disabled → no fill → enable dynamically → fill works → disable → no fill
+//   Round 2 — peer_cache_fill_compute_group_id: start with wrong id → no fill → correct id dynamically → fill works → wrong id → no fill
+//
+// Topology per round: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_server_fill_dynamic_config', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    // Two rounds with different initial configs.
+    def clusterOptionsList = [
+        new ClusterOptions(),  // Round 1: enable_peer_server_cache_fill toggle
+        new ClusterOptions(),  // Round 2: peer_cache_fill_compute_group_id toggle
+    ]
+
+    def commonFeConfigs = [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    def commonBeConfigs = [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+
+    for (options in clusterOptionsList) {
+        options.feConfigs += commonFeConfigs
+        options.beConfigs += commonBeConfigs
+        options.setFeNum(1)
+        options.setBeNum(1)
+        options.cloudMode = true
+        options.enableDebugPoints()
+    }
+
+    // Round 1: fill DISABLED initially, correct CG id.
+    clusterOptionsList[0].beConfigs += [
+        'enable_peer_server_cache_fill=false',
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+    ]
+    // Round 2: fill ENABLED initially, but WRONG CG id.
+    clusterOptionsList[1].beConfigs += [
+        'enable_peer_server_cache_fill=true',
+        'peer_cache_fill_compute_group_id=nonexistent_cg_id',
+    ]
+
+    def roundLabels = [
+        "enable_peer_server_cache_fill toggle",
+        "peer_cache_fill_compute_group_id toggle",
+    ]
+
+    for (int roundIdx = 0; roundIdx < clusterOptionsList.size(); roundIdx++) {
+        def options = clusterOptionsList[roundIdx]
+        def roundLabel = roundLabels[roundIdx]
+
+        logger.info("===== Round {}: {} =====", roundIdx + 1, roundLabel)
+
+        docker(options) {
+            def tbl = "test_dyn_cfg_tbl"
+            def nextK1 = 100
+
+            def checkBeHttpReady = { be, key ->
+                def cmd = "curl -s --max-time 2 -X GET " +
+                    "http://${be.Host}:${be.HttpPort}/api/show_config?conf_item=${key}"
+                def process = cmd.execute()
+                def out = new StringBuilder()
+                def err = new StringBuilder()
+                process.waitForProcessOutput(out, err)
+                process.exitValue() == 0 && out.toString().contains(key)
+            }
+
+            def waitForBeHttpReady = { be, key ->
+                awaitUntil(120) {
+                    checkBeHttpReady(be, key)
+                }
+            }
+
+            // ---- Helper: update a single BE config via HTTP API ----
+            def updateBeConfig = { be, key, value ->
+                waitForBeHttpReady(be, key)
+                def (code, out, err) = curl("POST",
+                    "http://${be.Host}:${be.HttpPort}/api/update_config?${key}=${value}")
+                assertEquals(0, code,
+                    "failed to set ${key}=${value} on ${be.Host}:${be.HttpPort}: ${err}")
+                assertTrue(out.contains("OK"),
+                    "failed to set ${key}=${value} on ${be.Host}:${be.HttpPort}: ${out}")
+            }
+
+            // ---- Helper: clear CG-A file cache (requires restart, used for setup only) ----
+            def clearCgACacheAndRestart = { beABackendId ->
+                cluster.stopBackends(1)
+                sleep(2000)
+                def node = cluster.getBeByBackendId(beABackendId as long)
+                def cacheDir = new File("${node.path}/storage/file_cache")
+                if (cacheDir.exists()) {
+                    cacheDir.deleteDir()
+                    logger.info("Deleted CG-A file cache: {}", cacheDir.absolutePath)
+                }
+                cluster.startBackends(1)
+                sleep(5000)
+                waitForBeHttpReady(node, "enable_peer_server_cache_fill")
+            }
+
+            // ---- Helper: insert new rows into CG-A and warm its cache ----
+            def insertAndWarmCGA = { count ->
+                def start = nextK1
+                nextK1 += count
+                def vals = (start..<nextK1).collect { i -> "(${i}, 'v${i}')" }.join(", ")
+                sql "use @compute_cluster"
+                sql "INSERT INTO ${tbl} VALUES ${vals}"
+                sql "SELECT * FROM ${tbl} ORDER BY k1"
+                sleep(1000)
+            }
+
+            // ---- Setup: Add CG-B ----
+            cluster.addBackend(1, "cross_cg_peer_cluster")
+            sleep(5000)
+
+            def backends = sql_return_maparray('show backends')
+            assert backends.size() == 2 : "Expected 2 backends"
+            def beA = backends.get(0)
+            def beB = backends.get(1)
+            logger.info("CG-A BE: host={} brpc={} http={}", beA.Host, beA.BrpcPort, beA.HttpPort)
+            logger.info("CG-B BE: host={} brpc={} http={}", beB.Host, beB.BrpcPort, beB.HttpPort)
+
+            // ---- Setup: Create table and seed data ----
+            sql "use @compute_cluster"
+            sql "DROP TABLE IF EXISTS ${tbl}"
+            sql """
+                CREATE TABLE ${tbl} (
+                    k1 INT,
+                    v1 VARCHAR(256)
+                )
+                DUPLICATE KEY(k1)
+                DISTRIBUTED BY HASH(k1) BUCKETS 2
+                PROPERTIES ("replication_num" = "1")
+            """
+            sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b')"
+            sql "INSERT INTO ${tbl} VALUES (3, 'c'), (4, 'd')"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A
+            sleep(1000)
+
+            // ---- Trigger lazy FE fetch from CG-B so CG-A becomes a candidate ----
+            sql "use @cross_cg_peer_cluster"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"
+            awaitUntil(30) {
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+            }
+            logger.info("CG-B lazy fetch done — CG-A is now a peer candidate")
+
+            // ==================================================================
+            // Phase 1: initial config — fill should NOT work
+            // ==================================================================
+            logger.info("--- Phase 1: fill should NOT work (initial config) ---")
+
+            insertAndWarmCGA(4)
+            clearCgACacheAndRestart(beA.BackendId)
+            // Refresh beA reference after restart.
+            backends = sql_return_maparray('show backends')
+            beA = backends.get(0)
+
+            def p1_fillBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+
+            sql "use @cross_cg_peer_cluster"
+            def p1_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(p1_result.size() >= 8, "Phase 1: query should succeed via S3 fallback")
+
+            assertEquals(p1_fillBefore,
+                getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested"),
+                "Phase 1: peer_server_fill_requested must NOT increase")
+            logger.info("Phase 1 PASS")
+
+            // ==================================================================
+            // Phase 2: dynamically enable fill — should take effect immediately
+            // ==================================================================
+            logger.info("--- Phase 2: dynamically enable fill ---")
+
+            if (roundLabel.contains("enable_peer_server_cache_fill")) {
+                updateBeConfig(beA, "enable_peer_server_cache_fill", "true")
+                logger.info("Dynamically set enable_peer_server_cache_fill=true on CG-A")
+            } else {
+                updateBeConfig(beA, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+                updateBeConfig(beB, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+                logger.info("Dynamically set peer_cache_fill_compute_group_id={}", CG_A_CLUSTER_ID)
+            }
+            sleep(500)
+
+            // Insert new data and clear CG-A cache so blocks are EMPTY.
+            insertAndWarmCGA(4)
+            clearCgACacheAndRestart(beA.BackendId)
+
+            // Re-apply the dynamic config after restart (restart resets to be_custom.conf).
+            backends = sql_return_maparray('show backends')
+            beA = backends.get(0)
+            if (roundLabel.contains("enable_peer_server_cache_fill")) {
+                updateBeConfig(beA, "enable_peer_server_cache_fill", "true")
+            } else {
+                updateBeConfig(beA, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+                updateBeConfig(beB, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+            }
+            sleep(500)
+
+            def p2_fillBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+
+            sql "use @cross_cg_peer_cluster"
+            def p2_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(p2_result.size() >= 12, "Phase 2: query should return all rows")
+
+            assertTrue(
+                getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested") > p2_fillBefore,
+                "Phase 2: peer_server_fill_requested must increase after dynamic enable")
+            logger.info("Phase 2 PASS")
+
+            // ==================================================================
+            // Phase 3: dynamically disable fill again — verify it stops
+            // ==================================================================
+            logger.info("--- Phase 3: dynamically disable fill ---")
+
+            if (roundLabel.contains("enable_peer_server_cache_fill")) {
+                updateBeConfig(beA, "enable_peer_server_cache_fill", "false")
+                logger.info("Dynamically set enable_peer_server_cache_fill=false on CG-A")
+            } else {
+                updateBeConfig(beA, "peer_cache_fill_compute_group_id", "nonexistent_cg_id")
+                updateBeConfig(beB, "peer_cache_fill_compute_group_id", "nonexistent_cg_id")
+                logger.info("Dynamically set peer_cache_fill_compute_group_id=nonexistent_cg_id")
+            }
+            sleep(500)
+
+            insertAndWarmCGA(4)
+            clearCgACacheAndRestart(beA.BackendId)
+
+            backends = sql_return_maparray('show backends')
+            beA = backends.get(0)
+
+            def p3_fillBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+
+            sql "use @cross_cg_peer_cluster"
+            def p3_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(p3_result.size() >= 16, "Phase 3: query should return all rows via S3 fallback")
+
+            assertEquals(p3_fillBefore,
+                getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested"),
+                "Phase 3: peer_server_fill_requested must NOT increase after re-disabling")
+            logger.info("Phase 3 PASS")
+
+            logger.info("===== Round '{}' PASS =====", roundLabel)
+        }
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_three_cg.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_three_cg.groovy
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_server_fill_three_cg', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A = "compute_cluster"
+    final String CG_B = "cross_cg_fill_allow_cluster"
+    final String CG_C = "cross_cg_fill_reject_cluster"
+    final String CG_B_ID = "${CG_B}_id"
+    final String CG_C_ID = "${CG_C}_id"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def findBackendsByClusterName = { clusterName ->
+            sql_return_maparray('show backends').findAll { backend ->
+                backend.CloudClusterName == clusterName || backend.Tag?.contains(clusterName)
+            }
+        }
+
+        def getSingleBackendByClusterName = { clusterName ->
+            def backendsInCluster = findBackendsByClusterName(clusterName)
+            assertEquals(1, backendsInCluster.size(),
+                "Expected exactly 1 backend in ${clusterName}, got ${backendsInCluster.size()}")
+            backendsInCluster[0]
+        }
+
+        def getBackendNodeIndex = { backend ->
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            assertTrue(node != null, "Backend node not found for BackendId=${backend.BackendId}")
+            node.index
+        }
+
+        def rewriteBeCustomConfigAndRestart = { backend, updates ->
+            def backendIndex = getBackendNodeIndex(backend)
+            cluster.stopBackends(backendIndex)
+            sleep(2000)
+
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            assertTrue(node != null, "Backend node not found for BackendId=${backend.BackendId}")
+            def customConf = new File("${node.path}/conf/be_custom.conf")
+            assertTrue(customConf.exists(), "be_custom.conf not found for BackendId=${backend.BackendId}")
+
+            def lines = customConf.readLines().findAll { line ->
+                def trimmed = line.trim()
+                !updates.keySet().any { key ->
+                    trimmed.startsWith("${key}=") || trimmed.startsWith("${key} =")
+                }
+            }
+            if (!lines.isEmpty() && lines[-1] != "") {
+                lines << ""
+            }
+            updates.each { key, value ->
+                lines << "${key} = ${value}"
+            }
+            customConf.text = lines.join(System.lineSeparator()) + System.lineSeparator()
+            logger.info("Updated {} with {}", customConf.absolutePath, updates)
+
+            cluster.startBackends(backendIndex)
+            sleep(5000)
+        }
+
+        def clearFileCacheAndRestart = { backend, reason ->
+            def backendIndex = getBackendNodeIndex(backend)
+            cluster.stopBackends(backendIndex)
+            sleep(2000)
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            def cacheDir = new File("${node.path}/storage/file_cache")
+            logger.info("Deleting {} file cache at {}", reason, cacheDir.absolutePath)
+            if (cacheDir.exists()) {
+                cacheDir.deleteDir()
+            }
+            cluster.startBackends(backendIndex)
+            sleep(5000)
+        }
+
+        def createTable = { clusterName, tableName ->
+            sql "use @${clusterName}"
+            sql "DROP TABLE IF EXISTS ${tableName}"
+            sql """
+                CREATE TABLE ${tableName} (
+                    k1 INT,
+                    v1 VARCHAR(256)
+                )
+                DUPLICATE KEY(k1)
+                DISTRIBUTED BY HASH(k1) BUCKETS 2
+                PROPERTIES ("replication_num" = "1")
+            """
+        }
+
+        def warmRows = { clusterName, tableName, predicate ->
+            sql "use @${clusterName}"
+            sql "SELECT * FROM ${tableName} WHERE ${predicate} ORDER BY k1"
+            sleep(1000)
+        }
+
+        cluster.addBackend(1, CG_B)
+        cluster.addBackend(1, CG_C)
+        awaitUntil(30) {
+            findBackendsByClusterName(CG_A).size() == 1 &&
+                findBackendsByClusterName(CG_B).size() == 1 &&
+                findBackendsByClusterName(CG_C).size() == 1
+        }
+
+        def beA = getSingleBackendByClusterName(CG_A)
+        def beB = getSingleBackendByClusterName(CG_B)
+        def beC = getSingleBackendByClusterName(CG_C)
+        logger.info("CG-A requester: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B fill-allow: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+        logger.info("CG-C fill-reject: host={} brpcPort={}", beC.Host, beC.BrpcPort)
+
+        // Case 1: A targets B, B allows server fill.
+        def tblAllow = "test_cross_cg_server_fill_three_cg_allow_tbl"
+        // These cloud configs are startup-only in the current docker image,
+        // so switch them through be_custom.conf and a BE restart.
+        rewriteBeCustomConfigAndRestart(beA,
+            ["peer_cache_fill_compute_group_id": CG_B_ID])
+
+        createTable(CG_B, tblAllow)
+        sql "use @${CG_B}"
+        sql "INSERT INTO ${tblAllow} VALUES (10, 'b10'), (20, 'b20'), (30, 'b30'), (40, 'b40')"
+        warmRows(CG_B, tblAllow, "k1 < 50")
+
+        def bFillReqBeforeAllow = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested")
+        def bFillSuccBeforeAllow = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_success")
+        def cFillReqBeforeAllow = getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested")
+
+        sql "use @${CG_A}"
+        def allowInitial = sql "SELECT * FROM ${tblAllow} WHERE k1 < 50 ORDER BY k1"
+        assertEquals(4, allowInitial.size(), "CG-A should read initial rows from CG-B")
+        // Candidate refresh is asynchronous and does not reliably surface as a lazy-fetch
+        // counter bump after the requester BE has been restarted. Give it a short settle window
+        // and validate the real peer/server-fill behavior on the next query.
+        sleep(1000)
+
+        sql "use @${CG_B}"
+        sql "INSERT INTO ${tblAllow} VALUES (50, 'b50'), (60, 'b60')"
+        warmRows(CG_B, tblAllow, "k1 >= 50")
+        clearFileCacheAndRestart(beB, "CG-B")
+
+        sql "use @${CG_A}"
+        def allowAll = sql "SELECT * FROM ${tblAllow} ORDER BY k1"
+        assertEquals(6, allowAll.size(), "CG-A should read all rows when CG-B server fill is enabled")
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested") > bFillReqBeforeAllow &&
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_success") > bFillSuccBeforeAllow
+        }
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested") > bFillReqBeforeAllow,
+            "CG-B should receive server fill requests from CG-A")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_success") > bFillSuccBeforeAllow,
+            "CG-B should complete server fill successfully")
+        assertEquals(
+            cFillReqBeforeAllow,
+            getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested"),
+            "CG-C should not receive server fill requests when CG-A targets CG-B")
+
+        // Case 2: A targets C, C rejects server fill.
+        def tblReject = "test_cross_cg_server_fill_three_cg_reject_tbl"
+        rewriteBeCustomConfigAndRestart(beA,
+            ["peer_cache_fill_compute_group_id": CG_C_ID])
+        rewriteBeCustomConfigAndRestart(beC,
+            ["enable_peer_server_cache_fill": "false"])
+
+        createTable(CG_C, tblReject)
+        sql "use @${CG_C}"
+        sql "INSERT INTO ${tblReject} VALUES (110, 'c110'), (120, 'c120'), (130, 'c130'), (140, 'c140')"
+        warmRows(CG_C, tblReject, "k1 < 150")
+
+        sql "use @${CG_A}"
+        def rejectInitial = sql "SELECT * FROM ${tblReject} WHERE k1 < 150 ORDER BY k1"
+        assertEquals(4, rejectInitial.size(), "CG-A should read initial rows from CG-C")
+        sleep(1000)
+
+        sql "use @${CG_C}"
+        sql "INSERT INTO ${tblReject} VALUES (150, 'c150'), (160, 'c160')"
+        warmRows(CG_C, tblReject, "k1 >= 150")
+        clearFileCacheAndRestart(beC, "CG-C")
+
+        def cFillReqBefore = getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested")
+        def cFillSuccBefore = getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_success")
+        def bFillReqBeforeReject = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested")
+        def rejectPeerBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_peer_read")
+        def rejectS3Before = getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_s3_read")
+
+        sql "use @${CG_A}"
+        def rejectAll = sql "SELECT * FROM ${tblReject} ORDER BY k1"
+        assertEquals(6, rejectAll.size(), "CG-A should fall back and still read all rows when CG-C rejects fill")
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_peer_read") > rejectPeerBefore,
+            "CG-A should attempt peer read against CG-C before fallback")
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_s3_read") > rejectS3Before,
+            "CG-A should fall back to S3 when CG-C refuses server fill")
+        assertEquals(
+            cFillReqBefore,
+            getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested"),
+            "CG-C should not trigger server fill when enable_peer_server_cache_fill=false")
+        assertEquals(
+            cFillSuccBefore,
+            getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_success"),
+            "CG-C should not report server fill success when fill is disabled")
+        assertEquals(
+            bFillReqBeforeReject,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested"),
+            "CG-B should stay uninvolved when CG-A targets CG-C")
+
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_peer_cache_http_api.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_peer_cache_http_api.groovy
@@ -1,0 +1,311 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Tests for /api/peer_cache HTTP admin endpoints:
+// 1. show_all returns empty initially
+// 2. set injects peer candidates for a tablet
+// 3. show returns the injected candidates
+// 4. reset_cooldown clears cooldown state
+// 5. remove deletes peer candidates
+// 6. peer read actually uses injected candidates (end-to-end)
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+suite('test_peer_cache_http_api', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def jsonSlurper = new JsonSlurper()
+
+    // Helper: call GET /api/peer_cache on a specific BE
+    def peerCacheGet = { beHost, beHttpPort, params ->
+        def result = null
+        httpTest {
+            endpoint ""
+            uri "${beHost}:${beHttpPort}/api/peer_cache?${params}"
+            op "get"
+            check { respCode, body ->
+                logger.info("GET /api/peer_cache?${params} => ${respCode}: ${body}")
+                result = [code: respCode, body: body]
+            }
+        }
+        return result
+    }
+
+    // Helper: call POST /api/peer_cache on a specific BE
+    def peerCachePost = { beHost, beHttpPort, params, jsonBody ->
+        def result = null
+        httpTest {
+            endpoint ""
+            uri "${beHost}:${beHttpPort}/api/peer_cache?${params}"
+            body jsonBody
+            check { respCode, body ->
+                logger.info("POST /api/peer_cache?${params} => ${respCode}: ${body}")
+                result = [code: respCode, body: body]
+            }
+        }
+        return result
+    }
+
+    // Read a bvar counter from a BE's brpc_metrics endpoint.
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_peer_cache_http_api_tbl"
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends after adding CG-B"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} httpPort={} brpcPort={}", beA.Host, beA.HttpPort, beA.BrpcPort)
+        logger.info("CG-B BE: host={} httpPort={} brpcPort={}", beB.Host, beB.HttpPort, beB.BrpcPort)
+
+        def beBHost = beB.Host
+        def beBHttpPort = beB.HttpPort as int
+        def beAHost = beA.Host
+        def beABrpcPort = beA.BrpcPort as int
+
+        // ==================== T1: show_all returns empty initially ====================
+        logger.info("=== T1: show_all returns empty initially ===")
+        def t1 = peerCacheGet(beBHost, beBHttpPort, "op=show_all")
+        assertEquals(200, t1.code, "show_all should succeed")
+        def t1Json = jsonSlurper.parseText(t1.body)
+        assertEquals(0, t1Json.total, "no peer candidates should exist initially")
+        logger.info("PASS: show_all empty")
+
+        // ==================== T2: set injects peer candidates ====================
+        logger.info("=== T2: set injects peer candidates for tablet 99999 ===")
+        def setBody = """{
+            "candidates": [
+                {"host": "${beAHost}", "brpc_port": ${beABrpcPort}, "compute_group_id": "compute_cluster"},
+                {"host": "10.0.0.99", "brpc_port": 9999, "compute_group_id": "fake_cg"}
+            ],
+            "last_successful_compute_group_id": "compute_cluster",
+            "consecutive_all_miss": 0,
+            "cooldown_until_ms": 0
+        }"""
+        def t2 = peerCachePost(beBHost, beBHttpPort, "op=set&tablet_id=99999", setBody)
+        assertEquals(200, t2.code, "set should succeed")
+        logger.info("PASS: set succeeded")
+
+        // ==================== T3: show returns injected candidates ====================
+        logger.info("=== T3: show returns injected candidates ===")
+        def t3 = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=99999")
+        assertEquals(200, t3.code, "show should succeed")
+        def t3Json = jsonSlurper.parseText(t3.body)
+        assertEquals(99999L, t3Json.tablet_id as long, "tablet_id should match")
+        assertEquals(2, t3Json.candidates.size(), "should have 2 candidates")
+        assertEquals(beAHost, t3Json.candidates[0].host, "first candidate host should be CG-A")
+        assertEquals(beABrpcPort, t3Json.candidates[0].brpc_port as int, "first candidate brpc_port should match")
+        assertEquals("compute_cluster", t3Json.candidates[0].compute_group_id)
+        assertEquals("10.0.0.99", t3Json.candidates[1].host)
+        assertEquals("compute_cluster", t3Json.last_successful_compute_group_id)
+        assertEquals(0, t3Json.consecutive_all_miss)
+        assertEquals(0L, t3Json.cooldown_until_ms as long)
+        logger.info("PASS: show returns correct data")
+
+        // ==================== T4: show_all now has 1 tablet ====================
+        logger.info("=== T4: show_all has 1 tablet ===")
+        def t4 = peerCacheGet(beBHost, beBHttpPort, "op=show_all&limit=10")
+        assertEquals(200, t4.code)
+        def t4Json = jsonSlurper.parseText(t4.body)
+        assertEquals(1, t4Json.total, "should have 1 tablet after set")
+        assertEquals(99999L, t4Json.tablets[0].tablet_id as long)
+        logger.info("PASS: show_all has 1 tablet")
+
+        // ==================== T5: set cooldown then reset ====================
+        logger.info("=== T5: set cooldown then reset ===")
+        // Force-set a tablet with cooldown active
+        def cooldownBody = """{
+            "candidates": [
+                {"host": "${beAHost}", "brpc_port": ${beABrpcPort}, "compute_group_id": "cg1"}
+            ],
+            "last_successful_compute_group_id": "",
+            "consecutive_all_miss": 10,
+            "cooldown_until_ms": 9999999999999
+        }"""
+        def t5set = peerCachePost(beBHost, beBHttpPort, "op=set&tablet_id=88888", cooldownBody)
+        assertEquals(200, t5set.code)
+
+        // Verify cooldown is set
+        def t5show = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=88888")
+        def t5Json = jsonSlurper.parseText(t5show.body)
+        assertEquals(10, t5Json.consecutive_all_miss)
+        assertTrue(t5Json.cooldown_until_ms as long > 0, "cooldown should be active")
+
+        // Reset cooldown
+        def t5reset = peerCachePost(beBHost, beBHttpPort, "op=reset_cooldown&tablet_id=88888", "")
+        assertEquals(200, t5reset.code)
+
+        // Verify cooldown is cleared
+        def t5after = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=88888")
+        def t5afterJson = jsonSlurper.parseText(t5after.body)
+        assertEquals(0, t5afterJson.consecutive_all_miss, "consecutive_all_miss should be reset")
+        assertEquals(0L, t5afterJson.cooldown_until_ms as long, "cooldown_until_ms should be reset")
+        logger.info("PASS: cooldown reset works")
+
+        // ==================== T6: remove deletes peer candidates ====================
+        logger.info("=== T6: remove deletes peer candidates ===")
+        def t6rm = peerCachePost(beBHost, beBHttpPort, "op=remove&tablet_id=99999", "")
+        assertEquals(200, t6rm.code)
+
+        // show should now return error (not found)
+        def t6show = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=99999")
+        assertEquals(500, t6show.code, "show should fail for removed tablet")
+
+        // Also remove the cooldown test tablet
+        peerCachePost(beBHost, beBHttpPort, "op=remove&tablet_id=88888", "")
+        logger.info("PASS: remove works")
+
+        // ==================== T7: show for non-existent tablet returns error ====================
+        logger.info("=== T7: show non-existent tablet ===")
+        def t7 = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=11111")
+        assertEquals(500, t7.code, "show non-existent tablet should return error")
+        logger.info("PASS: show non-existent returns error")
+
+        // ==================== T8: invalid op returns error ====================
+        logger.info("=== T8: invalid op ===")
+        def t8 = peerCacheGet(beBHost, beBHttpPort, "op=invalid_op")
+        assertEquals(500, t8.code, "invalid op should return error")
+        logger.info("PASS: invalid op returns error")
+
+        // ==================== T9: end-to-end — inject candidates, then query uses peer ====================
+        logger.info("=== T9: end-to-end peer read with injected candidates ===")
+
+        // Create table and insert data in CG-A
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')"
+        // Warm CG-A file cache
+        def warmResult = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(3, warmResult.size())
+        sleep(1000)
+
+        // Get the tablet ID of the table
+        def tablets = sql_return_maparray("SHOW TABLETS FROM ${tbl}")
+        assertTrue(tablets.size() > 0, "table should have at least one tablet")
+        def tabletId = tablets[0].TabletId as long
+        logger.info("tablet_id for ${tbl}: ${tabletId}")
+
+        // Inject CG-A as peer candidate for this tablet on CG-B
+        def e2eBody = """{
+            "candidates": [
+                {"host": "${beAHost}", "brpc_port": ${beABrpcPort}, "compute_group_id": "compute_cluster"}
+            ],
+            "last_successful_compute_group_id": "",
+            "consecutive_all_miss": 0,
+            "cooldown_until_ms": 0
+        }"""
+        def t9set = peerCachePost(beBHost, beBHttpPort, "op=set&tablet_id=${tabletId}", e2eBody)
+        assertEquals(200, t9set.code, "inject candidate for real tablet should succeed")
+
+        // Verify it shows up
+        def t9show = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=${tabletId}")
+        assertEquals(200, t9show.code)
+        def t9showJson = jsonSlurper.parseText(t9show.body)
+        assertEquals(1, t9showJson.candidates.size())
+        logger.info("Injected candidate for tablet ${tabletId}: {}", t9showJson)
+
+        // Insert new data in CG-A to create uncached rowset for CG-B
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (4, 'delta'), (5, 'epsilon')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1" // warm CG-A cache
+        sleep(1000)
+
+        // Record peer metrics before query from CG-B
+        def peerHitBefore = getBrpcMetrics(beBHost, beB.BrpcPort, "peer_candidate_cache_hit")
+
+        // Query from CG-B — new rowset not in CG-B local cache, should try peer from injected candidate
+        sql "use @cross_cg_peer_cluster"
+        def t9result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(5, t9result.size(), "CG-B query should return all 5 rows")
+
+        // Verify peer candidate cache was hit (the injected candidate was used)
+        def peerHitAfter = getBrpcMetrics(beBHost, beB.BrpcPort, "peer_candidate_cache_hit")
+        assertTrue(peerHitAfter > peerHitBefore,
+            "peer_candidate_cache_hit should increase after query with injected candidates")
+        logger.info("peer_candidate_cache_hit: before={} after={}", peerHitBefore, peerHitAfter)
+
+        // Verify via show that the candidate was accessed (last_access_time_ms updated)
+        def t9showAfter = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=${tabletId}")
+        def t9afterJson = jsonSlurper.parseText(t9showAfter.body)
+        assertTrue(t9afterJson.candidates[0].last_access_time_ms as long > 0,
+            "last_access_time_ms should be updated after access")
+        logger.info("PASS: end-to-end peer read with injected candidates works")
+
+        // Cleanup
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        logger.info("=== All peer cache HTTP API tests passed ===")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_peer_fetch_concurrent_same_block.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_peer_fetch_concurrent_same_block.groovy
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Peer fetch concurrent same-block regression.
+//
+// Topology: 1 FE + CG-A (source BE) + CG-B (reader 1) + CG-C (reader 2). Both CG-B
+// and CG-C have CG-A as a peer candidate. Fan-in from different reader BEs can
+// produce concurrent peer RPCs on CG-A for the same block. The server should serve
+// both requests instead of rejecting a duplicate in-flight block.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+
+suite('test_peer_fetch_concurrent_same_block', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+    final String CG_A_CLUSTER = "compute_cluster"
+    final String CG_B_CLUSTER = "cross_cg_peer_cluster_b"
+    final String CG_C_CLUSTER = "cross_cg_peer_cluster_c"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+        'peer_race_hedge_delay_ms=5000',
+        // Raise the queue timeout well above the DBUG hold so the second RPC is
+        // served concurrently rather than getting rejected by the queue guard.
+        'peer_fetch_queue_timeout_ms=5000',
+        'brpc_peer_fetch_pool_threads=4',
+        'brpc_peer_fetch_pool_max_queue_size=64',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getHttpUrl = { host, port, path ->
+        def url = "http://${host}:${port}${path}"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        return url
+    }
+
+    def getBrpcMetric = { host, port, name ->
+        def metrics = new URL(getHttpUrl(host, port, "/brpc_metrics")).text
+        def matcher = metrics =~ ~"${name}\\s+(-?\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return null
+    }
+
+    def getRequiredBrpcMetric = { host, port, name ->
+        def value = getBrpcMetric(host, port, name)
+        assertTrue(value != null, "missing brpc metric ${name} on ${host}:${port}")
+        return value
+    }
+
+    docker(options) {
+        def tbl = "test_peer_fetch_concurrent_same_block_tbl"
+        def nextK1 = 100
+
+        def insertAndWarmCGA = { count ->
+            def start = nextK1
+            nextK1 += count
+            def values = (start..<nextK1).collect { k -> "(${k}, 'row${k}')" }.join(', ')
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tbl} VALUES ${values}"
+            def rows = sql "SELECT * FROM ${tbl} WHERE k1 >= ${start} AND k1 < ${nextK1} ORDER BY k1"
+            assertEquals(count, rows.size(), "CG-A warm read should return inserted rows")
+            sleep(1000)
+            return [start, nextK1]
+        }
+
+        def queryRangeOnCluster = { String clusterName, range ->
+            sql "use @${clusterName}"
+            sql "SELECT * FROM ${tbl} WHERE k1 >= ${range[0]} AND k1 < ${range[1]} ORDER BY k1"
+        }
+
+        def clearFileCacheOnBE = { backend ->
+            def (code, out, err) = curl("GET", "http://${backend.Host}:${backend.HttpPort}/api/file_cache?op=clear&sync=false")
+            assertTrue(code == 0 && (out.contains("OK") || out.contains("success") || err == null),
+                    "failed to clear file cache on ${backend.Host}:${backend.HttpPort}: code=${code}, out=${out}, err=${err}")
+        }
+
+        def getBackendByCluster = { String clusterName ->
+            def backends = sql """SHOW BACKENDS"""
+            def clusterBackends = backends.findAll {
+                it[19].contains("""\"compute_group_name\" : \"${clusterName}\"""")
+            }
+            assertEquals(1, clusterBackends.size(), "expected exactly one BE for cluster ${clusterName}")
+            def backend = clusterBackends[0]
+            return [BackendId: backend[0], Host: backend[1], HttpPort: backend[4], BrpcPort: backend[5]]
+        }
+
+        cluster.addBackend(1, CG_B_CLUSTER)
+        cluster.addBackend(1, CG_C_CLUSTER)
+        awaitUntil(120) {
+            def backends = sql_return_maparray('show backends')
+            backends.size() == 3 && backends.every { backend -> backend.Alive.toString() == 'true' }
+        }
+
+        def beA = getBackendByCluster(CG_A_CLUSTER)
+        def beB = getBackendByCluster(CG_B_CLUSTER)
+        def beC = getBackendByCluster(CG_C_CLUSTER)
+        logger.info("CG-A BE: host={} brpc={} http={}", beA.Host, beA.BrpcPort, beA.HttpPort)
+        logger.info("CG-B BE: host={} brpc={} http={}", beB.Host, beB.BrpcPort, beB.HttpPort)
+        logger.info("CG-C BE: host={} brpc={} http={}", beC.Host, beC.BrpcPort, beC.HttpPort)
+
+        def capturePeerMetrics = { String stage ->
+            def metrics = [
+                cgb_peer_lazy_fetch_triggered: getRequiredBrpcMetric(beB.Host, beB.BrpcPort, 'peer_lazy_fetch_triggered'),
+                cgb_peer_race_peer_win: getRequiredBrpcMetric(beB.Host, beB.BrpcPort, 'peer_race_peer_win'),
+                cgc_peer_lazy_fetch_triggered: getRequiredBrpcMetric(beC.Host, beC.BrpcPort, 'peer_lazy_fetch_triggered'),
+                cgc_peer_race_peer_win: getRequiredBrpcMetric(beC.Host, beC.BrpcPort, 'peer_race_peer_win'),
+                cga_file_cache_get_by_peer_num: getRequiredBrpcMetric(beA.Host, beA.BrpcPort, 'file_cache_get_by_peer_num'),
+            ]
+            logger.info("peer metrics {}: CGB({}:{}) lazy={} peer_win={}, CGC({}:{}) lazy={} peer_win={}, " +
+                    "CGA({}:{}) get_by_peer={}",
+                    stage,
+                    beB.Host, beB.BrpcPort, metrics.cgb_peer_lazy_fetch_triggered, metrics.cgb_peer_race_peer_win,
+                    beC.Host, beC.BrpcPort, metrics.cgc_peer_lazy_fetch_triggered, metrics.cgc_peer_race_peer_win,
+                    beA.Host, beA.BrpcPort, metrics.cga_file_cache_get_by_peer_num)
+            return metrics
+        }
+
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1", "disable_auto_compaction" = "true")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        logger.info("=== prepare peer candidates on CG-B and CG-C ===")
+        def baselineB = queryRangeOnCluster(CG_B_CLUSTER, [1, 5])
+        assertEquals(4, baselineB.size(), "baseline CGB read should succeed")
+        def baselineC = queryRangeOnCluster(CG_C_CLUSTER, [1, 5])
+        assertEquals(4, baselineC.size(), "baseline CGC read should succeed")
+        awaitUntil(30) {
+            getRequiredBrpcMetric(beB.Host, beB.BrpcPort, 'peer_lazy_fetch_triggered') > 0L &&
+                    getRequiredBrpcMetric(beC.Host, beC.BrpcPort, 'peer_lazy_fetch_triggered') > 0L
+        }
+
+        logger.info("=== concurrent same-block peer fetch ===")
+        def concurrentRange = insertAndWarmCGA(8)
+        clearFileCacheOnBE(beB)
+        clearFileCacheOnBE(beC)
+        def metricsBeforeTrigger = capturePeerMetrics('before-trigger')
+        GetDebugPoint().enableDebugPoint(beA.Host, beA.HttpPort as int, NodeType.BE,
+                "CloudInternalServiceImpl::handle_peer_file_cache_block_request_hold_before_get_or_set", [sleep_ms: 3000])
+        try {
+            // Each reader BE emits exactly one outbound peer RPC for this block
+            // (client-side downloader CAS). Firing concurrently from CG-B and CG-C
+            // therefore puts two same-key RPCs on CG-A's pool at the same time.
+            def threadB = Thread.start {
+                def rows = queryRangeOnCluster(CG_B_CLUSTER, concurrentRange)
+                assertEquals(8, rows.size(), "CGB query should succeed via peer or S3 race")
+            }
+            def threadC = Thread.start {
+                def rows = queryRangeOnCluster(CG_C_CLUSTER, concurrentRange)
+                assertEquals(8, rows.size(), "CGC query should succeed via peer or S3 race")
+            }
+            threadB.join()
+            threadC.join()
+        } finally {
+            GetDebugPoint().disableDebugPoint(beA.Host, beA.HttpPort as int, NodeType.BE,
+                    "CloudInternalServiceImpl::handle_peer_file_cache_block_request_hold_before_get_or_set")
+        }
+        def metricsAfterQueries = capturePeerMetrics('after-queries')
+        awaitUntil(60) {
+            getRequiredBrpcMetric(beA.Host, beA.BrpcPort, 'file_cache_get_by_peer_num') >=
+                    metricsBeforeTrigger.cga_file_cache_get_by_peer_num + 2L
+        }
+        def metricsAfterAwait = capturePeerMetrics('after-await')
+        assertTrue(metricsAfterAwait.cgb_peer_race_peer_win > metricsBeforeTrigger.cgb_peer_race_peer_win,
+                "CGB should win the peer race for the concurrent same-block read")
+        assertTrue(metricsAfterAwait.cgc_peer_race_peer_win > metricsBeforeTrigger.cgc_peer_race_peer_win,
+                "CGC should win the peer race for the concurrent same-block read")
+        logger.info("peer metric deltas: before={}, afterQueries={}, afterAwait={}",
+                metricsBeforeTrigger, metricsAfterQueries, metricsAfterAwait)
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_peer_fetch_pool_isolation.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_peer_fetch_pool_isolation.groovy
@@ -1,0 +1,244 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Peer fetch pool isolation regression.
+//
+// Topology: 1 FE + CG-A (source BE) + CG-B (reader BE). CG-A cache is warmed, CG-B
+// discovers CG-A as a peer candidate, then CG-B cold reads should hit peer fetch RPCs.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+
+suite('test_peer_fetch_pool_isolation', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+    final String CG_A_CLUSTER = "compute_cluster"
+    final String CG_B_CLUSTER = "cross_cg_peer_cluster"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+        'peer_race_hedge_delay_ms=50',
+        'peer_fetch_queue_timeout_ms=500',
+        'brpc_peer_fetch_pool_threads=1',
+        'brpc_peer_fetch_pool_max_queue_size=64',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getHttpUrl = { host, port, path ->
+        def url = "http://${host}:${port}${path}"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        return url
+    }
+
+    def getBrpcMetric = { host, port, name ->
+        def metrics = new URL(getHttpUrl(host, port, "/brpc_metrics")).text
+        def matcher = metrics =~ ~"${name}\\s+(-?\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return null
+    }
+
+    def getRequiredBrpcMetric = { host, port, name ->
+        def value = getBrpcMetric(host, port, name)
+        assertTrue(value != null, "missing brpc metric ${name} on ${host}:${port}")
+        return value
+    }
+
+    def getVarzConfig = { host, httpPort, name ->
+        def vars = new URL(getHttpUrl(host, httpPort, "/varz")).text
+        def matcher = vars =~ ~"(?m)^${name}[=:]\\s*(\\S+)"
+        if (matcher.find()) {
+            return matcher[0][1]
+        }
+        return null
+    }
+
+    docker(options) {
+        def tbl = "test_peer_fetch_pool_isolation_tbl"
+        def nextK1 = 100
+
+        def updateBeConfig = { host, httpPort, key, value ->
+            def (code, out, err) = curl("POST", "http://${host}:${httpPort}/api/update_config?${key}=${value}")
+            assertTrue(out.contains("OK"),
+                    "failed to set ${key}=${value} on ${host}:${httpPort}: code=${code}, out=${out}, err=${err}")
+        }
+
+        def setPeerFetchTimeoutForAllBEs = { value ->
+            def configValue = value.toString()
+            sql_return_maparray('show backends').each { backend ->
+                updateBeConfig(backend.Host, backend.HttpPort as int, 'peer_fetch_queue_timeout_ms', configValue)
+                awaitUntil(10) {
+                    getVarzConfig(backend.Host, backend.HttpPort as int, 'peer_fetch_queue_timeout_ms') == configValue
+                }
+            }
+        }
+
+        def insertAndWarmCGA = { count ->
+            def start = nextK1
+            nextK1 += count
+            def values = (start..<nextK1).collect { k -> "(${k}, 'row${k}')" }.join(', ')
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tbl} VALUES ${values}"
+            def rows = sql "SELECT * FROM ${tbl} WHERE k1 >= ${start} AND k1 < ${nextK1} ORDER BY k1"
+            assertEquals(count, rows.size(), "CG-A warm read should return inserted rows")
+            sleep(1000)
+            return [start, nextK1]
+        }
+
+        def queryRangeOnCGB = { range ->
+            sql "use @cross_cg_peer_cluster"
+            sql "SELECT * FROM ${tbl} WHERE k1 >= ${range[0]} AND k1 < ${range[1]} ORDER BY k1"
+        }
+
+        def clearFileCacheOnBE = { backend ->
+            def (code, out, err) = curl("GET", "http://${backend.Host}:${backend.HttpPort}/api/file_cache?op=clear&sync=true")
+            assertTrue(code == 0 && (out.contains("OK") || out.contains("success") || err == null),
+                    "failed to clear file cache on ${backend.Host}:${backend.HttpPort}: code=${code}, out=${out}, err=${err}")
+        }
+
+        def setPeerFetchTimeoutOnBE = { backend, value ->
+            def configValue = value.toString()
+            updateBeConfig(backend.Host, backend.HttpPort as int, 'peer_fetch_queue_timeout_ms', configValue)
+            awaitUntil(10) {
+                getVarzConfig(backend.Host, backend.HttpPort as int, 'peer_fetch_queue_timeout_ms') == configValue
+            }
+        }
+
+        def getBackendByCluster = { String clusterName ->
+            def backends = sql """SHOW BACKENDS"""
+            def clusterBackends = backends.findAll {
+                it[19].contains("""\"compute_group_name\" : \"${clusterName}\"""")
+            }
+            assertEquals(1, clusterBackends.size(), "expected exactly one BE for cluster ${clusterName}")
+            def backend = clusterBackends[0]
+            return [BackendId: backend[0], Host: backend[1], HttpPort: backend[4], BrpcPort: backend[5]]
+        }
+
+        cluster.addBackend(1, CG_B_CLUSTER)
+        awaitUntil(120) {
+            def backends = sql_return_maparray('show backends')
+            backends.size() == 2 && backends.every { backend -> backend.Alive.toString() == 'true' }
+        }
+
+        def beA = getBackendByCluster(CG_A_CLUSTER)
+        def beB = getBackendByCluster(CG_B_CLUSTER)
+        logger.info("CG-A BE: host={} brpc={} http={}", beA.Host, beA.BrpcPort, beA.HttpPort)
+        logger.info("CG-B BE: host={} brpc={} http={}", beB.Host, beB.BrpcPort, beB.HttpPort)
+
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1", "disable_auto_compaction" = "true")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        logger.info("=== metrics existence smoke ===")
+        // Pool capacity metrics are REGISTER_HOOK_METRIC and live on /metrics with the doris_be_ prefix,
+        // unlike the bvars below on /brpc_metrics; smoke only new bvars here and let the queue timeout
+        // trigger below prove the peer fetch pool exists and runs.
+        assertEquals(0L, getRequiredBrpcMetric(beA.Host, beA.BrpcPort, 'file_cache_get_by_peer_queue_timeout_num'))
+
+        logger.info("=== dynamic config ===")
+        updateBeConfig(beA.Host, beA.HttpPort as int, 'peer_fetch_queue_timeout_ms', '1')
+        awaitUntil(10) { getVarzConfig(beA.Host, beA.HttpPort as int, 'peer_fetch_queue_timeout_ms') == '1' }
+        updateBeConfig(beA.Host, beA.HttpPort as int, 'peer_fetch_queue_timeout_ms', '1000')
+        awaitUntil(10) { getVarzConfig(beA.Host, beA.HttpPort as int, 'peer_fetch_queue_timeout_ms') == '1000' }
+        updateBeConfig(beA.Host, beA.HttpPort as int, 'peer_fetch_queue_timeout_ms', '500')
+        awaitUntil(10) { getVarzConfig(beA.Host, beA.HttpPort as int, 'peer_fetch_queue_timeout_ms') == '500' }
+
+        logger.info("=== prepare peer candidate on CG-B ===")
+        sql "use @cross_cg_peer_cluster"
+        def baseline = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(4, baseline.size(), "baseline CGB read should succeed")
+        awaitUntil(30) {
+            getRequiredBrpcMetric(beB.Host, beB.BrpcPort, 'peer_lazy_fetch_triggered') > 0L
+        }
+
+        logger.info("=== queue timeout trigger ===")
+        // Two separate rowsets so the two queries touch different files (different
+        // cache hashes). Query 1 populates CG-B's cache for its own block via the
+        // S3 race, so if both queries used the same range Query 2 would cache-hit
+        // locally and never emit a peer RPC. Distinct rowsets force Query 2 to be
+        // a real cold read, so its peer RPC actually queues behind the held worker
+        // on CG-A.
+        def timeoutRangeHold = insertAndWarmCGA(8)
+        def timeoutRangeQueued = insertAndWarmCGA(8)
+        clearFileCacheOnBE(beB)
+        def queueTimeoutBefore = getRequiredBrpcMetric(beA.Host, beA.BrpcPort, 'file_cache_get_by_peer_queue_timeout_num')
+        setPeerFetchTimeoutOnBE(beA, '100')
+        GetDebugPoint().enableDebugPoint(beA.Host, beA.HttpPort as int, NodeType.BE,
+                "CloudInternalServiceImpl::handle_peer_file_cache_block_request_hold_before_get_or_set", [sleep_ms: 3000])
+        def firstTimeoutThread = Thread.start {
+            def rows = queryRangeOnCGB(timeoutRangeHold)
+            assertEquals(8, rows.size(), "first CGB query should succeed while holding peer fetch pool")
+        }
+        sleep(100)
+        try {
+            def timeoutRows = queryRangeOnCGB(timeoutRangeQueued)
+            assertEquals(8, timeoutRows.size(), "CGB query should succeed via S3 fallback after peer queue timeout")
+            firstTimeoutThread.join()
+        } finally {
+            GetDebugPoint().disableDebugPoint(beA.Host, beA.HttpPort as int, NodeType.BE,
+                    "CloudInternalServiceImpl::handle_peer_file_cache_block_request_hold_before_get_or_set")
+        }
+        awaitUntil(30) {
+            getRequiredBrpcMetric(beA.Host, beA.BrpcPort, 'file_cache_get_by_peer_queue_timeout_num') > queueTimeoutBefore
+        }
+        setPeerFetchTimeoutOnBE(beA, '500')
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_peer_read_async_warmup.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_peer_read_async_warmup.groovy
@@ -75,6 +75,9 @@ suite('test_peer_read_async_warmup', 'docker') {
     def testCase = { table -> 
         def ms = cluster.getAllMetaservices().get(0)
         def msHttpPort = ms.host + ":" + ms.httpPort
+        def valueRows = { start, end ->
+            (start..end).collect { "(${it}, '${it}')" }.join(", ")
+        }
         sql """CREATE TABLE $table (
             `k1` int(11) NULL,
             `v1` VARCHAR(2048)
@@ -87,10 +90,10 @@ suite('test_peer_read_async_warmup', 'docker') {
             );
         """
         sql """
-            insert into $table values (10, '1'), (20, '2')
+            insert into $table values ${valueRows(10, 29)}
         """
         sql """
-            insert into $table values (30, '3'), (40, '4')
+            insert into $table values ${valueRows(30, 49)}
         """
 
         // before add be
@@ -120,14 +123,14 @@ suite('test_peer_read_async_warmup', 'docker') {
         } 
 
         sql """
-            insert into $table values (50, '4'), (60, '6')
+            insert into $table values ${valueRows(50, 69)}
         """
         // version 4, in new be, but not in old be
         def beforeCacheDirVersion4 = getTabletFileCacheDirFromBe(msHttpPort, table, 4)
         logger.info("cache dir version 4 {}", beforeCacheDirVersion4)
 
         sql """
-            insert into $table values (70, '7'), (80, '8')
+            insert into $table values ${valueRows(70, 89)}
         """
         // version 5, in new be, but not in old be
         def beforeCacheDirVersion5 = getTabletFileCacheDirFromBe(msHttpPort, table, 5)
@@ -147,6 +150,8 @@ suite('test_peer_read_async_warmup', 'docker') {
         // warm up task blocked by debug point, so old be should not have version 4,5 cache file
         assertFalse(afterMerged2345CacheDir[oldBe.Host].containsAll(newAddBeCacheDir), "old be should not have version 4,5 cache file")
 
+        def peerReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read")
+
         // The query triggers reading the file cache from the peer
         profile("test_peer_read_async_warmup_profile") {
             sql """ set enable_profile = true;"""
@@ -162,16 +167,37 @@ suite('test_peer_read_async_warmup', 'docker') {
                 def matcher = (profileString =~ /-  NumPeerIOTotal:\s+(\d+)/)
                 def total = 0
                 while (matcher.find()) {
-                    total += matcher.group(1).toInteger()
-                    logger.info("NumPeerIOTotal: {}", matcher.group(1))
+                    def peerIoTotal = matcher.group(1).toInteger()
+                    total += peerIoTotal
+                    logger.info("NumPeerIOTotal: {}", peerIoTotal)
+                }
+                def remoteMatcher = (profileString =~ /-  NumRemoteIOTotal:\s+(\d+)/)
+                def remoteTotal = 0
+                while (remoteMatcher.find()) {
+                    def remoteIoTotal = remoteMatcher.group(1).toInteger()
+                    remoteTotal += remoteIoTotal
+                    logger.info("NumRemoteIOTotal: {}", remoteIoTotal)
                 }
                 assertTrue(total > 0)
+                assertEquals(0, remoteTotal)
+
+                def sameCgMatcher = (profileString =~ /SameCGPeerIOTotal:\s+(\d+)/)
+                def sameCgTotal = 0
+                while (sameCgMatcher.find()) {
+                    sameCgTotal += sameCgMatcher.group(1).toInteger()
+                    logger.info("SameCGPeerIOTotal: {}", sameCgMatcher.group(1))
+                }
+                assertTrue(sameCgTotal > 0, "SameCGPeerIOTotal must be > 0 in profile")
+
+                def nodesMatcher = (profileString =~ /PeerCacheNodes:\s*(.+)/)
+                assertTrue(nodesMatcher.find(), "Profile must contain PeerCacheNodes info")
+                logger.info("PeerCacheNodes found: {}", nodesMatcher.group(1))
             } 
         }
 
-        // peer read cache, so it should read version 2,3 cache file from old be, not s3
-        assertTrue(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"), "new add be should have peer read cache")
-        assertTrue(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"), "new add be should not have s3 read cache")
+        // peer read cache, so it should read version 2,3 cache file from old be
+        assertTrue(getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read") > peerReadBeforeQuery,
+                "new add be should have peer read cache")
     }
 
     docker(options) {

--- a/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
+++ b/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
@@ -16,86 +16,107 @@
 // under the License.
 
 import org.apache.doris.regression.suite.ClusterOptions
-import groovy.json.JsonSlurper
-import org.awaitility.Awaitility;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import org.apache.doris.regression.util.NodeType
 
 suite('test_read_from_peer', 'docker') {
     if (!isCloudMode()) {
-        return;
+        return
     }
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
         'sys_log_verbose_modules=org',
         'heartbeat_interval_second=1',
-        'workload_group_check_interval_ms=1'
+        'auto_check_statistics_in_minutes=60',
     ]
     options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'max_concurrent_peer_races=64',
         'file_cache_each_block_size=131072',
-        // 'sys_log_verbose_modules=*',
-        'enable_cache_read_from_peer=true'
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
     ]
+    options.beConfigs.removeAll { it.startsWith('sys_log_verbose_modules=') }
     options.setFeNum(1)
     options.setBeNum(1)
     options.cloudMode = true
     options.enableDebugPoints()
-    
-    def tableName = "test_read_from_table"
 
-    def clusterBe = { clusterName ->
-        def bes = sql_return_maparray "show backends"
-        def clusterBes = bes.findAll { be -> be.Tag.contains(clusterName) }
-        logger.info("cluster {}, bes {}", clusterName, clusterBes)
-        clusterBes[0]
-    }
-
-    def testCase = { String clusterName, String runType ->
-        def startTime = System.currentTimeMillis()
-        GetDebugPoint().enableDebugPointForAllBEs("CachedRemoteFileReader.read_at_impl.change_type", [type: runType])
-        
-        try {
-            sql """
-                use @$clusterName
-            """
-
-            def be = clusterBe(clusterName)
-            def haveCacheBe = clusterBe("compute_cluster")
-
-            switch (runType) {
-                case "peer":
-                    GetDebugPoint().enableDebugPoint(be.Host, be.HttpPort as int, NodeType.BE, "PeerFileCacheReader::_fetch_from_peer_cache_blocks", 
-                        [host: haveCacheBe.Host, port: haveCacheBe.BrpcPort])
-                    break
-                case "s3":
-                    break
-                default:
-                    throw new IllegalArgumentException("Invalid type: $runType. Expected: peer, s3")
-            }
-            
-            // Execute the query and measure time
-            def queryStartTime = System.currentTimeMillis()
-            def ret = sql """
-                select count(*) from $tableName
-            """
-            logger.info("select ret={}", ret)
-            def queryTime = System.currentTimeMillis() - queryStartTime
-            logger.info("Test completed - Type:{}, Cluster: {}, Query execution time: {}ms", runType, clusterName, queryTime)
-        } catch (Exception e) {
-            def totalTime = System.currentTimeMillis() - startTime
-            logger.info("Test failed after {}ms - Type: {}, Cluster: {} Error: {}", totalTime, runType, clusterName, e.message)
-            throw e
+    def getBrpcMetric = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
         }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
     }
 
     docker(options) {
-        // 添加一个新的cluster, 只从s3上读
-        cluster.addBackend(1, "readS3cluster")
+        def tableName = "test_read_from_table"
 
-        // 添加一个新的cluster, 只从peer上读
+        def clusterBe = { clusterName ->
+            def be = sql_return_maparray("show backends").find { backend ->
+                backend.Tag.contains(clusterName)
+            }
+            assertTrue(be != null, "backend for ${clusterName} should exist")
+            be
+        }
+
+        def insertFreshRowsOnCompute = { List<String> rows ->
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tableName} VALUES ${rows.join(', ')}"
+        }
+
+        def queryFreshRows = { clusterName, List<Long> ticketNumbers ->
+            sql "use @${clusterName}"
+            sql """
+                SELECT ss_ticket_number
+                FROM ${tableName}
+                WHERE ss_ticket_number IN (${ticketNumbers.join(',')})
+                ORDER BY ss_ticket_number
+            """
+        }
+
+        def scanCountRows = { clusterName ->
+            sql "use @${clusterName}"
+            sql "set enable_push_down_no_group_agg=false"
+            sql "SELECT count(ss_ticket_number) FROM ${tableName}"
+        }
+
+        def warmFreshRowsOnCompute = { List<Long> ticketNumbers ->
+            def rows = queryFreshRows("compute_cluster", ticketNumbers)
+            assertEquals(ticketNumbers.size(), rows.size(), "compute_cluster should read all expected fresh rows")
+        }
+
+        cluster.addBackend(1, "readS3cluster")
         cluster.addBackend(1, "readPeercluster")
 
+        awaitUntil(120) {
+            def backends = sql_return_maparray("show backends")
+            backends.size() == 3 && backends.every { backend ->
+                backend.Alive.toString() == "true" && backend.TabletNum.toInteger() > 0
+            }
+        }
+
+        def beS3 = clusterBe("readS3cluster")
+        def bePeer = clusterBe("readPeercluster")
+
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tableName}"
         sql """
             CREATE TABLE IF NOT EXISTS ${tableName} (
                 ss_sold_date_sk bigint,
@@ -130,24 +151,10 @@ suite('test_read_from_peer', 'docker') {
             )
         """
 
-        sql """
-            use @compute_cluster
-        """
-
-        // in compute_cluster be-1, cache all data in file cache
-        def txnId = -1;
-        // version 2
         streamLoad {
             table "${tableName}"
-
-            // default label is UUID:
-            // set 'label' UUID.randomUUID().toString()
-
-            // default column_separator is specify in doris fe config, usually is '\t'.
-            // this line change to ','
             set 'column_separator', '|'
             set 'compress_type', 'GZ'
-
             file """${getS3Url()}/regression/tpcds/sf1/store_sales.dat.gz"""
             // file """store_sales.dat.gz"""
 
@@ -167,13 +174,46 @@ suite('test_read_from_peer', 'docker') {
             }
         }
 
-        def ret = sql """
-            select count(*) from $tableName
-        """
-        logger.info("ret after load, ret {}", ret)
+        def computeCount = scanCountRows("compute_cluster")
+        logger.info("count on compute_cluster={}", computeCount)
+        assertTrue((computeCount[0][0] as long) > 0L, "compute_cluster should have loaded rows")
 
-        testCase("compute_cluster", "s3")
-        testCase("readS3cluster", "s3")
-        testCase("readPeercluster", "peer")
+        logger.info("=== readS3cluster: first cold read succeeds ===")
+        def s3Read = scanCountRows("readS3cluster")
+        assertEquals(computeCount, s3Read, "readS3cluster should read loaded source data")
+
+        logger.info("=== readPeercluster: baseline read succeeds and populates peer candidates ===")
+        def peerLazyBefore = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_lazy_fetch_success")
+        def baselinePeerRead = scanCountRows("readPeercluster")
+        assertEquals(computeCount, baselinePeerRead, "readPeercluster baseline read should succeed")
+        awaitUntil(30) {
+            getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_lazy_fetch_success") > peerLazyBefore
+        }
+
+        logger.info("=== readPeercluster: fresh rowset should read from peer ===")
+        def freshTicketNumbers = [900000000001L, 900000000002L]
+        def freshRows = [
+            "(900001, 1, 1, 900001, 1, 1, 1, 1, 1, 900000000001, 1, 1.00, 2.00, 2.00, 0.00, 2.00, 1.00, 2.00, 0.10, 0.00, 2.10, 2.10, 1.10)",
+            "(900002, 2, 2, 900002, 2, 2, 2, 2, 2, 900000000002, 2, 2.00, 3.00, 3.00, 0.00, 6.00, 4.00, 6.00, 0.20, 0.00, 6.20, 6.20, 2.20)"
+        ]
+        insertFreshRowsOnCompute(freshRows)
+        warmFreshRowsOnCompute(freshTicketNumbers)
+
+        def peerWinBefore = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_race_peer_win")
+        def crossCgBefore = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_cross_compute_group_read")
+
+        def peerRead = queryFreshRows("readPeercluster", freshTicketNumbers)
+        assertEquals(freshTicketNumbers.size(), peerRead.size(), "readPeercluster should read fresh rows")
+
+        def peerWinAfter = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_race_peer_win")
+        def crossCgAfter = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_cross_compute_group_read")
+        assertTrue(
+            peerWinAfter > peerWinBefore || crossCgAfter > crossCgBefore,
+            "peer read counters should increase on readPeercluster " +
+            "(peer_race_peer_win ${peerWinBefore}->${peerWinAfter}, " +
+            "peer_cross_compute_group_read ${crossCgBefore}->${crossCgAfter})")
+
+        logger.info("=== readPeercluster PASS ===")
+        logger.info("readS3cluster brpc={}, readPeercluster brpc={}", beS3.BrpcPort, bePeer.BrpcPort)
     }
 }

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -472,6 +472,7 @@ export ORC_EXAMPLE_DIR="${DORIS_HOME}/contrib/apache-orc/examples"
 
 # set asan and ubsan env to generate core file
 export DORIS_HOME="${DORIS_TEST_BINARY_DIR}/"
+export LSAN_OPTIONS="suppressions=${ROOT}/conf/lsan_suppr.conf"
 ## detect_container_overflow=0, https://github.com/google/sanitizers/issues/193
 export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0
 export UBSAN_OPTIONS=print_stacktrace=1


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/63818

This commit combines two related changes to implement cross compute group peer read routing and optimize the peer cache I/O path. Changes:
1. Cross Compute Group Peer Read Routing:
- Implement peer read routing across different compute groups to enable data sharing between groups
   - Add routing logic to select optimal peer nodes for cache reads
   - Support cross-group tablet peer discovery and selection
2. Peer Cache I/O Path Optimization:
- Optimize peer cache server path using IOBuf attachment for zero-copy data transfer
- Reduce memory copies in the peer cache read path by leveraging bRPC IOBuf attachment mechanism
   - Improve peer cache read performance and reduce memory overhead

(cherry picked from commit d48b9320bad7ddc42234c730f50f8db7615fc236)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

