### PR TITLE
[fix](ci) Temporarily reduce code review reasoning effort

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -623,7 +623,7 @@ jobs:
           codex exec --goal "$GOAL_PROMPT" \
             --cd "$GITHUB_WORKSPACE" \
             --model "gpt-5.6-sol" \
-            --config "model_reasoning_effort=xhigh" \
+            --config "model_reasoning_effort=high" \
             --sandbox danger-full-access \
             --color never \
             --json \
@@ -800,7 +800,7 @@ jobs:
             --head-sha "$HEAD_SHA" \
             --base-sha "$BASE_SHA" \
             --model "gpt-5.6-sol" \
-            --reasoning-effort "xhigh" \
+            --reasoning-effort "high" \
             --environment "github-actions" \
             --max-payload-bytes 4000000 \
             --min-observations 4 \


### PR DESCRIPTION
## What changed

- Keep the automated reviewer on `gpt-5.6-sol`.
- Temporarily lower `model_reasoning_effort` from `xhigh` to `high`.
- Keep Litefuse metadata aligned with the runtime setting.

## Why

Three of the four review accounts have reached their current Codex usage limit. The official Codex guidance recommends `high` for reviewer and security-focused agents, while noting that higher reasoning effort increases response time and token usage. There is no published fixed `xhigh`-to-`high` consumption multiplier because usage depends on the task, context, reasoning, and tool calls.

This is intentionally a two-line operational change: model, prompts, subagent coverage, routing, permissions, status behavior, timeouts, and job topology remain unchanged.

## Validation

- `actionlint`
- `git diff --check`
- bash syntax checks for all 20 embedded `run` blocks
- verified exactly one runtime `model_reasoning_effort=high` and one matching Litefuse `--reasoning-effort high`
- verified no `xhigh` remains in the workflow

## Rollback

Restore both values to `xhigh` after account capacity recovers and post-change review quality has been sampled.
