### PR TITLE
[fix](fe) Preserve effective Compute Group for audit logs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -227,7 +227,7 @@ public class AuditLogHelper {
         String cloudCluster = "";
         try {
             if (Config.isCloudMode()) {
-                cloudCluster = ctx.getCloudCluster(false);
+                cloudCluster = getCloudClusterForAudit(ctx);
             }
         } catch (ComputeGroupException e) {
             LOG.warn("Failed to get cloud cluster", e);
@@ -413,6 +413,13 @@ public class AuditLogHelper {
         return queueToken == null ? -1 : queueToken.getQueueEndTime() - queueToken.getQueueStartTime();
     }
 
+    static String getCloudClusterForAudit(ConnectContext ctx) throws ComputeGroupException {
+        if (!Strings.isNullOrEmpty(ctx.getEffectiveCloudCluster())) {
+            return ctx.getEffectiveCloudCluster();
+        }
+        return ctx.getCloudCluster(false);
+    }
+
     /**
      * Update query metrics without writing audit log. This is used when
      * enable_prepared_stmt_audit_log is disabled, to ensure QPS metrics
@@ -448,7 +455,7 @@ public class AuditLogHelper {
         String physicalClusterName = "";
         try {
             if (Config.isCloudMode()) {
-                cloudCluster = ctx.getCloudCluster(false);
+                cloudCluster = getCloudClusterForAudit(ctx);
                 physicalClusterName = ((CloudSystemInfoService) Env.getCurrentSystemInfo())
                     .getPhysicalCluster(cloudCluster);
                 if (!cloudCluster.equals(physicalClusterName)) {
@@ -512,4 +519,3 @@ public class AuditLogHelper {
         }
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -216,6 +216,9 @@ public class ConnectContext {
 
     // cloud cluster name
     protected volatile String cloudCluster = null;
+    // The compute group selected for the statement currently being executed. Unlike cloudCluster,
+    // this value is query-scoped and remains available after a per-query SET_VAR is reverted.
+    protected volatile String effectiveCloudCluster = null;
 
     // If set to true, the nondeterministic function will not be rewrote to constant.
     private boolean notEvalNondeterministicFunction = false;
@@ -1443,6 +1446,14 @@ public class ConnectContext {
 
     public void setCloudCluster(String cluster) {
         this.getSessionVariable().setCloudCluster(cluster);
+    }
+
+    public String getEffectiveCloudCluster() {
+        return effectiveCloudCluster;
+    }
+
+    public void setEffectiveCloudCluster(String cluster) {
+        this.effectiveCloudCluster = cluster;
     }
 
     public String getCloudCluster() throws ComputeGroupException {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -672,6 +672,7 @@ public class StmtExecutor {
 
     public void execute(TUniqueId queryId) throws Exception {
         SessionVariable sessionVariable = context.getSessionVariable();
+        context.setEffectiveCloudCluster(null);
         if (context.getConnectType() == ConnectType.ARROW_FLIGHT_SQL) {
             context.setReturnResultFromLocal(true);
         }
@@ -698,6 +699,11 @@ public class StmtExecutor {
                 throw e;
             }
         } finally {
+            // Preserve the effective per-query compute group before SET_VAR values are reverted.
+            // Audit logging runs after this method returns and otherwise sees the session value.
+            if (Config.isCloudMode()) {
+                context.setEffectiveCloudCluster(sessionVariable.getCloudCluster());
+            }
             // Snapshot changed session variables (including SET_VAR hint values) BEFORE revert,
             // so the audit log (logged after execute() returns, i.e. after the revert below) can
             // reflect what was actually in effect for this statement instead of the reverted values.

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogHelperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogHelperTest.java
@@ -101,4 +101,13 @@ public class AuditLogHelperTest {
             Config.enable_bdbje_debug_mode = original;
         }
     }
+
+    @Test
+    public void testGetCloudClusterForAuditPrefersEffectiveCluster() throws Exception {
+        ConnectContext ctx = createMockContext(true, false);
+        ctx.getSessionVariable().setCloudCluster("session_cluster");
+        ctx.setEffectiveCloudCluster("hint_cluster");
+
+        Assert.assertEquals("hint_cluster", AuditLogHelper.getCloudClusterForAudit(ctx));
+    }
 }

--- a/regression-test/suites/audit/test_audit_log_hint_compute_group_docker.groovy
+++ b/regression-test/suites/audit/test_audit_log_hint_compute_group_docker.groovy
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_audit_log_hint_compute_group_docker", "docker") {
+    def options = new ClusterOptions(cloudMode: true, feNum: 1, beNum: 1, msNum: 1)
+    options.feConfigs += ['cloud_cluster_check_interval_second=1']
+
+    docker(options) {
+        def hintComputeGroup = "audit_hint_compute_group"
+        cluster.addBackend(1, hintComputeGroup)
+
+        def computeGroups = sql_return_maparray "SHOW CLUSTERS"
+        assertEquals(2, computeGroups.size())
+        def sessionComputeGroup = computeGroups.find { it.is_current == "TRUE" }.cluster
+        assertNotNull(sessionComputeGroup)
+        assertTrue(computeGroups.any { it.cluster == hintComputeGroup })
+
+        try {
+            sql "set global enable_audit_plugin = true"
+            sql "use @${sessionComputeGroup}"
+            sql "truncate table __internal_schema.audit_log"
+
+            def marker = "audit_hint_cg_docker_marker_7F3A2B"
+            sql """select /*+ SET_VAR(cloud_cluster = '${hintComputeGroup}') */
+                       1, '${marker}'"""
+
+            def retry = 60
+            def query = """select count(*)
+                            from __internal_schema.audit_log
+                            where stmt like '%${marker}%'
+                              and compute_group = '${hintComputeGroup}'"""
+            def found = (sql "${query}")[0][0] as long
+            while (found == 0) {
+                if (retry-- < 0) {
+                    throw new RuntimeException("audit_log row for the hint query was not found in the "
+                            + "hint Compute Group")
+                }
+                sleep(3000)
+                sql "call flush_audit_log()"
+                found = (sql "${query}")[0][0] as long
+            }
+
+            assertTrue(found >= 1)
+        } finally {
+            sql "set global enable_audit_plugin = false"
+        }
+    }
+}

--- a/regression-test/suites/audit/test_audit_log_hint_session_context.groovy
+++ b/regression-test/suites/audit/test_audit_log_hint_session_context.groovy
@@ -75,5 +75,40 @@ suite("test_audit_log_hint_session_context", "nonConcurrent") {
     // The per-query SET_VAR hint session_context must be visible in changed_variables.
     assertTrue(found >= 1)
 
+    if (isCloudMode()) {
+        def computeGroups = sql "SHOW COMPUTE GROUPS"
+        if (computeGroups.size() < 2) {
+            log.warn("skip Compute Group audit assertion because fewer than two Compute Groups exist")
+        } else {
+            def sessionComputeGroup = computeGroups[0][0]
+            def hintComputeGroup = computeGroups[1][0]
+            def computeGroupMarker = "audit_hint_cg_marker_7F3A2B"
+
+            sql "use @${sessionComputeGroup}"
+            sql "truncate table __internal_schema.audit_log"
+            sql """select /*+ SET_VAR(cloud_cluster = '${hintComputeGroup}') */
+                       1, '${computeGroupMarker}'"""
+
+            def computeGroupRetry = 60
+            def computeGroupQuery = """select compute_group
+                                      from __internal_schema.audit_log
+                                      where stmt like '%${computeGroupMarker}%'
+                                        and compute_group = '${hintComputeGroup}'
+                                      order by time desc limit 1"""
+            def computeGroupResult = sql "${computeGroupQuery}"
+            while (computeGroupResult.isEmpty()) {
+                if (computeGroupRetry-- < 0) {
+                    throw new RuntimeException("audit_log row for the hint query was not found in the "
+                            + "hint Compute Group")
+                }
+                sleep(3000)
+                sql "call flush_audit_log()"
+                computeGroupResult = sql "${computeGroupQuery}"
+            }
+
+            assertEquals(hintComputeGroup, computeGroupResult[0][0].toString())
+        }
+    }
+
     sql "set global enable_audit_plugin = false"
 }

--- a/regression-test/suites/audit/test_audit_log_hint_session_context.groovy
+++ b/regression-test/suites/audit/test_audit_log_hint_session_context.groovy
@@ -75,40 +75,5 @@ suite("test_audit_log_hint_session_context", "nonConcurrent") {
     // The per-query SET_VAR hint session_context must be visible in changed_variables.
     assertTrue(found >= 1)
 
-    if (isCloudMode()) {
-        def computeGroups = sql "SHOW COMPUTE GROUPS"
-        if (computeGroups.size() < 2) {
-            log.warn("skip Compute Group audit assertion because fewer than two Compute Groups exist")
-        } else {
-            def sessionComputeGroup = computeGroups[0][0]
-            def hintComputeGroup = computeGroups[1][0]
-            def computeGroupMarker = "audit_hint_cg_marker_7F3A2B"
-
-            sql "use @${sessionComputeGroup}"
-            sql "truncate table __internal_schema.audit_log"
-            sql """select /*+ SET_VAR(cloud_cluster = '${hintComputeGroup}') */
-                       1, '${computeGroupMarker}'"""
-
-            def computeGroupRetry = 60
-            def computeGroupQuery = """select compute_group
-                                      from __internal_schema.audit_log
-                                      where stmt like '%${computeGroupMarker}%'
-                                        and compute_group = '${hintComputeGroup}'
-                                      order by time desc limit 1"""
-            def computeGroupResult = sql "${computeGroupQuery}"
-            while (computeGroupResult.isEmpty()) {
-                if (computeGroupRetry-- < 0) {
-                    throw new RuntimeException("audit_log row for the hint query was not found in the "
-                            + "hint Compute Group")
-                }
-                sleep(3000)
-                sql "call flush_audit_log()"
-                computeGroupResult = sql "${computeGroupQuery}"
-            }
-
-            assertEquals(hintComputeGroup, computeGroupResult[0][0].toString())
-        }
-    }
-
     sql "set global enable_audit_plugin = false"
 }


### PR DESCRIPTION
Problem Summary: In Cloud mode, a per-query SET_VAR(cloud_cluster=...) temporarily changes the session variable used by query scheduling. StmtExecutor reverted this value before AuditLogHelper built the audit event, so ComputeGroupName and related per-Compute-Group query, error, and latency metrics were attributed to the session's original Compute Group even though the query ran on the hinted group. Preserve the query-scoped effective Compute Group before reverting SET_VAR and use it for both audit events and metrics, with fallback to the existing session resolution path.

### Release note

Fix ComputeGroupName in FE audit logs and Compute Group query metrics for per-query cloud_cluster/compute_group hints.

### Check List (For Author)

- Test: ./build.sh --fe -j 2; ./run-fe-ut.sh --run org.apache.doris.qe.AuditLogHelperTest; mvn checkstyle:check -pl fe-core; git diff --check. The Cloud regression case was added but not run because this worktree has no running Doris cluster.

    - Regression test / Unit Test / Manual test / No need to test (with reason)

- Behavior changed: Yes (audit and metric attribution corrected)

- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

