### PR TITLE
[chore](session-variable) remove the unused session variable plan_nereids_dump

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -545,8 +545,6 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String MINIDUMP_PATH = "minidump_path";
 
-    public static final String PLAN_NEREIDS_DUMP = "plan_nereids_dump";
-
     public static final String DUMP_NEREIDS_MEMO = "dump_nereids_memo";
 
     public static final String MEMO_LOGICAL_ROW_COUNT_AGGREGATION_POLICY = "memo_logical_row_count_aggregation_policy";
@@ -2565,8 +2563,10 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = ENABLE_FOLD_NONDETERMINISTIC_FN)
     public boolean enableFoldNondeterministicFn = false;
 
-    @VarAttrDef.VarAttr(name = PLAN_NEREIDS_DUMP)
-    public boolean planNereidsDump = false;
+    // Internal state, not a session variable: it is turned on only by MinidumpUtils while replaying
+    // a minidump file (PLAY '<dumpfile>'), where tables and statistics come from the dump instead of
+    // the catalog. It is intentionally not settable through SET, not forwarded and not serialized.
+    private boolean planNereidsDump = false;
 
     // If set to true, all query will be executed without returning result
     @VarAttrDef.VarAttr(name = DRY_RUN_QUERY, needForward = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -154,7 +154,8 @@ public class VariableMgr {
             "enable_common_expr_pushdown_for_inverted_index",
             "enable_phrase_query_sequential_opt",
             "enable_rust_lance_reader",
-            "shuffled_agg_node_ids");
+            "shuffled_agg_node_ids",
+            "plan_nereids_dump");
 
     private static boolean isRemovedSessionVar(String varName) {
         return varName != null && REMOVED_SESSION_VAR_NAMES.contains(varName.toLowerCase());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

`plan_nereids_dump` is a leftover session variable. It only has meaning while the planner replays a minidump file, and on that path the flag is set programmatically by `MinidumpUtils.setConnectContext()`. Nothing in the product code, the regression suite or the docs sets it through `SET` — the only thing exposing it as a session variable achieves is letting a normal session enter the replay-only planner mode, which is not a supported usage and produces a plan that cannot be executed.

This PR:

1. Drops the `plan_nereids_dump` session variable: the `PLAN_NEREIDS_DUMP` constant and the `@VarAttr` registration are removed, and the underlying flag becomes an internal private field of `SessionVariable`. It is still set by `MinidumpUtils` when replaying a dump, so `PLAY '<dumpfile>'` keeps working exactly as before. Being un-annotated it is no longer exposed by `SET` / `SELECT @@` / `SET_VAR` hints, and no longer forwarded to master or serialized into a dump file.

2. Adds `plan_nereids_dump` to `VariableMgr.REMOVED_SESSION_VAR_NAMES`, so old scripts, JDBC connection-init statements and replayed `SET GLOBAL` edit logs keep silently no-oping instead of failing with `ERR_UNKNOWN_SYSTEM_VARIABLE` during a rolling upgrade.

No behavior change for normal queries; the minidump dump/replay path is untouched.

### Release note

Removed the unused session variable `plan_nereids_dump`.

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] Previous test can cover this change.

    `SessionVariablesTest` + `VariableMgrTest`: `Tests run: 26, Failures: 0, Errors: 0`.
    FE build (`sh build.sh --fe`) passes with checkstyle enabled.

- Behavior changed:
    - [x] Yes. `plan_nereids_dump` is no longer a session variable. `SET plan_nereids_dump = ...` and `SELECT @@plan_nereids_dump` are silently ignored (the removed-variable compatibility path) instead of taking effect.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
