### PR TITLE
branch-4.1: [fix](paimon) Read Paimon tables on BE without reconstructing the catalog metastore #65867

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1039,6 +1039,37 @@ EOF
         fi
     done        
 
+    # Guard the Paimon FileIO SPI classloader boundary on the built artifacts. The FileIOLoader
+    # interface (paimon-common) and every provider implementing it must sit in the same jar:
+    # JniScannerClassLoader delegates parent-first, so a provider left on the shared
+    # preload-extensions (JVM app) classpath cannot resolve the child-only interface and
+    # ServiceLoader discovery aborts at runtime with "NoClassDefFoundError: FileIOLoader". Unit
+    # tests all run in one classloader and cannot reproduce that, so assert it on the packages.
+    PAIMON_CONNECTOR_JAR="${BE_JAVA_EXTENSIONS_DIR}/paimon-connector/paimon-connector-jar-with-dependencies.jar"
+    PRELOAD_JAR="${BE_JAVA_EXTENSIONS_DIR}/preload-extensions/preload-extensions-jar-with-dependencies.jar"
+    if [[ -f "${PAIMON_CONNECTOR_JAR}" ]]; then
+        # Tolerate a missing entry (unzip exits 11) so the message below is what the build prints.
+        FILE_IO_SERVICES="$(unzip -p "${PAIMON_CONNECTOR_JAR}" \
+            META-INF/services/org.apache.paimon.fs.FileIOLoader 2>/dev/null || true)"
+        for loader in org.apache.paimon.s3.S3Loader org.apache.paimon.jindo.JindoLoader; do
+            if ! echo "${FILE_IO_SERVICES}" | grep -q -x "${loader}"; then
+                echo "ERROR: ${loader} is missing from META-INF/services/org.apache.paimon.fs.FileIOLoader"
+                echo "       in ${PAIMON_CONNECTOR_JAR}. Paimon object-store reads on BE would fail;"
+                echo "       keep the FileIO plugins bundled in paimon-connector."
+                exit 1
+            fi
+        done
+    fi
+    # No "grep -q" here: it exits on the first match and SIGPIPEs unzip halfway through this jar's
+    # 120k-entry listing, which under "set -o pipefail" makes the pipeline 141 and silently skips
+    # the error below - exactly when a provider did leak in. Let grep consume the whole listing.
+    if [[ -f "${PRELOAD_JAR}" ]] &&
+        unzip -l "${PRELOAD_JAR}" | grep -E 'org/apache/paimon/(s3|jindo)/' >/dev/null; then
+        echo "ERROR: ${PRELOAD_JAR} bundles a Paimon FileIOLoader provider. It would be defined by"
+        echo "       the JVM app classloader, which carries no FileIOLoader interface."
+        exit 1
+    fi
+
     # Third-party filesystem jars (JuiceFS, JindoFS) are packaged by post-build.sh
     "${DORIS_HOME}/post-build.sh" --be --output "${DORIS_OUTPUT}"
 

--- a/fe/be-java-extensions/paimon-connector/pom.xml
+++ b/fe/be-java-extensions/paimon-connector/pom.xml
@@ -61,6 +61,32 @@ under the License.
             <artifactId>paimon-format</artifactId>
         </dependency>
 
+        <!--
+          Paimon OSS/S3 FileIO plugins. These register org.apache.paimon.fs.FileIOLoader
+          service providers (paimon-s3 -> S3Loader, paimon-jindo -> JindoLoader) used to read
+          object-store-backed Paimon tables (e.g. DLF REST catalogs over OSS). They MUST be
+          bundled here, alongside the FileIOLoader interface that lives in paimon-common: when a
+          BE-side read resolves the latest snapshot from the filesystem, RESTTokenFileIO.fileIO()
+          calls FileIO.get() -> ServiceLoader.load(FileIOLoader.class, FileIOLoader's classloader),
+          which eagerly instantiates every registered provider. A provider and the FileIOLoader
+          interface it implements must be reachable from the same classloader. These plugins used
+          to sit on the shared preload-extensions (JVM app) classpath, which does NOT carry
+          paimon-common's FileIOLoader; since JniScannerClassLoader is parent-first, the app-loaded
+          S3Loader/JindoLoader could not resolve the child-only interface -> NoClassDefFoundError:
+          FileIOLoader. Co-locating them here keeps the whole FileIO SPI in one classloader; the
+          assembly's metaInf-services handler merges their service files with paimon-common's
+          (local/hadoop) into one complete provider list.
+        -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-s3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-jindo</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>

--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -78,16 +78,19 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- For BE Paimon OSS/S3 Access -->
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-s3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-jindo</artifactId>
-        </dependency>
+        <!--
+          NOTE: the paimon OSS/S3 FileIO plugins (paimon-s3 / paimon-jindo) are intentionally
+          NOT here. They register org.apache.paimon.fs.FileIOLoader service providers
+          (S3Loader / JindoLoader), but the FileIOLoader interface itself lives in paimon-common,
+          which is bundled in paimon-connector, NOT on this shared/preload classpath. Because each
+          JniScannerClassLoader delegates parent-first to the JVM app classloader (where this
+          preload jar sits), a provider defined here could not resolve the child-only FileIOLoader
+          interface, so ServiceLoader discovery in paimon-connector's FileIO.get() failed with
+          NoClassDefFoundError: FileIOLoader. The plugins are therefore co-located with the
+          FileIOLoader interface in paimon-connector (its only BE consumer) so the whole FileIO SPI
+          lives in one classloader. Do not move them back here without also putting paimon-common
+          on this classpath.
+        -->
         <!-- For Avro and Hudi Scanner PreLoad -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonSysExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonSysExternalTable.java
@@ -36,8 +36,10 @@ import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.table.DataTable;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypeRoot;
 
@@ -71,6 +73,7 @@ public class PaimonSysExternalTable extends ExternalTable {
     private final String sysTableType;
     private volatile Boolean isDataTable;
     private volatile Table paimonSysTable;
+    private volatile FileStoreTable sysBaseTable;
     private volatile List<Column> fullSchema;
     private volatile SchemaCacheValue schemaCacheValue;
 
@@ -115,17 +118,48 @@ public class PaimonSysExternalTable extends ExternalTable {
     /**
      * Returns the Paimon system table instance (e.g., snapshots, binlog).
      * Note: system tables currently ignore snapshot semantics.
+     *
+     * <p>The wrapper is built over the cached base table, exactly the way the Paimon catalog builds
+     * it ({@code CatalogUtils#createSystemTable}). Loading it from the catalog instead would give
+     * this wrapper its own schema generation, independent of the cached base table: the FE would
+     * then plan on one generation while {@code PaimonScanNode} serializes a system table rebuilt
+     * over the other one, and a system table whose row type follows the base schema
+     * ({@code $audit_log}, {@code $binlog}, {@code $ro}) could reach the BE without the columns the
+     * FE asked for.
+     *
+     * <p>"Exactly the way the catalog builds it" includes building it over the <i>undecorated</i>
+     * base: {@code CatalogUtils#loadTable} hands {@code createSystemTable} the raw
+     * {@code FileStoreTableFactory#create} result, and the decorator a catalog may add afterwards
+     * never reaches a system table, because it only wraps a {@code FileStoreTable} and no system
+     * table is one. The meta cache, in contrast, holds the decorated table. That matters for
+     * {@code $ro}: {@code ReadOptimizedTable#newScan} builds its two-branch {@code FallbackReadScan}
+     * only when its immediate wrapped object is a {@code FallbackReadFileStoreTable}, so with a
+     * {@code PrivilegedFileStoreTable} in between it would plan the main branch alone through the
+     * pair's inherited {@code newSnapshotReader()} and silently drop every fallback-only partition.
      */
     public Table getSysPaimonTable() {
         if (paimonSysTable == null) {
             synchronized (this) {
                 if (paimonSysTable == null) {
-                    PaimonExternalCatalog catalog = (PaimonExternalCatalog) getCatalog();
-                    paimonSysTable = catalog.getPaimonTable(
-                            sourceTable.getOrBuildNameMapping(),
-                            "main",  // branch
-                            sysTableType  // queryType: snapshots, binlog, etc.
-                    );
+                    sourceTable.makeSureInitialized();
+                    // System tables ignore snapshot semantics, so the empty snapshot resolves the base table.
+                    Table baseTable = sourceTable.getPaimonTable(Optional.empty());
+                    FileStoreTable base = baseTable instanceof FileStoreTable
+                            ? PaimonUtil.unwrapToFallbackOrBase((FileStoreTable) baseTable)
+                            : null;
+                    Table sysTable = base == null ? null : SystemTableLoader.load(sysTableType, base);
+                    if (sysTable == null) {
+                        // Not a file store table (format / object table): let the catalog decide.
+                        PaimonExternalCatalog catalog = (PaimonExternalCatalog) getCatalog();
+                        paimonSysTable = catalog.getPaimonTable(
+                                sourceTable.getOrBuildNameMapping(),
+                                "main",  // branch
+                                sysTableType  // queryType: snapshots, binlog, etc.
+                        );
+                    } else {
+                        sysBaseTable = base;
+                        paimonSysTable = sysTable;
+                    }
                     LOG.info("Created Paimon system table: {} for source table: {}",
                             sysTableType, sourceTable.getName());
                 }
@@ -140,7 +174,7 @@ public class PaimonSysExternalTable extends ExternalTable {
             return table;
         }
         Map<String, String> resolvedOptions = scanParams.getOrResolveMapParams(
-                options -> PaimonScanParams.resolveOptions(sourceTable.getBasePaimonTable(), options));
+                options -> PaimonScanParams.resolveOptions(getOptionsResolutionTable(), options));
         if (PaimonScanParams.getPinnedFileCreationTime(resolvedOptions).isPresent()) {
             // Generic system-table wrappers cannot carry Paimon's manifest-entry predicate.
             // Reject the fallback instead of silently widening it to the whole pinned snapshot.
@@ -155,6 +189,29 @@ public class PaimonSysExternalTable extends ExternalTable {
         return PaimonUtil.parseSchema(table,
                 getCatalog().getEnableMappingVarbinary(),
                 getCatalog().getEnableMappingTimestampTz());
+    }
+
+    /**
+     * Returns the base table {@link #getSysPaimonTable()} was built over, so that consumers can
+     * rebuild an equivalent wrapper from the very same schema generation. Returns null when the
+     * wrapper came from the catalog fallback above.
+     */
+    public FileStoreTable getSysBaseTable() {
+        getSysPaimonTable();
+        return sysBaseTable;
+    }
+
+    /**
+     * The table a relation's OPTIONS are resolved against: the very base the wrapper above was
+     * built over, not a fresh meta cache lookup. The wrapper is created once and kept, while the
+     * cache behind {@code getBasePaimonTable()} can be refreshed or invalidated in between, so
+     * resolving there could freeze a snapshot or tag from a generation that the wrapper - and the
+     * table {@code PaimonScanNode} rebuilds from it for the BE - never belonged to. Only the
+     * catalog fallback above has no captured base, so only it still looks the table up.
+     */
+    private Table getOptionsResolutionTable() {
+        FileStoreTable capturedBase = getSysBaseTable();
+        return capturedBase != null ? capturedBase : sourceTable.getBasePaimonTable();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
@@ -60,6 +60,8 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.DataTable;
+import org.apache.paimon.table.DelegatedFileStoreTable;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.Table;
@@ -115,6 +117,37 @@ public class PaimonUtil {
 
     public static boolean isDigitalString(String value) {
         return value != null && DIGITAL_REGEX.matcher(value).matches();
+    }
+
+    /**
+     * Peel the decorators Paimon may have stacked on top of the table, down to the fallback-branch
+     * pair - the one layer that must stay on top, because that is what dispatches a read to the
+     * right branch.
+     *
+     * <p>{@code PrivilegedCatalog#getTable} wraps whatever {@code FileStoreTableFactory} built into
+     * a {@code PrivilegedFileStoreTable}, so with file based privileges enabled a
+     * {@code scan.fallback-branch} table reaches Doris as {@code Privileged(FallbackRead(...))}.
+     * Paimon itself never lets a decorator sit above the pair - {@code CatalogUtils#loadTable}
+     * builds system tables straight over the {@code FileStoreTableFactory} result and only wraps
+     * what it returns - and both Paimon and Doris dispatch on a direct {@code instanceof
+     * FallbackReadFileStoreTable}, which looks straight past a decorator and silently falls back to
+     * the delegated main branch alone.
+     *
+     * <p>The decorators are peeled off rather than re-applied, and what that costs differs by
+     * caller. Rebuilding the table the BE gets loses nothing: the privilege wrapper only asserts on
+     * {@code newScan()} / {@code newRead()}, which the FE has already run while planning, and a
+     * plain (non fallback) table loses the wrapper the same way once it is rebuilt out of
+     * fileIO / location / schema. Building a system table over the peeled base does drop that
+     * assertion, but that is Paimon's own semantics rather than a relaxation of it:
+     * {@code PrivilegedCatalog#getTable} wraps only a result that is a {@code FileStoreTable}, and
+     * no system table is one, so {@code db.tbl$ro} never carries the decorator there either.
+     */
+    public static FileStoreTable unwrapToFallbackOrBase(FileStoreTable dataTable) {
+        FileStoreTable current = dataTable;
+        while (current instanceof DelegatedFileStoreTable && !(current instanceof FallbackReadFileStoreTable)) {
+            current = ((DelegatedFileStoreTable) current).wrapped();
+        }
+        return current;
     }
 
     public static List<InternalRow> read(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -58,11 +58,16 @@ import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.CatalogEnvironment;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
@@ -72,6 +77,8 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.table.system.SystemTableLoader;
+import org.apache.paimon.utils.SnapshotManager;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -109,6 +116,11 @@ public class PaimonScanNode extends FileQueryScanNode {
             DORIS_JNI_IO_MANAGER_TMP_DIR,
             DORIS_JNI_IO_MANAGER_IMPL_CLASS,
             DORIS_ENABLE_FILE_READER_ASYNC);
+    private static final String PAIMON_FILES_SYSTEM_TABLE_TYPE = "files";
+    private static final String PAIMON_PARTITIONS_SYSTEM_TABLE_TYPE = "partitions";
+    private static final String PAIMON_MANIFESTS_SYSTEM_TABLE_TYPE = "manifests";
+    private static final String PAIMON_STATISTICS_SYSTEM_TABLE_TYPE = "statistics";
+    private static final String PAIMON_TABLE_INDEXES_SYSTEM_TABLE_TYPE = "table_indexes";
 
     private enum SplitReadType {
         JNI,
@@ -213,7 +225,343 @@ public class PaimonScanNode extends FileQueryScanNode {
     private void serializeProcessedTable() throws UserException {
         // System-table splits are materialized by the BE JNI reader, so it must receive the same
         // option-bearing table copy that FE uses to plan the split.
-        serializedTable = PaimonUtil.encodeObjectToString(getProcessedTable());
+        serializedTable = PaimonUtil.encodeObjectToString(getPaimonTableForBackend());
+    }
+
+    /**
+     * Build the Paimon table object that is serialized to the BE.
+     *
+     * <p>Every table loaded from a metastore-backed Paimon catalog (HMS / DLF) carries a Paimon
+     * {@code HiveCatalogLoader} in its {@link org.apache.paimon.table.CatalogEnvironment}. The BE
+     * only reads — via FE-resolved splits and the object store — and never needs the catalog, yet
+     * deserializing that loader forces the whole Hive metastore stack onto the BE classpath:
+     * {@code HiveConf}, the metastore API, and, when a system table resolves its latest snapshot,
+     * even the metastore client (DLF's {@code ProxyMetaStoreClient} and its REST stack). So we
+     * serialize a catalog-less table to the BE:
+     * <ul>
+     *   <li>data table: drop the catalog loader. A {@link FileStoreTable} is fully defined by
+     *       fileIO / location / schema / catalogEnvironment, and its dynamic options (time travel,
+     *       incremental) are merged into the schema by {@code copy(...)}, so rebuilding from
+     *       fileIO / location / schema preserves everything except the catalog loader.</li>
+     *   <li>system table (e.g. {@code $snapshots}): rebuild it over a catalog-less data table so
+     *       {@code SnapshotManager#latestSnapshotId} lists the snapshot directory on the filesystem
+     *       instead of calling the metastore. The base table is the one the FE-side wrapper was
+     *       built over, and for the system tables that pick their snapshot on the BE ({@link
+     *       #resolvesSnapshotOnBackend}) what the catalog would have done there is done here
+     *       instead: see {@link #authorizeDeferredScan} and {@link #pinCatalogSnapshot}. Every
+     *       other system table reads what the FE already planned, so it is handed over untouched.
+     *       The relation-scoped scan params the FE applied to the original wrapper are re-applied
+     *       to the rebuilt one by {@link #reapplyScanParams(Table)}.</li>
+     * </ul>
+     */
+    private Table getPaimonTableForBackend() throws UserException {
+        Table paimonTable = getProcessedTable();
+        if (paimonTable instanceof FileStoreTable) {
+            // copy(...) merges the relation's dynamic options into the schema, and the rebuild
+            // below goes through that schema, so this branch needs no re-application.
+            return dropCatalogLoader((FileStoreTable) paimonTable);
+        }
+        if (!(source.getExternalTable() instanceof PaimonSysExternalTable)) {
+            return paimonTable;
+        }
+        PaimonSysExternalTable sysTable = (PaimonSysExternalTable) source.getExternalTable();
+        // The very same base table the FE-side wrapper was built over, so that the BE never sees a
+        // different schema generation than the one this query was planned with.
+        FileStoreTable dataTable = sysTable.getSysBaseTable();
+        if (dataTable == null) {
+            return paimonTable;
+        }
+        String sysTableType = sysTable.getSysTableType();
+        boolean resolvesOnBackend = resolvesSnapshotOnBackend(sysTableType);
+        if (PAIMON_FILES_SYSTEM_TABLE_TYPE.equalsIgnoreCase(sysTableType)) {
+            authorizeDeferredScan(dataTable);
+        }
+        FileStoreTable baseForBackend = dropCatalogLoader(dataTable);
+        if (resolvesOnBackend) {
+            baseForBackend = pinCatalogSnapshot(baseForBackend, dataTable);
+        }
+        Table catalogLessSysTable = SystemTableLoader.load(sysTableType, baseForBackend);
+        if (catalogLessSysTable == null) {
+            return paimonTable;
+        }
+        return reapplyScanParams(catalogLessSysTable, dataTable, resolvesOnBackend);
+    }
+
+    /**
+     * Re-apply the relation-scoped scan params to a rebuilt system-table wrapper.
+     *
+     * <p>{@link #getProcessedTable()} applies {@code @incr} / {@code @options} to the wrapper the
+     * meta cache holds, and every Paimon system table delegates {@code copy(...)} to the data table
+     * it wraps. The wrapper rebuilt above is a different object, so the same copy has to be redone
+     * on it, otherwise the BE would materialize its splits against the unpinned latest state.
+     *
+     * <p>This runs last on purpose: an explicit relation option outranks anything this class pins
+     * on the rebuilt table, and {@code copy(...)} lets the option win. An incremental relation
+     * outranks {@link #pinCatalogSnapshot} the same way but cannot inherit its bound, so it is
+     * bound to the catalog's snapshot separately by {@link #bindIncrementalRangeToCatalog}.
+     *
+     * <p>Known gap: the {@code @options} branch reaches tables outside
+     * {@link #resolvesSnapshotOnBackend}, {@code $ro} among them, and on a
+     * {@code scan.fallback-branch} table the {@code copy(...)} here is what triggers
+     * {@code rewriteFallbackOptions} - on the already catalog-less pair, so the fallback branch's
+     * {@code scan.snapshot-id} is derived from its snapshot directory rather than from the catalog
+     * pointer, the same gap {@link #pinCatalogSnapshot} documents. It lands harder here: unlike the
+     * pin this is {@code copy(...)}, not {@code copyWithoutTimeTravel(...)}, so it also time-travels
+     * the fallback branch's schema, and {@code $ro} is a data table rather than read-only metadata.
+     */
+    private Table reapplyScanParams(Table rebuiltSysTable, FileStoreTable dataTable, boolean resolvesOnBackend)
+            throws UserException {
+        TableScanParams theScanParams = getScanParams();
+        if (theScanParams == null) {
+            return rebuiltSysTable;
+        }
+        if (theScanParams.incrementalRead()) {
+            Map<String, String> incrementalParams = getIncrReadParams();
+            if (resolvesOnBackend) {
+                incrementalParams = bindIncrementalRangeToCatalog(incrementalParams, dataTable);
+            }
+            return rebuiltSysTable.copy(incrementalParams);
+        }
+        if (theScanParams.isOptions()) {
+            return PaimonScanParams.applyOptions(rebuiltSysTable,
+                    theScanParams.getResolvedMapParams().orElse(Collections.emptyMap()));
+        }
+        return rebuiltSysTable;
+    }
+
+    /**
+     * Bind an incremental relation's range to the catalog-visible snapshot.
+     *
+     * <p>Only for {@link #resolvesSnapshotOnBackend} system tables, i.e. today {@code $partitions},
+     * the one table that both re-plans on the BE and accepts {@code @incr}. Paimon selects the
+     * incremental scanner from {@code incremental-between*} and never reads {@code scan.snapshot-id}
+     * in that mode, so {@link #pinCatalogSnapshot}'s pin cannot bound this scan - and
+     * {@code PaimonScanParams#isolateIncrementalRead} clears it anyway, so one relation's read state
+     * cannot leak into another's.
+     *
+     * <p>The timestamp form is the exposed one. {@code IncrementalDeltaStartingScanner
+     * #betweenTimestamps} turns both endpoints into snapshot ids through
+     * {@code SnapshotManager#earlierOrEqualTimeMills}, whose binary search runs up to
+     * {@code latestSnapshotId()}: the catalog's pointer here, but the newest file in the snapshot
+     * directory on the catalog-less BE. So resolve the endpoints while the loader is still around
+     * and hand the BE the explicit id range Paimon would have computed itself. Only the delta
+     * scanner's rule is reachable: {@code incremental-between-scan-mode} is cleared with the rest of
+     * the read state, and its default {@code AUTO} never selects the diff scanner.
+     *
+     * <p>Only when the requested end reaches the catalog's snapshot. An older end already resolves
+     * to the same id on both sides, because every snapshot the catalog has not published yet is
+     * younger than the one it points at. The snapshot-id form ({@code startSnapshotId} /
+     * {@code endSnapshotId}) names its endpoints outright and needs nothing.
+     *
+     * <p>Never on a {@code scan.fallback-branch} table, because an id range cannot be expressed for
+     * the pair. The two branches keep independent snapshot id sequences, and
+     * {@code FallbackReadFileStoreTable#rewriteFallbackOptions} translates only
+     * {@code scan.snapshot-id} - {@code incremental-between} is copied to the fallback branch
+     * verbatim. A main-branch id range would then be validated against the fallback branch's own
+     * range in {@code IncrementalDeltaStartingScanner#betweenSnapshotIds} and either fail out of
+     * range or select unrelated commits. The timestamp form needs no translation to begin with: a
+     * wall clock means the same thing on both branches, and each resolves it against its own
+     * {@code SnapshotManager}, so handing it over untouched is the branch-correct choice. What that
+     * keeps is the catalog-versus-filesystem endpoint gap {@link #pinCatalogSnapshot} documents for
+     * the fallback branch, which is the same gap on the same table.
+     */
+    private static Map<String, String> bindIncrementalRangeToCatalog(
+            Map<String, String> incrementalParams, FileStoreTable dataTable) {
+        String range = incrementalParams.get(PAIMON_INCREMENTAL_BETWEEN_TIMESTAMP);
+        if (range == null) {
+            return incrementalParams;
+        }
+        // Before any pair-level accessor is read: on a fallback pair both catalogEnvironment() and
+        // snapshotManager() describe the main branch alone, and the bound could not be carried to
+        // the fallback branch anyway.
+        if (PaimonUtil.unwrapToFallbackOrBase(dataTable) instanceof FallbackReadFileStoreTable) {
+            return incrementalParams;
+        }
+        if (!dataTable.catalogEnvironment().supportsVersionManagement()) {
+            return incrementalParams;
+        }
+        SnapshotManager snapshotManager = dataTable.snapshotManager();
+        Snapshot latest = snapshotManager.latestSnapshot();
+        Snapshot earliest = snapshotManager.earliestSnapshot();
+        if (latest == null || earliest == null) {
+            return incrementalParams;
+        }
+        String[] endpoints = range.split(",");
+        long startMillis = Long.parseLong(endpoints[0]);
+        long endMillis = Long.parseLong(endpoints[1]);
+        if (endMillis < latest.timeMillis()) {
+            return incrementalParams;
+        }
+        Snapshot start = snapshotManager.earlierOrEqualTimeMills(startMillis);
+        // The starting snapshot is exclusive, hence the id before the earliest one when the range
+        // opens before it - exactly what betweenTimestamps computes.
+        long startId = (start == null || earliest.timeMillis() > startMillis)
+                ? earliest.id() - 1
+                : start.id();
+        Map<String, String> boundParams = new HashMap<>(incrementalParams);
+        boundParams.put(PAIMON_INCREMENTAL_BETWEEN_TIMESTAMP, null);
+        boundParams.put(PAIMON_INCREMENTAL_BETWEEN, startId + "," + latest.id());
+        return boundParams;
+    }
+
+    /**
+     * The system tables whose rows are not fixed by what the FE planned: the FE only sends marker
+     * splits and the snapshot is picked inside the BE reader. Two shapes, both honoring
+     * {@code scan.snapshot-id}:
+     * <ul>
+     *   <li>{@code $files} / {@code $partitions} re-plan the base table on the BE
+     *       ({@code FilesTable.FilesRead#createReader} -&gt; {@code DataTableScan#plan()},
+     *       {@code PartitionsTable.PartitionsRead#createReader} -&gt;
+     *       {@code newScan().listPartitionEntries()});</li>
+     *   <li>{@code $manifests} / {@code $table_indexes} / {@code $statistics} resolve it directly
+     *       ({@code TimeTravelUtil#tryTravelOrLatest}, reached from {@code ManifestsTable},
+     *       {@code TableIndexesTable} and {@code AbstractFileStoreTable#statistics}).</li>
+     * </ul>
+     * All five have a fixed row type, so {@link #pinCatalogSnapshot} cannot rewind the BE schema.
+     */
+    private static boolean resolvesSnapshotOnBackend(String sysTableType) {
+        return PAIMON_FILES_SYSTEM_TABLE_TYPE.equalsIgnoreCase(sysTableType)
+                || PAIMON_PARTITIONS_SYSTEM_TABLE_TYPE.equalsIgnoreCase(sysTableType)
+                || PAIMON_MANIFESTS_SYSTEM_TABLE_TYPE.equalsIgnoreCase(sysTableType)
+                || PAIMON_STATISTICS_SYSTEM_TABLE_TYPE.equalsIgnoreCase(sysTableType)
+                || PAIMON_TABLE_INDEXES_SYSTEM_TABLE_TYPE.equalsIgnoreCase(sysTableType);
+    }
+
+    /**
+     * {@code $files} plans only partition-level splits on the FE and re-plans the base table on the
+     * BE through {@code DataTableScan#plan()} ({@code FilesTable.FilesRead#createReader}). That
+     * deferred plan normally authorizes itself through the catalog loader
+     * ({@code CatalogEnvironment#tableQueryAuth} -&gt; {@code Catalog#authTableQuery}); once the
+     * loader is dropped it silently allows everything. So authorize here, while the loader is still
+     * around. Paimon discards the predicates the call returns (row level access control is a TODO in
+     * {@code AbstractDataTableScan#authQuery}), so running it on the FE loses nothing.
+     *
+     * <p>Only {@code $files} may do this: {@code auth(null)} means "every column" to
+     * {@code Catalog#authTableQuery}, and the system tables that keep planning on the FE
+     * ({@code $ro}, {@code $row_tracking}, {@code $audit_log}, {@code $binlog}) already authorize
+     * themselves through {@code DataTableBatchScan} with the slot projection the query really reads.
+     * Authorizing those again for every column would reject a user allowed to read only some of the
+     * base columns. {@code $partitions} never reaches {@code plan()} on either side
+     * ({@code listPartitionEntries} does not authorize), so it has no authorization to transfer.
+     *
+     * <p>A {@code scan.fallback-branch} table has to be authorized branch by branch.
+     * {@code FallbackReadFileStoreTable#newScan} builds a {@code FallbackReadScan} over both
+     * branches' own scans, so each authorizes itself, and {@code FileStoreTableFactory#create} gives
+     * the fallback branch a {@link CatalogEnvironment} of its own carrying a branch-qualified
+     * {@code Identifier}. Since the pair delegates {@code catalogEnvironment()} to its main branch,
+     * authorizing the pair would check the main branch alone and never the fallback one - and once
+     * its loader is dropped that missing check turns into a permanent allow, letting a user denied on
+     * the fallback branch read the fallback rows of {@code $files}.
+     */
+    private static void authorizeDeferredScan(FileStoreTable dataTable) {
+        FileStoreTable undecorated = PaimonUtil.unwrapToFallbackOrBase(dataTable);
+        if (undecorated instanceof FallbackReadFileStoreTable) {
+            FallbackReadFileStoreTable fallbackReadTable = (FallbackReadFileStoreTable) undecorated;
+            authorizeBranch(fallbackReadTable.wrapped());
+            authorizeBranch(fallbackReadTable.fallback());
+            return;
+        }
+        authorizeBranch(undecorated);
+    }
+
+    private static void authorizeBranch(FileStoreTable branch) {
+        CoreOptions options = branch.coreOptions();
+        if (options.queryAuthEnabled()) {
+            branch.catalogEnvironment().tableQueryAuth(options).auth(null);
+        }
+    }
+
+    /**
+     * For catalogs that manage versions themselves (Paimon REST / DLF REST) the committed snapshot
+     * is the one the catalog points at, not the newest file in the snapshot directory: Paimon
+     * publishes the snapshot file before the pointer moves, and a rollback leaves newer files
+     * behind. Without the catalog loader {@code SnapshotManager} falls back to listing that
+     * directory, so the BE could plan on a snapshot the catalog has not published while the FE
+     * planned on the previous one. Pin the catalog-visible snapshot instead.
+     *
+     * <p>Only for {@link #resolvesSnapshotOnBackend} system tables, because only those pick their
+     * snapshot inside the BE reader. Every other system table materializes the splits the FE
+     * already planned, so pinning them would bind nothing that is not already bound. The pin goes
+     * through {@code copyWithoutTimeTravel}, so it bounds which snapshot the BE plans on without
+     * rewinding the BE's schema to that snapshot.
+     *
+     * <p>Known gap: {@code scan.snapshot-id} only bounds plans that go through
+     * {@code DataTableScan}. {@code $snapshots} ({@code SnapshotManager#snapshotsWithinRange}) and
+     * {@code $buckets} ({@code SnapshotReader#bucketEntries}) ignore it, so on the BE they observe
+     * the snapshot directory rather than the catalog's pointer. Both are read-only metadata tables,
+     * so this shows up only as a transient extra row inside the publication window of a
+     * version-managed catalog.
+     *
+     * <p>Known gap: {@code $files} is planned in two phases and only the second one can be pinned.
+     * The FE emits one marker split per partition of {@code SnapshotManager#latestSnapshot()} at
+     * split generation time ({@code FilesTable.FilesScan#innerPlan} -&gt;
+     * {@code SnapshotReader#partitions}), and that path reads {@code ManifestsReader#read(null, ..)},
+     * which ignores {@code scan.snapshot-id} - so the marker set cannot be bound to the pin, and
+     * {@code FilesSplit} is private to {@code FilesTable}, so Doris cannot emit a snapshot
+     * independent marker either. A commit landing between initialization and split generation that drops a partition
+     * therefore hides that partition's rows even though the BE stays on the older snapshot. Paimon's
+     * two-phase plan has this gap regardless: before the pin the BE resolved the latest snapshot at
+     * read time, i.e. across a strictly wider window, so this only moves which side of the window the
+     * mismatch falls on.
+     *
+     * <p>Known gap: on a table with {@code scan.fallback-branch} this bounds the main branch only.
+     * The pin itself is carried across correctly - {@code copyWithoutTimeTravel} is pair-aware and
+     * {@code rewriteFallbackOptions} converts the main id to the fallback branch's own through
+     * {@code SnapshotManager#earlierOrEqualTimeMills}. What is lost is the pointer that conversion
+     * searches against: the rebuilt pair has no catalog loader on either branch, so the fallback
+     * bound is capped by the newest file in that branch's snapshot directory instead of by the
+     * catalog. Of the pinned tables only {@code $partitions} and {@code $files} read the fallback
+     * branch at all ({@code $manifests} / {@code $statistics} / {@code $table_indexes} reach it
+     * through {@code store()} / {@code statistics()}, which describe the main branch), so the
+     * effect is confined to their rows. Note this outlasts a publication window when it is caused
+     * by a rollback: the abandoned snapshot file stays on the filesystem until it expires, and for
+     * as long as it does the fallback branch can be bound to it.
+     */
+    private static FileStoreTable pinCatalogSnapshot(FileStoreTable catalogLessTable, FileStoreTable dataTable) {
+        if (!dataTable.catalogEnvironment().supportsVersionManagement()) {
+            return catalogLessTable;
+        }
+        Long snapshotId = dataTable.snapshotManager().latestSnapshotId();
+        if (snapshotId == null) {
+            return catalogLessTable;
+        }
+        // Without time travel: pin which snapshot the BE plans on, leave schema resolution alone.
+        return catalogLessTable.copyWithoutTimeTravel(
+                Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshotId)));
+    }
+
+    /**
+     * Return an equivalent {@link FileStoreTable} without the catalog loader, so the BE never
+     * deserializes a {@code HiveCatalogLoader} (and snapshot loading uses the filesystem instead of
+     * the catalog's metastore). fileIO / location / schema (and the schema's options) are preserved.
+     *
+     * <p>A {@code scan.fallback-branch} table must be rebuilt branch by branch.
+     * {@link FallbackReadFileStoreTable} exposes only its main branch through {@code schema()}, and
+     * the plain {@code FileStoreTableFactory#create} re-expands the fallback branch from
+     * {@code SchemaManager(fallbackBranch).latest()} instead of the object the FE captured. That
+     * would ship a main/fallback pair from two different generations: after external DDL publishes
+     * a new schema on both branches, the FE keeps planning on the cached M1/F1 while the BE gets
+     * M1/F2 and fails in {@code FallbackReadFileStoreTable#validateSchema}. So rebuild each branch
+     * from the schema the FE really planned with, and re-wrap.
+     */
+    private static FileStoreTable dropCatalogLoader(FileStoreTable dataTable) {
+        if (dataTable.catalogEnvironment().catalogLoader() == null) {
+            return dataTable;
+        }
+        FileStoreTable undecorated = PaimonUtil.unwrapToFallbackOrBase(dataTable);
+        if (undecorated instanceof FallbackReadFileStoreTable) {
+            FallbackReadFileStoreTable fallbackReadTable = (FallbackReadFileStoreTable) undecorated;
+            return new FallbackReadFileStoreTable(
+                    rebuildWithoutCatalogLoader(fallbackReadTable.wrapped()),
+                    rebuildWithoutCatalogLoader(fallbackReadTable.fallback()));
+        }
+        return rebuildWithoutCatalogLoader(undecorated);
+    }
+
+    private static FileStoreTable rebuildWithoutCatalogLoader(FileStoreTable branch) {
+        return FileStoreTableFactory.createWithoutFallbackBranch(
+                branch.fileIO(), branch.location(), branch.schema(), new Options(),
+                CatalogEnvironment.empty());
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/PaimonSysExternalTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/PaimonSysExternalTableTest.java
@@ -1,0 +1,233 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.paimon;
+
+import org.apache.doris.analysis.TableScanParams;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.privilege.AllGrantedPrivilegeChecker;
+import org.apache.paimon.privilege.PrivilegedFileStoreTable;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.CatalogEnvironment;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.system.ReadOptimizedTable;
+import org.apache.paimon.table.system.SystemTableLoader;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class PaimonSysExternalTableTest {
+
+    @Test
+    public void testReadOptimizedSysTableKeepsTheFallbackPairVisible() throws Exception {
+        // With file based privileges enabled PrivilegedCatalog#getTable hands the meta cache a
+        // Privileged(FallbackRead(main, fallback)) - a shape Paimon's own catalog never lets a
+        // system table see, because CatalogUtils#loadTable builds one over the raw
+        // FileStoreTableFactory result and only wraps what it returns.
+        FileStoreTable pair = newFallbackBranchPair();
+        FileStoreTable cached = PrivilegedFileStoreTable.wrap(pair, new AllGrantedPrivilegeChecker(),
+                Identifier.create("db", "tbl"));
+
+        PaimonSysExternalTable sysTable = newSysTable(cached, "ro");
+        Table feWrapper = sysTable.getSysPaimonTable();
+
+        // The FE must plan tbl$ro over both branches.
+        Assert.assertTrue(((ReadOptimizedTable) feWrapper).newScan()
+                instanceof FallbackReadFileStoreTable.FallbackReadScan);
+        // And so must the BE, which rebuilds its table from this one.
+        Assert.assertSame(pair, sysTable.getSysBaseTable());
+
+        // Why the decorator has to come off rather than stay: ReadOptimizedTable#newScan dispatches
+        // on a direct instanceof, so with the privilege wrapper in between it plans the main branch
+        // alone - through the pair's inherited newSnapshotReader() - and every fallback-only
+        // partition silently produces no split at all.
+        Assert.assertFalse(((ReadOptimizedTable) SystemTableLoader.load("ro", cached)).newScan()
+                instanceof FallbackReadFileStoreTable.FallbackReadScan);
+    }
+
+    @Test
+    public void testReadOptimizedSysTablePlansTheFallbackOnlyPartition() throws Exception {
+        // What the assertion above stands for, end to end. FallbackReadScan#plan takes the main
+        // branch's splits, then adds the fallback branch's splits only for the partitions main does
+        // not have - so a partition living on the fallback branch alone is exactly what a
+        // single-branch plan loses, and it loses it silently: tbl$ro still succeeds, it just
+        // returns fewer rows.
+        FileStoreTable[] branches = newFallbackBranchPairWithData();
+        FileStoreTable cached = PrivilegedFileStoreTable.wrap(
+                new FallbackReadFileStoreTable(branches[0], branches[1]),
+                new AllGrantedPrivilegeChecker(), Identifier.create("db", "tbl"));
+
+        PaimonSysExternalTable sysTable = newSysTable(cached, "ro");
+
+        Assert.assertEquals(new TreeSet<>(Arrays.asList(1, 2)),
+                plannedPartitions((ReadOptimizedTable) sysTable.getSysPaimonTable()));
+        // Leaving the privilege decorator in place takes ReadOptimizedTable#newScan down its
+        // single-branch path, and pt=2 then produces no split at all.
+        Assert.assertEquals(new TreeSet<>(Collections.singletonList(1)),
+                plannedPartitions((ReadOptimizedTable) SystemTableLoader.load("ro", cached)));
+    }
+
+    @Test
+    public void testSystemTableOptionsResolveOnTheCapturedBaseGeneration() throws Exception {
+        // getSysPaimonTable() captures one base table and keeps the wrapper it built over it, but
+        // the meta cache behind getBasePaimonTable() can be refreshed or invalidated in between.
+        // Resolving the relation's OPTIONS there would freeze the newer generation's snapshot and
+        // then apply it to the wrapper over the captured one - which is also the table
+        // PaimonScanNode rebuilds from it for the BE.
+        FileStoreTable captured = newTableWithSnapshots("doris_paimon_sys_captured_ut", 1);
+        FileStoreTable refreshed = newTableWithSnapshots("doris_paimon_sys_refreshed_ut", 2);
+
+        PaimonSysExternalTable sysTable = newSysTable(captured, "ro");
+        Mockito.when(sysTable.getSourceTable().getBasePaimonTable()).thenReturn(refreshed);
+
+        TableScanParams scanParams = new TableScanParams(TableScanParams.OPTIONS,
+                ImmutableMap.of(CoreOptions.SCAN_MODE.key(), "latest"), Collections.emptyList());
+        sysTable.getSysPaimonTable(scanParams);
+
+        // Snapshot 1 is the captured generation's latest; the refreshed one is already at 2.
+        Assert.assertEquals("1", scanParams.getResolvedMapParams().get()
+                .get(CoreOptions.SCAN_SNAPSHOT_ID.key()));
+    }
+
+    /** A real table carrying {@code snapshots} committed generations. */
+    private FileStoreTable newTableWithSnapshots(String prefix, int snapshots) throws Exception {
+        java.nio.file.Path tempDir = Files.createTempDirectory(prefix);
+        Path tablePath = new Path("file://" + tempDir + "/db.db/tbl");
+        LocalFileIO fileIO = LocalFileIO.create();
+        new SchemaManager(fileIO, tablePath).createTable(new Schema(
+                Collections.singletonList(new DataField(0, "c1", DataTypes.INT())),
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), ""));
+        FileStoreTable table = FileStoreTableFactory.create(fileIO, tablePath);
+        for (int i = 0; i < snapshots; i++) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            try (BatchTableWrite write = writeBuilder.newWrite();
+                    BatchTableCommit commit = writeBuilder.newCommit()) {
+                write.write(GenericRow.of(i));
+                commit.commit(write.prepareCommit());
+            }
+        }
+        return table;
+    }
+
+    private Set<Integer> plannedPartitions(ReadOptimizedTable sysTable) {
+        Set<Integer> partitions = new TreeSet<>();
+        for (Split split : sysTable.newScan().plan().splits()) {
+            partitions.add(((DataSplit) split).partition().getInt(0));
+        }
+        return partitions;
+    }
+
+    /**
+     * A {@code {main, fallback}} pair holding real data: partition {@code pt=1} on the main branch
+     * and {@code pt=2} on the fallback branch alone. The {@code scan.fallback-branch} option only
+     * tells {@code FileStoreTableFactory} to build the pair - {@code FallbackReadScan} reads
+     * nothing from it - so the two branches are wrapped directly here.
+     */
+    private FileStoreTable[] newFallbackBranchPairWithData() throws Exception {
+        java.nio.file.Path tempDir = Files.createTempDirectory("doris_paimon_sys_ro_data_ut");
+        Path tablePath = new Path("file://" + tempDir + "/db.db/tbl");
+        LocalFileIO fileIO = LocalFileIO.create();
+        // No primary keys, so $ro reads every file of the snapshot and the fallback-only partition
+        // shows up without depending on compaction having run.
+        Schema schema = new Schema(
+                Arrays.asList(new DataField(0, "pt", DataTypes.INT()), new DataField(1, "c1", DataTypes.INT())),
+                Collections.singletonList("pt"), Collections.emptyList(), Collections.emptyMap(), "");
+        new SchemaManager(fileIO, tablePath).createTable(schema);
+        new SchemaManager(fileIO, tablePath, "fb").createTable(schema);
+
+        FileStoreTable main = FileStoreTableFactory.create(fileIO, tablePath);
+        commitPartition(main, 1);
+        FileStoreTable fallback = main.switchToBranch("fb");
+        commitPartition(fallback, 2);
+        return new FileStoreTable[] {main, fallback};
+    }
+
+    private void commitPartition(FileStoreTable branch, int partition) throws Exception {
+        BatchWriteBuilder writeBuilder = branch.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(GenericRow.of(partition, partition));
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private PaimonSysExternalTable newSysTable(FileStoreTable cached, String sysTableType) {
+        PaimonExternalDatabase db = Mockito.mock(PaimonExternalDatabase.class);
+        Mockito.when(db.getFullName()).thenReturn("db");
+        Mockito.when(db.getRemoteName()).thenReturn("db");
+        PaimonExternalTable sourceTable = Mockito.mock(PaimonExternalTable.class);
+        Mockito.when(sourceTable.getName()).thenReturn("tbl");
+        Mockito.when(sourceTable.getRemoteName()).thenReturn("tbl");
+        Mockito.when(sourceTable.getCatalog()).thenReturn(Mockito.mock(PaimonExternalCatalog.class));
+        Mockito.when(sourceTable.getDatabase()).thenReturn(db);
+        Mockito.when(sourceTable.getPaimonTable(Optional.empty())).thenReturn(cached);
+        return new PaimonSysExternalTable(sourceTable, sysTableType);
+    }
+
+    /**
+     * A {@code scan.fallback-branch} pair, built the way Paimon builds it: each branch without
+     * re-expanding the fallback branch, then the two wrapped into a
+     * {@link FallbackReadFileStoreTable}.
+     */
+    private FileStoreTable newFallbackBranchPair() throws Exception {
+        java.nio.file.Path tempDir = Files.createTempDirectory("doris_paimon_sys_ro_ut");
+        Path tablePath = new Path("file://" + tempDir + "/db.db/tbl");
+        Map<String, String> mainOptions = new HashMap<>();
+        mainOptions.put("scan.fallback-branch", "fb");
+        Map<String, String> fallbackOptions = new HashMap<>();
+        fallbackOptions.put("branch", "fb");
+        return new FallbackReadFileStoreTable(newBranchTable(tablePath, mainOptions),
+                newBranchTable(tablePath, fallbackOptions));
+    }
+
+    private FileStoreTable newBranchTable(Path tablePath, Map<String, String> options) {
+        List<DataField> fields = Collections.singletonList(new DataField(0, "c1", DataTypes.INT()));
+        TableSchema schema = new TableSchema(0L, fields, 0, Collections.emptyList(),
+                Collections.emptyList(), options, "");
+        return FileStoreTableFactory.createWithoutFallbackBranch(LocalFileIO.create(), tablePath, schema,
+                new Options(), CatalogEnvironment.empty());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -46,26 +46,38 @@ import org.apache.doris.thrift.TPushAggOp;
 import com.google.common.collect.ImmutableMap;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.privilege.AllGrantedPrivilegeChecker;
+import org.apache.paimon.privilege.PrivilegedFileStoreTable;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.CatalogEnvironment;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.SnapshotManager;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1192,6 +1204,540 @@ public class PaimonScanNodeTest {
         Assert.assertEquals(1, PaimonScanNode.getFieldIndex(fieldNames, "mixed_col"));
         Assert.assertEquals(2, PaimonScanNode.getFieldIndex(fieldNames, "part"));
         Assert.assertEquals(-1, PaimonScanNode.getFieldIndex(fieldNames, "missing_col"));
+    }
+
+    @Test
+    public void testSystemTableForBackendFollowsFeWrapperSchemaGeneration() throws Exception {
+        // $audit_log / $binlog / $ro derive their row type from the base table schema. The FE plans
+        // on the wrapper PaimonSysExternalTable holds; rebuilding the table serialized to the BE
+        // over a *different* generation of that base table (the meta cache keeps one for up to 24h,
+        // the catalog its own for 30 min) makes BE reject the query in
+        // PaimonJniScanner#getProjected - "RequiredField c2 not found in schema" - or read a stale
+        // type under the same name. Both wrappers must come from one generation.
+        FileStoreTable planned = newPaimonTable(catalogEnvironment(false, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()), new DataField(1, "c2", DataTypes.INT()));
+        FileStoreTable staleGeneration = newPaimonTable(catalogEnvironment(false, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()));
+        Table feWrapper = SystemTableLoader.load("audit_log", planned);
+
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("audit_log");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(planned);
+        PaimonExternalTable sourceTable = Mockito.mock(PaimonExternalTable.class);
+        Mockito.lenient().when(sourceTable.getPaimonTable(Optional.empty())).thenReturn(staleGeneration);
+        Mockito.lenient().when(sysTable.getSourceTable()).thenReturn(sourceTable);
+
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getPaimonTable()).thenReturn(feWrapper);
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+
+        Table forBackend = invokeGetPaimonTableForBackend(node);
+        Assert.assertEquals(feWrapper.rowType(), forBackend.rowType());
+        Assert.assertTrue(forBackend.rowType().getFieldNames().contains("c2"));
+    }
+
+    @Test
+    public void testDropCatalogLoaderKeepsEverythingButTheLoader() throws Exception {
+        FileStoreTable table = newPaimonTable(catalogEnvironment(false, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()));
+
+        FileStoreTable catalogLess = invokeDropCatalogLoader(table);
+
+        // The loader is the only thing the BE must not deserialize: it drags the whole Hive /
+        // metastore stack onto the BE classpath.
+        Assert.assertNull(catalogLess.catalogEnvironment().catalogLoader());
+        Assert.assertEquals(table.rowType(), catalogLess.rowType());
+        Assert.assertEquals(table.location(), catalogLess.location());
+        Assert.assertEquals(table.schema().id(), catalogLess.schema().id());
+    }
+
+    @Test
+    public void testPinsCatalogVisibleSnapshotForVersionManagedCatalog() throws Exception {
+        // A version-managed (REST / DLF REST) catalog owns the committed snapshot pointer. Without
+        // the catalog loader the BE resolves "latest" by listing the snapshot directory, and can
+        // plan on a snapshot the catalog has not published yet (or one a rollback left behind)
+        // while the FE planned on the previous one. Pin what the catalog sees.
+        FileStoreTable versionManaged = Mockito.spy(newPaimonTable(
+                catalogEnvironment(true, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT())));
+        SnapshotManager snapshotManager = Mockito.mock(SnapshotManager.class);
+        Mockito.when(snapshotManager.latestSnapshotId()).thenReturn(42L);
+        Mockito.doReturn(snapshotManager).when(versionManaged).snapshotManager();
+
+        FileStoreTable pinned = invokePinCatalogSnapshot(invokeDropCatalogLoader(versionManaged), versionManaged);
+        Assert.assertEquals("42", pinned.options().get("scan.snapshot-id"));
+
+        // And the table actually handed to the BE must go through that pin: $files is the system
+        // table that re-plans there.
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("files");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(versionManaged);
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getPaimonTable()).thenReturn(SystemTableLoader.load("files", versionManaged));
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+        invokeGetPaimonTableForBackend(node);
+        Mockito.verify(snapshotManager, Mockito.atLeastOnce()).latestSnapshotId();
+
+        // A catalog without version management keeps filesystem semantics, so there is nothing to
+        // pin and the BE must stay on "latest".
+        FileStoreTable plain = newPaimonTable(catalogEnvironment(false, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()));
+        Assert.assertNull(invokePinCatalogSnapshot(invokeDropCatalogLoader(plain), plain)
+                .options().get("scan.snapshot-id"));
+    }
+
+    @Test
+    public void testDeferredScanIsAuthorizedBeforeDroppingTheCatalogLoader() throws Exception {
+        // $files only plans partition-level splits on the FE and re-plans the base table on the BE,
+        // where Catalog#authTableQuery is what enforces query.auth. A loader-less table turns that
+        // check into a no-op, so a denied query would come back as a successful metadata read:
+        // authorize here instead, while the loader is still around.
+        Catalog catalog = Mockito.mock(Catalog.class);
+        Mockito.when(catalog.authTableQuery(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenThrow(new RuntimeException("no privilege for db.tbl"));
+        Map<String, String> options = new HashMap<>();
+        options.put("query-auth.enabled", "true");
+        FileStoreTable authorized = newPaimonTable(catalogEnvironment(true, catalog), options,
+                new DataField(0, "c1", DataTypes.INT()));
+
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("files");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(authorized);
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getPaimonTable()).thenReturn(SystemTableLoader.load("files", authorized));
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+
+        try {
+            invokeGetPaimonTableForBackend(node);
+            Assert.fail("denied query must not reach the BE as a catalog-less table");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            Assert.assertTrue(e.getCause().getMessage().contains("no privilege for db.tbl"));
+        }
+    }
+
+    @Test
+    public void testDataSystemTablesKeepTheirOwnProjectedAuthorization() throws Exception {
+        // $ro / $row_tracking / $audit_log / $binlog keep planning on the FE through
+        // DataTableBatchScan, which already calls Catalog#authTableQuery with the slot projection
+        // (AbstractDataTableScan#authQuery -> auth(readType.getFieldNames())). A second auth(null)
+        // here means "every column", so a user allowed to read only c1 would be rejected for
+        // "SELECT c1 FROM tbl$ro". Only $files, which loses its authorization by re-planning on the
+        // BE, may transfer it.
+        Catalog catalog = Mockito.mock(Catalog.class);
+        Map<String, String> options = new HashMap<>();
+        options.put("query-auth.enabled", "true");
+        FileStoreTable dataTable = newPaimonTable(catalogEnvironment(true, catalog), options,
+                new DataField(0, "c1", DataTypes.INT()));
+
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("ro");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(dataTable);
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getPaimonTable()).thenReturn(SystemTableLoader.load("ro", dataTable));
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+
+        invokeGetPaimonTableForBackend(node);
+
+        Mockito.verify(catalog, Mockito.never())
+                .authTableQuery(ArgumentMatchers.any(), ArgumentMatchers.any());
+    }
+
+    @Test
+    public void testPinIsKeptOffSystemTablesWhoseRowTypeFollowsTheBaseTable() throws Exception {
+        // PaimonJniScanner#initTable calls table.copy(table.options()) unconditionally, and every
+        // Paimon system-table wrapper delegates copy to FileStoreTable#copy, which time-travels the
+        // schema to scan.snapshot-id. $audit_log / $ro / $binlog / $row_tracking derive their row
+        // type from the base table, so pinning them would rewind the BE schema: c2, added after the
+        // latest snapshot, is planned by the FE and then rejected by getProjected() with
+        // "RequiredField c2 not found in schema". Only the fixed-row-type $files / $partitions,
+        // which re-plan on the BE, get the pin.
+        FileStoreTable versionManaged = Mockito.spy(newPaimonTable(
+                catalogEnvironment(true, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()), new DataField(1, "c2", DataTypes.INT())));
+        SnapshotManager snapshotManager = Mockito.mock(SnapshotManager.class);
+        Mockito.lenient().when(snapshotManager.latestSnapshotId()).thenReturn(42L);
+        Mockito.lenient().doReturn(snapshotManager).when(versionManaged).snapshotManager();
+
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("audit_log");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(versionManaged);
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getPaimonTable()).thenReturn(SystemTableLoader.load("audit_log", versionManaged));
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+
+        Table forBackend = invokeGetPaimonTableForBackend(node);
+
+        Assert.assertNull(forBackend.options().get("scan.snapshot-id"));
+        Assert.assertTrue(forBackend.rowType().getFieldNames().contains("c2"));
+        Mockito.verify(snapshotManager, Mockito.never()).latestSnapshotId();
+    }
+
+    @Test
+    public void testPinsCatalogVisibleSnapshotForMetadataTablesThatTravelOnBackend() throws Exception {
+        // $manifests / $table_indexes / $statistics send a stateless marker split from the FE and
+        // pick their snapshot inside the BE reader (ManifestsTable / TableIndexesTable ->
+        // TimeTravelUtil#tryTravelOrLatest, StatisticTable -> AbstractFileStoreTable#statistics ->
+        // the same helper). Without the catalog loader that resolves to whatever the snapshot
+        // directory holds, so a version-managed catalog would expose an unpublished snapshot inside
+        // the publication window, or a rollback-orphaned one. They honor scan.snapshot-id and their
+        // row type is fixed, so pin them like $files / $partitions.
+        for (String sysTableType : Arrays.asList("manifests", "table_indexes", "statistics")) {
+            FileStoreTable versionManaged = Mockito.spy(newPaimonTable(
+                    catalogEnvironment(true, Mockito.mock(Catalog.class)),
+                    new DataField(0, "c1", DataTypes.INT())));
+            SnapshotManager snapshotManager = Mockito.mock(SnapshotManager.class);
+            Mockito.when(snapshotManager.latestSnapshotId()).thenReturn(42L);
+            Mockito.doReturn(snapshotManager).when(versionManaged).snapshotManager();
+
+            PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+            Mockito.when(sysTable.getSysTableType()).thenReturn(sysTableType);
+            Mockito.when(sysTable.getSysBaseTable()).thenReturn(versionManaged);
+            PaimonSource source = Mockito.mock(PaimonSource.class);
+            Mockito.when(source.getPaimonTable())
+                    .thenReturn(SystemTableLoader.load(sysTableType, versionManaged));
+            Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+            PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+            node.setSource(source);
+
+            invokeGetPaimonTableForBackend(node);
+
+            Mockito.verify(snapshotManager, Mockito.atLeastOnce()).latestSnapshotId();
+        }
+    }
+
+    @Test
+    public void testRelationOptionsSurviveTheRebuiltSystemTable() throws Exception {
+        // The FE applies @options to the wrapper the meta cache holds (PaimonSysExternalTable
+        // #getSysPaimonTable(scanParams) -> PaimonScanParams#applyOptions), but the BE is handed a
+        // wrapper rebuilt over a catalog-less base - a different object, on which that copy() never
+        // ran. So the options have to be applied again on the way out, otherwise the reader that
+        // materializes this table's splits would silently fall back to the unpinned latest state.
+        FileStoreTable dataTable = newPaimonTable(catalogEnvironment(false, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()));
+
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("ro");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(dataTable);
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Table planned = SystemTableLoader.load("ro", dataTable);
+        Mockito.when(source.getPaimonTable()).thenReturn(planned);
+        Mockito.when(source.getPaimonTable(ArgumentMatchers.any(TableScanParams.class))).thenReturn(planned);
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+        TableScanParams scanParams = new TableScanParams(
+                TableScanParams.OPTIONS,
+                ImmutableMap.of(CoreOptions.SCAN_MANIFEST_PARALLELISM.key(), "4"),
+                Collections.emptyList());
+        // Binding already resolved these; this node only has to carry that decision to the BE.
+        scanParams.getOrResolveMapParams(options -> options);
+        node.setScanParams(scanParams);
+
+        Table forBackend = invokeGetPaimonTableForBackend(node);
+
+        // $ro delegates options() to the data table it wraps, so this reads the rebuilt base.
+        Assert.assertEquals("4", forBackend.options().get(CoreOptions.SCAN_MANIFEST_PARALLELISM.key()));
+    }
+
+    @Test
+    public void testFallbackBranchKeepsTheGenerationTheFeCaptured() throws Exception {
+        // FallbackReadFileStoreTable#schema() only exposes its main branch, so rebuilding it through
+        // FileStoreTableFactory#create re-reads the fallback branch from
+        // SchemaManager(fallbackBranch).latest() instead of the object the FE planned with. After
+        // external DDL publishes a new generation the BE would then get main M1 + fallback F2 and
+        // die in FallbackReadFileStoreTable#validateSchema. Rebuild both branches from the captured
+        // schemas instead.
+        FileStoreTable[] captured = newFallbackBranchPairWithNewerGenerationOnDisk("doris_paimon_fallback_ut");
+
+        FileStoreTable forBackend =
+                invokeDropCatalogLoader(new FallbackReadFileStoreTable(captured[0], captured[1]));
+
+        assertFallbackPairMatchesTheFeGeneration(forBackend, captured[0], captured[1]);
+    }
+
+    @Test
+    public void testFallbackBranchSurvivesAPaimonTableDecorator() throws Exception {
+        // With file based privileges enabled PrivilegedCatalog#getTable hands out
+        // Privileged(FallbackRead(..)). A direct instanceof looks straight past that wrapper and
+        // rebuilds an ordinary table from the delegated main branch, so the BE loses the
+        // FallbackReadFileStoreTable.Read that dispatches a fallback split to the fallback branch -
+        // while the FE keeps planning the wrapper and can still emit one. Peel decorators first.
+        FileStoreTable[] captured = newFallbackBranchPairWithNewerGenerationOnDisk("doris_paimon_privileged_ut");
+        FileStoreTable decorated = PrivilegedFileStoreTable.wrap(
+                new FallbackReadFileStoreTable(captured[0], captured[1]),
+                new AllGrantedPrivilegeChecker(), Identifier.create("db", "tbl"));
+
+        FileStoreTable forBackend = invokeDropCatalogLoader(decorated);
+
+        assertFallbackPairMatchesTheFeGeneration(forBackend, captured[0], captured[1]);
+    }
+
+    @Test
+    public void testFallbackBranchIsAuthorizedBeforeDroppingTheCatalogLoader() throws Exception {
+        // FallbackReadFileStoreTable#newScan builds a FallbackReadScan over both branches' own
+        // scans, so each authorizes itself, and FileStoreTableFactory#create gives the fallback
+        // branch a CatalogEnvironment of its own carrying a branch-qualified Identifier. The pair
+        // delegates catalogEnvironment() to its main branch, so authorizing the pair checks main and
+        // silently skips the fallback branch - and once the loaders are dropped that missing check
+        // is a permanent allow, letting a user denied on the fallback branch read the fallback rows
+        // of $files.
+        Catalog catalog = Mockito.mock(Catalog.class);
+        Identifier mainIdentifier = Identifier.create("db", "tbl");
+        Identifier fallbackIdentifier = new Identifier("db", "tbl", "fb");
+        Map<String, String> mainOptions = new HashMap<>();
+        mainOptions.put("query-auth.enabled", "true");
+        Map<String, String> fallbackOptions = new HashMap<>(mainOptions);
+        fallbackOptions.put("branch", "fb");
+        FileStoreTable main = newPaimonTable(
+                new CatalogEnvironment(mainIdentifier, null, () -> catalog, null, null, true),
+                mainOptions, new DataField(0, "c1", DataTypes.INT()));
+        FileStoreTable fallback = newPaimonTable(
+                new CatalogEnvironment(fallbackIdentifier, null, () -> catalog, null, null, true),
+                fallbackOptions, new DataField(0, "c1", DataTypes.INT()));
+
+        invokeAuthorizeDeferredScan(new FallbackReadFileStoreTable(main, fallback));
+
+        Mockito.verify(catalog).authTableQuery(ArgumentMatchers.eq(mainIdentifier), ArgumentMatchers.isNull());
+        Mockito.verify(catalog).authTableQuery(ArgumentMatchers.eq(fallbackIdentifier), ArgumentMatchers.isNull());
+    }
+
+    @Test
+    public void testIncrementalRangeIsResolvedOnTheCatalogVisibleSnapshot() throws Exception {
+        // Paimon selects the incremental scanner from incremental-between*, so pinCatalogSnapshot's
+        // scan.snapshot-id cannot bound this scan - and isolateIncrementalRead clears it anyway. The
+        // timestamp form would then resolve its endpoints inside the BE reader, through
+        // SnapshotManager#earlierOrEqualTimeMills, whose search runs up to latestSnapshotId(): the
+        // snapshot directory once the loader is gone, so a snapshot the catalog has not published
+        // yet (or one a rollback left behind) would close the range. Resolve them here instead and
+        // hand the BE the explicit id range IncrementalDeltaStartingScanner#betweenTimestamps would
+        // have computed from the catalog's own view.
+        FileStoreTable versionManaged = Mockito.spy(newPaimonTable(
+                catalogEnvironment(true, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT())));
+        SnapshotManager snapshotManager = Mockito.mock(SnapshotManager.class);
+        Mockito.doReturn(snapshotManager).when(versionManaged).snapshotManager();
+        // Catalog snapshot 42, committed at t=5000; snapshot 43 may already sit on the filesystem.
+        Snapshot catalogLatest = newSnapshot(42L, 5000L);
+        Snapshot earliest = newSnapshot(10L, 1000L);
+        Snapshot rangeStart = newSnapshot(20L, 2000L);
+        Mockito.when(snapshotManager.latestSnapshot()).thenReturn(catalogLatest);
+        Mockito.when(snapshotManager.earliestSnapshot()).thenReturn(earliest);
+        Mockito.when(snapshotManager.earlierOrEqualTimeMills(2000L)).thenReturn(rangeStart);
+
+        Map<String, String> unbounded = new HashMap<>();
+        unbounded.put("incremental-between-timestamp", "2000," + Long.MAX_VALUE);
+        Map<String, String> bound = invokeBindIncrementalRangeToCatalog(unbounded, versionManaged);
+
+        Assert.assertEquals("20,42", bound.get("incremental-between"));
+        // Cleared rather than dropped: Paimon's copy() removes a key only when it maps to null.
+        Assert.assertTrue(bound.containsKey("incremental-between-timestamp"));
+        Assert.assertNull(bound.get("incremental-between-timestamp"));
+
+        // An end older than the catalog's snapshot already resolves to the same id on both sides,
+        // because every snapshot the catalog has not published yet is younger than it.
+        Map<String, String> past = new HashMap<>();
+        past.put("incremental-between-timestamp", "2000,4000");
+        Assert.assertSame(past, invokeBindIncrementalRangeToCatalog(past, versionManaged));
+
+        // And a catalog that does not manage versions keeps filesystem semantics on both sides.
+        FileStoreTable plain = newPaimonTable(catalogEnvironment(false, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT()));
+        Assert.assertSame(unbounded, invokeBindIncrementalRangeToCatalog(unbounded, plain));
+    }
+
+    @Test
+    public void testIncrementalRangeIsNotBoundOnAFallbackBranchPair() throws Exception {
+        // The two branches keep independent snapshot id sequences, and
+        // FallbackReadFileStoreTable#rewriteFallbackOptions translates only scan.snapshot-id, so
+        // incremental-between reaches the fallback branch verbatim. A main-branch id range bound
+        // here would be validated against the fallback branch's own range in
+        // IncrementalDeltaStartingScanner#betweenSnapshotIds and either fail out of range or select
+        // unrelated commits. The timestamp form is branch-agnostic and each branch resolves it
+        // against its own SnapshotManager, so it has to reach the BE untouched.
+        Catalog catalog = Mockito.mock(Catalog.class);
+        Map<String, String> fallbackOptions = new HashMap<>();
+        fallbackOptions.put("branch", "fb");
+        FileStoreTable main = Mockito.spy(newPaimonTable(catalogEnvironment(true, catalog),
+                new DataField(0, "c1", DataTypes.INT())));
+        FileStoreTable fallback = newPaimonTable(catalogEnvironment(true, catalog), fallbackOptions,
+                new DataField(0, "c1", DataTypes.INT()));
+        // Stubbed so that the main branch alone would have produced a range: without the guard this
+        // test would see "20,42" written into incremental-between, not an unchanged map.
+        SnapshotManager mainSnapshots = Mockito.mock(SnapshotManager.class);
+        Mockito.doReturn(mainSnapshots).when(main).snapshotManager();
+        Snapshot catalogLatest = newSnapshot(42L, 5000L);
+        Snapshot earliest = newSnapshot(10L, 1000L);
+        Snapshot rangeStart = newSnapshot(20L, 2000L);
+        Mockito.lenient().when(mainSnapshots.latestSnapshot()).thenReturn(catalogLatest);
+        Mockito.lenient().when(mainSnapshots.earliestSnapshot()).thenReturn(earliest);
+        Mockito.lenient().when(mainSnapshots.earlierOrEqualTimeMills(2000L)).thenReturn(rangeStart);
+
+        Map<String, String> range = new HashMap<>();
+        range.put("incremental-between-timestamp", "2000," + Long.MAX_VALUE);
+        FileStoreTable pair = new FallbackReadFileStoreTable(main, fallback);
+
+        Assert.assertSame(range, invokeBindIncrementalRangeToCatalog(range, pair));
+        // And through the decorator PrivilegedCatalog adds, since that is what the meta cache holds.
+        Assert.assertSame(range, invokeBindIncrementalRangeToCatalog(range,
+                PrivilegedFileStoreTable.wrap(pair, new AllGrantedPrivilegeChecker(),
+                        Identifier.create("db", "tbl"))));
+
+        // Not merely "the output equals the input": the main branch's snapshots must never be read,
+        // because reading them is what produces an id range that cannot be carried to the fallback.
+        Mockito.verify(mainSnapshots, Mockito.never())
+                .earlierOrEqualTimeMills(ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    public void testIncrementalPartitionsScanBindsItsRangeBeforeTheBackend() throws Exception {
+        // $partitions is the one system table that both re-plans on the BE
+        // (PartitionsRead#createReader -> newScan().listPartitionEntries()) and accepts @incr, so it
+        // is the one that has to reach the BE with an already-resolved range.
+        FileStoreTable versionManaged = Mockito.spy(newPaimonTable(
+                catalogEnvironment(true, Mockito.mock(Catalog.class)),
+                new DataField(0, "c1", DataTypes.INT())));
+        SnapshotManager snapshotManager = Mockito.mock(SnapshotManager.class);
+        Mockito.doReturn(snapshotManager).when(versionManaged).snapshotManager();
+        Snapshot catalogLatest = newSnapshot(42L, 5000L);
+        Snapshot earliest = newSnapshot(10L, 1000L);
+        Snapshot rangeStart = newSnapshot(20L, 2000L);
+        Mockito.when(snapshotManager.latestSnapshotId()).thenReturn(42L);
+        Mockito.when(snapshotManager.latestSnapshot()).thenReturn(catalogLatest);
+        Mockito.when(snapshotManager.earliestSnapshot()).thenReturn(earliest);
+        Mockito.when(snapshotManager.earlierOrEqualTimeMills(2000L)).thenReturn(rangeStart);
+
+        PaimonSysExternalTable sysTable = Mockito.mock(PaimonSysExternalTable.class);
+        Mockito.when(sysTable.getSysTableType()).thenReturn("partitions");
+        Mockito.when(sysTable.getSysBaseTable()).thenReturn(versionManaged);
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getPaimonTable()).thenReturn(SystemTableLoader.load("partitions", versionManaged));
+        Mockito.when(source.getExternalTable()).thenReturn(sysTable);
+        PaimonScanNode node = newTestNode(new PlanNodeId(1), new TupleId(3), sv);
+        node.setSource(source);
+        node.setScanParams(new TableScanParams(TableScanParams.INCREMENTAL_READ,
+                ImmutableMap.of("startTimestamp", "2000"), Collections.emptyList()));
+
+        invokeGetPaimonTableForBackend(node);
+
+        // The range was closed here, on the catalog's snapshot, instead of inside the BE reader.
+        Mockito.verify(snapshotManager).earlierOrEqualTimeMills(2000L);
+        Mockito.verify(snapshotManager, Mockito.atLeastOnce()).latestSnapshot();
+    }
+
+    private Snapshot newSnapshot(long id, long timeMillis) {
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        Mockito.lenient().when(snapshot.id()).thenReturn(id);
+        Mockito.lenient().when(snapshot.timeMillis()).thenReturn(timeMillis);
+        return snapshot;
+    }
+
+    /**
+     * The {@code {main, fallback}} pair the FE cache captured (M1 / F1), with a newer fallback
+     * generation (F2, one column wider) already published on the filesystem - so a rebuild that
+     * re-reads the branch instead of reusing the captured object is visible in the row type.
+     */
+    private FileStoreTable[] newFallbackBranchPairWithNewerGenerationOnDisk(String prefix) throws Exception {
+        java.nio.file.Path tempDir = java.nio.file.Files.createTempDirectory(prefix);
+        Path tablePath = new Path("file://" + tempDir.toString() + "/db.db/tbl");
+        // F2: the generation external DDL has already published on the fallback branch.
+        new SchemaManager(LocalFileIO.create(), tablePath, "fb").createTable(new Schema(
+                Arrays.asList(new DataField(0, "c1", DataTypes.INT()), new DataField(1, "c2", DataTypes.INT())),
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), ""));
+
+        // F1 / M1: what the FE cache captured and planned this query with.
+        Map<String, String> mainOptions = new HashMap<>();
+        mainOptions.put("scan.fallback-branch", "fb");
+        Map<String, String> fallbackOptions = new HashMap<>();
+        fallbackOptions.put("branch", "fb");
+        return new FileStoreTable[] {newBranchTable(tablePath, mainOptions), newBranchTable(tablePath, fallbackOptions)};
+    }
+
+    private void assertFallbackPairMatchesTheFeGeneration(FileStoreTable forBackend, FileStoreTable main,
+            FileStoreTable fallback) {
+        Assert.assertTrue(forBackend instanceof FallbackReadFileStoreTable);
+        FallbackReadFileStoreTable fallbackForBackend = (FallbackReadFileStoreTable) forBackend;
+        // The fallback branch must stay on F1 - not the c2 generation sitting on the filesystem.
+        Assert.assertEquals(fallback.rowType(), fallbackForBackend.fallback().rowType());
+        Assert.assertEquals(main.rowType(), fallbackForBackend.wrapped().rowType());
+        // And neither branch may carry the loader that drags the metastore stack onto the BE.
+        Assert.assertNull(fallbackForBackend.wrapped().catalogEnvironment().catalogLoader());
+        Assert.assertNull(fallbackForBackend.fallback().catalogEnvironment().catalogLoader());
+    }
+
+    private FileStoreTable newPaimonTable(CatalogEnvironment catalogEnvironment, DataField... fields) {
+        return newPaimonTable(catalogEnvironment, new HashMap<>(), fields);
+    }
+
+    private FileStoreTable newPaimonTable(CatalogEnvironment catalogEnvironment, Map<String, String> options,
+            DataField... fields) {
+        List<DataField> fieldList = Arrays.asList(fields);
+        TableSchema schema = new TableSchema(0L, fieldList, fieldList.size() - 1, Collections.emptyList(),
+                Collections.emptyList(), options, "");
+        return FileStoreTableFactory.create(LocalFileIO.create(),
+                new Path("file:///tmp/doris_paimon_ut/db.db/tbl"), schema, catalogEnvironment);
+    }
+
+    /**
+     * One branch of a {@code scan.fallback-branch} pair, built the way Paimon builds them: without
+     * re-expanding the fallback branch, so the caller can wrap the two into a
+     * {@link FallbackReadFileStoreTable} itself.
+     */
+    private FileStoreTable newBranchTable(Path tablePath, Map<String, String> options) {
+        List<DataField> fieldList = Collections.singletonList(new DataField(0, "c1", DataTypes.INT()));
+        TableSchema schema = new TableSchema(0L, fieldList, 0, Collections.emptyList(),
+                Collections.emptyList(), options, "");
+        return FileStoreTableFactory.createWithoutFallbackBranch(LocalFileIO.create(), tablePath, schema,
+                new Options(), catalogEnvironment(false, Mockito.mock(Catalog.class)));
+    }
+
+    private CatalogEnvironment catalogEnvironment(boolean supportsVersionManagement, Catalog catalog) {
+        return new CatalogEnvironment(Identifier.create("db", "tbl"), null, () -> catalog, null, null,
+                supportsVersionManagement);
+    }
+
+    private Table invokeGetPaimonTableForBackend(PaimonScanNode node) throws Exception {
+        Method method = PaimonScanNode.class.getDeclaredMethod("getPaimonTableForBackend");
+        method.setAccessible(true);
+        return (Table) method.invoke(node);
+    }
+
+    private FileStoreTable invokeDropCatalogLoader(FileStoreTable table) throws Exception {
+        Method method = PaimonScanNode.class.getDeclaredMethod("dropCatalogLoader", FileStoreTable.class);
+        method.setAccessible(true);
+        return (FileStoreTable) method.invoke(null, table);
+    }
+
+    private void invokeAuthorizeDeferredScan(FileStoreTable table) throws Exception {
+        Method method = PaimonScanNode.class.getDeclaredMethod("authorizeDeferredScan", FileStoreTable.class);
+        method.setAccessible(true);
+        method.invoke(null, table);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> invokeBindIncrementalRangeToCatalog(Map<String, String> incrementalParams,
+            FileStoreTable dataTable) throws Exception {
+        Method method = PaimonScanNode.class.getDeclaredMethod("bindIncrementalRangeToCatalog", Map.class,
+                FileStoreTable.class);
+        method.setAccessible(true);
+        return (Map<String, String>) method.invoke(null, incrementalParams, dataTable);
+    }
+
+    private FileStoreTable invokePinCatalogSnapshot(FileStoreTable catalogLessTable, FileStoreTable dataTable)
+            throws Exception {
+        Method method = PaimonScanNode.class.getDeclaredMethod("pinCatalogSnapshot", FileStoreTable.class,
+                FileStoreTable.class);
+        method.setAccessible(true);
+        return (FileStoreTable) method.invoke(null, catalogLessTable, dataTable);
     }
 
     private void mockJniReader(PaimonScanNode spyNode) {


### PR DESCRIPTION
Backport of #65867 to branch-4.1.

### What problem does this PR solve?

Reading a Paimon table over a metastore-backed or REST catalog (HMS / DLF) fails on
BE whenever the JNI reader is used — most visibly system tables (e.g. `$snapshots`,
`$files`), which always go through JNI, and also branch / time-travel / incremental
reads. Two failures were observed, both caused by the BE rebuilding a catalog it does
not need:

```
# HMS catalog
[JNI_ERROR] NoClassDefFoundError: org/apache/hadoop/hive/conf/HiveConf
# DLF (REST) catalog
[JNI_ERROR] ClassNotFoundException: com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient
```

**Root cause.** A table loaded from a metastore-backed Paimon catalog carries a Paimon
`CatalogLoader` (e.g. `HiveCatalogLoader`) in its `CatalogEnvironment`. When FE
serializes that table to BE, `SnapshotManager#latestSnapshotId` resolves the latest
snapshot through the catalog's `SnapshotLoader`, which on BE reconstructs the catalog's
metastore client and its whole Hive / DLF-REST stack — even though the BE only reads
(via FE-resolved splits and the object store) and the snapshots already live there.
On master this became visible once #65733 replaced `java-udf`'s ~122MB
`hive-catalog-shade` with the slim `hive-udf-shade`; branch-4.1 still ships the fat
shade jar on BE's shared classpath, so there the HMS variant is partly masked while the
DLF / REST variant and the `FileIOLoader` gap below are not. Backporting keeps the two
branches aligned and removes the dependency on that jar staying fat.

**Fix 1 — serialize a catalog-less table to the BE (`PaimonScanNode`).**
- data table: rebuild via `FileStoreTableFactory` with an empty `CatalogEnvironment`.
  A `FileStoreTable` is fully defined by fileIO / location / schema, and its dynamic
  options (time travel, incremental) are already merged into the schema by `copy(...)`,
  so nothing is lost except the catalog loader.
- system table: rebuild it over such a catalog-less data table via `SystemTableLoader`.

With no catalog loader, `SnapshotManager#latestSnapshotId` lists the snapshot directory
on the filesystem instead of calling the metastore, so the BE never reconstructs the
catalog and no longer needs any Hive / metastore classes.

**Fix 2 — co-locate the Paimon FileIO plugins with `paimon-connector` (packaging).**
Reading the snapshot from the filesystem makes the BE materialize the object-store
`FileIO` lazily via `FileIO.get()` → `ServiceLoader.load(FileIOLoader.class, ...)`,
which eagerly instantiates every registered provider. The OSS/S3 plugins
(`paimon-s3` → `S3Loader`, `paimon-jindo` → `JindoLoader`) were bundled in
`preload-extensions`, on BE's JVM system (app) classpath, but the
`org.apache.paimon.fs.FileIOLoader` interface they implement ships in `paimon-common`,
bundled only in paimon-connector's own `JniScannerClassLoader`. That loader is
parent-first, so the app classloader defines `S3Loader` / `JindoLoader` and cannot
resolve the child-only `FileIOLoader` → `NoClassDefFoundError: FileIOLoader`, which
aborts discovery. Moving the two plugins into `paimon-connector` puts the whole FileIO
SPI (interface + all providers) in one classloader; the Jindo SDK stays on the app
classpath (`start_be.sh` adds `jindofs` to `DORIS_CLASSPATH`) and is still reachable
via parent delegation.

**Differences from the master PR.** Content-identical apart from the module rename:
on branch-4.1 the BE Paimon module is `be-java-extensions/paimon-connector`, not
`paimon-scanner`, so the pom dependencies, the `build.sh` packaging guard and the
comments refer to `paimon-connector`. The FE change applies unchanged.

Regression tests to re-run:
`io.trino.tests.product.paimon.TestPaimonSparkCompatibility` (system-table reads) and
`external_table_p2/paimon/test_paimon_dlf_rest_catalog`.

### Release note

Fix Paimon reads (system tables, branch / time-travel / incremental) failing on BE over
metastore-backed or REST catalogs (HMS / DLF) with `NoClassDefFoundError`
(`HiveConf` / `FileIOLoader`) or `ClassNotFoundException: ProxyMetaStoreClient`.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.
