### PR TITLE
[opt](parquet) accelerate fixed binary decimal decoding

### DIFF
--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -40,6 +40,7 @@
 #include "core/data_type_serde/parquet_decode_source.h"
 #include "core/types.h"
 #include "exec/common/arithmetic_overflow.h"
+#include "exec/common/endian.h"
 #include "exprs/function/cast/cast_to_decimal.h"
 #include "exprs/function/cast/cast_to_string.h"
 #include "orc/Int128.hh"
@@ -72,6 +73,15 @@ NativeType decode_big_endian_signed_integer(const uint8_t* data, int length) {
         }
         return static_cast<NativeType>(value);
     }
+}
+
+template <typename NativeType>
+NativeType decode_big_endian_full_width_integer(const uint8_t* data) {
+    using UnsignedNativeType =
+            std::conditional_t<std::is_same_v<NativeType, Int128>, unsigned __int128,
+                               std::make_unsigned_t<NativeType>>;
+    return static_cast<NativeType>(
+            to_endian<std::endian::big>(unaligned_load<UnsignedNativeType>(data)));
 }
 
 template <PrimitiveType T>
@@ -288,6 +298,19 @@ public:
                                         static_cast<int>(_context.physical_type));
         }
         DORIS_CHECK_EQ(value_width, static_cast<size_t>(_context.type_length));
+        if (_context.decimal_scale == _target_scale) {
+            // Same-scale values may use a narrow signed type selected by physical width, but
+            // target-precision validation must still happen before narrowing the result.
+            if (value_width <= sizeof(int32_t)) {
+                return append_same_scale_fixed_binary<int32_t>(values, num_values, value_width);
+            }
+            if (value_width <= sizeof(int64_t)) {
+                return append_same_scale_fixed_binary<int64_t>(values, num_values, value_width);
+            }
+            if (value_width <= sizeof(Int128)) {
+                return append_same_scale_fixed_binary<Int128>(values, num_values, value_width);
+            }
+        }
         const size_t old_size = _data.size();
         _data.resize(old_size + num_values);
         for (size_t row = 0; row < num_values; ++row) {
@@ -346,6 +369,58 @@ public:
     }
 
 private:
+    template <typename SourceType>
+    Status append_same_scale_fixed_binary(const uint8_t* values, size_t num_values,
+                                          size_t value_width) {
+        if (value_width == sizeof(SourceType)) {
+            return append_same_scale_fixed_binary_impl<SourceType, true>(values, num_values,
+                                                                         value_width);
+        }
+        return append_same_scale_fixed_binary_impl<SourceType, false>(values, num_values,
+                                                                      value_width);
+    }
+
+    template <typename SourceType, bool full_width>
+    Status append_same_scale_fixed_binary_impl(const uint8_t* values, size_t num_values,
+                                               size_t value_width) {
+        const size_t old_size = _data.size();
+        _data.resize(old_size + num_values);
+        const auto wide_limit = parquet_decimal_limit<T>(_target_precision);
+        const auto source_max = wide::Int256(std::numeric_limits<SourceType>::max());
+        const auto fixed_width = cast_set<int>(value_width);
+        const auto decode = [&](const uint8_t* value) {
+            if constexpr (full_width) {
+                return decode_big_endian_full_width_integer<SourceType>(value);
+            }
+            return decode_big_endian_signed_integer<SourceType>(value, fixed_width);
+        };
+        // A limit above signed max also covers the asymmetric minimum (-max - 1), so the whole
+        // source domain is safe to narrow without a per-row precision branch.
+        if (wide_limit > source_max) {
+            for (size_t row = 0; row < num_values; ++row) {
+                const auto source_value = decode(values + row * value_width);
+                _data[old_size + row] = FieldType {static_cast<NativeType>(source_value)};
+            }
+            return Status::OK();
+        }
+
+        const auto limit = static_cast<SourceType>(wide_limit);
+        for (size_t row = 0; row < num_values; ++row) {
+            const auto source_value = decode(values + row * value_width);
+            if (LIKELY(source_value >= -limit && source_value <= limit)) {
+                _data[old_size + row] = FieldType {static_cast<NativeType>(source_value)};
+                continue;
+            }
+            if (_state != nullptr && _state->mark_conversion_failure(old_size + row)) {
+                _data[old_size + row] = FieldType();
+                continue;
+            }
+            _data.resize(old_size);
+            return Status::DataQualityError("Parquet decimal value is out of range");
+        }
+        return Status::OK();
+    }
+
     template <typename SourceType>
     Status append_integers(const uint8_t* values, size_t num_values) {
         const size_t old_size = _data.size();

--- a/be/test/core/data_type_serde/data_type_serde_parquet_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_parquet_test.cpp
@@ -499,6 +499,90 @@ TEST(DataTypeSerDeParquetTest, DecimalUsesWideIntermediateBeforeNarrowing) {
     }
 }
 
+TEST(DataTypeSerDeParquetTest, FixedBinaryDecimalValidatesPrecisionBeforeNarrowing) {
+    const std::vector<uint8_t> values {
+            0x00, 0x98, 0x96, 0x7F, //  9,999,999: valid Decimal(7, 2) boundary.
+            0x00, 0x98, 0x96, 0x80, // 10,000,000: one unit above the boundary.
+            0xFF, 0x67, 0x69, 0x81, // -9,999,999: valid Decimal(7, 2) boundary.
+            0xFF, 0x67, 0x69, 0x80, // -10,000,000: one unit below the boundary.
+    };
+    ParquetDecodeContext context {.physical_type = ParquetPhysicalType::FIXED_LEN_BYTE_ARRAY,
+                                  .logical_type = ParquetLogicalType::DECIMAL,
+                                  .type_length = 4,
+                                  .decimal_precision = 9,
+                                  .decimal_scale = 2};
+    DataTypeDecimal32 type(7, 2);
+    {
+        TestParquetDecodeSource source;
+        source.set_fixed_bytes(values, 4);
+        IColumn::Filter null_map(4, 0);
+        ParquetMaterializationState state;
+        state.conversion_failure_null_map = &null_map;
+        auto column = type.create_column();
+
+        ASSERT_TRUE(type.get_serde()
+                            ->read_column_from_parquet(*column, source, context, 4, state)
+                            .ok());
+        const auto& data = assert_cast<const ColumnDecimal32&>(*column).get_data();
+        EXPECT_EQ(data[0].value, 9999999);
+        EXPECT_EQ(data[1].value, 0);
+        EXPECT_EQ(data[2].value, -9999999);
+        EXPECT_EQ(data[3].value, 0);
+        EXPECT_EQ(null_map, IColumn::Filter({0, 1, 0, 1}));
+    }
+    {
+        TestParquetDecodeSource source;
+        source.set_fixed_bytes({0x00, 0x98, 0x96, 0x80}, 4);
+        ParquetMaterializationState state;
+        state.enable_strict_mode = true;
+        auto column = type.create_column();
+        column->insert_default();
+
+        const auto status =
+                type.get_serde()->read_column_from_parquet(*column, source, context, 1, state);
+        EXPECT_TRUE(status.is<ErrorCode::DATA_QUALITY_ERROR>()) << status;
+        EXPECT_EQ(column->size(), 1);
+    }
+}
+
+TEST(DataTypeSerDeParquetTest, FixedBinaryDecimalSignExtendsNarrowSameScaleInput) {
+    TestParquetDecodeSource source;
+    source.set_fixed_bytes({0x04, 0xD2, 0xFB, 0x2E}, 2); // 12.34 and -12.34 at scale 2.
+    ParquetDecodeContext context {.physical_type = ParquetPhysicalType::FIXED_LEN_BYTE_ARRAY,
+                                  .logical_type = ParquetLogicalType::DECIMAL,
+                                  .type_length = 2,
+                                  .decimal_precision = 4,
+                                  .decimal_scale = 2};
+    ParquetMaterializationState state;
+    DataTypeDecimal32 type(4, 2);
+    auto column = type.create_column();
+
+    ASSERT_TRUE(
+            type.get_serde()->read_column_from_parquet(*column, source, context, 2, state).ok());
+    const auto& data = assert_cast<const ColumnDecimal32&>(*column).get_data();
+    EXPECT_EQ(data[0].value, 1234);
+    EXPECT_EQ(data[1].value, -1234);
+}
+
+TEST(DataTypeSerDeParquetTest, FixedBinaryDecimalAcceptsEntireNarrowSourceDomain) {
+    TestParquetDecodeSource source;
+    source.set_fixed_bytes({0x80, 0x00, 0x00, 0x00, 0x7F, 0xFF, 0xFF, 0xFF}, 4);
+    ParquetDecodeContext context {.physical_type = ParquetPhysicalType::FIXED_LEN_BYTE_ARRAY,
+                                  .logical_type = ParquetLogicalType::DECIMAL,
+                                  .type_length = 4,
+                                  .decimal_precision = 10,
+                                  .decimal_scale = 0};
+    ParquetMaterializationState state;
+    DataTypeDecimal64 type(18, 0);
+    auto column = type.create_column();
+
+    ASSERT_TRUE(
+            type.get_serde()->read_column_from_parquet(*column, source, context, 2, state).ok());
+    const auto& data = assert_cast<const ColumnDecimal64&>(*column).get_data();
+    EXPECT_EQ(data[0].value, std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(data[1].value, std::numeric_limits<int32_t>::max());
+}
+
 TEST(DataTypeSerDeParquetTest, DecimalAcceptsSignExtendedBinaryAfterWideExactScaling) {
     const std::vector<uint8_t> values {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0xCE,
                                        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFB, 0x32};


### PR DESCRIPTION
## Proposed changes

- Decode same-scale Parquet `FIXED_LEN_BYTE_ARRAY` decimals with an `int32_t`, `int64_t`, or `Int128` source selected from the physical width instead of always using `Int256`.
- Use unaligned full-width big-endian loads for 4-, 8-, and 16-byte values, while preserving sign extension for shorter widths.
- Validate the target decimal precision before narrowing, preserve permissive/strict conversion behavior, and keep rescaling and wider values on the existing `Int256` path.
- Add regression coverage for positive and negative precision boundaries, shorter signed inputs, strict rollback, permissive null marking, and the complete int32 source domain.

## Validation

- ASAN BE unit tests: 8 tests from `DataTypeSerDeParquetTest` passed.
- Release microbenchmark: 65,536 values per iteration through `DataTypeDecimalSerDe::read_column_from_parquet`, pinned to one CPU. Each stage used 3 warmups followed by 10 repetitions in ABBA order.

| Target / physical width | Before median CPU | After median CPU | Speedup | CPU reduction |
| --- | ---: | ---: | ---: | ---: |
| Decimal32 / 4 bytes | 1,359,514 ns | 88,527 ns | 15.36x | 93.49% |
| Decimal64 / 8 bytes | 1,634,757 ns | 90,609 ns | 18.04x | 94.46% |
| Decimal128 / 16 bytes | 2,206,272 ns | 152,823 ns | 14.44x | 93.07% |

The benchmark host was heavily loaded and CPU frequency scaling was enabled, so the exact ratios are noisy. However, the before/after median ranges did not overlap in any ABBA stage. A final optimized-build smoke run measured median CPU times of 95,077 ns, 94,635 ns, and 145,417 ns with CPU CVs of 0.41%, 1.76%, and 0.64%, respectively.