### PR TITLE
[opt](pipeline) Add passthrough between repeat and streaming aggregation

### DIFF
--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -133,6 +133,8 @@ public:
 
     virtual bool is_hash_join_probe() const { return false; }
 
+    virtual bool is_repeat() const { return false; }
+
     /**
      * Pipeline task is blockable means it will be blocked in the next run. So we should put the
      * pipeline task into the blocking task scheduler.

--- a/be/src/exec/operator/repeat_operator.h
+++ b/be/src/exec/operator/repeat_operator.h
@@ -73,6 +73,8 @@ public:
     Status pull(RuntimeState* state, Block* output_block, bool* eos) const override;
     Status push(RuntimeState* state, Block* input_block, bool eos) const override;
 
+    bool is_repeat() const override { return true; }
+
 private:
     friend class RepeatLocalState;
 

--- a/be/src/exec/operator/streaming_aggregation_operator.h
+++ b/be/src/exec/operator/streaming_aggregation_operator.h
@@ -222,6 +222,11 @@ public:
         _spill_streaming_agg_mem_limit = 1024 * 1024;
     }
     DataDistribution required_data_distribution(RuntimeState* state) const override {
+        // Repeat emits grouping sets as consecutive blocks. Fan them out without hashing every
+        // expanded row before the local streaming preaggregation.
+        if (_child && _child->is_repeat()) {
+            return {TLocalPartitionType::PASSTHROUGH};
+        }
         if (_child && _child->is_hash_join_probe() &&
             state->enable_streaming_agg_hash_join_force_passthrough()) {
             return {TLocalPartitionType::PASSTHROUGH};

--- a/be/test/exec/operator/streaming_agg_operator_test.cpp
+++ b/be/test/exec/operator/streaming_agg_operator_test.cpp
@@ -28,6 +28,7 @@
 #include "exec/operator/aggregation_source_operator.h"
 #include "exec/operator/mock_operator.h"
 #include "exec/operator/operator_helper.h"
+#include "exec/operator/repeat_operator.h"
 #include "exec/operator/streaming_aggregation_operator.h"
 #include "testutil/column_helper.h"
 #include "testutil/mock/mock_agg_fn_evaluator.h"
@@ -166,6 +167,13 @@ TEST_F(StreamingAggOperatorTest, require_hash_shuffle_after_non_hash_local_excha
 
     const auto distribution = op->required_data_distribution(state.get());
     EXPECT_EQ(TLocalPartitionType::GLOBAL_EXECUTION_HASH_SHUFFLE, distribution.distribution_type);
+}
+
+TEST_F(StreamingAggOperatorTest, require_passthrough_after_repeat) {
+    EXPECT_TRUE(op->set_child(std::make_shared<RepeatOperatorX>()));
+
+    const auto distribution = op->required_data_distribution(state.get());
+    EXPECT_EQ(TLocalPartitionType::PASSTHROUGH, distribution.distribution_type);
 }
 
 TEST_F(StreamingAggOperatorTest, test2) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -310,7 +310,11 @@ public class AggregationNode extends PlanNode {
             }
         } else if (useStreamingPreagg) {
             // StreamingAggOperatorX
-            if (children.get(0) instanceof HashJoinNode
+            // Repeat expands grouping sets before this local preaggregation. Use PASSTHROUGH
+            // to distribute the expanded blocks without hashing every row.
+            if (!needsFinalize && children.get(0) instanceof RepeatNode) {
+                requireChild = LocalExchangeTypeRequire.requirePassthrough();
+            } else if (children.get(0) instanceof HashJoinNode
                     && sessionVariable.enableStreamingAggHashJoinForcePassthrough) {
                 requireChild = LocalExchangeTypeRequire.requirePassthrough();
             } else if (!needsFinalize && !enableLeBeforeAgg) {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/LocalExchangePlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/LocalExchangePlannerTest.java
@@ -544,8 +544,9 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
     public void testStreamingAggAfterRepeatUsesPassthrough() throws Exception {
         // Repeat expands grouping sets into consecutive blocks. A passthrough local
         // exchange above Repeat distributes those blocks among streaming aggregation
-        // instances without hashing every expanded row.
-        setupLocalShuffleSession(null);
+        // instances without hashing every expanded row. Force two-phase aggregation
+        // so the lower Repeat-adjacent aggregation is a streaming preaggregation.
+        setupLocalShuffleSession(sv -> sv.setAggPhase(2));
         assertPlanShape(
                 "select k1, k2, count(*) from test.t1 group by grouping sets((k1), (k1, k2))",
                 anyTree(
@@ -589,11 +590,10 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
     @Test
     public void testMixedPlanWithPoolingScan() throws Exception {
         // Pooling: grouping-sets sub-query JOINed and re-aggregated.  Probe side
-        // hashes the inner agg output for the join, while Repeat→StreamingAgg uses
-        // PASSTHROUGH; the build side comes through LE(PASS_TO_ONE) over an
-        // inter-fragment Exchange.
+        // wraps the inner agg/Repeat with LE(LOCAL_HASH) over LE(PASSTHROUGH); build
+        // side comes through LE(PASS_TO_ONE) over an inter-fragment Exchange.
         //   Agg → HashJoin
-        //           ← LE(LOCAL_HASH) → Agg → LE(PASSTHROUGH) → Repeat → scan(t1)
+        //           ← Agg → LE(LOCAL_HASH) → LE(PASSTHROUGH) → Repeat → scan(t1)
         //           ← LE(PASS_TO_ONE) → Exchange → scan(t2)
         setupLocalShuffleSession(null);
         assertPlanShape(
@@ -602,8 +602,8 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
                 anyTree(
                         agg(
                                 hashJoin(
-                                        localExchange(LOCAL_HASH,
-                                                agg(
+                                        agg(
+                                                localExchange(LOCAL_HASH,
                                                         localExchange(PT,
                                                                 anyTree(olapScan("t1"))))),
                                         localExchange(PASS_TO_ONE_LE,

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/LocalExchangePlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/LocalExchangePlannerTest.java
@@ -532,9 +532,8 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
     }
 
     @Test
-    public void testGroupingSetsPlanContainsHashShuffle() throws Exception {
-        // Non-pooling grouping sets keeps the colocated BUCKET_HASH_SHUFFLE output of
-        // the scan all the way through Repeat→Agg; no LE(LOCAL_HASH) is needed.
+    public void testGroupingSetsDoesNotUseHashShuffle() throws Exception {
+        // Repeat→StreamingAgg uses PASSTHROUGH rather than hashing all expanded rows.
         setupLocalShuffleSession(sv -> sv.setIgnoreStorageDataDistribution(false));
         assertNoLocalExchangeOfType(
                 "select k1, k2, sum(v1) from test.t1 group by grouping sets((k1), (k1, k2))",
@@ -542,37 +541,23 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
     }
 
     @Test
-    public void testRepeatNoRequireKeepsHashLocalExchangeAboveRepeat() throws Exception {
-        // Behavior 1 of the RepeatNode fix — noRequire (tpcds q67, +73%).
-        // RepeatNode recurses with noRequire() instead of forwarding the streaming
-        // agg's HASH require to its child.  So when the pooling scan upstream does NOT
-        // already provide the distribution, the parent inserts the LE(LOCAL_HASH)
-        // ABOVE the Repeat, never below it:
-        //   Agg <- LE(LOCAL_HASH) <- LE(PASSTHROUGH) <- Repeat <- scan
-        // Pinning Repeat with repeat() (not anyTree) distinguishes the fixed plan from
-        // the buggy one (buggy forwarded the require, so the LE landed below the
-        // Repeat, hashing the pre-repeat rows by the child's single upstream key and
-        // collapsing them onto one instance).
+    public void testStreamingAggAfterRepeatUsesPassthrough() throws Exception {
+        // Repeat expands grouping sets into consecutive blocks. A passthrough local
+        // exchange above Repeat distributes those blocks among streaming aggregation
+        // instances without hashing every expanded row.
         setupLocalShuffleSession(null);
         assertPlanShape(
                 "select k1, k2, count(*) from test.t1 group by grouping sets((k1), (k1, k2))",
                 anyTree(
                         agg(
-                                localExchange(LOCAL_HASH,
-                                        localExchange(PT,
-                                                repeat(anyTree(olapScan("t1"))))))));
+                                localExchange(PT,
+                                        repeat(anyTree(olapScan("t1")))))));
     }
 
     @Test
-    public void testRepeatReturnsChildDistributionSkipsRedundantHash() throws Exception {
-        // Behavior 2 of the RepeatNode fix — return enforceResult.second (tpcds q70).
-        // RepeatNode reports its child's real output distribution to the parent (not
-        // NOOP).  With a non-pooling colocate scan, the child's BUCKET_HASH
-        // distribution propagates through the Repeat and already satisfies the agg's
-        // hash requirement, so the parent's satisfy-check SKIPS inserting any LE — no
-        // LOCAL_HASH appears.  Had RepeatNode returned NOOP (the discarded v1), the
-        // satisfy-check would fail and force a redundant LE(LOCAL_HASH) that
-        // re-shuffles the post-repeat rows into skew.
+    public void testStreamingAggAfterRepeatDoesNotUseHashForColocatedScan() throws Exception {
+        // The dedicated PASSTHROUGH requirement also takes precedence when the scan
+        // provides a colocated bucket distribution.
         setupLocalShuffleSession(sv -> sv.setIgnoreStorageDataDistribution(false));
         assertNoLocalExchangeOfType(
                 "select k1, k2, count(*) from test.t1 group by grouping sets((k1), (k1, k2))",
@@ -604,10 +589,11 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
     @Test
     public void testMixedPlanWithPoolingScan() throws Exception {
         // Pooling: grouping-sets sub-query JOINed and re-aggregated.  Probe side
-        // wraps the inner agg/Repeat with LE(LOCAL_HASH) over LE(PASSTHROUGH); build
-        // side comes through LE(PASS_TO_ONE) over an inter-fragment Exchange.
+        // hashes the inner agg output for the join, while Repeat→StreamingAgg uses
+        // PASSTHROUGH; the build side comes through LE(PASS_TO_ONE) over an
+        // inter-fragment Exchange.
         //   Agg → HashJoin
-        //           ← Agg → LE(LOCAL_HASH) → LE(PASSTHROUGH) → Repeat → scan(t1)
+        //           ← LE(LOCAL_HASH) → Agg → LE(PASSTHROUGH) → Repeat → scan(t1)
         //           ← LE(PASS_TO_ONE) → Exchange → scan(t2)
         setupLocalShuffleSession(null);
         assertPlanShape(
@@ -616,8 +602,8 @@ public class LocalExchangePlannerTest extends TestWithFeService implements PlanS
                 anyTree(
                         agg(
                                 hashJoin(
-                                        agg(
-                                                localExchange(LOCAL_HASH,
+                                        localExchange(LOCAL_HASH,
+                                                agg(
                                                         localExchange(PT,
                                                                 anyTree(olapScan("t1"))))),
                                         localExchange(PASS_TO_ONE_LE,


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Repeat expands grouping sets before local streaming aggregation. Without a passthrough local exchange, independent pipeline tasks create duplicate partial aggregation states, while hash shuffling every expanded row adds unnecessary hashing and skew. Request a passthrough exchange for a direct Repeat-to-StreamingAgg edge in both FE-planned and BE-planned local shuffle paths, and cover both distribution planning paths with tests.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

