### PR TITLE
  [fix](metacache) Repair external metadata ID mapping during refresh

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
@@ -94,20 +94,23 @@ public class MetaCache<T> {
 
     public Optional<T> getMetaObj(String name, long id) {
         Optional<T> val = metaObjCache.getIfPresent(name);
-        if (val == null || !val.isPresent()) {
-            synchronized (metaObjCache) {
-                val = metaObjCache.getIfPresent(name);
-                if (val != null && val.isPresent()) {
-                    return val;
-                }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("trigger getMetaObj in metacache {}, obj name: {}, id: {}",
-                            this.name, name, id, new Exception());
-                }
-                metaObjCache.invalidate(name);
-                val = metaObjCache.get(name);
+        if (val != null && val.isPresent()) {
+            idToName.put(id, name);
+            return val;
+        }
+        synchronized (metaObjCache) {
+            val = metaObjCache.getIfPresent(name);
+            if (val != null && val.isPresent()) {
                 idToName.put(id, name);
+                return val;
             }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("trigger getMetaObj in metacache {}, obj name: {}, id: {}",
+                        this.name, name, id, new Exception());
+            }
+            metaObjCache.invalidate(name);
+            val = metaObjCache.get(name);
+            idToName.put(id, name);
         }
         return val;
     }
@@ -160,8 +163,10 @@ public class MetaCache<T> {
         if (LOG.isDebugEnabled()) {
             LOG.debug("invalidate all in metacache {}", name, new Exception());
         }
-        metaObjCache.invalidateAll();
+        // Clear the reverse mapping first. A concurrent name-based load may then rebuild it, and its new mapping
+        // must not be erased after the corresponding object has already been inserted into metaObjCache.
         idToName.clear();
+        metaObjCache.invalidateAll();
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
@@ -163,9 +163,10 @@ public class MetaCache<T> {
         if (LOG.isDebugEnabled()) {
             LOG.debug("invalidate all in metacache {}", name, new Exception());
         }
-        // Clear the reverse mapping first. A concurrent name-based load may then rebuild it, and its new mapping
-        // must not be erased after the corresponding object has already been inserted into metaObjCache.
         idToName.clear();
+        // Clear idToName before invalidating metaObjCache. While metaObjCache is being invalidated,
+        // a concurrent getMetaObj(name, id) may reload the object and repopulate idToName.
+        // Do not clear idToName afterward, or the reloaded object can no longer be found by ID.
         metaObjCache.invalidateAll();
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/MetaCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/MetaCacheTest.java
@@ -34,7 +34,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class MetaCacheTest {
 
@@ -103,6 +105,42 @@ public class MetaCacheTest {
         Assert.assertEquals("meta3", metaObj.get());
 
         Assert.assertFalse(metaCache.getMetaObjById(99L).isPresent());
+    }
+
+    @Test
+    public void testGetMetaObjRepairsIdMappingOnNameCacheHit() {
+        metaCache.getMetaObjCache().put("local1", Optional.of("meta1"));
+        Assert.assertFalse(metaCache.getMetaObjById(1L).isPresent());
+
+        Assert.assertEquals("meta1", metaCache.getMetaObj("local1", 1L).get());
+        Assert.assertEquals("meta1", metaCache.getMetaObjById(1L).get());
+    }
+
+    @Test
+    public void testInvalidateAllKeepsMappingReloadedByRemovalListener() {
+        AtomicReference<MetaCache<String>> cacheRef = new AtomicReference<>();
+        AtomicBoolean reloadOnRemoval = new AtomicBoolean(false);
+        MetaCache<String> testCache = new MetaCache<>(
+                "testCache",
+                Executors.newCachedThreadPool(),
+                OptionalLong.of(1),
+                OptionalLong.of(1),
+                100,
+                key -> Lists.newArrayList(),
+                key -> Optional.of("reloaded_" + key),
+                (key, value, cause) -> {
+                    if (reloadOnRemoval.get()) {
+                        cacheRef.get().getMetaObj(key, 1L);
+                    }
+                }
+        );
+        cacheRef.set(testCache);
+        testCache.updateCache("remote1", "local1", "meta1", 1L);
+
+        reloadOnRemoval.set(true);
+        testCache.invalidateAll();
+
+        Assert.assertEquals("reloaded_local1", testCache.getMetaObjById(1L).get());
     }
 
     @Test


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: A full external catalog refresh invalidates the name-to-object cache and the ID-to-name mapping separately. A concurrent name lookup can reload an object after object invalidation but before the reverse mapping is cleared, leaving later ID-based metadata lookups unable to find an existing table. In addition, a name-cache hit did not repair a missing reverse mapping. Clear the reverse mapping before invalidating cached objects, and restore the mapping whenever a name lookup hits an existing cached object. ExternalRowCountCache remains unchanged and continues to use IDs only.

### Release note

Fix transient external table row-count lookup failures during catalog metadata refresh.

### Check List (For Author)

- Test: Unit Test
  - ./run-fe-ut.sh --run org.apache.doris.datasource.MetaCacheTest,org.apache.doris.datasource.ExternalRowCountCacheTest,org.apache.doris.datasource.metacache.MetaCacheDeadlockTest
  - mvn checkstyle:check -pl fe-core
- Behavior changed: Yes. Name-based external metadata cache hits repair the ID-to-name mapping, and refresh preserves mappings rebuilt during invalidation.
- Does this need documentation: No
