### PR TITLE
[fix](ci) Skip usage-limited Codex review accounts

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -212,15 +212,61 @@ jobs:
           OSS_CODEX_GOAL_FALLBACK_OBJECT: oss://doris-community-ci/codex/codex-goal
 
       - name: Configure Codex auth
+        id: auth
         timeout-minutes: 5
         run: |
           install -m 700 -d "$RUNNER_TEMP/codex-home"
           printf 'CODEX_HOME=%s\n' "$RUNNER_TEMP/codex-home" >> "$GITHUB_ENV"
 
-          auth_object="$(printf '%s\n' \
+          auth_object=""
+          earliest_retry_after_epoch=""
+          now_epoch="$(date +%s)"
+          while IFS= read -r candidate; do
+            context_file="$(mktemp "$RUNNER_TEMP/codex-auth-context.XXXXXX")"
+            if ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
+              cp -f "${candidate}.context" "$context_file" >/dev/null 2>&1; then
+              if raw_retry_after_epoch="$(jq -ser '
+                select(length == 1)
+                | .[0]
+                | select(type == "object"
+                    and .version == 1
+                    and .state == "usage_limited"
+                    and (.retry_after_epoch | type == "number" and floor == .))
+                | .retry_after_epoch
+              ' "$context_file" 2>/dev/null)" && \
+                 retry_after_epoch="$(date -u -d "@$raw_retry_after_epoch" +%s 2>/dev/null)"; then
+                if [ "$retry_after_epoch" -gt "$now_epoch" ]; then
+                  retry_at="$(date -u -d "@$retry_after_epoch" +%Y-%m-%dT%H:%M:%SZ)"
+                  echo "Skipping usage-limited Codex auth ${candidate##*/} until $retry_at."
+                  if [ -z "$earliest_retry_after_epoch" ] || \
+                     [ "$retry_after_epoch" -lt "$earliest_retry_after_epoch" ]; then
+                    earliest_retry_after_epoch="$retry_after_epoch"
+                  fi
+                  continue
+                fi
+              else
+                echo "::warning::Ignoring unusable Codex auth context for ${candidate##*/}; the account remains eligible."
+              fi
+            fi
+
+            auth_object="$candidate"
+            break
+          done < <(printf '%s\n' \
             'oss://doris-community-ci/codex/auth.json.1' \
+            'oss://doris-community-ci/codex/auth.json.2' \
+            'oss://doris-community-ci/codex/auth.json.3' \
+            'oss://doris-community-ci/codex/auth.json.4' \
             'oss://doris-community-ci/codex/auth.json.5' \
-            | shuf -n 1)"
+            | shuf)
+
+          if [ -z "$auth_object" ]; then
+            retry_at="$(date -u -d "@$earliest_retry_after_epoch" +%Y-%m-%dT%H:%M:%SZ)"
+            auth_failure_reason="All Codex review accounts are usage-limited; earliest retry is $retry_at."
+            echo "failure_reason=$auth_failure_reason" >> "$GITHUB_OUTPUT"
+            echo "::error::$auth_failure_reason"
+            exit 1
+          fi
+
           printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$auth_object" >> "$GITHUB_ENV"
           echo "Selected Codex auth object: ${auth_object##*/}"
           ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$auth_object" "$RUNNER_TEMP/codex-home/auth.json"
@@ -648,6 +694,27 @@ jobs:
             if [ -z "$failure_reason" ]; then
               failure_reason="Codex exited with status $status"
             fi
+
+            usage_limit_retry_after_epoch=""
+            if grep -Fqi "You've hit your usage limit" <<<"$failure_reason"; then
+              now_epoch="$(date +%s)"
+              retry_at_text="$(sed -nE \
+                's/.*[Tt]ry again at (([A-Za-z]{3} [0-9]{1,2}(st|nd|rd|th)?, [0-9]{4} )?[0-9]{1,2}:[0-9]{2} (AM|PM)).*/\1/p' \
+                <<<"$failure_reason")"
+              if [ -n "$retry_at_text" ]; then
+                retry_at_text="$(sed -E 's/([0-9])(st|nd|rd|th),/\1,/' <<<"$retry_at_text")"
+                usage_limit_retry_after_epoch="$(date -u -d "$retry_at_text" +%s 2>/dev/null || true)"
+              fi
+
+              if [ -z "$usage_limit_retry_after_epoch" ] || \
+                 [ "$usage_limit_retry_after_epoch" -le "$now_epoch" ]; then
+                usage_limit_retry_after_epoch="$((now_epoch + 30 * 60))"
+                echo "::warning::Codex usage limit had no usable future retry time; using the explicit 30-minute fallback."
+              fi
+              retry_at="$(date -u -d "@$usage_limit_retry_after_epoch" +%Y-%m-%dT%H:%M:%SZ)"
+              echo "Codex usage limit detected; account retry time is $retry_at."
+              echo "usage_limit_retry_after_epoch=$usage_limit_retry_after_epoch" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
           if [ -z "$failure_reason" ]; then
@@ -685,18 +752,54 @@ jobs:
             exit 1
           fi
 
+      - name: Record Codex usage limit
+        id: usage_limit_record
+        if: ${{ always() && steps.review.outputs.usage_limit_retry_after_epoch != '' }}
+        timeout-minutes: 5
+        env:
+          OSS_AK: ${{ secrets.OSS_AK }}
+          OSS_SK: ${{ secrets.OSS_SK }}
+          OSS_ENDPOINT: oss-cn-hongkong.aliyuncs.com
+          RETRY_AFTER_EPOCH: ${{ steps.review.outputs.usage_limit_retry_after_epoch }}
+        run: |
+          context_file="$(mktemp "$RUNNER_TEMP/codex-auth-context.XXXXXX")"
+          jq -n \
+            --argjson retry_after_epoch "$RETRY_AFTER_EPOCH" \
+            '{version: 1, state: "usage_limited", retry_after_epoch: $retry_after_epoch}' \
+            > "$context_file"
+
+          ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
+            cp -f "$context_file" "${CODEX_AUTH_OSS_OBJECT}.context"
+          retry_at="$(date -u -d "@$RETRY_AFTER_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Recorded usage limit for ${CODEX_AUTH_OSS_OBJECT##*/} until $retry_at."
+
       - name: Comment PR on review failure
         if: ${{ always() && (steps.review_context.outcome != 'success' || steps.review.outcome != 'success') }}
         timeout-minutes: 2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTH_FAILURE_REASON: ${{ steps.auth.outputs.failure_reason }}
+          USAGE_LIMIT_RECORD_OUTCOME: ${{ steps.usage_limit_record.outcome }}
+          USAGE_LIMIT_RETRY_AFTER_EPOCH: ${{ steps.review.outputs.usage_limit_retry_after_epoch }}
           REVIEW_CONTEXT_OUTCOME: ${{ steps.review_context.outcome }}
           REVIEW_FAILURE_REASON: ${{ steps.review.outputs.failure_reason }}
           REVIEW_OUTCOME: ${{ steps.review.outcome }}
           PR_NUMBER: ${{ steps.review_inputs.outputs.pr_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$REVIEW_CONTEXT_OUTCOME" != "success" ]; then
+          recovery_msg="Please inspect the workflow logs and rerun the review after the underlying issue is resolved."
+          if [ -n "$AUTH_FAILURE_REASON" ]; then
+            error_msg="$AUTH_FAILURE_REASON"
+            recovery_msg="Please trigger /review again after that time."
+          elif [ -n "$USAGE_LIMIT_RETRY_AFTER_EPOCH" ] && \
+               [ "$USAGE_LIMIT_RECORD_OUTCOME" = "success" ]; then
+            retry_at="$(date -u -d "@$USAGE_LIMIT_RETRY_AFTER_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+            error_msg="${REVIEW_FAILURE_REASON:-The selected Codex account reached its usage limit.}"
+            recovery_msg="The selected account is excluded until $retry_at. Please trigger /review again; another configured account may be available."
+          elif [ -n "$USAGE_LIMIT_RETRY_AFTER_EPOCH" ]; then
+            error_msg="Codex reached its usage limit, but the workflow failed to record the account context."
+            recovery_msg="Please inspect the workflow logs and trigger /review again after the recording problem is resolved."
+          elif [ "$REVIEW_CONTEXT_OUTCOME" != "success" ]; then
             error_msg="Review context preparation failed before Codex ran; inspect the 'Prepare authoritative PR context and required AGENTS guides' step."
           else
             error_msg="${REVIEW_FAILURE_REASON:-Review step was $REVIEW_OUTCOME (possibly timeout or cancelled)}"
@@ -707,7 +810,7 @@ jobs:
           Error: ${error_msg}
           Workflow run: ${RUN_URL}
 
-          Please inspect the workflow logs and rerun the review after the underlying issue is resolved.
+          ${recovery_msg}
           EOF
           )"
 
@@ -715,11 +818,14 @@ jobs:
         if: ${{ always() && (steps.review_context.outcome != 'success' || steps.review.outcome != 'success') }}
         timeout-minutes: 1
         env:
+          AUTH_FAILURE_REASON: ${{ steps.auth.outputs.failure_reason }}
           REVIEW_CONTEXT_OUTCOME: ${{ steps.review_context.outcome }}
           REVIEW_FAILURE_REASON: ${{ steps.review.outputs.failure_reason }}
           REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
-          if [ "$REVIEW_CONTEXT_OUTCOME" != "success" ]; then
+          if [ -n "$AUTH_FAILURE_REASON" ]; then
+            error_msg="$AUTH_FAILURE_REASON"
+          elif [ "$REVIEW_CONTEXT_OUTCOME" != "success" ]; then
             error_msg="Review context preparation failed before Codex ran; inspect the 'Prepare authoritative PR context and required AGENTS guides' step."
           else
             error_msg="${REVIEW_FAILURE_REASON:-Review step was $REVIEW_OUTCOME (possibly timeout or cancelled)}"


### PR DESCRIPTION
## Problem

Issue Number: None

Related PR: #66119

The automated `/review` workflow selects a persisted Codex account. If the selected account has reached its usage limit, a later review can select the same account again and fail for the same reason.

This PR adds a small, OSS-backed cooldown marker for each configured account. It does not change Codex token refresh or auth-file write-back.

## Phase boundary

This PR solves only account cooldown and lazy recovery:

1. Detect the currently observed Codex usage-limit failure.
2. Record a retry timestamp next to the selected auth object.
3. Skip that account while the timestamp is in the future.
4. Make it eligible again automatically after the timestamp expires.
5. Keep the failed workflow and post a PR comment; the user manually triggers `/review` again.

Automatic retry dispatch is intentionally deferred to a separate PR. This workflow does not add `actions: write` and does not generate another `/review` event.

## Exact account-selection behavior

For validation in this non-required workflow, the candidate pool contains all five configured objects:

- `oss://doris-community-ci/codex/auth.json.1`
- `oss://doris-community-ci/codex/auth.json.2`
- `oss://doris-community-ci/codex/auth.json.3`
- `oss://doris-community-ci/codex/auth.json.4`
- `oss://doris-community-ci/codex/auth.json.5`

The workflow shuffles the configured candidate list, examines candidates in that order, and selects the first account without an active usage-limit context. Some credentials may already be expired; this intentionally exercises Codex's existing refresh behavior, while revoked or otherwise invalid credential handling remains out of scope.

A context is usable only when it contains exactly one top-level JSON document with this exact version-1 shape: an object whose `state` is exactly `usage_limited` and whose `retry_after_epoch` is an integer GNU `date` can consume. This deliberately rejects extra JSON documents, whitespace-altered states, scientific/out-of-range epochs, malformed JSON, and unsupported versions.

| Context result | Account behavior |
| --- | --- |
| Context object is missing or cannot be downloaded | Eligible |
| Downloaded context is not usable by the exact rule above | Emit a warning and treat as eligible |
| Usable `retry_after_epoch` is at or before the current time | Eligible; no OSS cleanup or rewrite |
| Usable `retry_after_epoch` is in the future | Skip |

Treating unusable context as absent keeps the reader fail-open and simple. In the rare case of a corrupted or externally written sidecar, the account may be selected once and fail again; a successful usage-limit detection then replaces the sidecar with the expected format.

If every configured account is skipped, Codex does not run. The workflow comments the earliest recorded retry time and remains failed.

## Context schema

The sidecar object name is `<auth object>.context`, for example `auth.json.1.context`.

```json
{
  "version": 1,
  "state": "usage_limited",
  "retry_after_epoch": 2000000000
}
```

The sidecar contains no auth tokens or account credentials.

## Usage-limit detection and retry time

An account is quarantined only when the Codex failure reason contains the currently observed phrase:

```text
You've hit your usage limit
```

The match is case-insensitive. A standalone HTTP 429, auth error, refresh error, timeout, or network failure does not create a context object.

When the failure contains the observed English `Try again at ...` timestamp, the workflow parses both Codex formats: a same-day time-only value such as `5:01 PM`, and a cross-day full-date value such as `Aug 5th, 2026 4:09 AM`. The parsed UTC epoch must be in the future. If the timestamp is absent, unparseable, or not in the future, the workflow uses `now + 30 minutes`.

## Failure and user-visible behavior

| Situation | Comment and next action |
| --- | --- |
| Usage limit detected and context upload succeeds | Comment that the selected account is excluded until the parsed retry time. A later `/review` uses another account if the configured pool has one eligible; otherwise it reports the earliest retry time until recovery. |
| Usage limit detected but context upload fails | Comment that the account context was not recorded and point the user to the workflow logs. |
| Every account has an active usage-limit context | Comment the earliest retry time. The user should trigger `/review` again after that time. |
| Any other review failure | Preserve the existing generic failure comment. |

The original review run remains failed in every failure case. This PR does not hide or convert failures into success.

## Explicitly out of scope

- Automatic `/review` comments, `workflow_dispatch`, cron, or offline wake-up.
- Access-token refresh behavior or auth-file write-back.
- Revoked, expired, or otherwise invalid auth accounts.
- Leases, locks, CAS, account ownership, or workflow serialization.
- Round-robin selection, dynamic auth discovery, or usage balancing.
- Changes from #66119 unrelated to usage-limit cooldown.

## Accepted limitations

- The Codex usage-limit message is not a documented stable API contract. If it changes, the workflow deliberately avoids guessing and does not quarantine the account.
- Missing, unavailable, or unusable context fails open and leaves the account eligible.
- The validation pool intentionally includes credentials that may already be expired. Codex may refresh recoverable credentials; otherwise the non-required review workflow fails normally, because this PR does not quarantine revoked or invalid auth.
- Concurrent runs can select the same account before either writes its context. This PR relies on OSS object replacement as atomic last-writer-wins storage and adds no coordination.
- A context object is not deleted after expiration; it is ignored lazily.
- Recovery requires another user-triggered `/review`.

## Validation

- YAML parsing.
- `bash -n` for all 21 workflow `run` blocks.
- `git diff --check`.
- Verified that neither `actions: write` nor `gh workflow run` is present.
- Account-selection mocks: exact auth.json.1-through-.5 pool, all accounts available, the first four accounts limited with the fifth available, expired context, malformed JSON, unsupported state, leading/trailing state whitespace, multiple JSON documents, scientific epoch, out-of-range epoch, and all configured accounts limited.
- Retry timestamp mocks: same-day time-only, cross-day full-date, and missing timestamps.
- Failure-comment mocks: context recorded, context recording failed, all accounts limited, and ordinary review failure.
- Rebased onto current `master` after #66335 and verified that the validation pool contains exactly `auth.json.1` through `auth.json.5`.

