### PR TITLE
[fix](parquet) Restrict V2 dictionary filtering to strings

### DIFF
--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -162,6 +162,11 @@ bool supports_row_level_dictionary_filter(const ParquetColumnSchema& column_sche
         column_schema.max_repetition_level > 0) {
         return false;
     }
+    if (!is_string_type(remove_nullable(column_schema.type)->get_primitive_type())) {
+        // Dictionary-id predicates are only equivalent to value predicates for strings here.
+        // Decode other dictionary types first to preserve the V1-compatible filtering domain.
+        return false;
+    }
     bool is_supported_physical_type = false;
     switch (column_metadata.type) {
     case tparquet::Type::BYTE_ARRAY:
@@ -180,11 +185,6 @@ bool supports_row_level_dictionary_filter(const ParquetColumnSchema& column_sche
         break;
     }
     if (!is_supported_physical_type) {
-        return false;
-    }
-    if (remove_nullable(column_schema.type)->get_primitive_type() == TYPE_VARBINARY) {
-        // A table STRING predicate can be rewritten through a raw VARBINARY file slot. Evaluating
-        // it on dictionary Fields before the mapping expression is neither type-safe nor exact.
         return false;
     }
     // The row filter consumes dictionary ids rather than decoded values, so a plain data page

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.cpp
@@ -1782,7 +1782,8 @@ bool ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::can_filter_fixed_width_valu
     }
     const bool encoding_supports_raw_values =
             supports_raw_fixed_filter_encoding(_current_encoding, _metadata.type) ||
-            supports_raw_binary_filter_encoding(_current_encoding, _metadata.type);
+            supports_raw_binary_filter_encoding(_current_encoding, _metadata.type) ||
+            supports_dictionary_fixed_filter_encoding(_current_encoding, _metadata.type);
     const bool can_convert_logical_values = serde != nullptr && decode_context != nullptr &&
                                             encoding_supports_raw_values &&
                                             serde->supports_parquet_raw_predicate(*decode_context);
@@ -1837,6 +1838,11 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::filter_fixed_width_values
     // Direct filtering can be the first value operation on a page, so its SerDe dispatch must not
     // depend on materialize_values() having synchronized the page encoding first.
     RETURN_IF_ERROR(translate_value_encoding(_current_encoding, &page_decode_context.encoding));
+    if (supports_dictionary_fixed_filter_encoding(_current_encoding, _metadata.type)) {
+        // The dictionary decoder expands IDs into physical values before SerDe conversion, making
+        // the predicate input identical to a decoded PLAIN page while retaining dictionary cursors.
+        page_decode_context.encoding = ParquetValueEncoding::PLAIN;
+    }
     if (!can_filter_fixed_width_values(conjuncts, column_id, &serde, &page_decode_context)) {
         return Status::OK();
     }

--- a/be/src/format_v2/parquet/reader/native/column_chunk_reader.h
+++ b/be/src/format_v2/parquet/reader/native/column_chunk_reader.h
@@ -215,6 +215,19 @@ public:
                 encoding == tparquet::Encoding::BYTE_STREAM_SPLIT);
     }
 
+    static bool supports_dictionary_fixed_filter_encoding(tparquet::Encoding::type encoding,
+                                                          tparquet::Type::type physical_type) {
+        const bool is_dictionary = encoding == tparquet::Encoding::RLE_DICTIONARY ||
+                                   encoding == tparquet::Encoding::PLAIN_DICTIONARY;
+        if (!is_dictionary) {
+            return false;
+        }
+        return physical_type == tparquet::Type::INT32 || physical_type == tparquet::Type::INT64 ||
+               physical_type == tparquet::Type::INT96 || physical_type == tparquet::Type::FLOAT ||
+               physical_type == tparquet::Type::DOUBLE ||
+               physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY;
+    }
+
     // Evaluate selected fixed-width values and return one keep byte per selected logical row.
     // NULL comparisons are false and therefore never enter the physical consumer; non-null
     // matches are appended to projected_column when requested.

--- a/be/src/format_v2/parquet/reader/native/column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/native/column_reader.cpp
@@ -1271,6 +1271,9 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::read_fixed_width_filter(
                                            ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::
                                                    supports_raw_binary_filter_encoding(
                                                            encoding, _chunk_meta.meta_data.type) ||
+                                           ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::
+                                                   supports_dictionary_fixed_filter_encoding(
+                                                           encoding, _chunk_meta.meta_data.type) ||
                                            encoding == tparquet::Encoding::RLE ||
                                            encoding == tparquet::Encoding::BIT_PACKED;
                                 });

--- a/be/src/format_v2/parquet/reader/native/fix_length_dict_decoder.hpp
+++ b/be/src/format_v2/parquet/reader/native/fix_length_dict_decoder.hpp
@@ -39,6 +39,77 @@ public:
                                       static_cast<size_t>(_type_length));
     }
 
+    Status decode_selected_fixed_values(const ParquetSelection& selection,
+                                        ParquetFixedValueConsumer& consumer) override {
+        DORIS_CHECK_GT(_type_length, 0);
+        // Raw predicates on non-string dictionaries must observe decoded physical values, not
+        // dictionary IDs, so expand each validated index before invoking the predicate consumer.
+        class ExpandedValueConsumer final : public ParquetDictionaryValueConsumer {
+        public:
+            ExpandedValueConsumer(const uint8_t* dictionary, size_t dictionary_size,
+                                  size_t value_width, ParquetFixedValueConsumer& consumer,
+                                  std::vector<uint8_t>& scratch)
+                    : _dictionary(dictionary),
+                      _dictionary_size(dictionary_size),
+                      _value_width(value_width),
+                      _consumer(consumer),
+                      _scratch(scratch) {}
+
+            Status consume_indices(const uint32_t* indices, size_t num_values) override {
+                DORIS_CHECK(indices != nullptr || num_values == 0);
+                if (UNLIKELY(num_values > std::numeric_limits<size_t>::max() / _value_width)) {
+                    return Status::IOError("Parquet dictionary expansion size overflows");
+                }
+                _scratch.resize(num_values * _value_width);
+                for (size_t row = 0; row < num_values; ++row) {
+                    DORIS_CHECK_LT(indices[row], _dictionary_size);
+                    memcpy(_scratch.data() + row * _value_width,
+                           _dictionary + static_cast<size_t>(indices[row]) * _value_width,
+                           _value_width);
+                }
+                return _consumer.consume(_scratch.data(), num_values, _value_width);
+            }
+
+            Status consume_repeated(uint32_t index, size_t num_values) override {
+                DORIS_CHECK_LT(index, _dictionary_size);
+                constexpr size_t MAX_BATCH_VALUES = 1024;
+                const uint8_t* value = _dictionary + static_cast<size_t>(index) * _value_width;
+                while (num_values > 0) {
+                    const size_t batch = std::min(num_values, MAX_BATCH_VALUES);
+                    _scratch.resize(batch * _value_width);
+                    for (size_t row = 0; row < batch; ++row) {
+                        memcpy(_scratch.data() + row * _value_width, value, _value_width);
+                    }
+                    RETURN_IF_ERROR(_consumer.consume(_scratch.data(), batch, _value_width));
+                    num_values -= batch;
+                }
+                return Status::OK();
+            }
+
+        private:
+            const uint8_t* const _dictionary;
+            const size_t _dictionary_size;
+            const size_t _value_width;
+            ParquetFixedValueConsumer& _consumer;
+            std::vector<uint8_t>& _scratch;
+        } expanded_consumer(_dict.get(), _num_dictionary_values, static_cast<size_t>(_type_length),
+                            consumer, _expanded_values);
+        return decode_selected_dictionary_values(selection, expanded_consumer);
+    }
+
+    void release_scratch(size_t max_retained_bytes) override {
+        BaseDictDecoder::release_scratch(max_retained_bytes);
+        release_vector_if_oversized(&_expanded_values, max_retained_bytes);
+    }
+
+    size_t retained_scratch_bytes() const override {
+        return BaseDictDecoder::retained_scratch_bytes() + _expanded_values.capacity();
+    }
+
+    size_t active_scratch_bytes() const override {
+        return BaseDictDecoder::active_scratch_bytes() + _expanded_values.size();
+    }
+
     Status set_dict(DorisUniqueBufferPtr<uint8_t>& dict, int32_t length,
                     size_t num_values) override {
         if (UNLIKELY(_type_length <= 0 || length < 0 ||
@@ -59,6 +130,7 @@ public:
 
 private:
     size_t _num_dictionary_values = 0;
+    std::vector<uint8_t> _expanded_values;
 };
 
 } // namespace doris::format::parquet::native

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -74,6 +74,7 @@
 #include "storage/segment/condition_cache.h"
 #include "storage/utils.h"
 #include "util/defer_op.h"
+#include "util/unaligned.h"
 
 namespace doris {
 namespace {
@@ -175,6 +176,23 @@ public:
 
     bool can_evaluate_dictionary_filter() const override { return true; }
 
+    bool can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
+                                         int column_id) const override {
+        return column_id == _column_id &&
+               remove_nullable(data_type)->get_primitive_type() == TYPE_INT;
+    }
+
+    Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
+                                       const DataTypePtr&, int, uint8_t* matches) const override {
+        DORIS_CHECK_EQ(value_width, sizeof(int32_t));
+        // Non-string dictionaries bypass dictionary-id filtering, so this test predicate must
+        // preserve equality semantics when the reader evaluates decoded physical values directly.
+        for (size_t row = 0; row < num_values; ++row) {
+            matches[row] &= unaligned_load<int32_t>(values + row * sizeof(int32_t)) == _value;
+        }
+        return Status::OK();
+    }
+
     ZoneMapFilterResult evaluate_dictionary_filter(
             const DictionaryEvalContext& ctx) const override {
         const auto* dictionary = ctx.slot(_column_id);
@@ -214,6 +232,15 @@ public:
     const std::string& expr_name() const override { return _expr_name; }
 
     bool can_evaluate_dictionary_filter() const override { return true; }
+
+    bool can_execute_on_raw_fixed_values(const DataTypePtr&, int column_id) const override {
+        return column_id == _column_id;
+    }
+
+    Status execute_on_raw_fixed_values(const uint8_t*, size_t, size_t, const DataTypePtr&, int,
+                                       uint8_t*) const override {
+        return Status::OK();
+    }
 
     ZoneMapFilterResult evaluate_dictionary_filter(
             const DictionaryEvalContext& ctx) const override {
@@ -2851,7 +2878,7 @@ TEST_F(NewParquetReaderTest, DictionaryPredicateFiltersRowsInsideRowGroup) {
     EXPECT_GE(profile.get_counter("ReaderSelectRows")->value(), 8);
 }
 
-TEST_F(NewParquetReaderTest, FixedWidthDictionaryPredicateFiltersRowsByDictionaryId) {
+TEST_F(NewParquetReaderTest, FixedWidthDictionaryPredicateUsesRawDirectFilter) {
     write_fixed_width_dictionary_filter_parquet_file(_file_path);
 
     RuntimeProfile profile("new_parquet_reader_fixed_width_dictionary_filter_profile");
@@ -2889,14 +2916,19 @@ TEST_F(NewParquetReaderTest, FixedWidthDictionaryPredicateFiltersRowsByDictionar
 
     EXPECT_EQ(ids, std::vector<int32_t>({2, 4, 6}));
     EXPECT_EQ(values, std::vector<int32_t>({20, 20, 20}));
-    EXPECT_EQ(profile.get_counter("RowsFilteredByDictFilter")->value(), 3);
+    EXPECT_EQ(profile.get_counter("RowsFilteredByConjunct")->value(), 3);
+    EXPECT_EQ(profile.get_counter("RowsFilteredByDictFilter")->value(), 0);
     EXPECT_EQ(profile.get_counter("DictFilterCandidateColumns")->value(), 1);
-    EXPECT_EQ(profile.get_counter("DictFilterColumns")->value(), 1);
-    EXPECT_EQ(profile.get_counter("DictFilterUnsupportedColumns")->value(), 0);
+    EXPECT_EQ(profile.get_counter("DictFilterColumns")->value(), 0);
+    EXPECT_EQ(profile.get_counter("DictFilterUnsupportedColumns")->value(), 1);
     EXPECT_EQ(profile.get_counter("DictFilterReadFailures")->value(), 0);
+    EXPECT_EQ(profile.get_counter("RawValuePredicateDirectBatches")->value(), 1);
+    EXPECT_EQ(profile.get_counter("RawValuePredicateDirectRows")->value(), 6);
+    EXPECT_EQ(profile.get_counter("FixedWidthPredicateDirectBatches")->value(), 1);
+    EXPECT_EQ(profile.get_counter("FixedWidthPredicateDirectRows")->value(), 6);
 }
 
-TEST_F(NewParquetReaderTest, AllFixedWidthDictionaryTypesDecodeThroughDictionaryIds) {
+TEST_F(NewParquetReaderTest, OnlyStringFixedWidthDictionaryTypeUsesDictionaryIds) {
     write_all_fixed_width_dictionary_filter_parquet_file(_file_path);
 
     auto parquet_file_reader = ::parquet::ParquetFileReader::OpenFile(_file_path, false);
@@ -2941,9 +2973,15 @@ TEST_F(NewParquetReaderTest, AllFixedWidthDictionaryTypesDecodeThroughDictionary
     EXPECT_EQ(total_rows, 6);
     EXPECT_EQ(profile.get_counter("RowsFilteredByDictFilter")->value(), 0);
     EXPECT_EQ(profile.get_counter("DictFilterCandidateColumns")->value(), 5);
-    EXPECT_EQ(profile.get_counter("DictFilterColumns")->value(), 5);
-    EXPECT_EQ(profile.get_counter("DictFilterUnsupportedColumns")->value(), 0);
+    EXPECT_EQ(profile.get_counter("DictFilterColumns")->value(), 1);
+    EXPECT_EQ(profile.get_counter("DictFilterUnsupportedColumns")->value(), 4);
     EXPECT_EQ(profile.get_counter("DictFilterReadFailures")->value(), 0);
+    // INT64, FLOAT, and DOUBLE use decoded raw values directly. Legacy INT96 keeps its specialized
+    // conversion path, while FIXED_LEN_BYTE_ARRAY is the sole string dictionary-ID candidate.
+    EXPECT_EQ(profile.get_counter("RawValuePredicateDirectBatches")->value(), 3);
+    EXPECT_EQ(profile.get_counter("RawValuePredicateDirectRows")->value(), 18);
+    EXPECT_EQ(profile.get_counter("FixedWidthPredicateDirectBatches")->value(), 3);
+    EXPECT_EQ(profile.get_counter("FixedWidthPredicateDirectRows")->value(), 18);
 }
 
 TEST_F(NewParquetReaderTest, DictionaryPredicateReaderIsSharedOutsideMergeRangeReader) {

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -3125,7 +3125,7 @@ TEST_F(ParquetScanTest, DefinitionOnlyDatePredicatePreservesConversionSemantics)
     }
 }
 
-TEST_F(ParquetScanTest, PredicateOnlyDictionaryRangeSkipsTypedValueMaterialization) {
+TEST_F(ParquetScanTest, PredicateOnlyNonStringDictionaryRangeUsesDecodedValues) {
     write_dictionary_int_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -3154,16 +3154,17 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryRangeSkipsTypedValueMaterializati
               (ColumnInt32::Container {30, 40, 50, 60}));
     EXPECT_EQ(block.get_by_position(0).column->size(), rows);
     EXPECT_EQ(counter_value(profile, "DictFilterCandidateColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "RowsFilteredByDictFilter"), 2);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 6);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "RowsFilteredByDictFilter"), 0);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 0);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateProjectedRows"), 0);
     EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
     conjunct->close();
 }
 
-TEST_F(ParquetScanTest, PredicateOnlyDictionaryTopNUsesDictionaryIds) {
+TEST_F(ParquetScanTest, PredicateOnlyNonStringDictionaryTopNUsesDecodedValues) {
     write_dictionary_int_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -3190,13 +3191,14 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryTopNUsesDictionaryIds) {
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {10, 20, 30}));
     EXPECT_EQ(counter_value(profile, "DictFilterCandidateColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "RowsFilteredByDictFilter"), 3);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "RowsFilteredByDictFilter"), 0);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 0);
     prepared.conjunct->close();
 }
 
-TEST_F(ParquetScanTest, WideRuntimeFilterSlotUsesSparseDictionaryPlaceholders) {
+TEST_F(ParquetScanTest, WideRuntimeFilterSlotUsesDecodedDictionaryValues) {
     constexpr int COLUMN_COUNT = 128;
     constexpr int FILTER_COLUMN = COLUMN_COUNT - 1;
     write_int_columns_parquet_file(_file_path, COLUMN_COUNT, true);
@@ -3228,7 +3230,10 @@ TEST_F(ParquetScanTest, WideRuntimeFilterSlotUsesSparseDictionaryPlaceholders) {
     ASSERT_EQ(rows, 3);
     EXPECT_EQ(int32_data_column(*block.get_by_position(0).column).get_data(),
               (ColumnInt32::Container {3, 5, 6}));
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
     conjunct->close();
 }
 
@@ -3271,7 +3276,7 @@ TEST_F(ParquetScanTest, DictionaryTopNPreservesNullBeforeLateBound) {
     prepared.conjunct->close();
 }
 
-TEST_F(ParquetScanTest, PredicateOnlyDictionaryBloomRuntimeFilterUsesTypedValues) {
+TEST_F(ParquetScanTest, NonStringDictionaryRuntimeFilterUsesDecodedValues) {
     write_dictionary_int_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -3285,7 +3290,12 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryBloomRuntimeFilterUsesTypedValues
     ASSERT_TRUE(request_builder.add_predicate_column(format::LocalColumnId(0)).ok());
     ASSERT_TRUE(request_builder.add_non_predicate_column(format::LocalColumnId(1)).ok());
     request->predicate_only_columns.push_back(format::LocalColumnId(0));
-    request->conjuncts.push_back(create_int32_runtime_bloom_conjunct(0, {3, 5, 6}, 10));
+    auto conjunct = create_int32_runtime_bloom_conjunct(0, {3, 5, 6}, 10);
+    conjunct->_prepared = false;
+    conjunct->_opened = false;
+    ASSERT_TRUE(conjunct->prepare(&state, RowDescriptor()).ok());
+    ASSERT_TRUE(conjunct->open(&state).ok());
+    request->conjuncts.push_back(conjunct);
     ASSERT_TRUE(reader->open(request).ok());
 
     Block block = build_file_block(schema);
@@ -3295,9 +3305,13 @@ TEST_F(ParquetScanTest, PredicateOnlyDictionaryBloomRuntimeFilterUsesTypedValues
     ASSERT_EQ(rows, 3);
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {30, 50, 60}));
-    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "DictFilterTypedCompareColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 6);
+    EXPECT_EQ(counter_value(profile, "DictFilterCandidateColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictFilterTypedCompareColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 0);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
+    conjunct->close();
 }
 
 TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryBloomRuntimeFilterUsesVectorizedValues) {
@@ -3413,7 +3427,7 @@ TEST_F(ParquetScanTest, PredicateOnlyStringDictionaryMinMaxRuntimeFilterUsesVect
     max_conjunct->close();
 }
 
-TEST_F(ParquetScanTest, ProjectedDictionaryRangeGathersOnlySurvivors) {
+TEST_F(ParquetScanTest, ProjectedNonStringDictionaryRangeUsesDecodedValues) {
     write_dictionary_int_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -3441,15 +3455,16 @@ TEST_F(ParquetScanTest, ProjectedDictionaryRangeGathersOnlySurvivors) {
               (ColumnInt32::Container {3, 4, 5, 6}));
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {30, 40, 50, 60}));
-    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 1);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 1);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 6);
-    EXPECT_EQ(counter_value(profile, "DictionaryPredicateProjectedRows"), 4);
-    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 0);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 0);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateProjectedRows"), 0);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 1);
     conjunct->close();
 }
 
-TEST_F(ParquetScanTest, ProjectedBigIntDictionaryRangeUsesFusedGather) {
+TEST_F(ParquetScanTest, ProjectedBigIntDictionaryRangeUsesDecodedValues) {
     write_dictionary_bigint_pair_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -3477,12 +3492,11 @@ TEST_F(ParquetScanTest, ProjectedBigIntDictionaryRangeUsesFusedGather) {
               (ColumnInt64::Container {3, 4, 5, 6}));
     EXPECT_EQ(int32_data_column(*block.get_by_position(1).column).get_data(),
               (ColumnInt32::Container {30, 40, 50, 60}));
-    auto* fused_rows = profile.get_counter("DictionaryPredicateFusedProjectedRows");
-    ASSERT_NE(fused_rows, nullptr);
-    EXPECT_EQ(fused_rows->value(), 4);
-    auto* typed_filter_columns = profile.get_counter("DictFilterTypedCompareColumns");
-    ASSERT_NE(typed_filter_columns, nullptr);
-    EXPECT_EQ(typed_filter_columns->value(), 1);
+    EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
+    EXPECT_EQ(counter_value(profile, "DictionaryPredicateFusedProjectedRows"), 0);
+    EXPECT_EQ(counter_value(profile, "DictFilterTypedCompareColumns"), 0);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 1);
     conjunct->close();
 }
 

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -3233,7 +3233,9 @@ TEST_F(ParquetScanTest, WideRuntimeFilterSlotUsesDecodedDictionaryValues) {
     EXPECT_EQ(counter_value(profile, "DictFilterColumns"), 0);
     EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 0);
-    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
     conjunct->close();
 }
 
@@ -3310,7 +3312,10 @@ TEST_F(ParquetScanTest, NonStringDictionaryRuntimeFilterUsesDecodedValues) {
     EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
     EXPECT_EQ(counter_value(profile, "DictFilterTypedCompareColumns"), 0);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 0);
-    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectRows"), 6);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "TypedRuntimeFilterDirectBatches"), 0);
     conjunct->close();
 }
 
@@ -3460,7 +3465,9 @@ TEST_F(ParquetScanTest, ProjectedNonStringDictionaryRangeUsesDecodedValues) {
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectBatches"), 0);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateDirectRows"), 0);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateProjectedRows"), 0);
-    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
     conjunct->close();
 }
 
@@ -3496,7 +3503,9 @@ TEST_F(ParquetScanTest, ProjectedBigIntDictionaryRangeUsesDecodedValues) {
     EXPECT_EQ(counter_value(profile, "DictFilterUnsupportedColumns"), 1);
     EXPECT_EQ(counter_value(profile, "DictionaryPredicateFusedProjectedRows"), 0);
     EXPECT_EQ(counter_value(profile, "DictFilterTypedCompareColumns"), 0);
-    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 1);
+    EXPECT_EQ(counter_value(profile, "RawValuePredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "FixedWidthPredicateDirectBatches"), 1);
+    EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
     conjunct->close();
 }
 
@@ -3739,7 +3748,7 @@ TEST_F(ParquetScanTest, PredicateOnlyUint32UsesConvertedDecoderDirectPath) {
     EXPECT_EQ(counter_value(profile, "PredicateCompactionCount"), 0);
 }
 
-TEST_F(ParquetScanTest, FixedWidthPredicateReportsUnsupportedEncodingAfterProgress) {
+TEST_F(ParquetScanTest, FixedWidthPredicateRejectsMissingDictionaryAfterProgress) {
     write_misdeclared_two_page_parquet_file(_file_path);
     RuntimeProfile profile("profile");
     auto reader = create_reader(0, -1, &profile);
@@ -3760,7 +3769,7 @@ TEST_F(ParquetScanTest, FixedWidthPredicateReportsUnsupportedEncodingAfterProgre
     bool eof = false;
     const auto status = reader->get_block(&block, &rows, &eof);
     EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
-    EXPECT_NE(status.to_string().find("encoding"), std::string::npos) << status;
+    EXPECT_NE(status.to_string().find("dictionary"), std::string::npos) << status;
 }
 
 TEST_F(ParquetScanTest, PlainDirectPathKeepsPayloadForMultiColumnResidual) {

--- a/docs/file-scanner-v2-parquet-scan-design.md
+++ b/docs/file-scanner-v2-parquet-scan-design.md
@@ -328,8 +328,10 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-  A[Single-column Predicate] --> B{Column Fully Dictionary Encoded?}
-  B -- "No" --> F[Read Actual Values and Execute VExpr]
+  A[Single-column Predicate] --> T{Logical Type Is String?}
+  T -- "No" --> F[Decode Actual Values and Apply Direct or VExpr Filtering]
+  T -- "Yes" --> B{Column Fully Dictionary Encoded?}
+  B -- "No" --> F
   B -- "Yes" --> C[Read Dictionary Page]
   C --> D[Evaluate Predicate on Dictionary Values<br>Build Dictionary-ID Bitmap]
   D --> E[Decode Data-page Dictionary IDs<br>Update SelectionVector Directly]
@@ -338,14 +340,13 @@ flowchart LR
   G -- "Yes" --> I[Gather Survivors Directly Into Target Column]
 ```
 
-- Applies to compatible equality and range predicates on non-repeated primitive columns whose
-  complete Column Chunk uses `RLE_DICTIONARY` or legacy `PLAIN_DICTIONARY` data encoding.
+- Applies to compatible equality and range predicates on non-repeated string columns whose complete
+  Column Chunk uses `RLE_DICTIONARY` or legacy `PLAIN_DICTIONARY` data encoding. Other logical types
+  decode dictionary values before reader-side direct filtering or residual VExpr evaluation.
 - Predicate-only batches decode selected IDs straight from the page decoder and never materialize
-  a row-sized predicate value column. The typed dictionary is cached once per generation. Simple
-  numeric comparisons build its ID bitmap over contiguous typed values, while string equality and
-  range comparisons operate directly on dictionary slices. When projection is required, all
-  fixed-width survivors are written by the filtering loop itself; strings pre-size their character
-  and offset buffers and copy each compact survivor once.
+  a row-sized predicate value column. The typed dictionary is cached once per generation. String
+  equality and range comparisons operate directly on dictionary slices. When projection is
+  required, strings pre-size their character and offset buffers and copy each compact survivor once.
 - Safe AND subexpressions may remove components exactly covered by dictionary evaluation. OR or
   non-equivalent expressions are not rewritten aggressively.
 - Stateful, potentially throwing, or whole-batch-sensitive expressions disable staged
@@ -596,14 +597,14 @@ only remove candidates already expressed in the same Row Group logical-row domai
 from ColumnIndex and OffsetIndex are validated together before they become `selected_ranges` and a
 per-leaf physical page-skip plan.
 
-Dictionary row filtering starts only when metadata proves every data page in the Column Chunk uses
-a dictionary encoding. The predicate is evaluated against the current dictionary to produce an
-entry bitmap; decoded IDs are checked against both dictionary length and bitmap length. A mixed
-dictionary/plain transition falls back before consuming data. Once selected dictionary reading has
-advanced a page cursor, loss of dictionary output is corruption rather than a retry through another
-path with shifted state. Predicate-only slots stop after decoder-level ID filtering and retain only
-the output row shape. Projected slots write fixed-width survivors in the filtering loop or gather
-compact string survivors directly into pre-sized target buffers.
+Dictionary row filtering starts only for string columns when metadata proves every data page in the
+Column Chunk uses a dictionary encoding. The predicate is evaluated against the current dictionary
+to produce an entry bitmap; decoded IDs are checked against both dictionary length and bitmap
+length. Non-string dictionaries stay on the decoded-value path. A mixed dictionary/plain transition
+falls back before consuming data. Once selected dictionary reading has advanced a page cursor, loss
+of dictionary output is corruption rather than a retry through another path with shifted state.
+Predicate-only string slots stop after decoder-level ID filtering and retain only the output row
+shape. Projected string slots gather compact survivors directly into pre-sized target buffers.
 
 Missing optional indexes or unsupported predicate/type combinations retain rows. Malformed
 offsets, inconsistent page counts, out-of-range dictionary IDs, overlapping/unsorted invalid ranges,
@@ -622,7 +623,7 @@ storage indexes for external Parquet files.
 | Parquet Bloom Filter | Row Group / Column Chunk | Equality and IN membership-negation predicates | Negative result can prune; positive result requires verification | Controlled by configuration; file must contain Bloom data; false positives are possible |
 | ColumnIndex | Page | Predicates evaluable from min/max/null | Produces candidate pages and row ranges | Requires an index and decodable compatible types |
 | OffsetIndex | Page → Row Range | Does not evaluate predicates directly | Maps page results to row numbers and physical skip plans | Normally used with ColumnIndex |
-| Dictionary-ID Filter | Row / Batch | Safe typed equality and range predicates | Exact filtering of actual rows without a full predicate value column | Complete dictionary encoding and non-repeated primitive only |
+| Dictionary-ID Filter | Row / Batch | Safe string equality and range predicates | Exact filtering of actual rows without a full predicate value column | Complete dictionary encoding and non-repeated string column only |
 | Condition Cache Bitmap | File-global granule | Stable cacheable conditions | Reuses previous filtering to reduce row ranges | Not a native Parquet index; uncovered ranges remain candidates |
 
 ### Index-selection overview


### PR DESCRIPTION
### What problem does this PR solve?

File Scanner V2 applies row-level dictionary-ID filtering to non-string Parquet dictionaries. This differs from the V1 and StarRocks strategy, where non-string dictionary values are decoded before filtering, and can bypass the intended logical value domain.

### What is changed?

- Restrict row-level dictionary-ID filtering to logical string columns.
- Keep non-string dictionaries on the decoded-value reader-direct or residual VExpr path.
- Update focused INT/BIGINT/runtime-filter coverage and the V2 Parquet scan design.

### Verification

- ASAN BE UT: 68/68 tests passed for ParquetScanTest and ParquetRuntimeFilterDirectReaderTest.
- clang-format --dry-run --Werror passed.
- git diff --check passed.