### PR TITLE
fix fail-safe review termination and status fencing

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -56,9 +56,9 @@ jobs:
   code-review:
     runs-on: ubuntu-latest
     # Every pre-finalization step has its own timeout. Their worst-case budget,
-    # including review/failure/status handling and best-effort cleanup, is 153
+    # including review/failure/status handling and best-effort cleanup, is 208
     # minutes, leaving 12 minutes for runner setup and post-job cleanup.
-    timeout-minutes: 165
+    timeout-minutes: 220
     if: >-
       inputs.pr_number != '' ||
       (
@@ -607,7 +607,7 @@ jobs:
 
       - name: Run automated code review
         id: review
-        timeout-minutes: 60
+        timeout-minutes: 115
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -56,9 +56,9 @@ jobs:
   code-review:
     runs-on: ubuntu-latest
     # Every pre-finalization step has its own timeout. Their worst-case budget,
-    # including review/failure/status handling and best-effort cleanup, is 208
+    # including review/failure/status handling and best-effort cleanup, is 213
     # minutes, leaving 12 minutes for runner setup and post-job cleanup.
-    timeout-minutes: 220
+    timeout-minutes: 225
     if: >-
       inputs.pr_number != '' ||
       (
@@ -763,7 +763,7 @@ jobs:
       - name: Record review I/O to Litefuse
         if: ${{ always() }}
         continue-on-error: true
-        timeout-minutes: 5
+        timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PK }}

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -56,9 +56,9 @@ jobs:
   code-review:
     runs-on: ubuntu-latest
     # Every pre-finalization step has its own timeout. Their worst-case budget,
-    # including review/failure/status handling and best-effort cleanup, is 213
+    # including review/failure/status handling and best-effort cleanup, is 153
     # minutes, leaving 12 minutes for runner setup and post-job cleanup.
-    timeout-minutes: 225
+    timeout-minutes: 165
     if: >-
       inputs.pr_number != '' ||
       (
@@ -607,13 +607,14 @@ jobs:
 
       - name: Run automated code review
         id: review
-        timeout-minutes: 115
+        timeout-minutes: 60
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.review_inputs.outputs.pr_number }}
           HEAD_SHA: ${{ steps.review_inputs.outputs.head_sha }}
+          BASE_SHA: ${{ steps.review_inputs.outputs.base_sha }}
         run: |
           GOAL_PROMPT="$(cat "$REVIEW_CONTEXT_DIR/codex_goal_prompt.txt")"
           review_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -621,7 +622,10 @@ jobs:
           set +e
           # GitHub-hosted runners are ephemeral. Avoid workspace-write here because
           # Codex uses bubblewrap for that mode and uid maps can be unavailable.
-          codex exec --goal "$GOAL_PROMPT" \
+          # Keep the command under an internal process-group timeout so descendants
+          # cannot retain the job token after this step has failed or timed out.
+          timeout --signal=TERM --kill-after=10s 59m \
+            codex exec --goal "$GOAL_PROMPT" \
             --cd "$GITHUB_WORKSPACE" \
             --model "gpt-5.6-sol" \
             --config "model_reasoning_effort=xhigh" \
@@ -636,7 +640,11 @@ jobs:
 
           failure_reason=""
           if [ "$status" -ne 0 ]; then
-            if [ -s "$REVIEW_CONTEXT_DIR/codex-events.jsonl" ]; then
+            if [ "$status" -eq 124 ]; then
+              failure_reason="Codex review exceeded the 59-minute execution budget and was terminated before cleanup."
+            elif [ "$status" -eq 137 ]; then
+              failure_reason="Codex review did not stop after timeout and was force-terminated before cleanup."
+            elif [ -s "$REVIEW_CONTEXT_DIR/codex-events.jsonl" ]; then
               failure_reason="$(jq -r 'select(.type == "turn.failed") | .error.message // empty' "$REVIEW_CONTEXT_DIR/codex-events.jsonl" | tail -n 1)"
               if [ -z "$failure_reason" ]; then
                 failure_reason="$(jq -r 'select(.type == "error") | .message // .error.message // empty' "$REVIEW_CONTEXT_DIR/codex-events.jsonl" | tail -n 1)"
@@ -647,6 +655,15 @@ jobs:
             fi
             if [ -z "$failure_reason" ]; then
               failure_reason="Codex exited with status $status"
+            fi
+          fi
+
+          if [ -z "$failure_reason" ]; then
+            PR_JSON="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+            LIVE_HEAD_SHA="$(jq -er '.head.sha' <<<"$PR_JSON")"
+            LIVE_BASE_SHA="$(jq -er '.base.sha' <<<"$PR_JSON")"
+            if [ "$LIVE_HEAD_SHA" != "$HEAD_SHA" ] || [ "$LIVE_BASE_SHA" != "$BASE_SHA" ]; then
+              failure_reason="PR base/head changed while Codex was running; refusing to accept a stale review."
             fi
           fi
 
@@ -737,12 +754,24 @@ jobs:
         timeout-minutes: 2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.review_inputs.outputs.pr_number }}
           HEAD_SHA: ${{ steps.review_inputs.outputs.head_sha }}
+          BASE_SHA: ${{ steps.review_inputs.outputs.base_sha }}
           JOB_STATUS: ${{ job.status }}
           REPO: ${{ github.repository }}
           REVIEW_CONTEXT_OUTCOME: ${{ steps.review_context.outcome }}
           REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
+          PR_JSON="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          LIVE_HEAD_SHA="$(jq -er '.head.sha' <<<"$PR_JSON")"
+          LIVE_BASE_SHA="$(jq -er '.base.sha' <<<"$PR_JSON")"
+          if [ "$LIVE_HEAD_SHA" != "$HEAD_SHA" ] || [ "$LIVE_BASE_SHA" != "$BASE_SHA" ]; then
+            echo "PR base/head changed; leaving the declared head status pending." >&2
+            echo "Declared base/head: $BASE_SHA $HEAD_SHA" >&2
+            echo "Current base/head:  $LIVE_BASE_SHA $LIVE_HEAD_SHA" >&2
+            exit 0
+          fi
+
           state="pending"
           summary="Trigger /review to start automated review for ${HEAD_SHA}."
 
@@ -763,7 +792,7 @@ jobs:
       - name: Record review I/O to Litefuse
         if: ${{ always() }}
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PK }}


### PR DESCRIPTION
## What changed

- Keep the existing 60-minute review, 5-minute Litefuse, and 165-minute single-job budgets.
- Run Codex under a 59-minute process-group timeout with a 10-second forced-kill grace period, so a timed-out review cannot keep using the job token during later cleanup steps.
- Re-read the live PR base/head after Codex returns and again immediately before the final `code-review` status write. A moved PR is rejected and the declared head remains fail-safe pending.

## Why

Run 30605955928 hit the 60-minute review timeout and correctly published failure at 06:09 UTC, but its surviving Codex descendants submitted a review and inline comments about five minutes later while the consolidated runner job was still performing Litefuse cleanup. Keeping the GitHub token alive across finalization is a regression of the single-job layout from PR #66272.

The exact-head canary for the earlier timeout-expansion proposal also showed that increasing the review budget to 115 minutes and Litefuse to 10 minutes was not a safe fix: Litefuse still timed out at 10 minutes, runner occupancy increased, and the review identified lifecycle/concurrency blockers. Those scalar increases are therefore removed from the final diff.

## Validation

- `actionlint`
- `git diff --check`
- bash syntax checks for all 20 embedded `run` blocks
- GNU timeout process-group simulation: timeout returned 124 and the descendant process was terminated
- input/routing/permission/status-fence simulations, including multiline `/review` focus and independent `run`/`skip` commands
- topology/default checks: one `code-review` job; `workflow_dispatch` manages status by default; `workflow_call` does not
- timeout budget check: bounded steps total 153 minutes; job limit remains 165 minutes

The PR remains Draft. It must not merge until an exact-head terminal canary confirms timeout cleanup and ref-fence behavior.
