### PR TITLE
[fix](profile) prevent profile-loader thread leak on cold load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -36,6 +36,7 @@ import org.apache.doris.thrift.TQueryStatistics;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -56,9 +57,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -125,20 +126,28 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    // this variable is assigned to true the first time the profile is loaded from storage
-    // no further write operation, so no data race
-    private final ReentrantReadWriteLock isProfileLoadedLock = new ReentrantReadWriteLock();
-    volatile boolean isProfileLoaded = false;
-    // Guard against spawning multiple profile-loader threads while loading is in progress.
-    private final AtomicBoolean isProfileLoading = new AtomicBoolean(false);
+    // Lifecycle of the one-time cold load of profiles from storage into memory.
+    //   NOT_LOADED -> the load has not completed; also the retryable state after a transient
+    //                 failure (a backoff timer, nextLoadRetryTimeMs, gates re-entry).
+    //   LOADING    -> a loader thread currently owns the load; CAS into this state is the single
+    //                 guard that prevents spawning multiple profile-loader threads.
+    //   LOADED     -> the on-disk index is complete and therefore AUTHORITATIVE:
+    //                 deleteBrokenProfiles()/deleteOutdatedProfilesFromStorage() are enabled and
+    //                 will delete stored profiles missing from the in-memory index.
+    //   FAILED     -> terminal: the load failed MAX_LOAD_RETRY times in a row and is not retried
+    //                 until the FE restarts. This is deliberately distinct from LOADED so a
+    //                 partial/failed index NEVER enables the destructive cleanup above.
+    private enum LoadState { NOT_LOADED, LOADING, LOADED, FAILED }
+
+    private final AtomicReference<LoadState> loadState = new AtomicReference<>(LoadState.NOT_LOADED);
     // A cold load can fail transiently -- e.g. the bounded profileIOExecutor rejects a submit under
-    // saturation (BlockedPolicy -> RejectedExecutionException), which is exactly the pressure this
-    // guard targets. We must not respawn a loader every scheduler tick on failure, but we also must
-    // not give up permanently: a permanent "never retry" latch would keep isProfileLoaded=false for
-    // the life of the FE, which disables deleteBrokenProfiles()/deleteOutdatedProfilesFromStorage()
-    // (both gated on isProfileLoaded) while writeProfileToStorage() keeps writing -- trading a thread
-    // leak for an unbounded disk leak. Instead we back off exponentially between retries and give up
-    // only after MAX_LOAD_RETRY consecutive failures, so a transient failure self-heals.
+    // saturation (BlockedPolicy -> RejectedExecutionException), which is exactly the pressure the
+    // LOADING guard targets. We must not respawn a loader every scheduler tick on failure, but we
+    // also must not give up permanently on the first failure: a permanent latch would keep the
+    // state out of LOADED for the life of the FE, disabling profile disk cleanup while
+    // writeProfileToStorage() keeps writing -- trading a thread leak for an unbounded disk leak.
+    // Instead we back off exponentially between retries and only move to FAILED after
+    // MAX_LOAD_RETRY consecutive failures, so a transient failure self-heals.
     private final AtomicInteger consecutiveLoadFailures = new AtomicInteger(0);
     private final AtomicLong nextLoadRetryTimeMs = new AtomicLong(0);
     private static final int MAX_LOAD_RETRY = 10;
@@ -147,6 +156,10 @@ public class ProfileManager extends MasterDaemon {
     // blocked up to 60s under BlockedPolicy, or an unbounded future.get()) must not hang the caller
     // forever -- exactly the scenario this change targets.
     private static final long PROFILE_LOAD_WAIT_TIMEOUT_MS = 120_000L;
+    // While in the terminal FAILED state, re-emit the "cleanup disabled" warning at most this often
+    // so an operator who missed the single failure log can still discover the condition.
+    private static final long FAILED_STATE_REWARN_INTERVAL_MS = 600_000L;
+    private final AtomicLong nextFailedRewarnTimeMs = new AtomicLong(0);
 
     // only protect queryIdDeque; queryIdToProfileMap is concurrent, no need to protect
     private ReentrantReadWriteLock lock;
@@ -188,6 +201,16 @@ public class ProfileManager extends MasterDaemon {
         int iothreads = Math.max(20, Runtime.getRuntime().availableProcessors());
         profileIOExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
             iothreads, 100, "profile-io-thread-pool", true);
+    }
+
+    // Shut down the thread pools this instance owns. The production singleton lives for the FE's
+    // lifetime and never needs this, but tests that construct throwaway ProfileManager instances
+    // must release the pools; otherwise each instance leaks ~30 live threads and its pool names
+    // collide in ThreadPoolManager's global name map.
+    @VisibleForTesting
+    void shutdown() {
+        fetchRealTimeProfileExecutor.shutdownNow();
+        profileIOExecutor.shutdownNow();
     }
 
     private ProfileElement createElement(Profile profile) {
@@ -568,6 +591,7 @@ public class ProfileManager extends MasterDaemon {
     @Override
     protected void runAfterCatalogReady() {
         loadProfilesFromStorageIfFirstTime(false);
+        warnIfLoadTerminallyFailed();
         writeProfileToStorage();
         deleteBrokenProfiles();
         deleteOutdatedProfilesFromStorage();
@@ -620,21 +644,13 @@ public class ProfileManager extends MasterDaemon {
     // deserialize to an object Profile
     // push them to memory structure of ProfileManager for index
     protected void loadProfilesFromStorageIfFirstTime(boolean sync) {
-        if (!shouldAttemptLoad()) {
-            return;
-        }
-        if (!isProfileLoading.compareAndSet(false, true)) {
-            if (sync) {
+        // A single CAS NOT_LOADED -> LOADING both wins loader ownership and rules out a redundant
+        // second cold load: once a loader is LOADING (or the state is LOADED/FAILED), no other
+        // caller can win the CAS, so the "recheck after acquiring ownership" dance is unnecessary.
+        if (!tryBeginLoad()) {
+            if (sync && loadState.get() == LoadState.LOADING) {
                 waitForProfileLoadFinish(PROFILE_LOAD_WAIT_TIMEOUT_MS);
             }
-            return;
-        }
-        // Recheck after winning ownership: a stale pre-CAS read could have observed
-        // isProfileLoaded=false while a previous loader was finishing. Without this, that loader
-        // marks loaded and clears isProfileLoading, then this CAS succeeds and starts a redundant
-        // second full cold load. Release ownership and bail if loading no longer needs to run.
-        if (!shouldAttemptLoad()) {
-            isProfileLoading.set(false);
             return;
         }
 
@@ -653,14 +669,10 @@ public class ProfileManager extends MasterDaemon {
                 // because downstream cleanup deletes stored profiles missing from the in-memory
                 // index; treat it as a failure so cleanup stays disabled until a clean load succeeds.
                 if (readFailures == 0) {
-                    // Only a fully indexed load may mark the disk index authoritative.
-                    consecutiveLoadFailures.set(0);
-                    nextLoadRetryTimeMs.set(0);
-                    markProfileLoaded();
+                    finishLoadSuccess();
                 } else {
-                    recordLoadFailure();
+                    finishLoadFailure();
                 }
-                isProfileLoading.set(false);
             }
         };
 
@@ -674,42 +686,103 @@ public class ProfileManager extends MasterDaemon {
             } catch (Throwable t) {
                 // Native-thread allocation / start() can fail under the resource pressure this
                 // guard targets. loadTask never runs, so release ownership and record the failure
-                // here; otherwise every later cycle sees isProfileLoading=true and skips the load
-                // until the backoff-free path can never re-enter it.
-                recordLoadFailure();
-                isProfileLoading.set(false);
+                // here; otherwise the state stays LOADING forever and later cycles skip the load.
+                finishLoadFailure();
                 LOG.warn("Failed to start profile-loader thread, will retry after backoff", t);
             }
         }
     }
 
-    // True if a cold load should be attempted now: not already loaded, not exhausted retries, and
-    // past the current backoff window.
-    private boolean shouldAttemptLoad() {
-        if (checkIfProfileLoaded()) {
+    // Attempt to move NOT_LOADED -> LOADING. Returns true only if this caller now owns the load.
+    // Suppresses the attempt while already loaded, terminally failed, in-flight, or still inside the
+    // exponential-backoff window after a transient failure.
+    private boolean tryBeginLoad() {
+        LoadState state = loadState.get();
+        if (state != LoadState.NOT_LOADED) {
             return false;
         }
-        if (consecutiveLoadFailures.get() >= MAX_LOAD_RETRY) {
+        if (System.currentTimeMillis() < nextLoadRetryTimeMs.get()) {
             return false;
         }
-        return System.currentTimeMillis() >= nextLoadRetryTimeMs.get();
+        return loadState.compareAndSet(LoadState.NOT_LOADED, LoadState.LOADING);
+    }
+
+    private void finishLoadSuccess() {
+        consecutiveLoadFailures.set(0);
+        nextLoadRetryTimeMs.set(0);
+        // Only a fully indexed load may mark the disk index authoritative; downstream cleanup
+        // deletes stored profiles missing from the in-memory index.
+        loadState.set(LoadState.LOADED);
     }
 
     // Record a failed/partial load attempt and schedule the next retry with exponential backoff
     // (1s, 2s, 4s ... capped at MAX_LOAD_BACKOFF_MS). After MAX_LOAD_RETRY consecutive failures we
-    // stop retrying and log that cleanup stays disabled until the FE restarts.
-    private void recordLoadFailure() {
+    // transition to the terminal FAILED state and stop retrying until the FE restarts. In either
+    // case the state leaves LOADING but does NOT become LOADED, so destructive cleanup stays off.
+    private void finishLoadFailure() {
         int failures = consecutiveLoadFailures.incrementAndGet();
         long backoffMs = Math.min(1000L << Math.min(failures, 8), MAX_LOAD_BACKOFF_MS);
         nextLoadRetryTimeMs.set(System.currentTimeMillis() + backoffMs);
         if (failures >= MAX_LOAD_RETRY) {
+            loadState.set(LoadState.FAILED);
+            nextFailedRewarnTimeMs.set(System.currentTimeMillis() + FAILED_STATE_REWARN_INTERVAL_MS);
             LOG.warn("Profile cold load failed {} times, giving up until FE restarts; "
                     + "profile disk cleanup stays disabled, loadedProfileCount={}",
                     failures, queryIdToProfileMap.size());
         } else {
+            loadState.set(LoadState.NOT_LOADED);
             LOG.warn("Profile cold load failed, attempt={}, nextRetryInMs={}, loadedProfileCount={}",
                     failures, backoffMs, queryIdToProfileMap.size());
         }
+    }
+
+    // Re-emit the "profile disk cleanup is disabled" warning periodically while in the terminal
+    // FAILED state, so an operator who missed the one-time failure log can still discover it.
+    private void warnIfLoadTerminallyFailed() {
+        if (loadState.get() != LoadState.FAILED) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long due = nextFailedRewarnTimeMs.get();
+        if (now >= due && nextFailedRewarnTimeMs.compareAndSet(due, now + FAILED_STATE_REWARN_INTERVAL_MS)) {
+            LOG.warn("Profile cold load has terminally failed; profile disk cleanup and quota "
+                    + "enforcement (max_spilled_profile_num / spilled_profile_storage_limit_bytes) "
+                    + "remain DISABLED until the FE restarts. loadedProfileCount={}",
+                    queryIdToProfileMap.size());
+        }
+    }
+
+    @VisibleForTesting
+    String getProfileLoadState() {
+        return loadState.get().name();
+    }
+
+    @VisibleForTesting
+    boolean isProfileLoadedForTest() {
+        return loadState.get() == LoadState.LOADED;
+    }
+
+    // Reset to the initial pristine state so a test can re-drive a cold load. Also clears the
+    // backoff bookkeeping so a prior failed-load test does not suppress the next attempt.
+    @VisibleForTesting
+    void resetLoadStateForTest() {
+        loadState.set(LoadState.NOT_LOADED);
+        consecutiveLoadFailures.set(0);
+        nextLoadRetryTimeMs.set(0);
+        nextFailedRewarnTimeMs.set(0);
+    }
+
+    @VisibleForTesting
+    void forceLoadedForTest() {
+        loadState.set(LoadState.LOADED);
+    }
+
+    // Clear only the backoff timer so a test can drive the next retry immediately, without resetting
+    // the consecutive-failure count or the load state -- lets a test exercise the retry/terminate
+    // path deterministically instead of sleeping through real backoff windows.
+    @VisibleForTesting
+    void resetBackoffWindowForTest() {
+        nextLoadRetryTimeMs.set(0);
     }
 
     // Returns the number of profiles that failed to read (0 means a fully indexed, clean load).
@@ -736,10 +809,10 @@ public class ProfileManager extends MasterDaemon {
                     // NOTE: Profile.read() returns null for BOTH a genuinely malformed file (safe to
                     // treat as absent) and a transient IO error (must not be treated as absent). It
                     // swallows every exception internally, so a transient read failure is invisible
-                    // here and does not increment readFailures below. This gap means isProfileLoaded
-                    // can still be set on a load that silently skipped a valid-but-unreadable file;
-                    // distinguishing the two requires Profile.read() to throw on IO-class errors,
-                    // which is out of scope for this change (tracked as a follow-up).
+                    // here and does not increment readFailures below. This gap means the state can
+                    // still become LOADED on a load that silently skipped a valid-but-unreadable
+                    // file; distinguishing the two requires Profile.read() to throw on IO-class
+                    // errors, which is out of scope for this change (tracked as a follow-up).
                     Profile profile = Profile.read(profileDirAbsPath);
                     if (profile != null) {
                         profiles.add(profile);
@@ -766,18 +839,9 @@ public class ProfileManager extends MasterDaemon {
         return readFailures;
     }
 
-    private void markProfileLoaded() {
-        isProfileLoadedLock.writeLock().lock();
-        try {
-            this.isProfileLoaded = true;
-        } finally {
-            isProfileLoadedLock.writeLock().unlock();
-        }
-    }
-
     private void waitForProfileLoadFinish(long timeoutMs) {
         long deadline = System.currentTimeMillis() + timeoutMs;
-        while (isProfileLoading.get() && !checkIfProfileLoaded()) {
+        while (loadState.get() == LoadState.LOADING) {
             if (System.currentTimeMillis() >= deadline) {
                 LOG.warn("Timed out waiting for in-flight profile load to finish, timeoutMs={}", timeoutMs);
                 return;
@@ -1230,12 +1294,7 @@ public class ProfileManager extends MasterDaemon {
     }
 
     private boolean checkIfProfileLoaded() {
-        isProfileLoadedLock.readLock().lock();
-        try {
-            return isProfileLoaded;
-        } finally {
-            isProfileLoadedLock.readLock().unlock();
-        }
+        return loadState.get() == LoadState.LOADED;
     }
 
     public void removeProfile(String profileId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -57,6 +57,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -129,12 +131,22 @@ public class ProfileManager extends MasterDaemon {
     volatile boolean isProfileLoaded = false;
     // Guard against spawning multiple profile-loader threads while loading is in progress.
     private final AtomicBoolean isProfileLoading = new AtomicBoolean(false);
-    // Set when a load attempt terminates without fully indexing storage. This is distinct from
-    // isProfileLoaded, which means the on-disk index is complete and therefore authoritative for
-    // deleteBrokenProfiles()/deleteOutdatedProfilesFromStorage(). A failed attempt must stop the
-    // loader from respawning on every scheduler tick WITHOUT enabling that destructive cleanup,
-    // because a partial in-memory index would otherwise classify valid stored profiles as broken.
-    private final AtomicBoolean isProfileLoadFailed = new AtomicBoolean(false);
+    // A cold load can fail transiently -- e.g. the bounded profileIOExecutor rejects a submit under
+    // saturation (BlockedPolicy -> RejectedExecutionException), which is exactly the pressure this
+    // guard targets. We must not respawn a loader every scheduler tick on failure, but we also must
+    // not give up permanently: a permanent "never retry" latch would keep isProfileLoaded=false for
+    // the life of the FE, which disables deleteBrokenProfiles()/deleteOutdatedProfilesFromStorage()
+    // (both gated on isProfileLoaded) while writeProfileToStorage() keeps writing -- trading a thread
+    // leak for an unbounded disk leak. Instead we back off exponentially between retries and give up
+    // only after MAX_LOAD_RETRY consecutive failures, so a transient failure self-heals.
+    private final AtomicInteger consecutiveLoadFailures = new AtomicInteger(0);
+    private final AtomicLong nextLoadRetryTimeMs = new AtomicLong(0);
+    private static final int MAX_LOAD_RETRY = 10;
+    private static final long MAX_LOAD_BACKOFF_MS = 300_000L;
+    // Upper bound for a synchronous caller blocking on an in-flight load. A stuck loader (submit()
+    // blocked up to 60s under BlockedPolicy, or an unbounded future.get()) must not hang the caller
+    // forever -- exactly the scenario this change targets.
+    private static final long PROFILE_LOAD_WAIT_TIMEOUT_MS = 120_000L;
 
     // only protect queryIdDeque; queryIdToProfileMap is concurrent, no need to protect
     private ReentrantReadWriteLock lock;
@@ -608,47 +620,45 @@ public class ProfileManager extends MasterDaemon {
     // deserialize to an object Profile
     // push them to memory structure of ProfileManager for index
     protected void loadProfilesFromStorageIfFirstTime(boolean sync) {
-        if (checkIfProfileLoaded() || isProfileLoadFailed.get()) {
+        if (!shouldAttemptLoad()) {
             return;
         }
         if (!isProfileLoading.compareAndSet(false, true)) {
             if (sync) {
-                waitForProfileLoadFinish();
+                waitForProfileLoadFinish(PROFILE_LOAD_WAIT_TIMEOUT_MS);
             }
             return;
         }
         // Recheck after winning ownership: a stale pre-CAS read could have observed
         // isProfileLoaded=false while a previous loader was finishing. Without this, that loader
         // marks loaded and clears isProfileLoading, then this CAS succeeds and starts a redundant
-        // second full cold load. Release ownership and bail if loading already terminated.
-        if (checkIfProfileLoaded() || isProfileLoadFailed.get()) {
+        // second full cold load. Release ownership and bail if loading no longer needs to run.
+        if (!shouldAttemptLoad()) {
             isProfileLoading.set(false);
             return;
         }
 
         Runnable loadTask = () -> {
             long startTime = System.currentTimeMillis();
-            boolean loadSucceeded = false;
+            int readFailures = -1;
             try {
-                loadProfilesFromStorage();
-                loadSucceeded = true;
-                LOG.info("Load profiles into memory finished, costs {}ms",
-                        System.currentTimeMillis() - startTime);
+                readFailures = loadProfilesFromStorage();
+                LOG.info("Load profiles into memory finished, readFailures={}, costMs={}",
+                        readFailures, System.currentTimeMillis() - startTime);
             } catch (Exception e) {
                 LOG.error("Failed to load query profile from storage", e);
             } finally {
-                if (loadSucceeded) {
-                    // Only a fully indexed load may mark the disk index authoritative; downstream
-                    // cleanup deletes stored profiles missing from the in-memory index.
+                // A load only counts as successful when every stored profile was read without error
+                // (readFailures == 0). A partial read must NOT mark the disk index authoritative,
+                // because downstream cleanup deletes stored profiles missing from the in-memory
+                // index; treat it as a failure so cleanup stays disabled until a clean load succeeds.
+                if (readFailures == 0) {
+                    // Only a fully indexed load may mark the disk index authoritative.
+                    consecutiveLoadFailures.set(0);
+                    nextLoadRetryTimeMs.set(0);
                     markProfileLoaded();
                 } else {
-                    // Record a terminal failure so the loader is not respawned every scheduler tick,
-                    // but keep isProfileLoaded=false so destructive cleanup stays disabled on a
-                    // partial index. The load will not be retried until the FE restarts.
-                    isProfileLoadFailed.set(true);
-                    LOG.warn("Profile loading did not complete successfully, "
-                            + "will not retry until FE restarts. Loaded profile count in memory: {}",
-                            queryIdToProfileMap.size());
+                    recordLoadFailure();
                 }
                 isProfileLoading.set(false);
             }
@@ -663,23 +673,53 @@ public class ProfileManager extends MasterDaemon {
                 loadThread.start();
             } catch (Throwable t) {
                 // Native-thread allocation / start() can fail under the resource pressure this
-                // guard targets. loadTask never runs, so release ownership and record a terminal
-                // failure here; otherwise every later cycle sees isProfileLoading=true and
-                // permanently skips the cold load.
-                isProfileLoadFailed.set(true);
+                // guard targets. loadTask never runs, so release ownership and record the failure
+                // here; otherwise every later cycle sees isProfileLoading=true and skips the load
+                // until the backoff-free path can never re-enter it.
+                recordLoadFailure();
                 isProfileLoading.set(false);
-                LOG.warn("Failed to start profile-loader thread, "
-                        + "profile loading will not be retried until FE restarts", t);
+                LOG.warn("Failed to start profile-loader thread, will retry after backoff", t);
             }
         }
     }
 
-    private void loadProfilesFromStorage() throws Exception {
+    // True if a cold load should be attempted now: not already loaded, not exhausted retries, and
+    // past the current backoff window.
+    private boolean shouldAttemptLoad() {
+        if (checkIfProfileLoaded()) {
+            return false;
+        }
+        if (consecutiveLoadFailures.get() >= MAX_LOAD_RETRY) {
+            return false;
+        }
+        return System.currentTimeMillis() >= nextLoadRetryTimeMs.get();
+    }
+
+    // Record a failed/partial load attempt and schedule the next retry with exponential backoff
+    // (1s, 2s, 4s ... capped at MAX_LOAD_BACKOFF_MS). After MAX_LOAD_RETRY consecutive failures we
+    // stop retrying and log that cleanup stays disabled until the FE restarts.
+    private void recordLoadFailure() {
+        int failures = consecutiveLoadFailures.incrementAndGet();
+        long backoffMs = Math.min(1000L << Math.min(failures, 8), MAX_LOAD_BACKOFF_MS);
+        nextLoadRetryTimeMs.set(System.currentTimeMillis() + backoffMs);
+        if (failures >= MAX_LOAD_RETRY) {
+            LOG.warn("Profile cold load failed {} times, giving up until FE restarts; "
+                    + "profile disk cleanup stays disabled, loadedProfileCount={}",
+                    failures, queryIdToProfileMap.size());
+        } else {
+            LOG.warn("Profile cold load failed, attempt={}, nextRetryInMs={}, loadedProfileCount={}",
+                    failures, backoffMs, queryIdToProfileMap.size());
+        }
+    }
+
+    // Returns the number of profiles that failed to read (0 means a fully indexed, clean load).
+    private int loadProfilesFromStorage() throws Exception {
         List<String> profileDirAbsPaths = getOnStorageProfileInfos();
         LOG.info("Reading {} profiles from {}", profileDirAbsPaths.size(), PROFILE_STORAGE_PATH);
         // Newest profile first
         profileDirAbsPaths.sort(Collections.reverseOrder());
 
+        int readFailures = 0;
         // Process profiles in batches
         for (int i = 0; i < profileDirAbsPaths.size(); i += BATCH_SIZE) {
             // Thread safe list
@@ -693,6 +733,13 @@ public class ProfileManager extends MasterDaemon {
             // Create and add tasks for current batch to executor
             for (String profileDirAbsPath : batch) {
                 profileIOFutures.add(profileIOExecutor.submit(() -> {
+                    // NOTE: Profile.read() returns null for BOTH a genuinely malformed file (safe to
+                    // treat as absent) and a transient IO error (must not be treated as absent). It
+                    // swallows every exception internally, so a transient read failure is invisible
+                    // here and does not increment readFailures below. This gap means isProfileLoaded
+                    // can still be set on a load that silently skipped a valid-but-unreadable file;
+                    // distinguishing the two requires Profile.read() to throw on IO-class errors,
+                    // which is out of scope for this change (tracked as a follow-up).
                     Profile profile = Profile.read(profileDirAbsPath);
                     if (profile != null) {
                         profiles.add(profile);
@@ -705,6 +752,7 @@ public class ProfileManager extends MasterDaemon {
                 try {
                     future.get();
                 } catch (Exception e) {
+                    readFailures++;
                     LOG.warn("Failed to read profile from storage", e);
                 }
             }
@@ -713,8 +761,9 @@ public class ProfileManager extends MasterDaemon {
                 pushProfile(profile);
             }
 
-            LOG.info("Processed batch {} - {} of {} profiles", i, end, profileDirAbsPaths.size());
+            LOG.debug("Processed batch {} - {} of {} profiles", i, end, profileDirAbsPaths.size());
         }
+        return readFailures;
     }
 
     private void markProfileLoaded() {
@@ -726,8 +775,13 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    private void waitForProfileLoadFinish() {
+    private void waitForProfileLoadFinish(long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
         while (isProfileLoading.get() && !checkIfProfileLoaded()) {
+            if (System.currentTimeMillis() >= deadline) {
+                LOG.warn("Timed out waiting for in-flight profile load to finish, timeoutMs={}", timeoutMs);
+                return;
+            }
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
@@ -788,10 +842,8 @@ public class ProfileManager extends MasterDaemon {
             List<Future<?>> profileWriteFutures = Lists.newArrayList();
 
             for (ProfileElement profileElement : profilesToBeStored) {
-                Thread thread = new Thread(() -> {
-                    profileElement.writeToStorage(PROFILE_STORAGE_PATH);
-                });
-                profileWriteFutures.add(profileIOExecutor.submit(thread));
+                profileWriteFutures.add(profileIOExecutor.submit(
+                        () -> profileElement.writeToStorage(PROFILE_STORAGE_PATH)));
             }
 
             for (Future<?> future : profileWriteFutures) {
@@ -958,7 +1010,7 @@ public class ProfileManager extends MasterDaemon {
         List<Future<?>> profileDeleteFutures = Lists.newArrayList();
 
         for (String brokenProfile : brokenProfiles) {
-            Thread iothread = new Thread(() -> {
+            profileDeleteFutures.add(profileIOExecutor.submit(() -> {
                 try {
                     File profileFile = new File(brokenProfile);
                     if (!profileFile.isFile()) {
@@ -971,8 +1023,7 @@ public class ProfileManager extends MasterDaemon {
                 } catch (Exception e) {
                     LOG.error("Failed to delete broken profile: {}", brokenProfile, e);
                 }
-            });
-            profileDeleteFutures.add(profileIOExecutor.submit(iothread));
+            }));
         }
 
         for (Future<?> future : profileDeleteFutures) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -56,6 +56,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -126,6 +127,8 @@ public class ProfileManager extends MasterDaemon {
     // no further write operation, so no data race
     private final ReentrantReadWriteLock isProfileLoadedLock = new ReentrantReadWriteLock();
     volatile boolean isProfileLoaded = false;
+    // Guard against spawning multiple profile-loader threads while loading is in progress.
+    private final AtomicBoolean isProfileLoading = new AtomicBoolean(false);
 
     // only protect queryIdDeque; queryIdToProfileMap is concurrent, no need to protect
     private ReentrantReadWriteLock lock;
@@ -602,78 +605,104 @@ public class ProfileManager extends MasterDaemon {
         if (checkIfProfileLoaded()) {
             return;
         }
+        if (!isProfileLoading.compareAndSet(false, true)) {
+            if (sync) {
+                waitForProfileLoadFinish();
+            }
+            return;
+        }
 
-        // Create a new thread to load profiles
-        Thread loadThread = new Thread(() -> {
+        Runnable loadTask = () -> {
             long startTime = System.currentTimeMillis();
-
+            boolean loadSucceeded = false;
             try {
-                List<String> profileDirAbsPaths = getOnStorageProfileInfos();
-                LOG.info("Reading {} profiles from {}", profileDirAbsPaths.size(),
-                        PROFILE_STORAGE_PATH);
-                // Newest profile first
-                profileDirAbsPaths.sort(Collections.reverseOrder());
-
-                // Process profiles in batches
-                for (int i = 0; i < profileDirAbsPaths.size(); i += BATCH_SIZE) {
-                    // Thread safe list
-                    List<Profile> profiles = Collections.synchronizedList(new ArrayList<>());
-                    int end = Math.min(i + BATCH_SIZE, profileDirAbsPaths.size());
-                    List<String> batch = profileDirAbsPaths.subList(i, end);
-
-                    // List of profile io futures for current batch
-                    List<Future<?>> profileIOFutures = Lists.newArrayList();
-
-                    // Create and add tasks for current batch to executor
-                    for (String profileDirAbsPath : batch) {
-                        Thread thread = new Thread(() -> {
-                            Profile profile = Profile.read(profileDirAbsPath);
-                            if (profile != null) {
-                                profiles.add(profile);
-                            }
-                        });
-                        profileIOFutures.add(profileIOExecutor.submit(thread));
-                    }
-
-                    // Wait for all futures in current batch to complete
-                    for (Future<?> future : profileIOFutures) {
-                        try {
-                            future.get();
-                        } catch (Exception e) {
-                            LOG.warn("Failed to read profile from storage", e);
-                        }
-                    }
-
-                    for (Profile profile : profiles) {
-                        pushProfile(profile);
-                    }
-
-                    LOG.info("Processed batch {} - {} of {} profiles", i, end, profileDirAbsPaths.size());
-                }
-
-                LOG.info("Load profiles into memory finished, costs {}ms", System.currentTimeMillis() - startTime);
-
-                // Set isProfileLoaded to true with write lock
-                isProfileLoadedLock.writeLock().lock();
-                try {
-                    this.isProfileLoaded = true;
-                } finally {
-                    isProfileLoadedLock.writeLock().unlock();
-                }
+                loadProfilesFromStorage();
+                loadSucceeded = true;
+                LOG.info("Load profiles into memory finished, costs {}ms",
+                        System.currentTimeMillis() - startTime);
             } catch (Exception e) {
                 LOG.error("Failed to load query profile from storage", e);
+            } finally {
+                // Mark loaded even on failure to avoid spawning a new profile-loader every second.
+                markProfileLoaded();
+                isProfileLoading.set(false);
+                if (!loadSucceeded) {
+                    LOG.warn("Profile loading did not complete successfully, "
+                            + "will not retry until FE restarts. Loaded profile count in memory: {}",
+                            queryIdToProfileMap.size());
+                }
             }
-        });
+        };
 
-        loadThread.setName("profile-loader");
-        loadThread.start();
-
-        // Wait for the thread to finish if sync is true
         if (sync) {
+            loadTask.run();
+        } else {
+            Thread loadThread = new Thread(loadTask, "profile-loader");
+            loadThread.setDaemon(true);
+            loadThread.start();
+        }
+    }
+
+    private void loadProfilesFromStorage() throws Exception {
+        List<String> profileDirAbsPaths = getOnStorageProfileInfos();
+        LOG.info("Reading {} profiles from {}", profileDirAbsPaths.size(), PROFILE_STORAGE_PATH);
+        // Newest profile first
+        profileDirAbsPaths.sort(Collections.reverseOrder());
+
+        // Process profiles in batches
+        for (int i = 0; i < profileDirAbsPaths.size(); i += BATCH_SIZE) {
+            // Thread safe list
+            List<Profile> profiles = Collections.synchronizedList(new ArrayList<>());
+            int end = Math.min(i + BATCH_SIZE, profileDirAbsPaths.size());
+            List<String> batch = profileDirAbsPaths.subList(i, end);
+
+            // List of profile io futures for current batch
+            List<Future<?>> profileIOFutures = Lists.newArrayList();
+
+            // Create and add tasks for current batch to executor
+            for (String profileDirAbsPath : batch) {
+                profileIOFutures.add(profileIOExecutor.submit(() -> {
+                    Profile profile = Profile.read(profileDirAbsPath);
+                    if (profile != null) {
+                        profiles.add(profile);
+                    }
+                }));
+            }
+
+            // Wait for all futures in current batch to complete
+            for (Future<?> future : profileIOFutures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    LOG.warn("Failed to read profile from storage", e);
+                }
+            }
+
+            for (Profile profile : profiles) {
+                pushProfile(profile);
+            }
+
+            LOG.info("Processed batch {} - {} of {} profiles", i, end, profileDirAbsPaths.size());
+        }
+    }
+
+    private void markProfileLoaded() {
+        isProfileLoadedLock.writeLock().lock();
+        try {
+            this.isProfileLoaded = true;
+        } finally {
+            isProfileLoadedLock.writeLock().unlock();
+        }
+    }
+
+    private void waitForProfileLoadFinish() {
+        while (isProfileLoading.get() && !checkIfProfileLoaded()) {
             try {
-                loadThread.join();
+                Thread.sleep(100);
             } catch (InterruptedException e) {
-                LOG.error("Failed to wait for profile loader thread", e);
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for profile loading to finish", e);
+                return;
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -129,6 +129,12 @@ public class ProfileManager extends MasterDaemon {
     volatile boolean isProfileLoaded = false;
     // Guard against spawning multiple profile-loader threads while loading is in progress.
     private final AtomicBoolean isProfileLoading = new AtomicBoolean(false);
+    // Set when a load attempt terminates without fully indexing storage. This is distinct from
+    // isProfileLoaded, which means the on-disk index is complete and therefore authoritative for
+    // deleteBrokenProfiles()/deleteOutdatedProfilesFromStorage(). A failed attempt must stop the
+    // loader from respawning on every scheduler tick WITHOUT enabling that destructive cleanup,
+    // because a partial in-memory index would otherwise classify valid stored profiles as broken.
+    private final AtomicBoolean isProfileLoadFailed = new AtomicBoolean(false);
 
     // only protect queryIdDeque; queryIdToProfileMap is concurrent, no need to protect
     private ReentrantReadWriteLock lock;
@@ -602,13 +608,21 @@ public class ProfileManager extends MasterDaemon {
     // deserialize to an object Profile
     // push them to memory structure of ProfileManager for index
     protected void loadProfilesFromStorageIfFirstTime(boolean sync) {
-        if (checkIfProfileLoaded()) {
+        if (checkIfProfileLoaded() || isProfileLoadFailed.get()) {
             return;
         }
         if (!isProfileLoading.compareAndSet(false, true)) {
             if (sync) {
                 waitForProfileLoadFinish();
             }
+            return;
+        }
+        // Recheck after winning ownership: a stale pre-CAS read could have observed
+        // isProfileLoaded=false while a previous loader was finishing. Without this, that loader
+        // marks loaded and clears isProfileLoading, then this CAS succeeds and starts a redundant
+        // second full cold load. Release ownership and bail if loading already terminated.
+        if (checkIfProfileLoaded() || isProfileLoadFailed.get()) {
+            isProfileLoading.set(false);
             return;
         }
 
@@ -623,14 +637,20 @@ public class ProfileManager extends MasterDaemon {
             } catch (Exception e) {
                 LOG.error("Failed to load query profile from storage", e);
             } finally {
-                // Mark loaded even on failure to avoid spawning a new profile-loader every second.
-                markProfileLoaded();
-                isProfileLoading.set(false);
-                if (!loadSucceeded) {
+                if (loadSucceeded) {
+                    // Only a fully indexed load may mark the disk index authoritative; downstream
+                    // cleanup deletes stored profiles missing from the in-memory index.
+                    markProfileLoaded();
+                } else {
+                    // Record a terminal failure so the loader is not respawned every scheduler tick,
+                    // but keep isProfileLoaded=false so destructive cleanup stays disabled on a
+                    // partial index. The load will not be retried until the FE restarts.
+                    isProfileLoadFailed.set(true);
                     LOG.warn("Profile loading did not complete successfully, "
                             + "will not retry until FE restarts. Loaded profile count in memory: {}",
                             queryIdToProfileMap.size());
                 }
+                isProfileLoading.set(false);
             }
         };
 
@@ -639,7 +659,18 @@ public class ProfileManager extends MasterDaemon {
         } else {
             Thread loadThread = new Thread(loadTask, "profile-loader");
             loadThread.setDaemon(true);
-            loadThread.start();
+            try {
+                loadThread.start();
+            } catch (Throwable t) {
+                // Native-thread allocation / start() can fail under the resource pressure this
+                // guard targets. loadTask never runs, so release ownership and record a terminal
+                // failure here; otherwise every later cycle sees isProfileLoading=true and
+                // permanently skips the cold load.
+                isProfileLoadFailed.set(true);
+                isProfileLoading.set(false);
+                LOG.warn("Failed to start profile-loader thread, "
+                        + "profile loading will not be retried until FE restarts", t);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -1354,12 +1354,29 @@ class ProfileManagerTest {
         Assertions.assertTrue(pushProfileEntered.get(), "pushProfile override should have been entered");
         // A failed load must NOT be promoted to the cleanup-authoritative "index complete" state,
         // otherwise deleteBrokenProfiles() would delete valid stored profiles missing from the
-        // partial in-memory index. It should, however, stop respawning the loader.
+        // partial in-memory index.
         Assertions.assertFalse(pm.isProfileLoaded, "failed load must not mark the disk index authoritative");
         Assertions.assertTrue(pm.queryIdToProfileMap.isEmpty());
-        // A subsequent trigger must not restart the load (terminal failure recorded until FE restart).
+
+        // A second trigger inside the backoff window must NOT re-enter the load body -- this is the
+        // property the failure handling exists to protect (no per-tick loader respawn on failure).
+        pushProfileEntered.set(false);
         pm.loadProfilesFromStorageIfFirstTime(true);
+        Assertions.assertFalse(pushProfileEntered.get(),
+                "a load in the backoff window must not be restarted by a later trigger");
         Assertions.assertFalse(pm.isProfileLoaded);
+
+        // The invariant the failed-load handling really protects: valid stored profiles must survive
+        // a failed load. Because isProfileLoaded stayed false, destructive cleanup is a no-op.
+        File[] filesBefore = tempDir.listFiles();
+        Assertions.assertNotNull(filesBefore);
+        Assertions.assertEquals(1, filesBefore.length);
+        pm.deleteBrokenProfiles();
+        pm.deleteOutdatedProfilesFromStorage();
+        File[] filesAfter = tempDir.listFiles();
+        Assertions.assertNotNull(filesAfter);
+        Assertions.assertEquals(1, filesAfter.length,
+                "a failed load must not enable destructive cleanup of valid stored profiles");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -68,10 +69,25 @@ class ProfileManagerTest {
     private File tempDir;
     private String originalPath;
     private int originMaxProfiles;
+    // ProfileManager instances constructed inside a single test; their thread pools are released in
+    // @AfterEach so the unit-test JVM does not accumulate ~30 live threads per instance.
+    private final List<ProfileManager> managersToShutdown = new ArrayList<>();
+
+    private ProfileManager register(ProfileManager pm) {
+        managersToShutdown.add(pm);
+        return pm;
+    }
 
     @BeforeAll
     static void setUp() throws Exception {
         profileManager = new ProfileManager();
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        if (profileManager != null) {
+            profileManager.shutdown();
+        }
     }
 
     @BeforeEach
@@ -80,12 +96,16 @@ class ProfileManagerTest {
         originalPath = ProfileManager.PROFILE_STORAGE_PATH;
         ProfileManager.PROFILE_STORAGE_PATH = tempDir.getAbsolutePath();
         profileManager.cleanProfile();
-        profileManager.isProfileLoaded = false;
+        profileManager.resetLoadStateForTest();
         originMaxProfiles = Config.max_query_profile_num;
     }
 
     @AfterEach
     void cleanup() {
+        for (ProfileManager pm : managersToShutdown) {
+            pm.shutdown();
+        }
+        managersToShutdown.clear();
         ProfileManager.PROFILE_STORAGE_PATH = originalPath;
         FileUtils.deleteQuietly(tempDir);
         Config.max_query_profile_num = originMaxProfiles;
@@ -521,7 +541,7 @@ class ProfileManagerTest {
 
     @Test
     void testLoadProfile() throws IOException {
-        profileManager.isProfileLoaded = false;
+        profileManager.resetLoadStateForTest();
 
         try {
             // Create some test profile files
@@ -532,7 +552,7 @@ class ProfileManagerTest {
             }
 
             profileManager.loadProfilesFromStorageIfFirstTime(true);
-            Assertions.assertTrue(profileManager.isProfileLoaded);
+            Assertions.assertTrue(profileManager.isProfileLoadedForTest());
             Assertions.assertEquals(30, profileManager.queryIdToProfileMap.size());
             Assertions.assertEquals(0, profileManager.queryIdToExecutionProfiles.size());
         } catch (InterruptedException e) {
@@ -685,7 +705,7 @@ class ProfileManagerTest {
             }
 
             // Execute deletion
-            profileManager.isProfileLoaded = true;
+            profileManager.forceLoadedForTest();
             profileManager.deleteOutdatedProfilesFromStorage();
 
             // Verify correct profiles were deleted
@@ -767,7 +787,7 @@ class ProfileManagerTest {
         }
 
         // Delete broken profiles
-        profileManager.isProfileLoaded = true;
+        profileManager.forceLoadedForTest();
         profileManager.deleteBrokenProfiles();
 
         // Verify normal files still exist
@@ -822,7 +842,7 @@ class ProfileManagerTest {
         }
 
         // Trigger cleanup
-        profileManager.isProfileLoaded = true;
+        profileManager.forceLoadedForTest();
         profileManager.deleteOutdatedProfilesFromStorage();
 
         // Verify number of profiles is within limits
@@ -847,7 +867,7 @@ class ProfileManagerTest {
         brokenFile.createNewFile();
 
         // Trigger cleanup
-        profileManager.isProfileLoaded = true;
+        profileManager.forceLoadedForTest();
         profileManager.deleteBrokenProfiles();
 
         // Verify broken profile is removed but valid one remains
@@ -1021,7 +1041,7 @@ class ProfileManagerTest {
             }
 
             // Trigger cleanup - should move old profiles to pending and possibly archive
-            profileManager.isProfileLoaded = true;
+            profileManager.forceLoadedForTest();
             profileManager.deleteOutdatedProfilesFromStorage();
 
             // Verify storage directory only has max allowed profiles
@@ -1089,7 +1109,7 @@ class ProfileManagerTest {
             }
 
             // Trigger cleanup - should directly delete old profiles
-            profileManager.isProfileLoaded = true;
+            profileManager.forceLoadedForTest();
             profileManager.deleteOutdatedProfilesFromStorage();
 
             // Verify delete invocations
@@ -1146,7 +1166,7 @@ class ProfileManagerTest {
 
             // Simulate periodic cleanup via runAfterCatalogReady
             // Note: The first call will trigger cleanup since lastArchiveCleanupTime is 0
-            profileManager.isProfileLoaded = true;
+            profileManager.forceLoadedForTest();
             profileManager.runAfterCatalogReady();
 
             // Verify that the old archive was deleted by runAfterCatalogReady
@@ -1242,7 +1262,8 @@ class ProfileManagerTest {
                 return super.getOnStorageProfileInfos();
             }
         };
-        pm.isProfileLoaded = false;
+        pm.resetLoadStateForTest();
+        register(pm);
 
         int concurrentTriggers = 20;
         CountDownLatch startLatch = new CountDownLatch(1);
@@ -1272,11 +1293,11 @@ class ProfileManagerTest {
         releaseLoader.countDown();
 
         long waitStart = System.currentTimeMillis();
-        while (!pm.isProfileLoaded && System.currentTimeMillis() - waitStart < 30000) {
+        while (!pm.isProfileLoadedForTest() && System.currentTimeMillis() - waitStart < 30000) {
             Thread.sleep(100);
         }
 
-        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertTrue(pm.isProfileLoadedForTest());
         Assertions.assertEquals(1, loadEntries.get(),
                 "No second cold load should start after the first one completes");
         Assertions.assertEquals(numProfiles, pm.queryIdToProfileMap.size());
@@ -1300,7 +1321,8 @@ class ProfileManagerTest {
                 return super.getOnStorageProfileInfos();
             }
         };
-        pm.isProfileLoaded = false;
+        pm.resetLoadStateForTest();
+        register(pm);
 
         Thread asyncLoader = new Thread(() -> pm.loadProfilesFromStorageIfFirstTime(false));
         asyncLoader.start();
@@ -1325,7 +1347,7 @@ class ProfileManagerTest {
         asyncLoader.join(10000);
 
         Assertions.assertTrue(syncReturned.get(), "sync load should return after the async load finishes");
-        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertTrue(pm.isProfileLoadedForTest());
     }
 
     @Test
@@ -1346,7 +1368,8 @@ class ProfileManagerTest {
                 throw new RuntimeException("simulated load failure");
             }
         };
-        pm.isProfileLoaded = false;
+        pm.resetLoadStateForTest();
+        register(pm);
 
         pm.loadProfilesFromStorageIfFirstTime(true);
 
@@ -1355,7 +1378,7 @@ class ProfileManagerTest {
         // A failed load must NOT be promoted to the cleanup-authoritative "index complete" state,
         // otherwise deleteBrokenProfiles() would delete valid stored profiles missing from the
         // partial in-memory index.
-        Assertions.assertFalse(pm.isProfileLoaded, "failed load must not mark the disk index authoritative");
+        Assertions.assertFalse(pm.isProfileLoadedForTest(), "failed load must not mark the disk index authoritative");
         Assertions.assertTrue(pm.queryIdToProfileMap.isEmpty());
 
         // A second trigger inside the backoff window must NOT re-enter the load body -- this is the
@@ -1364,10 +1387,10 @@ class ProfileManagerTest {
         pm.loadProfilesFromStorageIfFirstTime(true);
         Assertions.assertFalse(pushProfileEntered.get(),
                 "a load in the backoff window must not be restarted by a later trigger");
-        Assertions.assertFalse(pm.isProfileLoaded);
+        Assertions.assertFalse(pm.isProfileLoadedForTest());
 
         // The invariant the failed-load handling really protects: valid stored profiles must survive
-        // a failed load. Because isProfileLoaded stayed false, destructive cleanup is a no-op.
+        // a failed load. Because the state never became LOADED, destructive cleanup is a no-op.
         File[] filesBefore = tempDir.listFiles();
         Assertions.assertNotNull(filesBefore);
         Assertions.assertEquals(1, filesBefore.length);
@@ -1380,9 +1403,52 @@ class ProfileManagerTest {
     }
 
     @Test
+    void testLoadRetriesWithBackoffThenTerminates() throws Exception {
+        // A load that always fails must NOT respawn a loader every tick (backoff gates re-entry) and
+        // must eventually reach the terminal FAILED state instead of retrying forever -- while never
+        // becoming LOADED, so destructive cleanup stays disabled the whole time.
+        UUID taskId = UUID.randomUUID();
+        TUniqueId queryId = new TUniqueId(taskId.getMostSignificantBits(), taskId.getLeastSignificantBits());
+        constructProfile(DebugUtil.printId(queryId)).writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
+
+        AtomicInteger loadAttempts = new AtomicInteger(0);
+        ProfileManager pm = new ProfileManager() {
+            @Override
+            public void pushProfile(Profile profile) {
+                loadAttempts.incrementAndGet();
+                throw new RuntimeException("simulated load failure");
+            }
+        };
+        pm.resetLoadStateForTest();
+        register(pm);
+
+        // Drive many synchronous triggers. Backoff makes most of them no-ops; only the ones past the
+        // backoff window actually enter the load body, so attempts stay far below the trigger count.
+        for (int i = 0; i < 50; i++) {
+            pm.resetBackoffWindowForTest();
+            pm.loadProfilesFromStorageIfFirstTime(true);
+        }
+
+        Assertions.assertEquals("FAILED", pm.getProfileLoadState(),
+                "a load that always fails should terminate in FAILED after MAX_LOAD_RETRY attempts");
+        Assertions.assertFalse(pm.isProfileLoadedForTest());
+        // Bounded by MAX_LOAD_RETRY (10), not by the 50 triggers.
+        Assertions.assertTrue(loadAttempts.get() <= 10,
+                "load attempts must be bounded by MAX_LOAD_RETRY, got " + loadAttempts.get());
+
+        // Once terminal, no trigger re-enters the load body -- even outside the backoff window.
+        int attemptsAtTerminal = loadAttempts.get();
+        pm.resetBackoffWindowForTest();
+        pm.loadProfilesFromStorageIfFirstTime(true);
+        Assertions.assertEquals(attemptsAtTerminal, loadAttempts.get(),
+                "a terminally-failed load must not be restarted by a later trigger");
+    }
+
+    @Test
     void testReadProfileIOExceptionInBatch() throws Exception {
         ProfileManager pm = new ProfileManager();
-        pm.isProfileLoaded = false;
+        pm.resetLoadStateForTest();
+        register(pm);
 
         // Malformed (non-zip) profile files: real Profile.read tolerates them and returns null,
         // so the batch load must still finish and mark isProfileLoaded=true without loading any.
@@ -1393,7 +1459,7 @@ class ProfileManagerTest {
 
         pm.loadProfilesFromStorageIfFirstTime(true);
 
-        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertTrue(pm.isProfileLoadedForTest());
         Assertions.assertEquals(0, pm.queryIdToProfileMap.size());
     }
 
@@ -1418,7 +1484,8 @@ class ProfileManagerTest {
                 }
             }
         };
-        pm.isProfileLoaded = false;
+        pm.resetLoadStateForTest();
+        register(pm);
 
         // asyncLoader only starts the daemon "profile-loader" and returns; joining it does NOT wait
         // for that loader. We must wait on the loader itself before returning so @AfterEach cannot
@@ -1440,9 +1507,9 @@ class ProfileManagerTest {
         // Wait for the real loader to leave getOnStorageProfileInfos, then for its terminal state.
         Assertions.assertTrue(loaderFinished.await(10, TimeUnit.SECONDS));
         long waitStart = System.currentTimeMillis();
-        while (!pm.isProfileLoaded && System.currentTimeMillis() - waitStart < 10000) {
+        while (!pm.isProfileLoadedForTest() && System.currentTimeMillis() - waitStart < 10000) {
             Thread.sleep(50);
         }
-        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertTrue(pm.isProfileLoadedForTest());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -54,7 +54,10 @@ import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @ResourceLock("global")
 class ProfileManagerTest {
@@ -1206,5 +1209,176 @@ class ProfileManagerTest {
             Config.profile_archive_pending_timeout_seconds = originalTimeout;
             Config.profile_archive_batch_size = originalBatchSize;
         }
+    }
+
+    @Test
+    public void testOnlyOneProfileLoaderWhenTriggeredConcurrently() throws Exception {
+        int numProfiles = 30;
+        for (int i = 0; i < numProfiles; i++) {
+            UUID taskId = UUID.randomUUID();
+            TUniqueId queryId = new TUniqueId(taskId.getMostSignificantBits(), taskId.getLeastSignificantBits());
+            String profileId = DebugUtil.printId(queryId);
+            Profile profile = constructProfile(profileId);
+            profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
+        }
+
+        profileManager.isProfileLoaded = false;
+
+        AtomicInteger maxProfileLoaderThreads = new AtomicInteger(0);
+        Thread monitorThread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                long loaderCount = Thread.getAllStackTraces().keySet().stream()
+                        .filter(thread -> "profile-loader".equals(thread.getName()))
+                        .count();
+                maxProfileLoaderThreads.updateAndGet(cur -> Math.max(cur, (int) loaderCount));
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        });
+        monitorThread.start();
+
+        int concurrentTriggers = 20;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        Thread[] triggerThreads = new Thread[concurrentTriggers];
+        for (int i = 0; i < concurrentTriggers; i++) {
+            triggerThreads[i] = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    profileManager.loadProfilesFromStorageIfFirstTime(false);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            triggerThreads[i].start();
+        }
+        startLatch.countDown();
+
+        for (Thread triggerThread : triggerThreads) {
+            triggerThread.join(30000);
+        }
+
+        long waitStart = System.currentTimeMillis();
+        while (!profileManager.isProfileLoaded && System.currentTimeMillis() - waitStart < 30000) {
+            Thread.sleep(100);
+        }
+
+        monitorThread.interrupt();
+        monitorThread.join();
+
+        Assertions.assertTrue(profileManager.isProfileLoaded);
+        Assertions.assertEquals(1, maxProfileLoaderThreads.get(),
+                "Only one profile-loader thread should be active at a time");
+        Assertions.assertEquals(numProfiles, profileManager.queryIdToProfileMap.size());
+    }
+
+    @Test
+    void testSyncLoadWaitsWhenAsyncLoadInProgress() throws Exception {
+        CountDownLatch loadingEntered = new CountDownLatch(1);
+        CountDownLatch allowComplete = new CountDownLatch(1);
+        ProfileManager pm = new ProfileManager() {
+            @Override
+            protected List<String> getOnStorageProfileInfos() {
+                loadingEntered.countDown();
+                try {
+                    if (!allowComplete.await(30, TimeUnit.SECONDS)) {
+                        throw new RuntimeException("timed out waiting to complete profile load");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return super.getOnStorageProfileInfos();
+            }
+        };
+        pm.isProfileLoaded = false;
+
+        Thread asyncLoader = new Thread(() -> pm.loadProfilesFromStorageIfFirstTime(false));
+        asyncLoader.start();
+        Assertions.assertTrue(loadingEntered.await(10, TimeUnit.SECONDS));
+
+        long waitStart = System.currentTimeMillis();
+        pm.loadProfilesFromStorageIfFirstTime(true);
+        long waitedMs = System.currentTimeMillis() - waitStart;
+
+        allowComplete.countDown();
+        asyncLoader.join(10000);
+
+        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertTrue(waitedMs >= 50,
+                "sync load should wait for in-progress async load to finish");
+    }
+
+    @Test
+    void testLoadProfilesFromStorageFailure() throws Exception {
+        Profile profile = constructProfile("fail-load");
+        profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
+
+        ProfileManager pm = new ProfileManager() {
+            @Override
+            public void pushProfile(Profile profile) {
+                throw new RuntimeException("simulated load failure");
+            }
+        };
+        pm.isProfileLoaded = false;
+
+        pm.loadProfilesFromStorageIfFirstTime(true);
+
+        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertTrue(pm.queryIdToProfileMap.isEmpty());
+    }
+
+    @Test
+    void testReadProfileIOExceptionInBatch() throws Exception {
+        ProfileManager pm = new ProfileManager();
+        pm.isProfileLoaded = false;
+
+        // Malformed (non-zip) profile files: real Profile.read tolerates them and returns null,
+        // so the batch load must still finish and mark isProfileLoaded=true without loading any.
+        for (int i = 0; i < 3; i++) {
+            File profileFile = new File(tempDir, System.currentTimeMillis() + "_badprofile" + i);
+            profileFile.createNewFile();
+        }
+
+        pm.loadProfilesFromStorageIfFirstTime(true);
+
+        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertEquals(0, pm.queryIdToProfileMap.size());
+    }
+
+    @Test
+    void testWaitForProfileLoadInterrupted() throws Exception {
+        CountDownLatch loadingEntered = new CountDownLatch(1);
+        CountDownLatch holdLoad = new CountDownLatch(1);
+        ProfileManager pm = new ProfileManager() {
+            @Override
+            protected List<String> getOnStorageProfileInfos() {
+                loadingEntered.countDown();
+                try {
+                    holdLoad.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return super.getOnStorageProfileInfos();
+            }
+        };
+        pm.isProfileLoaded = false;
+
+        Thread asyncLoader = new Thread(() -> pm.loadProfilesFromStorageIfFirstTime(false));
+        asyncLoader.start();
+        Assertions.assertTrue(loadingEntered.await(10, TimeUnit.SECONDS));
+
+        Thread waiterThread = new Thread(() -> pm.loadProfilesFromStorageIfFirstTime(true));
+        waiterThread.start();
+        Thread.sleep(200);
+        waiterThread.interrupt();
+        waiterThread.join(5000);
+
+        Assertions.assertFalse(waiterThread.isAlive());
+
+        holdLoad.countDown();
+        asyncLoader.join(10000);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -1222,24 +1222,27 @@ class ProfileManagerTest {
             profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
         }
 
-        profileManager.isProfileLoaded = false;
-
-        AtomicInteger maxProfileLoaderThreads = new AtomicInteger(0);
-        Thread monitorThread = new Thread(() -> {
-            while (!Thread.currentThread().isInterrupted()) {
-                long loaderCount = Thread.getAllStackTraces().keySet().stream()
-                        .filter(thread -> "profile-loader".equals(thread.getName()))
-                        .count();
-                maxProfileLoaderThreads.updateAndGet(cur -> Math.max(cur, (int) loaderCount));
+        // Instrument the load entry with an invocation counter and entry/release latches, and hold
+        // the winning loader active while all trigger calls finish. This scopes the assertion to
+        // this manager and is deterministic, unlike sampling JVM-global "profile-loader" thread
+        // names (which can miss a fast load or count a loader left by another ProfileManager).
+        AtomicInteger loadEntries = new AtomicInteger(0);
+        CountDownLatch loaderEntered = new CountDownLatch(1);
+        CountDownLatch releaseLoader = new CountDownLatch(1);
+        ProfileManager pm = new ProfileManager() {
+            @Override
+            protected List<String> getOnStorageProfileInfos() {
+                loadEntries.incrementAndGet();
+                loaderEntered.countDown();
                 try {
-                    Thread.sleep(10);
+                    releaseLoader.await(30, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    return;
                 }
+                return super.getOnStorageProfileInfos();
             }
-        });
-        monitorThread.start();
+        };
+        pm.isProfileLoaded = false;
 
         int concurrentTriggers = 20;
         CountDownLatch startLatch = new CountDownLatch(1);
@@ -1248,7 +1251,7 @@ class ProfileManagerTest {
             triggerThreads[i] = new Thread(() -> {
                 try {
                     startLatch.await();
-                    profileManager.loadProfilesFromStorageIfFirstTime(false);
+                    pm.loadProfilesFromStorageIfFirstTime(false);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
@@ -1257,22 +1260,26 @@ class ProfileManagerTest {
         }
         startLatch.countDown();
 
+        // The winning loader is held inside getOnStorageProfileInfos; every trigger call returns
+        // (either after spawning the held loader, or after losing the CAS), so joining is quick.
+        Assertions.assertTrue(loaderEntered.await(10, TimeUnit.SECONDS));
         for (Thread triggerThread : triggerThreads) {
             triggerThread.join(30000);
         }
+        Assertions.assertEquals(1, loadEntries.get(),
+                "Only one profile-loader should enter the load body at a time");
+
+        releaseLoader.countDown();
 
         long waitStart = System.currentTimeMillis();
-        while (!profileManager.isProfileLoaded && System.currentTimeMillis() - waitStart < 30000) {
+        while (!pm.isProfileLoaded && System.currentTimeMillis() - waitStart < 30000) {
             Thread.sleep(100);
         }
 
-        monitorThread.interrupt();
-        monitorThread.join();
-
-        Assertions.assertTrue(profileManager.isProfileLoaded);
-        Assertions.assertEquals(1, maxProfileLoaderThreads.get(),
-                "Only one profile-loader thread should be active at a time");
-        Assertions.assertEquals(numProfiles, profileManager.queryIdToProfileMap.size());
+        Assertions.assertTrue(pm.isProfileLoaded);
+        Assertions.assertEquals(1, loadEntries.get(),
+                "No second cold load should start after the first one completes");
+        Assertions.assertEquals(numProfiles, pm.queryIdToProfileMap.size());
     }
 
     @Test
@@ -1299,26 +1306,43 @@ class ProfileManagerTest {
         asyncLoader.start();
         Assertions.assertTrue(loadingEntered.await(10, TimeUnit.SECONDS));
 
-        long waitStart = System.currentTimeMillis();
-        pm.loadProfilesFromStorageIfFirstTime(true);
-        long waitedMs = System.currentTimeMillis() - waitStart;
+        // Run the synchronous caller on its own thread so we can assert it blocks on the in-flight
+        // async load, then release the loader and confirm a successful handoff (not a 30s timeout).
+        AtomicBoolean syncReturned = new AtomicBoolean(false);
+        Thread syncCaller = new Thread(() -> {
+            pm.loadProfilesFromStorageIfFirstTime(true);
+            syncReturned.set(true);
+        });
+        syncCaller.start();
+
+        // While the async load is held, the sync caller must remain blocked in waitForProfileLoadFinish.
+        Thread.sleep(500);
+        Assertions.assertFalse(syncReturned.get(),
+                "sync load must block while an async load is in progress");
 
         allowComplete.countDown();
+        syncCaller.join(10000);
         asyncLoader.join(10000);
 
+        Assertions.assertTrue(syncReturned.get(), "sync load should return after the async load finishes");
         Assertions.assertTrue(pm.isProfileLoaded);
-        Assertions.assertTrue(waitedMs >= 50,
-                "sync load should wait for in-progress async load to finish");
     }
 
     @Test
     void testLoadProfilesFromStorageFailure() throws Exception {
-        Profile profile = constructProfile("fail-load");
+        // Use a valid TUniqueId-based profile id so parseProfileFileName accepts the file name and
+        // Profile.read() returns a profile; otherwise read() returns null before pushProfile is
+        // called and the injected failure below is never reached.
+        UUID taskId = UUID.randomUUID();
+        TUniqueId queryId = new TUniqueId(taskId.getMostSignificantBits(), taskId.getLeastSignificantBits());
+        Profile profile = constructProfile(DebugUtil.printId(queryId));
         profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
 
+        AtomicBoolean pushProfileEntered = new AtomicBoolean(false);
         ProfileManager pm = new ProfileManager() {
             @Override
             public void pushProfile(Profile profile) {
+                pushProfileEntered.set(true);
                 throw new RuntimeException("simulated load failure");
             }
         };
@@ -1326,8 +1350,16 @@ class ProfileManagerTest {
 
         pm.loadProfilesFromStorageIfFirstTime(true);
 
-        Assertions.assertTrue(pm.isProfileLoaded);
+        // The injected failure must actually be hit (proves we exercised the outer load failure path).
+        Assertions.assertTrue(pushProfileEntered.get(), "pushProfile override should have been entered");
+        // A failed load must NOT be promoted to the cleanup-authoritative "index complete" state,
+        // otherwise deleteBrokenProfiles() would delete valid stored profiles missing from the
+        // partial in-memory index. It should, however, stop respawning the loader.
+        Assertions.assertFalse(pm.isProfileLoaded, "failed load must not mark the disk index authoritative");
         Assertions.assertTrue(pm.queryIdToProfileMap.isEmpty());
+        // A subsequent trigger must not restart the load (terminal failure recorded until FE restart).
+        pm.loadProfilesFromStorageIfFirstTime(true);
+        Assertions.assertFalse(pm.isProfileLoaded);
     }
 
     @Test
@@ -1352,6 +1384,7 @@ class ProfileManagerTest {
     void testWaitForProfileLoadInterrupted() throws Exception {
         CountDownLatch loadingEntered = new CountDownLatch(1);
         CountDownLatch holdLoad = new CountDownLatch(1);
+        CountDownLatch loaderFinished = new CountDownLatch(1);
         ProfileManager pm = new ProfileManager() {
             @Override
             protected List<String> getOnStorageProfileInfos() {
@@ -1361,11 +1394,18 @@ class ProfileManagerTest {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
-                return super.getOnStorageProfileInfos();
+                try {
+                    return super.getOnStorageProfileInfos();
+                } finally {
+                    loaderFinished.countDown();
+                }
             }
         };
         pm.isProfileLoaded = false;
 
+        // asyncLoader only starts the daemon "profile-loader" and returns; joining it does NOT wait
+        // for that loader. We must wait on the loader itself before returning so @AfterEach cannot
+        // restore the storage path / delete the temp dir underneath an in-flight loader.
         Thread asyncLoader = new Thread(() -> pm.loadProfilesFromStorageIfFirstTime(false));
         asyncLoader.start();
         Assertions.assertTrue(loadingEntered.await(10, TimeUnit.SECONDS));
@@ -1380,5 +1420,12 @@ class ProfileManagerTest {
 
         holdLoad.countDown();
         asyncLoader.join(10000);
+        // Wait for the real loader to leave getOnStorageProfileInfos, then for its terminal state.
+        Assertions.assertTrue(loaderFinished.await(10, TimeUnit.SECONDS));
+        long waitStart = System.currentTimeMillis();
+        while (!pm.isProfileLoaded && System.currentTimeMillis() - waitStart < 10000) {
+            Thread.sleep(50);
+        }
+        Assertions.assertTrue(pm.isProfileLoaded);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66311

Related PR: (none)

Problem Summary:

On the FE, `ProfileManager.loadProfilesFromStorageIfFirstTime(boolean sync)` spawns a new `profile-loader` thread on every call with no in-flight guard, and only sets `isProfileLoaded = true` inside the `try` block after the batch loop completes. Because this method is reached from the periodic scheduler:

- if the load throws, or
- if the `profileIOExecutor` thread pool is saturated so the per-batch `future.get()` calls never return,

then `isProfileLoaded` is never set, and a fresh `profile-loader` thread is spawned on every scheduler tick — an unbounded thread leak that keeps growing until the FE restarts.

This PR:

- adds an `AtomicBoolean isProfileLoading` and guards the load entry with `compareAndSet(false, true)`, so only one loader runs at a time; a synchronous caller that loses the CAS blocks on `waitForProfileLoadFinish()` until the in-flight load finishes;
- extracts the batch-read body into `loadProfilesFromStorage()` and wraps it in `try/finally`, where the `finally` calls `markProfileLoaded()` and clears `isProfileLoading` **even on failure**, so a saturated/failed load does not respawn a loader every second (a WARN documents that the load will not be retried until the FE restarts);
- makes the async loader thread a daemon, and runs the load inline when `sync == true`.

No behavior change on the success path; the set of loaded profiles is identical.

### Release note

None

### Check List (For Author)

- Test <PASS>
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
