### PR TITLE
[fix](ci) Approve clean automated reviews

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -546,7 +546,7 @@ jobs:
 
           ## Final response format
           - After completing the review, you MUST provide a final summary opinion based on the rules defined in AGENTS.md and the code-review skill. The summary must include conclusions for each applicable critical checkpoint.
-          - If the overall quality of PR is good and there are no critical blocking issues (even if there are some tolerable minor issues), submit an opinion on approval using: gh pr review PLACEHOLDER_PR_NUMBER --comment --body "<summary>"
+          - If the overall quality of PR is good and there are no critical blocking issues (even if there are some tolerable minor issues), submit an opinion on approval using: gh pr review PLACEHOLDER_PR_NUMBER --approve --body "<summary>"
               - Note that when submitting review comments in this way, the content will not be escaped, so you need to input multi-line text with line breaks directly, rather than using `\n`.
           - If issues found, submit a review with inline comments plus a comprehensive summary body. Use GitHub Reviews API to ensure comments are inline:
               - Inline comment bodies may include GitHub suggested changes blocks when you can propose a precise patch.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66242

The automated review prompt currently submits a `COMMENT` review after finding no critical blocking issue. GitHub does not treat that as approval, so an earlier automated `REQUEST_CHANGES` review can continue blocking merge while the `code-review` check is successful.

This changes the clean-review path to submit `APPROVE`; the issue path continues to submit `REQUEST_CHANGES`.

### Release note

None

### Check List (For Author)

- Test: Manual test
  - Parsed the updated workflow YAML.
  - Asserted the clean-review prompt uses `--approve` and no longer uses `--comment`.
- Behavior changed: Yes. A clean automated review now records a GitHub approval.
- Does this need documentation: No
