### PR TITLE
branch-4.0: [fix](be) remove changing segment cache blocks to index type

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -1083,19 +1083,6 @@ Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size
         LOG(INFO) << "segment flush consumes a lot time_ns " << timer.elapsed_time()
                   << ", segmemt_size " << *segment_file_size;
     }
-    // When the cache type is not ttl(expiration time == 0), the data should be split into normal cache queue
-    // and index cache queue
-    if (auto* cache_builder = _file_writer->cache_builder(); cache_builder != nullptr &&
-                                                             cache_builder->_expiration_time == 0 &&
-                                                             config::is_cloud_mode()) {
-        auto index_start = _index_file_cache_info.cache_start_offset();
-        auto size = *index_size + *segment_file_size;
-        auto holder = cache_builder->allocate_cache_holder(index_start, size);
-        for (auto& segment : holder->file_blocks) {
-            static_cast<void>(
-                    segment->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
-        }
-    }
     return Status::OK();
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65905

Problem Summary:

Backport #65905 to `branch-4.0`.

After a cloud segment is finalized, `SegmentWriter` allocates a cache holder over the segment index range and changes every intersecting cache block to `INDEX`. The range can cross S3 multipart buffer boundaries. If multipart buffers complete out of order, a later buffer can claim the cross-boundary block first and populate it with shifted bytes, corrupting cache reads while remote storage remains correct.

Remove the post-finalize cache-holder allocation and cache-type change so segment blocks retain the cache type selected by the file writer.

The source PR uses `be/src/storage/segment/segment_writer.cpp`. This backport applies the same deletion to the corresponding `branch-4.0` implementation in `be/src/olap/rowset/segment_v2/segment_writer.cpp`; it does not bring the master directory or API refactor into the release branch.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - Source PR #65905: `./run-be-ut.sh --run --filter=CloudFileCacheWriteIndexOnlyTest.* -j100` (3 tests passed).
        - This backport was not compiled or tested locally before PR creation, as requested.
        - Static validation: `git diff --check upstream/branch-4.0...HEAD`.
    - [ ] Manual test

- Behavior changed:
    - [ ] No.
    - [x] Yes. Segment cache blocks are no longer changed to `INDEX` after segment finalization.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
