### PR TITLE
[Improvement](file scan) Keep File Scanner V2 predicate pruning enabled

### DIFF
--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -632,9 +632,12 @@ Status FileScannerV2::_prepare_table_reader_split(const TFileRangeDesc& range,
     VExprContextSPtrs conjuncts;
     RETURN_IF_ERROR(_build_table_conjuncts(&conjuncts));
     VExprContextSPtrs partition_prune_conjuncts;
-    // FileScannerV2 owns its complete pruning pipeline, so safe partition predicates must not
-    // inherit the legacy scanner's session gate.
-    RETURN_IF_ERROR(_build_table_conjuncts(&partition_prune_conjuncts));
+    if (!partition_values.empty()) {
+        // A split without partition constants cannot be pruned here, so avoid cloning every
+        // conjunct solely for a consumer that must return immediately. FileScannerV2 otherwise
+        // keeps safe partition pruning enabled independently of the legacy session gate.
+        RETURN_IF_ERROR(_build_table_conjuncts(&partition_prune_conjuncts));
+    }
     RETURN_IF_ERROR(_table_reader->prepare_split({
             .partition_values = std::move(partition_values),
             .conjuncts = std::move(conjuncts),

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -632,9 +632,9 @@ Status FileScannerV2::_prepare_table_reader_split(const TFileRangeDesc& range,
     VExprContextSPtrs conjuncts;
     RETURN_IF_ERROR(_build_table_conjuncts(&conjuncts));
     VExprContextSPtrs partition_prune_conjuncts;
-    if (_state->query_options().enable_runtime_filter_partition_prune) {
-        RETURN_IF_ERROR(_build_table_conjuncts(&partition_prune_conjuncts));
-    }
+    // FileScannerV2 owns its complete pruning pipeline, so safe partition predicates must not
+    // inherit the legacy scanner's session gate.
+    RETURN_IF_ERROR(_build_table_conjuncts(&partition_prune_conjuncts));
     RETURN_IF_ERROR(_table_reader->prepare_split({
             .partition_values = std::move(partition_values),
             .conjuncts = std::move(conjuncts),

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -452,11 +452,9 @@ std::optional<format::LocalColumnId> file_column_id_by_block_position(
     return std::nullopt;
 }
 
-bool has_expr_zonemap_filter(const format::FileScanRequest& request,
-                             const RuntimeState* runtime_state) {
-    if (!expr_zonemap::is_expr_zonemap_filter_enabled(runtime_state)) {
-        return false;
-    }
+bool has_expr_zonemap_filter(const format::FileScanRequest& request, const RuntimeState*) {
+    // FileScannerV2 metadata pruning is a fixed part of its scan pipeline and must not inherit
+    // the legacy scanner's expression ZoneMap session gate.
     for (const auto& conjunct : request.conjuncts) {
         if (conjunct != nullptr && conjunct->root() != nullptr &&
             conjunct->root()->can_evaluate_zonemap_filter()) {

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -452,10 +452,28 @@ std::optional<format::LocalColumnId> file_column_id_by_block_position(
     return std::nullopt;
 }
 
-bool has_expr_zonemap_filter(const format::FileScanRequest& request, const RuntimeState*) {
-    // FileScannerV2 metadata pruning is a fixed part of its scan pipeline and must not inherit
-    // the legacy scanner's expression ZoneMap session gate.
-    for (const auto& conjunct : request.conjuncts) {
+VExprContextSPtrs metadata_pruning_safe_conjunct_prefix(const VExprContextSPtrs& conjuncts) {
+    VExprContextSPtrs safe_prefix;
+    safe_prefix.reserve(conjuncts.size());
+    for (const auto& conjunct : conjuncts) {
+        if (conjunct == nullptr || conjunct->root() == nullptr) {
+            break;
+        }
+        const auto root = conjunct->root();
+        const auto impl = root->get_impl();
+        const auto predicate = impl != nullptr ? impl : root;
+        // Metadata pruning must not skip an earlier error-preserving predicate and discard rows
+        // with a later predicate before the earlier one reaches row-level evaluation.
+        if (!predicate->is_safe_to_execute_on_selected_rows()) {
+            break;
+        }
+        safe_prefix.push_back(conjunct);
+    }
+    return safe_prefix;
+}
+
+bool has_expr_zonemap_filter(const VExprContextSPtrs& conjuncts) {
+    for (const auto& conjunct : conjuncts) {
         if (conjunct != nullptr && conjunct->root() != nullptr &&
             conjunct->root()->can_evaluate_zonemap_filter()) {
             return true;
@@ -531,9 +549,11 @@ void accumulate_zonemap_stats(const ZoneMapEvalContext& ctx, ParquetPruningStats
 
 } // namespace
 
-bool can_use_parquet_page_index(const format::FileScanRequest& request,
-                                const RuntimeState* runtime_state) {
-    return config::enable_parquet_page_index && has_expr_zonemap_filter(request, runtime_state);
+bool can_use_parquet_page_index(const format::FileScanRequest& request, const RuntimeState*) {
+    // FileScannerV2 metadata pruning is a fixed part of its scan pipeline and must not inherit
+    // the legacy scanner's expression ZoneMap session gate.
+    return config::enable_parquet_page_index &&
+           has_expr_zonemap_filter(metadata_pruning_safe_conjunct_prefix(request.conjuncts));
 }
 
 std::shared_ptr<segment_v2::ZoneMap> ParquetStatisticsUtils::MakeZoneMap(
@@ -632,8 +652,9 @@ bool check_native_statistics(const tparquet::FileMetaData& metadata,
                              const tparquet::RowGroup& row_group,
                              const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
                              const format::FileScanRequest& request,
-                             ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone) {
-    const auto slot_indexes = collect_expr_zonemap_slot_indexes(request.conjuncts);
+                             const VExprContextSPtrs& conjuncts, ParquetPruningStats* pruning_stats,
+                             const cctz::time_zone* timezone) {
+    const auto slot_indexes = collect_expr_zonemap_slot_indexes(conjuncts);
     if (slot_indexes.empty()) {
         return false;
     }
@@ -668,7 +689,7 @@ bool check_native_statistics(const tparquet::FileMetaData& metadata,
         }
         add_slot_zonemap(&ctx, slot_index, column_schema->type, std::move(zone_map));
     }
-    const auto result = VExprContext::evaluate_zonemap_filter(request.conjuncts, ctx);
+    const auto result = VExprContext::evaluate_zonemap_filter(conjuncts, ctx);
     accumulate_zonemap_stats(ctx, pruning_stats);
     return result == ZoneMapFilterResult::kNoMatch;
 }
@@ -881,9 +902,8 @@ Status select_row_groups_by_metadata(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, const std::vector<int>* candidate_row_groups,
         std::vector<int>* selected_row_groups, bool enable_bloom_filter,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
-        const RuntimeState* runtime_state, ParquetFileContext* file_context,
-        const ParquetColumnReaderProfile& column_reader_profile,
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone, const RuntimeState*,
+        ParquetFileContext* file_context, const ParquetColumnReaderProfile& column_reader_profile,
         ParquetMetadataProbeMode probe_mode) {
     int64_t timer_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
@@ -897,6 +917,7 @@ Status select_row_groups_by_metadata(
     if (pruning_stats != nullptr) {
         pruning_stats->total_row_groups = cast_set<int64_t>(candidate_size);
     }
+    const auto zonemap_conjuncts = metadata_pruning_safe_conjunct_prefix(request.conjuncts);
     selected_row_groups->reserve(candidate_size);
     for (size_t candidate_idx = 0; candidate_idx < candidate_size; ++candidate_idx) {
         const int row_group_idx = candidate_row_groups == nullptr
@@ -920,9 +941,9 @@ Status select_row_groups_by_metadata(
         }
         ParquetRowGroupPruneReason prune_reason = ParquetRowGroupPruneReason::NONE;
         if (probe_mode != ParquetMetadataProbeMode::EXPENSIVE_ONLY &&
-            has_expr_zonemap_filter(request, runtime_state) &&
-            check_native_statistics(metadata, row_group, file_schema, request, pruning_stats,
-                                    timezone)) {
+            has_expr_zonemap_filter(zonemap_conjuncts) &&
+            check_native_statistics(metadata, row_group, file_schema, request, zonemap_conjuncts,
+                                    pruning_stats, timezone)) {
             prune_reason = ParquetRowGroupPruneReason::STATISTICS;
         }
         if (probe_mode != ParquetMetadataProbeMode::FOOTER_ONLY &&
@@ -1241,8 +1262,7 @@ Status select_row_group_ranges_by_native_page_index(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, int64_t row_group_rows,
         std::vector<RowRange>* selected_ranges, std::map<int, ParquetPageSkipPlan>* page_skip_plans,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
-        const RuntimeState* runtime_state) {
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone, const RuntimeState*) {
     int64_t filter_time_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &filter_time_sink
                                               : &pruning_stats->page_index_filter_time);
@@ -1252,8 +1272,9 @@ Status select_row_group_ranges_by_native_page_index(
     if (page_skip_plans != nullptr) {
         page_skip_plans->clear();
     }
+    const auto zonemap_conjuncts = metadata_pruning_safe_conjunct_prefix(request.conjuncts);
     if (row_group_rows <= 0 || !config::enable_parquet_page_index ||
-        !has_expr_zonemap_filter(request, runtime_state) || page_indexes.empty()) {
+        !has_expr_zonemap_filter(zonemap_conjuncts) || page_indexes.empty()) {
         return Status::OK();
     }
     if (pruning_stats != nullptr) {
@@ -1261,7 +1282,7 @@ Status select_row_group_ranges_by_native_page_index(
     }
 
     std::map<int, VExprContextSPtrs> conjuncts_by_slot;
-    for (const auto& conjunct : request.conjuncts) {
+    for (const auto& conjunct : zonemap_conjuncts) {
         const auto slot_index = expr_zonemap::single_slot_zonemap_index(conjunct);
         if (slot_index >= 0) {
             conjuncts_by_slot[slot_index].push_back(conjunct);

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -452,28 +452,12 @@ std::optional<format::LocalColumnId> file_column_id_by_block_position(
     return std::nullopt;
 }
 
-VExprContextSPtrs metadata_pruning_safe_conjunct_prefix(const VExprContextSPtrs& conjuncts) {
-    VExprContextSPtrs safe_prefix;
-    safe_prefix.reserve(conjuncts.size());
-    for (const auto& conjunct : conjuncts) {
-        if (conjunct == nullptr || conjunct->root() == nullptr) {
-            break;
-        }
-        const auto root = conjunct->root();
-        const auto impl = root->get_impl();
-        const auto predicate = impl != nullptr ? impl : root;
-        // Metadata pruning must not skip an earlier error-preserving predicate and discard rows
-        // with a later predicate before the earlier one reaches row-level evaluation.
-        if (!predicate->is_safe_to_execute_on_selected_rows()) {
-            break;
-        }
-        safe_prefix.push_back(conjunct);
-    }
-    return safe_prefix;
-}
-
-bool has_expr_zonemap_filter(const VExprContextSPtrs& conjuncts) {
-    for (const auto& conjunct : conjuncts) {
+bool has_expr_zonemap_filter(const format::FileScanRequest& request, const RuntimeState*) {
+    // FileScannerV2 metadata pruning is a fixed part of its scan pipeline and must not inherit
+    // the legacy scanner's expression ZoneMap session gate.
+    // TODO: Fence metadata pruning at the first unsafe/error-preserving conjunct so a later
+    // ZoneMap predicate cannot bypass its row-level evaluation.
+    for (const auto& conjunct : request.conjuncts) {
         if (conjunct != nullptr && conjunct->root() != nullptr &&
             conjunct->root()->can_evaluate_zonemap_filter()) {
             return true;
@@ -549,11 +533,9 @@ void accumulate_zonemap_stats(const ZoneMapEvalContext& ctx, ParquetPruningStats
 
 } // namespace
 
-bool can_use_parquet_page_index(const format::FileScanRequest& request, const RuntimeState*) {
-    // FileScannerV2 metadata pruning is a fixed part of its scan pipeline and must not inherit
-    // the legacy scanner's expression ZoneMap session gate.
-    return config::enable_parquet_page_index &&
-           has_expr_zonemap_filter(metadata_pruning_safe_conjunct_prefix(request.conjuncts));
+bool can_use_parquet_page_index(const format::FileScanRequest& request,
+                                const RuntimeState* runtime_state) {
+    return config::enable_parquet_page_index && has_expr_zonemap_filter(request, runtime_state);
 }
 
 std::shared_ptr<segment_v2::ZoneMap> ParquetStatisticsUtils::MakeZoneMap(
@@ -652,9 +634,8 @@ bool check_native_statistics(const tparquet::FileMetaData& metadata,
                              const tparquet::RowGroup& row_group,
                              const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
                              const format::FileScanRequest& request,
-                             const VExprContextSPtrs& conjuncts, ParquetPruningStats* pruning_stats,
-                             const cctz::time_zone* timezone) {
-    const auto slot_indexes = collect_expr_zonemap_slot_indexes(conjuncts);
+                             ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone) {
+    const auto slot_indexes = collect_expr_zonemap_slot_indexes(request.conjuncts);
     if (slot_indexes.empty()) {
         return false;
     }
@@ -689,7 +670,7 @@ bool check_native_statistics(const tparquet::FileMetaData& metadata,
         }
         add_slot_zonemap(&ctx, slot_index, column_schema->type, std::move(zone_map));
     }
-    const auto result = VExprContext::evaluate_zonemap_filter(conjuncts, ctx);
+    const auto result = VExprContext::evaluate_zonemap_filter(request.conjuncts, ctx);
     accumulate_zonemap_stats(ctx, pruning_stats);
     return result == ZoneMapFilterResult::kNoMatch;
 }
@@ -902,8 +883,9 @@ Status select_row_groups_by_metadata(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, const std::vector<int>* candidate_row_groups,
         std::vector<int>* selected_row_groups, bool enable_bloom_filter,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone, const RuntimeState*,
-        ParquetFileContext* file_context, const ParquetColumnReaderProfile& column_reader_profile,
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
+        const RuntimeState* runtime_state, ParquetFileContext* file_context,
+        const ParquetColumnReaderProfile& column_reader_profile,
         ParquetMetadataProbeMode probe_mode) {
     int64_t timer_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
@@ -917,7 +899,6 @@ Status select_row_groups_by_metadata(
     if (pruning_stats != nullptr) {
         pruning_stats->total_row_groups = cast_set<int64_t>(candidate_size);
     }
-    const auto zonemap_conjuncts = metadata_pruning_safe_conjunct_prefix(request.conjuncts);
     selected_row_groups->reserve(candidate_size);
     for (size_t candidate_idx = 0; candidate_idx < candidate_size; ++candidate_idx) {
         const int row_group_idx = candidate_row_groups == nullptr
@@ -941,9 +922,9 @@ Status select_row_groups_by_metadata(
         }
         ParquetRowGroupPruneReason prune_reason = ParquetRowGroupPruneReason::NONE;
         if (probe_mode != ParquetMetadataProbeMode::EXPENSIVE_ONLY &&
-            has_expr_zonemap_filter(zonemap_conjuncts) &&
-            check_native_statistics(metadata, row_group, file_schema, request, zonemap_conjuncts,
-                                    pruning_stats, timezone)) {
+            has_expr_zonemap_filter(request, runtime_state) &&
+            check_native_statistics(metadata, row_group, file_schema, request, pruning_stats,
+                                    timezone)) {
             prune_reason = ParquetRowGroupPruneReason::STATISTICS;
         }
         if (probe_mode != ParquetMetadataProbeMode::FOOTER_ONLY &&
@@ -1262,7 +1243,8 @@ Status select_row_group_ranges_by_native_page_index(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, int64_t row_group_rows,
         std::vector<RowRange>* selected_ranges, std::map<int, ParquetPageSkipPlan>* page_skip_plans,
-        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone, const RuntimeState*) {
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
+        const RuntimeState* runtime_state) {
     int64_t filter_time_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &filter_time_sink
                                               : &pruning_stats->page_index_filter_time);
@@ -1272,9 +1254,8 @@ Status select_row_group_ranges_by_native_page_index(
     if (page_skip_plans != nullptr) {
         page_skip_plans->clear();
     }
-    const auto zonemap_conjuncts = metadata_pruning_safe_conjunct_prefix(request.conjuncts);
     if (row_group_rows <= 0 || !config::enable_parquet_page_index ||
-        !has_expr_zonemap_filter(zonemap_conjuncts) || page_indexes.empty()) {
+        !has_expr_zonemap_filter(request, runtime_state) || page_indexes.empty()) {
         return Status::OK();
     }
     if (pruning_stats != nullptr) {
@@ -1282,7 +1263,7 @@ Status select_row_group_ranges_by_native_page_index(
     }
 
     std::map<int, VExprContextSPtrs> conjuncts_by_slot;
-    for (const auto& conjunct : zonemap_conjuncts) {
+    for (const auto& conjunct : request.conjuncts) {
         const auto slot_index = expr_zonemap::single_slot_zonemap_index(conjunct);
         if (slot_index >= 0) {
             conjuncts_by_slot[slot_index].push_back(conjunct);

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -529,6 +529,12 @@ TEST(FileScannerV2Test, PartitionPruningRemainsEnabledWhenSessionSwitchIsFalse) 
     const auto range = range_with_format("hive", TFileFormatType::FORMAT_PARQUET);
     ASSERT_TRUE(scanner._prepare_table_reader_split(range, {}).ok());
     EXPECT_EQ(captured->conjunct_count, 1);
+    EXPECT_EQ(captured->partition_prune_conjunct_count, 0);
+
+    ASSERT_TRUE(scanner._prepare_table_reader_split(
+                               range, {{"partition_col", Field::create_field<TYPE_INT>(1)}})
+                        .ok());
+    EXPECT_EQ(captured->conjunct_count, 1);
     EXPECT_EQ(captured->partition_prune_conjunct_count, 1);
 }
 

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -144,6 +144,18 @@ private:
     std::shared_ptr<RetryableCloseState> _state;
 };
 
+class CapturingSplitTableReader final : public format::TableReader {
+public:
+    Status prepare_split(const format::SplitReadOptions& options) override {
+        conjunct_count = options.conjuncts.has_value() ? options.conjuncts->size() : 0;
+        partition_prune_conjunct_count = options.partition_prune_conjuncts.size();
+        return Status::OK();
+    }
+
+    size_t conjunct_count = 0;
+    size_t partition_prune_conjunct_count = 0;
+};
+
 VExprSPtr slot_ref(int slot_id, int column_id, DataTypePtr type, const std::string& name) {
     return VSlotRef::create_shared(slot_id, column_id, -1, std::move(type), name);
 }
@@ -476,6 +488,48 @@ TEST(FileScannerV2Test, FailedTableReaderCloseCanBeRetriedThroughScanner) {
     EXPECT_EQ(close_state->close_calls, 2);
     EXPECT_TRUE(scanner.close(&state).ok());
     EXPECT_EQ(close_state->close_calls, 2);
+}
+
+TEST(FileScannerV2Test, PartitionPruningRemainsEnabledWhenSessionSwitchIsFalse) {
+    TQueryOptions query_options;
+    query_options.__set_enable_runtime_filter_partition_prune(false);
+    RuntimeState state {query_options, TQueryGlobals()};
+    ObjectPool pool;
+    TDescriptorTable thrift_descriptors;
+    TTupleDescriptor tuple_descriptor;
+    tuple_descriptor.id = 0;
+    tuple_descriptor.byteSize = 0;
+    tuple_descriptor.numNullBytes = 0;
+    thrift_descriptors.tupleDescriptors.push_back(tuple_descriptor);
+    DescriptorTbl* descriptors = nullptr;
+    ASSERT_TRUE(DescriptorTbl::create(&pool, thrift_descriptors, &descriptors).ok());
+    TPlanNode plan_node;
+    plan_node.node_id = 0;
+    plan_node.node_type = TPlanNodeType::FILE_SCAN_NODE;
+    plan_node.num_children = 0;
+    plan_node.limit = -1;
+    plan_node.row_tuples.push_back(0);
+    plan_node.file_scan_node.tuple_id = 0;
+    plan_node.__isset.file_scan_node = true;
+    FileScanOperatorX parent(&pool, plan_node, 0, *descriptors, 1);
+    FileScanLocalState local_state(&state, &parent);
+    RuntimeProfile profile("file_scanner_v2_partition_prune");
+    auto table_reader = std::make_unique<CapturingSplitTableReader>();
+    auto* captured = table_reader.get();
+    FileScannerV2 scanner(&state, &profile, std::move(table_reader));
+    scanner._local_state = &local_state;
+
+    TFileScanRangeParams params;
+    params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+    scanner._params = &params;
+    scanner._slot_id_to_global_index.emplace(7, format::GlobalIndex(0));
+    scanner._conjuncts = {VExprContext::create_shared(
+            slot_ref(7, 7, std::make_shared<DataTypeInt32>(), "partition_col"))};
+
+    const auto range = range_with_format("hive", TFileFormatType::FORMAT_PARQUET);
+    ASSERT_TRUE(scanner._prepare_table_reader_split(range, {}).ok());
+    EXPECT_EQ(captured->conjunct_count, 1);
+    EXPECT_EQ(captured->partition_prune_conjunct_count, 1);
 }
 
 // Scenario: Once FileScannerV2 is selected, an unsupported range must fail instead of falling back

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -47,6 +47,7 @@
 #include "format_v2/parquet/parquet_file_context.h"
 #include "format_v2/parquet/reader/native/block_split_bloom_filter.h"
 #include "io/fs/file_reader.h"
+#include "runtime/runtime_state.h"
 #include "util/thrift_util.h"
 namespace doris {
 namespace {
@@ -665,6 +666,79 @@ TEST(NativeParquetStatisticsTest, TypeDefinedBoundsRequireSupportedColumnOrder) 
     ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
                         metadata, page_indexes, schema, request, 1, &selected_ranges, &skip_plans,
                         nullptr)
+                        .ok());
+    EXPECT_TRUE(selected_ranges.empty());
+}
+
+TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresDisabledSessionSwitch) {
+    auto encode_int32 = [](int32_t value) {
+        std::string bytes(sizeof(value), '\0');
+        memcpy(bytes.data(), &value, sizeof(value));
+        return bytes;
+    };
+
+    auto column_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+    column_schema->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+    column_schema->local_id = 0;
+    column_schema->leaf_column_id = 0;
+    column_schema->type = std::make_shared<DataTypeInt32>();
+    column_schema->type_descriptor.doris_type = column_schema->type;
+    column_schema->type_descriptor.physical_type = tparquet::Type::INT32;
+    std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+    schema.push_back(std::move(column_schema));
+
+    tparquet::Statistics statistics;
+    statistics.__set_min_value(encode_int32(1));
+    statistics.__set_max_value(encode_int32(2));
+    statistics.__set_null_count(0);
+    tparquet::ColumnMetaData column_metadata;
+    column_metadata.__set_type(tparquet::Type::INT32);
+    column_metadata.__set_num_values(1);
+    column_metadata.__set_statistics(statistics);
+    tparquet::ColumnChunk chunk;
+    chunk.__set_meta_data(column_metadata);
+    tparquet::RowGroup row_group;
+    row_group.__set_columns({chunk});
+    row_group.__set_num_rows(1);
+    tparquet::ColumnOrder order;
+    order.__set_TYPE_ORDER(tparquet::TypeDefinedOrder());
+    tparquet::FileMetaData metadata;
+    metadata.__set_column_orders({order});
+    metadata.__set_row_groups({row_group});
+
+    format::FileScanRequest request;
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.predicate_columns = {format::LocalColumnIndex::top_level(format::LocalColumnId(0))};
+    request.conjuncts = {
+            VExprContext::create_shared(std::make_shared<MetadataInt32GreaterThanExpr>(100))};
+
+    TQueryOptions query_options;
+    query_options.__set_enable_expr_zonemap_filter(false);
+    RuntimeState state {query_options, TQueryGlobals()};
+    std::vector<int> selected_row_groups;
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(metadata, schema, request, nullptr,
+                                                               &selected_row_groups, false, nullptr,
+                                                               nullptr, &state)
+                        .ok());
+    EXPECT_TRUE(selected_row_groups.empty());
+
+    format::parquet::NativeParquetPageIndex page_index;
+    page_index.column_index.__set_min_values({encode_int32(1)});
+    page_index.column_index.__set_max_values({encode_int32(2)});
+    page_index.column_index.__set_null_pages({false});
+    page_index.column_index.__set_null_counts({0});
+    tparquet::PageLocation location;
+    location.__set_offset(0);
+    location.__set_compressed_page_size(10);
+    location.__set_first_row_index(0);
+    page_index.offset_index.__set_page_locations({location});
+    std::unordered_map<int, format::parquet::NativeParquetPageIndex> page_indexes;
+    page_indexes.emplace(0, std::move(page_index));
+    std::vector<format::parquet::RowRange> selected_ranges;
+    std::map<int, format::parquet::ParquetPageSkipPlan> skip_plans;
+    ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
+                        metadata, page_indexes, schema, request, 1, &selected_ranges, &skip_plans,
+                        nullptr, nullptr, &state)
                         .ok());
     EXPECT_TRUE(selected_ranges.empty());
 }

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -165,6 +165,21 @@ private:
     const std::string _expr_name = "MetadataInt32GreaterThanExpr";
 };
 
+class UnsafeMetadataBarrierExpr final : public VExpr {
+public:
+    UnsafeMetadataBarrierExpr() : VExpr(std::make_shared<DataTypeUInt8>(), false) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("unsafe metadata barrier must remain on the row path");
+    }
+    bool is_safe_to_execute_on_selected_rows() const override { return false; }
+
+private:
+    const std::string _expr_name = "UnsafeMetadataBarrierExpr";
+};
+
 class MetadataBoundsProbeExpr final : public VExpr {
 public:
     explicit MetadataBoundsProbeExpr(bool require_false_boolean = false)
@@ -670,7 +685,7 @@ TEST(NativeParquetStatisticsTest, TypeDefinedBoundsRequireSupportedColumnOrder) 
     EXPECT_TRUE(selected_ranges.empty());
 }
 
-TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresDisabledSessionSwitch) {
+TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresSwitchAndPreservesUnsafePrefix) {
     auto encode_int32 = [](int32_t value) {
         std::string bytes(sizeof(value), '\0');
         memcpy(bytes.data(), &value, sizeof(value));
@@ -741,6 +756,23 @@ TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresDisabledSessionSwitch) {
                         nullptr, nullptr, &state)
                         .ok());
     EXPECT_TRUE(selected_ranges.empty());
+
+    request.conjuncts.insert(
+            request.conjuncts.begin(),
+            VExprContext::create_shared(std::make_shared<UnsafeMetadataBarrierExpr>()));
+    selected_row_groups.clear();
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(metadata, schema, request, nullptr,
+                                                               &selected_row_groups, false, nullptr,
+                                                               nullptr, &state)
+                        .ok());
+    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+    ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
+                        metadata, page_indexes, schema, request, 1, &selected_ranges, &skip_plans,
+                        nullptr, nullptr, &state)
+                        .ok());
+    ASSERT_EQ(selected_ranges.size(), 1);
+    EXPECT_EQ(selected_ranges[0].start, 0);
+    EXPECT_EQ(selected_ranges[0].length, 1);
 }
 
 TEST(NativeParquetStatisticsTest, ContradictoryAllNullPageCountsDisablePruning) {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -165,21 +165,6 @@ private:
     const std::string _expr_name = "MetadataInt32GreaterThanExpr";
 };
 
-class UnsafeMetadataBarrierExpr final : public VExpr {
-public:
-    UnsafeMetadataBarrierExpr() : VExpr(std::make_shared<DataTypeUInt8>(), false) {}
-
-    const std::string& expr_name() const override { return _expr_name; }
-    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
-                               ColumnPtr&) const override {
-        return Status::InternalError("unsafe metadata barrier must remain on the row path");
-    }
-    bool is_safe_to_execute_on_selected_rows() const override { return false; }
-
-private:
-    const std::string _expr_name = "UnsafeMetadataBarrierExpr";
-};
-
 class MetadataBoundsProbeExpr final : public VExpr {
 public:
     explicit MetadataBoundsProbeExpr(bool require_false_boolean = false)
@@ -685,7 +670,7 @@ TEST(NativeParquetStatisticsTest, TypeDefinedBoundsRequireSupportedColumnOrder) 
     EXPECT_TRUE(selected_ranges.empty());
 }
 
-TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresSwitchAndPreservesUnsafePrefix) {
+TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresDisabledSessionSwitch) {
     auto encode_int32 = [](int32_t value) {
         std::string bytes(sizeof(value), '\0');
         memcpy(bytes.data(), &value, sizeof(value));
@@ -756,23 +741,6 @@ TEST(NativeParquetStatisticsTest, ZonemapPruningIgnoresSwitchAndPreservesUnsafeP
                         nullptr, nullptr, &state)
                         .ok());
     EXPECT_TRUE(selected_ranges.empty());
-
-    request.conjuncts.insert(
-            request.conjuncts.begin(),
-            VExprContext::create_shared(std::make_shared<UnsafeMetadataBarrierExpr>()));
-    selected_row_groups.clear();
-    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(metadata, schema, request, nullptr,
-                                                               &selected_row_groups, false, nullptr,
-                                                               nullptr, &state)
-                        .ok());
-    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
-    ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
-                        metadata, page_indexes, schema, request, 1, &selected_ranges, &skip_plans,
-                        nullptr, nullptr, &state)
-                        .ok());
-    ASSERT_EQ(selected_ranges.size(), 1);
-    EXPECT_EQ(selected_ranges[0].start, 0);
-    EXPECT_EQ(selected_ranges[0].length, 1);
 }
 
 TEST(NativeParquetStatisticsTest, ContradictoryAllNullPageCountsDisablePruning) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2198,7 +2198,15 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = ENABLE_RUNTIME_FILTER_PRUNE, needForward = true, fuzzy = true)
     public boolean enableRuntimeFilterPrune = true;
 
-    @VarAttrDef.VarAttr(name = ENABLE_RUNTIME_FILTER_PARTITION_PRUNE, needForward = true, fuzzy = true)
+    @VarAttrDef.VarAttr(
+            name = ENABLE_RUNTIME_FILTER_PARTITION_PRUNE,
+            description = {"控制支持该变量的 scanner 是否启用运行时过滤器分区裁剪。"
+                    + "File Scanner V2 始终启用安全的分区裁剪。默认为 true。",
+                    "Controls runtime-filter partition pruning in scanners that honor this variable. "
+                            + "File Scanner V2 always enables safe partition pruning. "
+                            + "The default value is true."},
+            needForward = true,
+            fuzzy = true)
     public boolean enableRuntimeFilterPartitionPrune = true;
 
     /**
@@ -2719,8 +2727,10 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(
             name = ENABLE_EXPR_ZONEMAP_FILTER,
             fuzzy = true,
-            description = {"控制 scanner 是否启用表达式 ZoneMap 过滤。默认为 true。",
-                    "Controls whether to enable expression ZoneMap filtering in scanners. "
+            description = {"控制支持该变量的 scanner 是否启用表达式 ZoneMap 过滤。"
+                    + "File Scanner V2 始终启用安全的表达式 ZoneMap 过滤。默认为 true。",
+                    "Controls expression ZoneMap filtering in scanners that honor this variable. "
+                            + "File Scanner V2 always enables safe expression ZoneMap filtering. "
                             + "The default value is true."},
             needForward = true)
     public boolean enableExprZonemapFilter = true;

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -374,6 +374,8 @@ struct TQueryOptions {
 
   148: optional i32 min_scanners_concurrency = 1;
   149: optional i32 min_scan_scheduler_concurrency = 0; //deprecated
+  // Controls runtime-filter partition pruning for readers that honor this option.
+  // FileScannerV2 always enables safe partition pruning.
   150: optional bool enable_runtime_filter_partition_prune = true;
 
   // The minimum memory that an operator required to run.
@@ -501,7 +503,8 @@ struct TQueryOptions {
   // enable plan local exchange node in fe
   223: optional bool enable_local_shuffle_planner;
 
-  // To control whether BE scan readers may apply expression-based ZoneMap pruning.
+  // Controls expression-based ZoneMap pruning for readers that honor this option.
+  // FileScannerV2 always enables safe expression ZoneMap pruning.
   224: optional bool enable_expr_zonemap_filter = true
 
   225: optional i64 runtime_filter_tree_publish_max_send_bytes = 268435456


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

File Scanner V2 inherited the legacy session gates for runtime-filter partition pruning and Parquet expression ZoneMap pruning. Disabling either switch therefore also disabled the corresponding V2 pruning path, even though V2 owns an independent pruning pipeline.

This change keeps both pruning paths enabled for File Scanner V2 regardless of the legacy session switch values. File Scanner V1 behavior is unchanged.

### Release note

File Scanner V2 always applies partition predicate pruning and Parquet expression ZoneMap pruning.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. File Scanner V2 no longer honors runtime_filter_partition_prune or expr_zonemap_filter; both pruning paths remain enabled.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

