### PR TITLE
[fix](ci) Add Codex review auth account

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -219,6 +219,7 @@ jobs:
 
           auth_object="$(printf '%s\n' \
             'oss://doris-community-ci/codex/auth.json.1' \
+            'oss://doris-community-ci/codex/auth.json.5' \
             | shuf -n 1)"
           printf 'CODEX_AUTH_OSS_OBJECT=%s\n' "$auth_object" >> "$GITHUB_ENV"
           echo "Selected Codex auth object: ${auth_object##*/}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66323

Problem Summary: The AI Review workflow currently has only auth.json.1 in its credential pool. Add auth.json.5 so review jobs can select either active account.

### Release note

None

### Check List (For Author)

- Test: YAML parsing, bash syntax, and runtime account-pool selection validation
    - YAML parse and bash -n for all 20 workflow run blocks
    - Executed the auth selection fragment with macOS-compatible shuf test stubs; verified both auth.json.1 and auth.json.5
- Behavior changed: Yes (the AI Review credential pool now selects auth.json.1 or auth.json.5)
- Does this need documentation: No