### PR TITLE
[fix](paimon) Preserve system table validation details

### DIFF
--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonScanPlanProvider.java
@@ -353,6 +353,9 @@ public class PaimonScanPlanProvider implements ConnectorScanPlanProvider {
             Table dataTable = PaimonTableResolver.resolveSystemSource(catalogOps, handle, context);
             return PaimonReaderOptions.runtimeSafeSystemTable(
                     handle.getSysTableName(), systemTable, dataTable, scanOptions);
+        } catch (IllegalArgumentException e) {
+            // Validation details must reach the SQL boundary so users can correct unsafe table options.
+            throw new DorisConnectorException(e.getMessage(), e);
         } catch (Exception e) {
             throw new DorisConnectorException("Failed to validate Paimon system table source", e);
         }

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonScanPlanProviderTest.java
@@ -549,9 +549,10 @@ public class PaimonScanPlanProviderTest {
         PaimonScanPlanProvider provider = new PaimonScanPlanProvider(Collections.emptyMap(), ops);
 
         // The connector boundary must keep one stable exception type while preserving the
-        // validation failure as its cause for diagnostics.
+        // actionable validation detail in the user-facing message and the original cause.
         DorisConnectorException e = Assertions.assertThrows(DorisConnectorException.class,
                 () -> provider.resolveScanTable(handle));
+        Assertions.assertTrue(e.getMessage().contains("scan.manifest.parallelism"));
         Assertions.assertInstanceOf(IllegalArgumentException.class, e.getCause());
         Assertions.assertTrue(e.getCause().getMessage().contains("scan.manifest.parallelism"));
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Paimon system table safety validation wrapped actionable reader-option errors with a generic connector message. As a result, SQL clients could not identify the invalid option even though the original cause contained it.

This change preserves `IllegalArgumentException` validation details at the SQL boundary while retaining the original cause. Other unexpected failures continue to use the generic connector message.

### Release note

Paimon system table validation errors now report the invalid reader option.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `mvn -f fe/pom.xml -pl :fe-connector-paimon -am test -Dtest=PaimonScanPlanProviderTest#resolveSystemScanTableValidatesHiddenDataTable -DfailIfNoTests=false`
        - `mvn -f fe/pom.xml -pl :fe-connector-paimon -am package -Dmaven.build.cache.enabled=false -DfailIfNoTests=false`
        - Paimon module: 505 tests, 0 failures, 1 skipped live-connectivity test.
        - FE Checkstyle: 0 violations.
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Invalid Paimon system table reader options are visible in the SQL error message.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
