### PR TITLE
[feature](be) Add Variant Path Slot mapping for file scans

### DIFF
--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -820,10 +820,31 @@ Status FileScannerV2::_build_default_expr(const TFileScanSlotInfo& slot_info,
 format::ColumnDefinition FileScannerV2::_build_table_column(const SlotDescriptor* slot_desc) {
     DORIS_CHECK(slot_desc != nullptr);
     format::ColumnDefinition column;
-    // TODO(gabriel): why always BY_NAME here?
-    column.identifier = Field::create_field<TYPE_STRING>(slot_desc->col_name());
     column.name = slot_desc->col_name();
     column.type = slot_desc->get_data_type_ptr();
+    column.column_paths = slot_desc->column_paths();
+    if (column.column_paths.empty()) {
+        // Keep the existing generic root-column behavior. Non-Iceberg readers map these slots by
+        // name, and their catalog unique ids do not necessarily identify a physical file field.
+        column.identifier = Field::create_field<TYPE_STRING>(slot_desc->col_name());
+    } else {
+        // A rewritten Path Slot has its own SlotId while col_unique_id still identifies the
+        // Iceberg root v and column_paths identifies the requested value below it. FE encodes the
+        // path in the materialized name (for example "v.metric.x"). Preserve the root prefix in
+        // the existing name_mapping field so an entirely idless legacy Iceberg file can use its
+        // file-level BY_NAME policy. Files containing any field id remain in strict BY_FIELD_ID
+        // mode and never fall back to this name.
+        DORIS_CHECK(slot_desc->col_unique_id() >= 0);
+        column.identifier = Field::create_field<TYPE_INT>(slot_desc->col_unique_id());
+        std::string path_suffix;
+        for (const auto& key : column.column_paths) {
+            path_suffix.push_back('.');
+            path_suffix.append(key);
+        }
+        DORIS_CHECK(column.name.ends_with(path_suffix));
+        column.name_mapping.push_back(
+                column.name.substr(0, column.name.size() - path_suffix.size()));
+    }
     return column;
 }
 
@@ -962,21 +983,28 @@ size_t FileScannerV2::_predict_reader_batch_rows() {
     return predicted_rows;
 }
 
+size_t FileScannerV2::_adaptive_batch_sample_bytes(const Block& block,
+                                                   size_t materialization_input_bytes) {
+    return std::max(block.bytes(), materialization_input_bytes);
+}
+
 void FileScannerV2::_update_adaptive_batch_size(const Block& block) {
     if (!_should_run_adaptive_batch_size()) {
         return;
     }
-    COUNTER_SET(_adaptive_batch_actual_bytes_counter, static_cast<int64_t>(block.bytes()));
+    const size_t sample_bytes = _adaptive_batch_sample_bytes(
+            block, _table_reader->last_batch_materialization_input_bytes());
+    COUNTER_SET(_adaptive_batch_actual_bytes_counter, static_cast<int64_t>(sample_bytes));
     if (block.rows() == 0) {
         return;
     }
-    // The sample is taken after TableReader has finalized file-local columns to table columns.
-    // This matches the memory shape seen by upstream operators and catches very wide nested
-    // columns, such as map/string payloads, after the first probe batch.
+    // Use the wider of the final table block and TableReader's pre-extraction carrier. This keeps
+    // current readers that ignore Variant path projection from learning the tiny extracted leaf
+    // width, while a future physically pruned carrier naturally restores larger batches.
     if (!_block_size_predictor->has_history()) {
         COUNTER_UPDATE(_adaptive_batch_probe_count_counter, 1);
     }
-    _block_size_predictor->update(block);
+    _block_size_predictor->update(block.rows(), sample_bytes);
 }
 
 Status FileScannerV2::close(RuntimeState* state) {

--- a/be/src/exec/scan/file_scanner_v2.h
+++ b/be/src/exec/scan/file_scanner_v2.h
@@ -75,6 +75,9 @@ public:
                                        const std::string& column_name);
     static bool TEST_is_data_file_slot(const TFileScanSlotInfo& slot_info,
                                        const std::string& column_name);
+    static format::ColumnDefinition TEST_build_table_column(const SlotDescriptor* slot_desc) {
+        return _build_table_column(slot_desc);
+    }
     static Status TEST_rewrite_slot_refs_to_global_index(
             VExprSPtr* expr,
             const std::unordered_map<int32_t, format::GlobalIndex>& slot_id_to_global_index);
@@ -96,6 +99,10 @@ public:
                                                     bool current_split_uses_metadata_count) {
         return _should_run_adaptive_batch_size(predictor_initialized,
                                                current_split_uses_metadata_count);
+    }
+    static size_t TEST_adaptive_batch_sample_bytes(const Block& block,
+                                                   size_t materialization_input_bytes) {
+        return _adaptive_batch_sample_bytes(block, materialization_input_bytes);
     }
 #endif
 
@@ -154,6 +161,8 @@ private:
     bool _should_run_adaptive_batch_size() const;
     static bool _should_run_adaptive_batch_size(bool predictor_initialized,
                                                 bool current_split_uses_metadata_count);
+    static size_t _adaptive_batch_sample_bytes(const Block& block,
+                                               size_t materialization_input_bytes);
     size_t _predict_reader_batch_rows();
     void _update_adaptive_batch_size(const Block& block);
     static RealtimeCounterDeltas _collect_realtime_counter_deltas(

--- a/be/src/format_v2/column_data.h
+++ b/be/src/format_v2/column_data.h
@@ -224,8 +224,8 @@ struct GlobalRowIdContext {
 
 // Column schema definition shared by table/global projection and file-local schema matching.
 //
-// ColumnDefinition intentionally carries schema identity only. FE column unique ids are translated
-// to GlobalIndex at the FileScannerV2 boundary and must not appear in table/file reader APIs.
+// FE column unique ids are translated to typed schema identifiers or GlobalIndex values at the
+// FileScannerV2 boundary and must not otherwise appear in table/file reader APIs.
 struct ColumnDefinition {
     // Typed identifier value used to match a column against another schema.
     //
@@ -252,6 +252,13 @@ struct ColumnDefinition {
     // not fall back to the current name when matching fields in legacy files.
     bool has_name_mapping = false;
     DataTypePtr type;
+    // Object-key segments for one rewritten Variant Path Slot. Empty means this output requests
+    // the root column itself. These are logical projection segments, not physical schema children:
+    // a key containing '.' remains one segment, and readers must not insert these strings into
+    // ColumnDefinition::children.
+    // Keep the explicit empty initializer so existing designated initializers that name later
+    // members do not fail -Wmissing-designated-field-initializers.
+    std::vector<std::string> column_paths {}; // NOLINT(readability-redundant-member-init)
     // Semantic nested children for this schema node.
     //
     // Table/global columns carry projected table children. File-local schemas returned by
@@ -351,6 +358,16 @@ struct LocalColumnIndex {
     int32_t index = -1;
     bool project_all_children = true;
     std::vector<LocalColumnIndex> children {};
+    // Exact object-key paths requested from one Variant root. This deliberately stays separate
+    // from children, whose indexes are reader-local schema ids. Multiple rewritten Path Slots can
+    // share one root LocalColumnId and union their string paths here. A Variant-aware file reader
+    // must use the paths to prune physical typed streams, then materialize an encoded (possibly
+    // partial) root ColumnVariantV2 at this root's LocalIndex. TableReader extracts each logical
+    // Path Slot from that shared carrier; returning a typed leaf directly violates this contract.
+    // Keep the explicit empty initializer so top_level()/local()/partial_local() can continue to
+    // use concise designated initializers under -Wmissing-designated-field-initializers.
+    std::vector<std::vector<std::string>>
+            variant_paths {}; // NOLINT(readability-redundant-member-init)
 
     static LocalColumnIndex top_level(LocalColumnId column_id) {
         return {.index = column_id.value()};
@@ -404,7 +421,13 @@ inline Status merge_local_column_index(LocalColumnIndex* target, const LocalColu
     if (source.project_all_children) {
         target->project_all_children = true;
         target->children.clear();
+        target->variant_paths.clear();
         return Status::OK();
+    }
+    for (const auto& source_path : source.variant_paths) {
+        if (std::ranges::find(target->variant_paths, source_path) == target->variant_paths.end()) {
+            target->variant_paths.push_back(source_path);
+        }
     }
     for (const auto& source_child : source.children) {
         auto target_child_it = std::find_if(

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -36,7 +36,9 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_struct.h"
+#include "core/data_type/data_type_variant_v2.h"
 #include "core/data_type/primitive_type.h"
+#include "exprs/function/function_variant_element_v2.h"
 #include "exprs/runtime_filter_expr.h"
 #include "exprs/short_circuit_evaluation_expr.h"
 #include "exprs/vcase_expr.h"
@@ -57,6 +59,67 @@
 namespace doris::format {
 
 namespace {
+
+std::string mapping_mode_to_string(TableColumnMappingMode mode);
+
+bool is_variant_v2_type(const DataTypePtr& type) {
+    return type != nullptr &&
+           dynamic_cast<const DataTypeVariantV2*>(remove_nullable(type).get()) != nullptr;
+}
+
+Status resolve_variant_path(const std::vector<std::string>& column_paths,
+                            std::shared_ptr<const ResolvedVariantElementV2Path>* resolved_path) {
+    DORIS_CHECK(!column_paths.empty());
+    DORIS_CHECK(resolved_path != nullptr);
+    std::vector<VariantElementV2PathSegment> segments;
+    segments.reserve(column_paths.size());
+    for (const auto& key : column_paths) {
+        // TSlotDescriptor.column_paths is an already-tokenized list. Treat every entry as one
+        // object key; joining on '.' would turn a literal key such as "a.b" into two selectors.
+        // Array indexes need a typed transport and are intentionally outside this contract.
+        segments.push_back(
+                VariantElementV2PathSegment::object_key(StringRef(key.data(), key.size())));
+    }
+    std::unique_ptr<ResolvedVariantElementV2Path> candidate;
+    RETURN_IF_ERROR(resolve_variant_element_v2_path(segments, &candidate));
+    *resolved_path = std::move(candidate);
+    return Status::OK();
+}
+
+Status initialize_variant_path_mapping(const ColumnDefinition& table_column,
+                                       TableColumnMappingMode mode, ColumnMapping* mapping) {
+    DORIS_CHECK(mapping != nullptr);
+    mapping->column_paths = table_column.column_paths;
+    if (mapping->column_paths.empty()) {
+        return Status::OK();
+    }
+    if (mode == TableColumnMappingMode::BY_INDEX) {
+        return Status::NotSupported(
+                "Variant Path Slot '{}' requires field-id or name table-to-file mapping, got {}",
+                table_column.name, mapping_mode_to_string(mode));
+    }
+    if (!is_variant_v2_type(mapping->table_type)) {
+        return Status::NotSupported(
+                "Variant Path Slot '{}' requires Variant V2 table type, got {}", table_column.name,
+                mapping->table_type == nullptr ? "null" : mapping->table_type->get_name());
+    }
+    // SlotReference.withSubPath() makes every rewritten Path Slot nullable because a key can be
+    // absent even when the root column is NOT NULL. Treat a non-nullable Path Slot as an invalid
+    // FE/BE plan contract instead of materializing a non-null Variant default.
+    DORIS_CHECK(mapping->table_type->is_nullable());
+    return resolve_variant_path(mapping->column_paths, &mapping->resolved_variant_path);
+}
+
+Status validate_variant_path_file_type(const ColumnDefinition& table_column,
+                                       const ColumnMapping& mapping) {
+    if (mapping.column_paths.empty() || is_variant_v2_type(mapping.file_type)) {
+        return Status::OK();
+    }
+    return Status::NotSupported(
+            "Variant Path Slot '{}' requires a Variant V2 file root, but '{}' has type {}",
+            table_column.name, mapping.file_column_name,
+            mapping.file_type == nullptr ? "null" : mapping.file_type->get_name());
+}
 
 Status build_initial_default_column(const ColumnDefinition& column, ColumnPtr* value) {
     DORIS_CHECK(value != nullptr);
@@ -405,7 +468,9 @@ std::string ColumnDefinition::debug_string() const {
         << ", name_mapping="
         << join_debug_strings(name_mapping, [](const std::string& name) { return name; })
         << ", has_name_mapping=" << has_name_mapping << ", local_id=" << local_id
-        << ", type=" << data_type_debug_string(type) << ", children="
+        << ", type=" << data_type_debug_string(type) << ", column_paths="
+        << join_debug_strings(column_paths, [](const std::string& key) { return key; })
+        << ", children="
         << join_debug_strings(children,
                               [](const ColumnDefinition& child) { return child.debug_string(); })
         << ", identity_children="
@@ -419,6 +484,12 @@ std::string ColumnDefinition::debug_string() const {
 std::string LocalColumnIndex::debug_string() const {
     std::ostringstream out;
     out << "LocalColumnIndex{index=" << index << ", project_all_children=" << project_all_children
+        << ", variant_paths="
+        << join_debug_strings(variant_paths,
+                              [](const std::vector<std::string>& path) {
+                                  return join_debug_strings(
+                                          path, [](const std::string& key) { return key; });
+                              })
         << ", children="
         << join_debug_strings(children,
                               [](const LocalColumnIndex& child) { return child.debug_string(); })
@@ -447,7 +518,9 @@ std::string ColumnMapping::debug_string() const {
         << join_debug_strings(original_file_children,
                               [](const ColumnDefinition& child) { return child.debug_string(); })
         << ", file_type=" << data_type_debug_string(file_type)
-        << ", table_type=" << data_type_debug_string(table_type)
+        << ", table_type=" << data_type_debug_string(table_type) << ", column_paths="
+        << join_debug_strings(column_paths, [](const std::string& key) { return key; })
+        << ", has_resolved_variant_path=" << (resolved_variant_path != nullptr)
         << ", has_projection=" << (projection != nullptr) << ", child_mappings="
         << join_debug_strings(child_mappings,
                               [](const ColumnMapping& child) { return child.debug_string(); })
@@ -1344,6 +1417,11 @@ static bool needs_complex_rematerialize(const ColumnMapping& mapping) {
 }
 
 static bool mapping_can_use_file_column_directly(const ColumnMapping& mapping) {
+    if (!mapping.column_paths.empty()) {
+        // Equal VARIANT types only mean the shared root carrier has the same physical type as the
+        // Path Slot result. The logical values differ until finalize extracts column_paths.
+        return false;
+    }
     if (mapping.table_type == nullptr || mapping.file_type == nullptr) {
         return false;
     }
@@ -1792,8 +1870,16 @@ static Status add_scan_column(FileScanRequest* file_request, ColumnMapping* mapp
     // Columnar readers can turn a complex mapping into a nested file projection, but
     // row-oriented readers must scan the full top-level complex field because all children are
     // encoded in the same text cell.
-    if (!force_full_complex_scan_projection && needs_nested_file_projection(*mapping)) {
-        RETURN_IF_ERROR(build_complex_projection(*mapping, &projection));
+    if (!force_full_complex_scan_projection) {
+        if (!mapping->column_paths.empty()) {
+            // Path Slots remain separate output mappings, but their physical request is one
+            // partial projection on the shared Variant root. FileScanRequestBuilder unions these
+            // string paths by LocalColumnId just as it already unions numeric nested projections.
+            projection.project_all_children = false;
+            projection.variant_paths.push_back(mapping->column_paths);
+        } else if (needs_nested_file_projection(*mapping)) {
+            RETURN_IF_ERROR(build_complex_projection(*mapping, &projection));
+        }
     }
     if (is_predicate_column && !force_full_complex_scan_projection) {
         DCHECK(filter_projections != nullptr);
@@ -1914,7 +2000,8 @@ static Status build_nested_struct_filter_projection_map(
 
 static void rebuild_projection(ColumnMapping* mapping, LocalIndex block_position) {
     DORIS_CHECK(mapping->file_local_id.has_value());
-    if (mapping->is_trivial || needs_complex_rematerialize(*mapping)) {
+    if (!mapping->column_paths.empty() || mapping->is_trivial ||
+        needs_complex_rematerialize(*mapping)) {
         mapping->projection = VExprContext::create_shared(VSlotRef::create_shared(
                 cast_set<int>(block_position.value()), cast_set<int>(block_position.value()), -1,
                 mapping->file_type, mapping->file_column_name));
@@ -2004,6 +2091,7 @@ Status TableColumnMapper::_create_mapping_for_column(const ColumnDefinition& tab
     mapping->global_index = global_index;
     mapping->table_column_name = table_column.name;
     mapping->table_type = table_column.type;
+    RETURN_IF_ERROR(initialize_variant_path_mapping(table_column, _options.mode, mapping));
     // Row-lineage names are Iceberg metadata contracts, not reserved names in generic Hive,
     // Hudi, or Paimon schemas. Only the Iceberg reader may opt into virtual synthesis.
     const auto row_lineage_type =
@@ -2022,6 +2110,7 @@ Status TableColumnMapper::_create_mapping_for_column(const ColumnDefinition& tab
     } else if (const auto* file_field = _find_file_field(table_column, _file_schema)) {
         // Normal physical file column mapping.
         RETURN_IF_ERROR(_create_direct_mapping(table_column, *file_field, mapping));
+        RETURN_IF_ERROR(validate_variant_path_file_type(table_column, *mapping));
         if (row_lineage_type != TableVirtualColumnType::INVALID) {
             // Iceberg v3 rewritten files may physically contain row lineage metadata fields.
             // File non-null values must be preserved, while file NULLs still inherit from data file
@@ -2056,6 +2145,13 @@ Status TableColumnMapper::_create_mapping_for_column(const ColumnDefinition& tab
                     "Table column '{}' (global_index={}) does not have a matching partition value",
                     table_column.name, mapping->global_index.value());
         }
+    }
+    if (!mapping->column_paths.empty()) {
+        // The file-local carrier is the root Variant, not the Path Slot value. Never expose it as
+        // a localized filter/constant and never let equal root/output types mark this mapping
+        // trivial; extraction must run in TableReader::finalize_chunk().
+        mapping->is_trivial = false;
+        mapping->filter_conversion = FilterConversionType::FINALIZE_ONLY;
     }
     return Status::OK();
 }
@@ -2143,7 +2239,10 @@ Status TableColumnMapper::_build_filter_entries(const FileScanRequest& file_requ
     const auto mappings = _filter_visible_mappings();
     for (const auto& mapping : mappings) {
         FilterEntry entry;
-        if (mapping.constant_index.has_value()) {
+        if (!mapping.column_paths.empty()) {
+            // A constant/default is still a root carrier until the Variant path is extracted.
+            // Scanner-level filters refer to the Path Slot, so they must stay above finalize.
+        } else if (mapping.constant_index.has_value()) {
             entry = FilterEntry::constant(*mapping.constant_index);
         } else if (mapping.file_local_id.has_value() &&
                    filter_conversion_has_local_source(mapping.filter_conversion)) {

--- a/be/src/format_v2/column_mapper.h
+++ b/be/src/format_v2/column_mapper.h
@@ -32,6 +32,7 @@
 #include "format_v2/file_reader.h"
 
 namespace doris {
+class ResolvedVariantElementV2Path;
 class RuntimeState;
 } // namespace doris
 
@@ -135,6 +136,13 @@ struct ColumnMapping {
     DataTypePtr file_type;
     // Target table/global type after final materialization.
     DataTypePtr table_type;
+    // Existing TSlotDescriptor.column_paths copied through ColumnDefinition. Empty means a normal
+    // root projection. Non-empty paths are exact object-key segments and are never dotted-string
+    // parsed or represented as physical schema children.
+    std::vector<std::string> column_paths;
+    // Immutable, pre-resolved form of column_paths reused for every chunk. This is the existing
+    // Variant V2 element_at kernel representation, not a new FE/Thrift Path Slot protocol.
+    std::shared_ptr<const ResolvedVariantElementV2Path> resolved_variant_path;
 
     // Final projection expression used to convert file-local values into table/global values, such
     // as casts, defaults, partition values, generated columns, or complex-column remaps.

--- a/be/src/format_v2/file_reader.h
+++ b/be/src/format_v2/file_reader.h
@@ -149,6 +149,7 @@ private:
         if (projection->project_all_children) {
             return;
         }
+        std::ranges::sort(projection->variant_paths);
         for (auto& child : projection->children) {
             _sort_projection_children_by_file_id(&child);
         }
@@ -163,11 +164,19 @@ private:
         DORIS_CHECK(scan_columns != nullptr);
         const auto file_column_id = projection.column_id();
         DORIS_CHECK(file_column_id != LocalColumnId::invalid());
-        if (!is_predicate_column &&
-            std::ranges::find_if(_request->predicate_columns, [&](const LocalColumnIndex& p) {
-                return p.column_id() == file_column_id;
-            }) != _request->predicate_columns.end()) {
-            return Status::OK();
+        if (!is_predicate_column) {
+            auto predicate_it = std::ranges::find_if(
+                    _request->predicate_columns, [&](const LocalColumnIndex& candidate) {
+                        return candidate.column_id() == file_column_id;
+                    });
+            if (predicate_it != _request->predicate_columns.end()) {
+                // The same root can back several rewritten Path Slots. A later output-only path
+                // must still be merged into the earlier predicate projection instead of being
+                // dropped merely because the root LocalColumnId is already present.
+                RETURN_IF_ERROR(merge_local_column_index(&*predicate_it, projection));
+                _sort_projection_children_by_file_id(&*predicate_it);
+                return Status::OK();
+            }
         }
         if (!_request->local_positions.contains(file_column_id)) {
             _request->local_positions.emplace(file_column_id, _next_block_position(*_request));
@@ -189,6 +198,13 @@ private:
                     _request->non_predicate_columns,
                     [&](const LocalColumnIndex& p) { return p.column_id() == file_column_id; });
             if (it != _request->non_predicate_columns.end()) {
+                auto predicate_it = std::ranges::find_if(
+                        _request->predicate_columns, [&](const LocalColumnIndex& candidate) {
+                            return candidate.column_id() == file_column_id;
+                        });
+                DORIS_CHECK(predicate_it != _request->predicate_columns.end());
+                RETURN_IF_ERROR(merge_local_column_index(&*predicate_it, *it));
+                _sort_projection_children_by_file_id(&*predicate_it);
                 _request->non_predicate_columns.erase(it);
             }
         }

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -391,6 +391,23 @@ const schema::external::TField* find_external_root_field(const TFileScanRangePar
     if (!schema->__isset.root_field || !schema->root_field.__isset.fields) {
         return nullptr;
     }
+    if (column.has_identifier_field_id()) {
+        // A rewritten Variant Path Slot has a materialized output name such as "v.metric.x".
+        // Its existing col_unique_id is transported as
+        // ColumnDefinition::identifier and is the authoritative Iceberg root identity.
+        for (const auto& field_ptr : schema->root_field.fields) {
+            const auto* field = get_field_ptr(field_ptr);
+            if (field != nullptr && field->__isset.id &&
+                field->id == column.get_identifier_field_id()) {
+                return field;
+            }
+        }
+        if (!column.column_paths.empty()) {
+            // Schema evolution can drop field id 42 and later reuse the same name for field id 99.
+            // A Path Slot for 42 must remain a missing root instead of silently binding to 99.
+            return nullptr;
+        }
+    }
     if (!supports_iceberg_scan_semantics_v1(params)) {
         // Old BEs used one ordered current-name/alias pass. Preserve that result for old-FE plans
         // until the explicit scan-semantics marker makes exact-name precedence cluster-wide.
@@ -596,6 +613,16 @@ Status TableReader::annotate_projected_column(const TFileScanSlotInfo& slot_info
     context->schema_column.reset();
     const auto* schema_field = find_external_root_field(context->scan_params, *column);
     if (schema_field == nullptr) {
+        if (!column->column_paths.empty() && column->has_identifier_field_id() &&
+            context->scan_params != nullptr && context->scan_params->__isset.history_schema_info &&
+            !context->scan_params->history_schema_info.empty()) {
+            // History metadata was available but the authoritative root field id is absent. Do
+            // not carry FileScannerV2's legacy root-name alias into an entirely idless file: a
+            // later field can reuse that name with a different id. Authoritative empty mapping
+            // makes this Path Slot missing/default/NULL in both BY_FIELD_ID and BY_NAME modes.
+            column->name_mapping.clear();
+            column->has_name_mapping = true;
+        }
         return Status::OK();
     }
     context->schema_column = build_schema_column_from_external_field(*schema_field, column->type);
@@ -608,6 +635,18 @@ Status TableReader::annotate_projected_column(const TFileScanSlotInfo& slot_info
     column->identifier = context->schema_column->identifier;
     column->name_mapping = context->schema_column->name_mapping;
     column->has_name_mapping = context->schema_column->has_name_mapping;
+    if (!column->column_paths.empty() && !column->has_name_mapping) {
+        // A Path Slot keeps its materialized output name in `name`, so BY_NAME must use the
+        // current root name through the existing alias channel. An authoritative Iceberg name
+        // mapping, including an explicitly empty one, is kept exact and must not gain this
+        // fallback.
+        const auto& current_root_name = context->schema_column->name;
+        if (std::ranges::none_of(column->name_mapping, [&](const std::string& alias) {
+                return to_lower(alias) == to_lower(current_root_name);
+            })) {
+            column->name_mapping.push_back(current_root_name);
+        }
+    }
     // Projected roots already carry a generic FE default expression, but Iceberg binary defaults
     // need the raw Base64 marker so missing-file materialization can decode rather than copy text.
     column->initial_default_value = context->schema_column->initial_default_value;

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -24,8 +24,10 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -41,6 +43,7 @@
 #include "core/column/column_nullable.h"
 #include "core/column/column_struct.h"
 #include "core/column/column_vector.h"
+#include "core/column/variant_v2/column_variant_v2.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_map.h"
@@ -50,6 +53,7 @@
 #include "core/data_type/data_type_struct.h"
 #include "core/field.h"
 #include "exec/common/stringop_substring.h"
+#include "exprs/function/function_variant_element_v2.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
 #include "exprs/vexpr_fwd.h"
@@ -228,6 +232,12 @@ public:
         return _current_split_uses_metadata_count;
     }
 
+    // Largest logical input retained while materializing the last returned batch. FileScannerV2
+    // combines this with the final output width when learning its adaptive batch size.
+    size_t last_batch_materialization_input_bytes() const {
+        return _last_batch_materialization_input_bytes;
+    }
+
     // Discard the active split after the caller decides an error is ignorable, for example a
     // stale external-table file listing that returns NOT_FOUND. The next prepare_split() must start
     // with no concrete reader or split-local state left from the failed split.
@@ -258,6 +268,7 @@ public:
         SCOPED_TIMER(_profile.exec_timer);
         DORIS_CHECK(block->columns() == _projected_columns.size());
         block->clear_column_data(_projected_columns.size());
+        _last_batch_materialization_input_bytes = 0;
 
         while (true) {
             if (*eos) {
@@ -778,14 +789,86 @@ protected:
     // Finalize file-local block to table/global schema block.
     Status finalize_chunk(Block* block, const size_t rows) {
         SCOPED_TIMER(_profile.finalize_timer);
-        size_t idx = 0;
         const auto& mappings = _data_reader.column_mapper->mappings();
-        for (const auto& mapping : mappings) {
+        const size_t file_column_count = _data_reader.block_template.columns();
+        const bool has_variant_path = std::ranges::any_of(
+                mappings,
+                [](const ColumnMapping& mapping) { return !mapping.column_paths.empty(); });
+        // Record before any projection transfers a carrier out of the file-local block. Current
+        // Variant-aware Parquet readers may return a full root even when only a tiny Path Slot is
+        // requested; future physical pruning automatically lowers this sample.
+        _last_batch_materialization_input_bytes =
+                has_variant_path ? _data_reader.block_template.bytes() : 0;
+        auto materialize_mapping = [&](size_t mapping_index,
+                                       bool take_projection_result) -> Status {
             ColumnPtr column;
-            RETURN_IF_ERROR(_materialize_mapping_column(mapping, &_data_reader.block_template, rows,
-                                                        &column, idx + 1 == mappings.size()));
-            block->replace_by_position(idx, IColumn::mutate(std::move(column)));
-            idx++;
+            RETURN_IF_ERROR(_materialize_mapping_column(mappings[mapping_index],
+                                                        &_data_reader.block_template, rows, &column,
+                                                        take_projection_result));
+            // Materialization order is internal only. Always write the original global index
+            // position so the table/global output schema remains unchanged.
+            block->replace_by_position(mapping_index, IColumn::mutate(std::move(column)));
+            return Status::OK();
+        };
+
+        if (!has_variant_path) {
+            // Keep the common path identical to the original linear finalization. Building a
+            // carrier ownership plan is only necessary when a Path Slot shares its root source.
+            for (size_t mapping_index = 0; mapping_index < mappings.size(); ++mapping_index) {
+                RETURN_IF_ERROR(
+                        materialize_mapping(mapping_index, mapping_index + 1 == mappings.size()));
+            }
+        } else {
+            // Record the last consumer in execution order once per chunk. This avoids scanning all
+            // mappings for every output column when a Path Slot is present.
+            std::unordered_map<int32_t, size_t> last_file_column_consumers;
+            last_file_column_consumers.reserve(mappings.size());
+            auto record_phase = [&](bool record_paths) {
+                for (size_t mapping_index = 0; mapping_index < mappings.size(); ++mapping_index) {
+                    const auto& mapping = mappings[mapping_index];
+                    if ((!mapping.column_paths.empty()) != record_paths ||
+                        !mapping.file_local_id.has_value() || mapping.projection == nullptr) {
+                        continue;
+                    }
+                    last_file_column_consumers[*mapping.file_local_id] = mapping_index;
+                }
+            };
+            // Every Path Slot reads its shared carrier before any root/normal mapping can transfer
+            // that carrier out of the file block.
+            record_phase(true);
+            record_phase(false);
+
+            auto materialize_phase = [&](bool materialize_paths) -> Status {
+                for (size_t mapping_index = 0; mapping_index < mappings.size(); ++mapping_index) {
+                    const auto& mapping = mappings[mapping_index];
+                    if ((!mapping.column_paths.empty()) != materialize_paths) {
+                        continue;
+                    }
+                    bool take_projection_result = false;
+                    if (mapping.file_local_id.has_value() && mapping.projection != nullptr) {
+                        const auto last_consumer_it =
+                                last_file_column_consumers.find(*mapping.file_local_id);
+                        DORIS_CHECK(last_consumer_it != last_file_column_consumers.end());
+                        take_projection_result = last_consumer_it->second == mapping_index;
+                    }
+                    RETURN_IF_ERROR(materialize_mapping(mapping_index, take_projection_result));
+                }
+                return Status::OK();
+            };
+            RETURN_IF_ERROR(materialize_phase(true));
+            RETURN_IF_ERROR(materialize_phase(false));
+        }
+        // Expressions can append temporary result columns, while carrier transfer leaves same-row
+        // constant placeholders so later expressions retain Block::rows(). Remove the temporary
+        // results and restore only transferred file columns before the next physical batch. Other
+        // file columns keep their allocated buffers for clear_column_data() to reuse.
+        _data_reader.block_template.erase_tail(file_column_count);
+        for (size_t idx = 0; idx < file_column_count; ++idx) {
+            auto& file_column = _data_reader.block_template.get_by_position(idx);
+            if (is_column_const(*file_column.column)) {
+                DORIS_CHECK(file_column.type != nullptr);
+                file_column.column = file_column.type->create_column();
+            }
         }
         RETURN_IF_ERROR(materialize_virtual_columns(block));
         // Enforce CHAR/VARCHAR length declared by the table schema after all file-to-table
@@ -1148,7 +1231,11 @@ protected:
         ColumnPtr column = source.column;
         // The final mapping no longer needs the file block. Release its COW owner before mutate(),
         // otherwise nested MAP/STRING columns are deep-copied and a multi-GB payload can OOM.
-        block->replace_by_position(position, source.type->create_column());
+        // Keep a constant placeholder with the original row count: Block::rows() is derived from
+        // its first column, and later mapping/default expressions must still see the full batch
+        // after an earlier Path Slot transfers the carrier at position zero.
+        block->replace_by_position(
+                position, source.type->create_column_const_with_default_value(column->size()));
         return _detach_column(std::move(column));
     }
 
@@ -1297,6 +1384,10 @@ protected:
     Status _materialize_mapping_column(const ColumnMapping& mapping, Block* current_block,
                                        const size_t rows, ColumnPtr* column,
                                        bool take_projection_result = false) {
+        if (!mapping.column_paths.empty()) {
+            return _materialize_variant_path_mapping_column(mapping, current_block, rows, column,
+                                                            take_projection_result);
+        }
         if (!mapping.is_trivial && mapping.file_local_id.has_value() &&
             !mapping.child_mappings.empty()) {
             DCHECK(mapping.projection != nullptr);
@@ -1339,29 +1430,106 @@ protected:
             return Status::OK();
         }
         if (mapping.default_expr != nullptr) {
-            if (current_block->rows() == rows) {
-                ColumnWithTypeAndName result;
-                RETURN_IF_ERROR(_execute_default_expr_without_root_type_check(
-                        mapping.default_expr, current_block, &result));
-                ColumnPtr result_column = result.column;
-                RETURN_IF_ERROR(_align_column_nullability(&result_column, mapping.table_type));
-                *column = _detach_column(std::move(result_column));
-            } else {
-                DORIS_CHECK(mapping.constant_index.has_value());
-                Block eval_block;
-                eval_block.insert({mapping.table_type->create_column_const_with_default_value(rows),
-                                   mapping.table_type, "__table_reader_const_rows"});
-                ColumnWithTypeAndName result;
-                RETURN_IF_ERROR(_execute_default_expr_without_root_type_check(
-                        mapping.default_expr, &eval_block, &result));
-                ColumnPtr result_column = result.column;
-                RETURN_IF_ERROR(_align_column_nullability(&result_column, mapping.table_type));
-                *column = _detach_column(std::move(result_column));
-            }
-            return Status::OK();
+            return _materialize_default_mapping_column(mapping, current_block, rows, column);
         }
         ColumnPtr result_column = mapping.table_type->create_column_const_with_default_value(rows);
         *column = _detach_column(std::move(result_column));
+        return Status::OK();
+    }
+
+    Status _materialize_default_mapping_column(const ColumnMapping& mapping, Block* current_block,
+                                               size_t rows, ColumnPtr* column) {
+        DORIS_CHECK(mapping.default_expr != nullptr);
+        DORIS_CHECK(mapping.table_type != nullptr);
+        DORIS_CHECK(current_block != nullptr);
+        DORIS_CHECK(column != nullptr);
+        if (current_block->rows() == rows) {
+            ColumnWithTypeAndName result;
+            RETURN_IF_ERROR(_execute_default_expr_without_root_type_check(mapping.default_expr,
+                                                                          current_block, &result));
+            ColumnPtr result_column = result.column;
+            RETURN_IF_ERROR(_align_column_nullability(&result_column, mapping.table_type));
+            *column = _detach_column(std::move(result_column));
+            return Status::OK();
+        }
+
+        DORIS_CHECK(mapping.constant_index.has_value());
+        Block eval_block;
+        eval_block.insert({mapping.table_type->create_column_const_with_default_value(rows),
+                           mapping.table_type, "__table_reader_const_rows"});
+        ColumnWithTypeAndName result;
+        RETURN_IF_ERROR(_execute_default_expr_without_root_type_check(mapping.default_expr,
+                                                                      &eval_block, &result));
+        ColumnPtr result_column = result.column;
+        RETURN_IF_ERROR(_align_column_nullability(&result_column, mapping.table_type));
+        *column = _detach_column(std::move(result_column));
+        return Status::OK();
+    }
+
+    Status _materialize_variant_path_mapping_column(const ColumnMapping& mapping,
+                                                    Block* current_block, size_t rows,
+                                                    ColumnPtr* column,
+                                                    bool take_projection_result) {
+        DORIS_CHECK(!mapping.column_paths.empty());
+        DORIS_CHECK(mapping.resolved_variant_path != nullptr);
+        DORIS_CHECK(mapping.table_type != nullptr);
+        DORIS_CHECK(current_block != nullptr);
+        DORIS_CHECK(column != nullptr);
+
+        ColumnPtr root_column;
+        if (mapping.projection != nullptr) {
+            int result_id;
+            auto status = mapping.projection->execute(current_block, &result_id);
+            if (!status.ok()) {
+                return Status::InternalError(
+                        "Failed to read Variant root carrier for Path Slot '{}' "
+                        "(global_index={}, rows={}): {}, mapping={}",
+                        mapping.table_column_name, mapping.global_index.value(), rows,
+                        status.to_string(), mapping.debug_string());
+            }
+            root_column = take_projection_result
+                                  ? _take_and_detach_block_column(current_block, result_id)
+                                  : current_block->get_by_position(result_id).column;
+        } else if (mapping.default_expr != nullptr) {
+            // Schema-evolution defaults describe the missing root column. Apply the same path
+            // extraction after evaluating that root value instead of exposing the whole default.
+            RETURN_IF_ERROR(_materialize_default_mapping_column(mapping, current_block, rows,
+                                                                &root_column));
+        } else {
+            // A missing root without a default makes every requested subpath SQL NULL.
+            *column = _detach_column(
+                    mapping.table_type->create_column_const_with_default_value(rows));
+            return Status::OK();
+        }
+
+        const ColumnPtr materialized = root_column->convert_to_full_column_if_const();
+        _last_batch_materialization_input_bytes =
+                std::max(_last_batch_materialization_input_bytes, materialized->byte_size());
+        const IColumn* physical = materialized.get();
+        std::span<const uint8_t> outer_nulls;
+        if (const auto* nullable = check_and_get_column<ColumnNullable>(physical)) {
+            outer_nulls = nullable->get_null_map_data();
+            physical = &nullable->get_nested_column();
+        }
+        const auto* variant = check_and_get_column<ColumnVariantV2>(physical);
+        if (variant == nullptr) {
+            return Status::NotSupported(
+                    "Variant Path Slot '{}' requires a ColumnVariantV2 root carrier, got {}. "
+                    "Legacy ColumnVariant path extraction is not equivalent because it also needs "
+                    "sparse/document fallback semantics",
+                    mapping.table_column_name, materialized->get_name());
+        }
+        if (variant->size() != rows) {
+            return Status::InternalError(
+                    "Variant root carrier for Path Slot '{}' has {} rows, expected {}",
+                    mapping.table_column_name, variant->size(), rows);
+        }
+
+        ColumnPtr result;
+        RETURN_IF_ERROR(extract_variant_element_v2(*variant, *mapping.resolved_variant_path,
+                                                   outer_nulls, &result));
+        RETURN_IF_ERROR(_align_column_nullability(&result, mapping.table_type));
+        *column = std::move(result);
         return Status::OK();
     }
 
@@ -1763,6 +1931,7 @@ protected:
     TPushAggOp::type _push_down_agg_type = TPushAggOp::type::NONE;
     std::optional<std::vector<GlobalIndex>> _push_down_count_columns;
     size_t _batch_size = 0;
+    size_t _last_batch_materialization_input_bytes = 0;
     uint64_t _initial_condition_cache_digest = 0;
     uint64_t _condition_cache_digest = 0;
     // True only when prepare_split() received a digest for the exact conjunct snapshot used by

--- a/be/src/storage/segment/adaptive_block_size_predictor.cpp
+++ b/be/src/storage/segment/adaptive_block_size_predictor.cpp
@@ -32,11 +32,14 @@ AdaptiveBlockSizePredictor::AdaptiveBlockSizePredictor(size_t preferred_block_si
           _metadata_hint_bytes_per_row(metadata_hint_bytes_per_row) {}
 
 void AdaptiveBlockSizePredictor::update(const Block& block) {
-    size_t rows = block.rows();
+    update(block.rows(), block.bytes());
+}
+
+void AdaptiveBlockSizePredictor::update(size_t rows, size_t bytes) {
     if (rows == 0) {
         return;
     }
-    double cur = static_cast<double>(block.bytes()) / static_cast<double>(rows);
+    double cur = static_cast<double>(bytes) / static_cast<double>(rows);
 
     if (!_has_history) {
         _bytes_per_row = cur;

--- a/be/src/storage/segment/adaptive_block_size_predictor.h
+++ b/be/src/storage/segment/adaptive_block_size_predictor.h
@@ -61,6 +61,10 @@ public:
     // and the batch returned Status::OK().
     void update(const Block& block);
 
+    // Update from an explicit logical byte sample. This lets callers account for a wider
+    // pre-materialization carrier that is no longer present in the returned Block.
+    void update(size_t rows, size_t bytes);
+
     // Predict how many rows the next batch should read.
     // Never exceeds |block_size_rows|; never returns less than 1.
     // Uses pre-computed metadata hint for first-call estimate when no history exists.

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -35,6 +35,7 @@
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
+#include "core/data_type/data_type_variant_v2.h"
 #include "exec/operator/file_scan_operator.h"
 #include "exec/runtime_filter/runtime_filter_definitions.h"
 #include "exec/scan/file_scan_io_context.h"
@@ -121,6 +122,58 @@ TEST(FileScannerV2Test, AdaptiveBatchSizeRunsForCountFallbackOnly) {
     EXPECT_TRUE(FileScannerV2::TEST_should_run_adaptive_batch_size(true, false));
     EXPECT_FALSE(FileScannerV2::TEST_should_run_adaptive_batch_size(true, true));
     EXPECT_FALSE(FileScannerV2::TEST_should_run_adaptive_batch_size(false, false));
+}
+
+TEST(FileScannerV2Test, AdaptiveBatchSizeAccountsForPreExtractionVariantCarrier) {
+    constexpr size_t rows = FileScannerV2::ADAPTIVE_BATCH_INITIAL_PROBE_ROWS;
+    constexpr size_t preferred_bytes = 8 * 1024 * 1024;
+    constexpr size_t carrier_bytes = rows * 1024 * 1024;
+    Block tiny_path_output;
+    tiny_path_output.insert(
+            {ColumnInt64::create(rows, 7), std::make_shared<DataTypeInt64>(), "v.metric.x"});
+
+    const size_t sample_bytes =
+            FileScannerV2::TEST_adaptive_batch_sample_bytes(tiny_path_output, carrier_bytes);
+    EXPECT_EQ(sample_bytes, carrier_bytes);
+    EXPECT_EQ(FileScannerV2::TEST_adaptive_batch_sample_bytes(tiny_path_output, 0),
+              tiny_path_output.bytes());
+    AdaptiveBlockSizePredictor predictor(preferred_bytes, 0.0, rows, 4096);
+    predictor.update(tiny_path_output.rows(), sample_bytes);
+
+    // Learning from the tiny extracted INT64 alone would jump to the 4096-row cap. Accounting for
+    // the 1 MiB-per-row fallback carrier keeps the next batch within the 8 MiB target.
+    EXPECT_EQ(predictor.predict_next_rows(), 8);
+}
+
+TEST(FileScannerV2Test, BuildsVariantPathColumnFromExistingSlotFields) {
+    TSlotDescriptor thrift_slot;
+    thrift_slot.__set_id(7);
+    thrift_slot.__set_parent(1);
+    thrift_slot.__set_slotType(std::make_shared<DataTypeVariantV2>()->to_thrift());
+    thrift_slot.__set_columnPos(0);
+    thrift_slot.__set_colName("v.metric.x");
+    thrift_slot.__set_col_unique_id(100);
+    thrift_slot.__set_slotIdx(0);
+    thrift_slot.__set_isMaterialized(true);
+    thrift_slot.__set_is_key(false);
+    thrift_slot.__set_nullIndicatorBit(0);
+    thrift_slot.__set_column_paths({"metric", "x"});
+    SlotDescriptor path_slot(thrift_slot);
+
+    const auto path_column = FileScannerV2::TEST_build_table_column(&path_slot);
+    ASSERT_TRUE(path_column.has_identifier_field_id());
+    EXPECT_EQ(path_column.get_identifier_field_id(), 100);
+    EXPECT_EQ(path_column.name, "v.metric.x");
+    EXPECT_EQ(path_column.column_paths, std::vector<std::string>({"metric", "x"}));
+    EXPECT_EQ(path_column.name_mapping, std::vector<std::string>({"v"}));
+
+    thrift_slot.__set_column_paths({});
+    thrift_slot.__set_colName("v");
+    SlotDescriptor root_slot(thrift_slot);
+    const auto root_column = FileScannerV2::TEST_build_table_column(&root_slot);
+    ASSERT_TRUE(root_column.has_identifier_name());
+    EXPECT_EQ(root_column.get_identifier_name(), "v");
+    EXPECT_TRUE(root_column.column_paths.empty());
 }
 
 struct RetryableCloseState {

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -39,6 +39,8 @@
 #include "core/data_type/data_type_struct.h"
 #include "core/data_type/data_type_timestamptz.h"
 #include "core/data_type/data_type_varbinary.h"
+#include "core/data_type/data_type_variant.h"
+#include "core/data_type/data_type_variant_v2.h"
 #include "exprs/vectorized_fn_call.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
@@ -253,6 +255,105 @@ TEST(ColumnMapperDebugTest, CoversDebugStringEnumAndNestedBranches) {
         EXPECT_NE(debug.find("child_mappings=[ColumnMapping{global_index="), std::string::npos);
         EXPECT_NE(debug.find("has_default_expr=1"), std::string::npos);
     }
+}
+
+TEST(ColumnMapperTest, VariantPathSlotsShareOneRootCarrierAndFinalizeOnly) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto metric_x = field_id_col("v.metric.x", 100, variant_type);
+    metric_x.column_paths = {"metric", "x"};
+    auto metric_y = field_id_col("v.metric.y", 100, variant_type);
+    metric_y.column_paths = {"metric", "y"};
+    const auto file_root = field_id_col("v", 100, variant_type, 4);
+
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    const std::vector<ColumnDefinition> projected_columns {metric_x, metric_y};
+    ASSERT_TRUE(mapper.create_mapping(projected_columns, {}, {file_root}).ok());
+
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({}, projected_columns, &request).ok());
+    ASSERT_EQ(request.non_predicate_columns.size(), 1);
+    EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(4));
+    EXPECT_FALSE(request.non_predicate_columns[0].project_all_children);
+    EXPECT_EQ(request.non_predicate_columns[0].variant_paths,
+              (std::vector<std::vector<std::string>> {
+                      {"metric", "x"},
+                      {"metric", "y"},
+              }));
+    ASSERT_EQ(request.local_positions.size(), 1);
+    EXPECT_EQ(request.local_positions.at(LocalColumnId(4)), LocalIndex(0));
+
+    const auto& mappings = mapper.mappings();
+    ASSERT_EQ(mappings.size(), 2);
+    EXPECT_EQ(mappings[0].table_column_name, "v.metric.x");
+    EXPECT_EQ(mappings[1].table_column_name, "v.metric.y");
+    for (size_t mapping_index = 0; mapping_index < mappings.size(); ++mapping_index) {
+        const auto& mapping = mappings[mapping_index];
+        EXPECT_EQ(mapping.global_index, GlobalIndex(mapping_index));
+        ASSERT_TRUE(mapping.file_local_id.has_value());
+        EXPECT_EQ(*mapping.file_local_id, 4);
+        EXPECT_FALSE(mapping.is_trivial);
+        EXPECT_EQ(mapping.filter_conversion, FilterConversionType::FINALIZE_ONLY);
+        EXPECT_NE(mapping.projection, nullptr);
+        const auto filter_entry = mapper.filter_entries().find(mapping.global_index);
+        ASSERT_NE(filter_entry, mapper.filter_entries().end());
+        EXPECT_FALSE(filter_entry->second.is_set());
+    }
+    EXPECT_EQ(mappings[0].column_paths, std::vector<std::string>({"metric", "x"}));
+    EXPECT_EQ(mappings[1].column_paths, std::vector<std::string>({"metric", "y"}));
+}
+
+TEST(ColumnMapperTest, VariantPathSlotsSupportIdlessNameMappingAndRejectPositionMapping) {
+    auto legacy_path =
+            field_id_col("v.metric.x", 100, make_nullable(std::make_shared<DataTypeVariant>()));
+    legacy_path.column_paths = {"metric", "x"};
+    const auto legacy_root =
+            field_id_col("v", 100, make_nullable(std::make_shared<DataTypeVariant>()), 4);
+    TableColumnMapper field_id_mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    const auto legacy_status = field_id_mapper.create_mapping({legacy_path}, {}, {legacy_root});
+    EXPECT_FALSE(legacy_status.ok());
+    EXPECT_NE(legacy_status.to_string().find("Variant V2"), std::string::npos);
+
+    const auto variant_v2_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto name_mapped_path = field_id_col("v.metric.x", 100, variant_v2_type);
+    name_mapped_path.column_paths = {"metric", "x"};
+    name_mapped_path.name_mapping = {"legacy_v"};
+    const auto variant_v2_root = field_id_col("v", 100, variant_v2_type, 4);
+    auto idless_variant_v2_root = variant_v2_root;
+    idless_variant_v2_root.identifier = Field::create_field<TYPE_STRING>("legacy_v");
+    TableColumnMapper name_mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(name_mapper.create_mapping({name_mapped_path}, {}, {idless_variant_v2_root}).ok());
+    ASSERT_EQ(name_mapper.mappings().size(), 1);
+    ASSERT_TRUE(name_mapper.mappings()[0].file_local_id.has_value());
+    EXPECT_EQ(*name_mapper.mappings()[0].file_local_id, 4);
+
+    TableColumnMapper position_mapper({.mode = TableColumnMappingMode::BY_INDEX});
+    const auto position_status =
+            position_mapper.create_mapping({name_mapped_path}, {}, {variant_v2_root});
+    EXPECT_FALSE(position_status.ok());
+    EXPECT_NE(position_status.to_string().find("BY_INDEX"), std::string::npos);
+}
+
+TEST(ColumnMapperTest, VariantPathSlotsKeepAuthoritativeNameAndFieldIdSafety) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto table_path = field_id_col("v.metric.x", 42, variant_type);
+    table_path.column_paths = {"metric", "x"};
+    table_path.name_mapping = {"v"};
+    table_path.has_name_mapping = true;
+
+    auto idless_same_name = field_id_col("v", 99, variant_type, 4);
+    idless_same_name.identifier = Field::create_field<TYPE_STRING>("v");
+    table_path.name_mapping.clear();
+    TableColumnMapper name_mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(name_mapper.create_mapping({table_path}, {}, {idless_same_name}).ok());
+    ASSERT_EQ(name_mapper.mappings().size(), 1);
+    EXPECT_FALSE(name_mapper.mappings()[0].file_local_id.has_value());
+
+    table_path.name_mapping = {"v"};
+    auto same_name_different_id = field_id_col("v", 99, variant_type, 4);
+    TableColumnMapper field_id_mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    ASSERT_TRUE(field_id_mapper.create_mapping({table_path}, {}, {same_name_different_id}).ok());
+    ASSERT_EQ(field_id_mapper.mappings().size(), 1);
+    EXPECT_FALSE(field_id_mapper.mappings()[0].file_local_id.has_value());
 }
 
 TEST(ColumnMapperTest, ParquetRetainsIdlessComplexWrapperWithNestedFieldId) {

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -58,6 +58,7 @@
 #include "core/data_type/data_type_struct.h"
 #include "core/data_type/data_type_timestamptz.h"
 #include "core/data_type/data_type_varbinary.h"
+#include "core/data_type/data_type_variant_v2.h"
 #include "exec/common/endian.h"
 #include "exec/scan/access_path_parser.h"
 #include "exprs/runtime_filter_expr.h"
@@ -2010,6 +2011,18 @@ TEST(IcebergV2ReaderTest, IcebergMappingModeUsesAnyDataColumnFieldId) {
             make_file_column(3, "nested", std::make_shared<DataTypeInt32>()));
     EXPECT_EQ(reader.mapping_mode_for_schema(std::move(file_schema), &scan_params),
               TableColumnMappingMode::BY_FIELD_ID);
+}
+
+TEST(IcebergV2ReaderTest, IcebergMappingModeUsesNameForEntirelyIdlessFile) {
+    IcebergTableReaderMappingModeTestHelper reader;
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    auto idless_root =
+            make_file_column(1, "v", make_nullable(std::make_shared<DataTypeVariantV2>()));
+    idless_root.identifier = Field::create_field<TYPE_STRING>("v");
+
+    EXPECT_EQ(reader.mapping_mode_for_schema({std::move(idless_root)}, &scan_params),
+              TableColumnMappingMode::BY_NAME);
 }
 
 TEST(IcebergV2ReaderTest, IcebergLegacyPlanKeepsAllFieldIdsMappingRule) {

--- a/be/test/format_v2/table_reader_request_test.cpp
+++ b/be/test/format_v2/table_reader_request_test.cpp
@@ -71,6 +71,33 @@ TEST(FileScanRequestBuilderTest, PredicateColumnRemovesDuplicateNonPredicateColu
     EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(2));
 }
 
+TEST(FileScanRequestBuilderTest, MergesVariantPathsAcrossPredicateAndOutputSlots) {
+    FileScanRequest request;
+    FileScanRequestBuilder builder(&request);
+
+    auto output_path = LocalColumnIndex::partial_local(7);
+    output_path.variant_paths = {{"metric", "y"}};
+    ASSERT_TRUE(builder.add_non_predicate_column(std::move(output_path)).ok());
+
+    auto predicate_path = LocalColumnIndex::partial_local(7);
+    predicate_path.variant_paths = {{"metric", "x"}};
+    ASSERT_TRUE(builder.add_predicate_column(std::move(predicate_path)).ok());
+
+    auto later_output_path = LocalColumnIndex::partial_local(7);
+    later_output_path.variant_paths = {{"metric", "z"}};
+    ASSERT_TRUE(builder.add_non_predicate_column(std::move(later_output_path)).ok());
+
+    EXPECT_TRUE(request.non_predicate_columns.empty());
+    ASSERT_EQ(request.predicate_columns.size(), 1);
+    EXPECT_EQ(request.predicate_columns[0].variant_paths, (std::vector<std::vector<std::string>> {
+                                                                  {"metric", "x"},
+                                                                  {"metric", "y"},
+                                                                  {"metric", "z"},
+                                                          }));
+    ASSERT_EQ(request.local_positions.size(), 1);
+    EXPECT_EQ(request.local_positions.at(LocalColumnId(7)), LocalIndex(0));
+}
+
 // Scenario: TableReader's format-specific customization path delegates to FileScanRequestBuilder
 // and preserves the same predicate/non-predicate de-duplication rule.
 TEST(TableReaderRequestTest, AppendPredicateColumnKeepsOtherNonPredicateColumns) {

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <typeinfo>
 #include <vector>
 
@@ -43,6 +44,7 @@
 #include "core/column/column_struct.h"
 #include "core/column/column_varbinary.h"
 #include "core/column/column_vector.h"
+#include "core/column/variant_v2/column_variant_v2.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_map.h"
 #include "core/data_type/data_type_nullable.h"
@@ -50,6 +52,10 @@
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_struct.h"
 #include "core/data_type/data_type_varbinary.h"
+#include "core/data_type/data_type_variant_v2.h"
+#include "core/value/variant/variant_field.h"
+#include "core/value/variant/variant_parquet_encoding.h"
+#include "exprs/function/parse/variant_string_parse.h"
 #include "exprs/runtime_filter_expr.h"
 #include "exprs/vectorized_fn_call.h"
 #include "exprs/vexpr.h"
@@ -63,6 +69,7 @@
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
 #include "storage/segment/condition_cache.h"
+#include "util/variant/variant_test_utils.h"
 
 namespace doris::format {
 namespace {
@@ -78,17 +85,23 @@ std::vector<int32_t> projection_ids(const std::vector<LocalColumnIndex>& project
 
 TEST(LocalColumnIndexTest, MergeUnionsPartialChildrenAndFullProjectionDominates) {
     LocalColumnIndex target {.index = 10, .project_all_children = false};
+    target.variant_paths = {{"metric", "x"}};
     target.children.push_back({.index = 1});
     target.children.push_back({.index = 2, .project_all_children = false});
     target.children.back().children.push_back({.index = 20});
 
     LocalColumnIndex source {.index = 10, .project_all_children = false};
+    source.variant_paths = {{"metric", "x"}, {"metric", "y"}};
     source.children.push_back({.index = 2, .project_all_children = false});
     source.children.back().children.push_back({.index = 21});
     source.children.push_back({.index = 3});
 
     ASSERT_TRUE(merge_local_column_index(&target, source).ok());
     ASSERT_FALSE(target.project_all_children);
+    EXPECT_EQ(target.variant_paths, (std::vector<std::vector<std::string>> {
+                                            {"metric", "x"},
+                                            {"metric", "y"},
+                                    }));
     ASSERT_EQ(std::vector<int32_t>({1, 2, 3}), projection_ids(target.children));
     ASSERT_FALSE(target.children[1].project_all_children);
     ASSERT_EQ(std::vector<int32_t>({20, 21}), projection_ids(target.children[1].children));
@@ -98,6 +111,7 @@ TEST(LocalColumnIndexTest, MergeUnionsPartialChildrenAndFullProjectionDominates)
     ASSERT_TRUE(merge_local_column_index(&target, full_source).ok());
     ASSERT_TRUE(target.project_all_children);
     ASSERT_TRUE(target.children.empty());
+    ASSERT_TRUE(target.variant_paths.empty());
 }
 
 TEST(LocalColumnIndexTest, FindsProjectedChildren) {
@@ -332,6 +346,63 @@ class TableReaderMaterializeTestHelper final : public TableReader {
 public:
     using TableReader::_materialize_mapping_column;
     using TableReader::_materialize_map_mapping_column;
+
+    void set_finalize_state(std::unique_ptr<TableColumnMapper> mapper, Block file_block) {
+        // These materialization tests intentionally bypass TableReader::open(), which normally
+        // initializes the runtime state before finalize_chunk().
+        _runtime_state = nullptr;
+        _data_reader.column_mapper = std::move(mapper);
+        _data_reader.block_template = std::move(file_block);
+    }
+
+    Status open_mapping_exprs(RuntimeState* state) {
+        _runtime_state = state;
+        return _open_mapping_exprs();
+    }
+
+    Status finalize(Block* block, size_t rows) { return finalize_chunk(block, rows); }
+
+    const Block& file_block() const { return _data_reader.block_template; }
+    Block& mutable_file_block() { return _data_reader.block_template; }
+};
+
+VariantField encode_variant_v2_json(std::string_view json) {
+    JsonStringToVariantEncoder encoder({.max_json_key_length = 1024,
+                                        .throw_on_invalid_json = true,
+                                        .check_duplicate_json_path = false});
+    encoder.add_json({json.data(), json.size()});
+    VariantBatchBuilder batch = encoder.finish_batch();
+    return VariantField::from_ref(batch.value_at(0));
+}
+
+void append_variant_v2_json(ColumnVariantV2* column, std::string_view json) {
+    DORIS_CHECK(column != nullptr);
+    insert_encoded_field(*column, encode_variant_v2_json(json));
+}
+
+class VariantV2DefaultExpr final : public VExpr {
+public:
+    VariantV2DefaultExpr(DataTypePtr data_type, std::string json)
+            : _json(std::move(json)), _name("variant_v2_default") {
+        _data_type = std::move(data_type);
+    }
+
+    const std::string& expr_name() const override { return _name; }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector* selector, size_t count,
+                               ColumnPtr& result_column) const override {
+        DCHECK(selector == nullptr || selector->size() == count);
+        auto values = ColumnVariantV2::create();
+        for (size_t i = 0; i < count; ++i) {
+            append_variant_v2_json(values.get(), _json);
+        }
+        result_column = ColumnNullable::create(std::move(values), ColumnUInt8::create(count, 0));
+        return Status::OK();
+    }
+
+private:
+    std::string _json;
+    std::string _name;
 };
 
 TEST(TableReaderTest, LastProjectionDetachesNestedMapWithoutCopyingStrings) {
@@ -367,11 +438,425 @@ TEST(TableReaderTest, LastProjectionDetachesNestedMapWithoutCopyingStrings) {
     ASSERT_TRUE(reader._materialize_mapping_column(mapping, &block, 1, &detached,
                                                    /*take_projection_result=*/true)
                         .ok());
-    EXPECT_EQ(block.get_by_position(0).column->size(), 0);
+    EXPECT_EQ(block.get_by_position(0).column->size(), 1);
     const auto& detached_nullable = assert_cast<const ColumnNullable&>(*detached);
     const auto& detached_map = assert_cast<const ColumnMap&>(detached_nullable.get_nested_column());
     const auto& detached_values = assert_cast<const ColumnString&>(detached_map.get_values());
     EXPECT_EQ(detached_values.get_chars().data(), original_value_bytes);
+}
+
+TEST(TableReaderTest, FinalizeWithoutVariantPathRetainsDirectTransfer) {
+    const auto string_type = std::make_shared<DataTypeString>();
+    auto table_column = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "s",
+            .type = string_type,
+    };
+    auto file_column = table_column;
+    file_column.local_id = 4;
+
+    auto mapper = std::make_unique<TableColumnMapper>(TableColumnMapperOptions {
+            .mode = TableColumnMappingMode::BY_FIELD_ID,
+    });
+    const std::vector<ColumnDefinition> projected_columns {table_column};
+    ASSERT_TRUE(mapper->create_mapping(projected_columns, {}, {file_column}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper->create_scan_request({}, projected_columns, &request).ok());
+
+    const std::string large_value(1UL << 20, 'x');
+    auto source = ColumnString::create();
+    source->insert_data(large_value.data(), large_value.size());
+    const auto* original_value_bytes = source->get_chars().data();
+    Block file_block;
+    file_block.insert({std::move(source), string_type, "s"});
+
+    Block output;
+    output.insert({string_type->create_column(), string_type, "s"});
+    TableReaderMaterializeTestHelper reader;
+    reader.set_finalize_state(std::move(mapper), std::move(file_block));
+    const auto status = reader.finalize(&output, 1);
+    ASSERT_TRUE(status.ok()) << status;
+
+    const auto& values = assert_cast<const ColumnString&>(*output.get_by_position(0).column);
+    EXPECT_EQ(values.get_chars().data(), original_value_bytes);
+    EXPECT_EQ(values.get_data_at(0), StringRef(large_value));
+    EXPECT_EQ(reader.file_block().get_by_position(0).column->size(), 0);
+    EXPECT_EQ(reader.last_batch_materialization_input_bytes(), 0);
+}
+
+TEST(TableReaderTest, MaterializesTwoVariantPathSlotsFromSharedEncodedRootCarrier) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto metric_x = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "v.metric.x",
+            .type = variant_type,
+            .column_paths = {"metric", "x"},
+    };
+    auto metric_y = metric_x;
+    metric_y.name = "v.metric.y";
+    metric_y.column_paths = {"metric", "y"};
+    auto file_root = metric_x;
+    file_root.local_id = 4;
+    file_root.name = "v";
+    file_root.column_paths.clear();
+
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    const std::vector<ColumnDefinition> projected_columns {metric_x, metric_y};
+    ASSERT_TRUE(mapper.create_mapping(projected_columns, {}, {file_root}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({}, projected_columns, &request).ok());
+    ASSERT_EQ(mapper.mappings().size(), 2);
+    ASSERT_EQ(request.local_positions.size(), 1);
+    ASSERT_EQ(request.non_predicate_columns.size(), 1);
+    EXPECT_EQ(request.non_predicate_columns[0].variant_paths,
+              (std::vector<std::vector<std::string>> {
+                      {"metric", "x"},
+                      {"metric", "y"},
+              }));
+
+    auto source = ColumnVariantV2::create();
+    append_variant_v2_json(source.get(), R"({"metric":{"x":10,"y":20}})");
+    append_variant_v2_json(source.get(), R"({"metric":{"x":null,"y":21}})");
+    append_variant_v2_json(source.get(), R"({"metric":7})");
+    append_variant_v2_json(source.get(), R"({"metric.x":30})");
+    append_variant_v2_json(source.get(), R"({"metric":{"x":40,"y":41}})");
+    auto source_nulls = ColumnUInt8::create(source->size(), 0);
+    source_nulls->get_data()[4] = 1;
+    Block file_block;
+    file_block.insert({ColumnNullable::create(std::move(source), std::move(source_nulls)),
+                       variant_type, "v"});
+
+    TableReaderMaterializeTestHelper reader;
+    ColumnPtr metric_x_result;
+    const auto metric_x_status = reader._materialize_mapping_column(
+            mapper.mappings()[0], &file_block, file_block.rows(), &metric_x_result);
+    ASSERT_TRUE(metric_x_status.ok()) << metric_x_status;
+    ColumnPtr metric_y_result;
+    const auto metric_y_status = reader._materialize_mapping_column(
+            mapper.mappings()[1], &file_block, file_block.rows(), &metric_y_result,
+            /*take_projection_result=*/true);
+    ASSERT_TRUE(metric_y_status.ok()) << metric_y_status;
+
+    const auto& metric_x_nullable = assert_cast<const ColumnNullable&>(*metric_x_result);
+    const auto& metric_x_values =
+            assert_cast<const ColumnVariantV2&>(metric_x_nullable.get_nested_column());
+    ASSERT_EQ(metric_x_values.size(), 5);
+    EXPECT_EQ(metric_x_nullable.get_null_map_data()[0], 0);
+    EXPECT_EQ(metric_x_values.get_value_ref(0).get_int(), 10);
+    EXPECT_EQ(metric_x_nullable.get_null_map_data()[1], 0);
+    EXPECT_TRUE(metric_x_values.get_value_ref(1).is_null());
+    EXPECT_EQ(metric_x_nullable.get_null_map_data()[2], 1);
+    EXPECT_EQ(metric_x_nullable.get_null_map_data()[3], 1);
+    EXPECT_EQ(metric_x_nullable.get_null_map_data()[4], 1);
+
+    const auto& metric_y_nullable = assert_cast<const ColumnNullable&>(*metric_y_result);
+    const auto& metric_y_values =
+            assert_cast<const ColumnVariantV2&>(metric_y_nullable.get_nested_column());
+    ASSERT_EQ(metric_y_values.size(), 5);
+    EXPECT_EQ(metric_y_nullable.get_null_map_data()[0], 0);
+    EXPECT_EQ(metric_y_values.get_value_ref(0).get_int(), 20);
+    EXPECT_EQ(metric_y_nullable.get_null_map_data()[1], 0);
+    EXPECT_EQ(metric_y_values.get_value_ref(1).get_int(), 21);
+    EXPECT_EQ(metric_y_nullable.get_null_map_data()[2], 1);
+    EXPECT_EQ(metric_y_nullable.get_null_map_data()[3], 1);
+    EXPECT_EQ(metric_y_nullable.get_null_map_data()[4], 1);
+    EXPECT_EQ(file_block.get_by_position(0).column->size(), 5);
+}
+
+TEST(TableReaderTest, VariantPathTracksFullCarrierBytesForAdaptiveBatching) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto table_path = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "v.metric.x",
+            .type = variant_type,
+            .column_paths = {"metric", "x"},
+    };
+    auto file_root = table_path;
+    file_root.local_id = 4;
+    file_root.name = "v";
+    file_root.column_paths.clear();
+
+    auto mapper = std::make_unique<TableColumnMapper>(TableColumnMapperOptions {
+            .mode = TableColumnMappingMode::BY_FIELD_ID,
+    });
+    const std::vector<ColumnDefinition> projected_columns {table_path};
+    ASSERT_TRUE(mapper->create_mapping(projected_columns, {}, {file_root}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper->create_scan_request({}, projected_columns, &request).ok());
+
+    const std::string large_payload(1UL << 20, 'p');
+    auto source = ColumnVariantV2::create();
+    append_variant_v2_json(source.get(),
+                           "{\"metric\":{\"x\":7},\"payload\":\"" + large_payload + "\"}");
+    Block file_block;
+    file_block.insert({ColumnNullable::create(std::move(source), ColumnUInt8::create(1, 0)),
+                       variant_type, "v"});
+    const size_t carrier_bytes = file_block.bytes();
+
+    Block output;
+    output.insert({variant_type->create_column(), variant_type, "v.metric.x"});
+    TableReaderMaterializeTestHelper reader;
+    reader.set_finalize_state(std::move(mapper), std::move(file_block));
+    ASSERT_TRUE(reader.finalize(&output, 1).ok());
+
+    EXPECT_GE(reader.last_batch_materialization_input_bytes(), carrier_bytes);
+    EXPECT_GT(reader.last_batch_materialization_input_bytes(), output.bytes());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output.get_by_position(0).column);
+    const auto& values = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+    ASSERT_EQ(values.size(), 1);
+    EXPECT_EQ(values.get_value_ref(0).get_int(), 7);
+}
+
+TEST(TableReaderTest, VariantPathCarrierTransferPreservesRowsForLaterCast) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    const auto nullable_int_type = make_nullable(std::make_shared<DataTypeInt32>());
+    const auto nullable_bigint_type = make_nullable(std::make_shared<DataTypeInt64>());
+    auto table_path = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "v.metric.x",
+            .type = variant_type,
+            .column_paths = {"metric", "x"},
+    };
+    auto table_number = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(200),
+            .name = "n",
+            .type = nullable_bigint_type,
+    };
+    auto file_root = table_path;
+    file_root.local_id = 4;
+    file_root.name = "v";
+    file_root.column_paths.clear();
+    auto file_number = table_number;
+    file_number.local_id = 5;
+    file_number.type = nullable_int_type;
+
+    auto mapper = std::make_unique<TableColumnMapper>(TableColumnMapperOptions {
+            .mode = TableColumnMappingMode::BY_FIELD_ID,
+    });
+    const std::vector<ColumnDefinition> projected_columns {table_path, table_number};
+    ASSERT_TRUE(mapper->create_mapping(projected_columns, {}, {file_root, file_number}).ok());
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    FileScanRequest request;
+    ASSERT_TRUE(mapper->create_scan_request({}, projected_columns, &request, &state).ok());
+    ASSERT_EQ(request.local_positions.at(LocalColumnId(4)), LocalIndex(0));
+    ASSERT_EQ(request.local_positions.at(LocalColumnId(5)), LocalIndex(1));
+    ASSERT_FALSE(mapper->mappings()[1].is_trivial);
+
+    auto source = ColumnVariantV2::create();
+    append_variant_v2_json(source.get(), R"({"metric":{"x":7}})");
+    append_variant_v2_json(source.get(), R"({"metric":{"x":8}})");
+    auto numbers = ColumnInt32::create();
+    numbers->insert_value(11);
+    numbers->insert_value(22);
+    Block file_block;
+    file_block.insert({ColumnNullable::create(std::move(source), ColumnUInt8::create(2, 0)),
+                       variant_type, "v"});
+    file_block.insert({ColumnNullable::create(std::move(numbers), ColumnUInt8::create(2, 0)),
+                       nullable_int_type, "n"});
+    const IColumn* original_number_column = file_block.get_by_position(1).column.get();
+
+    Block output;
+    output.insert({variant_type->create_column(), variant_type, "v.metric.x"});
+    output.insert({nullable_bigint_type->create_column(), nullable_bigint_type, "n"});
+    TableReaderMaterializeTestHelper reader;
+    reader.set_finalize_state(std::move(mapper), std::move(file_block));
+    ASSERT_TRUE(reader.open_mapping_exprs(&state).ok());
+    const auto status = reader.finalize(&output, 2);
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_EQ(output.rows(), 2);
+
+    const auto& path_nullable =
+            assert_cast<const ColumnNullable&>(*output.get_by_position(0).column);
+    const auto& path_values =
+            assert_cast<const ColumnVariantV2&>(path_nullable.get_nested_column());
+    EXPECT_EQ(path_values.get_value_ref(0).get_int(), 7);
+    EXPECT_EQ(path_values.get_value_ref(1).get_int(), 8);
+    const auto& number_nullable =
+            assert_cast<const ColumnNullable&>(*output.get_by_position(1).column);
+    const auto& number_values =
+            assert_cast<const ColumnInt64&>(number_nullable.get_nested_column()).get_data();
+    ASSERT_EQ(number_values.size(), 2);
+    EXPECT_EQ(number_values[0], 11);
+    EXPECT_EQ(number_values[1], 22);
+
+    // Match get_block() between batches: it clears and reuses the persistent file-block columns.
+    // A transferred carrier must not leave a ColumnConst placeholder that cannot accept the next
+    // physical batch.
+    auto& next_file_block = reader.mutable_file_block();
+    ASSERT_FALSE(is_column_const(*next_file_block.get_by_position(0).column));
+    ASSERT_FALSE(is_column_const(*next_file_block.get_by_position(1).column));
+    EXPECT_EQ(next_file_block.get_by_position(0).column->size(), 0);
+    EXPECT_EQ(next_file_block.get_by_position(1).column.get(), original_number_column);
+    EXPECT_EQ(next_file_block.get_by_position(1).column->size(), 2);
+    next_file_block.clear_column_data(2);
+    ASSERT_FALSE(is_column_const(*next_file_block.get_by_position(0).column));
+    ASSERT_FALSE(is_column_const(*next_file_block.get_by_position(1).column));
+    EXPECT_EQ(next_file_block.get_by_position(0).column->size(), 0);
+    EXPECT_EQ(next_file_block.get_by_position(1).column->size(), 0);
+
+    auto next_source = ColumnVariantV2::create();
+    append_variant_v2_json(next_source.get(), R"({"metric":{"x":70}})");
+    append_variant_v2_json(next_source.get(), R"({"metric":{"x":80}})");
+    ColumnPtr next_root = ColumnNullable::create(std::move(next_source), ColumnUInt8::create(2, 0));
+    auto next_numbers = ColumnInt32::create();
+    next_numbers->insert_value(33);
+    next_numbers->insert_value(44);
+    ColumnPtr next_number_column =
+            ColumnNullable::create(std::move(next_numbers), ColumnUInt8::create(2, 0));
+    auto append_next_batch = [&](size_t position, const ColumnPtr& source_column) {
+        auto& destination = next_file_block.get_by_position(position).column;
+        auto mutable_destination = IColumn::mutate(std::move(destination));
+        mutable_destination->insert_range_from(*source_column, 0, source_column->size());
+        destination = std::move(mutable_destination);
+    };
+    append_next_batch(0, next_root);
+    append_next_batch(1, next_number_column);
+
+    output.clear_column_data(2);
+    ASSERT_TRUE(reader.finalize(&output, 2).ok());
+    const auto& next_path_nullable =
+            assert_cast<const ColumnNullable&>(*output.get_by_position(0).column);
+    const auto& next_path_values =
+            assert_cast<const ColumnVariantV2&>(next_path_nullable.get_nested_column());
+    EXPECT_EQ(next_path_values.get_value_ref(0).get_int(), 70);
+    EXPECT_EQ(next_path_values.get_value_ref(1).get_int(), 80);
+    const auto& next_number_nullable =
+            assert_cast<const ColumnNullable&>(*output.get_by_position(1).column);
+    const auto& next_number_values =
+            assert_cast<const ColumnInt64&>(next_number_nullable.get_nested_column()).get_data();
+    ASSERT_EQ(next_number_values.size(), 2);
+    EXPECT_EQ(next_number_values[0], 33);
+    EXPECT_EQ(next_number_values[1], 44);
+}
+
+TEST(TableReaderTest, RootBeforeVariantPathTransfersSharedCarrierWithoutCopy) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto root = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "v",
+            .type = variant_type,
+    };
+    auto path = root;
+    path.name = "v.metric.x";
+    path.column_paths = {"metric", "x"};
+    auto file_root = root;
+    file_root.local_id = 4;
+
+    auto mapper = std::make_unique<TableColumnMapper>(TableColumnMapperOptions {
+            .mode = TableColumnMappingMode::BY_FIELD_ID,
+    });
+    const std::vector<ColumnDefinition> projected_columns {root, path};
+    ASSERT_TRUE(mapper->create_mapping(projected_columns, {}, {file_root}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper->create_scan_request({}, projected_columns, &request).ok());
+    ASSERT_EQ(mapper->mappings().size(), 2);
+    EXPECT_TRUE(mapper->mappings()[0].column_paths.empty());
+    EXPECT_EQ(mapper->mappings()[1].column_paths, std::vector<std::string>({"metric", "x"}));
+    ASSERT_TRUE(mapper->mappings()[0].file_local_id.has_value());
+    ASSERT_TRUE(mapper->mappings()[1].file_local_id.has_value());
+    EXPECT_EQ(mapper->mappings()[0].file_local_id, mapper->mappings()[1].file_local_id);
+    ASSERT_EQ(request.local_positions.size(), 1);
+
+    const std::string large_value(1UL << 20, 'x');
+    auto source = ColumnVariantV2::create();
+    append_variant_v2_json(source.get(), "{\"metric\":{\"x\":\"" + large_value + "\"}}");
+    const char* original_value_bytes = source->get_value_ref(0).value.data;
+    Block file_block;
+    file_block.insert({ColumnNullable::create(std::move(source), ColumnUInt8::create(1, 0)),
+                       variant_type, "v"});
+
+    Block output;
+    output.insert({variant_type->create_column(), variant_type, "v"});
+    output.insert({variant_type->create_column(), variant_type, "v.metric.x"});
+    TableReaderMaterializeTestHelper reader;
+    reader.set_finalize_state(std::move(mapper), std::move(file_block));
+    const auto status = reader.finalize(&output, 1);
+    ASSERT_TRUE(status.ok()) << status;
+
+    ASSERT_EQ(output.columns(), 2);
+    EXPECT_EQ(output.get_by_position(0).name, "v");
+    EXPECT_EQ(output.get_by_position(1).name, "v.metric.x");
+    const auto& root_nullable =
+            assert_cast<const ColumnNullable&>(*output.get_by_position(0).column);
+    const auto& root_values =
+            assert_cast<const ColumnVariantV2&>(root_nullable.get_nested_column());
+    ASSERT_EQ(root_values.size(), 1);
+    // The full root must take the shared file-local carrier after every Path Slot has read it.
+    // A different address means the root was detached while the file block still owned it.
+    EXPECT_EQ(root_values.get_value_ref(0).value.data, original_value_bytes);
+
+    const auto& path_nullable =
+            assert_cast<const ColumnNullable&>(*output.get_by_position(1).column);
+    const auto& path_values =
+            assert_cast<const ColumnVariantV2&>(path_nullable.get_nested_column());
+    ASSERT_EQ(path_values.size(), 1);
+    EXPECT_EQ(path_values.get_value_ref(0).get_string(), StringRef(large_value));
+    EXPECT_EQ(reader.file_block().get_by_position(0).column->size(), 0);
+}
+
+TEST(TableReaderTest, MissingVariantPathRootMaterializesSqlNulls) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto table_path = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "v.metric.missing",
+            .type = variant_type,
+            .column_paths = {"metric", "missing"},
+    };
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    ASSERT_TRUE(mapper.create_mapping({table_path}, {}, {}).ok());
+    ASSERT_EQ(mapper.mappings().size(), 1);
+    EXPECT_FALSE(mapper.mappings()[0].file_local_id.has_value());
+    EXPECT_EQ(mapper.mappings()[0].projection, nullptr);
+
+    TableReaderMaterializeTestHelper reader;
+    Block file_block;
+    ColumnPtr result;
+    const auto status =
+            reader._materialize_mapping_column(mapper.mappings()[0], &file_block, 3, &result);
+    ASSERT_TRUE(status.ok()) << status;
+    const auto materialized = result->convert_to_full_column_if_const();
+    const auto& nullable = assert_cast<const ColumnNullable&>(*materialized);
+    EXPECT_EQ(nullable.size(), 3);
+    EXPECT_EQ(nullable.get_null_map_data(), NullMap({1, 1, 1}));
+}
+
+TEST(TableReaderTest, MissingVariantPathRootExtractsFromDefaultCarrier) {
+    const auto variant_type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    auto table_path = ColumnDefinition {
+            .identifier = Field::create_field<TYPE_INT>(100),
+            .name = "v.metric.x",
+            .type = variant_type,
+            .column_paths = {"metric", "x"},
+    };
+    const std::string large_payload(1UL << 20, 'd');
+    table_path.default_expr = VExprContext::create_shared(std::make_shared<VariantV2DefaultExpr>(
+            variant_type, "{\"metric\":{\"x\":17},\"payload\":\"" + large_payload + "\"}"));
+
+    // Entirely idless legacy Iceberg files select BY_NAME. A missing root must reach the existing
+    // default path instead of being rejected by Path Slot initialization.
+    table_path.name_mapping = {"v"};
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(mapper.create_mapping({table_path}, {}, {}).ok());
+    ASSERT_EQ(mapper.mappings().size(), 1);
+    EXPECT_EQ(mapper.mappings()[0].projection, nullptr);
+    EXPECT_NE(mapper.mappings()[0].default_expr, nullptr);
+
+    Block eval_block;
+    eval_block.insert({ColumnUInt8::create(3, 0), std::make_shared<DataTypeUInt8>(), "rows"});
+    TableReaderMaterializeTestHelper reader;
+    ColumnPtr result;
+    const auto status =
+            reader._materialize_mapping_column(mapper.mappings()[0], &eval_block, 3, &result);
+    ASSERT_TRUE(status.ok()) << status;
+
+    const auto& nullable = assert_cast<const ColumnNullable&>(*result);
+    const auto& values = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+    ASSERT_EQ(values.size(), 3);
+    EXPECT_GT(reader.last_batch_materialization_input_bytes(), result->byte_size());
+    for (size_t row = 0; row < values.size(); ++row) {
+        EXPECT_EQ(nullable.get_null_map_data()[row], 0);
+        EXPECT_EQ(values.get_value_ref(row).get_int(), 17);
+    }
 }
 
 VExprSPtr table_int32_sum_expr(int left_slot_id, int left_column_id, int right_slot_id,
@@ -2313,6 +2798,86 @@ TEST(TableReaderTest, AnnotateProjectedColumnUsesCurrentHistorySchemaForNestedTy
     EXPECT_EQ(context.schema_column->children[1].children[0].get_identifier_field_id(), 24);
     EXPECT_EQ(context.schema_column->children[1].children[1].name, "value");
     EXPECT_EQ(context.schema_column->children[1].children[1].get_identifier_field_id(), 25);
+}
+
+TEST(TableReaderTest, AnnotateVariantPathSlotFindsRootByFieldId) {
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_current_schema_id(100);
+    scan_params.__set_history_schema_info(
+            {external_schema(100, {external_schema_field("renamed_v", 42)})});
+
+    ColumnDefinition path_column =
+            make_table_column(42, "v.metric.x", std::make_shared<DataTypeVariantV2>());
+    path_column.column_paths = {"metric", "x"};
+    ProjectedColumnBuildContext context {.scan_params = &scan_params};
+    TFileScanSlotInfo slot_info;
+    TableReader reader;
+    ASSERT_TRUE(reader.annotate_projected_column(slot_info, &context, &path_column).ok());
+
+    ASSERT_TRUE(context.schema_column.has_value());
+    EXPECT_EQ(context.schema_column->name, "renamed_v");
+    EXPECT_EQ(path_column.get_identifier_field_id(), 42);
+    EXPECT_EQ(path_column.name, "v.metric.x");
+    EXPECT_EQ(path_column.column_paths, std::vector<std::string>({"metric", "x"}));
+    EXPECT_EQ(path_column.name_mapping, std::vector<std::string>({"renamed_v"}));
+}
+
+TEST(TableReaderTest, AnnotateVariantPathSlotDoesNotFallbackAfterMissingFieldId) {
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_current_schema_id(100);
+    scan_params.__set_history_schema_info({external_schema(100, {external_schema_field("v", 99)})});
+
+    // Match FileScannerV2's real Path Slot shape: the materialized slot name contains the path
+    // while name_mapping carries the derived root alias. A missing field id must clear that alias
+    // instead of binding to the new field id 99 through BY_NAME on an entirely idless file.
+    ColumnDefinition path_column =
+            make_table_column(42, "v.metric.x", std::make_shared<DataTypeVariantV2>());
+    path_column.column_paths = {"metric", "x"};
+    path_column.name_mapping = {"v"};
+    ProjectedColumnBuildContext context {.scan_params = &scan_params};
+    TFileScanSlotInfo slot_info;
+    TableReader reader;
+    ASSERT_TRUE(reader.annotate_projected_column(slot_info, &context, &path_column).ok());
+
+    EXPECT_FALSE(context.schema_column.has_value());
+    EXPECT_EQ(path_column.get_identifier_field_id(), 42);
+    EXPECT_EQ(path_column.name, "v.metric.x");
+    EXPECT_EQ(path_column.column_paths, std::vector<std::string>({"metric", "x"}));
+    EXPECT_TRUE(path_column.has_name_mapping);
+    EXPECT_TRUE(path_column.name_mapping.empty());
+
+    auto idless_same_name =
+            make_file_column(0, "v", make_nullable(std::make_shared<DataTypeVariantV2>()));
+    idless_same_name.identifier = Field::create_field<TYPE_STRING>("v");
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(mapper.create_mapping({path_column}, {}, {idless_same_name}).ok());
+    ASSERT_EQ(mapper.mappings().size(), 1);
+    EXPECT_FALSE(mapper.mappings()[0].file_local_id.has_value());
+}
+
+TEST(TableReaderTest, AnnotateVariantPathSlotKeepsAuthoritativeEmptyNameMapping) {
+    auto root_field = external_schema_field("v", 42);
+    root_field.field_ptr->__set_name_mapping({});
+    root_field.field_ptr->__set_name_mapping_is_authoritative(true);
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_current_schema_id(100);
+    scan_params.__set_history_schema_info({external_schema(100, {root_field})});
+
+    ColumnDefinition path_column =
+            make_table_column(42, "v.metric.x", std::make_shared<DataTypeVariantV2>());
+    path_column.column_paths = {"metric", "x"};
+    path_column.name_mapping = {"v"};
+    ProjectedColumnBuildContext context {.scan_params = &scan_params};
+    TFileScanSlotInfo slot_info;
+    TableReader reader;
+    ASSERT_TRUE(reader.annotate_projected_column(slot_info, &context, &path_column).ok());
+
+    ASSERT_TRUE(context.schema_column.has_value());
+    EXPECT_TRUE(path_column.has_name_mapping);
+    EXPECT_TRUE(path_column.name_mapping.empty());
 }
 
 TEST(TableReaderTest, AnnotateProjectedColumnPrefersCurrentNameOverHistoricalAlias) {

--- a/be/test/storage/segment/adaptive_block_size_predictor_test.cpp
+++ b/be/test/storage/segment/adaptive_block_size_predictor_test.cpp
@@ -89,6 +89,18 @@ TEST_F(AdaptiveBlockSizePredictorTest, NoHistoryReturnsMaxRows) {
     EXPECT_DOUBLE_EQ(pred.bytes_per_row_for_test(), expected_bpr);
 }
 
+TEST_F(AdaptiveBlockSizePredictorTest, ExplicitBytesAccountForPreMaterializationCarrier) {
+    AdaptiveBlockSizePredictor pred(kBlockBytes, 0.0);
+    constexpr size_t rows = 32;
+    constexpr size_t carrier_bytes = rows * 1024 * 1024;
+
+    pred.update(rows, carrier_bytes);
+
+    EXPECT_TRUE(pred.has_history_for_test());
+    EXPECT_DOUBLE_EQ(pred.bytes_per_row_for_test(), 1024.0 * 1024.0);
+    EXPECT_EQ(pred.predict_next_rows(), 8);
+}
+
 // ── Test 2: EWMA convergence ──────────────────────────────────────────────────
 // When every update delivers the same sample, the EWMA stays exactly at that
 // value (0.9*v + 0.1*v == v for any v).


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

A future Iceberg external-table Variant rewrite needs `select v['metric']['x']` to materialize a dedicated Path Slot. `FileScannerV2` previously dropped the existing `TSlotDescriptor.column_paths`, so BE could not preserve the logical path, resolve the Iceberg root, merge several Path Slots into one file-local read, or return each path at its own output position.

This PR adds that BE mapping and materialization contract while reusing existing descriptor fields:

- `TSlotDescriptor.col_unique_id` carries the Iceberg Variant root field id.
- `TSlotDescriptor.column_paths` (`list<string>`) carries exact object-key segments.
- No `TVariantPathSlot`, new Thrift field, or gensrc change is introduced.
- `FileScannerV2` derives the root alias only by removing the exact known path suffix; it never splits a column name on dots.
- Mapping supports authoritative field-id files and legacy entirely-idless files through the existing `BY_FIELD_ID` / `BY_NAME` modes. Positional mapping is rejected.
- Field id remains authoritative across schema evolution. A missing historical id cannot bind to a later same-name/different-id field; historical aliases and authoritative empty aliases are preserved.
- Path Slots sharing a root use one `LocalColumnId`; predicate and output requests union their `variant_paths`.
- `TableReader` materializes Path Slots first and invokes the existing Variant V2 element extraction kernel for each logical output.
- Missing roots become SQL NULL, while schema-evolution defaults are evaluated as root carriers and then extracted.
- Carrier ownership is computed once per chunk in expected linear time. The last consumer transfers the encoded root without a deep copy, while same-batch row count and next-batch writable block reuse are preserved.
- Adaptive batch sizing samples the pre-extraction root carrier as well as the small final Path Slot, avoiding an oversized second batch for wide Variant roots.

Important scope boundary:

- This is the BE Path Slot protocol and logical materialization layer for Iceberg Parquet, not the Parquet typed-stream pruning implementation.
- The current production Format V2 Parquet reader does not consume `LocalColumnIndex.variant_paths`; because the ordinary nested `children` projection is empty, it safely falls back to reading the full root.
- A future Variant-aware Parquet reader must use `variant_paths` to select typed streams and reconstruct an encoded, possibly partial, root `ColumnVariantV2` at the shared root local position. Returning a direct typed leaf would violate the current `TableReader` extraction contract.
- ORC Variant V2 is not supported by the current mapper and is outside this PR.
- Every `column_paths` entry is an exact object key. Array indices are intentionally unsupported because `list<string>` cannot distinguish index `0` from object key `"0"`; the future FE rewrite must only replace string-key `element_at`.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `GLIBC_COMPATIBILITY=OFF ./run-be-ut.sh --run --filter=TableReaderTest.LastProjectionDetachesNestedMapWithoutCopyingStrings:ColumnMapperTest.VariantPathSlotsShareOneRootCarrierAndFinalizeOnly:ColumnMapperTest.VariantPathSlotsSupportIdlessNameMappingAndRejectPositionMapping:ColumnMapperTest.VariantPathSlotsKeepAuthoritativeNameAndFieldIdSafety:TableReaderTest.FinalizeWithoutVariantPathRetainsDirectTransfer:TableReaderTest.MaterializesTwoVariantPathSlotsFromSharedEncodedRootCarrier:TableReaderTest.VariantPathTracksFullCarrierBytesForAdaptiveBatching:TableReaderTest.VariantPathCarrierTransferPreservesRowsForLaterCast:TableReaderTest.RootBeforeVariantPathTransfersSharedCarrierWithoutCopy:TableReaderTest.MissingVariantPathRootMaterializesSqlNulls:TableReaderTest.MissingVariantPathRootExtractsFromDefaultCarrier:FileScannerV2Test.BuildsVariantPathColumnFromExistingSlotFields:FileScannerV2Test.AdaptiveBatchSizeAccountsForPreExtractionVariantCarrier:FileScanRequestBuilderTest.MergesVariantPathsAcrossPredicateAndOutputSlots:TableReaderTest.AnnotateVariantPathSlotFindsRootByFieldId:TableReaderTest.AnnotateVariantPathSlotDoesNotFallbackAfterMissingFieldId:TableReaderTest.AnnotateVariantPathSlotKeepsAuthoritativeEmptyNameMapping:LocalColumnIndexTest.MergeUnionsPartialChildrenAndFullProjectionDominates:AdaptiveBlockSizePredictorTest.ExplicitBytesAccountForPreMaterializationCarrier:IcebergV2ReaderTest.IcebergMappingModeUsesNameForEntirelyIdlessFile`
    - 20/20 focused BE ASAN unit tests passed.
    - `GLIBC_COMPATIBILITY=OFF ./run-be-ut.sh --run --filter='LocalColumnIndexTest.*:TableReaderTest.*'`
    - 95/95 mapper-index and TableReader BE ASAN unit tests passed.
    - A previous-head full BE UT run exposed that the materialization-only test helper bypassed `TableReader::open()` without explicitly initializing its runtime-state pointer. The current head establishes the intended null test state before direct finalization; the same 95-test group and focused matrix pass locally.
    - TeamCity full BE UT build `1011033` passed on the current head: 10,277 tests passed and 77 were ignored. Its raw GTest log explicitly records the previously failing `FinalizeWithoutVariantPathRetainsDirectTransfer` case and the shared-carrier, same-row, and root-first zero-copy cases as passed.
    - TeamCity Compile `1011034`, Performance `1011035`, P0 `1011038` (5,667 passed / 4 muted), External `1011039` (630 / 1), `cloud_p0` `1011040` (4,579 / 3), `vault_p0` `1011041` (21 passed), and NonConcurrent `1011042` (431 / 1) passed on the current head.
    - GitHub Actions macOS BE UT passed. Current-head BE coverage `1011051` passed at 93.53% incremental line coverage against the 80% threshold after all producer artifacts were available. FE coverage `1011050` completed successfully and skipped calculation because the change is BE-only.
    - Red/green cases cover root-first shared-carrier deep copy, same-name/different-id rebinding, pre-extraction carrier width, a zero-row placeholder breaking a later cast, and a persistent placeholder breaking second-batch reader reuse.
    - `build-support/clang-format.sh`, `build-support/check-format.sh`, and `git diff --check` passed.
    - Targeted clang-tidy was attempted but did not produce a valid clean result: the default tool was unavailable, while the toolchain invocation failed on missing standard headers and existing header diagnostics.
- Behavior changed: Yes (adds the BE mapping and materialization contract for future Iceberg Parquet Variant Path Slots; existing path-empty root slots keep their previous behavior)
- Does this need documentation: No
