### PR TITLE
[fix](ci) Protect refreshed Codex auth updates

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -277,6 +277,9 @@ jobs:
             and (.tokens.access_token | type == "string" and length > 0)
             and (.tokens.refresh_token | type == "string" and length > 0)
           ' "$RUNNER_TEMP/codex-home/auth.json" >/dev/null
+          sha256sum "$RUNNER_TEMP/codex-home/auth.json" \
+            | awk '{print $1}' \
+            > "$RUNNER_TEMP/codex-auth-original.sha256"
 
           cat > "$RUNNER_TEMP/codex-home/config.toml" <<EOF
           cli_auth_credentials_store = "file"
@@ -946,27 +949,61 @@ jobs:
           OSS_ENDPOINT: oss-cn-hongkong.aliyuncs.com
           OSS_CODEX_SESSION_PREFIX: oss://doris-community-ci/session
 
-      - name: Sync Codex auth back to OSS
-        if: ${{ always() }}
-        continue-on-error: true
+      - name: Sync refreshed Codex auth back to OSS
+        if: ${{ always() && steps.auth.outcome == 'success' }}
         timeout-minutes: 5
         run: |
-          if [ -z "$CODEX_AUTH_OSS_OBJECT" ]; then
-            echo "No selected Codex auth object found; skipping OSS auth sync."
-            exit 0
-          fi
-
-          if [ ! -s "$CODEX_HOME/auth.json" ]; then
-            echo "No Codex auth file found; skipping OSS auth sync."
-            exit 0
-          fi
+          retry_oss_copy() {
+            local source="$1"
+            local destination="$2"
+            local description="$3"
+            for attempt in 1 2 3; do
+              if ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
+                cp -f "$source" "$destination" >/dev/null; then
+                return 0
+              fi
+              echo "::warning::$description failed (attempt $attempt/3)."
+              if [ "$attempt" -lt 3 ]; then
+                sleep 5
+              fi
+            done
+            return 1
+          }
 
           jq -e '
             .auth_mode == "chatgpt"
             and (.tokens.access_token | type == "string" and length > 0)
             and (.tokens.refresh_token | type == "string" and length > 0)
           ' "$CODEX_HOME/auth.json" >/dev/null
-          ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" cp -f "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT"
+
+          original_hash="$(<"$RUNNER_TEMP/codex-auth-original.sha256")"
+          local_hash="$(sha256sum "$CODEX_HOME/auth.json" | awk '{print $1}')"
+          if [ "$local_hash" = "$original_hash" ]; then
+            echo "Codex auth was not refreshed; skipping OSS auth sync."
+            exit 0
+          fi
+
+          remote_auth="$(mktemp "$RUNNER_TEMP/codex-auth-current.XXXXXX")"
+          trap 'rm -f "$remote_auth"' EXIT
+          chmod 600 "$remote_auth"
+          if ! retry_oss_copy "$CODEX_AUTH_OSS_OBJECT" "$remote_auth" \
+            "Reading the current OSS auth"; then
+            echo "::error::Could not verify the current OSS auth after 3 attempts."
+            exit 1
+          fi
+
+          remote_hash="$(sha256sum "$remote_auth" | awk '{print $1}')"
+          if [ "$remote_hash" != "$original_hash" ]; then
+            echo "::warning::OSS auth changed during this job; skipping stale auth sync."
+            exit 0
+          fi
+
+          if ! retry_oss_copy "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT" \
+            "Uploading the refreshed Codex auth"; then
+            echo "::error::Could not persist the refreshed Codex auth after 3 attempts."
+            exit 1
+          fi
+          echo "Uploaded refreshed Codex auth: ${CODEX_AUTH_OSS_OBJECT##*/}"
         env:
           OSS_AK: ${{ secrets.OSS_AK }}
           OSS_SK: ${{ secrets.OSS_SK }}

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -970,7 +970,7 @@ jobs:
           trap 'rm -f "$remote_auth"' EXIT
           chmod 600 "$remote_auth"
           if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
-            --retry-times=2 --connect-timeout=10 --read-timeout=30 \
+            --retry-times=3 --connect-timeout=10 --read-timeout=30 \
             cp -f "$CODEX_AUTH_OSS_OBJECT" "$remote_auth" >/dev/null; then
             echo "::error::Could not verify the current OSS auth after 3 attempts."
             exit 1
@@ -983,7 +983,7 @@ jobs:
           fi
 
           if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
-            --retry-times=2 --connect-timeout=10 --read-timeout=30 \
+            --retry-times=3 --connect-timeout=10 --read-timeout=30 \
             cp -f "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT" >/dev/null; then
             echo "::error::Could not persist the refreshed Codex auth after 3 attempts."
             exit 1

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -971,7 +971,7 @@ jobs:
           trap 'rm -f "$remote_auth" "${remote_auth}.temp"' EXIT
           if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
             --retry-times=3 --connect-timeout=10 --read-timeout=30 \
-            cp -f "$CODEX_AUTH_OSS_OBJECT" "$remote_auth" >/dev/null; then
+            cp -f "$CODEX_AUTH_OSS_OBJECT" "$remote_auth"; then
             echo "::error::Could not verify the current OSS auth after 3 attempts."
             exit 1
           fi
@@ -984,7 +984,7 @@ jobs:
 
           if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
             --retry-times=3 --connect-timeout=10 --read-timeout=30 \
-            cp -f "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT" >/dev/null; then
+            cp -f "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT"; then
             echo "::error::Could not persist the refreshed Codex auth after 3 attempts."
             exit 1
           fi

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -951,13 +951,16 @@ jobs:
 
       - name: Sync refreshed Codex auth back to OSS
         if: ${{ always() && steps.auth.outcome == 'success' }}
-        timeout-minutes: 5
+        timeout-minutes: 8
         run: |
-          jq -e '
+          if ! jq -e '
             .auth_mode == "chatgpt"
             and (.tokens.access_token | type == "string" and length > 0)
             and (.tokens.refresh_token | type == "string" and length > 0)
-          ' "$CODEX_HOME/auth.json" >/dev/null
+          ' "$CODEX_HOME/auth.json" >/dev/null; then
+            echo "::error::Refreshed Codex auth is invalid; refusing OSS auth sync."
+            exit 1
+          fi
 
           original_hash="$(<"$RUNNER_TEMP/codex-auth-original.sha256")"
           local_hash="$(sha256sum "$CODEX_HOME/auth.json" | awk '{print $1}')"

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -953,23 +953,6 @@ jobs:
         if: ${{ always() && steps.auth.outcome == 'success' }}
         timeout-minutes: 5
         run: |
-          retry_oss_copy() {
-            local source="$1"
-            local destination="$2"
-            local description="$3"
-            for attempt in 1 2 3; do
-              if ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
-                cp -f "$source" "$destination" >/dev/null; then
-                return 0
-              fi
-              echo "::warning::$description failed (attempt $attempt/3)."
-              if [ "$attempt" -lt 3 ]; then
-                sleep 5
-              fi
-            done
-            return 1
-          }
-
           jq -e '
             .auth_mode == "chatgpt"
             and (.tokens.access_token | type == "string" and length > 0)
@@ -986,8 +969,9 @@ jobs:
           remote_auth="$(mktemp "$RUNNER_TEMP/codex-auth-current.XXXXXX")"
           trap 'rm -f "$remote_auth"' EXIT
           chmod 600 "$remote_auth"
-          if ! retry_oss_copy "$CODEX_AUTH_OSS_OBJECT" "$remote_auth" \
-            "Reading the current OSS auth"; then
+          if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
+            --retry-times=2 --connect-timeout=10 --read-timeout=30 \
+            cp -f "$CODEX_AUTH_OSS_OBJECT" "$remote_auth" >/dev/null; then
             echo "::error::Could not verify the current OSS auth after 3 attempts."
             exit 1
           fi
@@ -998,8 +982,9 @@ jobs:
             exit 0
           fi
 
-          if ! retry_oss_copy "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT" \
-            "Uploading the refreshed Codex auth"; then
+          if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
+            --retry-times=2 --connect-timeout=10 --read-timeout=30 \
+            cp -f "$CODEX_HOME/auth.json" "$CODEX_AUTH_OSS_OBJECT" >/dev/null; then
             echo "::error::Could not persist the refreshed Codex auth after 3 attempts."
             exit 1
           fi

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -55,10 +55,9 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    # Every pre-finalization step has its own timeout. Their worst-case budget,
-    # including review/failure/status handling and best-effort cleanup, is 153
-    # minutes, leaving 12 minutes for runner setup and post-job cleanup.
-    timeout-minutes: 165
+    # Pre-finalization steps can use 153 minutes and auth sync can use 8 more,
+    # leaving 12 minutes for runner setup and post-job cleanup.
+    timeout-minutes: 173
     if: >-
       inputs.pr_number != '' ||
       (
@@ -215,6 +214,8 @@ jobs:
         id: auth
         timeout-minutes: 5
         run: |
+          set -o pipefail
+
           install -m 700 -d "$RUNNER_TEMP/codex-home"
           printf 'CODEX_HOME=%s\n' "$RUNNER_TEMP/codex-home" >> "$GITHUB_ENV"
 
@@ -953,6 +954,8 @@ jobs:
         if: ${{ always() && steps.auth.outcome == 'success' }}
         timeout-minutes: 8
         run: |
+          set -o pipefail
+
           if ! jq -e '
             .auth_mode == "chatgpt"
             and (.tokens.access_token | type == "string" and length > 0)

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -966,9 +966,9 @@ jobs:
             exit 0
           fi
 
+          umask 077
           remote_auth="$(mktemp "$RUNNER_TEMP/codex-auth-current.XXXXXX")"
-          trap 'rm -f "$remote_auth"' EXIT
-          chmod 600 "$remote_auth"
+          trap 'rm -f "$remote_auth" "${remote_auth}.temp"' EXIT
           if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" \
             --retry-times=3 --connect-timeout=10 --read-timeout=30 \
             cp -f "$CODEX_AUTH_OSS_OBJECT" "$remote_auth" >/dev/null; then


### PR DESCRIPTION
## What this PR changes

This PR makes the Codex `auth.json` write-back in the automated review workflow conditional and conflict-aware.

- Record the SHA-256 of the selected and validated OSS auth file before Codex starts.
- After the review finishes, upload `auth.json` only when Codex actually changed the local file.
- Re-download the current OSS object immediately before write-back and upload only when it still matches the originally downloaded version.
- Bound OSS reads and writes with the client's native retry policy: three total attempts, a 10-second connection timeout, and a 30-second read timeout. If a refreshed credential cannot be verified or persisted, fail this non-required workflow instead of silently losing the update.
- Keep the downloaded verification copy and the OSS SDK's intermediate `.temp` file private with `umask 077`, and clean both paths on every exit.
- Preserve the pinned OSS client's native output so fatal reads and writes retain the OSS error code, request ID, or concrete network cause.
- Run the sync whenever auth setup succeeded, even if the review later failed for an unrelated reason, because Codex may already have refreshed the credential.

The resulting decision is:

| Local auth after Codex | Current OSS auth | Result |
| --- | --- | --- |
| Unchanged from the downloaded version | Not read | Skip write-back |
| Changed | Still the downloaded version | Upload the refreshed auth |
| Changed | Changed by another job or operator | Skip the stale write-back |
| Changed | OSS cannot be read or written after retries | Fail the workflow |

## Why

The previous step uploaded `auth.json` unconditionally. An in-flight job could therefore overwrite a credential that an operator had just reseeded, or overwrite another newer OSS copy even when Codex had not refreshed anything in that job.

This change protects the normal operational reseed path without requiring jobs to drain first. It also keeps the implementation local to the existing workflow and does not introduce a lease or reduce review concurrency.

## Scope and accepted limitations

This PR intentionally addresses only safe persistence of a Codex-refreshed `auth.json`.

It does not change:

- account selection, randomization, or usage-limit cooldown handling;
- revoked-account handling;
- the fact that multiple jobs may select the same account;
- the shared-auth model into an officially supported serialized model;
- token refresh behavior inside Codex.

The OSS comparison and final upload are not an atomic compare-and-swap. A small race remains if the same OSS object changes between the final read and upload. Eliminating that race would require conditional object writes, versioning, or locking and is deliberately left out to keep this PR small. The workflow continues to accept rare concurrent-refresh failures rather than limiting review concurrency.

The hash comparison also has no generation ordering. If concurrent jobs start from the same auth and both refresh it, one job may observe the other job's upload and skip its own potentially newer refresh. This rare lost-refresh case is explicitly accepted: the immediate priority is protecting operational reseeds, while distinguishing refresh generations would require authoritative version/ownership metadata or serialization and would expand this PR beyond its intended scope.

## Validation

- Parsed the workflow as YAML.
- Ran `bash -n` on the updated shell step.
- Exercised the unchanged, refreshed, and remote-conflict decision paths with mocked OSS operations.
- Verified the native retry and timeout arguments against the pinned `ossutil` version's option semantics.
- Verified the pinned OSS SDK's temporary-file behavior and restrictive-umask cleanup path.
- Verified that the pinned client reports terminal transfer failures through stdout and that the workflow no longer discards it.
- Verified that digest-command failures propagate through all SHA-256 pipelines with `pipefail`.
- Budgeted the 173-minute job for 153 minutes of pre-finalization work, 8 minutes of auth sync, and 12 minutes of runner/post-job overhead.
- Ran `git diff --check`.
