### PR TITLE
branch-4.0: [fix](hive) invalidate stale file cache on partition refresh when partition cache misses #65334

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -529,21 +529,40 @@ public class HiveMetaStoreCache {
     }
 
     public void invalidatePartitionCache(ExternalTable dorisTable, String partitionName) {
-        NameMapping nameMapping = dorisTable.getOrBuildNameMapping();
+        invalidatePartitionCache(dorisTable.getOrBuildNameMapping(), partitionName);
+    }
+
+    public void invalidatePartitionCache(NameMapping nameMapping, String partitionName) {
         long id = Util.genIdByName(nameMapping.getLocalDbName(), nameMapping.getLocalTblName());
-        PartitionValueCacheKey key = new PartitionValueCacheKey(nameMapping, null);
-        HivePartitionValues partitionValues = partitionValuesCache.getIfPresent(key);
-        if (partitionValues != null) {
-            Long partitionId = partitionValues.partitionNameToIdMap.get(partitionName);
-            List<String> values = partitionValues.partitionValuesMap.get(partitionId);
-            PartitionCacheKey partKey = new PartitionCacheKey(nameMapping, values);
-            HivePartition partition = partitionCache.getIfPresent(partKey);
-            if (partition != null) {
-                fileCacheRef.get().invalidate(new FileCacheKey(id, partition.getPath(),
-                        null, partition.getPartitionValues()));
-                partitionCache.invalidate(partKey);
-            }
+        // Derive the partition values directly from the partition name (the partition-values cache is
+        // populated the same way, via HiveUtil.toPartitionValues) instead of reading them from that
+        // cache, so file cache invalidation still runs when the table's partition-values cache entry has
+        // been evicted while its file listings are still cached.
+        List<String> values = HiveUtil.toPartitionValues(partitionName);
+
+        PartitionCacheKey partKey = new PartitionCacheKey(nameMapping, values);
+        HivePartition partition = partitionCache.getIfPresent(partKey);
+        LoadingCache<FileCacheKey, FileCacheValue> fileCache = fileCacheRef.get();
+        if (partition == null) {
+            // Partition metadata cache miss: the exact FileCacheKey cannot be rebuilt here because it
+            // needs the partition path and input format carried by HivePartition. Invalidate this
+            // table's cached file listings for the partition by (table id + partition values). Scoping
+            // by table id is intentional: matching partition values alone would also drop other tables'
+            // listings that merely share the same partition value names (e.g. dt=...) at a different
+            // location, forcing needless re-listing. The exact-key path below (taken when the partition
+            // is cached) already clears a listing regardless of which table id populated it.
+            fileCache.asMap().keySet().forEach(k -> {
+                if (k.isSameTable(id) && Objects.equals(k.getPartitionValues(), values)) {
+                    fileCache.invalidate(k);
+                }
+            });
+            partitionCache.invalidate(partKey);
+            return;
         }
+
+        fileCache.invalidate(new FileCacheKey(id, partition.getPath(),
+                null, partition.getPartitionValues()));
+        partitionCache.invalidate(partKey);
     }
 
     /**
@@ -593,7 +612,7 @@ public class HiveMetaStoreCache {
 
         // Invalidate cache for modified partitions (both partition cache and file cache)
         for (String partitionName : modifiedPartNames) {
-            invalidatePartitionCache(table, partitionName);
+            invalidatePartitionCache(table.getOrBuildNameMapping(), partitionName);
         }
         // Merge modifiedPartNames and newPartNames
         // Case:
@@ -700,7 +719,7 @@ public class HiveMetaStoreCache {
             partitionValuesMap.remove(partitionId);
 
             if (invalidPartitionCache) {
-                invalidatePartitionCache(dorisTable, partitionName);
+                invalidatePartitionCache(nameMapping, partitionName);
             }
         }
         // Rebuild sorted partition ranges after dropping partitions

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveMetaStoreCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveMetaStoreCacheTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class HiveMetaStoreCacheTest {
@@ -68,6 +70,64 @@ public class HiveMetaStoreCacheTest {
         Assertions.assertEquals(0, fileCache.asMap().size());
         Assertions.assertEquals(0, partitionCache.asMap().size());
         Assertions.assertEquals(0, partitionValuesCache.asMap().size());
+    }
+
+    @Test
+    public void testInvalidatePartitionCacheClearsStaleFileCacheOnPartitionMiss() {
+        ThreadPoolExecutor executor = ThreadPoolManager.newDaemonFixedThreadPool(
+                1, 1, "refresh", 1, false);
+        ThreadPoolExecutor listExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+                1, 1, "file", 1, false);
+        try {
+            HiveMetaStoreCache cache = new HiveMetaStoreCache(
+                    new HMSExternalCatalog(1L, "catalog", null, new HashMap<>(), null), executor, listExecutor);
+            LoadingCache<HiveMetaStoreCache.FileCacheKey, HiveMetaStoreCache.FileCacheValue> fileCache =
+                    cache.getFileCacheRef().get();
+
+            String dbName = "db";
+            String tbName = "tb";
+            NameMapping nameMapping = NameMapping.createForTest(dbName, tbName);
+            long tableId = Util.genIdByName(dbName, tbName);
+            long otherTableId = Util.genIdByName(dbName, "tb2");
+
+            String targetPartName = "dt=2024-01-01";
+            List<String> targetValues = Collections.singletonList("2024-01-01");
+            String otherPartName = "dt=2024-01-02";
+            List<String> otherValues = Collections.singletonList("2024-01-02");
+
+            // Neither the `partition` cache nor the `partition_values` cache is populated for this table,
+            // simulating entries that were evicted or never loaded. invalidatePartitionCache must still
+            // clear the stale file listing: it derives the partition values from the partition name and
+            // cannot rebuild the exact FileCacheKey (which needs the partition path / input format).
+            HiveMetaStoreCache.FileCacheKey targetFileKey = new HiveMetaStoreCache.FileCacheKey(
+                    tableId, "/wh/db/tb/" + targetPartName, "orc", targetValues);
+            // Same table, a different partition -> must be kept.
+            HiveMetaStoreCache.FileCacheKey otherPartFileKey = new HiveMetaStoreCache.FileCacheKey(
+                    tableId, "/wh/db/tb/" + otherPartName, "orc", otherValues);
+            // A different table that merely shares the same partition value names at a different location
+            // -> must be kept (the fallback is intentionally scoped by table id, not by values alone).
+            HiveMetaStoreCache.FileCacheKey otherTableFileKey = new HiveMetaStoreCache.FileCacheKey(
+                    otherTableId, "/wh/db/tb2/" + targetPartName, "orc", targetValues);
+            fileCache.put(targetFileKey, new HiveMetaStoreCache.FileCacheValue());
+            fileCache.put(otherPartFileKey, new HiveMetaStoreCache.FileCacheValue());
+            fileCache.put(otherTableFileKey, new HiveMetaStoreCache.FileCacheValue());
+            Assertions.assertEquals(3, fileCache.asMap().size());
+
+            // Partition-level refresh for the target partition. Even though its `partition` cache entry
+            // is missing, the stale file listing for that partition must still be invalidated.
+            cache.invalidatePartitionCache(nameMapping, targetPartName);
+
+            Assertions.assertNull(fileCache.getIfPresent(targetFileKey),
+                    "stale file cache for the refreshed partition must be cleared even on partition cache miss");
+            Assertions.assertNotNull(fileCache.getIfPresent(otherPartFileKey),
+                    "file cache for other partitions of the same table must NOT be affected");
+            Assertions.assertNotNull(fileCache.getIfPresent(otherTableFileKey),
+                    "file cache for other tables sharing the same partition values must NOT be affected");
+            Assertions.assertEquals(2, fileCache.asMap().size());
+        } finally {
+            executor.shutdownNow();
+            listExecutor.shutdownNow();
+        }
     }
 
     private void putCache(


### PR DESCRIPTION
### What problem does this PR solve?

Cherry-pick from master #65334.

Problem Summary:

Partition-level refresh / invalidation (`HiveMetaStoreCache.invalidatePartitionCache`) returned early when the target partition was absent from the partition metadata cache — evicted under `max_hive_partition_cache_num` pressure, or simply never loaded — and left that partition's file listing cache untouched.

The partition cache (`partitionCache`) and the file listing cache (`fileCache`) are independent caches with independent size limits (`max_hive_partition_cache_num` vs `max_external_file_cache_num`) and evict separately, so the partition entry can be evicted while its file listing survives. In that state a partition-level refresh cannot rebuild the exact `FileCacheKey` (it needs the partition path / input format that only the cached `HivePartition` carries), so the old code gave up and the stale file listing remained. A later query would reload the partition metadata and re-hit the same stale file listing — i.e. "the partition exists, but Doris keeps seeing the old files/data".

Fix: when the exact `FileCacheKey` cannot be rebuilt, fall back to a predicate-based invalidation on the file cache keyed by `table id + partition values`, so the stale listing for that partition is cleared without over-invalidating other partitions. This mirrors table-level invalidation, which already invalidates the file cache by predicate.

The partition invalidation entry point is also decoupled from `ExternalTable` to `NameMapping` (mirroring the existing `invalidateTableCache(NameMapping)`) so the path can be unit tested directly.

This behavior has existed since partition-level invalidation was first introduced in #15702 (the file cache was only invalidated inside the `if (partition != null)` branch).

#### Backport notes

This is a manual port, not a clean cherry-pick, because branch-4.0 predates two master changes:

- **#60937 (external meta cache framework)** — branch-4.0 still has the legacy `HiveMetaStoreCache` rather than `HiveExternalMetaCache`, and has no `MetaCacheEntry.invalidateIf`. The predicate invalidation therefore walks `fileCache.asMap().keySet()`, exactly the way `invalidateTableCache` already does on this branch.
- **#64867 (key Hive partition cache by name)** — `HivePartitionValues` here is still keyed by local partition id (`partitionNameToIdMap` / `partitionValuesMap`) instead of master's `nameToPartitionValues`. Replacing that lookup with `HiveUtil.toPartitionValues(partitionName)` is behavior-preserving on the happy path: on this branch `partitionValuesMap` is built from `PartitionKey.createListPartitionKeyWithTypes(..., isHive=true)`, whose `getPartitionValuesAsStringList()` returns `originHiveKeys`, i.e. exactly the strings `HiveUtil.toPartitionValues(partitionName)` produced in the first place.

The unit test from #65334 was ported to the branch-4.0 cache API and verified to fail without the fix and pass with it.

### Release note

Fix a Hive external catalog consistency issue where a partition-level refresh could leave a stale file listing cached when the partition metadata cache had been evicted, causing queries to keep seeing outdated files for that partition.

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [ ] No.
    - [x] Yes. Partition-level refresh now also invalidates the file listing cache when the partition metadata cache entry is missing (previously it was left stale).

- Does this need documentation?
    - [x] No.
