### PR TITLE
[fix](ci) Remove inactive Codex review auth

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -219,7 +219,6 @@ jobs:
 
           auth_object="$(printf '%s\n' \
             'oss://doris-community-ci/codex/auth.json.1' \
-            'oss://doris-community-ci/codex/auth.json.2' \
             | shuf -n 1)"
           printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$auth_object" >> "$GITHUB_ENV"
           echo "Selected Codex auth object: ${auth_object##*/}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66318

Problem Summary: After the review credential pool was updated to auth.json.1 and auth.json.2, auth.json.2 is no longer active. Remove it from the AI Review selection list so every review run uses the only active credential object, auth.json.1.

### Release note

None

### Check List (For Author)

- Test: YAML parsing, bash syntax, and runtime account-pool selection validation
    - YAML parse and bash -n for all 20 workflow run blocks
    - Executed the auth selection fragment with a macOS-compatible shuf test stub; result was auth.json.1
- Behavior changed: Yes (the AI Review credential pool now selects only auth.json.1)
- Does this need documentation: No