### PR TITLE
[improvement](be) Avoid eager formatting in hot paths

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -1545,7 +1545,7 @@ Status CloudTablet::check_delete_bitmap_cache(int64_t txn_id,
         if (expected_cardinality != cached_cardinality) {
             auto msg = fmt::format(
                     "delete bitmap cache check failed, cur_cardinality={}, cached_cardinality={}"
-                    "txn_id={}, tablet_id={}",
+                    ", txn_id={}, tablet_id={}",
                     expected_cardinality, cached_cardinality, txn_id, tablet_id());
             DCHECK_EQ(expected_cardinality, cached_cardinality) << msg;
             return Status::InternalError<false>(msg);

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -1540,14 +1540,14 @@ Status CloudTablet::check_delete_bitmap_cache(int64_t txn_id,
     Status st = engine.txn_delete_bitmap_cache().get_delete_bitmap(
             txn_id, tablet_id(), &cached_delete_bitmap, nullptr, nullptr);
     if (st.ok()) {
-        bool res = (expected_delete_bitmap->cardinality() == cached_delete_bitmap->cardinality());
-        auto msg = fmt::format(
-                "delete bitmap cache check failed, cur_cardinality={}, cached_cardinality={}"
-                "txn_id={}, tablet_id={}",
-                expected_delete_bitmap->cardinality(), cached_delete_bitmap->cardinality(), txn_id,
-                tablet_id());
-        if (!res) {
-            DCHECK(res) << msg;
+        const auto expected_cardinality = expected_delete_bitmap->cardinality();
+        const auto cached_cardinality = cached_delete_bitmap->cardinality();
+        if (expected_cardinality != cached_cardinality) {
+            auto msg = fmt::format(
+                    "delete bitmap cache check failed, cur_cardinality={}, cached_cardinality={}"
+                    "txn_id={}, tablet_id={}",
+                    expected_cardinality, cached_cardinality, txn_id, tablet_id());
+            DCHECK_EQ(expected_cardinality, cached_cardinality) << msg;
             return Status::InternalError<false>(msg);
         }
     }

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -583,12 +583,12 @@ Status DataTypeNumberSerDe<T>::write_column_to_arrow(const IColumn& column, cons
     } else if constexpr (T == TYPE_LARGEINT) {
         auto& string_builder = assert_cast<arrow::StringBuilder&>(*array_builder);
         for (size_t i = start; i < end; ++i) {
-            auto& data_value = col_data[i];
-            std::string value_str = fmt::format("{}", data_value);
             if (null_map && (*null_map)[i]) {
                 RETURN_IF_ERROR(
                         checkArrowStatus(string_builder.AppendNull(), column, *array_builder));
             } else {
+                const auto& data_value = col_data[i];
+                std::string value_str = fmt::format("{}", data_value);
                 RETURN_IF_ERROR(checkArrowStatus(
                         string_builder.Append(value_str.data(),
                                               cast_set<int, size_t, false>(value_str.length())),

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -397,14 +397,31 @@ std::shared_ptr<Block> create_test_block(std::vector<PrimitiveType> cols, int ro
             block->insert(std::move(type_and_name));
         } break;
         case TYPE_LARGEINT: {
-            auto vec = ColumnInt128::create();
-            auto& data = vec->get_data();
-            for (int i = 0; i < row_num; ++i) {
-                data.push_back(__int128_t(i));
+            if (is_nullable) {
+                auto column_int128 = ColumnInt128::create();
+                auto column_nullable = make_nullable(std::move(column_int128));
+                auto mutable_nullable = std::move(*column_nullable).mutate();
+                for (int i = 0; i < row_num; ++i) {
+                    if (i % 2 == 0) {
+                        mutable_nullable->insert_default();
+                    } else {
+                        mutable_nullable->insert(Field::create_field<TYPE_LARGEINT>(__int128_t(i)));
+                    }
+                }
+                auto data_type = make_nullable(std::make_shared<DataTypeInt128>());
+                ColumnWithTypeAndName type_and_name(mutable_nullable->get_ptr(), data_type,
+                                                    col_name);
+                block->insert(std::move(type_and_name));
+            } else {
+                auto vec = ColumnInt128::create();
+                auto& data = vec->get_data();
+                for (int i = 0; i < row_num; ++i) {
+                    data.push_back(__int128_t(i));
+                }
+                DataTypePtr data_type(std::make_shared<DataTypeInt128>());
+                ColumnWithTypeAndName type_and_name(vec->get_ptr(), data_type, col_name);
+                block->insert(std::move(type_and_name));
             }
-            DataTypePtr data_type(std::make_shared<DataTypeInt128>());
-            ColumnWithTypeAndName type_and_name(vec->get_ptr(), data_type, col_name);
-            block->insert(std::move(type_and_name));
         } break;
         default:
             LOG(FATAL) << "error column type";


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #66363

Problem Summary: Successful delete bitmap cache checks repeatedly traversed both bitmaps to construct an unused error message, and nullable LARGEINT Arrow serialization formatted values before checking whether rows were null. Reuse the computed bitmap cardinalities, construct the mismatch message only on failure, and format LARGEINT values only for non-null rows.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

