### PR TITLE
[fix](test) handle Polaris one-shot init outside compose wait

### DIFF
--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -1653,7 +1653,11 @@ start_polaris() {
     register_stack_metadata "polaris" "${POLARIS_DIR}/docker-compose.yaml" ""
     compose_cmd "${POLARIS_DIR}/docker-compose.yaml" "" down --remove-orphans
     if [[ "${STOP}" -ne 1 ]]; then
-        compose_cmd "${POLARIS_DIR}/docker-compose.yaml" "" up -d --wait --remove-orphans
+        # polaris-init is a one-shot service. Keep it out of `up --wait`,
+        # otherwise Compose reports the successfully exited container as a
+        # failed stack startup.
+        compose_cmd "${POLARIS_DIR}/docker-compose.yaml" "" up -d --wait --remove-orphans polaris
+        compose_cmd "${POLARIS_DIR}/docker-compose.yaml" "" run --rm --no-deps polaris-init
     fi
 }
 


### PR DESCRIPTION
### What changed

Start the long-running Polaris service stack with `docker compose up -d --wait`, then run the `polaris-init` one-shot service separately with `docker compose run --rm --no-deps`.

### Why

The branch-4.1 scheduled External build 205163 finished with `FAILURE` before any tests ran. Its exact inputs were selectdb-qa `50242397c3686d443125266fd749f4d947744915` and Doris artifact `6fb81ea8331fe61e3f6470d4c47ce1f0a9b621bb`.

The first real deploy failure was Polaris: the long-running Polaris container became healthy and `polaris-init` completed successfully with exit code 0, but the top-level `docker compose up -d --wait` still returned exit code 1 because the one-shot service was no longer running. A later retry then failed in another third-party component, so the External suite produced zero test occurrences.

Separating the one-shot initializer preserves its exit-code check while letting Compose's wait gate cover only the long-running Polaris service and its dependencies.

### Validation

- `bash -n docker/thirdparties/run-thirdparties-docker.sh`
- `git diff --check`

Runtime validation should rerun the branch-4.1 External third-party deployment and confirm Polaris initialization plus terminal suite execution.
