### PR TITLE
branch-4.1: [fix](test) bound recycler polling waits

### DIFF
--- a/regression-test/plugins/cloud_recycler_plugin.groovy
+++ b/regression-test/plugins/cloud_recycler_plugin.groovy
@@ -37,6 +37,48 @@ import org.apache.hadoop.fs.LocatedFileStatus
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.fs.RemoteIterator
 import org.apache.hadoop.security.UserGroupInformation
+import java.util.concurrent.atomic.AtomicBoolean
+
+// Keep the suite-wide guard below TeamCity's 24-hour limit while allowing check_meta's
+// intentional one-hour leak-check window and the existing 30-minute phase deadlines.
+Suite.metaClass.enableRecyclerCaseTimeout = { long timeoutMs = 2 * 60 * 60 * 1000L ->
+    Suite suite = delegate as Suite
+    if (timeoutMs <= 0) {
+        throw new IllegalArgumentException("Recycler case timeout must be positive: ${timeoutMs}")
+    }
+
+    Thread suiteThread = Thread.currentThread()
+    AtomicBoolean timedOut = new AtomicBoolean(false)
+    def watchdog = suite.extraThread("recycler-case-timeout-${suite.name}", true) {
+        try {
+            Thread.sleep(timeoutMs)
+            timedOut.set(true)
+            suite.getLogger().error(
+                    "Recycler case ${suite.name} timed out after ${timeoutMs / 1000}s; interrupting the suite thread")
+            suiteThread.interrupt()
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    suite.onSuccess { ignored ->
+        if (timedOut.get()) {
+            throw new IllegalStateException(
+                    "Recycler case ${suite.name} timed out after ${timeoutMs / 1000}s")
+        }
+    }
+    suite.onFail { ignored ->
+        if (timedOut.get()) {
+            throw new IllegalStateException(
+                    "Recycler case ${suite.name} timed out after ${timeoutMs / 1000}s")
+        }
+    }
+    suite.onFinish { ignored ->
+        watchdog.cancel(true)
+    }
+}
+
+logger.info("Added 'enableRecyclerCaseTimeout' function to Suite")
 
 Suite.metaClass.triggerRecycle = { String token, String instanceId /* param */ ->
     // which suite invoke current function?

--- a/regression-test/suites/cloud_p0/recycler/check_meta.groovy
+++ b/regression-test/suites/cloud_p0/recycler/check_meta.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite("check_meta", "check_meta") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId;

--- a/regression-test/suites/cloud_p0/recycler/check_meta.groovy
+++ b/regression-test/suites/cloud_p0/recycler/check_meta.groovy
@@ -24,6 +24,8 @@ suite("check_meta", "check_meta") {
     def status = 200
     def recyclerLastSuccessTime = -1
     def recyclerLastFinishTime = -1
+    def waitTimeoutMs = 30 * 60 * 1000L
+    def recyclerWaitDeadline = caseStartTime + waitTimeoutMs
 
     String jdbcUrl = context.config.jdbcUrl
     String urlWithoutSchema = jdbcUrl.substring(jdbcUrl.indexOf("://") + 3)
@@ -88,6 +90,12 @@ suite("check_meta", "check_meta") {
         logger.info("caseStartTime=${caseStartTime}, recyclerLastSuccessTime=${recyclerLastSuccessTime}")
         if (recyclerLastSuccessTime > caseStartTime) {
             break
+        }
+        if (System.currentTimeMillis() >= recyclerWaitDeadline) {
+            throw new IllegalStateException(
+                    "Timed out waiting for recycler job after ${waitTimeoutMs / 1000}s: " +
+                    "caseStartTime=${caseStartTime}, recyclerLastFinishTime=${recyclerLastFinishTime}, " +
+                    "recyclerLastSuccessTime=${recyclerLastSuccessTime}")
         }
     } while (true)
     assertEquals(recyclerLastFinishTime, recyclerLastSuccessTime)

--- a/regression-test/suites/cloud_p0/recycler/test_checker.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_checker.groovy
@@ -41,6 +41,8 @@ import com.azure.storage.common.StorageSharedKeyCredential
 import java.time.Duration
 
 suite("test_checker") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId;

--- a/regression-test/suites/cloud_p0/recycler/test_checker.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_checker.groovy
@@ -180,6 +180,9 @@ suite("test_checker") {
         // Make sure to complete at least one round of checking
         def checkerLastSuccessTime = -1
         def checkerLastFinishTime = -1
+        def waitTimeoutMs = 30 * 60 * 1000L
+        def checkerWaitStartTime = System.currentTimeMillis()
+        def checkerWaitDeadline = checkerWaitStartTime + waitTimeoutMs
 
         def triggerChecker = {
             def triggerCheckerApi = { checkFunc ->
@@ -232,6 +235,12 @@ suite("test_checker") {
             logger.info("checkerLastFinishTime=${checkerLastFinishTime}, checkerLastSuccessTime=${checkerLastSuccessTime}")
             if (checkerLastFinishTime > caseStartTime) {
                 break
+            }
+            if (System.currentTimeMillis() >= checkerWaitDeadline) {
+                throw new IllegalStateException(
+                        "Timed out waiting for checker job after ${waitTimeoutMs / 1000}s: " +
+                        "caseStartTime=${caseStartTime}, checkerLastFinishTime=${checkerLastFinishTime}, " +
+                        "checkerLastSuccessTime=${checkerLastSuccessTime}")
             }
         } while (true)
         assertTrue(checkerLastSuccessTime < checkerLastFinishTime) // Check MUST fail

--- a/regression-test/suites/cloud_p0/recycler/test_recycler.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler.groovy
@@ -25,6 +25,8 @@ suite("test_recycler") {
     def caseStartTime = System.currentTimeMillis()
     def recyclerLastSuccessTime = -1
     def recyclerLastFinishTime = -1
+    def waitTimeoutMs = 30 * 60 * 1000L
+    def recyclerWaitDeadline = caseStartTime + waitTimeoutMs
 
     // Make sure to complete at least one round of recycling
     def getRecycleJobInfo = {
@@ -61,6 +63,12 @@ suite("test_recycler") {
         if (recyclerLastFinishTime > caseStartTime) {
             break
         }
+        if (System.currentTimeMillis() >= recyclerWaitDeadline) {
+            throw new IllegalStateException(
+                    "Timed out waiting for recycler job after ${waitTimeoutMs / 1000}s: " +
+                    "caseStartTime=${caseStartTime}, recyclerLastFinishTime=${recyclerLastFinishTime}, " +
+                    "recyclerLastSuccessTime=${recyclerLastSuccessTime}")
+        }
     } while (true)
     assertEquals(recyclerLastFinishTime, recyclerLastSuccessTime)
 
@@ -86,6 +94,8 @@ suite("test_recycler") {
     // Make sure to complete at least one round of checking
     def checkerLastSuccessTime = -1
     def checkerLastFinishTime = -1
+    def checkerWaitStartTime = System.currentTimeMillis()
+    def checkerWaitDeadline = checkerWaitStartTime + waitTimeoutMs
 
     def triggerChecker = {
         def triggerCheckerApi = { checkFunc ->
@@ -138,6 +148,13 @@ suite("test_recycler") {
         logger.info("checkerLastFinishTime=${checkerLastFinishTime}, checkerLastSuccessTime=${checkerLastSuccessTime}")
         if (checkerLastSuccessTime > recyclerLastSuccessTime) {
             break
+        }
+        if (System.currentTimeMillis() >= checkerWaitDeadline) {
+            throw new IllegalStateException(
+                    "Timed out waiting for checker job after ${waitTimeoutMs / 1000}s: " +
+                    "recyclerLastSuccessTime=${recyclerLastSuccessTime}, " +
+                    "checkerLastFinishTime=${checkerLastFinishTime}, " +
+                    "checkerLastSuccessTime=${checkerLastSuccessTime}")
         }
     } while (true)
     assertEquals(checkerLastFinishTime, checkerLastSuccessTime)

--- a/regression-test/suites/cloud_p0/recycler/test_recycler.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_expired_stage_objects.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_expired_stage_objects.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_expired_stage_objects") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId
     def cloudUniqueId = context.config.cloudUniqueId

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_inverted_index.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_inverted_index.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_inverted_index") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_column.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_column.groovy
@@ -19,6 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 import java.util.stream.Collectors
 
 suite("test_recycler_with_drop_column") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_db.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_db.groovy
@@ -21,6 +21,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_drop_db") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
@@ -130,4 +132,3 @@ suite("test_recycler_with_drop_db") {
     } while (retry--)
     assertTrue(success)
 }
-

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_index.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_index.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_drop_index") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_multi_db.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_multi_db.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_drop_multi_db") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
@@ -142,4 +144,3 @@ suite("test_recycler_with_drop_multi_db") {
         assertTrue(success)
     }
 }
-

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_mv.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_mv.groovy
@@ -19,6 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 import java.util.stream.Collectors
 
 suite("test_recycler_with_drop_mv") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_partition.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_partition.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_drop_partition") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_rollup.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_drop_rollup.groovy
@@ -19,6 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 import java.util.stream.Collectors
 
 suite("test_recycler_with_drop_rollup") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_dynamic_partition.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_dynamic_partition.groovy
@@ -17,6 +17,8 @@
 import java.text.SimpleDateFormat;
 
 suite("test_recycler_with_dynamic_partition") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_internal_copy.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_internal_copy.groovy
@@ -17,6 +17,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_internal_copy") {
+    enableRecyclerCaseTimeout()
+
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;
     def cloudUniqueId = context.config.cloudUniqueId

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_many_partitions.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_many_partitions.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_many_partitions") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_schema_change.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_schema_change.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_schema_change") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_truncate_table.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_truncate_table.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_truncate_table") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;

--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_txn_label.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_txn_label.groovy
@@ -18,6 +18,8 @@ import groovy.json.JsonOutput
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("test_recycler_with_txn_label") {
+    enableRecyclerCaseTimeout()
+
     // create table
     def token = "greedisgood9999"
     def instanceId = context.config.instanceId;


### PR DESCRIPTION
## What changed

Add two layers of timeout protection to `cloud_p0/recycler`:

- Every one of the 18 Recycler suites now enables a suite-wide 2-hour watchdog through `enableRecyclerCaseTimeout()`.
- The four previously unbounded Recycler/Checker polling phases keep their more specific 30-minute deadlines and timestamp-rich failure messages.

The watchdog interrupts the suite thread when its deadline expires. It also checks both success and failure callbacks, so a suite cannot be reported successful after the watchdog has fired. Existing retry limits and success conditions are unchanged.

The 2-hour suite limit is intentionally below TeamCity’s 24-hour build timeout while preserving `check_meta`’s one-hour leak-check window plus the existing 30-minute Recycler phase deadline.

## Why

The branch-4.1 Recycler pipeline has repeatedly remained inside a polling wait with no test occurrence until TeamCity terminated the build after 1440 minutes (for example, builds 204533 and 204268).

The original change bounded the four known infinite loops. The suite-level watchdog now also covers the other Recycler cases and protects against future unbounded waits outside those loops, including sleeps or calls that honor thread interruption.

This does not suppress a Recycler or Checker failure and does not relax any assertion. It turns a stuck case into an actionable timeout before the whole build reaches the 24-hour limit.

## Validation

- `git diff --check`
- Groovy parser accepted the Recycler plugin and all 18 Recycler suite files
- Verified 18/18 Recycler suite files call `enableRecyclerCaseTimeout()`
- Verified all four unbounded polling loops retain their local timeout guards
- Full framework Maven compilation was attempted but the isolated checkout lacks generated `org.apache.doris.thrift` classes; compilation stopped on those pre-existing missing generated sources before exercising this script-only change

Related: DORIS-27416