### PR TITLE
[fix](job scheduler) Record task finish time on execution failure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
@@ -71,6 +71,7 @@ public abstract class AbstractTask implements Task {
             return false;
         }
         status = TaskStatus.FAILED;
+        setFinishTimeMs(System.currentTimeMillis());
         if (!isCallable()) {
             return false;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/AbstractJobStatusTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/AbstractJobStatusTest.java
@@ -66,6 +66,18 @@ class AbstractJobStatusTest {
         }
     }
 
+    private static class FailingTask extends DummyTask {
+        FailingTask(long taskId) {
+            super(taskId);
+            setJobId(1L);
+        }
+
+        @Override
+        public void run() throws JobException {
+            throw new JobException("task failed");
+        }
+    }
+
     private static class DummyJob extends AbstractJob<DummyTask, Void> {
         private final List<DummyTask> history = new ArrayList<>();
 
@@ -129,6 +141,17 @@ class AbstractJobStatusTest {
         DummyJob job = new DummyJob(JobStatus.PAUSED);
         job.updateJobStatus(JobStatus.PENDING);
         Assertions.assertEquals(JobStatus.PENDING, job.getJobStatus());
+    }
+
+    @Test
+    void testTaskFailureSetsFinishTime() throws Exception {
+        FailingTask task = new FailingTask(100L);
+
+        task.runTask();
+
+        Assertions.assertEquals(TaskStatus.FAILED, task.getStatus());
+        Assertions.assertNotNull(task.getFinishTimeMs());
+        Assertions.assertEquals("task failed", task.getErrMsg());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

When a task fails through the execution exception path, `AbstractTask.runTask()` calls the no-argument `onFail()`, which marked the task FAILED without recording `finishTimeMs`. MTMV failed refresh tasks therefore exposed an empty FinishTime and could not calculate DurationMs.

relate PR:   #27703

### What changes were made?

- Record `finishTimeMs` when `AbstractTask.onFail()` transitions a task to FAILED.
- Add a regression unit test covering the `runTask()` exception path and preserving the error message.

### Testing

- `AbstractJobStatusTest`: 13 tests passed.