### PR TITLE
[fix](be) Report stream load size limits in MiB

### DIFF
--- a/be/src/service/http/action/http_stream.cpp
+++ b/be/src/service/http/action/http_stream.cpp
@@ -246,10 +246,11 @@ Status HttpStreamAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {:.2f} MiB exceeds the limit of {} MiB set by BE config "
-                    "`streaming_load_max_mb`. Increase it if you "
-                    "are sure this load is reasonable",
-                    static_cast<double>(ctx->body_bytes) / MEBIBYTE, csv_max_body_mb);
+                    "body size {} bytes ({:.2f} MiB) exceeds the limit of {} bytes ({} MiB) set "
+                    "by BE config `streaming_load_max_mb`. Increase it if you are sure this load "
+                    "is reasonable",
+                    ctx->body_bytes, static_cast<double>(ctx->body_bytes) / MEBIBYTE,
+                    csv_max_body_bytes, csv_max_body_mb);
         }
     }
 

--- a/be/src/service/http/action/http_stream.cpp
+++ b/be/src/service/http/action/http_stream.cpp
@@ -67,6 +67,8 @@ using namespace ErrorCode;
 
 namespace {
 
+constexpr size_t MEBIBYTE = 1024 * 1024;
+
 bool is_compressed_file_scan(const TPipelineFragmentParams& params) {
     if (!params.__isset.file_scan_params) {
         return false;
@@ -231,7 +233,8 @@ Status HttpStreamAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
     // TODO(zs) : need Need to request an FE to obtain information such as format
     // check content length
     ctx->body_bytes = 0;
-    size_t csv_max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
+    const auto csv_max_body_mb = config::streaming_load_max_mb;
+    size_t csv_max_body_bytes = csv_max_body_mb * MEBIBYTE;
     if (!http_req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
         try {
             ctx->body_bytes = std::stol(http_req->header(HttpHeaders::CONTENT_LENGTH));
@@ -243,9 +246,10 @@ Status HttpStreamAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {} exceed BE's conf `streaming_load_max_mb` {}. increase it if you "
+                    "body size {:.2f} MiB exceeds the limit of {} MiB set by BE config "
+                    "`streaming_load_max_mb`. Increase it if you "
                     "are sure this load is reasonable",
-                    ctx->body_bytes, csv_max_body_bytes);
+                    static_cast<double>(ctx->body_bytes) / MEBIBYTE, csv_max_body_mb);
         }
     }
 

--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -333,19 +333,21 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if ((ctx->format == TFileFormatType::FORMAT_JSON) &&
             (ctx->body_bytes > json_max_body_bytes) && !read_json_by_line) {
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "json body size {:.2f} MiB exceeds the limit of {} MiB set by BE's conf "
-                    "streaming_load_json_max_mb. Increase it if you are sure "
+                    "json body size {} bytes ({:.2f} MiB) exceeds the limit of {} bytes ({} MiB) "
+                    "set by BE's conf streaming_load_json_max_mb. Increase it if you are sure "
                     "this load is reasonable",
-                    static_cast<double>(ctx->body_bytes) / MEBIBYTE, json_max_body_mb);
+                    ctx->body_bytes, static_cast<double>(ctx->body_bytes) / MEBIBYTE,
+                    json_max_body_bytes, json_max_body_mb);
         }
         // csv max body size
         else if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {:.2f} MiB exceeds the limit of {} MiB set by BE's conf "
-                    "streaming_load_max_mb. Increase it if you "
-                    "are sure this load is reasonable",
-                    static_cast<double>(ctx->body_bytes) / MEBIBYTE, csv_max_body_mb);
+                    "body size {} bytes ({:.2f} MiB) exceeds the limit of {} bytes ({} MiB) set "
+                    "by BE's conf streaming_load_max_mb. Increase it if you are sure this load is "
+                    "reasonable",
+                    ctx->body_bytes, static_cast<double>(ctx->body_bytes) / MEBIBYTE,
+                    csv_max_body_bytes, csv_max_body_mb);
         }
     } else {
 #ifndef BE_TEST

--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -312,7 +312,8 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
     // check content length
     ctx->body_bytes = 0;
     size_t csv_max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
-    size_t json_max_body_bytes = config::streaming_load_json_max_mb * 1024 * 1024;
+    const auto json_max_body_mb = config::streaming_load_json_max_mb;
+    size_t json_max_body_bytes = json_max_body_mb * 1024 * 1024;
     bool read_json_by_line = false;
     if (!http_req->header(HTTP_READ_JSON_BY_LINE).empty()) {
         if (iequal(http_req->header(HTTP_READ_JSON_BY_LINE), "true")) {
@@ -330,9 +331,10 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if ((ctx->format == TFileFormatType::FORMAT_JSON) &&
             (ctx->body_bytes > json_max_body_bytes) && !read_json_by_line) {
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "json body size {} exceed BE's conf `streaming_load_json_max_mb` {}. increase "
-                    "it if you are sure this load is reasonable",
-                    ctx->body_bytes, json_max_body_bytes);
+                    "json body size {} bytes exceeds the limit of {} bytes set by BE config "
+                    "`streaming_load_json_max_mb` (currently {} MB). Increase it if you are sure "
+                    "this load is reasonable",
+                    ctx->body_bytes, json_max_body_bytes, json_max_body_mb);
         }
         // csv max body size
         else if (ctx->body_bytes > csv_max_body_bytes) {

--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -83,6 +83,7 @@ bvar::LatencyRecorder g_stream_load_commit_and_publish_latency_ms("stream_load",
                                                                   "commit_and_publish_ms");
 
 static constexpr size_t MIN_CHUNK_SIZE = 64 * 1024;
+static constexpr size_t MEBIBYTE = 1024 * 1024;
 static const std::string CHUNK = "chunked";
 static const std::string OFF_MODE = "off_mode";
 static const std::string SYNC_MODE = "sync_mode";
@@ -311,9 +312,10 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
 
     // check content length
     ctx->body_bytes = 0;
-    size_t csv_max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
+    const auto csv_max_body_mb = config::streaming_load_max_mb;
+    size_t csv_max_body_bytes = csv_max_body_mb * MEBIBYTE;
     const auto json_max_body_mb = config::streaming_load_json_max_mb;
-    size_t json_max_body_bytes = json_max_body_mb * 1024 * 1024;
+    size_t json_max_body_bytes = json_max_body_mb * MEBIBYTE;
     bool read_json_by_line = false;
     if (!http_req->header(HTTP_READ_JSON_BY_LINE).empty()) {
         if (iequal(http_req->header(HTTP_READ_JSON_BY_LINE), "true")) {
@@ -331,18 +333,19 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if ((ctx->format == TFileFormatType::FORMAT_JSON) &&
             (ctx->body_bytes > json_max_body_bytes) && !read_json_by_line) {
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "json body size {} bytes exceeds the limit of {} bytes set by BE config "
-                    "`streaming_load_json_max_mb` (currently {} MB). Increase it if you are sure "
+                    "json body size {:.2f} MiB exceeds the limit of {} MiB set by BE config "
+                    "`streaming_load_json_max_mb`. Increase it if you are sure "
                     "this load is reasonable",
-                    ctx->body_bytes, json_max_body_bytes, json_max_body_mb);
+                    static_cast<double>(ctx->body_bytes) / MEBIBYTE, json_max_body_mb);
         }
         // csv max body size
         else if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {} exceed BE's conf `streaming_load_max_mb` {}. increase it if you "
+                    "body size {:.2f} MiB exceeds the limit of {} MiB set by BE config "
+                    "`streaming_load_max_mb`. Increase it if you "
                     "are sure this load is reasonable",
-                    ctx->body_bytes, csv_max_body_bytes);
+                    static_cast<double>(ctx->body_bytes) / MEBIBYTE, csv_max_body_mb);
         }
     } else {
 #ifndef BE_TEST

--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -333,8 +333,8 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if ((ctx->format == TFileFormatType::FORMAT_JSON) &&
             (ctx->body_bytes > json_max_body_bytes) && !read_json_by_line) {
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "json body size {:.2f} MiB exceeds the limit of {} MiB set by BE config "
-                    "`streaming_load_json_max_mb`. Increase it if you are sure "
+                    "json body size {:.2f} MiB exceeds the limit of {} MiB set by BE's conf "
+                    "streaming_load_json_max_mb. Increase it if you are sure "
                     "this load is reasonable",
                     static_cast<double>(ctx->body_bytes) / MEBIBYTE, json_max_body_mb);
         }
@@ -342,8 +342,8 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         else if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {:.2f} MiB exceeds the limit of {} MiB set by BE config "
-                    "`streaming_load_max_mb`. Increase it if you "
+                    "body size {:.2f} MiB exceeds the limit of {} MiB set by BE's conf "
+                    "streaming_load_max_mb. Increase it if you "
                     "are sure this load is reasonable",
                     static_cast<double>(ctx->body_bytes) / MEBIBYTE, csv_max_body_mb);
         }

--- a/be/test/service/http/stream_load_test.cpp
+++ b/be/test/service/http/stream_load_test.cpp
@@ -127,7 +127,7 @@ TEST_F(StreamLoadTest, TestHeader) {
     }
 }
 
-TEST_F(StreamLoadTest, JsonBodySizeLimitErrorUsesMiB) {
+TEST_F(StreamLoadTest, JsonBodySizeLimitPlusOneErrorIncludesExactBytes) {
     const auto original_json_max_mb = config::streaming_load_json_max_mb;
     Defer restore_json_max_mb {
             [original_json_max_mb] { config::streaming_load_json_max_mb = original_json_max_mb; }};
@@ -137,7 +137,7 @@ TEST_F(StreamLoadTest, JsonBodySizeLimitErrorUsesMiB) {
     HttpRequest req(evhttp_req);
     req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
     req.set_header(HTTP_FORMAT_KEY, "json");
-    req.set_header(HttpHeaders::CONTENT_LENGTH, "113403999");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
 
     StreamLoadAction action(nullptr);
     auto ctx = std::make_shared<StreamLoadContext>(nullptr);
@@ -145,12 +145,13 @@ TEST_F(StreamLoadTest, JsonBodySizeLimitErrorUsesMiB) {
 
     EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
     EXPECT_EQ(status.to_string_no_stack(),
-              "[E-217]json body size 108.15 MiB exceeds the limit of 100 MiB set by BE's conf "
-              "streaming_load_json_max_mb. Increase it if you are sure this load is reasonable");
+              "[E-217]json body size 104857601 bytes (100.00 MiB) exceeds the limit of 104857600 "
+              "bytes (100 MiB) set by BE's conf streaming_load_json_max_mb. Increase it if you "
+              "are sure this load is reasonable");
     evhttp_request_free(evhttp_req);
 }
 
-TEST_F(StreamLoadTest, CsvBodySizeLimitErrorUsesMiB) {
+TEST_F(StreamLoadTest, CsvBodySizeLimitPlusOneErrorIncludesExactBytes) {
     const auto original_max_mb = config::streaming_load_max_mb;
     Defer restore_max_mb {[original_max_mb] { config::streaming_load_max_mb = original_max_mb; }};
     config::streaming_load_max_mb = 100;
@@ -159,7 +160,7 @@ TEST_F(StreamLoadTest, CsvBodySizeLimitErrorUsesMiB) {
     HttpRequest req(evhttp_req);
     req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
     req.set_header(HTTP_FORMAT_KEY, "csv");
-    req.set_header(HttpHeaders::CONTENT_LENGTH, "113403999");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
 
     StreamLoadAction action(nullptr);
     auto ctx = std::make_shared<StreamLoadContext>(nullptr);
@@ -167,12 +168,13 @@ TEST_F(StreamLoadTest, CsvBodySizeLimitErrorUsesMiB) {
 
     EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
     EXPECT_EQ(status.to_string_no_stack(),
-              "[E-217]body size 108.15 MiB exceeds the limit of 100 MiB set by BE's conf "
-              "streaming_load_max_mb. Increase it if you are sure this load is reasonable");
+              "[E-217]body size 104857601 bytes (100.00 MiB) exceeds the limit of 104857600 bytes "
+              "(100 MiB) set by BE's conf streaming_load_max_mb. Increase it if you are sure this "
+              "load is reasonable");
     evhttp_request_free(evhttp_req);
 }
 
-TEST_F(StreamLoadTest, HttpStreamBodySizeLimitErrorUsesMiB) {
+TEST_F(StreamLoadTest, HttpStreamBodySizeLimitPlusOneErrorIncludesExactBytes) {
     const auto original_max_mb = config::streaming_load_max_mb;
     Defer restore_max_mb {[original_max_mb] { config::streaming_load_max_mb = original_max_mb; }};
     config::streaming_load_max_mb = 100;
@@ -180,7 +182,7 @@ TEST_F(StreamLoadTest, HttpStreamBodySizeLimitErrorUsesMiB) {
     auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
     HttpRequest req(evhttp_req);
     req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-    req.set_header(HttpHeaders::CONTENT_LENGTH, "113403999");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
 
     HttpStreamAction action(nullptr);
     auto ctx = std::make_shared<StreamLoadContext>(nullptr);
@@ -188,8 +190,9 @@ TEST_F(StreamLoadTest, HttpStreamBodySizeLimitErrorUsesMiB) {
 
     EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
     EXPECT_EQ(status.to_string_no_stack(),
-              "[E-217]body size 108.15 MiB exceeds the limit of 100 MiB set by BE config "
-              "`streaming_load_max_mb`. Increase it if you are sure this load is reasonable");
+              "[E-217]body size 104857601 bytes (100.00 MiB) exceeds the limit of 104857600 bytes "
+              "(100 MiB) set by BE config `streaming_load_max_mb`. Increase it if you are sure "
+              "this load is reasonable");
     evhttp_request_free(evhttp_req);
 }
 } // namespace doris

--- a/be/test/service/http/stream_load_test.cpp
+++ b/be/test/service/http/stream_load_test.cpp
@@ -145,8 +145,8 @@ TEST_F(StreamLoadTest, JsonBodySizeLimitErrorUsesMiB) {
 
     EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
     EXPECT_EQ(status.to_string_no_stack(),
-              "[E-217]json body size 108.15 MiB exceeds the limit of 100 MiB set by BE config "
-              "`streaming_load_json_max_mb`. Increase it if you are sure this load is reasonable");
+              "[E-217]json body size 108.15 MiB exceeds the limit of 100 MiB set by BE's conf "
+              "streaming_load_json_max_mb. Increase it if you are sure this load is reasonable");
     evhttp_request_free(evhttp_req);
 }
 
@@ -167,8 +167,8 @@ TEST_F(StreamLoadTest, CsvBodySizeLimitErrorUsesMiB) {
 
     EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
     EXPECT_EQ(status.to_string_no_stack(),
-              "[E-217]body size 108.15 MiB exceeds the limit of 100 MiB set by BE config "
-              "`streaming_load_max_mb`. Increase it if you are sure this load is reasonable");
+              "[E-217]body size 108.15 MiB exceeds the limit of 100 MiB set by BE's conf "
+              "streaming_load_max_mb. Increase it if you are sure this load is reasonable");
     evhttp_request_free(evhttp_req);
 }
 

--- a/be/test/service/http/stream_load_test.cpp
+++ b/be/test/service/http/stream_load_test.cpp
@@ -28,6 +28,7 @@
 #include "event2/http_struct.h"
 #include "evhttp.h"
 #include "load/group_commit/wal/wal_manager.h"
+#include "load/stream_load/stream_load_context.h"
 #include "runtime/exec_env.h"
 #include "service/http/ev_http_server.h"
 #include "service/http/http_channel.h"
@@ -37,6 +38,7 @@
 #include "service/http/http_headers.h"
 #include "service/http/http_request.h"
 #include "service/http/utils.h"
+#include "util/defer_op.h"
 
 namespace doris {
 
@@ -122,5 +124,29 @@ TEST_F(StreamLoadTest, TestHeader) {
         evhttp_req->uri_elems = nullptr;
         evhttp_request_free(evhttp_req);
     }
+}
+
+TEST_F(StreamLoadTest, JsonBodySizeLimitErrorIncludesUnits) {
+    const auto original_json_max_mb = config::streaming_load_json_max_mb;
+    Defer restore_json_max_mb {
+            [original_json_max_mb] { config::streaming_load_json_max_mb = original_json_max_mb; }};
+    config::streaming_load_json_max_mb = 100;
+
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req.set_header(HTTP_FORMAT_KEY, "json");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "113403999");
+
+    StreamLoadAction action(nullptr);
+    auto ctx = std::make_shared<StreamLoadContext>(nullptr);
+    auto status = action._on_header(&req, ctx);
+
+    EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
+    EXPECT_EQ(status.to_string_no_stack(),
+              "[E-217]json body size 113403999 bytes exceeds the limit of 104857600 bytes set by "
+              "BE config `streaming_load_json_max_mb` (currently 100 MB). Increase it if you are "
+              "sure this load is reasonable");
+    evhttp_request_free(evhttp_req);
 }
 } // namespace doris

--- a/be/test/service/http/stream_load_test.cpp
+++ b/be/test/service/http/stream_load_test.cpp
@@ -30,6 +30,7 @@
 #include "load/group_commit/wal/wal_manager.h"
 #include "load/stream_load/stream_load_context.h"
 #include "runtime/exec_env.h"
+#include "service/http/action/http_stream.h"
 #include "service/http/ev_http_server.h"
 #include "service/http/http_channel.h"
 #include "service/http/http_common.h"
@@ -126,7 +127,7 @@ TEST_F(StreamLoadTest, TestHeader) {
     }
 }
 
-TEST_F(StreamLoadTest, JsonBodySizeLimitErrorIncludesUnits) {
+TEST_F(StreamLoadTest, JsonBodySizeLimitErrorUsesMiB) {
     const auto original_json_max_mb = config::streaming_load_json_max_mb;
     Defer restore_json_max_mb {
             [original_json_max_mb] { config::streaming_load_json_max_mb = original_json_max_mb; }};
@@ -144,9 +145,51 @@ TEST_F(StreamLoadTest, JsonBodySizeLimitErrorIncludesUnits) {
 
     EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
     EXPECT_EQ(status.to_string_no_stack(),
-              "[E-217]json body size 113403999 bytes exceeds the limit of 104857600 bytes set by "
-              "BE config `streaming_load_json_max_mb` (currently 100 MB). Increase it if you are "
-              "sure this load is reasonable");
+              "[E-217]json body size 108.15 MiB exceeds the limit of 100 MiB set by BE config "
+              "`streaming_load_json_max_mb`. Increase it if you are sure this load is reasonable");
+    evhttp_request_free(evhttp_req);
+}
+
+TEST_F(StreamLoadTest, CsvBodySizeLimitErrorUsesMiB) {
+    const auto original_max_mb = config::streaming_load_max_mb;
+    Defer restore_max_mb {[original_max_mb] { config::streaming_load_max_mb = original_max_mb; }};
+    config::streaming_load_max_mb = 100;
+
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req.set_header(HTTP_FORMAT_KEY, "csv");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "113403999");
+
+    StreamLoadAction action(nullptr);
+    auto ctx = std::make_shared<StreamLoadContext>(nullptr);
+    auto status = action._on_header(&req, ctx);
+
+    EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
+    EXPECT_EQ(status.to_string_no_stack(),
+              "[E-217]body size 108.15 MiB exceeds the limit of 100 MiB set by BE config "
+              "`streaming_load_max_mb`. Increase it if you are sure this load is reasonable");
+    evhttp_request_free(evhttp_req);
+}
+
+TEST_F(StreamLoadTest, HttpStreamBodySizeLimitErrorUsesMiB) {
+    const auto original_max_mb = config::streaming_load_max_mb;
+    Defer restore_max_mb {[original_max_mb] { config::streaming_load_max_mb = original_max_mb; }};
+    config::streaming_load_max_mb = 100;
+
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "113403999");
+
+    HttpStreamAction action(nullptr);
+    auto ctx = std::make_shared<StreamLoadContext>(nullptr);
+    auto status = action._on_header(&req, ctx);
+
+    EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
+    EXPECT_EQ(status.to_string_no_stack(),
+              "[E-217]body size 108.15 MiB exceeds the limit of 100 MiB set by BE config "
+              "`streaming_load_max_mb`. Increase it if you are sure this load is reasonable");
     evhttp_request_free(evhttp_req);
 }
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Stream Load body-size limit errors display raw byte counts next to BE configuration items whose names and values are expressed in MB, making the message misleading. Report both the actual body size and configured limit in MiB for JSON Stream Load, CSV Stream Load, and HTTP Stream. The limit calculation and rejection behavior are unchanged.

### Release note

Report Stream Load body-size limit errors consistently in MiB.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

    ./run-be-ut.sh --run --filter=StreamLoadTest.* -j48 (4 tests passed)

- Behavior changed:
    - [ ] No.
    - [x] Yes. JSON and CSV Stream Load size-limit errors now display both values in MiB.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label