### PR TITLE
branch-4.1: [fix](build) Restore LSan detection

### DIFF
--- a/be/src/util/debug/leak_annotations.h
+++ b/be/src/util/debug/leak_annotations.h
@@ -21,16 +21,24 @@
 // Does nothing if LeakSanitizer is not enabled.
 #define ANNOTATE_LEAKING_OBJECT_PTR(p)
 
+// Check if LeakSanitizer is enabled
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#if defined(__linux__)
+#if __has_feature(address_sanitizer) || __has_feature(leak_sanitizer)
+#define DORIS_LSAN_ENABLED 1
+#endif
+#endif
+
+#if !defined(DORIS_LSAN_ENABLED) && (defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER))
+#define DORIS_LSAN_ENABLED 1
+#endif
+
+// DORIS_LSAN_ENABLED && __linux__
+#if defined(DORIS_LSAN_ENABLED) && defined(__linux__)
 
 #undef ANNOTATE_LEAKING_OBJECT_PTR
 #define ANNOTATE_LEAKING_OBJECT_PTR(p) __lsan_ignore_object(p);
 
-#endif
-#endif
-#endif
+#endif // DORIS_LSAN_ENABLED && __linux__
 
 // API definitions from LLVM lsan_interface.h
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PRs: #64164, #66049

Problem Summary:

The `branch-4.1` backport of #66049 makes `ScopedLSANDisabler` call the LSan runtime only when
`DORIS_LSAN_ENABLED` is defined. However, this branch did not receive the sanitizer detection
introduced by #64164, so the macro remains undefined even for ASAN/LSAN builds.

As a result, `ScopedLSANDisabler` incorrectly becomes a no-op and no longer suppresses the known
BRPC allocations in `LoadStreamMgrTest`, causing BE unit-test leak reports.

This change restores the unified sanitizer detection from master. It recognizes Clang's
`address_sanitizer`/`leak_sanitizer` features and the Doris build macros
`ADDRESS_SANITIZER`/`LEAK_SANITIZER`, allowing sanitized builds to invoke
`__lsan_disable()` and `__lsan_enable()` again. Non-sanitized builds retain the no-op behavior
added by #66049.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: This is a focused backport of the sanitizer detection already validated
          on master. A local BE build was intentionally skipped because of its compilation cost;
          CI will validate the branch build.

- Behavior changed:
    - [ ] No.
    - [x] Yes. ASAN/LSAN builds now enable `ScopedLSANDisabler`; non-sanitized builds are unchanged.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
