### PR TITLE
[fix](prepare) Clear stale partition state for prepared statements

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -46,6 +46,7 @@ import org.apache.doris.nereids.hint.UseMvHint;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.analysis.ColumnAliasGenerator;
+import org.apache.doris.nereids.rules.exploration.mv.InitMaterializationContextHook;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -1473,6 +1474,10 @@ public class StatementContext implements Closeable {
         tableUsedPartitionNameMap.clear();
         commonTableIdToRelationIdToMap.clear();
         mvCanRewritePartitionsMap.clear();
+        candidateMTMVs.clear();
+        candidateMVs.clear();
+        mtmvRelatedTables.clear();
+        plannerHooks.removeIf(InitMaterializationContextHook.class::isInstance);
         materializedViewRewriteDuration = 0;
         hints.removeIf(UseMvHint.class::isInstance);
         tmpPlanForMvRewrite.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -1469,8 +1469,8 @@ public class StatementContext implements Closeable {
         return mvCanRewritePartitionsMap;
     }
 
-    /** Clear materialized-view planning state retained by a prepared statement between executions. */
-    public void resetMaterializedViewStateForPreparedExecution() {
+    /** Clear materialized-view state produced by the previous planning attempt. */
+    public void resetMaterializedViewStateForPlanningAttempt() {
         tableUsedPartitionNameMap.clear();
         commonTableIdToRelationIdToMap.clear();
         mvCanRewritePartitionsMap.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -1468,6 +1468,22 @@ public class StatementContext implements Closeable {
         return mvCanRewritePartitionsMap;
     }
 
+    /** Clear materialized-view planning state retained by a prepared statement between executions. */
+    public void resetMaterializedViewStateForPreparedExecution() {
+        tableUsedPartitionNameMap.clear();
+        commonTableIdToRelationIdToMap.clear();
+        mvCanRewritePartitionsMap.clear();
+        materializedViewRewriteDuration = 0;
+        hints.removeIf(UseMvHint.class::isInstance);
+        tmpPlanForMvRewrite.clear();
+        rewrittenPlansByMv.clear();
+        needPreMvRewriteRuleMasks.clear();
+        needPreMvRewrite = false;
+        preMvRewritten = false;
+        materializationRewrittenSuccessSet.clear();
+        relationIdToStatisticsMap.clear();
+    }
+
     public void setPrepareStage(boolean isPrepare) {
         this.prepareStage = isPrepare;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionCompensator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionCompensator.java
@@ -291,10 +291,8 @@ public class PartitionCompensator {
                     continue tableLoop;
                 }
                 // If currentUsedRelationIdSet is not empty, need check relation id to get concrete used partitions
-                BitSet usedPartitionRelation = new BitSet();
-                usedPartitionRelation.set(tableUsedPartitionPair.key().asInt());
                 if (!currentUsedRelationIdSet.isEmpty()
-                        && !currentUsedRelationIdSet.intersects(usedPartitionRelation)) {
+                        && !currentUsedRelationIdSet.get(tableUsedPartitionPair.key().asInt())) {
                     continue;
                 }
                 usedPartitionSet.addAll(tableUsedPartitionPair.value());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
@@ -91,6 +91,10 @@ public class ExecuteCommand extends Command {
         }
         PrepareCommand prepareCommand = preparedStmtCtx.command;
         StatementContext statementContext = preparedStmtCtx.getStatementContext();
+        // Prepared statements reuse StatementContext across executions. Discard partition
+        // information collected by the previous execution before planning the current one.
+        statementContext.getTableUsedPartitionNameMap().clear();
+        statementContext.getCommonTableIdToRelationIdMap().clear();
         statementContext.setPrepareStage(false);
         statementContext.setIsInsert(false);
         // A prepared EXECUTE reuses this one StatementContext across executions; drop the connector

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
@@ -93,7 +93,7 @@ public class ExecuteCommand extends Command {
         StatementContext statementContext = preparedStmtCtx.getStatementContext();
         // Prepared statements reuse StatementContext across executions. Discard partition and MV
         // planning results collected by the previous execution before planning the current one.
-        statementContext.resetMaterializedViewStateForPreparedExecution();
+        statementContext.resetMaterializedViewStateForPlanningAttempt();
         statementContext.setPrepareStage(false);
         statementContext.setIsInsert(false);
         // A prepared EXECUTE reuses this one StatementContext across executions; drop the connector

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
@@ -91,10 +91,9 @@ public class ExecuteCommand extends Command {
         }
         PrepareCommand prepareCommand = preparedStmtCtx.command;
         StatementContext statementContext = preparedStmtCtx.getStatementContext();
-        // Prepared statements reuse StatementContext across executions. Discard partition
-        // information collected by the previous execution before planning the current one.
-        statementContext.getTableUsedPartitionNameMap().clear();
-        statementContext.getCommonTableIdToRelationIdMap().clear();
+        // Prepared statements reuse StatementContext across executions. Discard partition and MV
+        // planning results collected by the previous execution before planning the current one.
+        statementContext.resetMaterializedViewStateForPreparedExecution();
         statementContext.setPrepareStage(false);
         statementContext.setIsInsert(false);
         // A prepared EXECUTE reuses this one StatementContext across executions; drop the connector

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -263,6 +263,9 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
             // Each internal attempt must repin connector metadata; retaining the previous writer schema can
             // plan defaults and partition fields against the table version that triggered the retry.
             ctx.getStatementContext().resetConnectorStatementScope();
+            if (retryTimes > 1) {
+                ctx.getStatementContext().resetMaterializedViewStateForPlanningAttempt();
+            }
             TableIf targetTableIf = getTargetTableIf(ctx, qualifiedTargetTableName);
             DatabaseIf<?> targetDatabase = getTargetDatabase(targetTableIf);
             // check auth

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -263,9 +263,7 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
             // Each internal attempt must repin connector metadata; retaining the previous writer schema can
             // plan defaults and partition fields against the table version that triggered the retry.
             ctx.getStatementContext().resetConnectorStatementScope();
-            if (retryTimes > 1) {
-                ctx.getStatementContext().resetMaterializedViewStateForPlanningAttempt();
-            }
+            ctx.getStatementContext().resetMaterializedViewStateForPlanningAttempt();
             TableIf targetTableIf = getTargetTableIf(ctx, qualifiedTargetTableName);
             DatabaseIf<?> targetDatabase = getTargetDatabase(targetTableIf);
             // check auth

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -616,6 +616,9 @@ public class StmtExecutor {
         }
         for (int i = 1; i <= retryTime; i++) {
             try {
+                if (i > 1) {
+                    statementContext.resetMaterializedViewStateForPlanningAttempt();
+                }
                 if (disableCloudVersionCacheOnRetry) {
                     executeWithVersionCacheDisabled(queryId);
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1050,7 +1050,9 @@ public class StmtExecutor {
         // Only do this when isProxy is true, because other code paths like
         // executeInternalQuery() rely on legacy Coordinator behavior with mock backends.
         if (isProxy) {
-            this.context.getStatementContext().setParsedStatement(parsedStmt);
+            StatementContext parsedStatementContext = ((LogicalPlanAdapter) parsedStmt).getStatementContext();
+            parsedStatementContext.setParsedStatement(parsedStmt);
+            setStatementContext(parsedStatementContext);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
@@ -20,6 +20,8 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.TableScanParams;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
@@ -30,6 +32,7 @@ import org.apache.doris.datasource.mvcc.MvccSnapshot;
 import org.apache.doris.datasource.mvcc.MvccTable;
 import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.PlannerHook;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -37,6 +40,7 @@ import org.apache.doris.nereids.hint.Hint;
 import org.apache.doris.nereids.hint.UseMvHint;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.exploration.mv.InitMaterializationContextHook;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.commands.merge.MergeIntoCommand;
@@ -157,13 +161,19 @@ public class ExecuteCommandTest {
         Mockito.when(executor.getContext()).thenReturn(connectContext);
 
         Hint retainedHint = new Hint("Distribute");
+        PlannerHook retainedHook = Mockito.mock(PlannerHook.class);
         statementContext.addHint(retainedHint);
+        statementContext.addPlannerHook(retainedHook);
         statementContext.setForceRecordTmpPlan(true);
         AtomicInteger executionCount = new AtomicInteger();
         Mockito.doAnswer(invocation -> {
             Assertions.assertTrue(statementContext.getTableUsedPartitionNameMap().isEmpty());
             Assertions.assertTrue(statementContext.getCommonTableIdToRelationIdMap().isEmpty());
             Assertions.assertTrue(statementContext.getMvCanRewritePartitionsMap().isEmpty());
+            Assertions.assertTrue(statementContext.getCandidateMTMVs().isEmpty());
+            Assertions.assertTrue(statementContext.getCandidateMVs().isEmpty());
+            Assertions.assertTrue(statementContext.getMtmvRelatedTables().isEmpty());
+            Assertions.assertEquals(Collections.singleton(retainedHook), statementContext.getPlannerHooks());
             Assertions.assertEquals(0, statementContext.getMaterializedViewRewriteDuration());
             Assertions.assertEquals(Collections.singletonList(retainedHint), statementContext.getHints());
             Assertions.assertTrue(statementContext.getTmpPlanForMvRewrite().isEmpty());
@@ -339,11 +349,16 @@ public class ExecuteCommandTest {
     }
 
     private void populateMaterializedViewState(StatementContext statementContext, LogicalPlan logicalPlan) {
+        MTMV candidateMTMV = Mockito.mock(MTMV.class);
         statementContext.getTableUsedPartitionNameMap().put(Collections.singletonList("table"),
                 Pair.of(new RelationId(1), Collections.singleton("partition")));
         statementContext.getCommonTableIdToRelationIdMap().put(1, 1);
         statementContext.getMvCanRewritePartitionsMap().put(Mockito.mock(BaseTableInfo.class),
                 Collections.singleton(Mockito.mock(Partition.class)));
+        statementContext.getCandidateMTMVs().add(candidateMTMV);
+        statementContext.getCandidateMVs().add(Mockito.mock(MaterializedIndexMeta.class));
+        statementContext.getMtmvRelatedTables().put(Collections.singletonList("mv"), candidateMTMV);
+        statementContext.addPlannerHook(InitMaterializationContextHook.INSTANCE);
         statementContext.addMaterializedViewRewriteDuration(1);
         statementContext.addHint(Mockito.mock(UseMvHint.class));
         statementContext.addTmpPlanForMvRewrite(logicalPlan);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ExecuteCommandTest {
 
     @Test
-    public void testExecutionStateIsResetForEveryExecute() throws Exception {
+    public void testResolvedScanOptionsAreResetForEveryExecute() throws Exception {
         String sql = "select * from p@options('scan.mode'='latest')";
         LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
         UnboundRelation relation = logicalPlan.<UnboundRelation>collectToList(
@@ -77,21 +77,57 @@ public class ExecuteCommandTest {
         Mockito.when(connectContext.getStatementContext()).thenReturn(statementContext);
         Mockito.when(executor.getContext()).thenReturn(connectContext);
 
-        statementContext.getTableUsedPartitionNameMap().put(
-                Collections.singletonList("table"), Pair.of(new RelationId(0), Collections.singleton("p1")));
-        statementContext.getCommonTableIdToRelationIdMap().put(0, 0);
         new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
-        Assertions.assertTrue(statementContext.getTableUsedPartitionNameMap().isEmpty());
-        Assertions.assertTrue(statementContext.getCommonTableIdToRelationIdMap().isEmpty());
         Assertions.assertEquals("2", resolveNextSnapshot(scanParams, snapshotId));
 
-        statementContext.getTableUsedPartitionNameMap().put(
-                Collections.singletonList("table"), Pair.of(new RelationId(1), Collections.singleton("p2")));
-        statementContext.getCommonTableIdToRelationIdMap().put(0, 1);
         new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
-        Assertions.assertTrue(statementContext.getTableUsedPartitionNameMap().isEmpty());
-        Assertions.assertTrue(statementContext.getCommonTableIdToRelationIdMap().isEmpty());
         Assertions.assertEquals("3", resolveNextSnapshot(scanParams, snapshotId));
+        Mockito.verify(executor, Mockito.times(2)).execute();
+    }
+
+    @Test
+    public void testPartitionStateIsResetForEveryExecute() throws Exception {
+        String sql = "select 1";
+        LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+        StatementContext statementContext = new StatementContext();
+        PrepareCommand prepareCommand = new PrepareCommand(
+                "stmt", logicalPlan, Collections.emptyList(), new OriginStatement(sql, 0));
+        PreparedStatementContext preparedStatement = new PreparedStatementContext(
+                prepareCommand, connectContext, statementContext, "stmt");
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(connectContext.getPreparedStementContext("stmt")).thenReturn(preparedStatement);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(new SessionVariable());
+        Mockito.when(connectContext.getStatementContext()).thenReturn(statementContext);
+        Mockito.when(executor.getContext()).thenReturn(connectContext);
+
+        List<String> tableQualifier = Collections.singletonList("table");
+        AtomicInteger relationId = new AtomicInteger();
+        Mockito.doAnswer(invocation -> {
+            int currentRelationId = relationId.getAndIncrement();
+            statementContext.getTableUsedPartitionNameMap().put(tableQualifier,
+                    Pair.of(new RelationId(currentRelationId), Collections.singleton("p")));
+            statementContext.getCommonTableIdToRelationIdMap().put(0, currentRelationId);
+            return null;
+        }).when(executor).execute();
+
+        statementContext.getTableUsedPartitionNameMap().put(
+                tableQualifier, Pair.of(new RelationId(100), Collections.singleton("old")));
+        statementContext.getCommonTableIdToRelationIdMap().put(0, 100);
+
+        new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
+        Assertions.assertEquals(1, statementContext.getTableUsedPartitionNameMap().size());
+        Assertions.assertEquals(0, statementContext.getTableUsedPartitionNameMap()
+                .get(tableQualifier).iterator().next().key().asInt());
+        Assertions.assertEquals(Collections.singleton(0),
+                statementContext.getCommonTableIdToRelationIdMap().get(0));
+
+        new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
+        Assertions.assertEquals(1, statementContext.getTableUsedPartitionNameMap().size());
+        Assertions.assertEquals(1, statementContext.getTableUsedPartitionNameMap()
+                .get(tableQualifier).iterator().next().key().asInt());
+        Assertions.assertEquals(Collections.singleton(1),
+                statementContext.getCommonTableIdToRelationIdMap().get(0));
         Mockito.verify(executor, Mockito.times(2)).execute();
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.TableScanParams;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.TableIf;
@@ -27,18 +28,26 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.mvcc.MvccSnapshot;
 import org.apache.doris.datasource.mvcc.MvccTable;
+import org.apache.doris.mtmv.BaseTableInfo;
+import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.hint.Hint;
+import org.apache.doris.nereids.hint.UseMvHint;
 import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.commands.merge.MergeIntoCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.qe.PreparedStatementContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.statistics.Statistics;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
@@ -129,6 +138,55 @@ public class ExecuteCommandTest {
         Assertions.assertEquals(Collections.singleton(1),
                 statementContext.getCommonTableIdToRelationIdMap().get(0));
         Mockito.verify(executor, Mockito.times(2)).execute();
+    }
+
+    @Test
+    public void testMaterializedViewStateIsResetForEveryExecute() throws Exception {
+        String sql = "select 1";
+        LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        StatementContext statementContext = new StatementContext(
+                connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        PrepareCommand prepareCommand = new PrepareCommand(
+                "stmt", logicalPlan, Collections.emptyList(), new OriginStatement(sql, 0));
+        PreparedStatementContext preparedStatement = new PreparedStatementContext(
+                prepareCommand, connectContext, statementContext, "stmt");
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        connectContext.addPreparedStatementContext("stmt", preparedStatement);
+        Mockito.when(executor.getContext()).thenReturn(connectContext);
+
+        Hint retainedHint = new Hint("Distribute");
+        statementContext.addHint(retainedHint);
+        statementContext.setForceRecordTmpPlan(true);
+        AtomicInteger executionCount = new AtomicInteger();
+        Mockito.doAnswer(invocation -> {
+            Assertions.assertTrue(statementContext.getTableUsedPartitionNameMap().isEmpty());
+            Assertions.assertTrue(statementContext.getCommonTableIdToRelationIdMap().isEmpty());
+            Assertions.assertTrue(statementContext.getMvCanRewritePartitionsMap().isEmpty());
+            Assertions.assertEquals(0, statementContext.getMaterializedViewRewriteDuration());
+            Assertions.assertEquals(Collections.singletonList(retainedHint), statementContext.getHints());
+            Assertions.assertTrue(statementContext.getTmpPlanForMvRewrite().isEmpty());
+            Assertions.assertTrue(statementContext.getRewrittenPlansByMv().isEmpty());
+            Assertions.assertTrue(statementContext.getNeedPreMvRewriteRuleMasks().isEmpty());
+            Assertions.assertFalse(statementContext.isNeedPreMvRewrite());
+            Assertions.assertFalse(statementContext.isPreMvRewritten());
+            Assertions.assertTrue(statementContext.getMaterializationRewrittenSuccessSet().isEmpty());
+            Assertions.assertTrue(statementContext.getRelationIdToStatisticsMap().isEmpty());
+            Assertions.assertTrue(statementContext.isForceRecordTmpPlan());
+            NereidsPlanner planner = new NereidsPlanner(statementContext);
+            planner.plan(new LogicalPlanAdapter(logicalPlan, statementContext));
+            Assertions.assertNotNull(planner.getPhysicalPlan());
+            populateMaterializedViewState(statementContext, logicalPlan);
+            executionCount.incrementAndGet();
+            return null;
+        }).when(executor).execute();
+
+        populateMaterializedViewState(statementContext, logicalPlan);
+        new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
+        new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
+
+        Assertions.assertEquals(2, executionCount.get());
     }
 
     @Test
@@ -278,6 +336,23 @@ public class ExecuteCommandTest {
         return scanParams.getOrResolveMapParams(ignored -> ImmutableMap.of(
                 "scan.snapshot-id", String.valueOf(snapshotId.incrementAndGet())))
                 .get("scan.snapshot-id");
+    }
+
+    private void populateMaterializedViewState(StatementContext statementContext, LogicalPlan logicalPlan) {
+        statementContext.getTableUsedPartitionNameMap().put(Collections.singletonList("table"),
+                Pair.of(new RelationId(1), Collections.singleton("partition")));
+        statementContext.getCommonTableIdToRelationIdMap().put(1, 1);
+        statementContext.getMvCanRewritePartitionsMap().put(Mockito.mock(BaseTableInfo.class),
+                Collections.singleton(Mockito.mock(Partition.class)));
+        statementContext.addMaterializedViewRewriteDuration(1);
+        statementContext.addHint(Mockito.mock(UseMvHint.class));
+        statementContext.addTmpPlanForMvRewrite(logicalPlan);
+        statementContext.addRewrittenPlanByMv(logicalPlan);
+        statementContext.ruleSetApplied(RuleType.REORDER_JOIN);
+        statementContext.setNeedPreMvRewrite(true);
+        statementContext.setPreMvRewritten(true);
+        statementContext.addMaterializationRewrittenSuccess(Collections.singletonList("mv"));
+        statementContext.addStatistics(new RelationId(1), Mockito.mock(Statistics.class));
     }
 
     private void assertPreparedCommandResetsScanOptions(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
@@ -31,6 +31,8 @@ import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.mvcc.MvccSnapshot;
 import org.apache.doris.datasource.mvcc.MvccTable;
 import org.apache.doris.mtmv.BaseTableInfo;
+import org.apache.doris.mtmv.MTMVRelationManager;
+import org.apache.doris.mtmv.MTMVRewriteUtil;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.PlannerHook;
 import org.apache.doris.nereids.StatementContext;
@@ -56,6 +58,7 @@ import org.apache.doris.statistics.Statistics;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -197,6 +200,91 @@ public class ExecuteCommandTest {
         new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
 
         Assertions.assertEquals(2, executionCount.get());
+    }
+
+    @Test
+    public void testMvValidPartitionsAreRefreshedForEveryExecute() throws Exception {
+        String sql = "select 1";
+        LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        StatementContext statementContext = new StatementContext(
+                connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        PrepareCommand prepareCommand = new PrepareCommand(
+                "stmt", logicalPlan, Collections.emptyList(), new OriginStatement(sql, 0));
+        connectContext.addPreparedStatementContext("stmt", new PreparedStatementContext(
+                prepareCommand, connectContext, statementContext, "stmt"));
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.getContext()).thenReturn(connectContext);
+
+        MTMV mtmv = Mockito.mock(MTMV.class);
+        DatabaseIf<TableIf> database = Mockito.mock(DatabaseIf.class);
+        CatalogIf<?> catalog = Mockito.mock(CatalogIf.class);
+        Mockito.when(mtmv.getId()).thenReturn(3L);
+        Mockito.when(mtmv.getName()).thenReturn("mv");
+        Mockito.when(mtmv.getDatabase()).thenReturn(database);
+        Mockito.when(database.getId()).thenReturn(2L);
+        Mockito.when(database.getFullName()).thenReturn("db");
+        Mockito.when(database.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getId()).thenReturn(1L);
+        Mockito.when(catalog.getName()).thenReturn("internal");
+        Partition firstPartition = Mockito.mock(Partition.class);
+        Partition secondPartition = Mockito.mock(Partition.class);
+        MTMVRelationManager relationManager = new MTMVRelationManager();
+
+        try (MockedStatic<MTMVRewriteUtil> rewriteUtil = Mockito.mockStatic(MTMVRewriteUtil.class)) {
+            rewriteUtil.when(() -> MTMVRewriteUtil.getMTMVCanRewritePartitions(
+                    Mockito.eq(mtmv), Mockito.eq(connectContext), Mockito.anyLong(), Mockito.eq(false),
+                    Mockito.anyMap())).thenReturn(Arrays.asList(firstPartition, secondPartition),
+                            Collections.singleton(firstPartition));
+            Mockito.doAnswer(invocation -> {
+                relationManager.isMVPartitionValid(
+                        mtmv, connectContext, false, Collections.emptyMap());
+                return null;
+            }).when(executor).execute();
+
+            ExecuteCommand executeCommand = new ExecuteCommand("stmt", prepareCommand, statementContext);
+            executeCommand.run(connectContext, executor);
+            Assertions.assertEquals(Arrays.asList(firstPartition, secondPartition),
+                    statementContext.getMvCanRewritePartitionsMap().get(new BaseTableInfo(mtmv)));
+
+            executeCommand.run(connectContext, executor);
+            Assertions.assertEquals(Collections.singleton(firstPartition),
+                    statementContext.getMvCanRewritePartitionsMap().get(new BaseTableInfo(mtmv)));
+        }
+    }
+
+    @Test
+    public void testMaterializationHookFollowsRewriteSettingForEveryExecute() throws Exception {
+        String sql = "select 1";
+        LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        StatementContext statementContext = new StatementContext(
+                connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        connectContext.getState().setIsQuery(true);
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(true);
+        PrepareCommand prepareCommand = new PrepareCommand(
+                "stmt", logicalPlan, Collections.emptyList(), new OriginStatement(sql, 0));
+        connectContext.addPreparedStatementContext("stmt", new PreparedStatementContext(
+                prepareCommand, connectContext, statementContext, "stmt"));
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.getContext()).thenReturn(connectContext);
+        Mockito.doAnswer(invocation -> {
+            NereidsPlanner planner = new NereidsPlanner(statementContext);
+            planner.plan(new LogicalPlanAdapter(logicalPlan, statementContext));
+            return null;
+        }).when(executor).execute();
+
+        ExecuteCommand executeCommand = new ExecuteCommand("stmt", prepareCommand, statementContext);
+        executeCommand.run(connectContext, executor);
+        Assertions.assertTrue(statementContext.getPlannerHooks().stream()
+                .anyMatch(InitMaterializationContextHook.class::isInstance));
+
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
+        executeCommand.run(connectContext, executor);
+        Assertions.assertFalse(statementContext.getPlannerHooks().stream()
+                .anyMatch(InitMaterializationContextHook.class::isInstance));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.mvcc.MvccSnapshot;
 import org.apache.doris.datasource.mvcc.MvccTable;
@@ -30,6 +31,7 @@ import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
+import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.commands.merge.MergeIntoCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.qe.ConnectContext;
@@ -53,7 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ExecuteCommandTest {
 
     @Test
-    public void testResolvedScanOptionsAreResetForEveryExecute() throws Exception {
+    public void testExecutionStateIsResetForEveryExecute() throws Exception {
         String sql = "select * from p@options('scan.mode'='latest')";
         LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
         UnboundRelation relation = logicalPlan.<UnboundRelation>collectToList(
@@ -75,10 +77,20 @@ public class ExecuteCommandTest {
         Mockito.when(connectContext.getStatementContext()).thenReturn(statementContext);
         Mockito.when(executor.getContext()).thenReturn(connectContext);
 
+        statementContext.getTableUsedPartitionNameMap().put(
+                Collections.singletonList("table"), Pair.of(new RelationId(0), Collections.singleton("p1")));
+        statementContext.getCommonTableIdToRelationIdMap().put(0, 0);
         new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
+        Assertions.assertTrue(statementContext.getTableUsedPartitionNameMap().isEmpty());
+        Assertions.assertTrue(statementContext.getCommonTableIdToRelationIdMap().isEmpty());
         Assertions.assertEquals("2", resolveNextSnapshot(scanParams, snapshotId));
 
+        statementContext.getTableUsedPartitionNameMap().put(
+                Collections.singletonList("table"), Pair.of(new RelationId(1), Collections.singleton("p2")));
+        statementContext.getCommonTableIdToRelationIdMap().put(0, 1);
         new ExecuteCommand("stmt", prepareCommand, statementContext).run(connectContext, executor);
+        Assertions.assertTrue(statementContext.getTableUsedPartitionNameMap().isEmpty());
+        Assertions.assertTrue(statementContext.getCommonTableIdToRelationIdMap().isEmpty());
         Assertions.assertEquals("3", resolveNextSnapshot(scanParams, snapshotId));
         Mockito.verify(executor, Mockito.times(2)).execute();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommandTest.java
@@ -26,13 +26,16 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.mvcc.MvccSnapshot;
 import org.apache.doris.datasource.mvcc.MvccTable;
 import org.apache.doris.mtmv.BaseTableInfo;
+import org.apache.doris.mtmv.MTMVRelation;
 import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.mtmv.MTMVRewriteUtil;
+import org.apache.doris.mtmv.MTMVUtil;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.PlannerHook;
 import org.apache.doris.nereids.StatementContext;
@@ -251,6 +254,51 @@ public class ExecuteCommandTest {
             executeCommand.run(connectContext, executor);
             Assertions.assertEquals(Collections.singleton(firstPartition),
                     statementContext.getMvCanRewritePartitionsMap().get(new BaseTableInfo(mtmv)));
+        }
+    }
+
+    @Test
+    public void testMvCandidateIsRebuiltAfterSameNameReplacement() throws Exception {
+        String sql = "select 1";
+        LogicalPlan logicalPlan = new NereidsParser().parseSingle(sql);
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        StatementContext statementContext = new StatementContext(
+                connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        PrepareCommand prepareCommand = new PrepareCommand(
+                "stmt", logicalPlan, Collections.emptyList(), new OriginStatement(sql, 0));
+        connectContext.addPreparedStatementContext("stmt", new PreparedStatementContext(
+                prepareCommand, connectContext, statementContext, "stmt"));
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.getContext()).thenReturn(connectContext);
+
+        BaseTableInfo baseTableInfo = new BaseTableInfo(new TableNameInfo("internal", "db", "base"));
+        BaseTableInfo mtmvInfo = new BaseTableInfo(new TableNameInfo("internal", "db", "mv"));
+        MTMVRelation relation = new MTMVRelation(
+                Collections.singleton(baseTableInfo), Collections.singleton(baseTableInfo),
+                Collections.singleton(baseTableInfo), Collections.emptySet(), Collections.emptySet());
+        MTMVRelationManager relationManager = new MTMVRelationManager();
+        relationManager.refreshMTMVCache(relation, mtmvInfo);
+        MTMV oldMtmv = Mockito.mock(MTMV.class);
+        MTMV replacementMtmv = Mockito.mock(MTMV.class);
+        Mockito.when(oldMtmv.canBeCandidate()).thenReturn(true);
+        Mockito.when(replacementMtmv.canBeCandidate()).thenReturn(true);
+
+        try (MockedStatic<MTMVUtil> mtmvUtil = Mockito.mockStatic(MTMVUtil.class)) {
+            mtmvUtil.when(() -> MTMVUtil.getTable(mtmvInfo)).thenReturn(oldMtmv, replacementMtmv);
+            Mockito.doAnswer(invocation -> {
+                statementContext.getCandidateMTMVs().addAll(relationManager.getCandidateMTMVs(
+                        Collections.singletonList(baseTableInfo)));
+                return null;
+            }).when(executor).execute();
+
+            ExecuteCommand executeCommand = new ExecuteCommand("stmt", prepareCommand, statementContext);
+            executeCommand.run(connectContext, executor);
+            Assertions.assertEquals(Collections.singleton(oldMtmv), statementContext.getCandidateMTMVs());
+
+            relationManager.refreshMTMVCache(relation, mtmvInfo);
+            executeCommand.run(connectContext, executor);
+            Assertions.assertEquals(Collections.singleton(replacementMtmv), statementContext.getCandidateMTMVs());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommandRetryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommandRetryTest.java
@@ -52,6 +52,37 @@ public class InsertIntoTableCommandRetryTest extends TestWithFeService {
     }
 
     @Test
+    public void testFirstAttemptResetsPreviousInsertPlanningState() throws Exception {
+        String sql = "insert into insert_retry_test.target select 1, 2 where false";
+        connectContext.setQueryId(new TUniqueId(1, 2));
+        StmtExecutor executor = new StmtExecutor(connectContext, sql);
+        ((InsertIntoTableCommand) new NereidsParser().parseSingle(sql))
+                .initPlan(connectContext, executor, false);
+
+        connectContext.getStatementContext().getMvCanRewritePartitionsMap().put(
+                new BaseTableInfo(new TableNameInfo("internal", "db", "mv")),
+                Collections.singleton(Mockito.mock(Partition.class)));
+        InsertIntoTableCommand parsedCommand = (InsertIntoTableCommand) new NereidsParser().parseSingle(sql);
+        TableIf targetTable = Env.getCurrentInternalCatalog().getDbOrMetaException("insert_retry_test")
+                .getTableOrMetaException("target");
+        InsertIntoTableCommand command = new InsertIntoTableCommand(
+                parsedCommand, PlanType.INSERT_INTO_TABLE_COMMAND) {
+            @Override
+            protected TableIf getTargetTableIf(ConnectContext ctx, List<String> qualifiedTargetTableName) {
+                Assertions.assertTrue(ctx.getStatementContext().getMvCanRewritePartitionsMap().isEmpty());
+                return targetTable;
+            }
+
+            @Override
+            protected boolean needAuthCheck(TableIf targetTableIf) {
+                return false;
+            }
+        };
+
+        command.initPlan(connectContext, executor, false);
+    }
+
+    @Test
     public void testInternalReplanResetsMaterializedViewPlanningState() throws Exception {
         String sql = "insert into insert_retry_test.target select 1, 2 where false";
         InsertIntoTableCommand parsedCommand = (InsertIntoTableCommand) new NereidsParser().parseSingle(sql);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommandRetryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommandRetryTest.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.mtmv.BaseTableInfo;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InsertIntoTableCommandRetryTest extends TestWithFeService {
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        FeConstants.runningUnitTest = true;
+        createDatabase("insert_retry_test");
+        connectContext.setDatabase("insert_retry_test");
+        createTable("create table insert_retry_test.target (k1 int, k2 int) "
+                + "distributed by hash(k1) buckets 1 properties('replication_num'='1')");
+    }
+
+    @Test
+    public void testInternalReplanResetsMaterializedViewPlanningState() throws Exception {
+        String sql = "insert into insert_retry_test.target select 1, 2 where false";
+        InsertIntoTableCommand parsedCommand = (InsertIntoTableCommand) new NereidsParser().parseSingle(sql);
+        Database database = (Database) Env.getCurrentInternalCatalog().getDbOrMetaException("insert_retry_test");
+        TableIf targetTable = database.getTableOrMetaException("target");
+        TableIf replacedTable = Mockito.mock(TableIf.class);
+        Mockito.when(replacedTable.getId()).thenReturn(targetTable.getId() + 1);
+        AtomicInteger targetResolutions = new AtomicInteger();
+        InsertIntoTableCommand command = new InsertIntoTableCommand(
+                parsedCommand, PlanType.INSERT_INTO_TABLE_COMMAND) {
+            @Override
+            protected TableIf getTargetTableIf(ConnectContext ctx, List<String> qualifiedTargetTableName) {
+                int resolution = targetResolutions.incrementAndGet();
+                if (resolution == 2) {
+                    return replacedTable;
+                }
+                if (resolution == 3) {
+                    Assertions.assertTrue(ctx.getStatementContext().getMvCanRewritePartitionsMap().isEmpty());
+                }
+                return targetTable;
+            }
+
+            @Override
+            protected boolean needAuthCheck(TableIf targetTableIf) {
+                return false;
+            }
+        };
+
+        connectContext.setQueryId(new TUniqueId(1, 2));
+        StmtExecutor executor = new StmtExecutor(connectContext, sql);
+        StatementContext statementContext = connectContext.getStatementContext();
+        statementContext.getMvCanRewritePartitionsMap().put(
+                new BaseTableInfo(new TableNameInfo("internal", "db", "mv")),
+                Collections.singleton(Mockito.mock(Partition.class)));
+
+        command.initPlan(connectContext, executor, true);
+
+        Assertions.assertEquals(4, targetResolutions.get());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -20,18 +20,24 @@ package org.apache.doris.qe;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
+import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
+import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.UserException;
+import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
 import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
 import org.apache.doris.qe.ConnectContext.ConnectType;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.utframe.TestWithFeService;
@@ -602,5 +608,39 @@ public class StmtExecutorTest extends TestWithFeService {
                 + "   \"ai.model_name\" = \"gpt-test\",\n"
                 + "   \"ai.api_key\" = \"" + apiKey + "\"\n"
                 + ");";
+    }
+
+    @Test
+    public void testQueryReplanResetsMaterializedViewPlanningState() throws Exception {
+        int originalRetryTime = Config.max_query_retry_time;
+        AtomicInteger attempts = new AtomicInteger();
+        BaseTableInfo mvInfo = new BaseTableInfo(new TableNameInfo("internal", "db", "mv"));
+        Partition firstPartition = Mockito.mock(Partition.class);
+        Partition secondPartition = Mockito.mock(Partition.class);
+        try {
+            Config.max_query_retry_time = 1;
+            StmtExecutor executor = new StmtExecutor(connectContext, "select 1") {
+                @Override
+                public void execute(TUniqueId queryId) throws Exception {
+                    StatementContext statementContext = getContext().getStatementContext();
+                    if (attempts.getAndIncrement() == 0) {
+                        statementContext.getMvCanRewritePartitionsMap().putIfAbsent(
+                                mvInfo, Lists.newArrayList(firstPartition, secondPartition));
+                        throw new UserException(SystemInfoService.ERROR_E230);
+                    }
+                    statementContext.getMvCanRewritePartitionsMap().putIfAbsent(
+                            mvInfo, Lists.newArrayList(firstPartition));
+                }
+            };
+
+            executor.queryRetry(new TUniqueId(1, 2));
+
+            Assertions.assertEquals(2, attempts.get());
+            Assertions.assertEquals(Lists.newArrayList(firstPartition),
+                    connectContext.getStatementContext().getMvCanRewritePartitionsMap().get(mvInfo));
+        } finally {
+            Config.max_query_retry_time = originalRetryTime;
+            connectContext.getStatementContext().getMvCanRewritePartitionsMap().clear();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -412,8 +413,21 @@ public class StmtExecutorTest extends TestWithFeService {
         // "fragment has no children" error.
 
         // Simulate the proxy flow: StmtExecutor(ConnectContext, OriginStatement, boolean isProxy)
+        AtomicInteger attempts = new AtomicInteger();
+        BaseTableInfo mvInfo = new BaseTableInfo(new TableNameInfo("internal", "db", "mv"));
         StmtExecutor executor = new StmtExecutor(connectContext,
-                new OriginStatement("select 1", 0), true);
+                new OriginStatement("select 1", 0), true) {
+            @Override
+            public void execute(TUniqueId queryId) throws Exception {
+                if (attempts.getAndIncrement() == 0) {
+                    getContext().getStatementContext().getMvCanRewritePartitionsMap().put(
+                            mvInfo, Collections.singleton(Mockito.mock(Partition.class)));
+                    throw new UserException(SystemInfoService.ERROR_E230);
+                }
+                Assertions.assertTrue(getContext().getStatementContext()
+                        .getMvCanRewritePartitionsMap().isEmpty());
+            }
+        };
 
         // Before parsing, statementContext should exist but parsedStatement should be null
         Assertions.assertNotNull(connectContext.getStatementContext());
@@ -434,6 +448,19 @@ public class StmtExecutorTest extends TestWithFeService {
                 parsedStatement instanceof org.apache.doris.nereids.glue.LogicalPlanAdapter,
                 "ParsedStatement should be a LogicalPlanAdapter after parseByNereids(), but was: "
                         + (parsedStatement == null ? "null" : parsedStatement.getClass().getName()));
+        Field statementContextField = StmtExecutor.class.getDeclaredField("statementContext");
+        statementContextField.setAccessible(true);
+        Assertions.assertSame(connectContext.getStatementContext(), statementContextField.get(executor),
+                "Proxy executor must use the context created by lazy parsing");
+
+        int originalRetryTime = Config.max_query_retry_time;
+        try {
+            Config.max_query_retry_time = 1;
+            executor.queryRetry(new TUniqueId(1, 2));
+            Assertions.assertEquals(2, attempts.get());
+        } finally {
+            Config.max_query_retry_time = originalRetryTime;
+        }
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #49514, #58643

Problem Summary:

Server prepared statements reuse one `StatementContext` for every external `EXECUTE`. Materialized-view planning state collected by one execution can therefore be read by a later execution.

The retained partition mappings both accumulate work and can make the next MV compensation pass use stale relation/partition information. The retained MV discovery and rewrite-phase state can also keep old candidates, plans, statistics, hints, or hooks alive after the current execution's MV settings and catalog state have changed.

Change Summary:

| File | Change Description |
|------|-------------------|
| `ExecuteCommand.java` | Reset MV-specific prepared-execution state once at the external `EXECUTE` boundary before planning. |
| `StatementContext.java` | Clear query partition mappings, MV-valid-partition cache, MV candidates/related tables, MV hooks, rewrite duration, `USE_MV` hints, pre-rewrite plans/flags/masks, rewrite successes, and MV relation statistics. Unrelated hooks and hints are preserved. |
| `PartitionCompensator.java` | Use `BitSet.get(relationId)` directly instead of allocating a singleton `BitSet` for each relation mapping. |
| `ExecuteCommandTest.java` | Cover reset timing, changed valid partitions, same-name MV replacement, enabled-to-disabled MV rewrite, and retained MV rewrite state across repeated EXECUTEs. |

The reset is intentionally limited to materialized-view and partition-planning state. `joinFilters`, `disableRules`, `queryStatsRecorded`, and other generic prepared-`StatementContext` lifecycle fields are not changed in this PR; they require separate scope and behavior coverage.

### Release note

Fixed stale materialized-view planning state and avoidable FE allocation when repeatedly executing prepared statements with MV rewrite.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  `./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.ExecuteCommandTest`
  Result: 12 tests passed.

  `./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.ExecuteCommandTest,org.apache.doris.nereids.rules.exploration.mv.PartitionCompensatorTest`
  Result: 23 tests passed.

- Behavior changed
    - [x] No.
    - [ ] Yes (bug fix only; no protocol or compatibility change)

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
