### PR TITLE
[fix](fe) Allow retention count ALTER in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2855,13 +2855,6 @@ public class SchemaChangeHandler extends AlterHandler {
             olapTable.readUnlock();
         }
 
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT)
-                && !(olapTable.getPartitionInfo().enableAutomaticPartition()
-                        && olapTable.getPartitionInfo().getType() == PartitionType.RANGE)) {
-            throw new UserException("Only AUTO RANGE PARTITION table could set "
-                    + PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT);
-        }
-
         String inMemory = properties.get(PropertyAnalyzer.PROPERTIES_INMEMORY);
         int isInMemory = -1; // < 0 means don't update inMemory properties
         if (inMemory != null) {
@@ -2997,6 +2990,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         olapTable.writeLockOrDdlException();
         try {
+            checkPartitionRetentionCount(olapTable, properties);
             Env.getCurrentEnv().modifyTableProperties(db, olapTable, properties);
         } finally {
             olapTable.writeUnlock();
@@ -3004,6 +2998,24 @@ public class SchemaChangeHandler extends AlterHandler {
 
         // after modifyTableProperties, buildPartitionRetentionCount has been done.
         DynamicPartitionUtil.registerOrRemoveDynamicPartitionTable(db.getId(), olapTable, false);
+    }
+
+    protected void checkPartitionRetentionCount(OlapTable olapTable, Map<String, String> properties)
+            throws UserException {
+        if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT)) {
+            return;
+        }
+        if (!(olapTable.getPartitionInfo().enableAutomaticPartition()
+                && olapTable.getPartitionInfo().getType() == PartitionType.RANGE)) {
+            throw new UserException("Only AUTO RANGE PARTITION table could set "
+                    + PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT);
+        }
+        // Dynamic partition creation and retention-count cleanup are mutually exclusive scheduler modes.
+        if (olapTable.dynamicPartitionExists()
+                && olapTable.getTableProperty().getDynamicPartitionProperty().getEnable()) {
+            throw new UserException("Can not use partition.retention_count and "
+                    + "dynamic_partition properties at the same time");
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/alter/CloudSchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/alter/CloudSchemaChangeHandler.java
@@ -370,6 +370,8 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
             param.type = UpdatePartitionMetaParam.TabletMetaType.ENABLE_MOW_LIGHT_DELETE;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_ANALYZE_POLICY)) {
             // Do nothing.
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT)) {
+            // Retention count only changes FE table properties and scheduler registration below.
         } else if (properties.containsKey(
                 PropertyAnalyzer.PROPERTIES_VERTICAL_COMPACTION_NUM_COLUMNS_PER_GROUP)) {
             int verticalCompactionNumColumnsPerGroup = Integer.parseInt(properties.get(

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/alter/CloudSchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/alter/CloudSchemaChangeHandler.java
@@ -25,7 +25,6 @@ import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
-import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.cloud.proto.Cloud;
@@ -137,13 +136,6 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
         List<Partition> partitions = Lists.newArrayList();
         OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName, Table.TableType.OLAP);
         UpdatePartitionMetaParam param = new UpdatePartitionMetaParam();
-
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT)
-                && !(olapTable.getPartitionInfo().enableAutomaticPartition()
-                        && olapTable.getPartitionInfo().getType() == PartitionType.RANGE)) {
-            throw new UserException("Only AUTO RANGE PARTITION table could set "
-                    + PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_COUNT);
-        }
 
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_CACHE_TTL_SECONDS)) {
             long ttlSeconds = PropertyAnalyzer.analyzeTTL(properties);
@@ -395,6 +387,7 @@ public class CloudSchemaChangeHandler extends SchemaChangeHandler {
 
         olapTable.writeLockOrDdlException();
         try {
+            checkPartitionRetentionCount(olapTable, properties);
             Env.getCurrentEnv().modifyTableProperties(db, olapTable, properties);
         } finally {
             olapTable.writeUnlock();

--- a/regression-test/suites/cloud_p0/partition/test_cloud_alter_partition_retention_count.groovy
+++ b/regression-test/suites/cloud_p0/partition/test_cloud_alter_partition_retention_count.groovy
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_cloud_alter_partition_retention_count", "p0") {
+    sql "DROP TABLE IF EXISTS test_cloud_alter_partition_retention_count"
+    sql """
+        CREATE TABLE test_cloud_alter_partition_retention_count (
+            k1 DATETIME NOT NULL
+        )
+        AUTO PARTITION BY RANGE (date_trunc(k1, 'day')) ()
+        DISTRIBUTED BY HASH(k1) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        )
+    """
+
+    sql """
+        ALTER TABLE test_cloud_alter_partition_retention_count
+        SET ("partition.retention_count" = "3")
+    """
+
+    sql "DROP TABLE IF EXISTS test_cloud_alter_partition_retention_count_with_dynamic"
+    sql """
+        CREATE TABLE test_cloud_alter_partition_retention_count_with_dynamic (
+            k1 DATETIME NOT NULL
+        )
+        AUTO PARTITION BY RANGE (date_trunc(k1, 'day')) ()
+        DISTRIBUTED BY HASH(k1) BUCKETS 1
+        PROPERTIES (
+            "dynamic_partition.enable" = "true",
+            "dynamic_partition.time_unit" = "DAY",
+            "dynamic_partition.start" = "-3",
+            "dynamic_partition.end" = "3",
+            "dynamic_partition.prefix" = "p",
+            "dynamic_partition.buckets" = "1",
+            "replication_num" = "1"
+        )
+    """
+
+    test {
+        sql """
+            ALTER TABLE test_cloud_alter_partition_retention_count_with_dynamic
+            SET ("partition.retention_count" = "3")
+        """
+        exception "Can not use partition.retention_count and dynamic_partition properties at the same time"
+    }
+}

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_new_recycle.groovy
@@ -66,6 +66,28 @@ suite("test_auto_new_recycle", "nonConcurrent") {
     def res = sql "show create table auto_recycle"
     assertTrue(res[0][1].contains('"partition.retention_count" = "3"'))
 
+    sql "drop table if exists auto_recycle_with_dynamic"
+    sql """
+        create table auto_recycle_with_dynamic(
+            k0 datetime(6) not null
+        )
+        auto partition by range (date_trunc(k0, 'day')) ()
+        DISTRIBUTED BY HASH(`k0`) BUCKETS 1
+        properties(
+            "dynamic_partition.enable" = "true",
+            "dynamic_partition.time_unit" = "DAY",
+            "dynamic_partition.start" = "-3",
+            "dynamic_partition.end" = "3",
+            "dynamic_partition.prefix" = "p",
+            "dynamic_partition.buckets" = "1",
+            "replication_num" = "1"
+        );
+    """
+    test {
+        sql "alter table auto_recycle_with_dynamic set ('partition.retention_count' = '3')"
+        exception "Can not use partition.retention_count and dynamic_partition properties at the same time"
+    }
+
     sql "drop table auto_recycle force"
     sql """
         create table auto_recycle(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: Cloud table ALTER accepts `partition.retention_count` during analysis, but the cloud schema-change handler did not dispatch the property. Valid ALTER statements therefore failed as `invalid properties` before table-property persistence and retention scheduler registration. The fix treats the property as an FE-only metadata update, while shared validation rejects it atomically when dynamic partitioning is enabled so the two scheduler modes cannot coexist.

### Release note

Cloud AUTO RANGE tables can update `partition.retention_count` through `ALTER TABLE` when dynamic partitioning is not enabled.

### Check List (For Author)

- Test
  - [x] Regression test coverage added in Cloud P0 for valid cloud ALTER and dynamic-first rejection.
  - [x] Non-concurrent regression coverage added for dynamic-first rejection in the shared handler.


- Behavior changed:
  - [x] Yes. Valid cloud-mode retention ALTER succeeds, while retention_count is rejected when dynamic partitioning is enabled.

- Does this need documentation?
  - [x] No.