### PR TITLE
[feature](dbt) Complete Doris incremental strategies

### DIFF
--- a/extension/dbt-doris/.pre-commit-config.yaml
+++ b/extension/dbt-doris/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ exclude: "^tests/.*"
 
 
 default_language_version:
-  python: python3.8
+  python: python3.10
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -40,13 +40,13 @@ repos:
   - id: black
     args:
     - "--line-length=99"
-    - "--target-version=py38"
+    - "--target-version=py310"
   - id: black
     alias: black-check
     stages: [manual]
     args:
     - "--line-length=99"
-    - "--target-version=py38"
+    - "--target-version=py310"
     - "--check"
     - "--diff"
 - repo: https://gitlab.com/pycqa/flake8
@@ -69,4 +69,3 @@ repos:
     args: [--show-error-codes, --pretty, --ignore-missing-imports]
     files: ^dbt/adapters
     language: system
-

--- a/extension/dbt-doris/README.md
+++ b/extension/dbt-doris/README.md
@@ -9,6 +9,15 @@ git clone https://github.com/apache/doris.git
 cd doris/extension/dbt-doris && pip install .
 ```
 
+## Status
+
+This adapter targets dbt Core 1.12.x on Python 3.10 or newer. It is not yet a
+dbt Fusion adapter.
+
+The Doris SQL, staging behavior, version boundaries, and configuration for
+incremental models are documented in
+[docs/incremental.zh-CN.md](docs/incremental.zh-CN.md).
+
 ## Configuring your profile
 
 Example entry for profiles.yml:

--- a/extension/dbt-doris/dbt/adapters/doris/__init__.py
+++ b/extension/dbt-doris/dbt/adapters/doris/__init__.py
@@ -30,4 +30,4 @@ Plugin = AdapterPlugin(
     adapter=DorisAdapter,
     credentials=DorisCredentials,
     include_path=doris.PACKAGE_PATH,
-    )
+)

--- a/extension/dbt-doris/dbt/adapters/doris/__version__.py
+++ b/extension/dbt-doris/dbt/adapters/doris/__version__.py
@@ -20,6 +20,6 @@
 
 
 # this 'version' must be set !!!
-# otherwise the adapters will not be found after the 'dbt init xxx' command 
+# otherwise the adapters will not be found after the 'dbt init xxx' command
 
 version = "1.0.0"

--- a/extension/dbt-doris/dbt/adapters/doris/column.py
+++ b/extension/dbt-doris/dbt/adapters/doris/column.py
@@ -19,12 +19,52 @@
 # under the License.
 
 from dataclasses import dataclass
+import re
 
 from dbt.adapters.base.column import Column
 
 
 @dataclass
 class DorisColumn(Column):
+    @classmethod
+    def from_description(cls, name: str, raw_data_type: str) -> "DorisColumn":
+        """Parse only Doris types whose parameters dbt must reason about.
+
+        The generic dbt parser truncates nested types such as
+        ``ARRAY<VARCHAR(20)>`` and parameterized non-numeric types such as
+        ``DATETIMEV2(6)``. Preserve those verbatim while structuring VARCHAR and
+        DECIMAL so schema comparison and safe string widening retain their
+        sizes.
+        """
+        raw_data_type = raw_data_type.strip()
+        varchar = re.fullmatch(
+            r"varchar\s*\(\s*(\d+)\s*\)",
+            raw_data_type,
+            flags=re.IGNORECASE,
+        )
+        if varchar is not None:
+            return cls(name, "varchar", char_size=int(varchar.group(1)))
+
+        decimal = re.fullmatch(
+            r"decimal\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)",
+            raw_data_type,
+            flags=re.IGNORECASE,
+        )
+        if decimal is not None:
+            return cls(
+                name,
+                "decimal",
+                numeric_precision=int(decimal.group(1)),
+                numeric_scale=int(decimal.group(2)),
+            )
+
+        return cls(name, raw_data_type)
+
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        """Render Doris syntax rather than dbt's unsupported CHARACTER VARYING."""
+        return "varchar({})".format(size)
+
     @property
     def quoted(self) -> str:
         return "`{}`".format(self.column)

--- a/extension/dbt-doris/dbt/adapters/doris/connections.py
+++ b/extension/dbt-doris/dbt/adapters/doris/connections.py
@@ -28,7 +28,7 @@ from mysql.connector.constants import FieldType
 from dbt import exceptions
 from dbt.adapters.contracts.connection import Credentials
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.adapters.contracts.connection import AdapterResponse, Connection, ConnectionState
+from dbt.adapters.contracts.connection import AdapterResponse, Connection
 from dbt.adapters.events.logging import AdapterLogger
 
 logger = AdapterLogger("doris")
@@ -42,7 +42,6 @@ class DorisCredentials(Credentials):
     password: str = ""
     database: Optional[str] = None
     schema: Optional[str] = None
-
 
     @property
     def type(self):
@@ -143,7 +142,26 @@ class DorisConnectionManager(SQLConnectionManager):
     def exception_handler(self, sql: str) -> ContextManager:
         try:
             yield
-        except mysql.connector.DatabaseError as e:
+        except mysql.connector.Error as e:
+            # A small number of adapter operations (currently transactional
+            # delete+insert on Doris 3.0+) issue a literal BEGIN. Roll back
+            # immediately on a failed statement so a pooled connection never
+            # retains an open server-side transaction. Outside an explicit
+            # transaction mysql-connector's rollback is a harmless no-op.
+            connection = self.get_if_exists()
+            if connection is not None and connection.handle is not None:
+                try:
+                    connection.handle.rollback()
+                except Exception:
+                    # The server-side transaction state is now unknown. Mark
+                    # the connection unusable so the pool cannot issue later
+                    # model SQL on it.
+                    connection.state = "fail"
+                    logger.debug(
+                        "Failed to roll back Doris connection after error; "
+                        "marking the connection failed"
+                    )
+                connection.transaction_open = False
             logger.debug(f"Doris database error: {e}, sql: {sql}")
             raise exceptions.DbtRuntimeError(str(e)) from e
         except Exception as e:
@@ -222,3 +240,49 @@ class DorisConnectionManager(SQLConnectionManager):
     def add_commit_query(self):
         """Override to prevent literal 'COMMIT' SQL from being sent to Doris."""
         pass
+
+    def add_query(
+        self,
+        sql,
+        auto_begin=True,
+        bindings=None,
+        abridge_sql_log=False,
+        retryable_exceptions=(),
+        retry_limit=1,
+    ):
+        """Run a query, then drain any extra result sets it produced.
+
+        mysql-connector executes semicolon-separated statements in a single
+        `execute()` call but only surfaces the first result. The remaining sets
+        stay queued on the connection, and the next statement fails with
+        `2014 (HY000) Commands out of sync; you can't run this command now`.
+        The originating statement itself succeeds, so the error surfaces on
+        whatever dbt does next -- typically dropping a temp relation, which then
+        leaks.
+
+        Macros are expected to emit one statement per dbt statement, so this is a
+        safety net rather than the primary fix. Draining only runs for statements
+        that produced no fetchable rows, which leaves ordinary SELECT results
+        intact for dbt to consume.
+        """
+        connection, cursor = super().add_query(
+            sql,
+            auto_begin=auto_begin,
+            bindings=bindings,
+            abridge_sql_log=abridge_sql_log,
+            retryable_exceptions=retryable_exceptions,
+            retry_limit=retry_limit,
+        )
+
+        if cursor is not None and not cursor.with_rows:
+            drained = 0
+            with self.exception_handler(sql):
+                while cursor.nextset():
+                    drained += 1
+            if drained:
+                logger.debug(
+                    f"Drained {drained} extra result set(s); a macro emitted "
+                    f"multiple statements in one dbt statement: {sql}"
+                )
+
+        return connection, cursor

--- a/extension/dbt-doris/dbt/adapters/doris/doris_column_item.py
+++ b/extension/dbt-doris/dbt/adapters/doris/doris_column_item.py
@@ -40,7 +40,7 @@ class DorisColumnItem:
     def get_view_column_constraint(self):
         res = ""
         if self._col_comment != "":
-            res  = f"`{self._col_name}` COMMENT '{self._col_comment}'"
+            res = f"`{self._col_name}` COMMENT '{self._col_comment}'"
         else:
             res = f"`{self._col_name}`"
         return res

--- a/extension/dbt-doris/dbt/adapters/doris/impl.py
+++ b/extension/dbt-doris/dbt/adapters/doris/impl.py
@@ -21,25 +21,26 @@
 from dbt.adapters.sql import SQLAdapter
 
 from enum import Enum
+import re
+import time
 from typing import (
     Any,
     Dict,
     FrozenSet,
-    Iterable,
     List,
     Optional,
-    Set,
     Tuple,
 )
 
 import agate
 import dbt.exceptions
 from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.base.meta import available
 from dbt.adapters.doris.column import DorisColumn
 from dbt.adapters.doris.connections import DorisConnectionManager
 from dbt.adapters.doris.relation import DorisRelation
 from dbt.adapters.protocol import AdapterConfig
-from dbt.adapters.contracts.relation import RelationConfig, RelationType
+from dbt.adapters.contracts.relation import RelationType
 from dbt.adapters.sql.impl import LIST_RELATIONS_MACRO_NAME, LIST_SCHEMAS_MACRO_NAME
 from dbt_common.clients.agate_helper import table_from_rows
 from dbt.adapters.doris.doris_column_item import DorisColumnItem
@@ -75,6 +76,133 @@ class DorisAdapter(SQLAdapter):
     AdapterSpecificConfigs = DorisConfig
     Column = DorisColumn
 
+    def valid_incremental_strategies(self):
+        """Return the dbt built-in strategies implemented by dbt-doris."""
+        return ["append", "merge", "delete+insert", "insert_overwrite"]
+
+    @staticmethod
+    def _parse_doris_version(version_string):
+        if not version_string:
+            return None
+
+        match = re.search(
+            r"(?:doris\s+version\s+)?doris-"
+            r"(\d+)\.(\d+)(?:\.(\d+))?",
+            str(version_string),
+            flags=re.IGNORECASE,
+        )
+        if match is None:
+            return None
+
+        return tuple(int(part or 0) for part in match.groups())
+
+    def _doris_version(self):
+        _, variables = self.execute(
+            "show variables like 'version_comment'",
+            auto_begin=False,
+            fetch=True,
+        )
+        if len(variables.rows) > 0:
+            version = self._parse_doris_version(variables.rows[0][1])
+            if version is not None and version != (0, 0, 0):
+                return version
+
+        # Source/custom builds may omit a usable version from version_comment.
+        _, frontends = self.execute(
+            "show frontends",
+            auto_begin=False,
+            fetch=True,
+        )
+        version_index = list(frontends.column_names).index("Version")
+        connected_index = (
+            list(frontends.column_names).index("CurrentConnected")
+            if "CurrentConnected" in frontends.column_names
+            else None
+        )
+        rows = list(frontends.rows)
+        if connected_index is not None:
+            connected_rows = [
+                row
+                for row in rows
+                if str(row[connected_index]).lower() in ("yes", "true")
+            ]
+            if connected_rows:
+                rows = connected_rows
+
+        for row in rows:
+            version = self._parse_doris_version(row[version_index])
+            if version is not None and version != (0, 0, 0):
+                return version
+        return None
+
+    @available
+    def supports_transactional_delete_insert(self):
+        """Whether Doris supports DELETE and INSERT SELECT in one transaction."""
+        version = self._doris_version()
+        return version is not None and version >= (3, 0, 0)
+
+    def _latest_schema_change_job(self, relation: BaseRelation):
+        schema = self.quote(relation.schema)
+        table_name = relation.identifier.replace("'", "''")
+        _, table = self.execute(
+            "show alter table column from {} "
+            "where TableName = '{}' "
+            "order by JobId desc limit 1".format(schema, table_name),
+            auto_begin=False,
+            fetch=True,
+        )
+        if len(table.rows) == 0:
+            return None
+
+        row = table.rows[0]
+        return {
+            "job_id": str(row[0]),
+            "state": str(row[9]).upper(),
+            "message": str(row[10] or ""),
+        }
+
+    @available
+    def get_latest_schema_change_job_id(self, relation: BaseRelation):
+        """Return the newest column-alter job id for a Doris table."""
+        job = self._latest_schema_change_job(relation)
+        return None if job is None else job["job_id"]
+
+    @available
+    def wait_for_schema_change(
+        self,
+        relation: BaseRelation,
+        previous_job_id=None,
+        timeout_seconds: int = 300,
+    ):
+        """Wait for the column-alter job started by the preceding DDL."""
+        deadline = time.monotonic() + timeout_seconds
+
+        while True:
+            job = self._latest_schema_change_job(relation)
+            if job is None or job["job_id"] == previous_job_id:
+                return
+            if job["state"] == "FINISHED":
+                return
+            if job["state"] == "CANCELLED":
+                raise dbt.exceptions.DbtRuntimeError(
+                    "Doris schema change job {} for {} was cancelled: {}".format(
+                        job["job_id"],
+                        relation,
+                        job["message"],
+                    )
+                )
+            if time.monotonic() >= deadline:
+                raise dbt.exceptions.DbtRuntimeError(
+                    "Timed out after {} seconds waiting for Doris schema "
+                    "change job {} on {} (state: {})".format(
+                        timeout_seconds,
+                        job["job_id"],
+                        relation,
+                        job["state"],
+                    )
+                )
+            time.sleep(0.2)
+
     @classmethod
     def date_function(cls) -> str:
         return "current_date()"
@@ -87,7 +215,8 @@ class DorisAdapter(SQLAdapter):
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "string"
 
-    def quote(self, identifier):
+    @classmethod
+    def quote(cls, identifier):
         return "`{}`".format(identifier)
 
     def check_schema_exists(self, database, schema):
@@ -177,7 +306,6 @@ class DorisAdapter(SQLAdapter):
         # '+ interval' syntax used in postgres/redshift is relatively common
         # and might even be the SQL standard's intention.
         return f"{add_to} + interval {number} {interval}"
-
 
     @classmethod
     def render_raw_columns_constraints(cls, raw_columns: Dict[str, Dict[str, Any]]) -> List:

--- a/extension/dbt-doris/dbt/include/doris/macros/adapters/columns.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/adapters/columns.sql
@@ -28,23 +28,100 @@
         order by ordinal_position
     {% endcall %}
     {% set table = load_result('get_columns_in_relation').table %}
-    {{ return(sql_convert_columns_in_relation(table)) }}
-{%- endmacro %}
-
-{% macro sql_convert_columns_in_relation(table) -%}
     {% set columns = [] %}
     {% for row in table %}
         {% set col_name = row['column'] %}
         {% set col_type = row['dtype'] %}
-        {% do columns.append(api.Column.create(col_name, col_type)) %}
+        {# Preserve complex Doris types verbatim. Only split the two primitive
+           parameterized types dbt itself compares structurally. #}
+        {% if col_type.lower().startswith('varchar(') %}
+            {% do columns.append(api.Column(
+                col_name,
+                'varchar',
+                row['char_size'],
+                none,
+                none
+            )) %}
+        {% elif col_type.lower().startswith('decimal(') %}
+            {% do columns.append(api.Column(
+                col_name,
+                'decimal',
+                none,
+                row['numeric_precision'],
+                row['numeric_scale']
+            )) %}
+        {% else %}
+            {% do columns.append(api.Column(
+                col_name,
+                col_type,
+                none,
+                none,
+                none
+            )) %}
+        {% endif %}
     {% endfor %}
     {{ return(columns) }}
 {%- endmacro %}
 
 {% macro doris__alter_column_type(relation, column_name, new_column_type) -%}
+    {% set previous_job_id = adapter.get_latest_schema_change_job_id(relation) %}
     {% call statement('alter_column_type') %}
-        alter table {{ relation }} modify column {{ column_name }} {{ new_column_type }}
+        alter table {{ relation }} modify column
+            {{ adapter.quote(column_name) }} {{ new_column_type }}
     {% endcall %}
+    {% do adapter.wait_for_schema_change(relation, previous_job_id) %}
+{% endmacro %}
+
+
+{% macro doris__sync_column_schemas(
+    on_schema_change,
+    target_relation,
+    schema_changes_dict
+) %}
+    {% set add_to_target = schema_changes_dict['source_not_in_target'] %}
+    {% set remove_from_target = schema_changes_dict['target_not_in_source'] %}
+    {% set new_target_types = schema_changes_dict['new_target_types'] %}
+
+    {% if on_schema_change == 'append_new_columns' %}
+        {% if add_to_target | length > 0 %}
+            {% set previous_job_id = adapter.get_latest_schema_change_job_id(
+                target_relation
+            ) %}
+            {% do alter_relation_add_remove_columns(
+                target_relation,
+                add_to_target,
+                none
+            ) %}
+            {% do adapter.wait_for_schema_change(
+                target_relation,
+                previous_job_id
+            ) %}
+        {% endif %}
+
+    {% elif on_schema_change == 'sync_all_columns' %}
+        {% if add_to_target | length > 0 or remove_from_target | length > 0 %}
+            {% set previous_job_id = adapter.get_latest_schema_change_job_id(
+                target_relation
+            ) %}
+            {% do alter_relation_add_remove_columns(
+                target_relation,
+                add_to_target,
+                remove_from_target
+            ) %}
+            {% do adapter.wait_for_schema_change(
+                target_relation,
+                previous_job_id
+            ) %}
+        {% endif %}
+
+        {% for type_change in new_target_types %}
+            {% do alter_column_type(
+                target_relation,
+                type_change['column_name'],
+                type_change['new_type']
+            ) %}
+        {% endfor %}
+    {% endif %}
 {% endmacro %}
 
 {% macro columns_and_constraints(table_type="table") %}
@@ -72,7 +149,7 @@
     {#-- Views do not support MODIFY COMMENT, only tables do --#}
     {% if relation.type != 'view' %}
         {% call statement('alter_relation_comment') %}
-            alter table {{ relation }} modify comment '{{ relation_comment }}'
+            alter table {{ relation }} modify comment '{{ relation_comment | replace("\\", "\\\\") | replace("'", "\\'") }}'
         {% endcall %}
     {% endif %}
 {% endmacro %}
@@ -81,10 +158,20 @@
     {#-- Views do not support MODIFY COLUMN COMMENT; column comments for views
          are set at CREATE VIEW time via column definitions --#}
     {% if relation.type != 'view' %}
-        {% for column_name, column_comment in column_dict.items() %}
-            {% call statement('alter_column_comment') %}
-                alter table {{ relation }} modify column `{{ column_name }}` comment '{{ column_comment }}'
-            {% endcall %}
+        {#-- dbt hands us {column_name: column_info_dict}, not {name: description}.
+             Interpolating the value directly wrote the whole dict repr into the
+             comment, and its embedded quotes broke the statement outright.
+
+             The column type is deliberately omitted: Doris accepts
+             `MODIFY COLUMN <col> COMMENT '<c>'`, and naming a type there is
+             rejected for distribution and key columns. --#}
+        {% for column_name, column_info in column_dict.items() %}
+            {% set comment = (column_info.get('description') or '') if column_info is mapping else (column_info or '') %}
+            {% if comment %}
+                {% call statement('alter_column_comment') %}
+                    alter table {{ relation }} modify column `{{ column_name }}` comment '{{ comment | replace("\\", "\\\\") | replace("'", "\\'") }}'
+                {% endcall %}
+            {% endif %}
         {% endfor %}
     {% endif %}
 {% endmacro %}

--- a/extension/dbt-doris/dbt/include/doris/macros/adapters/relation.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/adapters/relation.sql
@@ -80,7 +80,7 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro doris__distributed_by(column_names) -%}
+{% macro doris__distributed_by(column_names=none) -%}
   {% set engine = config.get('engine', validator=validation.any[basestring]) %}
   {% set cols = config.get('distributed_by', validator=validation.any[list, basestring]) %}
   {% if cols is none and engine in [none,'OLAP'] %}
@@ -99,18 +99,26 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro doris__properties() -%}
-  {% set properties = config.get('properties', validator=validation.any[dict]) %}
-  {% set replice_num =  config.get('replication_num') %}
+{% macro doris__properties(default_properties=none) -%}
+  {# Work on a new dictionary. Mutating config.get('properties') leaked
+     adapter defaults into the parsed model config for later macros. #}
+  {% set properties = {} %}
+  {% if default_properties %}
+    {% do properties.update(default_properties) %}
+  {% endif %}
+
+  {% set configured_properties = config.get('properties', validator=validation.any[dict]) %}
+  {% if configured_properties %}
+    {% do properties.update(configured_properties) %}
+  {% endif %}
+
+  {% set replice_num = config.get('replication_num') %}
 
   {% if replice_num is not none %}
-    {% if properties is none %}
-      {% set properties = {} %}
-    {% endif %}
     {% do properties.update({'replication_num': replice_num}) %}
   {% endif %}
 
-  {% if properties is not none %}
+  {% if properties %}
     PROPERTIES (
         {% for key, value in properties.items() %}
           "{{ key }}" = "{{ value }}"{% if not loop.last %},{% endif %}
@@ -138,6 +146,24 @@
     {% endcall %}
 {%- endmacro %}
 
+{% macro doris__view_query_from_show_create(show_create_sql) -%}
+  {# SHOW CREATE VIEW includes an output-column list before the real AS
+     delimiter. Split only on a complete AS token: identifiers such as
+     ASSET_ID must not be mistaken for that delimiter. #}
+  {% set parts = modules.re.split(
+      '\\s+AS\\s+',
+      show_create_sql,
+      maxsplit=1,
+      flags=modules.re.IGNORECASE
+  ) %}
+  {% if parts | length != 2 %}
+    {% do exceptions.raise_compiler_error(
+        "Could not extract the Doris view query from SHOW CREATE VIEW output."
+    ) %}
+  {% endif %}
+  {{ return(parts[1] | trim | trim(';')) }}
+{%- endmacro %}
+
 {% macro doris__rename_relation(from_relation, to_relation) -%}
   {% call statement('drop_relation') %}
     drop {{ to_relation.type }} if exists {{ to_relation }}
@@ -145,7 +171,9 @@
   {% call statement('rename_relation') %}
     {% if to_relation.is_view %}
     {% set results = run_query('show create view ' + from_relation.render() ) %}
-    create view {{ to_relation }} as {{ results[0]['Create View'].split('AS',1)[1] }}
+    create view {{ to_relation }} as {{ doris__view_query_from_show_create(
+        results[0]['Create View']
+    ) }}
     {% else %}
     alter table {{ from_relation }} rename {{ to_relation.table }}
     {% endif %}
@@ -166,13 +194,17 @@
     {% set from_results = run_query('show create view ' + relation1.render() ) %}
     {% set to_results = run_query('show create view ' + relation2.render() ) %}
       {% call statement('exchange_view_relation') %}
-        alter view {{ relation1 }} as {{  to_results[0]['Create View'].split('AS',1)[1] }}
+        alter view {{ relation1 }} as {{ doris__view_query_from_show_create(
+            to_results[0]['Create View']
+        ) }}
       {% endcall %}
     {% if is_drop_r1 %}
       {% do doris__drop_relation(relation2) %}
     {% else %}
       {% call statement('exchange_view_relation') %}
-        alter view {{ relation2 }} as {{  from_results[0]['Create View'].split('AS',1)[1] }}
+        alter view {{ relation2 }} as {{ doris__view_query_from_show_create(
+            from_results[0]['Create View']
+        ) }}
       {% endcall %}
     {% endif %}
   {% else %}

--- a/extension/dbt-doris/dbt/include/doris/macros/materializations/incremental/help.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/materializations/incremental/help.sql
@@ -28,40 +28,430 @@
 {% endmacro %}
 
 
-{% macro tmp_delete(tmp_relation, target_relation, unique_key=none, statement_name="pre_main") %}
-  {% if unique_key is not none %}
-    {% set unique_key_str %}
-        {% for item in unique_key %} 
-                {{ item }},  
-        {% endfor %}
-    {% endset %}
-     insert into  {{ target_relation }} ( {{unique_key_str ~'`__DORIS_DELETE_SIGN__`'}})
-    select  {{ unique_key_str }} 
-        1 as `__DORIS_DELETE_SIGN__`
-        from {{ tmp_relation }}
-  {% endif %}
-{%- endmacro %}
+{% macro doris__normalize_unique_key(unique_key) %}
+    {% if unique_key is none %}
+        {{ return([]) }}
+    {% elif unique_key is string %}
+        {{ return([unique_key]) }}
+    {% else %}
+        {{ return(unique_key | list) }}
+    {% endif %}
+{% endmacro %}
 
 
-{% macro tmp_insert(tmp_relation, target_relation, unique_key=none, statement_name="main") %}
-    {%- set dest_cols_csv = adapter.get_columns_in_relation(target_relation) | map(attribute='quoted') | join(', ') -%}
-    insert into {{ target_relation }} ({{ dest_cols_csv }})
-    (
-       select {{ dest_cols_csv }}
-       from {{ tmp_relation }}
-    )
-{%- endmacro %}
+{% macro doris__effective_incremental_strategy(strategy, unique_key) %}
+    {% if strategy == 'default' %}
+        {{ return('merge' if doris__normalize_unique_key(unique_key) else 'append') }}
+    {% endif %}
+    {{ return(strategy) }}
+{% endmacro %}
 
-{% macro show_create( target_relation, statement_name="table_model") %}
-    show create table {{ target_relation }}
-{%- endmacro %}
 
-{% macro is_unique_model( target_relation ) %}
-    {% set build_show_create = show_create( target_relation, statement_name='table_model') %}
-    {% call statement('table_model' , fetch_result=True)  %}
-        {{ build_show_create }}
+{% macro doris__normalized_column_names(columns) %}
+    {% set names = [] %}
+    {% for column in columns %}
+        {% do names.append(column.name | lower) %}
+    {% endfor %}
+    {{ return(names) }}
+{% endmacro %}
+
+
+{% macro doris__validate_source_unique_key_columns(source_columns, unique_key) %}
+    {% set source_names = doris__normalized_column_names(source_columns) %}
+    {% set missing_keys = [] %}
+    {% for key in doris__normalize_unique_key(unique_key) %}
+        {% if key | lower not in source_names %}
+            {% do missing_keys.append(key) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if missing_keys %}
+        {% set message -%}
+Incremental model {{ model.unique_id }} does not return configured unique_key
+column(s) {{ missing_keys }}. No target data has been changed.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+{% endmacro %}
+
+
+{% macro doris__validate_unique_key_schema_changes(schema_changes, unique_key) %}
+    {% set unique_keys = [] %}
+    {% for key in doris__normalize_unique_key(unique_key) %}
+        {% do unique_keys.append(key | lower) %}
+    {% endfor %}
+
+    {% set changed_key_types = [] %}
+    {% for type_change in schema_changes['new_target_types'] %}
+        {% if type_change['column_name'] | lower in unique_keys %}
+            {% do changed_key_types.append(type_change['column_name']) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if changed_key_types %}
+        {% set message -%}
+Incremental model {{ model.unique_id }} changes the data type of UNIQUE KEY
+column(s) {{ changed_key_types }}. Doris cannot mutate physical key columns
+during an incremental run; use --full-refresh.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+{% endmacro %}
+
+
+{% macro doris__incremental_dest_columns_csv(dest_columns) %}
+    {% set quoted_columns = [] %}
+    {% for column in dest_columns %}
+        {% do quoted_columns.append(adapter.quote(column.name)) %}
+    {% endfor %}
+    {{ return(quoted_columns | join(', ')) }}
+{% endmacro %}
+
+
+{% macro doris__incremental_source_select(arg_dict) %}
+    {% set dest_columns = arg_dict['dest_columns'] %}
+    {% set source_sql = arg_dict.get('source_sql', none) %}
+    {# dbt's public strategy contract contains only target_relation,
+       temp_relation, unique_key, dest_columns and incremental_predicates.
+       Doris's direct path adds source_sql, but packages calling this macro with
+       the standard five keys must continue to read temp_relation. #}
+    {% set temp_relation_exists = arg_dict.get(
+        'temp_relation_exists',
+        source_sql is none
+    ) %}
+    select
+        {% for column in dest_columns -%}
+        DBT_INTERNAL_SOURCE.{{ adapter.quote(column.name) }}{% if not loop.last %}, {% endif %}
+        {%- endfor %}
+    from
+        {% if temp_relation_exists %}
+        {{ arg_dict['temp_relation'] }} DBT_INTERNAL_SOURCE
+        {% else %}
+        (
+            {{ source_sql }}
+        ) DBT_INTERNAL_SOURCE
+        {% endif %}
+{% endmacro %}
+
+
+{#
+    Make duplicate source keys fail inside the same statement as a direct Unique
+    Key upsert. The source is consumed once by a windowed derived table. A
+    correlated scalar subquery maps every duplicate count to two constant rows,
+    which Doris rejects before publishing the INSERT.
+
+    Do not rewrite this as two consumers of a CTE: Doris 2.1 may inline both
+    consumers, evaluating volatile model SQL twice and validating a different
+    batch from the one inserted.
+#}
+{% macro doris__validated_unique_source_select(arg_dict) %}
+    {% set unique_key = doris__normalize_unique_key(arg_dict['unique_key']) %}
+    {% set source_sql = arg_dict.get('source_sql', none) %}
+    {% set temp_relation_exists = arg_dict.get(
+        'temp_relation_exists',
+        source_sql is none
+    ) %}
+    {% set dest_columns = arg_dict['dest_columns'] %}
+
+    select
+        {% for column in dest_columns -%}
+        DBT_INTERNAL_SOURCE.{{ adapter.quote(column.name) }}{% if not loop.last %}, {% endif %}
+        {%- endfor %}
+    from (
+        select
+            {% for column in dest_columns -%}
+            DBT_INTERNAL_RAW_SOURCE.{{ adapter.quote(column.name) }},
+            {%- endfor %}
+            if(
+                count(*) over (
+                    partition by
+                        {% for key in unique_key -%}
+                        DBT_INTERNAL_RAW_SOURCE.{{ adapter.quote(key) }}{% if not loop.last %}, {% endif %}
+                        {%- endfor %}
+                ) > 1,
+                2,
+                1
+            ) as DBT_INTERNAL_UNIQUE_KEY_VALIDATION
+        from (
+            {% if temp_relation_exists %}
+            select * from {{ arg_dict['temp_relation'] }}
+            {% else %}
+            {{ source_sql }}
+            {% endif %}
+        ) DBT_INTERNAL_RAW_SOURCE
+    ) DBT_INTERNAL_SOURCE
+    where (
+        select DBT_INTERNAL_VALIDATION_MARKER
+        from (
+            select 1 as DBT_INTERNAL_VALIDATION_MARKER
+            union all
+            select 2 as DBT_INTERNAL_VALIDATION_MARKER
+            union all
+            select 2 as DBT_INTERNAL_VALIDATION_MARKER
+        ) DBT_INTERNAL_DUPLICATE_KEYS
+        where DBT_INTERNAL_DUPLICATE_KEYS.DBT_INTERNAL_VALIDATION_MARKER
+            = DBT_INTERNAL_SOURCE.DBT_INTERNAL_UNIQUE_KEY_VALIDATION
+    ) = 1
+{% endmacro %}
+
+
+{% macro doris__validated_unique_ctas_source_sql(
+    source_sql,
+    unique_key,
+    source_columns
+) %}
+    {% set arg_dict = {
+        'source_sql': source_sql,
+        'temp_relation_exists': false,
+        'unique_key': unique_key,
+        'dest_columns': source_columns
+    } %}
+    {{ return(doris__validated_unique_source_select(arg_dict)) }}
+{% endmacro %}
+
+
+{% macro doris__assert_staged_unique_keys(temp_relation, unique_key) %}
+    {% set arg_dict = {
+        'temp_relation': temp_relation,
+        'temp_relation_exists': true,
+        'unique_key': unique_key,
+        'dest_columns': adapter.get_columns_in_relation(temp_relation)
+    } %}
+    {% call statement('validate_incremental_unique_keys', fetch_result=true) %}
+        select count(*)
+        from (
+            {{ doris__validated_unique_source_select(arg_dict) }}
+        ) DBT_INTERNAL_VALIDATED_SOURCE
     {% endcall %}
-    {%- set table_create_obj = load_result('table_model') -%}
-    {% set create_table = table_create_obj['data'][0][1]%}
-    {{ return('\nUNIQUE KEY(' in create_table  and '\nDUPLICATE KEY(' not in create_table and '\nAGGREGATE KEY(' not in create_table) }}
-{%- endmacro %}
+{% endmacro %}
+
+
+{% macro doris__create_incremental_schema_view(relation, source_sql) %}
+    create or replace view {{ relation }} as {{ source_sql }}
+{% endmacro %}
+
+
+{% macro doris__schema_changes_from_columns(source_columns, target_columns) %}
+    {% set source_not_in_target = diff_columns(source_columns, target_columns) %}
+    {% set target_not_in_source = diff_columns(target_columns, source_columns) %}
+    {% set new_target_types = diff_column_data_types(
+        source_columns,
+        target_columns
+    ) %}
+    {% set schema_changed = (
+        source_not_in_target | length > 0
+        or target_not_in_source | length > 0
+        or new_target_types | length > 0
+    ) %}
+
+    {{ return({
+        'schema_changed': schema_changed,
+        'source_not_in_target': source_not_in_target,
+        'target_not_in_source': target_not_in_source,
+        'source_columns': source_columns,
+        'target_columns': target_columns,
+        'new_target_types': new_target_types
+    }) }}
+{% endmacro %}
+
+
+{% macro doris__raise_schema_change_failure(schema_changes) %}
+    {% set message -%}
+The source and target schemas on incremental model {{ model.unique_id }} are
+out of sync.
+
+Source columns not in target: {{ schema_changes['source_not_in_target'] }}
+Target columns not in source: {{ schema_changes['target_not_in_source'] }}
+New column types: {{ schema_changes['new_target_types'] }}
+
+Set on_schema_change to append_new_columns or sync_all_columns, update the
+schema manually, or run:
+
+    dbt run --full-refresh --select {{ model.name }}
+    {%- endset %}
+    {% do exceptions.raise_compiler_error(message) %}
+{% endmacro %}
+
+
+{% macro doris__overwrite_partition_clause(overwrite_partitions) %}
+    {% if overwrite_partitions is none %}
+        {{ return('') }}
+    {% endif %}
+
+    {% if overwrite_partitions is string %}
+        {% set partitions = [overwrite_partitions] %}
+    {% else %}
+        {% set partitions = overwrite_partitions | list %}
+    {% endif %}
+
+    {% if partitions == ['*'] %}
+        {{ return('partition(*)') }}
+    {% endif %}
+
+    {% set quoted_partitions = [] %}
+    {% for partition in partitions %}
+        {% do quoted_partitions.append(adapter.quote(partition)) %}
+    {% endfor %}
+    {{ return('partition(' ~ (quoted_partitions | join(', ')) ~ ')') }}
+{% endmacro %}
+
+
+{% macro doris__show_create_table(target_relation, statement_name='doris_incremental_show_create') %}
+    {% call statement(statement_name, fetch_result=True) %}
+        show create table {{ target_relation }}
+    {% endcall %}
+    {% set result = load_result(statement_name) %}
+    {% if result is none or result['data'] | length == 0 %}
+        {{ return('') }}
+    {% endif %}
+    {{ return(result['data'][0][1]) }}
+{% endmacro %}
+
+
+{% macro doris__get_table_model(target_relation) %}
+    {% set create_table = doris__show_create_table(target_relation) | upper %}
+    {% if 'UNIQUE KEY(' in create_table %}
+        {{ return('unique') }}
+    {% elif 'AGGREGATE KEY(' in create_table %}
+        {{ return('aggregate') }}
+    {% elif 'DUPLICATE KEY(' in create_table %}
+        {{ return('duplicate') }}
+    {% endif %}
+    {{ return('unknown') }}
+{% endmacro %}
+
+
+{% macro doris__is_mow_unique_model(target_relation) %}
+    {% set create_table = doris__show_create_table(
+        target_relation,
+        statement_name='doris_incremental_show_create_mow'
+    ) | lower | replace(' ', '') | replace('\n', '') %}
+    {{ return(
+        'uniquekey(' in create_table
+        and '"enable_unique_key_merge_on_write"="true"' in create_table
+    ) }}
+{% endmacro %}
+
+
+{% macro doris__has_physical_sequence_column(target_relation) %}
+    {% set create_table = doris__show_create_table(
+        target_relation,
+        statement_name='doris_incremental_show_create_sequence'
+    ) | lower | replace(' ', '') | replace('\n', '') %}
+    {{ return(
+        '"function_column.sequence_col"=' in create_table
+        or '"function_column.sequence_type"=' in create_table
+    ) }}
+{% endmacro %}
+
+
+{% macro doris__get_unique_key_columns(target_relation) %}
+    {% call statement('doris_incremental_unique_key_columns', fetch_result=True) %}
+        select column_name
+        from information_schema.columns
+        where table_schema = '{{ target_relation.schema | replace("'", "''") }}'
+          and table_name = '{{ target_relation.identifier | replace("'", "''") }}'
+          and column_key = 'UNI'
+        order by ordinal_position
+    {% endcall %}
+    {% set result = load_result('doris_incremental_unique_key_columns') %}
+    {% set columns = [] %}
+    {% for row in result['data'] %}
+        {% do columns.append(row[0]) %}
+    {% endfor %}
+    {{ return(columns) }}
+{% endmacro %}
+
+
+{% macro doris__validate_incremental_target(strategy, target_relation, unique_key) %}
+    {% set table_model = doris__get_table_model(target_relation) %}
+
+    {% if strategy == 'append' and table_model != 'duplicate' %}
+        {% set message -%}
+Doris incremental strategy 'append' requires a DUPLICATE KEY target, but
+{{ target_relation }} is {{ table_model | upper }}. Rebuild the model with:
+
+    dbt run --full-refresh --select {{ model.name }}
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+
+    {% if strategy in ['merge', 'delete+insert'] %}
+        {% if table_model != 'unique' %}
+            {% set message -%}
+Doris incremental strategy '{{ strategy }}' requires a UNIQUE KEY target, but
+{{ target_relation }} is {{ table_model | upper }}. Rebuild the model with:
+
+    dbt run --full-refresh --select {{ model.name }}
+            {%- endset %}
+            {% do exceptions.raise_compiler_error(message) %}
+        {% endif %}
+
+        {% set configured_keys = [] %}
+        {% for key in doris__normalize_unique_key(unique_key) %}
+            {% do configured_keys.append(key | lower) %}
+        {% endfor %}
+        {% set physical_keys = [] %}
+        {% for key in doris__get_unique_key_columns(target_relation) %}
+            {% do physical_keys.append(key | lower) %}
+        {% endfor %}
+
+        {% if configured_keys != physical_keys %}
+            {% set message -%}
+Doris incremental strategy '{{ strategy }}' configured unique_key
+{{ configured_keys }}, but {{ target_relation }} uses physical UNIQUE KEY
+{{ physical_keys }}. Rebuild it with:
+
+    dbt run --full-refresh --select {{ model.name }}
+            {%- endset %}
+            {% do exceptions.raise_compiler_error(message) %}
+        {% endif %}
+    {% endif %}
+
+    {% if strategy == 'merge' and not doris__is_mow_unique_model(target_relation) %}
+        {% set message -%}
+Doris incremental strategy 'merge' requires a Merge-on-Write UNIQUE KEY target.
+{{ target_relation }} is not Merge-on-Write. Rebuild it with:
+
+    dbt run --full-refresh --select {{ model.name }}
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+{% endmacro %}
+
+
+{# Backwards-compatible helpers retained for packages that called them directly. #}
+{% macro tmp_insert(tmp_relation, target_relation, unique_key=none, statement_name='main') %}
+    {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
+    {% set arg_dict = {
+        'temp_relation': tmp_relation,
+        'temp_relation_exists': true,
+        'dest_columns': dest_columns
+    } %}
+    insert into {{ target_relation }}
+        ({{ doris__incremental_dest_columns_csv(dest_columns) }})
+    {{ doris__incremental_source_select(arg_dict) }}
+{% endmacro %}
+
+
+{% macro tmp_delete(tmp_relation, target_relation, unique_key=none, statement_name='pre_main') %}
+    {% set keys = doris__normalize_unique_key(unique_key) %}
+    delete from {{ target_relation }} DBT_INTERNAL_DEST
+    using {{ tmp_relation }} DBT_INTERNAL_SOURCE
+    where
+        {% for key in keys %}
+        DBT_INTERNAL_DEST.{{ adapter.quote(key) }}
+            <=> DBT_INTERNAL_SOURCE.{{ adapter.quote(key) }}
+            {% if not loop.last %}and{% endif %}
+        {% endfor %}
+{% endmacro %}
+
+
+{% macro show_create(target_relation, statement_name='table_model') %}
+    show create table {{ target_relation }}
+{% endmacro %}
+
+
+{% macro is_unique_model(target_relation) %}
+    {{ return(doris__get_table_model(target_relation) == 'unique') }}
+{% endmacro %}

--- a/extension/dbt-doris/dbt/include/doris/macros/materializations/incremental/incremental.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/materializations/incremental/incremental.sql
@@ -16,98 +16,619 @@
 -- under the License.
 
 {% materialization incremental, adapter='doris' %}
-  {% set unique_key = config.get('unique_key', validator=validation.any[list]) %}
-  {% set strategy = dbt_doris_validate_get_incremental_strategy(config) %}
-  {% set full_refresh_mode = (should_full_refresh()) %}
   {% set target_relation = this.incorporate(type='table') %}
-  {% set existing_relation = load_relation(this) %}
-  {% set tmp_relation = make_temp_relation(this) %}
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
-  {% set to_drop = [] %}
-  {#-- append or no unique key --#}
-
-
-
-  {% if not unique_key or strategy == 'append'  %}
-        {#-- create table first --#}
-        {% if existing_relation is none  %}
-            {% set build_sql = doris__create_table_as(False, target_relation, sql) %}
-        {% elif existing_relation.is_view or full_refresh_mode %}
-            {#-- backup table is new table ,exchange table backup and old table #}
-            {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}
-            {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
-            {% do adapter.drop_relation(backup_relation) %} {#-- likes 'drop table if exists ... ' --#}
-            {% set run_sql = doris__create_table_as(False, backup_relation, sql) %}
-            {% call statement("run_sql") %}
-                {{ run_sql }}
-            {% endcall %}
-            {% do exchange_relation(target_relation, backup_relation, True) %}
-            {% set build_sql = "select 'hello doris'" %}
-        {#-- append data --#}
-        {% else %}
-            {% do to_drop.append(tmp_relation) %}
-            {% do run_query(create_table_as(True, tmp_relation, sql)) %}
-            {% set build_sql = tmp_insert(tmp_relation, target_relation, unique_key=none) %}
-        {% endif %}
-  {#-- insert overwrite --#}
-  {% elif strategy == 'insert_overwrite' %}
-        {#-- create table first --#}
-        {% if existing_relation is none  %}
-            {% set build_sql = doris__create_unique_table_as(False, target_relation, sql) %}
-        {#-- insert data refresh --#}
-        {% elif existing_relation.is_view or full_refresh_mode %}
-            {#-- backup table is new table ,exchange table backup and old table #}
-            {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}
-            {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
-            {% do adapter.drop_relation(backup_relation) %} {#-- likes 'drop table if exists ... ' --#}
-            {% set run_sql = doris__create_unique_table_as(False, backup_relation, sql) %}
-            {% call statement("run_sql") %}
-                {{ run_sql }}
-            {% endcall %}
-            {% do exchange_relation(target_relation, backup_relation, True) %}
-            {% set build_sql = "select 'hello doris'" %}
-        {#-- append data --#}
-        {% else %}
-          {#-- check doris unique table  --#}
-          {% if not is_unique_model(target_relation) %}
-                {% do exceptions.raise_compiler_error("doris table:"~ target_relation ~ ", model must be 'UNIQUE'" ) %}
-          {% endif %}
-          {#-- create temp duplicate table for this incremental task  --#}
-          {% do run_query(create_table_as(True, tmp_relation, sql)) %}
-          {% do to_drop.append(tmp_relation) %}
-          {% do adapter.expand_target_column_types(
-                 from_relation=tmp_relation,
-                 to_relation=target_relation) %}
-          {% set build_sql = tmp_insert(tmp_relation, target_relation, unique_key=unique_key) %}
-        {% endif %}
-  {% else %}
-          {#-- never  --#}
+  {% set existing_relation = load_cached_relation(this) %}
+  {% set temp_relation = make_temp_relation(target_relation) %}
+  {% set intermediate_relation = make_intermediate_relation(target_relation) %}
+  {# A failed view -> table replacement can leave the old object at dbt's
+     backup name while the canonical target is absent. Restore it before stale
+     helper cleanup, so a retry can never delete the only good copy. #}
+  {% set recovery_backup_relation = load_cached_relation(
+      make_backup_relation(target_relation, 'table')
+  ) %}
+  {% if existing_relation is none and recovery_backup_relation is not none %}
+      {% set recovery_target_relation = target_relation.incorporate(
+          type=recovery_backup_relation.type
+      ) %}
+      {% do adapter.rename_relation(
+          recovery_backup_relation,
+          recovery_target_relation
+      ) %}
+      {% set existing_relation = load_cached_relation(
+          recovery_target_relation
+      ) %}
   {% endif %}
 
-  {% call statement("main") %}
+  {% set backup_relation_type = (
+      'table' if existing_relation is none else existing_relation.type
+  ) %}
+  {% set backup_relation = make_backup_relation(
+      target_relation,
+      backup_relation_type
+  ) %}
+
+  {% set unique_key = config.get('unique_key') %}
+  {% set strategy = dbt_doris_validate_get_incremental_strategy(config) %}
+  {% set effective_strategy = doris__effective_incremental_strategy(
+      strategy,
+      unique_key
+  ) %}
+  {# Resolve the public dbt strategy before hooks or writes, so a missing
+     custom macro and an unsupported built-in fail early. #}
+  {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(
+      context,
+      strategy
+  ) %}
+  {% set full_refresh_mode = (
+      should_full_refresh()
+      or (existing_relation is not none and existing_relation.type != 'table')
+  ) %}
+  {% set on_schema_change = incremental_validate_on_schema_change(
+      config.get('on_schema_change'),
+      default='ignore'
+  ) %}
+  {% set incremental_predicates = (
+      config.get('predicates', none)
+      or config.get('incremental_predicates', none)
+  ) %}
+  {% set overwrite_partitions = config.get('overwrite_partitions', none) %}
+  {% set grant_config = config.get('grants') %}
+
+  {% set preexisting_temp_relation = load_cached_relation(temp_relation) %}
+  {% set preexisting_intermediate_relation = load_cached_relation(
+      intermediate_relation
+  ) %}
+  {% set preexisting_backup_relation = load_cached_relation(backup_relation) %}
+  {{ drop_relation_if_exists(preexisting_temp_relation) }}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {% if existing_relation is not none and not full_refresh_mode %}
+      {% do doris__validate_incremental_target(
+          effective_strategy,
+          target_relation,
+          unique_key
+      ) %}
+  {% endif %}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set to_drop = [] %}
+  {% set need_swap = false %}
+  {% set delete_insert_transaction = false %}
+  {% set sql_header = config.get('sql_header', none) %}
+  {# Execute the header once, before metadata inspection and model SQL. Embedding
+     it in the empty-schema query loses cursor.description when the header is a
+     SET statement, while repeating it in helper/view/DML statements is not the
+     dbt sql_header contract. #}
+  {% if sql_header is not none %}
+      {% do run_query(sql_header) %}
+  {% endif %}
+  {% set source_sql = doris__table_colume_type(sql) %}
+
+  {# A MOW Unique Key INSERT already has the exact final-row semantics of
+     delete+insert when predicates and partial updates are absent. Avoid the
+     physical batch and the Doris 3.0 transaction requirement in that case.
+     Existing MOR Unique targets retain the real two-statement strategy. #}
+  {% set execution_strategy = effective_strategy %}
+  {% set target_has_sequence_column = false %}
+  {% if (
+      existing_relation is not none
+      and not full_refresh_mode
+      and effective_strategy == 'delete+insert'
+  ) %}
+      {% set target_has_sequence_column =
+          doris__has_physical_sequence_column(target_relation) %}
+  {% endif %}
+  {% if target_has_sequence_column %}
+      {% do exceptions.raise_compiler_error(
+          "Doris incremental strategy 'delete+insert' is unsafe for a "
+          ~ "Unique Key target with a physical Sequence Column on "
+          ~ model.unique_id ~ ": the DELETE tombstone can retain the old "
+          ~ "sequence and suppress the replacement INSERT. Use strategy='merge' "
+          ~ "to preserve Doris Sequence semantics, or rebuild without Sequence."
+      ) %}
+  {% endif %}
+  {% if (
+      existing_relation is not none
+      and not full_refresh_mode
+      and effective_strategy == 'delete+insert'
+      and doris__is_mow_unique_model(target_relation)
+      and not target_has_sequence_column
+  ) %}
+      {% set execution_strategy = 'merge' %}
+      {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(
+          context,
+          'merge'
+      ) %}
+      {% do log(
+          "Routing Doris delete+insert to one-statement MOW Unique Key upsert "
+          ~ "for " ~ target_relation,
+          info=false
+      ) %}
+  {% endif %}
+
+  {# Validate configured keys against the query metadata before CTAS, DELETE,
+     INSERT, or target schema mutation. This is a zero-row metadata query. #}
+  {% set source_columns = none %}
+  {% if effective_strategy in ['merge', 'delete+insert'] %}
+      {% set source_columns = get_column_schema_from_query(
+          source_sql
+      ) %}
+      {% do doris__validate_source_unique_key_columns(
+          source_columns,
+          unique_key
+      ) %}
+  {% endif %}
+
+  {% if (
+      execution_strategy == 'delete+insert'
+      and (
+          (existing_relation is not none and not full_refresh_mode)
+          or (
+              (config.get('properties', none) or {}).get(
+                  'enable_unique_key_merge_on_write',
+                  none
+              ) | string | lower == 'false'
+          )
+      )
+      and not adapter.supports_transactional_delete_insert()
+  ) %}
+      {% do exceptions.raise_compiler_error(
+          "Doris incremental strategy 'delete+insert' requires Doris 3.0+ "
+          ~ "for transactional DELETE plus INSERT on " ~ model.unique_id
+          ~ ". Use a MOW Unique Key table without a Sequence Column and "
+          ~ "strategy='merge', or upgrade Doris."
+      ) %}
+  {% endif %}
+
+  {% if existing_relation is none %}
+      {% set build_sql = doris__get_incremental_create_table_as_sql(
+          effective_strategy,
+          target_relation,
+          source_sql,
+          source_columns
+      ) %}
+      {% set relation_for_indexes = target_relation %}
+
+  {% elif full_refresh_mode %}
+      {% set build_sql = doris__get_incremental_create_table_as_sql(
+          effective_strategy,
+          intermediate_relation,
+          source_sql,
+          source_columns
+      ) %}
+      {% set relation_for_indexes = intermediate_relation %}
+      {% set need_swap = true %}
+
+  {% else %}
+      {% set source_relation = none %}
+      {% set temp_relation_exists = false %}
+      {% set dest_columns = none %}
+
+      {# Multi-statement/custom strategies and schema-changing runs need a
+         frozen batch. Ordinary built-ins use only a metadata view and execute
+         one direct DML against inline source_sql. #}
+      {% set needs_physical_staging = (
+          execution_strategy not in ['append', 'merge', 'insert_overwrite']
+          or on_schema_change != 'ignore'
+      ) %}
+      {% if execution_strategy == 'delete+insert' %}
+          {% set delete_insert_transaction = true %}
+      {% endif %}
+
+      {% if needs_physical_staging %}
+          {% do run_query(doris__create_incremental_staging_table(
+              temp_relation,
+              source_sql
+          )) %}
+          {% set source_relation = temp_relation %}
+          {% set temp_relation_exists = true %}
+          {% do to_drop.append(source_relation) %}
+
+      {% else %}
+          {# A logical view stores no batch data. It gives Doris/dbt exact
+             VARCHAR lengths for Core-compatible type widening and preserves
+             dbt's standard five-key strategy contract through the DML. #}
+          {% set source_relation = temp_relation.incorporate(type='view') %}
+          {% do run_query(doris__create_incremental_schema_view(
+              source_relation,
+              source_sql
+          )) %}
+          {% set temp_relation_exists = true %}
+          {% do to_drop.append(source_relation) %}
+      {% endif %}
+
+      {% if source_relation is not none %}
+          {% if on_schema_change != 'ignore' %}
+              {% set schema_changes = check_for_schema_changes(
+                  source_relation,
+                  existing_relation
+              ) %}
+              {% if effective_strategy in ['merge', 'delete+insert'] %}
+                  {% do doris__validate_unique_key_schema_changes(
+                      schema_changes,
+                      unique_key
+                  ) %}
+              {% endif %}
+
+          {% endif %}
+
+          {% set contract_config = config.get('contract') %}
+          {% if (
+              source_relation is not none
+              and (not contract_config or not contract_config.enforced)
+          ) %}
+              {% do adapter.expand_target_column_types(
+                  from_relation=source_relation,
+                  to_relation=target_relation
+              ) %}
+          {% endif %}
+
+          {# Re-read after widening: dbt Core does not treat an automatically
+             widened string column as an on_schema_change mismatch. #}
+          {% if (
+              on_schema_change != 'ignore'
+              and source_relation is not none
+          ) %}
+              {% set schema_changes = check_for_schema_changes(
+                  source_relation,
+                  existing_relation
+              ) %}
+          {% endif %}
+
+          {% if on_schema_change != 'ignore' %}
+              {% if (
+                  on_schema_change == 'fail'
+                  and schema_changes['schema_changed']
+              ) %}
+                  {# Remove the frozen physical stage before raising. #}
+                  {% if source_relation is not none %}
+                      {% do adapter.drop_relation(source_relation) %}
+                  {% endif %}
+                  {% do doris__raise_schema_change_failure(schema_changes) %}
+              {% endif %}
+
+              {% if schema_changes['schema_changed'] %}
+                  {% do sync_column_schemas(
+                      on_schema_change,
+                      target_relation,
+                      schema_changes
+                  ) %}
+              {% endif %}
+              {% set dest_columns = schema_changes['source_columns'] %}
+          {% endif %}
+      {% endif %}
+
+      {% if not dest_columns %}
+          {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
+      {% endif %}
+
+      {% set strategy_arg_dict = {
+          'target_relation': target_relation,
+          'temp_relation': temp_relation,
+          'unique_key': unique_key,
+          'dest_columns': dest_columns,
+          'incremental_predicates': incremental_predicates,
+          'source_sql': source_sql,
+          'temp_relation_exists': temp_relation_exists,
+          'overwrite_partitions': overwrite_partitions,
+          'doris_transaction_managed': delete_insert_transaction
+      } %}
+      {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}
+      {% if delete_insert_transaction %}
+          {% set delete_sql = doris__get_delete_incremental_rows_sql(
+              strategy_arg_dict
+          ) %}
+      {% endif %}
+  {% endif %}
+
+  {% if delete_insert_transaction %}
+      {% do doris__assert_staged_unique_keys(temp_relation, unique_key) %}
+      {% call statement(
+          'begin_delete_insert_transaction',
+          auto_begin=false
+      ) %}
+          begin
+      {% endcall %}
+      {% call statement('delete_incremental_rows', auto_begin=false) %}
+          {{ delete_sql }}
+      {% endcall %}
+  {% endif %}
+
+  {% call statement('main') %}
       {{ build_sql }}
   {% endcall %}
 
-  {#--  {% do persist_docs(target_relation, model) %}  #}
+  {# DorisConnectionManager.commit intentionally manages only dbt's logical
+     flag. Real delete+insert opened a server transaction, so close it before
+     any hook, SHOW, DDL, grant, docs, or staging cleanup statement. A failed
+     DELETE/INSERT/COMMIT is rolled back by the connection exception handler. #}
+  {% if delete_insert_transaction %}
+      {% call statement(
+          'commit_delete_insert_transaction',
+          auto_begin=false
+      ) %}
+          commit
+      {% endcall %}
+  {% endif %}
+
+  {% if existing_relation is none or full_refresh_mode %}
+      {% do create_indexes(relation_for_indexes) %}
+  {% endif %}
+
+  {% if need_swap %}
+      {% if existing_relation.type == 'table' %}
+          {# swap=true leaves the old target online under intermediate_relation
+             until all post-processing succeeds and cleanup runs. #}
+          {% do exchange_relation(
+              target_relation,
+              intermediate_relation,
+              false
+          ) %}
+          {% do to_drop.append(intermediate_relation) %}
+      {% else %}
+          {% do adapter.rename_relation(existing_relation, backup_relation) %}
+          {% do adapter.rename_relation(intermediate_relation, target_relation) %}
+          {% do to_drop.append(backup_relation) %}
+      {% endif %}
+  {% endif %}
+
+  {% set should_revoke = should_revoke(
+      existing_relation,
+      full_refresh_mode=full_refresh_mode
+  ) %}
+  {% do apply_grants(
+      target_relation,
+      grant_config,
+      should_revoke=should_revoke
+  ) %}
+  {% do persist_docs(target_relation, model) %}
+
   {{ run_hooks(post_hooks, inside_transaction=True) }}
   {% do adapter.commit() %}
-  {% for rel in to_drop %}
-      {% do doris__drop_relation(rel) %}
+
+  {% for relation in to_drop %}
+      {% do adapter.drop_relation(relation) %}
   {% endfor %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 {%- endmaterialization %}
 
+
+{% macro doris__get_incremental_create_table_as_sql(
+    strategy,
+    relation,
+    sql,
+    source_columns=none
+) %}
+    {% if strategy in ['merge', 'delete+insert'] %}
+        {% set validated_sql = doris__validated_unique_ctas_source_sql(
+            sql,
+            config.get('unique_key'),
+            source_columns
+        ) %}
+        {{ return(doris__create_unique_table_as(
+            false,
+            relation,
+            validated_sql,
+            false,
+            true
+        )) }}
+    {% endif %}
+    {{ return(doris__create_table_as(
+        false,
+        relation,
+        sql,
+        false,
+        true
+    )) }}
+{% endmacro %}
+
+
 {% macro dbt_doris_validate_get_incremental_strategy(config) %}
-  {#-- Find and validate the incremental strategy #}
-  {%- set strategy = config.get('incremental_strategy') or 'insert_overwrite' -%}
-  {% set invalid_strategy_msg -%}
-    Invalid incremental strategy provided: {{ strategy }}
-    Expected one of: 'append', 'insert_overwrite'
-  {%- endset %}
-  {% if strategy not in ['append', 'insert_overwrite'] %}
-    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
-  {% endif %}
-  {% do return (strategy) %}
+    {% set unique_key = config.get('unique_key') %}
+    {% set strategy = config.get('incremental_strategy') or 'default' %}
+
+    {% if config.get('grants', none) %}
+        {% do exceptions.raise_compiler_error(
+            "The dbt 'grants' config is not implemented by dbt-doris yet. "
+            ~ "Remove it from incremental model " ~ model.unique_id
+            ~ " and manage Doris privileges separately."
+        ) %}
+    {% endif %}
+
+    {% if config.get('sequence_col', none) %}
+        {% do exceptions.raise_compiler_error(
+            "dbt-doris does not implement the bare 'sequence_col' config. "
+            ~ "Use Doris table property 'function_column.sequence_col' on "
+            ~ model.unique_id ~ " instead."
+        ) %}
+    {% endif %}
+
+    {# dbt maps '+' to '_' when resolving a strategy macro. Without this guard,
+       the non-standard alias silently resolves Doris's built-in macro while
+       bypassing dbt's built-in strategy validation. #}
+    {% if strategy == 'delete_insert' %}
+        {% do exceptions.raise_compiler_error(
+            "Incremental strategy 'delete_insert' is not a dbt strategy name. "
+            ~ "Use 'delete+insert' on model " ~ model.unique_id
+        ) %}
+    {% endif %}
+
+    {% set effective_strategy = doris__effective_incremental_strategy(
+        strategy,
+        unique_key
+    ) %}
+    {% set properties = config.get('properties', none) or {} %}
+    {% set normalized_property_names = [] %}
+    {% for property_name in properties.keys() %}
+        {% do normalized_property_names.append(property_name | lower) %}
+    {% endfor %}
+    {% if (
+        effective_strategy == 'delete+insert'
+        and (
+            'function_column.sequence_col' in normalized_property_names
+            or 'function_column.sequence_type' in normalized_property_names
+        )
+    ) %}
+        {% do exceptions.raise_compiler_error(
+            "Incremental strategy 'delete+insert' cannot create a Doris "
+            ~ "Sequence Column target on " ~ model.unique_id
+            ~ ". Use strategy='merge' to preserve Sequence semantics."
+        ) %}
+    {% endif %}
+
+    {% set configured_mow = properties.get(
+        'enable_unique_key_merge_on_write',
+        none
+    ) %}
+    {% if (
+        effective_strategy == 'merge'
+        and configured_mow is not none
+        and configured_mow | string | lower == 'false'
+    ) %}
+        {% do exceptions.raise_compiler_error(
+            "Incremental strategy 'merge' requires "
+            ~ "properties.enable_unique_key_merge_on_write=true on model "
+            ~ model.unique_id ~ ". Use strategy='delete+insert' for a "
+            ~ "Merge-on-Read Unique Key table."
+        ) %}
+    {% endif %}
+
+    {% set normalized_unique_key = doris__normalize_unique_key(unique_key) %}
+    {% if (
+        effective_strategy in ['merge', 'delete+insert']
+        and not normalized_unique_key
+    ) %}
+        {% set message -%}
+Incremental strategy '{{ effective_strategy }}' requires a 'unique_key' config on model
+{{ model.unique_id }}.
+
+Add a key, for example:
+    {{ '{{' }} config(
+        materialized='incremental',
+        incremental_strategy='{{ effective_strategy }}',
+        unique_key=['id']
+    ) {{ '}}' }}
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+
+    {% if effective_strategy in ['merge', 'delete+insert'] %}
+        {% for key in normalized_unique_key %}
+            {% if key is not string or not modules.re.fullmatch(
+                '[A-Za-z_][A-Za-z0-9_]*',
+                key
+            ) %}
+                {% set message -%}
+Invalid unique_key {{ key }} on model {{ model.unique_id }}. Doris table keys
+must be unquoted column names containing only letters, digits, and underscores.
+                {%- endset %}
+                {% do exceptions.raise_compiler_error(message) %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+    {% set overwrite_partitions = config.get('overwrite_partitions', none) %}
+    {% if (
+        overwrite_partitions is not none
+        and effective_strategy != 'insert_overwrite'
+    ) %}
+        {% set message -%}
+Config 'overwrite_partitions' is only valid with incremental strategy
+'insert_overwrite' on model {{ model.unique_id }}.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+
+    {% if overwrite_partitions is not none %}
+        {% if overwrite_partitions is string %}
+            {% set partitions = [overwrite_partitions] %}
+        {% else %}
+            {% set partitions = overwrite_partitions | list %}
+        {% endif %}
+
+        {% if not partitions %}
+            {% do exceptions.raise_compiler_error(
+                "Config 'overwrite_partitions' must not be empty on model "
+                ~ model.unique_id
+            ) %}
+        {% endif %}
+        {% if '*' in partitions and partitions != ['*'] %}
+            {% do exceptions.raise_compiler_error(
+                "Dynamic partition '*' cannot be combined with named "
+                "overwrite_partitions on model " ~ model.unique_id
+            ) %}
+        {% endif %}
+        {% if config.get('partition_by', none) is none %}
+            {% do exceptions.raise_compiler_error(
+                "Config 'overwrite_partitions' requires a partitioned Doris "
+                "target via 'partition_by' on model " ~ model.unique_id
+            ) %}
+        {% endif %}
+        {% for partition in partitions %}
+            {% if partition != '*' and (
+                partition is not string
+                or not modules.re.fullmatch(
+                    '[A-Za-z_][A-Za-z0-9_]*',
+                    partition
+                )
+            ) %}
+                {% do exceptions.raise_compiler_error(
+                    "Unsafe Doris partition name '" ~ partition
+                    ~ "' in overwrite_partitions on model " ~ model.unique_id
+                ) %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+    {% set incremental_predicates = (
+        config.get('predicates', none)
+        or config.get('incremental_predicates', none)
+    ) %}
+    {% if incremental_predicates and effective_strategy in [
+        'append',
+        'merge',
+        'delete+insert',
+        'insert_overwrite'
+    ] %}
+        {% set message -%}
+Config 'incremental_predicates' is not supported by Doris strategy
+'{{ effective_strategy }}'. Conditional target filtering requires the Doris
+4.1+ native MERGE INTO path, which is not enabled yet.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+
+    {% if effective_strategy == 'merge' and (
+        config.get('merge_update_columns', none)
+        or config.get('merge_exclude_columns', none)
+    ) %}
+        {% set message -%}
+Doris strategy 'merge' currently performs a full-row Unique Key upsert.
+'merge_update_columns' and 'merge_exclude_columns' require the Doris 4.1+
+native MERGE INTO path, which is not enabled yet.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+
+    {% set properties = config.get('properties', none) or {} %}
+    {% set mow = properties.get('enable_unique_key_merge_on_write') %}
+    {% if (
+        effective_strategy == 'merge'
+        and mow is not none
+        and mow | string | lower != 'true'
+    ) %}
+        {% set message -%}
+Doris strategy 'merge' requires
+properties={'enable_unique_key_merge_on_write': 'true'} on model
+{{ model.unique_id }}.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(message) %}
+    {% endif %}
+
+    {{ return(strategy) }}
 {% endmacro %}

--- a/extension/dbt-doris/dbt/include/doris/macros/materializations/incremental/strategies.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/materializations/incremental/strategies.sql
@@ -1,0 +1,106 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+{#
+    Doris strategy macros keep dbt Core's standard arg_dict keys and accept two
+    adapter-specific keys:
+
+      source_sql               compiled model SQL for a direct, single DML
+      temp_relation_exists     whether temp_relation is a named source
+
+    append, merge and insert_overwrite normally inline source_sql. The
+    delete+insert strategy receives a physical staging table because both DML
+    statements must read the exact same batch.
+#}
+
+{% macro doris__get_incremental_default_sql(arg_dict) %}
+    {% set effective_strategy = doris__effective_incremental_strategy(
+        'default',
+        arg_dict.get('unique_key')
+    ) %}
+    {% if effective_strategy == 'merge' %}
+        {{ return(doris__get_incremental_merge_sql(arg_dict)) }}
+    {% endif %}
+    {{ return(doris__get_incremental_append_sql(arg_dict)) }}
+{% endmacro %}
+
+
+{% macro doris__get_incremental_append_sql(arg_dict) %}
+    {% set target_relation = arg_dict['target_relation'] %}
+    {% set dest_columns = arg_dict['dest_columns'] %}
+    insert into {{ target_relation }}
+        ({{ doris__incremental_dest_columns_csv(dest_columns) }})
+    {{ doris__incremental_source_select(arg_dict) }}
+{% endmacro %}
+
+
+{% macro doris__get_incremental_merge_sql(arg_dict) %}
+    {# A full-row MOW Unique Key INSERT is Doris's portable 2.1+ upsert. Native
+       MERGE INTO is reserved for conditional/partial 4.1+ operations. #}
+    {% set target_relation = arg_dict['target_relation'] %}
+    {% set dest_columns = arg_dict['dest_columns'] %}
+    insert into {{ target_relation }}
+        ({{ doris__incremental_dest_columns_csv(dest_columns) }})
+    {{ doris__validated_unique_source_select(arg_dict) }}
+{% endmacro %}
+
+
+{% macro doris__get_incremental_delete_insert_sql(arg_dict) %}
+    {% set target_relation = arg_dict['target_relation'] %}
+    {% set dest_columns = arg_dict['dest_columns'] %}
+    {# This public strategy macro must remain one statement when called with
+       dbt's standard five-key arg_dict. On a Doris Unique Key target, a full-row
+       INSERT has the same final-row result as delete+insert and cannot leave an
+       uncommitted server transaction. The Doris materialization explicitly
+       performs the staged DELETE transaction for MOR targets around this
+       returned INSERT. #}
+    insert into {{ target_relation }}
+        ({{ doris__incremental_dest_columns_csv(dest_columns) }})
+    {% if arg_dict.get('doris_transaction_managed', false) %}
+        {{ doris__incremental_source_select(arg_dict) }}
+    {% else %}
+        {{ doris__validated_unique_source_select(arg_dict) }}
+    {% endif %}
+{% endmacro %}
+
+
+{% macro doris__get_delete_incremental_rows_sql(arg_dict) %}
+    {% set target_relation = arg_dict['target_relation'] %}
+    {% set temp_relation = arg_dict['temp_relation'] %}
+    {% set unique_key = doris__normalize_unique_key(arg_dict['unique_key']) %}
+    delete from {{ target_relation }} DBT_INTERNAL_DEST
+    using {{ temp_relation }} DBT_INTERNAL_SOURCE
+    where
+        {% for key in unique_key %}
+        DBT_INTERNAL_DEST.{{ adapter.quote(key) }}
+            <=> DBT_INTERNAL_SOURCE.{{ adapter.quote(key) }}
+            {% if not loop.last %}and{% endif %}
+        {% endfor %}
+{% endmacro %}
+
+
+{% macro doris__get_incremental_insert_overwrite_sql(arg_dict) %}
+    {% set target_relation = arg_dict['target_relation'] %}
+    {% set dest_columns = arg_dict['dest_columns'] %}
+    {% set partition_clause = doris__overwrite_partition_clause(
+        arg_dict.get('overwrite_partitions')
+    ) %}
+    insert overwrite table {{ target_relation }}
+        {{ partition_clause }}
+        ({{ doris__incremental_dest_columns_csv(dest_columns) }})
+    {{ doris__incremental_source_select(arg_dict) }}
+{% endmacro %}

--- a/extension/dbt-doris/dbt/include/doris/macros/materializations/table/create_table_as.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/materializations/table/create_table_as.sql
@@ -15,39 +15,103 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
-{% macro doris__create_table_as(temporary, relation, sql) -%}
+{#--
+    NOTE: this macro must emit exactly one statement.
+
+    It used to prepend `drop table if exists ...` when temporary=True, which put
+    two semicolon-separated statements into a single dbt statement. The connector
+    executes those in one `execute()` call and leaves unconsumed result sets
+    behind, so the next statement on that connection fails with
+    `2014 Commands out of sync`. Callers now drop the relation themselves.
+--#}
+{% macro doris__create_table_as(
+    temporary,
+    relation,
+    sql,
+    include_sql_header=true,
+    sql_is_prepared=false
+) -%}
     {% set sql_header = config.get('sql_header', none) %}
     {% set table = relation.include(database=False) %}
-    {{ sql_header if sql_header is not none }}
-    {%if temporary %}
-        {{doris__drop_relation(relation)}}
-    {% endif %}
+    {% set select_sql = (
+        sql if sql_is_prepared else doris__table_colume_type(sql)
+    ) %}
+    {{ sql_header if include_sql_header and sql_header is not none }}
     create table {{ table }}
     {{ doris__duplicate_key() }}
     {{ doris__table_comment()}}
     {{ doris__partition_by() }}
     {{ doris__distributed_by() }}
-    {{ doris__properties() }} as {{ doris__table_colume_type(sql) }};
+    {{ doris__properties() }} as {{ select_sql }};
 
 {%- endmacro %}
 
-{% macro doris__create_unique_table_as(temporary, relation, sql) -%}
+{% macro doris__create_unique_table_as(
+    temporary,
+    relation,
+    sql,
+    include_sql_header=true,
+    sql_is_prepared=false
+) -%}
     {% set sql_header = config.get('sql_header', none) %}
     {% set table = relation.include(database=False) %}
-    {{ sql_header if sql_header is not none }}
+    {% set select_sql = (
+        sql if sql_is_prepared else doris__table_colume_type(sql)
+    ) %}
+    {{ sql_header if include_sql_header and sql_header is not none }}
     create table {{ table }}
     {{ doris__unique_key() }}
     {{ doris__table_comment()}}
     {{ doris__partition_by() }}
     {{ doris__distributed_by() }}
-    {{ doris__properties() }} as {{ doris__table_colume_type(sql) }};
+    {{ doris__properties({
+        'enable_unique_key_merge_on_write': 'true'
+    }) }} as {{ select_sql }};
 
 {%- endmacro %}
 
 
+{#--
+    Create the frozen source used by the multi-statement delete+insert strategy.
+
+    This is deliberately not create_table_as(True, ...). Doris does not have a
+    non-physical CTAS mode on the supported 2.1+ baseline, and inheriting the
+    target model's partition clauses or Unique-Key-only properties can make a
+    batch staging table invalid. Keep only distribution and replication here.
+--#}
+{% macro doris__create_incremental_staging_table(relation, source_sql) -%}
+    {% set configured_properties = config.get('properties', validator=validation.any[dict]) %}
+    {% set replication_num = config.get('replication_num') %}
+    {% if replication_num is none and configured_properties %}
+        {% set replication_num = configured_properties.get('replication_num') %}
+    {% endif %}
+
+    create table {{ relation.include(database=False) }}
+    {{ doris__distributed_by() }}
+    {% if replication_num is not none %}
+    properties ("replication_num" = "{{ replication_num }}")
+    {% endif %}
+    as {{ source_sql }};
+{%- endmacro %}
+
+
+{#--
+    Wrap the model SQL so that declared column types are applied via CAST.
+
+    This projection lists columns explicitly, so it may only be used when dbt
+    guarantees that the declared column set matches the SQL column set exactly
+    -- that is, when the model contract is enforced. `assert_columns_equivalent`
+    raises a contract error on any mismatch.
+
+    Without an enforced contract, `columns:` in schema.yml is documentation and
+    must not change the model result. Projecting a partial column list there
+    silently dropped every undeclared column from the target table. Column
+    comments are applied separately by `persist_docs`.
+--#}
 {% macro doris__table_colume_type(sql) -%}
-    {% set cols = model.get('columns') %}
-    {% if cols %}
+    {% set contract_config = config.get('contract') %}
+    {% if contract_config and contract_config.enforced %}
+        {{ get_assert_columns_equivalent(sql) }}
         select {{get_table_columns_and_constraints()}} from (
             {{sql}}
         ) `_table_colume_type_name`

--- a/extension/dbt-doris/dev-requirements.txt
+++ b/extension/dbt-doris/dev-requirements.txt
@@ -15,9 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# install latest changes in dbt-core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+# dbt-core and dbt-tests-adapter are installed from PyPI.
+#
+# These were previously git dependencies pointing at subdirectories of the
+# dbt-core repository (`core` and `tests/adapter`). Neither path exists any more,
+# so pip failed before it could even resolve versions. dbt-tests-adapter is also
+# published on its own release line, with version numbers that do not track
+# dbt-core -- pin it independently.
+dbt-core~=1.12.0
+dbt-tests-adapter~=1.20.0
 
 mypy
 freezegun
@@ -31,10 +37,18 @@ pre-commit
 pytest
 pytest-dotenv
 pytest-logbook
+# pytest-logbook still imports logbook.compat, which logbook removed in 1.8.
+# Without this ceiling every test errors during setup with
+# "AttributeError: module 'logbook' has no attribute 'compat'".
+logbook<1.8
 pytest-csv
 pytest-xdist
 pytz
 tox>=3.13
 twine
 wheel
-mysql-connector-python>=8.0.33,<8.3
+# Keep the floor at 8.0.33 for the authentication fixes, and no ceiling: the
+# 8.x line caps protobuf at 4.x, while dbt-core needs 5.x, so `<8.3` made the
+# environment unresolvable. setup.py has no ceiling either -- the two must agree,
+# or tests run against a connector major version users never get.
+mysql-connector-python>=8.0.33

--- a/extension/dbt-doris/docs/incremental.zh-CN.md
+++ b/extension/dbt-doris/docs/incremental.zh-CN.md
@@ -1,0 +1,223 @@
+# dbt-doris Incremental
+
+本文描述当前代码的实际行为。开发计划和未完成项见
+[dbt-doris TODO](dbt-doris-todo-list.zh-CN.md)。
+
+## 策略总览
+
+| `incremental_strategy` | 目标表 | 普通增量 SQL | dbt 物理 Staging |
+| --- | --- | --- | :---: |
+| `append` | Duplicate Key | `INSERT INTO ... SELECT` | 否 |
+| `merge` | MOW Unique Key | `INSERT INTO ... SELECT` Upsert | 否 |
+| `delete+insert`，目标为无 Sequence 的 MOW Unique Key | MOW Unique Key | 自动路由到单条 Upsert | 否 |
+| `delete+insert`，目标为 MOR Unique Key | MOR Unique Key | 事务内 `DELETE USING` + `INSERT` | 是 |
+| `delete+insert`，目标带 Sequence Column | Unique Key | 前置拒绝；改用 `merge` | 否 |
+| `insert_overwrite` | Doris 可写目标表 | 原生 `INSERT OVERWRITE` | 否 |
+
+未显式配置策略时，dbt 的策略名仍为标准 `default`：
+
+- 配置了 `unique_key`：按 `merge` 执行；
+- 没有 `unique_key`：按 `append` 执行。
+
+`microbatch` 和 Doris 4.1+ 原生 `MERGE INTO` 尚未启用。
+
+## 为什么大多数策略不再创建物理临时表
+
+`append`、`merge` 和 `insert_overwrite` 都只需要一条最终 DML。普通
+`on_schema_change='ignore'` 运行先建立一个不保存数据的逻辑 View；最终 DML
+读取该 View：
+
+```sql
+insert into target (`id`, `value`)
+select source.`id`, source.`value`
+from model__dbt_tmp source;
+```
+
+因此 Model 数据只写入目标一次；逻辑 View 只保存 SQL 定义，同时让 dbt 获得
+准确的 `VARCHAR(n)` 等类型，并保持标准五 Key Strategy Macro 对
+`temp_relation` 的契约。成功后 View 会被清理。
+
+以下场景仍会创建物理表：
+
+- `on_schema_change` 为 `fail`、`append_new_columns` 或
+  `sync_all_columns` 时，必须在修改目标 Schema 前冻结本批结果；否则读取
+  `{{ this }}` 的 Model SQL 可能在 DROP/ADD 后无法再次执行；
+- MOR Unique Key 执行真实 `delete+insert` 时，必须冻结同一批 Source，供
+  DELETE 和 INSERT 各读取一次；
+- `--full-refresh` 必须先完整构建中间表，再原子交换目标；
+- 自定义多语句 Strategy 默认获得命名的物理 Source Relation。
+
+## `append`
+
+```jinja
+{{
+  config(
+    materialized='incremental',
+    incremental_strategy='append',
+    duplicate_key=['id'],
+    distributed_by=['id']
+  )
+}}
+
+select id, value
+from {{ ref('source_model') }}
+
+{% if is_incremental() %}
+where loaded_at > (select max(loaded_at) from {{ this }})
+{% endif %}
+```
+
+Append 不检查 Key，也不去重。重复选择同一批数据会产生重复行。已有目标必须是
+Duplicate Key 表，否则 Adapter 会要求 `--full-refresh`。
+
+## `merge`：兼容 Doris 2.1+ 的全行 Upsert
+
+```jinja
+{{
+  config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['tenant_id', 'id'],
+    distributed_by=['tenant_id']
+  )
+}}
+```
+
+首次运行创建 Merge-on-Write Unique Key 表；后续运行执行一条
+`INSERT INTO ... SELECT`。同 Key 行被完整替换，新 Key 被插入，本批未出现的旧
+Key 保留。
+
+Adapter 会校验：
+
+- `unique_key` 存在，且 Model 输出包含全部 Key；
+- 现有目标是 MOW Unique Key；
+- 配置 Key 与物理 Key 的顺序和内容完全一致；
+- 同一批 Source 不得出现重复 Key；即使目标有 Sequence Column，当前 Adapter
+  也要求上游先确定性去重。
+
+当前 `merge` 是全行 Upsert，不是 Doris 4.1 的原生 `MERGE INTO`。
+`merge_update_columns`、`merge_exclude_columns` 和
+`incremental_predicates` 会在写数据前报错。
+
+## `delete+insert`
+
+配置名必须包含加号：
+
+```jinja
+{{
+  config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key=['id'],
+    distributed_by=['id']
+  )
+}}
+```
+
+不能写成 `delete_insert`。
+
+对于默认创建、且没有 Sequence Column 的 MOW Unique Key 目标，按 Key删除后
+插入与全行 Upsert 的最终结果相同，因此 Adapter 自动走 `merge` 的单条写入
+路径，不创建物理 Staging。带 Sequence Column 时，DELETE Tombstone 可能继承
+旧 Sequence，并继续压制低 Sequence 的替换 INSERT；因此 Adapter 前置拒绝该
+组合，用户应改用 `merge` 保留 Doris Sequence 语义。
+
+现有目标为 MOR Unique Key 时，执行真正的两语句路径：
+
+```text
+CTAS staging
+  -> 校验 staging 内没有重复 Key
+  -> BEGIN
+  -> DELETE target USING staging
+  -> INSERT INTO target SELECT ... FROM staging
+  -> COMMIT
+  -> DROP staging
+```
+
+这条路径要求正式发布的 Doris 3.0+，并要求部署模式支持显式事务中的
+`DELETE + INSERT SELECT`。Doris 2.1 会在事务内拒绝 DELETE，不会先删除后以成功
+状态继续；数据库语句失败时 Adapter 显式回滚连接。版本号为 `0.0.0` 的源码构建
+无法证明具备该事务能力，会在创建 Staging 前明确拒绝。
+
+要在首次构建时创建 MOR 目标，可明确配置：
+
+```jinja
+properties={
+  'enable_unique_key_merge_on_write': 'false'
+}
+```
+
+同一个 Model 不应并发运行真实的 staged `delete+insert`；当前物理 Staging 名称
+是确定的，异常退出留下的 Relation 会在下次运行开始时清理。
+
+## `insert_overwrite`
+
+整表覆盖：
+
+```jinja
+{{ config(
+  materialized='incremental',
+  incremental_strategy='insert_overwrite'
+) }}
+```
+
+指定分区：
+
+```jinja
+{{ config(
+  materialized='incremental',
+  incremental_strategy='insert_overwrite',
+  partition_by=['event_date'],
+  overwrite_partitions=['p202607', 'p202608']
+) }}
+```
+
+自动识别本批涉及的分区：
+
+```jinja
+overwrite_partitions='*'
+```
+
+对应 Doris 原生 SQL 分别为：
+
+```sql
+insert overwrite table target ...;
+insert overwrite table target partition (`p202607`, `p202608`) ...;
+insert overwrite table target partition(*) ...;
+```
+
+`PARTITION(*)` 要求 Doris 2.1.3+。空 Source 无法自动识别需要清空的分区；需要清空
+空分区时应显式列出分区名。
+
+## Schema Change 与 Full Refresh
+
+支持 dbt 1.12 的四种 `on_schema_change`：
+
+- `ignore`
+- `fail`
+- `append_new_columns`
+- `sync_all_columns`
+
+Doris Column Schema Change 可能异步执行。Adapter 在 ALTER 后轮询
+`SHOW ALTER TABLE COLUMN`，直到 `FINISHED`；`CANCELLED` 和超时会使本轮失败。
+增量运行不能修改 Unique Key 列类型，这种变更必须使用 `--full-refresh`。
+
+表到表的 Full Refresh 会先创建完整中间表，再使用 Doris
+`REPLACE WITH TABLE ... swap=true` 原子交换。View 切换成 Table 时 Doris
+没有跨对象类型的原子 rename；Adapter 先保留旧对象到 Backup，再切换新表。若
+第二步失败，下次运行会先把 Backup 恢复到标准目标名，而不会删除唯一可用副本。
+
+## 失败前置校验
+
+以下配置会在目标数据写入前失败：
+
+- 内置策略不支持 `incremental_predicates`；
+- `merge` 不支持局部更新列配置；
+- `merge` 与 `enable_unique_key_merge_on_write=false` 冲突；
+- `delete+insert` 用于带物理 Sequence Column 的目标；
+- dbt-doris 尚未实现 `grants` 配置；
+- 裸 `sequence_col` 配置未实现；应使用 Doris Table Property；
+- Key 缺失、非法、与物理 Unique Key 不一致；
+- Source 缺少 Key 或同批 Key 重复；
+- 分区覆盖配置用于非 `insert_overwrite` 策略；
+- `overwrite_partitions` 为空、混用 `*` 与分区名，或包含不安全标识符。

--- a/extension/dbt-doris/pytest.ini
+++ b/extension/dbt-doris/pytest.ini
@@ -19,9 +19,8 @@
 filterwarnings =
     ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
     ignore:unclosed file .*:ResourceWarning
-env_files =
-    test.env
+; test/unit runs anywhere. test/functional needs a reachable Doris cluster --
+; point DORIS_TEST_* at one (see test/conftest.py) or select test/unit only.
 testpaths =
-    tests/unit
-    tests/integration
-    tests/functional
+    test/unit
+    test/functional

--- a/extension/dbt-doris/setup.py
+++ b/extension/dbt-doris/setup.py
@@ -23,7 +23,7 @@ from setuptools import find_namespace_packages, setup
 package_name = "dbt-doris"
 # make sure this always matches dbt/adapters/{adapter}/__version__.py
 package_version = "1.0.0"
-dbt_core_version = "1.10.4"
+dbt_core_version = "1.12.0"
 description = """The doris adapter plugin for dbt """
 
 setup(
@@ -37,8 +37,8 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-core>={}".format(dbt_core_version),
+        "dbt-core~={}".format(dbt_core_version),
         "mysql-connector-python>=8.0.0",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )

--- a/extension/dbt-doris/test/functional/adapter/test_doris_incremental.py
+++ b/extension/dbt-doris/test/functional/adapter/test_doris_incremental.py
@@ -20,13 +20,62 @@
 
 """
 Tests for Doris incremental materialization:
-- append strategy (duplicate key table)
-- insert_overwrite strategy (unique key table)
-- full refresh mode
+- append writes directly without a staging relation
+- merge uses a Merge-on-Write Unique Key table without a staging relation
+- delete+insert freezes the batch in a physical staging relation
+- insert_overwrite performs real whole-table and partition overwrites
+- full refresh replaces the target and preserves its Doris table configuration
 """
 
 import pytest
-from dbt.tests.util import run_dbt, relation_from_name
+from dbt.tests.adapter.incremental.test_incremental_on_schema_change import (
+    BaseIncrementalOnSchemaChange,
+)
+from dbt.tests.util import relation_from_name, run_dbt
+
+
+def _run_and_capture_sql(model_name, args=None, expect_pass=True):
+    """Run dbt and return SQLQuery events for one model.
+
+    Inspecting the catalog after a run only proves that a staging relation was
+    cleaned up. SQLQuery events prove whether dbt physically created and read one
+    during the run.
+    """
+    statements = []
+
+    def capture_sql(event):
+        if (
+            event.info.name == "SQLQuery"
+            and event.data.node_info.node_name == model_name
+        ):
+            statements.append(" ".join(event.data.sql.lower().split()))
+
+    results = run_dbt(
+        args or ["run"],
+        expect_pass=expect_pass,
+        callbacks=[capture_sql],
+    )
+    return results, list(statements)
+
+
+def _assert_no_physical_dbt_staging(statements):
+    physical_staging_statements = [
+        statement
+        for statement in statements
+        if "__dbt_tmp" in statement
+        and "create table" in statement
+    ]
+    assert physical_staging_statements == []
+
+
+def _dbt_helper_relations(project, relation):
+    return project.run_sql(
+        "select table_name from information_schema.tables "
+        f"where table_schema = '{relation.schema}' "
+        f"and table_name like '{relation.identifier}__dbt_%' "
+        "order by table_name",
+        fetch="all",
+    )
 
 
 # -- Append strategy: works with duplicate key tables --
@@ -35,6 +84,7 @@ INCREMENTAL_APPEND_SQL = """
 {{ config(
     materialized='incremental',
     incremental_strategy='append',
+    duplicate_key=['id'],
     distributed_by=['id'],
     properties={'replication_num': '1'}
 ) }}
@@ -53,15 +103,19 @@ select 3 as id, 'charlie' as name
 """
 
 
-# -- Insert overwrite strategy: works with unique key tables --
+# -- Merge strategy: Doris Unique Key upsert --
 
-INCREMENTAL_UNIQUE_SQL = """
+INCREMENTAL_MERGE_SQL = """
 {{ config(
     materialized='incremental',
-    incremental_strategy='insert_overwrite',
+    incremental_strategy='merge',
     unique_key=['id'],
     distributed_by=['id'],
-    properties={'replication_num': '1'}
+    sql_header='set enable_nereids_planner = true',
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'true'
+    }
 ) }}
 
 {% if is_incremental() %}
@@ -78,17 +132,319 @@ select 3 as id, 'charlie' as name, 300 as score
 """
 
 
+INCREMENTAL_DUPLICATE_KEY_MERGE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['id'],
+    distributed_by=['id'],
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'true'
+    }
+) }}
+
+{% if is_incremental() %}
+select 1 as id, 'conflicting_first' as name
+union all
+select 1 as id, 'conflicting_second' as name
+{% else %}
+select 1 as id, 'alice' as name
+union all
+select 2 as id, 'bob' as name
+{% endif %}
+"""
+
+
+INCREMENTAL_COMPOSITE_MERGE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['tenant_id', 'id'],
+    distributed_by=['tenant_id'],
+    properties={'replication_num': '1'}
+) }}
+
+{% if is_incremental() %}
+select 1 as tenant_id, 1 as id, 'updated' as value
+union all
+select 2 as tenant_id, 2 as id, 'new' as value
+{% else %}
+select 1 as tenant_id, 1 as id, 'old' as value
+union all
+select 1 as tenant_id, 2 as id, 'keep' as value
+union all
+select 2 as tenant_id, 1 as id, 'other_tenant' as value
+{% endif %}
+"""
+
+
+# -- Delete and insert: physical staging freezes one batch for both DMLs --
+
+INCREMENTAL_DELETE_INSERT_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key=['id'],
+    duplicate_key=['id'],
+    distributed_by=['id'],
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'false'
+    }
+) }}
+
+{% if is_incremental() %}
+select 1 as id, 'alice_replaced' as name, 175 as score
+union all
+select 4 as id, 'dave' as name, 400 as score
+{% else %}
+select 1 as id, 'alice' as name, 100 as score
+union all
+select 2 as id, 'bob' as name, 200 as score
+union all
+select 3 as id, 'charlie' as name, 300 as score
+{% endif %}
+"""
+
+
+INCREMENTAL_DELETE_INSERT_MOW_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key=['id'],
+    distributed_by=['id'],
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'true'
+    }
+) }}
+
+{% if is_incremental() %}
+select 1 as id, 'alice_replaced' as name, 175 as score
+union all
+select 4 as id, 'dave' as name, 400 as score
+{% else %}
+select 1 as id, 'alice' as name, 100 as score
+union all
+select 2 as id, 'bob' as name, 200 as score
+union all
+select 3 as id, 'charlie' as name, 300 as score
+{% endif %}
+"""
+
+
+INCREMENTAL_DELETE_INSERT_SEQUENCE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key=['id'],
+    distributed_by=['id'],
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'true'
+    }
+) }}
+
+{% if is_incremental() %}
+select 1 as id, 50 as sequence_id, 'lower_sequence' as value
+{% else %}
+select 1 as id, 100 as sequence_id, 'original' as value
+{% endif %}
+"""
+
+
+INCREMENTAL_DUPLICATE_KEY_DELETE_INSERT_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key=['id'],
+    distributed_by=['id'],
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'false'
+    }
+) }}
+
+{% if is_incremental() %}
+select 1 as id, 'conflicting_first' as name
+union all
+select 1 as id, 'conflicting_second' as name
+{% else %}
+select 1 as id, 'alice' as name
+union all
+select 2 as id, 'bob' as name
+{% endif %}
+"""
+
+
+INCREMENTAL_COMPOSITE_DELETE_INSERT_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key=['tenant_id', 'id'],
+    distributed_by=['tenant_id'],
+    properties={
+        'replication_num': '1',
+        'enable_unique_key_merge_on_write': 'false'
+    }
+) }}
+
+{% if is_incremental() %}
+select 1 as tenant_id, 1 as id, 'replaced' as value
+union all
+select 2 as tenant_id, 2 as id, 'new' as value
+{% else %}
+select 1 as tenant_id, 1 as id, 'old' as value
+union all
+select 1 as tenant_id, 2 as id, 'keep' as value
+union all
+select 2 as tenant_id, 1 as id, 'other_tenant' as value
+{% endif %}
+"""
+
+
+# -- Insert overwrite: replace the complete target with the current batch --
+
+INCREMENTAL_OVERWRITE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    duplicate_key=['id'],
+    distributed_by=['id'],
+    properties={'replication_num': '1'}
+) }}
+
+{% if is_incremental() %}
+select 1 as id, 'alice_replaced' as name
+union all
+select 4 as id, 'dave' as name
+{% else %}
+select 1 as id, 'alice' as name
+union all
+select 2 as id, 'bob' as name
+union all
+select 3 as id, 'charlie' as name
+{% endif %}
+"""
+
+
+# -- Static partition overwrite: replace p1 while retaining p2 --
+
+INCREMENTAL_STATIC_PARTITION_OVERWRITE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    overwrite_partitions=['p1'],
+    duplicate_key=['part_id'],
+    partition_by=['part_id'],
+    partition_type='RANGE',
+    partition_by_init=[
+        'PARTITION p1 VALUES LESS THAN ("2")',
+        'PARTITION p2 VALUES LESS THAN ("3")'
+    ],
+    distributed_by=['part_id'],
+    properties={'replication_num': '1'}
+) }}
+
+{% if is_incremental() %}
+select 1 as part_id, 'static_new_p1' as value
+{% else %}
+select 1 as part_id, 'static_old_p1' as value
+union all
+select 2 as part_id, 'static_unchanged_p2' as value
+{% endif %}
+"""
+
+
+# -- Dynamic partition overwrite: replace only partitions present in this batch --
+
+INCREMENTAL_DYNAMIC_PARTITION_OVERWRITE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    overwrite_partitions='*',
+    duplicate_key=['part_id'],
+    partition_by=['part_id'],
+    partition_type='RANGE',
+    partition_by_init=[
+        'PARTITION p1 VALUES LESS THAN ("2")',
+        'PARTITION p2 VALUES LESS THAN ("3")'
+    ],
+    distributed_by=['part_id'],
+    properties={'replication_num': '1'}
+) }}
+
+{% if is_incremental() %}
+select 1 as part_id, 'dynamic_new_p1' as value
+{% else %}
+select 1 as part_id, 'dynamic_old_p1' as value
+union all
+select 2 as part_id, 'dynamic_unchanged_p2' as value
+{% endif %}
+"""
+
+
 # -- Full refresh --
 
 INCREMENTAL_FULL_REFRESH_SQL = """
 {{ config(
     materialized='incremental',
     incremental_strategy='append',
+    duplicate_key=['id'],
+    distributed_by=['id'],
+    properties={
+        'replication_num': '1',
+        'disable_auto_compaction': 'true'
+    }
+) }}
+
+select 1 as id, 'only_row' as name
+"""
+
+
+INCREMENTAL_VIEW_TO_TABLE_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    duplicate_key=['ASSET_ID'],
+    distributed_by=['ASSET_ID'],
+    properties={'replication_num': '1'}
+) }}
+
+select 7 as `ASSET_ID`, 'new_table' as value
+"""
+
+
+INCREMENTAL_VARCHAR_WIDEN_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    on_schema_change='ignore',
+    duplicate_key=['id'],
     distributed_by=['id'],
     properties={'replication_num': '1'}
 ) }}
 
-select 1 as id, 'only_row' as name
+{% if is_incremental() %}
+select 2 as id, cast('expanded' as varchar(40)) as name
+{% else %}
+select 1 as id, cast('a' as varchar(5)) as name
+{% endif %}
+"""
+
+
+INCREMENTAL_RECOVERY_SQL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    duplicate_key=['id'],
+    distributed_by=['id'],
+    properties={'replication_num': '1'}
+) }}
+
+select *
+from dbt_incremental_intentional_missing_relation
 """
 
 
@@ -98,7 +454,6 @@ class TestDorisIncrementalAppend:
         return {"incremental_append.sql": INCREMENTAL_APPEND_SQL}
 
     def test_incremental_append(self, project):
-        # First run: creates table with 3 rows
         results = run_dbt(["run"])
         assert len(results) == 1
 
@@ -106,47 +461,595 @@ class TestDorisIncrementalAppend:
         result = project.run_sql(f"select count(*) from {relation}", fetch="one")
         assert result[0] == 3
 
-        # Second run: appends 2 more rows
-        results = run_dbt(["run"])
+        results, statements = _run_and_capture_sql("incremental_append")
         assert len(results) == 1
 
-        result = project.run_sql(f"select count(*) from {relation}", fetch="one")
-        assert result[0] == 5
+        rows = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, "alice"),
+            (2, "bob"),
+            (3, "charlie"),
+            (4, "dave"),
+            (5, "eve"),
+        ]
+
+        direct_inserts = [
+            statement
+            for statement in statements
+            if "insert into" in statement and "incremental_append" in statement
+        ]
+        assert len(direct_inserts) == 1
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
 
 
-class TestDorisIncrementalUniqueKey:
+class TestDorisIncrementalMerge:
     @pytest.fixture(scope="class")
     def models(self):
-        return {"incremental_unique.sql": INCREMENTAL_UNIQUE_SQL}
+        return {"incremental_merge.sql": INCREMENTAL_MERGE_SQL}
 
-    def test_incremental_unique_key(self, project):
-        # First run: creates unique key table with 3 rows
+    def test_merge_upserts_without_staging(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
 
-        relation = relation_from_name(project.adapter, "incremental_unique")
+        relation = relation_from_name(project.adapter, "incremental_merge")
         result = project.run_sql(f"select count(*) from {relation}", fetch="one")
         assert result[0] == 3
 
-        # Second run: upserts 2 rows (1 update + 1 new)
+        results, statements = _run_and_capture_sql("incremental_merge")
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select id, name, score from {relation} order by id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, "alice_updated", 150),
+            (2, "bob", 200),
+            (3, "charlie", 300),
+            (4, "dave", 400),
+        ]
+
+        create_table = project.run_sql(
+            f"show create table {relation}",
+            fetch="one",
+        )[1].lower()
+        assert "unique key" in create_table
+        assert '"enable_unique_key_merge_on_write" = "true"' in create_table
+
+        direct_inserts = [
+            statement
+            for statement in statements
+            if "insert into" in statement and "incremental_merge" in statement
+        ]
+        assert len(direct_inserts) == 1
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalMergeRejectsDuplicateKeys:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_duplicate_key_merge.sql": (
+                INCREMENTAL_DUPLICATE_KEY_MERGE_SQL
+            ),
+        }
+
+    def test_duplicate_source_keys_fail_without_changing_target(self, project):
+        assert len(run_dbt(["run"])) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_duplicate_key_merge",
+        )
+        rows_before = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
+        )
+
+        failure, statements = _run_and_capture_sql(
+            "incremental_duplicate_key_merge",
+            expect_pass=False,
+        )
+        assert len(failure.results) == 1
+        assert any(
+            "dbt_internal_duplicate_keys" in statement
+            for statement in statements
+        )
+        _assert_no_physical_dbt_staging(statements)
+
+        rows_after = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
+        )
+        assert rows_after == rows_before == [
+            (1, "alice"),
+            (2, "bob"),
+        ]
+
+
+class TestDorisIncrementalCompositeMerge:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_composite_merge.sql": INCREMENTAL_COMPOSITE_MERGE_SQL}
+
+    def test_merge_uses_all_unique_key_columns(self, project):
+        assert len(run_dbt(["run"])) == 1
+        results, statements = _run_and_capture_sql("incremental_composite_merge")
+        assert len(results) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_composite_merge",
+        )
+        rows = project.run_sql(
+            f"select tenant_id, id, value from {relation} "
+            "order by tenant_id, id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, 1, "updated"),
+            (1, 2, "keep"),
+            (2, 1, "other_tenant"),
+            (2, 2, "new"),
+        ]
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalDeleteInsert:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_delete_insert.sql": INCREMENTAL_DELETE_INSERT_SQL,
+        }
+
+    def test_delete_insert_reuses_and_cleans_staging(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
 
+        relation = relation_from_name(project.adapter, "incremental_delete_insert")
+        results, statements = _run_and_capture_sql("incremental_delete_insert")
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select id, name, score from {relation} order by id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, "alice_replaced", 175),
+            (2, "bob", 200),
+            (3, "charlie", 300),
+            (4, "dave", 400),
+        ]
+
+        staging_name = "incremental_delete_insert__dbt_tmp"
+        assert any(
+            "create table" in statement and staging_name in statement
+            for statement in statements
+        )
+        assert any(
+            staging_name in statement
+            and (
+                "delete from" in statement
+                or "__doris_delete_sign__" in statement
+            )
+            for statement in statements
+        )
+        assert any(
+            "insert into" in statement
+            and "incremental_delete_insert" in statement
+            and staging_name in statement
+            and "__doris_delete_sign__" not in statement
+            for statement in statements
+        )
+        assert any(
+            "drop table if exists" in statement and staging_name in statement
+            for statement in statements
+        )
+
+        begin_statements = [
+            index
+            for index, statement in enumerate(statements)
+            if statement.rstrip(";").endswith("begin")
+        ]
+        delete_statements = [
+            index
+            for index, statement in enumerate(statements)
+            if "delete from" in statement
+            and "incremental_delete_insert" in statement
+        ]
+        insert_statements = [
+            index
+            for index, statement in enumerate(statements)
+            if "insert into" in statement
+            and "incremental_delete_insert" in statement
+            and staging_name in statement
+        ]
+        commit_statements = [
+            index
+            for index, statement in enumerate(statements)
+            if statement.rstrip(";").endswith("commit")
+        ]
+        assert len(begin_statements) == 1
+        assert len(delete_statements) == 1
+        assert len(insert_statements) == 1
+        assert len(commit_statements) == 1
+        assert (
+            begin_statements[0]
+            < delete_statements[0]
+            < insert_statements[0]
+            < commit_statements[0]
+        )
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalDeleteInsertOnMow:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_delete_insert_mow.sql": (
+                INCREMENTAL_DELETE_INSERT_MOW_SQL
+            ),
+        }
+
+    def test_delete_insert_uses_single_mow_upsert(self, project):
+        assert len(run_dbt(["run"])) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_delete_insert_mow",
+        )
+        results, statements = _run_and_capture_sql(
+            "incremental_delete_insert_mow"
+        )
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select id, name, score from {relation} order by id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, "alice_replaced", 175),
+            (2, "bob", 200),
+            (3, "charlie", 300),
+            (4, "dave", 400),
+        ]
+
+        create_table = project.run_sql(
+            f"show create table {relation}",
+            fetch="one",
+        )[1].lower()
+        assert "unique key" in create_table
+        assert '"enable_unique_key_merge_on_write" = "true"' in create_table
+
+        direct_inserts = [
+            statement
+            for statement in statements
+            if "insert into" in statement
+            and "incremental_delete_insert_mow" in statement
+        ]
+        assert len(direct_inserts) == 1
+        assert "dbt_internal_duplicate_keys" in direct_inserts[0]
+
+        _assert_no_physical_dbt_staging(statements)
+        assert not any(
+            statement.rstrip(";").endswith("begin")
+            for statement in statements
+        )
+        assert not any("delete from" in statement for statement in statements)
+        assert not any(
+            statement.rstrip(";").endswith("commit")
+            for statement in statements
+        )
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalDeleteInsertRejectsSequence:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_delete_insert_sequence.sql": (
+                INCREMENTAL_DELETE_INSERT_SEQUENCE_SQL
+            ),
+        }
+
+    def test_sequence_target_fails_before_staging_or_write(self, project):
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_delete_insert_sequence",
+        )
+        project.run_sql(
+            f"create table {relation} ("
+            "`id` int, `sequence_id` int, `value` varchar(20)"
+            ") unique key(`id`) "
+            "distributed by hash(`id`) buckets auto "
+            "properties("
+            '"replication_num" = "1", '
+            '"enable_unique_key_merge_on_write" = "true", '
+            '"function_column.sequence_col" = "sequence_id"'
+            ")"
+        )
+        project.run_sql(
+            f"insert into {relation} values (1, 100, 'original')"
+        )
+
+        failure, statements = _run_and_capture_sql(
+            "incremental_delete_insert_sequence",
+            expect_pass=False,
+        )
+        assert len(failure.results) == 1
+        assert "sequence column" in failure.results[0].message.lower()
+        _assert_no_physical_dbt_staging(statements)
+
+        rows = project.run_sql(
+            f"select id, sequence_id, value from {relation}",
+            fetch="all",
+        )
+        assert rows == [(1, 100, "original")]
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalDeleteInsertRejectsDuplicateKeys:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_duplicate_key_delete_insert.sql": (
+                INCREMENTAL_DUPLICATE_KEY_DELETE_INSERT_SQL
+            ),
+        }
+
+    def test_duplicate_source_keys_fail_without_changing_target(self, project):
+        assert len(run_dbt(["run"])) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_duplicate_key_delete_insert",
+        )
+        rows_before = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
+        )
+
+        failure, statements = _run_and_capture_sql(
+            "incremental_duplicate_key_delete_insert",
+            expect_pass=False,
+        )
+        assert len(failure.results) == 1
+        assert any(
+            "dbt_internal_duplicate_keys" in statement
+            for statement in statements
+        )
+        assert not any(
+            statement.rstrip(";").endswith("begin")
+            for statement in statements
+        )
+
+        rows_after = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
+        )
+        assert rows_after == rows_before == [
+            (1, "alice"),
+            (2, "bob"),
+        ]
+
+
+class TestDorisIncrementalCompositeDeleteInsert:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_composite_delete_insert.sql": (
+                INCREMENTAL_COMPOSITE_DELETE_INSERT_SQL
+            ),
+        }
+
+    def test_delete_insert_matches_the_complete_composite_key(self, project):
+        assert len(run_dbt(["run"])) == 1
+        results, statements = _run_and_capture_sql(
+            "incremental_composite_delete_insert"
+        )
+        assert len(results) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_composite_delete_insert",
+        )
+        rows = project.run_sql(
+            f"select tenant_id, id, value from {relation} "
+            "order by tenant_id, id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, 1, "replaced"),
+            (1, 2, "keep"),
+            (2, 1, "other_tenant"),
+            (2, 2, "new"),
+        ]
+
+        delete_sql = next(
+            statement for statement in statements if "delete from" in statement
+        )
+        assert "dbt_internal_dest.`tenant_id`" in delete_sql
+        assert "dbt_internal_dest.`id`" in delete_sql
+        assert delete_sql.count("<=>") == 2
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalInsertOverwrite:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_overwrite.sql": INCREMENTAL_OVERWRITE_SQL}
+
+    def test_whole_table_insert_overwrite_removes_old_rows(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        relation = relation_from_name(project.adapter, "incremental_overwrite")
         result = project.run_sql(f"select count(*) from {relation}", fetch="one")
-        assert result[0] == 4
+        assert result[0] == 3
 
-        # Verify id=1 was updated
-        result = project.run_sql(
-            f"select name, score from {relation} where id = 1", fetch="one"
-        )
-        assert result[0] == "alice_updated"
-        assert result[1] == 150
+        results, statements = _run_and_capture_sql("incremental_overwrite")
+        assert len(results) == 1
 
-        # Verify id=2 remains unchanged
-        result = project.run_sql(
-            f"select name from {relation} where id = 2", fetch="one"
+        rows = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
         )
-        assert result[0] == "bob"
+        assert rows == [
+            (1, "alice_replaced"),
+            (4, "dave"),
+        ]
+
+        overwrite_statements = [
+            statement
+            for statement in statements
+            if "insert overwrite" in statement
+            and "incremental_overwrite" in statement
+        ]
+        assert len(overwrite_statements) == 1
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalStaticPartitionOverwrite:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_static_partition_overwrite.sql": (
+                INCREMENTAL_STATIC_PARTITION_OVERWRITE_SQL
+            ),
+        }
+
+    def test_static_partition_overwrite_replaces_only_named_partition(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_static_partition_overwrite",
+        )
+        results, statements = _run_and_capture_sql(
+            "incremental_static_partition_overwrite"
+        )
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select part_id, value from {relation} order by part_id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, "static_new_p1"),
+            (2, "static_unchanged_p2"),
+        ]
+
+        overwrite_statements = [
+            statement
+            for statement in statements
+            if "insert overwrite" in statement
+            and "incremental_static_partition_overwrite" in statement
+        ]
+        assert len(overwrite_statements) == 1
+        assert "partition(`p1`)" in overwrite_statements[0].replace(" ", "")
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalDynamicPartitionOverwrite:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_dynamic_partition_overwrite.sql": (
+                INCREMENTAL_DYNAMIC_PARTITION_OVERWRITE_SQL
+            ),
+        }
+
+    def test_dynamic_partition_overwrite_preserves_unseen_partitions(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_dynamic_partition_overwrite",
+        )
+        results, statements = _run_and_capture_sql(
+            "incremental_dynamic_partition_overwrite"
+        )
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select part_id, value from {relation} order by part_id",
+            fetch="all",
+        )
+        assert rows == [
+            (1, "dynamic_new_p1"),
+            (2, "dynamic_unchanged_p2"),
+        ]
+
+        overwrite_statements = [
+            statement
+            for statement in statements
+            if "insert overwrite" in statement
+            and "incremental_dynamic_partition_overwrite" in statement
+        ]
+        assert len(overwrite_statements) == 1
+        assert "partition(*)" in overwrite_statements[0].replace(" ", "")
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalVarcharWidening:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_varchar_widen.sql": INCREMENTAL_VARCHAR_WIDEN_SQL,
+        }
+
+    def test_ignore_widens_string_without_physical_staging(self, project):
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_varchar_widen",
+        )
+        project.run_sql(
+            f"create table {relation} ("
+            "`id` int, `name` varchar(5)"
+            ") duplicate key(`id`) "
+            "distributed by hash(`id`) buckets auto "
+            'properties("replication_num" = "1")'
+        )
+        project.run_sql(f"insert into {relation} values (1, 'a')")
+
+        results, statements = _run_and_capture_sql("incremental_varchar_widen")
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select id, name from {relation} order by id",
+            fetch="all",
+        )
+        assert rows == [(1, "a"), (2, "expanded")]
+
+        column_type = project.run_sql(
+            "select column_type from information_schema.columns "
+            f"where table_schema = '{relation.schema}' "
+            f"and table_name = '{relation.identifier}' "
+            "and column_name = 'name'",
+            fetch="one",
+        )[0]
+        widened_size = int(
+            column_type.lower().removeprefix("varchar(").removesuffix(")")
+        )
+        assert widened_size >= 40
+        assert any(
+            "create or replace view" in statement
+            and "__dbt_tmp" in statement
+            for statement in statements
+        )
+        _assert_no_physical_dbt_staging(statements)
+        assert _dbt_helper_relations(project, relation) == []
 
 
 class TestDorisIncrementalFullRefresh:
@@ -155,7 +1058,6 @@ class TestDorisIncrementalFullRefresh:
         return {"incremental_fr.sql": INCREMENTAL_FULL_REFRESH_SQL}
 
     def test_full_refresh(self, project):
-        # First run
         results = run_dbt(["run"])
         assert len(results) == 1
 
@@ -163,15 +1065,107 @@ class TestDorisIncrementalFullRefresh:
         result = project.run_sql(f"select count(*) from {relation}", fetch="one")
         assert result[0] == 1
 
-        # Second run: normal incremental (appends same row)
         results = run_dbt(["run"])
         assert len(results) == 1
         result = project.run_sql(f"select count(*) from {relation}", fetch="one")
         assert result[0] == 2
 
-        # Full refresh: should reset to 1 row
-        results = run_dbt(["run", "--full-refresh"])
+        results, statements = _run_and_capture_sql(
+            "incremental_fr",
+            ["run", "--full-refresh"],
+        )
         assert len(results) == 1
 
         result = project.run_sql(f"select count(*) from {relation}", fetch="one")
         assert result[0] == 1
+
+        create_table = project.run_sql(
+            f"show create table {relation}",
+            fetch="one",
+        )[1].lower()
+        assert "duplicate key" in create_table
+        assert "distributed by hash(`id`)" in create_table
+        assert '"disable_auto_compaction" = "true"' in create_table
+
+        # Full refresh intentionally builds an intermediate table before the
+        # atomic REPLACE WITH TABLE. The no-staging rule applies to ordinary
+        # incremental DML, not to safe full-refresh replacement.
+        assert any(
+            "create table" in statement
+            and "incremental_fr__dbt_tmp" in statement
+            for statement in statements
+        )
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalViewToTable:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_view_to_table.sql": INCREMENTAL_VIEW_TO_TABLE_SQL,
+        }
+
+    def test_view_with_as_identifier_is_replaced_by_table(self, project):
+        relation = relation_from_name(
+            project.adapter,
+            "incremental_view_to_table",
+        )
+        project.run_sql(
+            f"create view {relation} (`ASSET_ID`, `value`) as "
+            "select 99 as `ASSET_ID`, 'old_view' as `value`"
+        )
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select `ASSET_ID`, `value` from {relation}",
+            fetch="all",
+        )
+        assert rows == [(7, "new_table")]
+        table_type = project.run_sql(
+            "select table_type from information_schema.tables "
+            f"where table_schema = '{relation.schema}' "
+            f"and table_name = '{relation.identifier}'",
+            fetch="one",
+        )[0]
+        assert table_type == "BASE TABLE"
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalBackupRecovery:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_recovery.sql": INCREMENTAL_RECOVERY_SQL}
+
+    def test_restores_view_backup_before_a_failed_retry(self, project):
+        relation = relation_from_name(project.adapter, "incremental_recovery")
+        backup_name = f"{relation.identifier}__dbt_backup"
+        project.run_sql(
+            f"create view `{relation.schema}`.`{backup_name}` "
+            "as select 99 as id, 'old_definition' as value"
+        )
+
+        failure = run_dbt(["run"], expect_pass=False)
+        assert len(failure.results) == 1
+
+        rows = project.run_sql(
+            f"select id, value from {relation}",
+            fetch="all",
+        )
+        assert rows == [(99, "old_definition")]
+        assert _dbt_helper_relations(project, relation) == []
+
+
+class TestDorisIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):
+    """Run dbt's 1.12 schema-change contract against logical source views."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+properties": {
+                    "replication_num": "1",
+                }
+            }
+        }

--- a/extension/dbt-doris/test/unit/__init__.py
+++ b/extension/dbt-doris/test/unit/__init__.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,28 +17,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-# Inline `#` comments are not allowed inside a value list. flake8 4.x tolerated
-# them; current versions abort with
-#   ValueError: Error code '#' supplied to 'ignore' option does not match ...
-# so the rationale for each code goes above the list instead.
-#
-# W503, W504, E203: line-break and whitespace-before-`:` rules that disagree with
-#                   black's formatting.
-# E741:             single-character names such as `l`, used in the existing code.
-# E501:             line length, left to black.
-[flake8]
-select =
-    E
-    W
-    F
-ignore =
-    W503
-    W504
-    E203
-    E741
-    E501
-exclude =
-    .tox
-    build
-    dist

--- a/extension/dbt-doris/test/unit/macro_harness.py
+++ b/extension/dbt-doris/test/unit/macro_harness.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Render dbt-doris Jinja macros in isolation, with no Doris cluster.
+
+The functional suite under ``test/functional`` needs a reachable cluster, so it
+cannot guard a pull request. These helpers make the macros themselves testable:
+they compile the shipped .sql files with dbt's own Jinja environment and run a
+single macro against a hand-built context.
+
+What that catches: Jinja syntax errors, macros that emit more than one SQL
+statement, unescaped values interpolated into SQL, and dispatch/naming mistakes.
+What it does not catch: anything about how Doris executes the SQL. Keep
+behavioural coverage in the functional suite.
+"""
+
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+from dbt_common.clients.jinja import extract_toplevel_blocks, get_environment
+from dbt_common.exceptions.macros import MacroReturn
+from dbt_common.utils.jinja import MACRO_PREFIX
+
+from dbt.include import doris as doris_include
+
+MACRO_ROOT = os.path.join(doris_include.PACKAGE_PATH, "macros")
+
+#: Blocks dbt itself allows at the top level of a macro file.
+ALLOWED_BLOCKS = {"macro", "materialization", "test", "docs", "snapshot"}
+
+
+def macro_files() -> List[str]:
+    """Every .sql file shipped in the adapter's macro directory, repo-relative."""
+    found = []
+    for dirpath, _, filenames in os.walk(MACRO_ROOT):
+        for filename in filenames:
+            if filename.endswith(".sql"):
+                found.append(
+                    os.path.relpath(os.path.join(dirpath, filename), MACRO_ROOT)
+                )
+    return sorted(found)
+
+
+def read_macro_file(rel_path: str) -> str:
+    with open(os.path.join(MACRO_ROOT, rel_path)) as fh:
+        return fh.read()
+
+
+def top_level_blocks(rel_path: str):
+    """Parse a macro file into its top-level macro/materialization blocks."""
+    return extract_toplevel_blocks(
+        read_macro_file(rel_path),
+        allowed_blocks=ALLOWED_BLOCKS,
+        collect_raw_data=False,
+    )
+
+
+class Statement:
+    """One ``{% call statement(...) %}`` block captured during a render."""
+
+    def __init__(self, name: Optional[str], sql: str):
+        self.name = name
+        self.sql = sql.strip()
+
+    def __repr__(self) -> str:
+        return f"Statement(name={self.name!r}, sql={self.sql!r})"
+
+
+class FakeConfig:
+    """Stand-in for dbt's model ``config`` object.
+
+    ``validator`` is accepted and ignored: the macros pass
+    ``validation.any[...]`` to it, and validating the fake values here would only
+    test dbt, not the adapter.
+    """
+
+    def __init__(self, values: Optional[Dict[str, Any]] = None):
+        self.values = dict(values or {})
+
+    def get(self, name, default=None, validator=None):
+        return self.values.get(name, default)
+
+    def require(self, name, validator=None):
+        return self.values[name]
+
+    def persist_relation_docs(self):
+        return self.values.get("persist_docs", {}).get("relation", False)
+
+    def persist_column_docs(self):
+        return self.values.get("persist_docs", {}).get("columns", False)
+
+
+class _AnyValidator:
+    """``validation.any[list, basestring]`` -- subscript, then ignore."""
+
+    def __getitem__(self, item):
+        def noop(value):
+            return None
+
+        return noop
+
+
+class FakeValidation:
+    any = _AnyValidator()
+
+
+class FakeRelation:
+    """Minimal Relation: enough for the string interpolation the macros do."""
+
+    def __init__(self, schema="dbt_test", identifier="my_model", relation_type="table"):
+        self.schema = schema
+        self.identifier = identifier
+        self.table = identifier
+        self.type = relation_type
+
+    @property
+    def is_view(self):
+        return self.type == "view"
+
+    def include(self, database=True, schema=True, identifier=True):
+        return self
+
+    def incorporate(self, **kwargs):
+        path = kwargs.get("path") or {}
+        return FakeRelation(
+            schema=path.get("schema", self.schema),
+            identifier=path.get("identifier", self.identifier),
+            relation_type=kwargs.get("type", self.type),
+        )
+
+    def render(self):
+        return str(self)
+
+    def __str__(self):
+        return f"`{self.schema}`.`{self.identifier}`"
+
+
+class FakeColumn:
+    """Minimal dbt Column used by SQL-producing strategy macro tests."""
+
+    def __init__(self, name):
+        self.name = name
+
+    @property
+    def quoted(self):
+        return f"`{self.name}`"
+
+
+class FakeAdapter:
+    """Small adapter surface shared by isolated SQL macro tests."""
+
+    @staticmethod
+    def quote(identifier):
+        return f"`{identifier}`"
+
+
+class FakeRow:
+    """Stand-in for an agate Row, as returned by ``run_query``.
+
+    Iteration yields *values*, not keys -- the partition macros rely on that.
+    """
+
+    def __init__(self, mapping: Dict[str, Any]):
+        self._mapping = dict(mapping)
+
+    def __iter__(self):
+        return iter(self._mapping.values())
+
+    def __len__(self):
+        return len(self._mapping)
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return list(self._mapping.values())[key]
+        return self._mapping[key]
+
+    def items(self):
+        return self._mapping.items()
+
+    def keys(self):
+        return self._mapping.keys()
+
+    def values(self):
+        return self._mapping.values()
+
+
+class CapturedCompilerError(Exception):
+    """Raised in place of dbt's compiler error, so tests can assert on it."""
+
+
+class FakeExceptions:
+    @staticmethod
+    def raise_compiler_error(msg, node=None):
+        raise CapturedCompilerError(msg)
+
+    @staticmethod
+    def raise_not_implemented(msg):
+        raise CapturedCompilerError(msg)
+
+    @staticmethod
+    def raise_fail_fast_error(msg, node=None):
+        raise CapturedCompilerError(msg)
+
+    @staticmethod
+    def warn(msg):
+        return None
+
+
+class MacroRunner:
+    """Compile a macro file and call one macro out of it.
+
+    Macros in the same file call each other by bare name, while dbt's Jinja
+    parser renames every *definition* to ``dbt_macro__<name>``. Bare names are
+    resolved from the render context in real dbt, so the runner re-binds each
+    compiled macro into the context under its bare name before rendering. That
+    is what lets, say, ``doris__create_table_as`` reach ``doris__properties``.
+    """
+
+    def __init__(self, *rel_paths: str, context: Optional[Dict[str, Any]] = None):
+        self.rel_paths = rel_paths
+        self.source = "\n".join(read_macro_file(p) for p in rel_paths)
+        self.statements: List[Statement] = []
+        self.context: Dict[str, Any] = self._base_context()
+        self.context.update(context or {})
+
+    def _base_context(self) -> Dict[str, Any]:
+        def statement(name=None, fetch_result=False, auto_begin=True, caller=None):
+            sql = caller() if caller is not None else ""
+            self.statements.append(Statement(name, sql))
+            return ""
+
+        def do_return(value):
+            raise MacroReturn(value)
+
+        return {
+            "statement": statement,
+            "return": do_return,
+            "config": FakeConfig(),
+            "validation": FakeValidation(),
+            "exceptions": FakeExceptions(),
+            "model": {},
+            "basestring": str,
+            "modules": {"re": re},
+            "log": lambda msg, info=False: "",
+        }
+
+    @staticmethod
+    def _catch_return(macro):
+        """Mirror dbt's MacroGenerator: ``return()`` ends one macro, not the stack.
+
+        ``return()`` raises MacroReturn, and dbt catches it around each macro
+        call. Without this wrapper a ``return()`` in a nested macro -- say
+        ``get_partition_items`` -- would unwind the caller's loop as well.
+        """
+
+        def wrapper(*args, **kwargs):
+            try:
+                return macro(*args, **kwargs)
+            except MacroReturn as e:
+                return e.value
+
+        return wrapper
+
+    def render(self, macro_name: str, *args, **kwargs):
+        """Call ``macro_name``; return its ``return()`` value, else its output."""
+        env = get_environment(None, capture_macros=False)
+        template = env.from_string(self.source)
+        # A module render binds the macros; MacroFuzzTemplate.new_context takes
+        # the context dict by reference, so later mutations are visible to the
+        # macro bodies.
+        module = template.make_module(self.context)
+        macros = {}
+        for attr in dir(module):
+            if attr.startswith(MACRO_PREFIX):
+                bare = attr[len(MACRO_PREFIX) :]
+                macros[bare] = getattr(module, attr)
+                self.context[bare] = self._catch_return(macros[bare])
+
+        macro = macros.get(macro_name)
+        if macro is None:
+            raise AssertionError(
+                f"macro {macro_name!r} is not defined in {', '.join(self.rel_paths)}"
+            )
+        self.statements = []
+        try:
+            return str(macro(*args, **kwargs))
+        except MacroReturn as e:
+            return e.value
+
+    def sql(self, macro_name: str, *args, **kwargs) -> str:
+        """Render and normalise whitespace, for readable assertions."""
+        return " ".join(self.render(macro_name, *args, **kwargs).split())

--- a/extension/dbt-doris/test/unit/test_incremental.py
+++ b/extension/dbt-doris/test/unit/test_incremental.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit coverage for Doris incremental strategy contracts and SQL."""
+
+import mysql.connector
+import pytest
+from dbt.adapters.doris.column import DorisColumn
+from dbt.adapters.doris.connections import DorisConnectionManager
+from dbt.adapters.doris.impl import DorisAdapter
+from dbt.adapters.doris.relation import DorisRelation
+from dbt.adapters.sql import SQLConnectionManager
+from dbt.exceptions import DbtRuntimeError
+
+from .macro_harness import (
+    CapturedCompilerError,
+    FakeAdapter,
+    FakeColumn,
+    FakeConfig,
+    FakeRelation,
+    MacroRunner,
+)
+
+INCREMENTAL_MACROS = (
+    "materializations/incremental/incremental.sql",
+    "materializations/incremental/help.sql",
+    "materializations/incremental/strategies.sql",
+)
+RELATION_MACROS = ("adapters/relation.sql",)
+
+
+def statement_count(sql):
+    return len([part for part in sql.split(";") if part.strip()])
+
+
+def incremental_runner(config=None):
+    return MacroRunner(
+        *INCREMENTAL_MACROS,
+        context={
+            "adapter": FakeAdapter(),
+            "config": FakeConfig(config),
+            "model": {
+                "unique_id": "model.project.model",
+                "name": "model",
+            },
+        },
+    )
+
+
+def validate(config):
+    return incremental_runner(config).render(
+        "dbt_doris_validate_get_incremental_strategy",
+        FakeConfig(config),
+    )
+
+
+def strategy_args(**updates):
+    values = {
+        "target_relation": FakeRelation(identifier="target"),
+        "temp_relation": FakeRelation(identifier="target__dbt_tmp"),
+        "unique_key": ["id"],
+        "dest_columns": [FakeColumn("id"), FakeColumn("value")],
+        "incremental_predicates": None,
+        "source_sql": "select 1 as id, 'new' as value",
+        "temp_relation_exists": False,
+        "overwrite_partitions": None,
+    }
+    values.update(updates)
+    return values
+
+
+class TestIncrementalValidation:
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            ({"unique_key": ["id"]}, "default"),
+            ({}, "default"),
+            ({"incremental_strategy": "append"}, "append"),
+            ({"incremental_strategy": "insert_overwrite"}, "insert_overwrite"),
+        ],
+    )
+    def test_public_strategy_name(self, config, expected):
+        assert validate(config) == expected
+
+    @pytest.mark.parametrize("strategy", ["merge", "delete+insert"])
+    def test_keyed_strategies_require_a_key(self, strategy):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate({"incremental_strategy": strategy})
+        assert "requires a 'unique_key'" in str(excinfo.value)
+
+    @pytest.mark.parametrize("strategy", ["merge", "delete+insert"])
+    def test_keyed_strategies_accept_composite_keys(self, strategy):
+        assert (
+            validate(
+                {
+                    "incremental_strategy": strategy,
+                    "unique_key": ["tenant_id", "id"],
+                }
+            )
+            == strategy
+        )
+
+    def test_delete_insert_alias_is_rejected(self):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate(
+                {
+                    "incremental_strategy": "delete_insert",
+                    "unique_key": "id",
+                }
+            )
+        assert "Use 'delete+insert'" in str(excinfo.value)
+
+    def test_unimplemented_grants_fail_before_execution(self):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate(
+                {
+                    "incremental_strategy": "append",
+                    "grants": {"select": ["analyst"]},
+                }
+            )
+        assert "not implemented" in str(excinfo.value)
+
+    def test_bare_sequence_config_is_rejected(self):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate(
+                {
+                    "incremental_strategy": "merge",
+                    "unique_key": "id",
+                    "sequence_col": "updated_at",
+                }
+            )
+        assert "function_column.sequence_col" in str(excinfo.value)
+
+    def test_merge_rejects_merge_on_read_property(self):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate(
+                {
+                    "incremental_strategy": "merge",
+                    "unique_key": "id",
+                    "properties": {
+                        "enable_unique_key_merge_on_write": "false",
+                    },
+                }
+            )
+        assert "delete+insert" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "property_name",
+        [
+            "function_column.sequence_col",
+            "FUNCTION_COLUMN.SEQUENCE_TYPE",
+        ],
+    )
+    def test_delete_insert_rejects_sequence_property(self, property_name):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate(
+                {
+                    "incremental_strategy": "delete+insert",
+                    "unique_key": "id",
+                    "properties": {property_name: "sequence_id"},
+                }
+            )
+        assert "strategy='merge'" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "strategy",
+        ["append", "merge", "delete+insert", "insert_overwrite"],
+    )
+    def test_predicates_are_rejected_by_builtins(self, strategy):
+        config = {
+            "incremental_strategy": strategy,
+            "incremental_predicates": ["DBT_INTERNAL_DEST.id > 0"],
+        }
+        if strategy in ["merge", "delete+insert"]:
+            config["unique_key"] = "id"
+        with pytest.raises(CapturedCompilerError):
+            validate(config)
+
+    def test_partition_config_is_validated(self):
+        with pytest.raises(CapturedCompilerError):
+            validate(
+                {
+                    "incremental_strategy": "append",
+                    "overwrite_partitions": ["p1"],
+                }
+            )
+        assert (
+            validate(
+                {
+                    "incremental_strategy": "insert_overwrite",
+                    "partition_by": ["event_date"],
+                    "overwrite_partitions": "*",
+                }
+            )
+            == "insert_overwrite"
+        )
+
+    def test_partial_merge_is_rejected(self):
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            validate(
+                {
+                    "incremental_strategy": "merge",
+                    "unique_key": "id",
+                    "merge_update_columns": ["value"],
+                }
+            )
+        assert "native MERGE INTO" in str(excinfo.value)
+
+    def test_source_must_return_every_unique_key(self):
+        runner = incremental_runner()
+        with pytest.raises(CapturedCompilerError):
+            runner.render(
+                "doris__validate_source_unique_key_columns",
+                [FakeColumn("value")],
+                ["tenant_id", "id"],
+            )
+
+    def test_unique_key_type_change_requires_full_refresh(self):
+        runner = incremental_runner()
+        with pytest.raises(CapturedCompilerError) as excinfo:
+            runner.render(
+                "doris__validate_unique_key_schema_changes",
+                {
+                    "new_target_types": [
+                        {"column_name": "id", "new_type": "bigint"}
+                    ]
+                },
+                ["id"],
+            )
+        assert "--full-refresh" in str(excinfo.value)
+
+
+class TestIncrementalStrategySql:
+    @pytest.mark.parametrize(
+        "macro",
+        [
+            "doris__get_incremental_append_sql",
+            "doris__get_incremental_merge_sql",
+        ],
+    )
+    def test_direct_insert_inlines_source_once(self, macro):
+        runner = incremental_runner()
+        sql = runner.sql(macro, strategy_args())
+        assert statement_count(sql) == 1
+        assert sql.count("select 1 as id") == 1
+        assert "__dbt_tmp" not in sql
+        assert "insert into `dbt_test`.`target` (`id`, `value`)" in sql
+
+    @pytest.mark.parametrize(
+        ("partitions", "expected"),
+        [
+            (None, "insert overwrite table `dbt_test`.`target` (`id`, `value`)"),
+            ("*", "partition(*) (`id`, `value`)"),
+            (["p1", "p2"], "partition(`p1`, `p2`) (`id`, `value`)"),
+        ],
+    )
+    def test_native_insert_overwrite(self, partitions, expected):
+        sql = incremental_runner().sql(
+            "doris__get_incremental_insert_overwrite_sql",
+            strategy_args(overwrite_partitions=partitions),
+        )
+        assert statement_count(sql) == 1
+        assert expected in sql
+        assert "__dbt_tmp" not in sql
+
+    def test_public_delete_insert_is_one_safe_statement(self):
+        runner = incremental_runner()
+        sql = runner.sql(
+            "doris__get_incremental_delete_insert_sql",
+            strategy_args(temp_relation_exists=True),
+        )
+        assert statement_count(sql) == 1
+        assert runner.statements == []
+        assert "`dbt_test`.`target__dbt_tmp`" in sql
+        assert "DBT_INTERNAL_DUPLICATE_KEYS" in sql
+
+    @pytest.mark.parametrize(
+        "macro",
+        [
+            "doris__get_incremental_append_sql",
+            "doris__get_incremental_merge_sql",
+            "doris__get_incremental_delete_insert_sql",
+            "doris__get_incremental_insert_overwrite_sql",
+        ],
+    )
+    def test_standard_five_key_contract_reads_temp_relation(self, macro):
+        arg_dict = strategy_args()
+        for key in (
+            "source_sql",
+            "temp_relation_exists",
+            "overwrite_partitions",
+        ):
+            arg_dict.pop(key)
+        sql = incremental_runner().sql(macro, arg_dict)
+        assert "`dbt_test`.`target__dbt_tmp`" in sql
+        assert "from ( )" not in sql
+
+    @pytest.mark.parametrize(
+        ("unique_key", "expected"),
+        [
+            (None, "select DBT_INTERNAL_SOURCE.`id`"),
+            (["id"], "DBT_INTERNAL_DUPLICATE_KEYS"),
+        ],
+    )
+    def test_default_routes_by_unique_key(self, unique_key, expected):
+        sql = incremental_runner().sql(
+            "doris__get_incremental_default_sql",
+            strategy_args(unique_key=unique_key),
+        )
+        assert expected in sql
+
+    def test_initial_unique_ctas_validates_the_prepared_contract_sql_once(self):
+        prepared_sql = (
+            "select cast(raw_id as int) as id, value "
+            "from raw_events /* PREPARED_CONTRACT_SOURCE */"
+        )
+        runner = MacroRunner(
+            *INCREMENTAL_MACROS,
+            "materializations/table/create_table_as.sql",
+            context={
+                "adapter": FakeAdapter(),
+                "config": FakeConfig({"unique_key": ["id"]}),
+                "model": {
+                    "unique_id": "model.project.model",
+                    "name": "model",
+                },
+                "doris__unique_key": lambda: "unique key(`id`)",
+                "doris__table_comment": lambda: "",
+                "doris__partition_by": lambda: "",
+                "doris__distributed_by": lambda: "",
+                "doris__properties": lambda *args: "",
+            },
+        )
+
+        sql = runner.sql(
+            "doris__get_incremental_create_table_as_sql",
+            "merge",
+            FakeRelation(identifier="target"),
+            prepared_sql,
+            [FakeColumn("id"), FakeColumn("value")],
+        )
+
+        assert sql.count("PREPARED_CONTRACT_SOURCE") == 1
+        assert (
+            "from ( select cast(raw_id as int) as id, value "
+            "from raw_events /* PREPARED_CONTRACT_SOURCE */ "
+            ") DBT_INTERNAL_RAW_SOURCE"
+        ) in sql
+
+
+def test_valid_incremental_strategy_allowlist():
+    adapter = object.__new__(DorisAdapter)
+    assert adapter.valid_incremental_strategies() == [
+        "append",
+        "merge",
+        "delete+insert",
+        "insert_overwrite",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("raw_type", "expected"),
+    [
+        ("VARCHAR(20)", "varchar(20)"),
+        ("DECIMAL(18, 4)", "decimal(18,4)"),
+        ("CHAR(7)", "CHAR(7)"),
+        ("DATETIMEV2(6)", "DATETIMEV2(6)"),
+        ("ARRAY<VARCHAR(20)>", "ARRAY<VARCHAR(20)>"),
+    ],
+)
+def test_doris_column_preserves_parameterized_types(raw_type, expected):
+    column = DorisColumn.from_description("value", raw_type)
+    assert column.data_type == expected
+
+
+def test_doris_column_widens_with_valid_varchar_syntax():
+    target = DorisColumn.from_description("value", "varchar(10)")
+    source = DorisColumn.from_description("value", "varchar(40)")
+
+    assert target.can_expand_to(source)
+    assert DorisColumn.string_type(source.string_size()) == "varchar(40)"
+
+
+def test_view_query_extraction_does_not_split_identifier_containing_as():
+    show_create_sql = (
+        "CREATE VIEW `events`\n"
+        "(ASSET_ID, VALUE)\n"
+        " AS select 1 AS `ASSET_ID`, 'current' AS `VALUE`;"
+    )
+
+    query = MacroRunner(*RELATION_MACROS).render(
+        "doris__view_query_from_show_create",
+        show_create_sql,
+    )
+
+    assert query == "select 1 AS `ASSET_ID`, 'current' AS `VALUE`"
+
+
+@pytest.mark.parametrize(
+    ("version_string", "expected"),
+    [
+        ("doris-4.1.2-rc01-abc", (4, 1, 2)),
+        ("Doris version doris-3.0.7-release", (3, 0, 7)),
+        ("doris-2.1.10", (2, 1, 10)),
+        ("5.7.99", None),
+        ("doris version doris-0.0.0-dev", (0, 0, 0)),
+    ],
+)
+def test_parse_doris_version(version_string, expected):
+    assert DorisAdapter._parse_doris_version(version_string) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ((2, 1, 10), False),
+        ((3, 0, 0), True),
+        ((4, 1, 2), True),
+        ((0, 0, 0), False),
+        (None, False),
+    ],
+)
+def test_transactional_delete_insert_version_gate(monkeypatch, version, expected):
+    adapter = object.__new__(DorisAdapter)
+    monkeypatch.setattr(adapter, "_doris_version", lambda: version)
+    assert adapter.supports_transactional_delete_insert() is expected
+
+
+def test_version_falls_back_from_zero_comment_to_frontend(monkeypatch):
+    adapter = object.__new__(DorisAdapter)
+
+    class Table:
+        def __init__(self, rows, column_names=()):
+            self.rows = rows
+            self.column_names = column_names
+
+    results = iter(
+        [
+            (
+                None,
+                Table(
+                    [
+                        (
+                            "version_comment",
+                            "doris version doris-0.0.0-dev",
+                        )
+                    ]
+                ),
+            ),
+            (
+                None,
+                Table(
+                    [("doris-4.1.2-rc01-abc", "Yes")],
+                    ("Version", "CurrentConnected"),
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(adapter, "execute", lambda *args, **kwargs: next(results))
+
+    assert adapter._doris_version() == (4, 1, 2)
+
+
+def test_unknown_zero_version_is_not_treated_as_transaction_capable(monkeypatch):
+    adapter = object.__new__(DorisAdapter)
+
+    class Table:
+        def __init__(self, rows, column_names=()):
+            self.rows = rows
+            self.column_names = column_names
+
+    results = iter(
+        [
+            (
+                None,
+                Table(
+                    [
+                        (
+                            "version_comment",
+                            "doris version doris-0.0.0-dev",
+                        )
+                    ]
+                ),
+            ),
+            (
+                None,
+                Table(
+                    [("doris-0.0.0-dev", "Yes")],
+                    ("Version", "CurrentConnected"),
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(adapter, "execute", lambda *args, **kwargs: next(results))
+
+    assert adapter.supports_transactional_delete_insert() is False
+
+
+def test_multi_statement_drain_propagates_later_error(monkeypatch):
+    manager = object.__new__(DorisConnectionManager)
+
+    class Cursor:
+        with_rows = False
+
+        @staticmethod
+        def nextset():
+            raise mysql.connector.DatabaseError("later statement failed")
+
+    monkeypatch.setattr(
+        SQLConnectionManager,
+        "add_query",
+        lambda *args, **kwargs: (object(), Cursor()),
+    )
+    monkeypatch.setattr(manager, "get_if_exists", lambda: None)
+
+    with pytest.raises(DbtRuntimeError) as excinfo:
+        manager.add_query("set ok = true; set invalid = true")
+    assert "later statement failed" in str(excinfo.value)
+
+
+def test_database_error_rolls_back_and_closes_transaction_flag(monkeypatch):
+    manager = object.__new__(DorisConnectionManager)
+
+    class Handle:
+        rollback_calls = 0
+
+        def rollback(self):
+            self.rollback_calls += 1
+
+    class Connection:
+        handle = Handle()
+        state = "open"
+        transaction_open = True
+
+    connection = Connection()
+    monkeypatch.setattr(manager, "get_if_exists", lambda: connection)
+
+    with pytest.raises(DbtRuntimeError) as excinfo:
+        with manager.exception_handler("insert into target select * from stage"):
+            raise mysql.connector.DatabaseError("insert failed")
+
+    assert "insert failed" in str(excinfo.value)
+    assert connection.handle.rollback_calls == 1
+    assert connection.transaction_open is False
+    assert connection.state == "open"
+
+
+def test_rollback_failure_marks_connection_failed(monkeypatch):
+    manager = object.__new__(DorisConnectionManager)
+
+    class Handle:
+        @staticmethod
+        def rollback():
+            raise RuntimeError("connection lost during rollback")
+
+    class Connection:
+        handle = Handle()
+        state = "open"
+        transaction_open = True
+
+    connection = Connection()
+    monkeypatch.setattr(manager, "get_if_exists", lambda: connection)
+
+    with pytest.raises(DbtRuntimeError) as excinfo:
+        with manager.exception_handler("delete from target"):
+            raise mysql.connector.DatabaseError("delete failed")
+
+    assert "delete failed" in str(excinfo.value)
+    assert connection.transaction_open is False
+    assert connection.state == "fail"
+
+
+def test_schema_change_waits_for_finished_job(monkeypatch):
+    adapter = object.__new__(DorisAdapter)
+    relation = DorisRelation.create(schema="analytics", identifier="events")
+    jobs = iter(
+        [
+            {"job_id": "2", "state": "RUNNING", "message": ""},
+            {"job_id": "2", "state": "FINISHED", "message": ""},
+        ]
+    )
+    monkeypatch.setattr(adapter, "_latest_schema_change_job", lambda _: next(jobs))
+    sleeps = []
+    monkeypatch.setattr(
+        "dbt.adapters.doris.impl.time.sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
+    adapter.wait_for_schema_change(relation, previous_job_id="1")
+    assert sleeps == [0.2]
+
+
+def test_latest_schema_change_job_orders_by_job_id(monkeypatch):
+    adapter = object.__new__(DorisAdapter)
+    relation = DorisRelation.create(schema="analytics", identifier="events")
+    captured = {}
+
+    class Result:
+        rows = []
+
+    def execute(sql, auto_begin, fetch):
+        captured["sql"] = sql
+        return None, Result()
+
+    monkeypatch.setattr(adapter, "execute", execute)
+
+    assert adapter._latest_schema_change_job(relation) is None
+    assert "order by JobId desc limit 1" in captured["sql"]
+
+
+def test_schema_change_cancel_is_reported(monkeypatch):
+    adapter = object.__new__(DorisAdapter)
+    relation = DorisRelation.create(schema="analytics", identifier="events")
+    monkeypatch.setattr(
+        adapter,
+        "_latest_schema_change_job",
+        lambda _: {
+            "job_id": "2",
+            "state": "CANCELLED",
+            "message": "invalid type conversion",
+        },
+    )
+    with pytest.raises(DbtRuntimeError) as excinfo:
+        adapter.wait_for_schema_change(relation, previous_job_id="1")
+    assert "invalid type conversion" in str(excinfo.value)

--- a/extension/dbt-doris/tox.ini
+++ b/extension/dbt-doris/tox.ini
@@ -15,27 +15,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
+; Python floor is 3.10, matching dbt Core 1.12 and python_requires in setup.py.
+;
+; Two suites:
+;   unit       -- renders the shipped macros with dbt's Jinja; no cluster needed,
+;                 so this is what CI can run on a pull request.
+;   functional -- dbt-tests-adapter against a real cluster. Point DORIS_TEST_* at
+;                 it (see test/conftest.py for the defaults; default port 9030).
 [tox]
 skipsdist = True
-envlist = py37,py38,py39
+envlist = unit,py310,py311,py312,py313,py314
 
-[testenv:{unit,py37,py38,py39,py}]
-description = unit testing
+[testenv:unit]
+description = macro unit tests (no Doris cluster required)
 skip_install = True
-passenv = DBT_* PYTEST_ADOPTS
-commands = {envpython} -m pytest {posargs} tests/unit
+commands = {envpython} -m pytest {posargs} test/unit
 deps =
   -rdev-requirements.txt
   -e.
 
-
-[testenv:{integration,py37,py38,py39,py}-{ doris }]
-description = adapter plugin integration testing
-skip_install = true
+[testenv:{functional,py310,py311,py312,py313,py314,py}]
+description = adapter plugin functional testing (requires a running Doris cluster)
+skip_install = True
 passenv = DBT_* DORIS_TEST_* PYTEST_ADOPTS
-commands =
-  doris: {envpython} -m pytest -m profile_doris {posargs:test/integration}
-  doris: {envpython} -m pytest {posargs} tests/functional
+commands = {envpython} -m pytest {posargs} test/unit test/functional
 deps =
-  -rdev_requirements.txt
+  -rdev-requirements.txt
   -e.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

dbt-doris previously materialized every incremental batch and exposed Unique Key upsert behavior under the standard `insert_overwrite` name. That made the public strategy semantics differ from dbt Core and prevented native Doris overwrite behavior.

This PR implements the dbt Core 1.12 incremental strategy contract for:

- `append` on Duplicate Key tables;
- `merge` as a full-row Merge-on-Write Unique Key upsert;
- `delete+insert`, using a single MOW upsert where equivalent and a staged transactional `DELETE USING` plus `INSERT` path for Merge-on-Read targets;
- native whole-table, static-partition, and dynamic-partition `insert_overwrite`.

It also adds early source/target key validation, duplicate-key protection, `on_schema_change` handling with Doris schema-change polling, atomic full-refresh table exchange, failed View-to-Table recovery, and cleanup of dbt helper relations.

The adapter now targets dbt Core 1.12.x and Python 3.10 or newer. `microbatch`, Doris 4.1 native `MERGE INTO`, partial merge columns, and incremental predicates remain out of scope.

### Release note

Incremental strategy names now match dbt semantics. Projects that previously used `insert_overwrite` for Doris Unique Key upserts must migrate to `merge`. Native whole-table and partition `INSERT OVERWRITE` are now supported.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `python -m pytest -q test/unit`: 61 passed on Python 3.12
        - 20 Doris incremental functional tests passed on the original implementation snapshot before this branch was rebased onto current master; they were not rerun for this draft PR.
        - flake8 passed for every Python file changed by this PR.
        - `git diff --check origin/master...HEAD` passed.
        - A full-tree flake8 invocation still reports the pre-existing unused `pytest` import in `test/functional/adapter/test_basic.py`, which this PR does not modify.
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. `insert_overwrite` now performs a real overwrite; Unique Key upsert uses `merge`.

- Does this need documentation?
    - [ ] No.
    - [x] Yes. Usage and migration notes are included in `extension/dbt-doris/docs/incremental.zh-CN.md`.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
