### PR TITLE
[fix](iceberg connector) Use native Iceberg types for sink coercion

### DIFF
--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/write/ConnectorWritePlanProvider.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/write/ConnectorWritePlanProvider.java
@@ -26,6 +26,7 @@ import org.apache.doris.connector.api.handle.WriteOperation;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -96,6 +97,20 @@ public interface ConnectorWritePlanProvider {
     default List<ConnectorWriteSortColumn> getWriteSortColumns(ConnectorSession session,
             ConnectorTableHandle tableHandle) {
         return null;
+    }
+
+    /**
+     * Returns the target schema used to coerce rows before they reach the connector writer.
+     *
+     * <p>The table schema exposed for reads may use compatibility types that differ from the native writer
+     * types. A connector can return its native write schema here so the engine performs the final coercion
+     * against the type expected by the writer. The columns must be in physical write order. An empty optional
+     * keeps the table's exposed schema and preserves existing behavior for connectors without a separate write
+     * type system.</p>
+     */
+    default Optional<List<ConnectorColumn>> getWriteSchema(ConnectorSession session,
+            ConnectorTableHandle tableHandle, boolean isRewrite) {
+        return Optional.empty();
     }
 
     /**

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnectorMetadata.java
@@ -2182,15 +2182,19 @@ public class IcebergConnectorMetadata implements ConnectorMetadata {
      * Convert an Iceberg Schema to a list of ConnectorColumn.
      */
     private List<ConnectorColumn> parseSchema(Schema schema) {
-        List<Types.NestedField> fields = schema.columns();
-        List<ConnectorColumn> columns = new ArrayList<>(fields.size());
         boolean enableVarbinary = Boolean.parseBoolean(
                 properties.getOrDefault(
                         IcebergConnectorProperties.ENABLE_MAPPING_VARBINARY, "false"));
         boolean enableTimestampTz = Boolean.parseBoolean(
                 properties.getOrDefault(
                         IcebergConnectorProperties.ENABLE_MAPPING_TIMESTAMP_TZ, "false"));
+        return parseSchema(schema, enableVarbinary, enableTimestampTz);
+    }
 
+    static List<ConnectorColumn> parseSchema(Schema schema,
+            boolean enableVarbinary, boolean enableTimestampTz) {
+        List<Types.NestedField> fields = schema.columns();
+        List<ConnectorColumn> columns = new ArrayList<>(fields.size());
         for (Types.NestedField field : fields) {
             // Legacy IcebergUtils.parseSchema parity (mirrors PaimonConnectorMetadata): the column name is
             // case-preserved (#65094 read-path alignment; top-level slot names keep their remote case),

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergWritePlanProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergWritePlanProvider.java
@@ -284,6 +284,19 @@ public class IcebergWritePlanProvider implements ConnectorWritePlanProvider {
     }
 
     @Override
+    public Optional<List<ConnectorColumn>> getWriteSchema(ConnectorSession session,
+            ConnectorTableHandle tableHandle, boolean isRewrite) {
+        Table table = resolveTable(session, (IcebergTableHandle) tableHandle);
+        Schema schema = table.schema();
+        if (isRewrite && IcebergWriterHelper.getFormatVersion(table) >= 3) {
+            schema = IcebergWriterHelper.appendRowLineageFieldsForV3(schema);
+        }
+        boolean enableVarbinary = Boolean.parseBoolean(properties.getOrDefault(
+                IcebergConnectorProperties.ENABLE_MAPPING_VARBINARY, "false"));
+        return Optional.of(IcebergConnectorMetadata.parseSchema(schema, enableVarbinary, true));
+    }
+
+    @Override
     public ConnectorWritePartitionSpec getWritePartitioning(ConnectorSession session,
             ConnectorTableHandle tableHandle) {
         Table table = resolveTable(session, (IcebergTableHandle) tableHandle);

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergWritePlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergWritePlanProviderTest.java
@@ -1096,6 +1096,48 @@ public class IcebergWritePlanProviderTest {
         Assertions.assertEquals("t1", sink.getTbName());
     }
 
+    @Test
+    public void writeSchemaUsesNativeTimestampSemantics() {
+        InMemoryCatalog catalog = freshCatalog();
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "timestamp", Types.TimestampType.withoutZone()),
+                Types.NestedField.required(2, "timestamptz", Types.TimestampType.withZone()),
+                Types.NestedField.required(3, "nested_timestamptz",
+                        Types.ListType.ofOptional(4, Types.TimestampType.withZone())));
+        Table table = catalog.createTable(TableIdentifier.of("db1", "write_schema"), schema,
+                PartitionSpec.unpartitioned(), Collections.emptyMap());
+        IcebergWritePlanProvider provider = providerFor(table, contextWithStorage());
+        ConnectorTableHandle handle = new IcebergTableHandle("db1", "write_schema");
+
+        List<ConnectorColumn> exposedSchema = IcebergConnectorMetadata.parseSchema(schema, false, false);
+        List<ConnectorColumn> writeSchema = provider.getWriteSchema(
+                sessionFor(table, contextWithStorage()), handle, false).orElseThrow(AssertionError::new);
+
+        Assertions.assertEquals("DATETIMEV2", exposedSchema.get(1).getType().getTypeName());
+        Assertions.assertEquals("DATETIMEV2", writeSchema.get(0).getType().getTypeName());
+        Assertions.assertEquals("TIMESTAMPTZ", writeSchema.get(1).getType().getTypeName());
+        Assertions.assertEquals(2, writeSchema.get(1).getUniqueId());
+        Assertions.assertEquals("TIMESTAMPTZ",
+                writeSchema.get(2).getType().getChildren().get(0).getTypeName());
+    }
+
+    @Test
+    public void rewriteWriteSchemaAddsV3RowLineageColumns() {
+        Table table = formatVersionThreeTable(freshCatalog());
+        IcebergWritePlanProvider provider = providerFor(table, contextWithStorage());
+        List<ConnectorColumn> insertSchema = provider.getWriteSchema(
+                sessionFor(table, contextWithStorage()), new IcebergTableHandle("db1", "tv3"), false)
+                .orElseThrow(AssertionError::new);
+        List<ConnectorColumn> rewriteSchema = provider.getWriteSchema(
+                sessionFor(table, contextWithStorage()), new IcebergTableHandle("db1", "tv3"), true)
+                .orElseThrow(AssertionError::new);
+
+        Assertions.assertEquals(2, insertSchema.size());
+        Assertions.assertEquals(4, rewriteSchema.size());
+        Assertions.assertEquals("_row_id", rewriteSchema.get(2).getName());
+        Assertions.assertEquals("_last_updated_sequence_number", rewriteSchema.get(3).getName());
+    }
+
     // ───────────────────────────── write capability declarations (single-source-of-truth) ─────────────────────────────
     //
     // WHY: the write plan provider is now the single source of truth for a connector's write capabilities

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalTable.java
@@ -458,8 +458,10 @@ public class PluginDrivenExternalTable extends ExternalTable {
             return Optional.empty();
         }
         List<Column> writeSchema = ConnectorColumnConverter.convertColumns(connectorSchema.get());
+        String remoteDbName = db != null ? db.getRemoteName() : "";
         for (Column column : writeSchema) {
-            column.setName(metadata.fromRemoteColumnName(session, dbName, tableName, column.getName()));
+            column.setName(metadata.fromRemoteColumnName(
+                    session, remoteDbName, getRemoteName(), column.getName()));
         }
         return Optional.of(writeSchema);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalTable.java
@@ -432,6 +432,38 @@ public class PluginDrivenExternalTable extends ExternalTable {
         return provider != null && provider.requiresFullSchemaWriteOrder();
     }
 
+    /** Returns the connector's native writer schema when it differs from the exposed table schema. */
+    public Optional<List<Column>> getConnectorWriteSchema(boolean isRewrite) {
+        if (!(catalog instanceof PluginDrivenExternalCatalog)) {
+            return Optional.empty();
+        }
+        PluginDrivenExternalCatalog pluginCatalog = (PluginDrivenExternalCatalog) catalog;
+        Connector connector = pluginCatalog.getConnector();
+        if (connector == null) {
+            return Optional.empty();
+        }
+        ConnectorSession session = pluginCatalog.buildConnectorSession();
+        ConnectorMetadata metadata = PluginDrivenMetadata.get(session, connector);
+        Optional<ConnectorTableHandle> handleOpt = resolveConnectorTableHandle(session, metadata);
+        if (!handleOpt.isPresent()) {
+            return Optional.empty();
+        }
+        ConnectorWritePlanProvider provider = connector.getWritePlanProvider(handleOpt.get());
+        if (provider == null) {
+            return Optional.empty();
+        }
+        Optional<List<ConnectorColumn>> connectorSchema =
+                provider.getWriteSchema(session, handleOpt.get(), isRewrite);
+        if (!connectorSchema.isPresent()) {
+            return Optional.empty();
+        }
+        List<Column> writeSchema = ConnectorColumnConverter.convertColumns(connectorSchema.get());
+        for (Column column : writeSchema) {
+            column.setName(metadata.fromRemoteColumnName(session, dbName, tableName, column.getName()));
+        }
+        return Optional.of(writeSchema);
+    }
+
     /**
      * Returns whether the underlying connector's data files retain partition columns, so a static-partition
      * write must materialize the PARTITION-clause literal into the data column instead of NULL-filling it

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -358,6 +358,26 @@ public class BindSink implements AnalysisRuleFactory {
             MatchingContext<? extends UnboundLogicalSink<Plan>> ctx,
             TableIf table, boolean isPartialUpdate, boolean isDeletePartialUpdate,
             LogicalTableSink<?> boundSink, LogicalPlan child) {
+        return getColumnToOutput(ctx, table, isPartialUpdate, isDeletePartialUpdate,
+                boundSink, child, Maps.newHashMap());
+    }
+
+    private static Map<String, NamedExpression> getColumnToOutput(
+            MatchingContext<? extends UnboundLogicalSink<Plan>> ctx,
+            TableIf table, boolean isPartialUpdate, boolean isDeletePartialUpdate,
+            LogicalTableSink<?> boundSink, LogicalPlan child, List<Column> coercionSchema) {
+        Map<String, DataType> coercionTypes = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        for (Column column : coercionSchema) {
+            coercionTypes.put(column.getName(), DataType.fromCatalogType(column.getType()));
+        }
+        return getColumnToOutput(ctx, table, isPartialUpdate, isDeletePartialUpdate,
+                boundSink, child, coercionTypes);
+    }
+
+    private static Map<String, NamedExpression> getColumnToOutput(
+            MatchingContext<? extends UnboundLogicalSink<Plan>> ctx,
+            TableIf table, boolean isPartialUpdate, boolean isDeletePartialUpdate,
+            LogicalTableSink<?> boundSink, LogicalPlan child, Map<String, DataType> coercionTypes) {
         // we need to insert all the columns of the target table
         // although some columns are not mentions.
         // so we add a projects to supply the default value.
@@ -384,12 +404,14 @@ public class BindSink implements AnalysisRuleFactory {
                 shadowColumns.add(column);
                 continue;
             }
+            DataType coercionType = coercionTypes.getOrDefault(
+                    column.getName(), DataType.fromCatalogType(column.getType()));
             if (columnToChildOutput.containsKey(column)
                     // do not process explicitly use DEFAULT value here:
                     // insert into table t values(DEFAULT)
                     && !(columnToChildOutput.get(column) instanceof DefaultValueSlot)) {
                 Alias output = new Alias(TypeCoercionUtils.castIfNotSameType(
-                        columnToChildOutput.get(column), DataType.fromCatalogType(column.getType())),
+                        columnToChildOutput.get(column), coercionType),
                         column.getName());
                 columnToOutput.put(column.getName(), output);
                 columnToReplaced.put(column.getName(), output.toSlot());
@@ -433,7 +455,7 @@ public class BindSink implements AnalysisRuleFactory {
                                 boundSink, ctx.cascadesContext, unboundFunctionDefaultValue
                         );
                         Alias output = new Alias(TypeCoercionUtils.castIfNotSameType(
-                                defualtValueExpression, DataType.fromCatalogType(column.getType())),
+                                defualtValueExpression, coercionType),
                                 column.getName());
                         columnToOutput.put(column.getName(), output);
                         columnToReplaced.put(column.getName(), output.toSlot());
@@ -450,7 +472,7 @@ public class BindSink implements AnalysisRuleFactory {
                     }
                     // Otherwise, the unmentioned columns should be filled with default values
                     // or null values
-                    Alias output = new Alias(new NullLiteral(DataType.fromCatalogType(column.getType())),
+                    Alias output = new Alias(new NullLiteral(coercionType),
                             column.getName());
                     columnToOutput.put(column.getName(), output);
                     columnToReplaced.put(column.getName(), output.toSlot());
@@ -465,7 +487,7 @@ public class BindSink implements AnalysisRuleFactory {
                             defualtValueExpression = ((Alias) defualtValueExpression).child();
                         }
                         Alias output = new Alias((TypeCoercionUtils.castIfNotSameType(
-                                defualtValueExpression, DataType.fromCatalogType(column.getType()))),
+                                defualtValueExpression, coercionType)),
                                 column.getName());
                         columnToOutput.put(column.getName(), output);
                         columnToReplaced.put(column.getName(), output.toSlot());
@@ -480,13 +502,15 @@ public class BindSink implements AnalysisRuleFactory {
         // if processed in upper for loop, will lead to not found slot error
         // It's the same reason for moving the processing of materialized columns down.
         for (Column column : generatedColumns) {
+            DataType coercionType = coercionTypes.getOrDefault(
+                    column.getName(), DataType.fromCatalogType(column.getType()));
             if (isDeletePartialUpdate) {
                 NamedExpression childOutput = columnToChildOutput.get(column);
                 if (childOutput == null) {
                     continue;
                 }
                 Alias output = new Alias(TypeCoercionUtils.castIfNotSameType(
-                        childOutput, DataType.fromCatalogType(column.getType())), column.getName());
+                        childOutput, coercionType), column.getName());
                 columnToOutput.put(column.getName(), output);
                 columnToReplaced.put(column.getName(), output.toSlot());
                 replaceMap.put(output.toSlot(), output.child());
@@ -518,6 +542,8 @@ public class BindSink implements AnalysisRuleFactory {
             }
         }
         for (Column column : materializedViewColumn) {
+            DataType coercionType = coercionTypes.getOrDefault(
+                    column.getName(), DataType.fromCatalogType(column.getType()));
             List<SlotRef> refs = column.getRefColumns();
             // now we have to replace the column to slots.
             Preconditions.checkArgument(refs != null,
@@ -543,7 +569,7 @@ public class BindSink implements AnalysisRuleFactory {
                             new AddSessionVarGuardRewriter(column.getSessionVariables()), Boolean.FALSE);
                 }
                 boundExpression = TypeCoercionUtils.castIfNotSameType(boundExpression,
-                        DataType.fromCatalogType(column.getType()));
+                        coercionType);
                 Alias output = new Alias(boundExpression, column.getDefineExpr().accept(
                         ExprToSqlVisitor.INSTANCE, ToSqlParams.WITHOUT_TABLE));
                 columnToOutput.put(column.getName(), output);
@@ -552,11 +578,13 @@ public class BindSink implements AnalysisRuleFactory {
             }
         }
         for (Column column : shadowColumns) {
+            DataType coercionType = coercionTypes.getOrDefault(
+                    column.getName(), DataType.fromCatalogType(column.getType()));
             NamedExpression expression = columnToOutput.get(column.getNonShadowName());
             if (expression != null) {
                 Alias alias = (Alias) expression;
                 Expression newExpr = TypeCoercionUtils.castIfNotSameType(alias.child(),
-                        DataType.fromCatalogType(column.getType()));
+                        coercionType);
                 columnToOutput.put(column.getName(), new Alias(newExpr, column.getName()));
             }
         }
@@ -814,6 +842,13 @@ public class BindSink implements AnalysisRuleFactory {
                     + "Expected " + boundSink.getCols().size() + " columns but got " + child.getOutput().size());
         }
         if (table.requiresFullSchemaWriteOrder()) {
+            List<Column> exposedWriteSchema = sink.isRewrite()
+                    ? table.getFullSchema()
+                    : table.getFullSchema().stream()
+                            .filter(Column::isVisible)
+                            .collect(ImmutableList.toImmutableList());
+            List<Column> writeSchema = table.getConnectorWriteSchema(sink.isRewrite())
+                    .orElse(exposedWriteSchema);
             // Positional-write connector (e.g. MaxCompute): its BE writer maps data columns positionally
             // against the full table schema, so project the child to FULL-SCHEMA order with any
             // unmentioned / static-partition columns filled in (NULL literals), exactly like legacy
@@ -823,7 +858,8 @@ public class BindSink implements AnalysisRuleFactory {
             // trailing partition columns by position, so they must sit at their full-schema (tail)
             // positions; and (3) PhysicalConnectorTableSink.getRequirePhysicalProperties locates
             // partition columns by their full-schema position, so the child must be in full-schema order.
-            Map<String, NamedExpression> columnToOutput = getColumnToOutput(ctx, table, false, false, boundSink, child);
+            Map<String, NamedExpression> columnToOutput = getColumnToOutput(
+                    ctx, table, false, false, boundSink, child, writeSchema);
             if (table.materializeStaticPartitionValues() && !staticPartitionColNames.isEmpty()) {
                 // Connectors that consume the partition value FROM THE ROW must write the static partition value
                 // INTO the data column: getColumnToOutput excluded it from the bound columns and NULL-filled it,
@@ -836,11 +872,9 @@ public class BindSink implements AnalysisRuleFactory {
                 for (Map.Entry<String, Expression> entry : staticPartitions.entrySet()) {
                     Column column = table.getColumn(entry.getKey());
                     if (column != null) {
-                        Expression castExpr = TypeCoercionUtils.castIfNotSameType(
-                                entry.getValue(), DataType.fromCatalogType(column.getType()));
                         // Key and alias use the canonical schema name, so they line up with
                         // getOutputProjectByCoercion, which looks columnToOutput up by getFullSchema() names.
-                        columnToOutput.put(column.getName(), new Alias(castExpr, column.getName()));
+                        columnToOutput.put(column.getName(), new Alias(entry.getValue(), column.getName()));
                     }
                 }
             }
@@ -852,11 +886,6 @@ public class BindSink implements AnalysisRuleFactory {
             // columns M"), so drop them unless this is a rewrite — mirroring the retired legacy iceberg
             // bind's insertSchema visible filter. Connectors with no invisible columns (e.g. MaxCompute) are
             // unaffected: the filter is a no-op there.
-            List<Column> writeSchema = sink.isRewrite()
-                    ? table.getFullSchema()
-                    : table.getFullSchema().stream()
-                            .filter(Column::isVisible)
-                            .collect(ImmutableList.toImmutableList());
             LogicalProject<?> fullOutputProject =
                     getOutputProjectByCoercion(writeSchema, child, columnToOutput);
             return boundSink.withChildAndUpdateOutput(fullOutputProject);

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_timestamp_ntz.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_timestamp_ntz.groovy
@@ -48,20 +48,25 @@ suite("test_iceberg_write_timestamp_ntz", "p0,external") {
         logger.info("switched to catalog " + catalog_name)
         sql """ use test_db;""" 
 
+        sql "set time_zone = 'Asia/Shanghai'"
         sql """INSERT INTO t_ntz_doris VALUES ('2025-02-07 20:12:00');"""
         sql """INSERT INTO t_tz_doris VALUES ('2025-02-07 20:12:01');"""
 
-     
-        sql "set time_zone = 'Asia/Shanghai'"
         qt_timestamp_ntz """select * from t_ntz_doris;"""
-        qt_timestamp_tz  """select * from t_tz_doris;"""
+        order_qt_timestamp_tz  """select * from t_tz_doris;"""
         // test Extra column in desc result
         qt_desc01 """desc t_ntz_doris"""
         qt_desc02 """desc t_tz_doris"""
 
         sql "set time_zone = 'Europe/Tirane'"
         qt_timestamp_ntz2 """select * from t_ntz_doris;"""
-        qt_timestamp_tz2  """select * from t_tz_doris;"""
+        order_qt_timestamp_tz2  """select * from t_tz_doris;"""
+
+        sql "set time_zone = 'Asia/Shanghai'"
+        sql """
+            INSERT INTO t_tz_doris
+            SELECT CAST('2025-02-07 20:12:02' AS DATETIMEV2(6));
+        """
       
         // sql """drop catalog if exists ${catalog_name}"""
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Iceberg timestamptz columns can be exposed as DATETIMEV2 when timestamp timezone mapping is disabled, while the native Iceberg writer schema remains timezone-aware. The FE previously coerced sink expressions using the compatibility catalog type, which could send DATETIMEV2 columns to a timezone-aware Arrow target. Derive the writer coercion schema from the native Iceberg schema so timestamptz values use TIMESTAMPTZ, and share the native schema construction with IcebergTableSink.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

