### PR TITLE
[fix](regression) Stabilize initial rowset visibility check

### DIFF
--- a/regression-test/suites/query_p0/system/test_query_sys_rowsets.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_rowsets.groovy
@@ -45,8 +45,23 @@ suite("test_query_sys_rowsets", "query,p0") {
         );
     """
     
-    List<List<Object>> rowsets_table_name_tablets   = sql """ show tablets from ${rowsets_table_name} """
-    order_qt_rowsets1 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """ 
+    List<List<Object>> rowsets_table_name_tablets = sql """ show tablets from ${rowsets_table_name} """
+    def tabletId = rowsets_table_name_tablets[0][0]
+    logger.info("Tablet metadata after creation: ${rowsets_table_name_tablets}")
+    // information_schema.rowsets is a distributed BE snapshot. Retry the observation
+    // of the synchronously created initial rowset before validating the full result.
+    awaitUntil(30) {
+        def visibleRowsets = sql """
+            select BACKEND_ID, ROWSET_ID, START_VERSION, END_VERSION,
+                   CREATION_TIME, NEWEST_WRITE_TIMESTAMP
+            from information_schema.rowsets
+            where TABLET_ID = ${tabletId}
+        """
+        logger.info("Visible rowsets for tablet ${tabletId}: ${visibleRowsets}")
+        return visibleRowsets != null
+                && visibleRowsets.any { rowset -> rowset[2] == 0 && rowset[3] == 1 }
+    }
+    order_qt_rowsets1 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${tabletId}  group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """
     sql """ insert into  ${rowsets_table_name} values (1,0,"abc");  """ 
     order_qt_rowsets2 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  group by START_VERSION,END_VERSION order by START_VERSION,END_VERSION; """ 
     sql """ insert into  ${rowsets_table_name} values (2,1,"hello world");  """ 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary: `information_schema.rowsets` is a distributed BE snapshot and can briefly return an incomplete result immediately after table creation. The regression test queried it only once, so the initial `[0, 1]` rowset assertion could fail intermittently even though table creation had completed successfully.

### What is changed?

- Poll for up to 30 seconds until the system table observes the synchronously created `[0, 1]` rowset.
- Keep the existing golden query after the wait, so the expected result is not weakened.
- Log the tablet metadata and the observed BE rowset metadata to make any timeout diagnosable.
- Keep the later post-insert assertions synchronous so genuine publish-visibility regressions are still detected.

### Release note

None

### Check List (For Author)

- Test:
    - Regression test: `test_query_sys_rowsets` passed 50/50 consecutive runs on an isolated local cluster using the existing branch-4.1 FE/BE binaries.
    - Groovy compilation: `FileSystemCompiler regression-test/suites/query_p0/system/test_query_sys_rowsets.groovy` passed.
    - Static check: `git diff --check` passed.
- Behavior changed: No
- Does this need documentation: No
