### PR TITLE
[fix](ci) Update Codex review auth pool

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -218,9 +218,8 @@ jobs:
           printf 'CODEX_HOME=%s\n' "$RUNNER_TEMP/codex-home" >> "$GITHUB_ENV"
 
           auth_object="$(printf '%s\n' \
+            'oss://doris-community-ci/codex/auth.json.1' \
             'oss://doris-community-ci/codex/auth.json.2' \
-            'oss://doris-community-ci/codex/auth.json.3' \
-            'oss://doris-community-ci/codex/auth.json.4' \
             | shuf -n 1)"
           printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$auth_object" >> "$GITHUB_ENV"
           echo "Selected Codex auth object: ${auth_object##*/}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The AI Review workflow currently selects auth.json.2, auth.json.3, or auth.json.4. Add auth.json.1 to the account pool and remove auth.json.3 and auth.json.4 so only the requested active accounts are eligible.

### Release note

None

### Check List (For Author)

- Test: YAML parsing, bash syntax, and runtime account-pool selection validation
    - YAML parse and bash -n for all 20 workflow run blocks
    - Executed the auth selection fragment with a macOS-compatible shuf test stub; result was auth.json.1
- Behavior changed: Yes (the AI Review credential pool now selects auth.json.1 or auth.json.2)
- Does this need documentation: No