### PR TITLE
[fix](ci) deduplicate comment-triggered TeamCity builds

### DIFF
--- a/.github/workflows/comment-to-trigger-teamcity.yml
+++ b/.github/workflows/comment-to-trigger-teamcity.yml
@@ -29,8 +29,55 @@ permissions:
 jobs:
   check-comment-if-need-to-trigger-teamcity:
 
-    # This job only runs for pull request comments, and comment body contains 'run'
-    if: ${{ github.event.issue.pull_request && !startsWith(github.event.comment.body, '/review') && (contains(github.event.comment.body, 'run') || contains(github.event.comment.body, 'skip buildall') || contains(github.event.comment.body, 'skip check_coverage')) }}
+    # Keep this server-side filter aligned with the supported commands parsed below.
+    # A generic "run" match also catches performance reports such as "Total hot run time".
+    if: >-
+      ${{
+        github.event.issue.pull_request &&
+        !startsWith(github.event.comment.body, '/review') &&
+        (
+          contains(github.event.comment.body, 'run buildall') ||
+          contains(github.event.comment.body, 'run compile') ||
+          contains(github.event.comment.body, 'run beut') ||
+          contains(github.event.comment.body, 'run feut') ||
+          contains(github.event.comment.body, 'run cloudut') ||
+          contains(github.event.comment.body, 'run p0') ||
+          contains(github.event.comment.body, 'run p1') ||
+          contains(github.event.comment.body, 'run external') ||
+          contains(github.event.comment.body, 'run cloud_p0') ||
+          contains(github.event.comment.body, 'run cloud_p1') ||
+          contains(github.event.comment.body, 'run vault_p0') ||
+          contains(github.event.comment.body, 'run nonConcurrent') ||
+          contains(github.event.comment.body, 'run check_coverage') ||
+          contains(github.event.comment.body, 'run performance') ||
+          contains(github.event.comment.body, 'skip buildall') ||
+          contains(github.event.comment.body, 'skip check_coverage')
+        )
+      }}
+
+    # Serialize duplicate commands for one PR. The next run then sees the build
+    # queued by the previous run and can safely skip an identical PR revision.
+    concurrency:
+      group: >-
+        comment-to-trigger-teamcity-${{ github.event.issue.number }}-${{
+          contains(github.event.comment.body, 'run buildall') && 'buildall' ||
+          contains(github.event.comment.body, 'run compile') && 'compile' ||
+          contains(github.event.comment.body, 'run beut') && 'beut' ||
+          contains(github.event.comment.body, 'run feut') && 'feut' ||
+          contains(github.event.comment.body, 'run cloudut') && 'cloudut' ||
+          contains(github.event.comment.body, 'run p0') && 'p0' ||
+          contains(github.event.comment.body, 'run p1') && 'p1' ||
+          contains(github.event.comment.body, 'run external') && 'external' ||
+          contains(github.event.comment.body, 'run cloud_p0') && 'cloud-p0' ||
+          contains(github.event.comment.body, 'run cloud_p1') && 'cloud-p1' ||
+          contains(github.event.comment.body, 'run vault_p0') && 'vault-p0' ||
+          contains(github.event.comment.body, 'run nonConcurrent') && 'non-concurrent' ||
+          contains(github.event.comment.body, 'run check_coverage') && 'check-coverage' ||
+          contains(github.event.comment.body, 'run performance') && 'performance' ||
+          contains(github.event.comment.body, 'skip buildall') && 'skip-buildall' ||
+          'skip-check-coverage'
+        }}
+      cancel-in-progress: false
 
     runs-on: ubuntu-latest
     env:

--- a/regression-test/pipeline/common/teamcity-utils.sh
+++ b/regression-test/pipeline/common/teamcity-utils.sh
@@ -159,6 +159,51 @@ get_queue_build_of_pr() {
 }
 # get_queue_build_of_pr "$1" "$2"
 
+get_active_builds_of_revision() {
+    # Return active build IDs for the same PR, pipeline, and revision.
+    # Return 0 when a duplicate exists, 1 when none exists, and 2 when lookup fails.
+    local PULL_REQUEST_NUM="${PULL_REQUEST_NUM:-$1}"
+    local COMMENT_TRIGGER_TYPE="${COMMENT_TRIGGER_TYPE:-$2}"
+    local COMMIT_ID_FROM_TRIGGER="${COMMIT_ID_FROM_TRIGGER:-$3}"
+    if [[ -z "${PULL_REQUEST_NUM}" ||
+        -z "${COMMENT_TRIGGER_TYPE}" ||
+        -z "${COMMIT_ID_FROM_TRIGGER}" ]]; then
+        echo "Usage: get_active_builds_of_revision PULL_REQUEST_NUM COMMENT_TRIGGER_TYPE COMMIT_ID_FROM_TRIGGER" >&2
+        return 2
+    fi
+
+    local queue_build_ids
+    local running_build_ids
+    if ! queue_build_ids=$(get_queue_build_of_pr "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"); then
+        echo "WARNING: failed to get queued builds for duplicate check" >&2
+        return 2
+    fi
+    if ! running_build_ids=$(get_running_build_of_pr "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"); then
+        echo "WARNING: failed to get running builds for duplicate check" >&2
+        return 2
+    fi
+
+    local build_id
+    local build_revision
+    local duplicate_build_ids=()
+    for build_id in ${queue_build_ids} ${running_build_ids}; do
+        if ! build_revision=$(get_commit_id_of_build "${build_id}"); then
+            echo "WARNING: failed to get revision of active build ${build_id}" >&2
+            return 2
+        fi
+        if [[ "${build_revision}" == "${COMMIT_ID_FROM_TRIGGER}" ]]; then
+            duplicate_build_ids+=("${build_id}")
+        fi
+    done
+
+    if [[ ${#duplicate_build_ids[@]} -gt 0 ]]; then
+        printf '%s\n' "${duplicate_build_ids[@]}"
+        return 0
+    fi
+    return 1
+}
+# get_active_builds_of_revision "$1" "$2" "$3"
+
 cancel_running_build() {
     local PULL_REQUEST_NUM="${PULL_REQUEST_NUM:-$1}"
     local COMMENT_TRIGGER_TYPE="${COMMENT_TRIGGER_TYPE:-$2}"
@@ -300,6 +345,21 @@ trigger_or_skip_build() {
     fi
 
     if [[ "${FILE_CHANGED:-"true"}" == "true" ]]; then
+        local duplicate_build_ids
+        local duplicate_lookup_status=0
+        duplicate_build_ids=$(
+            get_active_builds_of_revision \
+                "${PULL_REQUEST_NUM}" \
+                "${COMMENT_TRIGGER_TYPE}" \
+                "${COMMIT_ID_FROM_TRIGGER}"
+        ) || duplicate_lookup_status=$?
+        if [[ ${duplicate_lookup_status} -eq 0 ]]; then
+            echo "INFO: active build(s) ${duplicate_build_ids//$'\n'/,} already exist for PR ${PULL_REQUEST_NUM}, pipeline ${COMMENT_TRIGGER_TYPE}, revision ${COMMIT_ID_FROM_TRIGGER}; skip duplicate trigger"
+            return 0
+        elif [[ ${duplicate_lookup_status} -ne 1 ]]; then
+            echo "WARNING: duplicate lookup failed for PR ${PULL_REQUEST_NUM}, pipeline ${COMMENT_TRIGGER_TYPE}; continue with the existing trigger flow"
+        fi
+
         cancel_running_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"
         cancel_queue_build "${PULL_REQUEST_NUM}" "${COMMENT_TRIGGER_TYPE}"
         trigger_build "${PULL_REQUEST_NUM}" "${COMMIT_ID_FROM_TRIGGER}" "${COMMENT_TRIGGER_TYPE}" "${COMMENT_REPEAT_TIMES}"


### PR DESCRIPTION
## What changed

- Narrow the `issue_comment` job filter to supported TeamCity commands instead of matching every comment containing `run`.
- Serialize the same command for one PR so duplicate comments do not race each other.
- Before canceling or triggering a TeamCity pipeline, check queued and running builds for the same PR, pipeline, and revision.
- Skip only an exact active duplicate. Preserve the existing cancel-old-revision and trigger-new-revision behavior.
- Fail open when the duplicate lookup is unavailable so a legitimate CI request is not blocked.

## Why

Performance result comments such as `Total hot run time` matched the generic `contains(..., 'run')` condition and unnecessarily consumed GitHub-hosted runners. Repeated `run buildall` comments for the same PR revision could also cancel and recreate identical TeamCity builds.

This reduces false GitHub Actions queue pressure and avoids duplicate TeamCity fan-out without changing valid command semantics.

## Validation

- `actionlint .github/workflows/comment-to-trigger-teamcity.yml`
- `bash -n regression-test/pipeline/common/teamcity-utils.sh`
- Filter scenarios covering performance reports, `run buildall`, numbered pipeline runs, and skip commands
- Mocked TeamCity scenarios covering exact-revision dedupe, new-revision trigger flow, and fail-open lookup errors
- Read-only verification against active PR #66191 builds: FEUT `1008222`, BEUT `1008223`, CloudUT `1008224`, and Compile `1008225` all matched the same PR HEAD revision
