### PR TITLE
[opt](expr) Enable vectorization for conditional updates

### DIFF
--- a/be/src/exprs/function/least_greast.cpp
+++ b/be/src/exprs/function/least_greast.cpp
@@ -134,30 +134,29 @@ private:
 
         if constexpr (std::is_same_v<ColumnType, ColumnDecimal128V2>) {
             for (size_t i = 0; i < input_rows_count; ++i) {
-                result_raw_data[i] =
-                        Op<TYPE_DECIMALV2>::apply(column_raw_data[index_check_const(i, ArgConst)],
-                                                  result_raw_data[i])
-                                ? column_raw_data[index_check_const(i, ArgConst)]
-                                : result_raw_data[i];
+                if (Op<TYPE_DECIMALV2>::apply(column_raw_data[index_check_const(i, ArgConst)],
+                                              result_raw_data[i])) {
+                    result_raw_data[i] = column_raw_data[index_check_const(i, ArgConst)];
+                }
             }
         } else if constexpr (std::is_same_v<ColumnType, ColumnDecimal32> ||
                              std::is_same_v<ColumnType, ColumnDecimal64> ||
                              std::is_same_v<ColumnType, ColumnDecimal128V3> ||
                              std::is_same_v<ColumnType, ColumnDecimal256>) {
             for (size_t i = 0; i < input_rows_count; ++i) {
-                result_raw_data[i] =
-                        Op<PType>::apply(column_raw_data[index_check_const(i, ArgConst)].value,
-                                         result_raw_data[i].value)
-                                ? column_raw_data[index_check_const(i, ArgConst)]
-                                : result_raw_data[i];
+                if (Op<PType>::apply(column_raw_data[index_check_const(i, ArgConst)].value,
+                                     result_raw_data[i].value)) {
+                    result_raw_data[i] = column_raw_data[index_check_const(i, ArgConst)];
+                }
             }
         } else {
+            // A ternary self-assignment triggers a false UnsafeDep in Clang's loop vectorizer.
+            // See https://github.com/llvm/llvm-project/issues/212787.
             for (size_t i = 0; i < input_rows_count; ++i) {
-                result_raw_data[i] =
-                        Op<PType>::apply(column_raw_data[index_check_const(i, ArgConst)],
-                                         result_raw_data[i])
-                                ? column_raw_data[index_check_const(i, ArgConst)]
-                                : result_raw_data[i];
+                if (Op<PType>::apply(column_raw_data[index_check_const(i, ArgConst)],
+                                     result_raw_data[i])) {
+                    result_raw_data[i] = column_raw_data[index_check_const(i, ArgConst)];
+                }
             }
         }
     }

--- a/be/src/exprs/vcase_expr.h
+++ b/be/src/exprs/vcase_expr.h
@@ -252,9 +252,12 @@ private:
                           std::is_same_v<ColumnType, ColumnDateV2> ||
                           std::is_same_v<ColumnType, ColumnDateTimeV2> ||
                           std::is_same_v<ColumnType, ColumnTimeStampTz>) {
+                // A ternary self-assignment triggers a false UnsafeDep in Clang's loop vectorizer.
+                // See https://github.com/llvm/llvm-project/issues/212787.
                 for (int row_idx = 0; row_idx < rows_count; row_idx++) {
-                    result_raw_data[row_idx] = (then_idx[row_idx] == i) ? column_raw_data[row_idx]
-                                                                        : result_raw_data[row_idx];
+                    if (then_idx[row_idx] == i) {
+                        result_raw_data[row_idx] = column_raw_data[row_idx];
+                    }
                 }
             } else {
                 for (int row_idx = 0; row_idx < rows_count; row_idx++) {

--- a/be/test/exprs/function/function_math_test.cpp
+++ b/be/test/exprs/function/function_math_test.cpp
@@ -484,23 +484,56 @@ TEST(MathFunctionTest, round_bankers_test) {
 TEST(MathFunctionTest, least_test) {
     std::string func_name = "least";
 
-    InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};
 
-    DataSet data_set = {
-            {{3, 2}, 2}, {{3, 3}, 3}, {{Null(), -2}, Null()}, {{193, -2}, -2}, {{193, -1}, -1}};
+        DataSet data_set = {
+                {{3, 2}, 2}, {{3, 3}, 3}, {{Null(), -2}, Null()}, {{193, -2}, -2}, {{193, -1}, -1}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_DECIMALV2, PrimitiveType::TYPE_DECIMALV2};
+
+        DataSet data_set = {{{DECIMALV2VALUEFROMDOUBLE(3.0), DECIMALV2VALUEFROMDOUBLE(2.0)},
+                             DECIMALV2VALUEFROMDOUBLE(2.0)},
+                            {{DECIMALV2VALUEFROMDOUBLE(3.0), DECIMALV2VALUEFROMDOUBLE(3.0)},
+                             DECIMALV2VALUEFROMDOUBLE(3.0)},
+                            {{DECIMALV2VALUEFROMDOUBLE(-1.0), DECIMALV2VALUEFROMDOUBLE(2.0)},
+                             DECIMALV2VALUEFROMDOUBLE(-1.0)}};
+
+        check_function_all_arg_comb<DataTypeDecimalV2, true>(func_name, input_types, data_set, 9,
+                                                             27);
+    }
 }
 
 TEST(MathFunctionTest, greatest_test) {
     std::string func_name = "greatest";
 
-    InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_INT};
 
-    DataSet data_set = {
-            {{3, 2}, 3}, {{3, 3}, 3}, {{Null(), -2}, Null()}, {{193, -2}, 193}, {{193, -1}, 193}};
+        DataSet data_set = {{{3, 2}, 3},
+                            {{3, 3}, 3},
+                            {{Null(), -2}, Null()},
+                            {{193, -2}, 193},
+                            {{193, -1}, 193}};
 
-    static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_DECIMALV2, PrimitiveType::TYPE_DECIMALV2};
+
+        DataSet data_set = {{{DECIMALV2VALUEFROMDOUBLE(3.0), DECIMALV2VALUEFROMDOUBLE(2.0)},
+                             DECIMALV2VALUEFROMDOUBLE(3.0)},
+                            {{DECIMALV2VALUEFROMDOUBLE(3.0), DECIMALV2VALUEFROMDOUBLE(3.0)},
+                             DECIMALV2VALUEFROMDOUBLE(3.0)},
+                            {{DECIMALV2VALUEFROMDOUBLE(-1.0), DECIMALV2VALUEFROMDOUBLE(2.0)},
+                             DECIMALV2VALUEFROMDOUBLE(2.0)}};
+
+        check_function_all_arg_comb<DataTypeDecimalV2, true>(func_name, input_types, data_set, 9,
+                                                             27);
+    }
 }
 
 TEST(MathFunctionTest, bin_test) {

--- a/be/test/exprs/function/function_test_util.h
+++ b/be/test/exprs/function/function_test_util.h
@@ -492,7 +492,8 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
 // invocation is needed.
 template <typename ReturnType, bool nullable = false>
 void check_function_all_arg_comb(const std::string& func_name, const InputTypeSet& base_types,
-                                 const DataSet& data_set) {
+                                 const DataSet& data_set, int result_scale = -1,
+                                 int result_precision = -1) {
     TestCaseInfo::func_call_index++;
     size_t arg_cnt = base_types.size();
     // Consider each parameter as a bit, if the j-th bit is 1, the j-th parameter is const; otherwise, it is not.
@@ -522,13 +523,13 @@ void check_function_all_arg_comb(const std::string& func_name, const InputTypeSe
                 DataSet tmp_set {line};
                 // check_function_all_arg_comb is ONE call. adding here and minuing in check_function to make it consistent.
                 TestCaseInfo::func_call_index--;
-                static_cast<void>(
-                        check_function<ReturnType, nullable>(func_name, input_types, tmp_set));
+                static_cast<void>(check_function<ReturnType, nullable>(
+                        func_name, input_types, tmp_set, result_scale, result_precision));
             }
         } else {
             TestCaseInfo::func_call_index--;
-            static_cast<void>(
-                    check_function<ReturnType, nullable>(func_name, input_types, data_set));
+            static_cast<void>(check_function<ReturnType, nullable>(func_name, input_types, data_set,
+                                                                   result_scale, result_precision));
         }
     }
 }

--- a/be/test/exprs/vcase_expr_test.cpp
+++ b/be/test/exprs/vcase_expr_test.cpp
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/vcase_expr.h"
+
+#include <gen_cpp/Exprs_types.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "core/assert_cast.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_date.h"
+#include "core/data_type/data_type_number.h"
+#include "core/value/vdatetime_value.h"
+#include "exprs/vexpr_context.h"
+
+namespace doris {
+namespace {
+
+class ColumnVExpr final : public VExpr {
+public:
+    ColumnVExpr(ColumnPtr column, DataTypePtr data_type)
+            : _column(std::move(column)), _name("column expr") {
+        _data_type = std::move(data_type);
+    }
+
+    const std::string& expr_name() const override { return _name; }
+
+    Status execute_column_impl(VExprContext* /*context*/, const Block* /*block*/,
+                               const Selector* /*selector*/, size_t /*count*/,
+                               ColumnPtr& result_column) const override {
+        result_column = _column;
+        return Status::OK();
+    }
+
+private:
+    ColumnPtr _column;
+    std::string _name;
+};
+
+TExprNode create_date_v2_case_node() {
+    TCaseExpr case_node;
+    case_node.__set_has_case_expr(false);
+    case_node.__set_has_else_expr(true);
+
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::CASE_EXPR);
+    node.__set_type(DataTypeDateV2().to_thrift());
+    node.__set_is_nullable(false);
+    node.__set_num_children(3);
+    node.__set_case_expr(case_node);
+    return node;
+}
+
+ColumnDateV2::value_type create_date(uint32_t year, uint32_t month, uint32_t day) {
+    const uint64_t olap_date = (year << 9) | (month << 5) | day;
+    return ColumnDateV2::value_type::create_from_olap_date(olap_date);
+}
+
+TEST(VCaseExprTest, UpdateNonNullableDateV2Result) {
+    auto condition = ColumnUInt8::create();
+    condition->insert_value(1);
+    condition->insert_value(0);
+    condition->insert_value(1);
+
+    auto then_column = ColumnDateV2::create();
+    then_column->insert_value(create_date(2024, 1, 1));
+    then_column->insert_value(create_date(2024, 1, 2));
+    then_column->insert_value(create_date(2024, 1, 3));
+
+    auto else_column = ColumnDateV2::create();
+    else_column->insert_value(create_date(2025, 1, 1));
+    else_column->insert_value(create_date(2025, 1, 2));
+    else_column->insert_value(create_date(2025, 1, 3));
+
+    auto case_expr = VCaseExpr::create_shared(create_date_v2_case_node());
+    auto date_type = std::make_shared<DataTypeDateV2>();
+    case_expr->add_child(
+            std::make_shared<ColumnVExpr>(std::move(condition), std::make_shared<DataTypeUInt8>()));
+    case_expr->add_child(std::make_shared<ColumnVExpr>(std::move(then_column), date_type));
+    case_expr->add_child(std::make_shared<ColumnVExpr>(std::move(else_column), date_type));
+
+    VExprContext context(case_expr);
+    ColumnPtr result;
+    const auto status = case_expr->execute_column(&context, /*block=*/nullptr,
+                                                  /*selector=*/nullptr, /*count=*/3, result);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+
+    const auto& result_data = assert_cast<const ColumnDateV2&>(*result).get_data();
+    ASSERT_EQ(result_data.size(), 3);
+    EXPECT_EQ(result_data[0], create_date(2024, 1, 1));
+    EXPECT_EQ(result_data[1], create_date(2025, 1, 2));
+    EXPECT_EQ(result_data[2], create_date(2024, 1, 3));
+}
+
+} // namespace
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Clang treats ternary self-assignment as an unsafe indirect memory dependence, preventing loop vectorization in CASE and least/greatest fixed-width update paths. Replace the ternary read-modify-write form with equivalent conditional stores so Clang can generate vectorized masked updates.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

