### PR TITLE
[fix](variant) Recognize nullable array elements as NestedGroup types

### DIFF
--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -142,6 +142,9 @@ size_t get_number_of_dimensions(const IDataType& type) {
 // which indicates NG-originated array<object> data.
 bool is_nested_group_type(const DataTypePtr& type) {
     auto base = get_base_type_of_array(type);
+    if (get_number_of_dimensions(*type) > 0) {
+        base = remove_nullable(base);
+    }
     return typeid_cast<const DataTypeVariant*>(base.get()) != nullptr;
 }
 

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -3610,6 +3610,14 @@ TEST_F(ColumnVariantTest, subcolumn_finalize_and_insert) {
     array_subcolumn.finalize();
 }
 
+TEST(ColumnVariantNestedGroupTypeTest, nullable_array_element_is_recognized) {
+    EXPECT_TRUE(is_nested_group_type(ColumnVariant::NESTED_TYPE));
+
+    auto variant = std::make_shared<DataTypeVariant>(0, false);
+    EXPECT_TRUE(is_nested_group_type(variant));
+    EXPECT_FALSE(is_nested_group_type(make_nullable(variant)));
+}
+
 TEST_F(ColumnVariantTest, deserialize_mixed_array_elements) {
     ColumnVariant::Subcolumn subcolumn(0, true /* is_nullable */, false /* is_root */);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63088

Problem Summary:

Array elements are nullable after #63088. `get_base_type_of_array()` therefore returns `Nullable<Variant>` for the NestedGroup physical type, but `is_nested_group_type()` directly casts that wrapper to `DataTypeVariant`. The false negative bypasses the NestedGroup-specific type-conflict policy during Variant merge/compaction.

This PR unwraps the nullable base type only when the input has an Array dimension. It recognizes `Array<Nullable<Variant>>` as NestedGroup while preserving the existing classifications of scalar `Variant` and `Nullable<Variant>`.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `GLIBC_COMPATIBILITY=OFF ./run-be-ut.sh --run --filter=ColumnVariantNestedGroupTypeTest.nullable_array_element_is_recognized`
        - `GLIBC_COMPATIBILITY=OFF ./run-be-ut.sh --run --filter='ColumnVariantTest.*'` (91 tests passed)
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Arrays whose innermost element is `Nullable<Variant>` are now recognized as NestedGroup and use its intended conflict-resolution policy.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
