### PR TITLE
[fix](build) Allow generated regression fixtures in Gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,6 +7,18 @@ useDefault = true
 id = "generic-api-key"
 
 [[rules.allowlists]]
+description = "Ignore generated random-string fixtures in selected regression outputs"
+condition = "AND"
+regexTarget = "match"
+paths = [
+    '''^regression-test/data/datatype_p0/nested_types/query/test_nested_types_insert_into_with_s3\.out$''',
+    '''^regression-test/data/datatype_p0/nested_types/query/test_nestedtypes_csv_insert_into_with_s3\.out$''',
+    '''^regression-test/data/external_table_p0/tvf/test_http_tvf\.out$''',
+    '''^regression-test/data/external_table_p0/tvf/test_local_tvf_with_complex_type_element_at\.out$''',
+]
+regexes = ['''[A-Za-z0-9]{6}-[A-Za-z0-9]{7}-[A-Za-z0-9]{3}-[A-Za-z0-9]{4}''']
+
+[[rules.allowlists]]
 description = "Ignore prose 'version token: iceberg/paimon' in code comments/plan-doc — a cache version-token discussion, not a credential (generic-api-key false positive: 'iceberg/paimon' entropy 3.52 barely clears the 3.5 threshold)"
 condition = "AND"
 regexTarget = "match"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65609

Problem Summary: The `generic-api-key` rule treats random-string fixtures in four generated regression result files as credentials when unrelated floating-point formatting changes rewrite their very long lines. PR #65609 therefore reports 11 Gitleaks findings even though every detected candidate already exists in its parent commit.

This change adds a rule-level allowlist scoped by both:

- the four exact generated `.out` paths that triggered the false positives; and
- the fixed synthetic random-string shape used by those fixtures.

It does not disable `generic-api-key` and does not allowlist the broader regression data tree.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Replayed Gitleaks v8.30.0 on `0dde2739..48239854`: 11 findings before the change, 0 after.
    - Confirmed a generic credential positive control is still detected.
    - Scanned this PR commit with Gitleaks v8.30.0: 0 findings.
- Behavior changed: No
- Does this need documentation: No

Failed job being addressed: https://github.com/apache/doris/actions/runs/30459616022/job/90601962857
