### PR TITLE
[fix](cloud) Fix SchemaVariablesScanner crash due to incomplete FE response (#65994)

### DIFF
--- a/be/src/information_schema/schema_variables_scanner.cpp
+++ b/be/src/information_schema/schema_variables_scanner.cpp
@@ -86,6 +86,15 @@ Status SchemaVariablesScanner::get_next_block_internal(Block* block, bool* eos) 
 
 Status SchemaVariablesScanner::_fill_block_impl(Block* block) {
     SCOPED_TIMER(_fill_block_timer);
+    constexpr int num_columns = 4;
+    for (const auto& row : _var_result.variables) {
+        if (row.size() < num_columns) {
+            return Status::InternalError(
+                    "Incomplete variable entry from FE (expected {} fields, got {}), "
+                    "please retry",
+                    num_columns, row.size());
+        }
+    }
     auto row_num = _var_result.variables.size();
     std::vector<void*> datas(row_num);
     // variables names


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/65994
Problem Summary: When the Thrift connection to FE is unstable, a partially deserialized TShowVariableResult can contain variable rows with fewer than four fields. SchemaVariablesScanner accessed fields 0 through 3 unconditionally and could crash the BE process. Validate every row before accessing its fields and return an InternalError asking the user to retry when the response is incomplete.

### Release note

Fix a BE crash when scanning variables after receiving an incomplete FE response; the query now returns an error asking the user to retry.

(cherry picked from commit d3bf6b89bdedfa38d17d99c287c2c1b37304cd9f)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

