### PR TITLE
[fix](schema-change) reset table state when cancelling a job stuck in WAITING_STABLE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -3148,6 +3148,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(dbName);
         AlterJobV2 schemaChangeJobV2 = null;
+        boolean healOrphanedWaitingStable = false;
 
         OlapTable olapTable = db.getOlapTableOrDdlException(tableName);
         olapTable.writeLockOrDdlException();
@@ -3163,11 +3164,36 @@ public class SchemaChangeHandler extends AlterHandler {
             schemaChangeJobV2 = schemaChangeJobV2List.size() == 0 ? null
                     : Iterables.getOnlyElement(schemaChangeJobV2List);
             if (schemaChangeJobV2 == null) {
-                throw new DdlException(
-                    "Table[" + tableName + "] is under schema change state" + " but could not find related job");
+                if (olapTable.getState() == OlapTableState.WAITING_STABLE) {
+                    // WAITING_STABLE but no live job: an orphaned state produced by an old binary that
+                    // cancelled a still-WAITING_STABLE job without resetting the table (the job's
+                    // cancelInternal already dropped the shadow indexes, only the table state was left
+                    // stuck). Self-heal by resetting to NORMAL so the table is usable again instead of
+                    // leaving DROP TABLE as the only escape. The reset is done durably via
+                    // setTableStatusInternal (edit log + follower replay), so we only flag it here and
+                    // perform it after releasing the table lock.
+                    healOrphanedWaitingStable = true;
+                } else {
+                    // SCHEMA_CHANGE with no backing job is not a known-reachable state; a silent reset
+                    // could abandon still-present shadow indexes/tablets. Keep failing loudly so it is
+                    // investigated rather than masked.
+                    throw new DdlException("Table[" + tableName + "] is under SCHEMA_CHANGE"
+                            + " but could not find related job");
+                }
             }
         } finally {
             olapTable.writeUnlock();
+        }
+
+        if (healOrphanedWaitingStable) {
+            LOG.warn("table[{}] is in state WAITING_STABLE but has no related schema change job, "
+                    + "reset table state to NORMAL", tableName);
+            try {
+                Env.getCurrentEnv().setTableStatusInternal(dbName, tableName, OlapTableState.NORMAL, false);
+            } catch (MetaNotFoundException e) {
+                throw new DdlException(e.getMessage());
+            }
+            return;
         }
 
         // alter job v2's cancel must be called outside the database lock

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -1102,7 +1102,13 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
             try {
                 if (olapTable.getState() == olapTableState) {
                     return;
-                } else if (olapTable.getState() == OlapTableState.SCHEMA_CHANGE) {
+                } else if (olapTable.getState() == OlapTableState.SCHEMA_CHANGE
+                        || olapTable.getState() == OlapTableState.WAITING_STABLE) {
+                    // WAITING_STABLE is a transient sub-state of a pending SCHEMA_CHANGE job (the table is
+                    // not yet stable). If the job is cancelled while still WAITING_STABLE, we must also reset
+                    // the table back to NORMAL; otherwise the table stays stuck in WAITING_STABLE with no
+                    // live job, and every following ALTER / TRUNCATE / DROP PARTITION / RENAME / CANCEL is
+                    // rejected (deadlock, only recoverable by DROP TABLE).
                     olapTable.setState(olapTableState);
                 }
             } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -42,6 +42,7 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.info.ColumnPosition;
+import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
@@ -49,6 +50,7 @@ import org.apache.doris.common.SchemaVersionAndHash;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.meta.MetaContext;
+import org.apache.doris.nereids.trees.plans.commands.CancelAlterTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.AddColumnOp;
 import org.apache.doris.nereids.trees.plans.commands.info.AlterOp;
 import org.apache.doris.nereids.trees.plans.commands.info.ColumnDefinition;
@@ -582,5 +584,114 @@ public class SchemaChangeJobV2Test {
         expectedEx.expectMessage("errCode = 2, detailMessage = Cannot change "
                 + "distribution type of aggregate keys table which has value columns with REPLACE type.");
         Env.getCurrentEnv().convertDistributionType(db, table);
+    }
+
+    // A schema-change job cancelled while the table is still WAITING_STABLE (it never became
+    // stable, so it was never promoted to SCHEMA_CHANGE) must reset the table back to NORMAL.
+    // Otherwise the table is permanently stuck in WAITING_STABLE with no live job, and every
+    // subsequent ALTER / TRUNCATE / DROP PARTITION / RENAME / CANCEL is rejected (deadlock).
+    @Test
+    public void testCancelSchemaChangeWhileWaitingStable() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        // add a schema change job
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(addColumnOp);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        schemaChangeHandler.process(alterOps, db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
+        Assert.assertEquals(1, alterJobsV2.size());
+        SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) alterJobsV2.values().stream().findAny().get();
+
+        // make the table unstable so the pending job parks in WAITING_STABLE
+        MaterializedIndex baseIndex = testPartition.getBaseIndex();
+        Replica replica1 = baseIndex.getTablets().get(0).getReplicas().get(0);
+        replica1.setState(Replica.ReplicaState.DECOMMISSION);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.PENDING, schemaChangeJob.getJobState());
+        Assert.assertEquals(OlapTableState.WAITING_STABLE, olapTable.getState());
+
+        // cancel while WAITING_STABLE: the table must return to NORMAL (before the fix it stayed
+        // stuck in WAITING_STABLE because changeTableState() only reset from SCHEMA_CHANGE).
+        boolean cancelled = schemaChangeJob.cancel("test cancel while waiting stable");
+        Assert.assertTrue(cancelled);
+        Assert.assertEquals(JobState.CANCELLED, schemaChangeJob.getJobState());
+        Assert.assertEquals(OlapTableState.NORMAL, olapTable.getState());
+    }
+
+    // A table left in WAITING_STABLE with no backing schema-change job (an orphaned state that older
+    // binaries could produce) must be self-healed by CANCEL ALTER TABLE: the table is reset to NORMAL
+    // instead of throwing "could not find related job" (which previously left DROP TABLE as the only escape).
+    @Test
+    public void testCancelColumnJobSelfHealsOrphanedState() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+
+        // simulate the orphaned state: table flagged WAITING_STABLE but no alter job backs it
+        olapTable.setState(OlapTableState.WAITING_STABLE);
+        Assert.assertTrue(schemaChangeHandler.getUnfinishedAlterJobV2ByTableId(olapTable.getId()).isEmpty());
+
+        TableNameInfo tableNameInfo = new TableNameInfo(db.getName(), olapTable.getName());
+        CancelAlterTableCommand cancelCommand = new CancelAlterTableCommand(
+                tableNameInfo, CancelAlterTableCommand.AlterType.COLUMN, Lists.newArrayList());
+        // must not throw, and must reset the table back to NORMAL
+        schemaChangeHandler.cancel(cancelCommand);
+        Assert.assertEquals(OlapTableState.NORMAL, olapTable.getState());
+    }
+
+    // A table flagged SCHEMA_CHANGE with no backing job is not a known-reachable state and a silent reset
+    // could abandon still-present shadow indexes; CANCEL must fail loudly and leave the state untouched
+    // (only WAITING_STABLE is self-healed).
+    @Test
+    public void testCancelColumnJobRejectsOrphanedSchemaChangeState() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+
+        // simulate an unexpected orphaned state: table flagged SCHEMA_CHANGE but no alter job backs it
+        olapTable.setState(OlapTableState.SCHEMA_CHANGE);
+        Assert.assertTrue(schemaChangeHandler.getUnfinishedAlterJobV2ByTableId(olapTable.getId()).isEmpty());
+
+        TableNameInfo tableNameInfo = new TableNameInfo(db.getName(), olapTable.getName());
+        CancelAlterTableCommand cancelCommand = new CancelAlterTableCommand(
+                tableNameInfo, CancelAlterTableCommand.AlterType.COLUMN, Lists.newArrayList());
+        // must throw and must NOT change the table state
+        Assert.assertThrows(DdlException.class, () -> schemaChangeHandler.cancel(cancelCommand));
+        Assert.assertEquals(OlapTableState.SCHEMA_CHANGE, olapTable.getState());
+
+        // restore state so it does not leak into other tests sharing the catalog fixture
+        olapTable.setState(OlapTableState.NORMAL);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66177

Related PR: N/A

Problem Summary:

When a schema-change job is cancelled while the table is still in the `WAITING_STABLE` sub-state (the table never became stable, so the job was never promoted to `SCHEMA_CHANGE`), the table state was not reset back to `NORMAL`: `SchemaChangeJobV2.changeTableState` only reset from `SCHEMA_CHANGE`. The table was then permanently stuck in `WAITING_STABLE` with no live job, and every subsequent ALTER / TRUNCATE / DROP PARTITION / RENAME / CANCEL was rejected — the only escape was DROP TABLE.

This fixes it in two places:
1. `SchemaChangeJobV2.changeTableState` now also resets the table from `WAITING_STABLE` (not just `SCHEMA_CHANGE`) when a job is cancelled, so the normal "cancel a WAITING_STABLE job" path returns the table to `NORMAL`.
2. `SchemaChangeHandler.cancelColumnJob` now self-heals a table left in an orphaned `WAITING_STABLE` state with no backing job (which older binaries could produce) by resetting it to `NORMAL` durably via `setTableStatusInternal`, instead of throwing "could not find related job". An orphaned `SCHEMA_CHANGE` state (not a known-reachable state) still fails loudly so it is investigated rather than silently masked.

### Release note

Fix a schema-change table state leak: cancelling a job that is stuck in WAITING_STABLE now correctly resets the table to NORMAL instead of leaving it permanently blocked for all subsequent ALTER operations.

### Check List (For Author)

- [x] Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Please explain why:

- [ ] Behavior changed:

- [ ] Does this need documentation?

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label